### PR TITLE
feat: add Pony Alpha as recommended free model

### DIFF
--- a/src/lib/providers/recommended-models.ts
+++ b/src/lib/providers/recommended-models.ts
@@ -34,6 +34,11 @@ export const recommendedModels = [
     random_vercel_routing: false,
   },
   {
+    public_id: 'openrouter/pony-alpha',
+    tool_choice_required: false,
+    random_vercel_routing: false,
+  },
+  {
     public_id: giga_potato_model.public_id,
     tool_choice_required: false,
     random_vercel_routing: false,

--- a/src/tests/openrouter-models-sorting.approved.json
+++ b/src/tests/openrouter-models-sorting.approved.json
@@ -186,7 +186,7 @@
         "include_reasoning"
       ],
       "default_parameters": {},
-      "preferredIndex": 4,
+      "preferredIndex": 5,
       "versioned_settings": {
         "4.146.0": {
           "included_tools": [
@@ -238,7 +238,7 @@
         "tools"
       ],
       "default_parameters": {},
-      "preferredIndex": 5
+      "preferredIndex": 6
     },
     {
       "id": "anthropic/claude-sonnet-4",


### PR DESCRIPTION
## Summary

- Add Pony Alpha (free) as a recommended model above Giga Potato
- Pony Alpha is an OpenRouter model with 200k context, free pricing, and strong performance in coding/agentic workflows
- Add 'openrouter' to inference provider schema to support the new model