### PR TITLE
GitTokenService - Add empty fetch handler to fix deployment

### DIFF
--- a/cloudflare-git-token-service/src/index.ts
+++ b/cloudflare-git-token-service/src/index.ts
@@ -86,5 +86,8 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
 }
 
 export default {
-  // No fetch handler needed - this is RPC-only
+  // Cloudflare requires a fetch handler to deploy, even for RPC-only workers
+  fetch() {
+    return new Response(null, { status: 404 });
+  },
 };


### PR DESCRIPTION
## Summary

- Add a no-op `fetch` handler returning 404 to the git-token-service worker's default export. Cloudflare requires a fetch handler to deploy, even for RPC-only workers.