### PR TITLE
fix(ci): Allow GH Actions to run for external contributors

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,58 @@
+name: Autofix
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  autofix:
+    runs-on: ubuntu-24.04-8core
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          # Need to fetch with a token that can push
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint with autofix
+        run: pnpm run lint --fix || true
+
+      - name: Run formatter
+        run: pnpm run format
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push fixes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "ci: auto-fix formatting and linting"
+          git push

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -54,5 +54,5 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add .
-          git commit -m "ci: auto-fix formatting and linting"
+          git commit --no-verify -m "ci: auto-fix formatting and linting"
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,6 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
-      - name: Format check
-        run: pnpm run format:check
-
       - name: Dependency cycle check
         run: pnpm run dependency-cycle-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          # For internal PRs, checkout the head branch so we can push auto-fixes
+          # For fork PRs, use the merge commit (default) - auto-fixes won't be pushed
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -120,7 +122,13 @@ jobs:
 
           echo "Changes detected, committing..."
           git commit -n -F ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          git push
+
+          # Only push for internal PRs (not forks) - we don't have write access to fork repos
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+            git push
+          else
+            echo "::warning::Auto-fix changes detected but cannot push to fork PR. Please apply the fixes manually."
+          fi
 
           exit $TEST_EXIT_CODE
 
@@ -136,7 +144,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -184,7 +191,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -270,7 +276,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -315,7 +320,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,22 @@ jobs:
       JEST_MAX_WORKERS: 4
 
     steps:
+      - name: Check if fork PR
+        id: check-fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] && [ -n "${{ github.event.pull_request.head.repo.full_name }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v4
         with:
           lfs: true
           fetch-depth: 0
           # For internal PRs, checkout the head branch so we can push auto-fixes
-          # For fork PRs, use the merge commit (default) - auto-fixes won't be pushed
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
+          # For fork PRs, use the merge commit (default)
+          ref: ${{ steps.check-fork.outputs.is_fork == 'false' && github.head_ref || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -84,10 +93,22 @@ jobs:
       - name: Typecheck (fail fast)
         run: pnpm run typecheck
 
+      # For external contributions: just check, don't fix
+      - name: Lint and format check (external contributions)
+        if: steps.check-fork.outputs.is_fork == 'true'
+        run: |
+          pnpm run lint
+          pnpm run format:check
+
+      - name: Run tests (external contributions)
+        if: steps.check-fork.outputs.is_fork == 'true'
+        run: pnpm run test
+
+      # For internal PRs: auto-fix and commit
       - name: Fix Formatting, Lint, Run Tests, and Commit Changes
+        if: steps.check-fork.outputs.is_fork == 'false'
         shell: bash
         run: |
-
           echo building message in ${{ runner.temp }}/TMP_CI_commit_msg.txt
           # Prepare the commit message file from the start
           echo "ci: auto-fix formatting, linting, and snapshot updates" > ${{ runner.temp }}/TMP_CI_commit_msg.txt
@@ -122,21 +143,20 @@ jobs:
 
           echo "Changes detected, committing..."
           git commit -n -F ${{ runner.temp }}/TMP_CI_commit_msg.txt
-
-          # Only push for internal PRs (not forks) - we don't have write access to fork repos
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
-            git push
-          else
-            echo "::warning::Auto-fix changes detected but cannot push to fork PR. Please apply the fixes manually."
-          fi
+          git push
 
           exit $TEST_EXIT_CODE
 
       - name: Lints after autofixes
+        if: steps.check-fork.outputs.is_fork == 'false'
         run: |
           pnpm run typecheck
           pnpm run lint
           pnpm run dependency-cycle-check
+
+      - name: Dependency cycle check (external contributions)
+        if: steps.check-fork.outputs.is_fork == 'true'
+        run: pnpm run dependency-cycle-check
 
   build:
     runs-on: ubuntu-24.04-8core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:
@@ -58,22 +58,9 @@ jobs:
       JEST_MAX_WORKERS: 4
 
     steps:
-      - name: Check if fork PR
-        id: check-fork
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] && [ -n "${{ github.event.pull_request.head.repo.full_name }}" ]; then
-            echo "is_fork=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_fork=false" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v4
         with:
           lfs: true
-          fetch-depth: 0
-          # For internal PRs, checkout the head branch so we can push auto-fixes
-          # For fork PRs, use the merge commit (default)
-          ref: ${{ steps.check-fork.outputs.is_fork == 'false' && github.head_ref || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -90,73 +77,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck (fail fast)
+      - name: Typecheck
         run: pnpm run typecheck
 
-      # For external contributions: just check, don't fix
-      - name: Lint and format check (external contributions)
-        if: steps.check-fork.outputs.is_fork == 'true'
-        run: |
-          pnpm run lint
-          pnpm run format:check
+      - name: Lint
+        run: pnpm run lint
 
-      - name: Run tests (external contributions)
-        if: steps.check-fork.outputs.is_fork == 'true'
-        run: pnpm run test
+      - name: Format check
+        run: pnpm run format:check
 
-      # For internal PRs: auto-fix and commit
-      - name: Fix Formatting, Lint, Run Tests, and Commit Changes
-        if: steps.check-fork.outputs.is_fork == 'false'
-        shell: bash
-        run: |
-          echo building message in ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          # Prepare the commit message file from the start
-          echo "ci: auto-fix formatting, linting, and snapshot updates" > ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          echo "" >> ${{ runner.temp }}/TMP_CI_commit_msg.txt
-
-          echo "--- Linter Output ---" >> ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          (pnpm run lint --fix 2>&1 || true) | tee -a ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          #...and we DO ignore errors, since we'll relint later on and we want to commit what we can
-
-          echo "" >> ${{ runner.temp }}/TMP_CI_commit_msg.txt # Add a separator
-
-          echo "--- Formatter Output ---" >> ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          pnpm run format 2>&1 | tee -a ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          #...but here, do NOT ignore errors, since mere reformats don't count as error
-
-          TEST_EXIT_CODE=0
-          pnpm run test || TEST_EXIT_CODE=$?
-
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add .
-
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-            exit $TEST_EXIT_CODE
-          fi
-
-          if [ "$(git log -1 --pretty=format:'%ae')" = "action@github.com" ]; then
-            echo "::error::CI autofix produced changes on a CI-generated commit. Committing could cause an infinite loop."
-            exit 1
-          fi
-
-          echo "Changes detected, committing..."
-          git commit -n -F ${{ runner.temp }}/TMP_CI_commit_msg.txt
-          git push
-
-          exit $TEST_EXIT_CODE
-
-      - name: Lints after autofixes
-        if: steps.check-fork.outputs.is_fork == 'false'
-        run: |
-          pnpm run typecheck
-          pnpm run lint
-          pnpm run dependency-cycle-check
-
-      - name: Dependency cycle check (external contributions)
-        if: steps.check-fork.outputs.is_fork == 'true'
+      - name: Dependency cycle check
         run: pnpm run dependency-cycle-check
+
+      - name: Run tests
+        run: pnpm run test
 
   build:
     runs-on: ubuntu-24.04-8core


### PR DESCRIPTION
Currently, even when we manually approve workflows to run for external contributions, the jobs all fail because they can't check out the repository. This PR attempts to fix that