### PR TITLE
Update security model to use Opus 4.6

### DIFF
--- a/src/lib/security-agent/core/constants.ts
+++ b/src/lib/security-agent/core/constants.ts
@@ -11,8 +11,8 @@ import type { SecurityAgentConfig } from './types';
  * Order matters - first one is the default
  */
 export const SECURITY_AGENT_MODELS = [
+  { id: 'anthropic/claude-opus-4.6', name: 'Claude Opus 4.6', free: false },
   { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5', free: false },
-  { id: 'anthropic/claude-opus-4.5', name: 'Claude Opus 4.5', free: false },
   { id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast 1 (free)', free: true },
 ] as const;
 

--- a/src/lib/security-agent/core/constants.ts
+++ b/src/lib/security-agent/core/constants.ts
@@ -12,6 +12,7 @@ import type { SecurityAgentConfig } from './types';
  */
 export const SECURITY_AGENT_MODELS = [
   { id: 'anthropic/claude-opus-4.6', name: 'Claude Opus 4.6', free: false },
+  { id: 'anthropic/claude-opus-4.5', name: 'Claude Opus 4.5', free: false },
   { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5', free: false },
   { id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast 1 (free)', free: true },
 ] as const;


### PR DESCRIPTION
We should swap the security agent to use Opus 4.6 instead of 4.5.