### PR TITLE
WebRisk - Add Slack Notification For Deploy Threat Detections

### DIFF
--- a/src/lib/config.server.ts
+++ b/src/lib/config.server.ts
@@ -103,6 +103,9 @@ export const SLACK_SIGNING_SECRET = getEnvVariable('SLACK_SIGNING_SECRET');
 // Posts user feedback into a fixed Slack channel in the Kilo workspace.
 // Expected to be a Slack Incoming Webhook URL.
 export const SLACK_USER_FEEDBACK_WEBHOOK_URL = getEnvVariable('SLACK_USER_FEEDBACK_WEBHOOK_URL');
+// Posts deploy threat alerts to a dedicated Slack channel.
+// Expected to be a Slack Incoming Webhook URL.
+export const SLACK_DEPLOY_THREAT_WEBHOOK_URL = getEnvVariable('SLACK_DEPLOY_THREAT_WEBHOOK_URL');
 export const ENABLE_MILVUS_DUAL_WRITE = true;
 
 // AI Attribution Service


### PR DESCRIPTION
## Summary

- Add `SLACK_DEPLOY_THREAT_WEBHOOK_URL` env variable for a dedicated deploy-threat Slack channel
- Implement Slack webhook notification in `alertAdmins` when a deployment threat is detected, replacing the previous TODO stub
- Notification includes deployment slug, URL, threat types, build ID, timestamp, and a direct link to the admin deployments page
- Nullable fields (`deployment_slug`, `deployment_url`, `last_build_id`) are conditionally omitted from the message