### PR TITLE
Cloudflare Workers - Add account_id to wrangler configs

### DIFF
--- a/cloudflare-app-builder/wrangler.jsonc
+++ b/cloudflare-app-builder/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-app-builder",
   "main": "src/index.ts",
   "compatibility_date": "2025-09-01",

--- a/cloudflare-db-proxy/wrangler.jsonc
+++ b/cloudflare-db-proxy/wrangler.jsonc
@@ -1,4 +1,5 @@
 {
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "db-proxy",
   "main": "src/index.ts",
   "compatibility_date": "2025-09-01",

--- a/cloudflare-deploy-infra/builder/wrangler.jsonc
+++ b/cloudflare-deploy-infra/builder/wrangler.jsonc
@@ -4,6 +4,7 @@
  */
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-deploy-builder",
   "main": "src/index.ts",
   "compatibility_date": "2025-10-11",

--- a/cloudflare-deploy-infra/dispatcher/wrangler.jsonc
+++ b/cloudflare-deploy-infra/dispatcher/wrangler.jsonc
@@ -4,6 +4,7 @@
  */
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-deploy-dispatcher",
   "main": "src/index.ts",
   "compatibility_date": "2025-10-11",

--- a/cloudflare-git-token-service/wrangler.jsonc
+++ b/cloudflare-git-token-service/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "git-token-service",
   "main": "src/index.ts",
   "compatibility_date": "2025-09-15",


### PR DESCRIPTION
## Summary

- Add explicit `account_id` to wrangler configs for workers that were missing it: app-builder, git-token-service, deploy-dispatcher, deploy-builder, and db-proxy.
- Uses the same account ID (`e115e769bcdd4c3d66af59d3332cb394`) already present in the other worker configs.