### PR TITLE
fix: add try-catch for JSON parsing in redeem-promocode endpoint

### DIFF
--- a/src/app/api/profile/redeem-promocode/route.ts
+++ b/src/app/api/profile/redeem-promocode/route.ts
@@ -17,7 +17,14 @@ export async function POST(
 
   if (authFailedResponse) return authFailedResponse;
 
-  const { credit_category } = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+
+  const { credit_category } = body as { credit_category?: unknown };
 
   if (!credit_category || typeof credit_category !== 'string') {
     return NextResponse.json({ error: 'Promotional code is required' }, { status: 400 });


### PR DESCRIPTION
Add error handling around request.json() to gracefully handle malformed JSON requests with a proper 400 error response instead of crashing with an unhandled SyntaxError.
