### PR TITLE
feat(slack): Upgrade free Slack bot model to Claude Opus 4.6

### DIFF
--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -10,14 +10,14 @@ import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } from '@/lib/config.server';
 import { APP_URL } from '@/lib/constants';
 import { WebClient } from '@slack/web-api';
 import type { OAuthV2Response } from '@slack/oauth';
-import { opus_45_free_slackbot_model } from '@/lib/providers/anthropic';
+import { opus_46_free_slackbot_model } from '@/lib/providers/anthropic';
 import { getOrganizationById } from '@/lib/organizations/organizations';
 import { getDefaultAllowedModel } from '@/lib/slack-bot/model-allow-list';
 import { createProviderAwareModelAllowPredicate } from '@/lib/model-allow.server';
 
 // Default model for Slack integrations - separate from the global platform default
-const SLACK_DEFAULT_MODEL = opus_45_free_slackbot_model.is_enabled
-  ? opus_45_free_slackbot_model.public_id
+const SLACK_DEFAULT_MODEL = opus_46_free_slackbot_model.is_enabled
+  ? opus_46_free_slackbot_model.public_id
   : 'minimax/minimax-m2.1';
 
 // Slack OAuth scopes for the integration

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -2,7 +2,7 @@
  * Utility functions for working with AI models
  */
 
-import { opus_45_free_slackbot_model } from '@/lib/providers/anthropic';
+import { opus_46_free_slackbot_model } from '@/lib/providers/anthropic';
 import { arcee_trinity_large_preview_free_model } from '@/lib/providers/arcee';
 import { corethink_free_model } from '@/lib/providers/corethink';
 import { giga_potato_model } from '@/lib/providers/gigapotato';
@@ -40,7 +40,7 @@ export const kiloFreeModels = [
   kat_coder_pro_free_model,
   minimax_m21_free_model,
   minimax_m21_free_slackbot_model,
-  opus_45_free_slackbot_model,
+  opus_46_free_slackbot_model,
   zai_glm47_free_model,
 ] as KiloFreeModel[];
 

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -3,16 +3,16 @@ import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter
 import { normalizeToolCallIds } from '@/lib/tool-calling';
 import type OpenAI from 'openai';
 
-export const opus_45_free_slackbot_model = {
-  public_id: 'anthropic/claude-opus-4.5:slackbot',
-  display_name: 'Claude Opus 4.5 (Free for Kilo for Slack)',
-  description: 'Free version of Claude Opus 4.5 for use in Kilo for Slack only',
+export const opus_46_free_slackbot_model = {
+  public_id: 'anthropic/claude-opus-4.6:slackbot',
+  display_name: 'Claude Opus 4.6 (Free for Kilo for Slack)',
+  description: 'Free version of Claude Opus 4.6 for use in Kilo for Slack only',
   context_length: 200000,
   max_completion_tokens: 32000,
   is_enabled: true,
   flags: ['reasoning', 'vision'],
   gateway: 'vercel',
-  internal_id: 'anthropic/claude-opus-4.5',
+  internal_id: 'anthropic/claude-opus-4.6',
   inference_providers: ['anthropic'],
   slackbot_only: true,
 } as KiloFreeModel;


### PR DESCRIPTION
## Summary
- Upgrade the free Kilo for Slack model from Claude Opus 4.5 to Claude Opus 4.6
- Updates model ID, display name, and description across all references