### PR TITLE
App Builder - Add preview URL tracking with navigation controls

### DIFF
--- a/src/components/app-builder/AppBuilderPreview.tsx
+++ b/src/components/app-builder/AppBuilderPreview.tsx
@@ -8,7 +8,7 @@
 
 'use client';
 
-import { useState, useCallback, useEffect, memo } from 'react';
+import { useState, useCallback, useEffect, useRef, memo } from 'react';
 import Link from 'next/link';
 import {
   Loader2,
@@ -18,6 +18,9 @@ import {
   ExternalLink,
   AlertCircle,
   Rocket,
+  Home,
+  Copy,
+  Check,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -111,8 +114,13 @@ function IframeLoadingOverlay() {
 
 type PreviewFrameProps = {
   url: string;
+  currentPath: string;
+  isAtRoot: boolean;
   isFullscreen: boolean;
+  iframeRef: React.RefObject<HTMLIFrameElement | null>;
   onRefresh: () => void;
+  onGoHome: () => void;
+  onCopyUrl: () => void;
   onToggleFullscreen: () => void;
   onOpenExternal: () => void;
 };
@@ -121,18 +129,35 @@ type PreviewFrameProps = {
  * Preview frame controls bar
  */
 function PreviewControls({
-  url,
+  currentPath,
+  isAtRoot,
   isFullscreen,
   onRefresh,
+  onGoHome,
+  onCopyUrl,
   onToggleFullscreen,
   onOpenExternal,
-}: PreviewFrameProps) {
+}: Omit<PreviewFrameProps, 'url' | 'iframeRef'>) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    onCopyUrl();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [onCopyUrl]);
+
   return (
     <div className="flex items-center justify-between gap-4 border-b px-4 py-2">
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">{url}</span>
+        <Button variant="ghost" size="sm" onClick={onGoHome} disabled={isAtRoot} title="Go to home">
+          <Home className="h-4 w-4" />
+        </Button>
+        <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">{currentPath}</span>
       </div>
       <div className="flex items-center gap-1">
+        <Button variant="ghost" size="sm" onClick={handleCopy} title="Copy URL">
+          {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+        </Button>
         <Button variant="ghost" size="sm" onClick={onRefresh} title="Refresh preview">
           <RefreshCw className="h-4 w-4" />
         </Button>
@@ -152,29 +177,22 @@ function PreviewControls({
   );
 }
 
-const isDev = process.env.NODE_ENV === 'development';
-
-/** In dev, remove subdomain: "https://app-id.builder.kiloapps.io/path" -> "https://builder.kiloapps.io/" */
-function getPreviewUrl(url: string): string {
-  if (!isDev) return url;
-  try {
-    const parsed = new URL(url);
-    const parts = parsed.hostname.split('.');
-    if (parts.length > 2) {
-      parsed.hostname = parts.slice(1).join('.');
-    }
-    parsed.pathname = '/';
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
 /**
  * Preview iframe with controls - renders dev or production iframe based on environment
  */
 function PreviewFrame(props: PreviewFrameProps) {
-  const { url, isFullscreen } = props;
+  const {
+    url,
+    currentPath,
+    isAtRoot,
+    isFullscreen,
+    iframeRef,
+    onRefresh,
+    onGoHome,
+    onCopyUrl,
+    onToggleFullscreen,
+    onOpenExternal,
+  } = props;
   const [isIframeLoading, setIsIframeLoading] = useState(true);
 
   // Reset loading state when URL changes
@@ -188,11 +206,21 @@ function PreviewFrame(props: PreviewFrameProps) {
 
   return (
     <div className={cn('flex h-full flex-col', isFullscreen && 'bg-background fixed inset-0 z-50')}>
-      <PreviewControls {...props} />
+      <PreviewControls
+        currentPath={currentPath}
+        isAtRoot={isAtRoot}
+        isFullscreen={isFullscreen}
+        onRefresh={onRefresh}
+        onGoHome={onGoHome}
+        onCopyUrl={onCopyUrl}
+        onToggleFullscreen={onToggleFullscreen}
+        onOpenExternal={onOpenExternal}
+      />
       <div className="relative flex-1">
         {isIframeLoading && <IframeLoadingOverlay />}
         <iframe
-          src={getPreviewUrl(url)}
+          ref={iframeRef}
+          src={url}
           className="h-full w-full border-0"
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
           title="App Preview"
@@ -311,6 +339,15 @@ function DeploymentControls({ state, onDeploy }: { state: DeploymentState; onDep
   }
 }
 
+/** Extract pathname from URL, stripping query params */
+function getPathFromUrl(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return '/';
+  }
+}
+
 /**
  * Main preview component
  */
@@ -319,12 +356,59 @@ export const AppBuilderPreview = memo(function AppBuilderPreview({
 }: AppBuilderPreviewProps) {
   // Get state and manager from ProjectSession context
   const { manager, state } = useProject();
-  const { previewUrl, previewStatus, deploymentId } = state;
+  const { previewUrl, previewStatus, deploymentId, currentIframeUrl } = state;
   const projectId = manager.projectId;
 
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [iframeKey, setIframeKey] = useState(0);
   const [isCreatingDeployment, setIsCreatingDeployment] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Derive current path from tracked URL or fall back to previewUrl
+  const currentPath = currentIframeUrl
+    ? getPathFromUrl(currentIframeUrl)
+    : previewUrl
+      ? getPathFromUrl(previewUrl)
+      : '/';
+  const isAtRoot = currentPath === '/';
+
+  // Listen for postMessage navigation events from the preview iframe
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // Validate origin: only accept messages from the preview iframe's origin
+      // and verify the message comes from the iframe's content window
+      if (!previewUrl) return;
+      let previewOrigin: string;
+      try {
+        previewOrigin = new URL(previewUrl).origin;
+      } catch {
+        return;
+      }
+      if (event.origin !== previewOrigin) return;
+      if (event.source !== iframeRef.current?.contentWindow) return;
+
+      if (event.data?.type === 'kilo-preview-navigation') {
+        // Validate that the reported URL's origin matches the preview origin
+        // to prevent a compromised app from injecting arbitrary external URLs
+        try {
+          const reportedUrl = event.data.url;
+          if (typeof reportedUrl === 'string' && new URL(reportedUrl).origin === previewOrigin) {
+            manager.setCurrentIframeUrl(reportedUrl);
+          }
+        } catch {
+          // Invalid URL, ignore
+        }
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [manager, previewUrl]);
+
+  // Reset currentIframeUrl when previewUrl changes
+  useEffect(() => {
+    manager.setCurrentIframeUrl(null);
+  }, [previewUrl, manager]);
 
   // Get tRPC for queries
   const trpc = useTRPC();
@@ -385,18 +469,43 @@ export const AppBuilderPreview = memo(function AppBuilderPreview({
   }, [previewUrl, previewStatus]);
 
   const handleRefresh = useCallback(() => {
+    manager.setCurrentIframeUrl(null);
     setIframeKey(prev => prev + 1);
-  }, []);
+  }, [manager]);
 
   const handleToggleFullscreen = useCallback(() => {
     setIsFullscreen(prev => !prev);
   }, []);
 
   const handleOpenExternal = useCallback(() => {
-    if (previewUrl) {
-      window.open(previewUrl, '_blank');
+    const urlToOpen = currentIframeUrl || previewUrl;
+    if (urlToOpen) {
+      window.open(urlToOpen, '_blank');
+    }
+  }, [currentIframeUrl, previewUrl]);
+
+  const handleGoHome = useCallback(() => {
+    if (previewUrl && iframeRef.current?.contentWindow) {
+      const baseUrl = new URL(previewUrl);
+      baseUrl.pathname = '/';
+      baseUrl.search = '';
+      iframeRef.current.contentWindow.postMessage(
+        { type: 'kilo-preview-navigate', url: baseUrl.toString() },
+        baseUrl.origin
+      );
     }
   }, [previewUrl]);
+
+  const handleCopyUrl = useCallback(async () => {
+    const urlToCopy = currentIframeUrl || previewUrl;
+    if (urlToCopy) {
+      try {
+        await navigator.clipboard.writeText(urlToCopy);
+      } catch {
+        toast.error('Failed to copy URL to clipboard');
+      }
+    }
+  }, [currentIframeUrl, previewUrl]);
 
   // Handle deploy using ProjectManager
   const handleDeploy = useCallback(async () => {
@@ -445,8 +554,13 @@ export const AppBuilderPreview = memo(function AppBuilderPreview({
           <PreviewFrame
             key={iframeKey}
             url={previewUrl}
+            currentPath={currentPath}
+            isAtRoot={isAtRoot}
             isFullscreen={isFullscreen}
+            iframeRef={iframeRef}
             onRefresh={handleRefresh}
+            onGoHome={handleGoHome}
+            onCopyUrl={handleCopyUrl}
             onToggleFullscreen={handleToggleFullscreen}
             onOpenExternal={handleOpenExternal}
           />

--- a/src/components/app-builder/ProjectManager.ts
+++ b/src/components/app-builder/ProjectManager.ts
@@ -41,6 +41,8 @@ export type ProjectState = {
   previewStatus: PreviewStatus;
   deploymentId: string | null;
   model: string;
+  /** Current URL the user is viewing in the preview iframe (tracked via postMessage) */
+  currentIframeUrl: string | null;
 };
 
 export type ProjectManagerConfig = {
@@ -173,6 +175,14 @@ export class ProjectManager {
    */
   sendMessage(message: string, images?: Images, model?: string): void {
     this.streamingCoordinator.sendMessage(message, images, model);
+  }
+
+  /**
+   * Update the current iframe URL (called from preview component via postMessage listener).
+   * @param url - The current URL in the preview iframe, or null to clear
+   */
+  setCurrentIframeUrl(url: string | null): void {
+    this.store.setState({ currentIframeUrl: url });
   }
 
   /** Interrupt the current streaming response. */

--- a/src/components/app-builder/project-manager/__tests__/messages.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/messages.test.ts
@@ -22,6 +22,7 @@ function createMockStore(initialMessages: CloudMessage[] = []): ProjectStore {
       previewStatus: 'idle' as const,
       deploymentId: null,
       model: 'anthropic/claude-sonnet-4',
+      currentIframeUrl: null,
     }),
     setState: jest.fn(partial => {
       if (partial.messages) {

--- a/src/components/app-builder/project-manager/__tests__/preview-polling.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/preview-polling.test.ts
@@ -18,6 +18,7 @@ function createMockStore(): ProjectStore & { stateUpdates: Array<Record<string, 
     previewStatus: 'idle',
     deploymentId: null,
     model: 'anthropic/claude-sonnet-4',
+    currentIframeUrl: null,
   };
 
   return {

--- a/src/components/app-builder/project-manager/__tests__/store.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/store.test.ts
@@ -53,6 +53,7 @@ describe('createProjectStore', () => {
     previewStatus: 'idle',
     deploymentId: null,
     model: 'anthropic/claude-sonnet-4',
+    currentIframeUrl: null,
   };
 
   describe('getState', () => {

--- a/src/components/app-builder/project-manager/__tests__/streaming.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/streaming.test.ts
@@ -35,6 +35,7 @@ function createMockStore(): ProjectStore & { stateUpdates: Array<Record<string, 
     previewStatus: 'idle',
     deploymentId: null,
     model: 'anthropic/claude-sonnet-4',
+    currentIframeUrl: null,
   };
 
   return {

--- a/src/components/app-builder/project-manager/store.ts
+++ b/src/components/app-builder/project-manager/store.ts
@@ -28,6 +28,7 @@ export function createInitialState(
     previewStatus: 'idle',
     deploymentId,
     model: modelId ?? 'anthropic/claude-sonnet-4',
+    currentIframeUrl: null,
   };
 }
 

--- a/src/components/app-builder/project-manager/types.ts
+++ b/src/components/app-builder/project-manager/types.ts
@@ -29,6 +29,8 @@ export type ProjectState = {
   previewStatus: PreviewStatus;
   deploymentId: string | null;
   model: string;
+  /** Current URL the user is viewing in the preview iframe (tracked via postMessage) */
+  currentIframeUrl: string | null;
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add PostMessage bridge to track current URL in preview iframe
- Display pathname in address bar instead of full URL
- Add Home button to navigate to root (disabled when already at root)
- Add Copy URL button with visual checkmark feedback
- Fix dev mode to return correct preview URL without subdomain

## Changes

**Cloudflare Worker** (`cloudflare-app-builder/src/handlers/preview.ts`):
- Inject bridge script into HTML responses to send navigation events to parent
- Return preview URL without subdomain in dev mode

**Frontend** (`src/components/app-builder/`):
- Add `currentIframeUrl` to ProjectState for URL tracking
- Update PreviewControls with Home, Copy buttons and pathname display
- Listen for `kilo-preview-navigation` postMessage events

## Future Work

The tracked URL (`useProjectState().currentIframeUrl`) can be included in prompt context when sending messages.

<img width="1515" height="942" alt="Screenshot 2026-02-02 at 16 29 55" src="https://github.com/user-attachments/assets/10d7a46e-b75a-4ace-8b27-99bf17fbb712" />