### PR TITLE
Cloud Agent: prompt autocomplete (ghost text)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -182,3 +182,11 @@
     animation: pulse-glow 0.6s ease-out;
   }
 }
+
+/* Ghost text for chat autocomplete */
+.chat-ghost-text {
+  color: var(--muted-foreground);
+  opacity: 0.6;
+  pointer-events: none;
+  user-select: none;
+}

--- a/src/components/cloud-agent/hooks/useChatGhostText.ts
+++ b/src/components/cloud-agent/hooks/useChatGhostText.ts
@@ -1,0 +1,259 @@
+import { useState, useRef, useCallback, useEffect, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { trpc } from '@/lib/trpc.client';
+
+type UseChatGhostTextProps = {
+  textAreaRef: React.RefObject<HTMLTextAreaElement>;
+  enableChatAutocomplete: boolean;
+};
+
+// Generate a unique ID for each request to avoid race conditions
+function generateRequestId(): string {
+  return Math.random().toString(36).substring(2, 15);
+}
+
+// Insert text at cursor position in a textarea
+function insertTextAtCursor(textarea: HTMLTextAreaElement, text: string): void {
+  const { selectionStart, value } = textarea;
+  const newValue = value.slice(0, selectionStart) + text + value.slice(selectionStart);
+  textarea.value = newValue;
+  // Move cursor to end of inserted text
+  const newCursorPos = selectionStart + text.length;
+  textarea.setSelectionRange(newCursorPos, newCursorPos);
+  // Trigger input event so React sees the change
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+// Extract the next word from ghost text (for ArrowRight partial acceptance)
+function extractNextWord(text: string): { word: string; remainder: string } {
+  const match = text.match(/^(\s*\S+)/);
+  if (!match) {
+    return { word: text, remainder: '' };
+  }
+  const word = match[1];
+  const remainder = text.slice(word.length);
+  return { word, remainder };
+}
+
+let debugEnabled = false;
+if (typeof window !== 'undefined') {
+  debugEnabled = window.localStorage?.getItem('debug:cloud-agent:autocomplete') === 'true';
+}
+
+function debugCloudAgentAutocomplete(label: string, data?: unknown): void {
+  if (debugEnabled) {
+    console.log(`[useChatGhostText:${label}]`, data);
+  }
+}
+
+/**
+ * Hook that manages ghost text autocomplete for the cloud agent chat input.
+ * Provides debounced FIM completion suggestions and keyboard handlers for accepting them.
+ */
+export function useChatGhostText({ textAreaRef, enableChatAutocomplete }: UseChatGhostTextProps) {
+  const [ghostText, setGhostText] = useState('');
+  const completionDebounceRef = useRef<NodeJS.Timeout | null>(null);
+  const skipNextCompletionRef = useRef(false);
+  const completionRequestIdRef = useRef<string>('');
+  const trpcClient = trpc.useUtils();
+
+  const requestCompletion = useCallback(
+    async ({ prefix, requestId }: { prefix: string; requestId: string }) => {
+      console.log('[useChatGhostText] requestCompletion called', {
+        prefixLength: prefix.length,
+        requestId,
+        currentRequestId: completionRequestIdRef.current,
+      });
+      debugCloudAgentAutocomplete('request', {
+        prefixLength: prefix.length,
+        requestId,
+      });
+
+      // Only process if this is still the latest request
+      if (requestId !== completionRequestIdRef.current) {
+        console.log('[useChatGhostText] stale request, ignoring', {
+          requestId,
+          currentRequestId: completionRequestIdRef.current,
+        });
+        debugCloudAgentAutocomplete('stale', { requestId });
+        return;
+      }
+
+      try {
+        const result = await trpcClient.cloudAgent.getFimAutocomplete.mutate({
+          prefix,
+          suffix: '',
+          requestId,
+        });
+
+        console.log('[useChatGhostText] got result', {
+          requestId,
+          currentRequestId: completionRequestIdRef.current,
+          suggestionLength: result.suggestion.length,
+          suggestionPreview: result.suggestion.slice(0, 50),
+        });
+        debugCloudAgentAutocomplete('result', {
+          requestId,
+          suggestionLength: result.suggestion.length,
+        });
+
+        // Only update ghost text if this is still the latest request
+        if (requestId === completionRequestIdRef.current) {
+          setGhostText(result.suggestion);
+        } else {
+          console.log('[useChatGhostText] result is stale, not updating ghost text', {
+            requestId,
+            currentRequestId: completionRequestIdRef.current,
+          });
+          debugCloudAgentAutocomplete('result-stale', { requestId });
+        }
+      } catch (error) {
+        debugCloudAgentAutocomplete('error', error);
+        // Silently ignore errors - just don't show ghost text
+        setGhostText('');
+      }
+    },
+    [trpcClient]
+  );
+
+  const clearGhostText = useCallback(() => {
+    setGhostText('');
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>): boolean => {
+      const textArea = textAreaRef.current;
+      if (!textArea) {
+        return false;
+      }
+
+      const hasSelection = textArea.selectionStart !== textArea.selectionEnd;
+      const isCursorAtEnd = textArea.selectionStart === textArea.value.length;
+      const canAcceptCompletion = ghostText && !hasSelection && isCursorAtEnd;
+
+      // Tab: Accept full ghost text
+      if (event.key === 'Tab' && !event.shiftKey && canAcceptCompletion) {
+        debugCloudAgentAutocomplete('accept', { via: 'Tab', ghostText });
+        event.preventDefault();
+        skipNextCompletionRef.current = true;
+        insertTextAtCursor(textArea, ghostText);
+        setGhostText('');
+        return true;
+      }
+
+      // ArrowRight: Accept next word only
+      if (
+        event.key === 'ArrowRight' &&
+        !event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        canAcceptCompletion
+      ) {
+        const { word, remainder } = extractNextWord(ghostText);
+        debugCloudAgentAutocomplete('accept', {
+          via: 'ArrowRight',
+          word,
+          remainderPreview: remainder.slice(0, 120),
+        });
+        event.preventDefault();
+        skipNextCompletionRef.current = true;
+        insertTextAtCursor(textArea, word);
+        setGhostText(remainder);
+        return true;
+      }
+
+      // Escape: Clear ghost text
+      if (event.key === 'Escape' && ghostText) {
+        debugCloudAgentAutocomplete('clear', { via: 'Escape' });
+        setGhostText('');
+      }
+      return false;
+    },
+    [ghostText, textAreaRef]
+  );
+
+  const handleInputChange = useCallback(
+    (newValue: string) => {
+      console.log('[useChatGhostText] handleInputChange called', {
+        enableChatAutocomplete,
+        newValueLength: newValue.length,
+      });
+      debugCloudAgentAutocomplete('input-change', {
+        enableChatAutocomplete,
+        newValueLength: newValue.length,
+        startsWithSlash: newValue.startsWith('/'),
+        includesAt: newValue.includes('@'),
+        skipNext: skipNextCompletionRef.current,
+      });
+
+      // Clear any existing ghost text when typing
+      setGhostText('');
+
+      // Clear any pending completion request
+      if (completionDebounceRef.current) {
+        clearTimeout(completionDebounceRef.current);
+      }
+
+      // Skip completion request if we just accepted a suggestion (Tab) or undid
+      if (skipNextCompletionRef.current) {
+        console.log('[useChatGhostText] skipping - skipNextCompletionRef is true');
+        skipNextCompletionRef.current = false;
+        // Don't request a new completion - wait for user to type more
+      } else if (
+        enableChatAutocomplete &&
+        newValue.length >= 5 &&
+        !newValue.startsWith('/') &&
+        !newValue.includes('@')
+      ) {
+        // Request new completion after debounce (only if feature is enabled)
+        const requestId = generateRequestId();
+        completionRequestIdRef.current = requestId;
+
+        console.log('[useChatGhostText] scheduling completion request', {
+          requestId,
+          debounceMs: 300,
+          textLength: newValue.length,
+        });
+        debugCloudAgentAutocomplete('schedule', {
+          requestId,
+          debounceMs: 300,
+        });
+
+        completionDebounceRef.current = setTimeout(() => {
+          console.log('[useChatGhostText] debounce fired, calling requestCompletion', {
+            requestId,
+          });
+          void requestCompletion({
+            prefix: newValue,
+            requestId,
+          });
+        }, 300); // 300ms debounce
+      } else {
+        console.log('[useChatGhostText] not scheduling', {
+          enableChatAutocomplete,
+          length: newValue.length,
+          startsWithSlash: newValue.startsWith('/'),
+          includesAt: newValue.includes('@'),
+        });
+        debugCloudAgentAutocomplete('no-schedule', {
+          reason: enableChatAutocomplete ? 'guards-not-met' : 'disabled',
+        });
+      }
+    },
+    [enableChatAutocomplete, requestCompletion]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (completionDebounceRef.current) {
+        clearTimeout(completionDebounceRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    ghostText,
+    handleKeyDown,
+    handleInputChange,
+    clearGhostText,
+  };
+}

--- a/src/lib/cloud-agent/chat-completion.ts
+++ b/src/lib/cloud-agent/chat-completion.ts
@@ -1,0 +1,131 @@
+import { APP_URL } from '@/lib/constants';
+
+// Version string for API requests - must be >= 4.69.1 to pass version check
+const FIM_COMPLETION_VERSION = '5.0.0';
+
+// Model to use for FIM completions - using Mistral's Codestral model
+const FIM_MODEL = 'mistralai/codestral-latest';
+
+// Maximum tokens for autocomplete suggestions
+const FIM_MAX_TOKENS = 100;
+
+type MistralFimResponse = {
+  id: string;
+  object: string;
+  model: string;
+  choices: Array<{
+    index: number;
+    text: string;
+    finish_reason: string;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+};
+
+type GetFimCompletionInput = {
+  prefix: string;
+  suffix?: string;
+  authToken: string;
+};
+
+/**
+ * Get a FIM (fill-in-the-middle) completion suggestion for autocomplete in the cloud agent chat input.
+ * Uses Mistral's FIM endpoint for fast, context-aware completions.
+ */
+export async function getFimCompletion(input: GetFimCompletionInput): Promise<string> {
+  const { prefix, suffix, authToken } = input;
+
+  console.log('[getFimCompletion] called', {
+    prefixLength: prefix.length,
+    suffixLength: suffix?.length ?? 0,
+    prefixPreview: prefix.slice(-50),
+  });
+
+  // Don't try to complete very short text
+  if (prefix.length < 5) {
+    console.log('[getFimCompletion] prefix too short, returning empty');
+    return '';
+  }
+
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${authToken}`,
+    'X-KiloCode-Version': FIM_COMPLETION_VERSION,
+    'User-Agent': `Kilo-Code/${FIM_COMPLETION_VERSION}`,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(`${APP_URL}/api/fim/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: FIM_MODEL,
+        prompt: prefix,
+        suffix: suffix || '',
+        max_tokens: FIM_MAX_TOKENS,
+        stream: false,
+      }),
+    });
+  } catch (error) {
+    console.error('[getFimCompletion] fetch failed', { error });
+    return '';
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[getFimCompletion] API error:', {
+      status: response.status,
+      error: errorText.slice(0, 2000),
+    });
+    return '';
+  }
+
+  console.log('[getFimCompletion] API call succeeded');
+
+  let responseBody: MistralFimResponse;
+  try {
+    responseBody = await response.json();
+  } catch (error) {
+    console.error('[getFimCompletion] failed to parse response', { error });
+    return '';
+  }
+
+  const choice = responseBody.choices?.[0];
+
+  if (!choice) {
+    console.log('[getFimCompletion] no choice in response');
+    return '';
+  }
+
+  const suggestion = choice.text || '';
+  console.log('[getFimCompletion] raw suggestion', { suggestion: suggestion.slice(0, 100) });
+
+  // Clean up the suggestion
+  const cleaned = cleanSuggestion(suggestion);
+  console.log('[getFimCompletion] cleaned suggestion', { cleaned: cleaned.slice(0, 100) });
+  return cleaned;
+}
+
+/**
+ * Clean the suggestion by removing unwanted patterns
+ */
+function cleanSuggestion(suggestion: string): string {
+  let cleaned = suggestion;
+
+  // Only take the first line/sentence for brevity
+  const firstNewline = cleaned.indexOf('\n');
+  if (firstNewline !== -1) {
+    cleaned = cleaned.substring(0, firstNewline);
+  }
+
+  // Filter out suggestions that are just punctuation or whitespace
+  if (cleaned.length < 2 || /^[\s\p{P}]+$/u.test(cleaned)) {
+    return '';
+  }
+
+  return cleaned;
+}

--- a/src/routers/cloud-agent-schemas.ts
+++ b/src/routers/cloud-agent-schemas.ts
@@ -239,3 +239,10 @@ export function isPreparedSessionInput(
 
   return hasCloudAgentSessionId && !hasLegacyFields;
 }
+
+// Schema for FIM autocomplete requests (prefix/suffix based)
+export const fimAutocompleteSchema = z.object({
+  prefix: z.string().min(1).max(2000),
+  suffix: z.string().max(2000).optional(),
+  requestId: z.string().min(1).max(20),
+});


### PR DESCRIPTION
Implements ghost-text prompt autocomplete for the Cloud Agent chat input (based on kilocode-backend PR #3966).

- Adds `cloudAgent.getFimAutocomplete` tRPC mutation
- Adds client-side ghost text hook and overlay rendering in ChatInput
- Adds minimal CSS for ghost text styling
- Improves error handling in llm-proxy-helpers

Accept suggestion: Tab (all), ArrowRight (next word), Escape clears.