### PR TITLE
Free GLM: Add 'prompt_cache' flag and update inference providers

### DIFF
--- a/src/lib/providers/zai.ts
+++ b/src/lib/providers/zai.ts
@@ -8,8 +8,8 @@ export const zai_glm47_free_model = {
   context_length: 202752,
   max_completion_tokens: 65535,
   is_enabled: true,
-  flags: ['reasoning'],
+  flags: ['reasoning', 'prompt_cache'],
   gateway: 'openrouter',
   internal_id: 'z-ai/glm-4.7',
-  inference_providers: ['novita', 'deepinfra'],
+  inference_providers: ['novita'],
 } as KiloFreeModel;

--- a/src/tests/openrouter-models-sorting.approved.json
+++ b/src/tests/openrouter-models-sorting.approved.json
@@ -114,7 +114,8 @@
         "request": "0",
         "image": "0",
         "web_search": "0",
-        "internal_reasoning": "0"
+        "internal_reasoning": "0",
+        "input_cache_read": "0.00000000"
       },
       "top_provider": {
         "context_length": 202752,


### PR DESCRIPTION
switching providers mid-conversation seems to be causing issues like reasoning loops and failure to parse tool calls