### PR TITLE
AppBuilder - Add structured logging to DB provisioner

### DIFF
--- a/cloudflare-app-builder/src/db-provisioner.ts
+++ b/cloudflare-app-builder/src/db-provisioner.ts
@@ -1,6 +1,6 @@
 import type { Sandbox } from '@cloudflare/sandbox';
 import type { Env, DbCredentials } from './types';
-import { logger } from './utils/logger';
+import { logger, withLogTags, formatError } from './utils/logger';
 
 export const DBProvisionResult = {
   NO_DB: 'NO_DB',
@@ -19,54 +19,88 @@ type DBProvisionerDeps = {
 export function createDBProvisioner(deps: DBProvisionerDeps) {
   async function needsDB(sandbox: Sandbox): Promise<boolean> {
     const result = await sandbox.readFile('/workspace/package.json');
-    if (!result.success) return false;
+    if (!result.success) {
+      logger.debug('needsDB: package.json not found');
+      return false;
+    }
     try {
       const pkg = JSON.parse(result.content);
       const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
-      return '@kilocode/app-builder-db' in allDeps;
-    } catch {
+      const found = '@kilocode/app-builder-db' in allDeps;
+      logger.debug(found ? 'needsDB: dependency found' : 'needsDB: dependency not in package.json');
+      return found;
+    } catch (error) {
+      logger.warn('needsDB: failed to parse package.json', formatError(error));
       return false;
     }
   }
 
   async function provisionDB(appId: string): Promise<void> {
     logger.info('Provisioning database');
+    const start = Date.now();
     const { token } = await deps.env.DB_PROXY.provision(appId);
     const url = deps.env.DB_PROXY_URL + '/api/' + appId + '/query';
     await deps.setCredentials({ url, token });
-    logger.info('Database provisioned');
+    logger.info('Database provisioned', { durationMs: Date.now() - start });
   }
 
   async function runMigrations(sandbox: Sandbox): Promise<void> {
-    logger.debug('Running migrations');
+    logger.info('Running migrations');
     const dbCreds = deps.getCredentials();
     if (!dbCreds) {
-      logger.warn('Missing db credentials');
+      logger.warn('Skipping migrations: missing db credentials');
       return;
     }
 
+    const start = Date.now();
     const result = await sandbox.exec('cd /workspace && bun run db:migrate', {
       env: { DB_URL: dbCreds.url, DB_TOKEN: dbCreds.token },
     });
+    const durationMs = Date.now() - start;
 
     if (!result.success) {
+      logger.error('Migration failed', {
+        durationMs,
+        exitCode: result.exitCode,
+        stderr: result.stderr,
+        stdout: result.stdout,
+      });
       throw new Error(`Migration failed: ${result.stderr || 'Unknown error'}`);
     }
-    logger.debug('Migrations completed');
+    logger.info('Migrations completed', { durationMs });
   }
 
   async function provisionIfNeeded(sandbox: Sandbox, appId: string): Promise<DBProvisionResult> {
-    if (!(await needsDB(sandbox))) {
-      return DBProvisionResult.NO_DB;
-    }
+    return withLogTags({ source: 'DBProvisioner' }, async () => {
+      const start = Date.now();
+      try {
+        if (!(await needsDB(sandbox))) {
+          logger.info('DB provisioning: no database needed', {
+            result: DBProvisionResult.NO_DB,
+            durationMs: Date.now() - start,
+          });
+          return DBProvisionResult.NO_DB;
+        }
 
-    const needsProvisioning = !deps.getCredentials();
-    if (needsProvisioning) {
-      await provisionDB(appId);
-    }
+        const needsProvisioning = !deps.getCredentials();
+        if (needsProvisioning) {
+          await provisionDB(appId);
+        }
 
-    await runMigrations(sandbox);
-    return needsProvisioning ? DBProvisionResult.PROVISIONED : DBProvisionResult.MIGRATED;
+        await runMigrations(sandbox);
+        const result = needsProvisioning
+          ? DBProvisionResult.PROVISIONED
+          : DBProvisionResult.MIGRATED;
+        logger.info('DB provisioning completed', { result, durationMs: Date.now() - start });
+        return result;
+      } catch (error) {
+        logger.error('DB provisioning failed', {
+          durationMs: Date.now() - start,
+          ...formatError(error),
+        });
+        throw error;
+      }
+    });
   }
 
   return { provisionIfNeeded };


### PR DESCRIPTION
## Summary

- Add structured logging to `cloudflare-app-builder/src/db-provisioner.ts` so per-app database provisioning and migration activity is observable in Axiom.
- All logs tagged with `source: "DBProvisioner"` for easy filtering (`appId == "..." AND source == "DBProvisioner"`).

## Changes

- **`needsDB()`**: Log outcome at every exit path. Warn on `package.json` parse failure (previously silently swallowed).
- **`provisionDB()`**: Add `durationMs` to the "Database provisioned" log.
- **`runMigrations()`**: On failure, log `exitCode`, `stderr`, `stdout`, `durationMs` as separate structured fields (`stdout` was previously discarded entirely). Elevate from debug to info level.
- **`provisionIfNeeded()`**: Wrap in `withLogTags({ source: "DBProvisioner" })`. Log overall result (`NO_DB | PROVISIONED | MIGRATED`) with total `durationMs`. Log error summary before re-throwing.

No new dependencies, no state/schema changes, no behavior changes.