### PR TITLE
feat(kiloclaw): auth + routing skeleton

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -1,6 +1,12 @@
 # Copy this to .dev.vars and fill in your values
 # .dev.vars is gitignored and used by wrangler dev
 
+# Auth
+NEXTAUTH_SECRET=dev-secret-change-me
+INTERNAL_API_SECRET=dev-internal-secret
+GATEWAY_TOKEN_SECRET=dev-gateway-secret
+WORKER_ENV=development
+
 # AI Provider (at least one required)
 ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
@@ -15,28 +21,15 @@ ANTHROPIC_API_KEY=sk-ant-...
 # AI_GATEWAY_API_KEY=your-key
 # AI_GATEWAY_BASE_URL=https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic
 
-# Local development mode - skips Cloudflare Access auth and bypasses device pairing
-# DEV_MODE=true
+# R2 Storage
+# R2_ACCESS_KEY_ID=...
+# R2_SECRET_ACCESS_KEY=...
+# CF_ACCOUNT_ID=...
 
-# E2E test mode - skips Cloudflare Access auth but keeps device pairing enabled
-# Use this for automated tests that need to test the real pairing flow
-# E2E_TEST_MODE=true
+# Encryption (for user secrets -- PR5+)
+# AGENT_ENV_VARS_PRIVATE_KEY=...
 
-# Enable debug routes at /debug/* (optional)
-# DEBUG_ROUTES=true
-
-# Optional - set a fixed token instead of auto-generated
-OPENCLAW_GATEWAY_TOKEN=dev-token-change-in-prod
-
-# Cloudflare Access configuration for /_admin and /api routes
-# Required for admin UI and device pairing API in production
-# CF_ACCESS_TEAM_DOMAIN=myteam.cloudflareaccess.com
-# CF_ACCESS_AUD=your-application-audience-tag
-
-# Optional chat channels
-# TELEGRAM_BOT_TOKEN=optional
-# DISCORD_BOT_TOKEN=optional
-
-# CDP (Chrome DevTools Protocol) configuration for browser automation
-# CDP_SECRET=shared-secret-for-cdp-auth
-# WORKER_URL=https://your-worker.example.com
+# Development
+DEV_MODE=true
+DEBUG_ROUTES=true
+DEBUG_ROUTES_SECRET=dev-debug-secret

--- a/kiloclaw/src/auth/debug-gate.test.ts
+++ b/kiloclaw/src/auth/debug-gate.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { debugRoutesGate } from './debug-gate';
+
+function mountDebugApp() {
+  const app = new Hono<AppEnv>();
+  app.use('/debug/*', debugRoutesGate);
+  app.get('/debug/ping', c => c.json({ ok: true }));
+  return app;
+}
+
+async function jsonBody(res: Response): Promise<Record<string, unknown>> {
+  return res.json();
+}
+
+describe('debugRoutesGate', () => {
+  it('returns 404 when DEBUG_ROUTES is not enabled', async () => {
+    const app = mountDebugApp();
+    const res = await app.request('/debug/ping', {}, {} as never);
+    expect(res.status).toBe(404);
+    const body = await jsonBody(res);
+    expect(body.error).toBe('Debug routes are disabled');
+  });
+
+  it('returns 403 when enabled but no secret is configured', async () => {
+    const app = mountDebugApp();
+    const res = await app.request('/debug/ping', {}, { DEBUG_ROUTES: 'true' } as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when secret is set but header is missing', async () => {
+    const app = mountDebugApp();
+    const res = await app.request('/debug/ping', {}, {
+      DEBUG_ROUTES: 'true',
+      DEBUG_ROUTES_SECRET: 'my-secret',
+    } as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when header does not match secret', async () => {
+    const app = mountDebugApp();
+    const res = await app.request('/debug/ping', { headers: { 'x-debug-api-key': 'wrong' } }, {
+      DEBUG_ROUTES: 'true',
+      DEBUG_ROUTES_SECRET: 'my-secret',
+    } as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('allows access when header matches secret', async () => {
+    const app = mountDebugApp();
+    const res = await app.request('/debug/ping', { headers: { 'x-debug-api-key': 'my-secret' } }, {
+      DEBUG_ROUTES: 'true',
+      DEBUG_ROUTES_SECRET: 'my-secret',
+    } as never);
+    expect(res.status).toBe(200);
+    const body = await jsonBody(res);
+    expect(body.ok).toBe(true);
+  });
+});

--- a/kiloclaw/src/auth/debug-gate.ts
+++ b/kiloclaw/src/auth/debug-gate.ts
@@ -1,0 +1,22 @@
+import type { Context, Next } from 'hono';
+import type { AppEnv } from '../types';
+
+/** Require DEBUG_ROUTES=true AND a matching x-debug-api-key header. */
+export async function debugRoutesGate(c: Context<AppEnv>, next: Next) {
+  if (c.env.DEBUG_ROUTES !== 'true') {
+    return c.json({ error: 'Debug routes are disabled' }, 404);
+  }
+
+  const secret = c.env.DEBUG_ROUTES_SECRET;
+  if (!secret) {
+    console.error('[debug] DEBUG_ROUTES is enabled but DEBUG_ROUTES_SECRET is not set');
+    return c.json({ error: 'Debug routes are not allowed without a configured secret' }, 403);
+  }
+
+  const key = c.req.header('x-debug-api-key');
+  if (key !== secret) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  return next();
+}

--- a/kiloclaw/src/auth/gateway-token.test.ts
+++ b/kiloclaw/src/auth/gateway-token.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { deriveGatewayToken } from './gateway-token';
+
+describe('deriveGatewayToken', () => {
+  const SECRET = 'test-gateway-secret';
+
+  it('produces a 64-char hex string (SHA-256)', async () => {
+    const token = await deriveGatewayToken('sandbox-abc', SECRET);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic -- same inputs produce same output', async () => {
+    const token1 = await deriveGatewayToken('sandbox-abc', SECRET);
+    const token2 = await deriveGatewayToken('sandbox-abc', SECRET);
+    expect(token1).toBe(token2);
+  });
+
+  it('differs for different sandboxIds', async () => {
+    const token1 = await deriveGatewayToken('sandbox-abc', SECRET);
+    const token2 = await deriveGatewayToken('sandbox-xyz', SECRET);
+    expect(token1).not.toBe(token2);
+  });
+
+  it('differs for different secrets', async () => {
+    const token1 = await deriveGatewayToken('sandbox-abc', 'secret-1');
+    const token2 = await deriveGatewayToken('sandbox-abc', 'secret-2');
+    expect(token1).not.toBe(token2);
+  });
+});

--- a/kiloclaw/src/auth/gateway-token.ts
+++ b/kiloclaw/src/auth/gateway-token.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-sandbox gateway token derivation using Web Crypto HMAC.
+ *
+ * Each sandbox gets a deterministic token derived from its sandboxId
+ * and the worker's GATEWAY_TOKEN_SECRET. This replaces the single
+ * shared OPENCLAW_GATEWAY_TOKEN from the single-tenant setup.
+ */
+export async function deriveGatewayToken(sandboxId: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(sandboxId));
+  return Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/kiloclaw/src/auth/index.ts
+++ b/kiloclaw/src/auth/index.ts
@@ -1,0 +1,6 @@
+export { validateKiloToken } from './jwt';
+export type { TokenPayload, ValidateResult } from './jwt';
+export { authMiddleware, internalApiMiddleware } from './middleware';
+export { debugRoutesGate } from './debug-gate';
+export { sandboxIdFromUserId, userIdFromSandboxId } from './sandbox-id';
+export { deriveGatewayToken } from './gateway-token';

--- a/kiloclaw/src/auth/jwt.test.ts
+++ b/kiloclaw/src/auth/jwt.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { SignJWT } from 'jose';
+import { validateKiloToken } from './jwt';
+import { KILO_TOKEN_VERSION } from '../config';
+
+const TEST_SECRET = 'test-secret-for-jwt-verification';
+
+async function signToken(
+  payload: Record<string, unknown>,
+  options?: { secret?: string; exp?: number | string }
+) {
+  const secret = new TextEncoder().encode(options?.secret ?? TEST_SECRET);
+  let builder = new SignJWT(payload).setProtectedHeader({ alg: 'HS256' }).setIssuedAt();
+  if (typeof options?.exp === 'number') {
+    builder = builder.setExpirationTime(options.exp);
+  } else {
+    builder = builder.setExpirationTime(options?.exp ?? '1h');
+  }
+  return builder.sign(secret);
+}
+
+describe('validateKiloToken', () => {
+  it('validates a well-formed token', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION,
+      env: 'development',
+    });
+
+    const result = await validateKiloToken(token, TEST_SECRET, 'development');
+    expect(result).toEqual({
+      success: true,
+      userId: 'user_123',
+      token,
+      pepper: 'pepper_abc',
+    });
+  });
+
+  it('rejects wrong token version', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION - 1,
+    });
+
+    const result = await validateKiloToken(token, TEST_SECRET, undefined);
+    expect(result).toEqual({
+      success: false,
+      error: `Invalid token version: ${KILO_TOKEN_VERSION - 1}`,
+    });
+  });
+
+  it('rejects env mismatch', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION,
+      env: 'production',
+    });
+
+    const result = await validateKiloToken(token, TEST_SECRET, 'development');
+    expect(result).toEqual({
+      success: false,
+      error: 'Token env mismatch: production !== development',
+    });
+  });
+
+  it('allows missing env in token when expectedEnv is set', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION,
+    });
+
+    const result = await validateKiloToken(token, TEST_SECRET, 'production');
+    expect(result.success).toBe(true);
+  });
+
+  it('allows missing expectedEnv when token has env', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION,
+      env: 'production',
+    });
+
+    const result = await validateKiloToken(token, TEST_SECRET, undefined);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects expired tokens', async () => {
+    // Set exp to 1 hour in the past -- no sleep needed
+    const token = await signToken(
+      {
+        kiloUserId: 'user_123',
+        apiTokenPepper: 'pepper_abc',
+        version: KILO_TOKEN_VERSION,
+      },
+      { exp: Math.floor(Date.now() / 1000) - 3600 }
+    );
+
+    const result = await validateKiloToken(token, TEST_SECRET, undefined);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('exp');
+    }
+  });
+
+  it('rejects tokens signed with wrong secret', async () => {
+    const token = await signToken(
+      {
+        kiloUserId: 'user_123',
+        apiTokenPepper: 'pepper_abc',
+        version: KILO_TOKEN_VERSION,
+      },
+      { secret: 'wrong-secret' }
+    );
+
+    const result = await validateKiloToken(token, TEST_SECRET, undefined);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('signature');
+    }
+  });
+
+  it('rejects malformed tokens', async () => {
+    const result = await validateKiloToken('not-a-jwt', TEST_SECRET, undefined);
+    expect(result.success).toBe(false);
+  });
+});

--- a/kiloclaw/src/auth/jwt.ts
+++ b/kiloclaw/src/auth/jwt.ts
@@ -46,7 +46,9 @@ export async function validateKiloToken(
 ): Promise<ValidateResult> {
   let payload: TokenPayload;
   try {
-    const result = await jwtVerify(token, new TextEncoder().encode(secret));
+    const result = await jwtVerify(token, new TextEncoder().encode(secret), {
+      algorithms: ['HS256'],
+    });
     const parsed = parseTokenPayload(result.payload);
     if (!parsed.ok) {
       return { success: false, error: parsed.error };

--- a/kiloclaw/src/auth/jwt.ts
+++ b/kiloclaw/src/auth/jwt.ts
@@ -1,0 +1,74 @@
+import { jwtVerify } from 'jose';
+import { KILO_TOKEN_VERSION } from '../config';
+
+/**
+ * Shape of the JWT payload issued by the cloud Next.js app.
+ * Must stay in sync with cloud's generateApiToken() in src/lib/tokens.ts.
+ */
+export type TokenPayload = {
+  kiloUserId: string;
+  apiTokenPepper: string;
+  version: number;
+  env?: string;
+};
+
+export type ValidateResult =
+  | { success: true; userId: string; token: string; pepper: string }
+  | { success: false; error: string };
+
+function parseTokenPayload(
+  raw: Record<string, unknown>
+): { ok: true; payload: TokenPayload } | { ok: false; error: string } {
+  const { kiloUserId, apiTokenPepper, version } = raw;
+  if (typeof kiloUserId !== 'string') {
+    return { ok: false, error: 'Missing or invalid kiloUserId' };
+  }
+  if (typeof apiTokenPepper !== 'string') {
+    return { ok: false, error: 'Missing or invalid apiTokenPepper' };
+  }
+  if (typeof version !== 'number') {
+    return { ok: false, error: 'Missing or invalid version' };
+  }
+  const env = typeof raw.env === 'string' ? raw.env : undefined;
+  return { ok: true, payload: { kiloUserId, apiTokenPepper, version, env } };
+}
+
+/**
+ * Verify a Kilo JWT using HS256 symmetric secret.
+ *
+ * Checks: signature, expiration (built into jose), version === KILO_TOKEN_VERSION,
+ * and optional env match against the worker's WORKER_ENV.
+ */
+export async function validateKiloToken(
+  token: string,
+  secret: string,
+  expectedEnv: string | undefined
+): Promise<ValidateResult> {
+  let payload: TokenPayload;
+  try {
+    const result = await jwtVerify(token, new TextEncoder().encode(secret));
+    const parsed = parseTokenPayload(result.payload);
+    if (!parsed.ok) {
+      return { success: false, error: parsed.error };
+    }
+    payload = parsed.payload;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'JWT verification failed';
+    return { success: false, error: message };
+  }
+
+  if (payload.version !== KILO_TOKEN_VERSION) {
+    return { success: false, error: `Invalid token version: ${payload.version}` };
+  }
+
+  if (expectedEnv && payload.env && payload.env !== expectedEnv) {
+    return { success: false, error: `Token env mismatch: ${payload.env} !== ${expectedEnv}` };
+  }
+
+  return {
+    success: true,
+    userId: payload.kiloUserId,
+    token,
+    pepper: payload.apiTokenPepper,
+  };
+}

--- a/kiloclaw/src/auth/middleware.test.ts
+++ b/kiloclaw/src/auth/middleware.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { SignJWT } from 'jose';
+import type { AppEnv } from '../types';
+import { authMiddleware, internalApiMiddleware } from './middleware';
+import { KILO_TOKEN_VERSION, KILO_WORKER_AUTH_COOKIE } from '../config';
+
+const TEST_SECRET = 'test-nextauth-secret';
+
+async function signToken(payload: Record<string, unknown>, secret?: string) {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(new TextEncoder().encode(secret ?? TEST_SECRET));
+}
+
+function createTestApp() {
+  const app = new Hono<AppEnv>();
+
+  // Auth-protected route
+  app.use('/protected/*', authMiddleware);
+  app.get('/protected/whoami', c => {
+    return c.json({ userId: c.get('userId'), authToken: c.get('authToken') });
+  });
+
+  // Internal API route
+  app.use('/internal/*', internalApiMiddleware);
+  app.get('/internal/status', c => {
+    return c.json({ ok: true });
+  });
+
+  return app;
+}
+
+async function jsonBody(res: Response): Promise<Record<string, unknown>> {
+  return res.json();
+}
+
+describe('authMiddleware', () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  it('allows DEV_MODE bypass with synthetic userId', async () => {
+    const res = await app.request('/protected/whoami', {}, { DEV_MODE: 'true' } as never);
+    expect(res.status).toBe(200);
+    const body = await jsonBody(res);
+    expect(body.userId).toBe('dev@kilocode.ai');
+    expect(body.authToken).toBe('dev-token');
+  });
+
+  it('rejects when no NEXTAUTH_SECRET is configured', async () => {
+    const res = await app.request('/protected/whoami', {}, {} as never);
+    expect(res.status).toBe(500);
+    const body = await jsonBody(res);
+    expect(body.error).toContain('configuration');
+  });
+
+  it('rejects when no token is provided', async () => {
+    const res = await app.request('/protected/whoami', {}, {
+      NEXTAUTH_SECRET: TEST_SECRET,
+    } as never);
+    expect(res.status).toBe(401);
+    const body = await jsonBody(res);
+    expect(body.error).toContain('Authentication required');
+  });
+
+  it('authenticates via Bearer header', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION,
+    });
+
+    const res = await app.request(
+      '/protected/whoami',
+      { headers: { Authorization: `Bearer ${token}` } },
+      { NEXTAUTH_SECRET: TEST_SECRET } as never
+    );
+    expect(res.status).toBe(200);
+    const body = await jsonBody(res);
+    expect(body.userId).toBe('user_123');
+    expect(body.authToken).toBe(token);
+  });
+
+  it('authenticates via cookie fallback', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_cookie',
+      apiTokenPepper: 'pepper_cookie',
+      version: KILO_TOKEN_VERSION,
+    });
+
+    const res = await app.request(
+      '/protected/whoami',
+      { headers: { Cookie: `${KILO_WORKER_AUTH_COOKIE}=${token}` } },
+      { NEXTAUTH_SECRET: TEST_SECRET } as never
+    );
+    expect(res.status).toBe(200);
+    const body = await jsonBody(res);
+    expect(body.userId).toBe('user_cookie');
+  });
+
+  it('prefers Bearer header over cookie', async () => {
+    const bearerToken = await signToken({
+      kiloUserId: 'user_bearer',
+      apiTokenPepper: 'pepper_b',
+      version: KILO_TOKEN_VERSION,
+    });
+    const cookieToken = await signToken({
+      kiloUserId: 'user_cookie',
+      apiTokenPepper: 'pepper_c',
+      version: KILO_TOKEN_VERSION,
+    });
+
+    const res = await app.request(
+      '/protected/whoami',
+      {
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+          Cookie: `${KILO_WORKER_AUTH_COOKIE}=${cookieToken}`,
+        },
+      },
+      { NEXTAUTH_SECRET: TEST_SECRET } as never
+    );
+    expect(res.status).toBe(200);
+    const body = await jsonBody(res);
+    expect(body.userId).toBe('user_bearer');
+  });
+
+  it('rejects invalid token', async () => {
+    const res = await app.request(
+      '/protected/whoami',
+      { headers: { Authorization: 'Bearer not-a-jwt' } },
+      { NEXTAUTH_SECRET: TEST_SECRET } as never
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects token with wrong version', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION - 1,
+    });
+
+    const res = await app.request(
+      '/protected/whoami',
+      { headers: { Authorization: `Bearer ${token}` } },
+      { NEXTAUTH_SECRET: TEST_SECRET } as never
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('validates env match when WORKER_ENV is set', async () => {
+    const token = await signToken({
+      kiloUserId: 'user_123',
+      apiTokenPepper: 'pepper_abc',
+      version: KILO_TOKEN_VERSION,
+      env: 'production',
+    });
+
+    const res = await app.request(
+      '/protected/whoami',
+      { headers: { Authorization: `Bearer ${token}` } },
+      { NEXTAUTH_SECRET: TEST_SECRET, WORKER_ENV: 'development' } as never
+    );
+    expect(res.status).toBe(401);
+    const body = await jsonBody(res);
+    expect(body.error).toContain('env mismatch');
+  });
+});
+
+describe('internalApiMiddleware', () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    app = createTestApp();
+  });
+
+  it('rejects when no INTERNAL_API_SECRET configured', async () => {
+    const res = await app.request('/internal/status', {}, {} as never);
+    expect(res.status).toBe(500);
+  });
+
+  it('rejects when no api key header provided', async () => {
+    const res = await app.request('/internal/status', {}, {
+      INTERNAL_API_SECRET: 'secret-123',
+    } as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects wrong api key', async () => {
+    const res = await app.request(
+      '/internal/status',
+      { headers: { 'x-internal-api-key': 'wrong-key' } },
+      { INTERNAL_API_SECRET: 'secret-123' } as never
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('allows correct api key', async () => {
+    const res = await app.request(
+      '/internal/status',
+      { headers: { 'x-internal-api-key': 'secret-123' } },
+      { INTERNAL_API_SECRET: 'secret-123' } as never
+    );
+    expect(res.status).toBe(200);
+    const body = await jsonBody(res);
+    expect(body.ok).toBe(true);
+  });
+});

--- a/kiloclaw/src/auth/middleware.ts
+++ b/kiloclaw/src/auth/middleware.ts
@@ -1,0 +1,85 @@
+import type { Context, Next } from 'hono';
+import { getCookie } from 'hono/cookie';
+import type { AppEnv } from '../types';
+import { KILO_WORKER_AUTH_COOKIE } from '../config';
+import { validateKiloToken } from './jwt';
+
+/**
+ * Auth middleware for user-facing routes.
+ *
+ * 1. Extract JWT from Authorization: Bearer header
+ * 2. Fallback: extract from kilo-worker-auth cookie
+ * 3. Verify HS256 with NEXTAUTH_SECRET; check version and env
+ * 4. Set ctx.userId, ctx.authToken on context
+ * 5. DEV_MODE bypass: synthetic userId 'dev@kilocode.ai'
+ *
+ * Note: pepper validation against DB via Hyperdrive is deferred to PR4
+ * when the Hyperdrive binding is wired. For now, the pepper is extracted
+ * from the token but not validated against the database.
+ */
+export async function authMiddleware(c: Context<AppEnv>, next: Next) {
+  // DEV_MODE bypass
+  if (c.env.DEV_MODE === 'true') {
+    c.set('userId', 'dev@kilocode.ai');
+    c.set('authToken', 'dev-token');
+    return next();
+  }
+
+  const secret = c.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    console.error('[auth] NEXTAUTH_SECRET not configured');
+    return c.json({ error: 'Server configuration error' }, 500);
+  }
+
+  // Extract token: Bearer header first, then cookie fallback
+  let token: string | undefined;
+  const authHeader = c.req.header('authorization');
+  if (authHeader?.toLowerCase().startsWith('bearer ')) {
+    token = authHeader.substring(7);
+  }
+  if (!token) {
+    token = getCookie(c, KILO_WORKER_AUTH_COOKIE);
+  }
+
+  if (!token) {
+    return c.json({ error: 'Authentication required' }, 401);
+  }
+
+  const result = await validateKiloToken(token, secret, c.env.WORKER_ENV);
+  if (!result.success) {
+    console.warn('[auth] Token validation failed:', result.error);
+    return c.json({ error: result.error }, 401);
+  }
+
+  c.set('userId', result.userId);
+  c.set('authToken', result.token);
+
+  return next();
+}
+
+/**
+ * Internal API middleware for backend-to-backend routes (platform API).
+ *
+ * 1. Check x-internal-api-key header against INTERNAL_API_SECRET
+ * 2. Applied INSTEAD of authMiddleware (not stacked on top)
+ * 3. userId comes from the request body, not from a JWT
+ * 4. Users cannot call these routes even with a valid JWT
+ */
+export async function internalApiMiddleware(c: Context<AppEnv>, next: Next) {
+  const secret = c.env.INTERNAL_API_SECRET;
+  if (!secret) {
+    console.error('[auth] INTERNAL_API_SECRET not configured');
+    return c.json({ error: 'Server configuration error' }, 500);
+  }
+
+  const apiKey = c.req.header('x-internal-api-key');
+  if (!apiKey) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  if (apiKey !== secret) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  return next();
+}

--- a/kiloclaw/src/auth/sandbox-id.test.ts
+++ b/kiloclaw/src/auth/sandbox-id.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { sandboxIdFromUserId, userIdFromSandboxId } from './sandbox-id';
+
+describe('sandboxIdFromUserId', () => {
+  it('encodes a simple userId', () => {
+    const sandboxId = sandboxIdFromUserId('user_abc123');
+    expect(sandboxId).toBe('dXNlcl9hYmMxMjM');
+  });
+
+  it('roundtrips a simple userId', () => {
+    const userId = 'user_abc123';
+    const sandboxId = sandboxIdFromUserId(userId);
+    expect(userIdFromSandboxId(sandboxId)).toBe(userId);
+  });
+
+  it('roundtrips a userId with slashes and colons', () => {
+    const userId = 'oauth/google:118234567890';
+    const sandboxId = sandboxIdFromUserId(userId);
+    expect(userIdFromSandboxId(sandboxId)).toBe(userId);
+  });
+
+  it('roundtrips a UUID userId', () => {
+    const userId = '550e8400-e29b-41d4-a716-446655440000';
+    const sandboxId = sandboxIdFromUserId(userId);
+    expect(userIdFromSandboxId(sandboxId)).toBe(userId);
+    // UUID (36 chars) -> 48 chars encoded, under 63 limit
+    expect(sandboxId.length).toBeLessThanOrEqual(63);
+  });
+
+  it('roundtrips an email-like userId', () => {
+    const userId = 'user@example.com';
+    const sandboxId = sandboxIdFromUserId(userId);
+    expect(userIdFromSandboxId(sandboxId)).toBe(userId);
+  });
+
+  it('roundtrips a userId with + character', () => {
+    const userId = 'user+tag@example.com';
+    const sandboxId = sandboxIdFromUserId(userId);
+    // sandboxId should use - instead of + (base64url)
+    expect(sandboxId).not.toContain('+');
+    expect(sandboxId).not.toContain('/');
+    expect(sandboxId).not.toContain('=');
+    expect(userIdFromSandboxId(sandboxId)).toBe(userId);
+  });
+
+  it('throws for overly long userId', () => {
+    // 48 bytes of userId -> 64 chars encoded, over the 63-char limit
+    const longUserId = 'a'.repeat(48);
+    expect(() => sandboxIdFromUserId(longUserId)).toThrow('userId too long');
+  });
+
+  it('accepts maximum-length userId (47 bytes)', () => {
+    const maxUserId = 'a'.repeat(47);
+    const sandboxId = sandboxIdFromUserId(maxUserId);
+    expect(sandboxId.length).toBeLessThanOrEqual(63);
+    expect(userIdFromSandboxId(sandboxId)).toBe(maxUserId);
+  });
+
+  it('produces URL-safe output', () => {
+    // Use a userId that would produce +, /, = in standard base64
+    const userId = '>>>???';
+    const sandboxId = sandboxIdFromUserId(userId);
+    expect(sandboxId).not.toContain('+');
+    expect(sandboxId).not.toContain('/');
+    expect(sandboxId).not.toContain('=');
+  });
+});

--- a/kiloclaw/src/auth/sandbox-id.test.ts
+++ b/kiloclaw/src/auth/sandbox-id.test.ts
@@ -64,4 +64,10 @@ describe('sandboxIdFromUserId', () => {
     expect(sandboxId).not.toContain('/');
     expect(sandboxId).not.toContain('=');
   });
+
+  it('roundtrips a Unicode userId without throwing', () => {
+    const userId = 'ユーザー@例.jp';
+    const sandboxId = sandboxIdFromUserId(userId);
+    expect(userIdFromSandboxId(sandboxId)).toBe(userId);
+  });
 });

--- a/kiloclaw/src/auth/sandbox-id.ts
+++ b/kiloclaw/src/auth/sandbox-id.ts
@@ -1,0 +1,28 @@
+/**
+ * Reversible base64url encoding of userId into sandboxId.
+ *
+ * NOT the cloud-agent-next SHA-256 pattern -- we need to recover userId
+ * from sandboxId in lifecycle hooks without a DB lookup.
+ *
+ * No prefix -- the full 63-char sandboxId limit is available.
+ */
+
+const MAX_SANDBOX_ID_LENGTH = 63;
+
+export function sandboxIdFromUserId(userId: string): string {
+  const encoded = btoa(userId).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  if (encoded.length > MAX_SANDBOX_ID_LENGTH) {
+    throw new Error(
+      `userId too long: encoded sandboxId would be ${encoded.length} chars (max ${MAX_SANDBOX_ID_LENGTH})`
+    );
+  }
+  return encoded;
+}
+
+export function userIdFromSandboxId(sandboxId: string): string {
+  let encoded = sandboxId.replace(/-/g, '+').replace(/_/g, '/');
+  while (encoded.length % 4 !== 0) {
+    encoded += '=';
+  }
+  return atob(encoded);
+}

--- a/kiloclaw/src/auth/sandbox-id.ts
+++ b/kiloclaw/src/auth/sandbox-id.ts
@@ -4,13 +4,32 @@
  * NOT the cloud-agent-next SHA-256 pattern -- we need to recover userId
  * from sandboxId in lifecycle hooks without a DB lookup.
  *
+ * Uses TextEncoder/TextDecoder so non-Latin1 userIds (e.g. Unicode from
+ * some IdPs) don't throw at runtime. ASCII userIds encode identically
+ * to the old btoa() approach.
+ *
  * No prefix -- the full 63-char sandboxId limit is available.
  */
 
 const MAX_SANDBOX_ID_LENGTH = 63;
 
+function bytesToBase64url(bytes: Uint8Array): string {
+  const binString = Array.from(bytes, b => String.fromCodePoint(b)).join('');
+  return btoa(binString).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBytes(encoded: string): Uint8Array {
+  let b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  while (b64.length % 4 !== 0) {
+    b64 += '=';
+  }
+  const binString = atob(b64);
+  return Uint8Array.from(binString, c => c.codePointAt(0) ?? 0);
+}
+
 export function sandboxIdFromUserId(userId: string): string {
-  const encoded = btoa(userId).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const bytes = new TextEncoder().encode(userId);
+  const encoded = bytesToBase64url(bytes);
   if (encoded.length > MAX_SANDBOX_ID_LENGTH) {
     throw new Error(
       `userId too long: encoded sandboxId would be ${encoded.length} chars (max ${MAX_SANDBOX_ID_LENGTH})`
@@ -20,9 +39,6 @@ export function sandboxIdFromUserId(userId: string): string {
 }
 
 export function userIdFromSandboxId(sandboxId: string): string {
-  let encoded = sandboxId.replace(/-/g, '+').replace(/_/g, '/');
-  while (encoded.length % 4 !== 0) {
-    encoded += '=';
-  }
-  return atob(encoded);
+  const bytes = base64urlToBytes(sandboxId);
+  return new TextDecoder().decode(bytes);
 }

--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -11,6 +11,12 @@ export const STARTUP_TIMEOUT_MS = 180_000;
 /** Mount path for R2 persistent storage inside the container */
 export const R2_MOUNT_PATH = '/data/openclaw';
 
+/** Cookie name for worker auth token (set by Next.js, read by worker) */
+export const KILO_WORKER_AUTH_COOKIE = 'kilo-worker-auth';
+
+/** Expected JWT token version -- must match cloud's JWT_TOKEN_VERSION */
+export const KILO_TOKEN_VERSION = 3;
+
 /**
  * R2 bucket name for persistent storage.
  * Can be overridden via R2_BUCKET_NAME env var for test isolation.

--- a/kiloclaw/src/types.ts
+++ b/kiloclaw/src/types.ts
@@ -6,6 +6,13 @@ import type { Sandbox } from '@cloudflare/sandbox';
 export type KiloClawEnv = {
   Sandbox: DurableObjectNamespace<Sandbox>;
   KILOCLAW_BUCKET: R2Bucket;
+
+  // Auth secrets
+  NEXTAUTH_SECRET?: string;
+  INTERNAL_API_SECRET?: string;
+  GATEWAY_TOKEN_SECRET?: string;
+  WORKER_ENV?: string; // e.g. 'production' or 'development' -- for JWT env validation
+
   // Cloudflare AI Gateway configuration (preferred)
   CF_AI_GATEWAY_ACCOUNT_ID?: string;
   CF_AI_GATEWAY_GATEWAY_ID?: string;
@@ -20,6 +27,7 @@ export type KiloClawEnv = {
   OPENAI_API_KEY?: string;
   DEV_MODE?: string;
   DEBUG_ROUTES?: string;
+  DEBUG_ROUTES_SECRET?: string;
   SANDBOX_SLEEP_AFTER?: string;
   TELEGRAM_BOT_TOKEN?: string;
   TELEGRAM_DM_POLICY?: string;
@@ -41,5 +49,8 @@ export type AppEnv = {
   Bindings: KiloClawEnv;
   Variables: {
     sandbox: Sandbox;
+    userId: string;
+    authToken: string;
+    sandboxId: string;
   };
 };


### PR DESCRIPTION
## PR2: Auth + Routing Skeleton

Adds the HS256 auth system, sandbox ID derivation, and debug route gating to kiloclaw. After this PR, every request is authenticated and has a `userId` + `sandboxId` on context, but no per-user sandbox containers are created yet (in the next pr).

### What changed

**New auth modules (`src/auth/`)**

- **`jwt.ts`** -- HS256 JWT verification via `jose`. Validates signature, expiration, token version (must equal `KILO_TOKEN_VERSION = 3`), and optional `WORKER_ENV` match. Uses a runtime type guard (`parseTokenPayload`) instead of `as` casts to validate payload shape.
- **`middleware.ts`** -- Two middlewares:
  - `authMiddleware`: extracts JWT from `Authorization: Bearer` header, with a `kilo-worker-auth` cookie fallback (see note below). `DEV_MODE=true` bypasses auth with a synthetic `dev@kilocode.ai` userId.
  - `internalApiMiddleware`: checks `x-internal-api-key` header against `INTERNAL_API_SECRET` for backend-to-backend routes. Implemented and tested but not yet mounted on any routes (PR4 adds `/api/platform/*`).
- **`sandbox-id.ts`** -- Reversible base64url encoding: `sandboxIdFromUserId()` / `userIdFromSandboxId()`. Unlike cloud-agent-next's SHA-256 pattern, this is reversible so lifecycle hooks can recover the userId without a DB lookup. Enforces the 63-char sandboxId limit.
- **`gateway-token.ts`** -- HMAC-SHA256 per-sandbox gateway token derivation via Web Crypto. Each sandbox gets a deterministic token derived from its `sandboxId` + the worker's `GATEWAY_TOKEN_SECRET`.
- **`debug-gate.ts`** -- Requires both `DEBUG_ROUTES=true` AND a matching `x-debug-api-key` header checked against `DEBUG_ROUTES_SECRET`. Missing secret is a hard 403 -- no silent pass-through.

**Updated files**

- **`index.ts`** -- Extracted all middleware into named functions (`logRequest`, `initSandbox`, `requireEnvVars`, `authGuard`, `deriveSandboxId`). Added auth middleware after public routes, sandboxId derivation after auth. `validateRequiredEnv` now checks `NEXTAUTH_SECRET` and `GATEWAY_TOKEN_SECRET` in addition to AI provider keys.
- **`types.ts`** -- Added `NEXTAUTH_SECRET`, `INTERNAL_API_SECRET`, `GATEWAY_TOKEN_SECRET`, `WORKER_ENV`, `DEBUG_ROUTES_SECRET` to `KiloClawEnv`. Added `userId`, `authToken`, `sandboxId` to `AppEnv.Variables`.
- **`config.ts`** -- Added `KILO_WORKER_AUTH_COOKIE` and `KILO_TOKEN_VERSION` constants.
- **`.dev.vars.example`** -- Replaced with auth-focused template including all new secrets.

### About the `kilo-worker-auth` cookie

The kiloclaw worker lives on a different origin than the Next.js app. CLI and API clients authenticate via `Authorization: Bearer` headers, but browsers can't send Bearer headers on WebSocket upgrades. The cookie bridges this gap: a later PR adds a `POST /api/kiloclaw/refresh-cookie` route in Next.js that mints a `kilo-worker-auth` cookie scoped to `.kilo.ai`. The browser then sends it automatically on every request to the kiloclaw worker subdomain `claw.kilo.ai`.

This PR implements the **reader side only** -- `authMiddleware` checks for the cookie as a fallback when no Bearer header is present. The **writer side** (the Next.js route that actually sets the cookie) lands in a later PR. Until then, the cookie path is inert -- it falls through to "no token" → 401.

In short: Bearer header is for CLI/API clients, cookie is for the browser UI when connecting to the Websocket endpoint.

### About `deriveGatewayToken`

The function itself is correct and compatible with how OpenClaw consumes gateway tokens (it treats them as opaque strings). However, `deriveGatewayToken` is currently just a helper -- it doesn't yet recreate the full moltworker behavior.

What moltworker did:
1. Set `OPENCLAW_GATEWAY_TOKEN` in the container env from `MOLTBOT_GATEWAY_TOKEN` (single shared token for all requests)
2. Appended `?token=...` to gateway URLs when proxying HTTP/WebSocket requests
3. Required the token in env validation

What this PR does:
- Produces a **per-sandbox** deterministic token (HMAC-SHA256 hex) instead of a single shared one -- step 3 is done (`GATEWAY_TOKEN_SECRET` is required in env validation)

What still needs wiring (PR4+):
- `buildEnvVars` needs to call `deriveGatewayToken(sandboxId, secret)` and set `OPENCLAW_GATEWAY_TOKEN` in the container env
- The proxy code needs to inject `?token=` on requests when the header/query param is missing
- Both of these are per-sandbox now, so they depend on the per-user sandbox resolution that PR4 introduces

### Key deferrals

| Item | Deferred to | Reason |
|------|-------------|--------|
| Pepper validation via Hyperdrive | PR4 | No Hyperdrive binding yet |
| Per-user sandbox resolution | PR4 | Needs the provisioning DO |
| Gateway token wiring (buildEnvVars + proxy) | PR4 | Depends on per-user sandbox |
| Internal API routes (`/api/platform/*`) | PR4 | Middleware ready, routes not |
| Cookie writer (`/api/kiloclaw/refresh-cookie`) | B1.1 | Next.js side, separate workstream |