### PR TITLE
feat(slack): Make Opus 4.5 the default model for new installs

### DIFF
--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -10,16 +10,15 @@ import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } from '@/lib/config.server';
 import { APP_URL } from '@/lib/constants';
 import { WebClient } from '@slack/web-api';
 import type { OAuthV2Response } from '@slack/oauth';
-import { minimax_m21_free_slackbot_model } from '@/lib/providers/minimax';
-
-// Default model for Slack integrations - separate from the global platform default
-const SLACK_DEFAULT_MODEL = minimax_m21_free_slackbot_model.is_enabled
-  ? minimax_m21_free_slackbot_model.public_id
-  : 'minimax/minimax-m2.1';
-
+import { opus_45_free_slackbot_model } from '@/lib/providers/anthropic';
 import { getOrganizationById } from '@/lib/organizations/organizations';
 import { getDefaultAllowedModel } from '@/lib/slack-bot/model-allow-list';
 import { createProviderAwareModelAllowPredicate } from '@/lib/model-allow.server';
+
+// Default model for Slack integrations - separate from the global platform default
+const SLACK_DEFAULT_MODEL = opus_45_free_slackbot_model.is_enabled
+  ? opus_45_free_slackbot_model.public_id
+  : 'minimax/minimax-m2.1';
 
 // Slack OAuth scopes for the integration
 // These should be kept in sync with the scopes requested in the Slack app configuration


### PR DESCRIPTION
Now that we've enabled a free promotion for Opus 4.5 with Kilo for Slack, I want to make it the default for new installs.