### PR TITLE
feat: add free Claude Opus 4.5 for Kilo for Slack integration

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -17,6 +17,7 @@ import {
   isDataCollectionRequiredOnKiloCodeOnly,
   extraRequiredProviders,
   isDeadFreeModel,
+  isSlackbotOnlyModel,
   isStealthModelOnKiloCodeOnly,
 } from '@/lib/models';
 import {
@@ -41,7 +42,6 @@ import { ENABLE_TOOL_REPAIR, repairTools } from '@/lib/tool-calling';
 import { isRateLimitedToDeathFree } from '@/lib/providers/openrouter';
 import { isFreePromptTrainingAllowed } from '@/lib/providers/openrouter/types';
 import { redactedModelResponse } from '@/lib/redactedModelResponse';
-import { minimax_m21_free_slackbot_model } from '@/lib/providers/minimax';
 import {
   createAnonymousContext,
   isAnonymousContext,
@@ -238,7 +238,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return alphaPeriodEndedResponse();
   }
 
-  if (originalModelIdLowerCased === minimax_m21_free_slackbot_model.public_id && !internalApiUse) {
+  // Slackbot-only models are only available through Kilo for Slack (internalApiUse)
+  if (isSlackbotOnlyModel(originalModelIdLowerCased) && !internalApiUse) {
     return modelDoesNotExistResponse();
   }
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -2,14 +2,15 @@
  * Utility functions for working with AI models
  */
 
+import { opus_45_free_slackbot_model } from '@/lib/providers/anthropic';
 import { arcee_trinity_large_preview_free_model } from '@/lib/providers/arcee';
-import { minimax_m21_free_model, minimax_m21_free_slackbot_model } from '@/lib/providers/minimax';
-import { giga_potato_model } from '@/lib/providers/gigapotato';
-import { devstral_2512_free_model, devstral_small_2512_free_model } from '@/lib/providers/mistral';
-import type { KiloFreeModel } from '@/lib/providers/kilo-free-model';
-import { kat_coder_pro_free_model } from '@/lib/providers/streamlake';
-import { recommendedModels } from '@/lib/providers/recommended-models';
 import { corethink_free_model } from '@/lib/providers/corethink';
+import { giga_potato_model } from '@/lib/providers/gigapotato';
+import type { KiloFreeModel } from '@/lib/providers/kilo-free-model';
+import { minimax_m21_free_model, minimax_m21_free_slackbot_model } from '@/lib/providers/minimax';
+import { devstral_2512_free_model, devstral_small_2512_free_model } from '@/lib/providers/mistral';
+import { recommendedModels } from '@/lib/providers/recommended-models';
+import { kat_coder_pro_free_model } from '@/lib/providers/streamlake';
 import { zai_glm47_free_model } from '@/lib/providers/zai';
 
 export const DEFAULT_MODEL_CHOICES = ['anthropic/claude-sonnet-4.5', 'anthropic/claude-opus-4.5'];
@@ -32,13 +33,14 @@ export function isDataCollectionRequiredOnKiloCodeOnly(model: string): boolean {
 
 export const kiloFreeModels = [
   arcee_trinity_large_preview_free_model,
+  corethink_free_model,
   devstral_2512_free_model,
   devstral_small_2512_free_model,
   giga_potato_model,
   kat_coder_pro_free_model,
   minimax_m21_free_model,
-  corethink_free_model,
   minimax_m21_free_slackbot_model,
+  opus_45_free_slackbot_model,
   zai_glm47_free_model,
 ] as KiloFreeModel[];
 
@@ -54,4 +56,13 @@ export function extraRequiredProviders(model: string) {
 
 export function isDeadFreeModel(model: string): boolean {
   return !!kiloFreeModels.find(m => m.public_id === model && !m.is_enabled);
+}
+
+/**
+ * Check if a model is only available through Kilo for Slack (internalApiUse).
+ * These models are hidden from the public model list and return "model does not exist"
+ * when accessed outside of the Slack integration.
+ */
+export function isSlackbotOnlyModel(model: string): boolean {
+  return !!kiloFreeModels.find(m => m.public_id === model && m.slackbot_only);
 }

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,6 +1,21 @@
+import type { KiloFreeModel } from '@/lib/providers/kilo-free-model';
 import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter/types';
 import { normalizeToolCallIds } from '@/lib/tool-calling';
 import type OpenAI from 'openai';
+
+export const opus_45_free_slackbot_model = {
+  public_id: 'anthropic/claude-opus-4.5:slackbot',
+  display_name: 'Claude Opus 4.5 (Free for Kilo for Slack)',
+  description: 'Free version of Claude Opus 4.5 for use in Kilo for Slack only',
+  context_length: 200000,
+  max_completion_tokens: 32000,
+  is_enabled: true,
+  flags: ['reasoning', 'vision'],
+  gateway: 'vercel',
+  internal_id: 'anthropic/claude-opus-4.5',
+  inference_providers: ['anthropic'],
+  slackbot_only: true,
+} as KiloFreeModel;
 
 const ENABLE_ANTHROPIC_STRICT_TOOL_USE = false;
 

--- a/src/lib/providers/kilo-free-model.ts
+++ b/src/lib/providers/kilo-free-model.ts
@@ -14,6 +14,8 @@ export type KiloFreeModel = {
   gateway: ProviderId;
   internal_id: string;
   inference_providers: [OpenRouterInferenceProviderId, ...OpenRouterInferenceProviderId[]];
+  /** If true, this model is only available through Kilo for Slack (internalApiUse) and hidden from public model list */
+  slackbot_only?: boolean;
 };
 
 export function convertFromKiloModel(model: KiloFreeModel) {

--- a/src/lib/providers/minimax.ts
+++ b/src/lib/providers/minimax.ts
@@ -26,6 +26,7 @@ export const minimax_m21_free_slackbot_model = {
   gateway: 'vercel',
   internal_id: 'minimax/minimax-m2.1',
   inference_providers: ['minimax'],
+  slackbot_only: true,
 } as KiloFreeModel;
 
 export function applyMinimaxProviderSettings(requestToMutate: OpenRouterChatCompletionRequest) {

--- a/src/lib/providers/openrouter/index.ts
+++ b/src/lib/providers/openrouter/index.ts
@@ -63,7 +63,11 @@ function enhancedModelList(models: OpenRouterModel[]) {
         !isRateLimitedToDeathFree(model.id) &&
         !kiloFreeModels.some(m => m.public_id === model.id && m.is_enabled)
     )
-    .concat(kiloFreeModels.filter(m => m.is_enabled).map(model => convertFromKiloModel(model)))
+    .concat(
+      kiloFreeModels
+        .filter(m => m.is_enabled && !m.slackbot_only)
+        .map(model => convertFromKiloModel(model))
+    )
     .concat([autoModel])
     .map((model: OpenRouterModel) => {
       const preferredIndex =

--- a/src/lib/providers/openrouter/inference-provider-id.ts
+++ b/src/lib/providers/openrouter/inference-provider-id.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 
 export const OpenRouterInferenceProviderIdSchema = z.enum([
   'amazon-bedrock',
+  'anthropic',
   'arcee-ai',
   'deepinfra',
   'fireworks',

--- a/src/tests/openrouter-models-sorting.approved.json
+++ b/src/tests/openrouter-models-sorting.approved.json
@@ -475,57 +475,6 @@
         "tools"
       ],
       "default_parameters": {}
-    },
-    {
-      "id": "minimax/minimax-m2.1:slackbot",
-      "canonical_slug": "minimax/minimax-m2.1:slackbot",
-      "hugging_face_id": "",
-      "name": "MiniMax: MiniMax M2.1 (Free for Kilo for Slack)",
-      "created": 1756238927,
-      "description": "Free version of MiniMax M2.1 for use in Kilo for Slack only",
-      "context_length": 204800,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000000",
-        "completion": "0.0000000",
-        "request": "0",
-        "image": "0",
-        "web_search": "0",
-        "internal_reasoning": "0"
-      },
-      "top_provider": {
-        "context_length": 204800,
-        "max_completion_tokens": 131072,
-        "is_moderated": false
-      },
-      "per_request_limits": null,
-      "supported_parameters": [
-        "max_tokens",
-        "temperature",
-        "tools",
-        "reasoning",
-        "include_reasoning"
-      ],
-      "default_parameters": {},
-      "settings": {
-        "included_tools": [
-          "search_and_replace"
-        ],
-        "excluded_tools": [
-          "apply_diff",
-          "edit_file"
-        ]
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add free Claude Opus 4.5 model (`anthropic/claude-opus-4.5:slackbot`) for Kilo for Slack integration
- Introduce `slackbot_only` flag to `KiloFreeModel` type to support models only available through internal API
- Hide slackbot-only models from the public model list for better UX
- Use generic `isSlackbotOnlyModel()` helper for access control instead of model-specific checks

## Testing
- All 131 test suites pass (1867 tests)
- Updated model list snapshot to reflect slackbot models being hidden

## Notes
- The Opus 4.5 slackbot model uses the existing Anthropic API key through Vercel AI Gateway
- No dedicated promotional API key needed (unlike MiniMax which uses `MINIMAX_FREE_SLACKBOT_PROMOTION_API_KEY`)