### PR TITLE
feat(auth): add cloudflare access authentication for abuse service

### DIFF
--- a/src/lib/config.server.ts
+++ b/src/lib/config.server.ts
@@ -110,6 +110,25 @@ export const AI_ATTRIBUTION_ADMIN_SECRET = getEnvVariable('AI_ATTRIBUTION_ADMIN_
 
 // Abuse Detection Service
 export const ABUSE_SERVICE_SECRET = getEnvVariable('ABUSE_SERVICE_SECRET');
+export const ABUSE_SERVICE_CF_ACCESS_CLIENT_ID = getEnvVariable(
+  'ABUSE_SERVICE_CF_ACCESS_CLIENT_ID'
+);
+export const ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET = getEnvVariable(
+  'ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET'
+);
+export const ABUSE_SERVICE_URL =
+  getEnvVariable('ABUSE_SERVICE_URL') ||
+  (process.env.NODE_ENV === 'production' ? 'https://abuse.kiloapps.io' : null);
+
+// Validate CF Access credentials are present in production (not test/preview environments)
+if (process.env.NODE_ENV === 'production') {
+  if (!ABUSE_SERVICE_CF_ACCESS_CLIENT_ID) {
+    throw new Error('ABUSE_SERVICE_CF_ACCESS_CLIENT_ID is required in production');
+  }
+  if (!ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
+    throw new Error('ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET is required in production');
+  }
+}
 
 /**
  * RSA public key used for encrypting agent environment profile secrets.


### PR DESCRIPTION
Implement Cloudflare Access service-to-service authentication for the abuse detection service. This adds support for client ID and secret headers and moves the service URL configuration to environment variables with production validation.