### PR TITLE
GitHub Actions - Auto-deploy Cloudflare workers on merge to main

### DIFF
--- a/.github/workflows/deploy-app-builder.yml
+++ b/.github/workflows/deploy-app-builder.yml
@@ -2,6 +2,7 @@ name: Deploy App Builder Worker
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-deployment-builder.yml
+++ b/.github/workflows/deploy-deployment-builder.yml
@@ -2,6 +2,7 @@ name: Deploy Builder Worker
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy:
@@ -23,7 +24,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        working-directory: cloud-agent
+        working-directory: cloudflare-deploy-infra/builder
         run: pnpm install --frozen-lockfile
 
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/deploy-deployment-dispatcher.yml
+++ b/.github/workflows/deploy-deployment-dispatcher.yml
@@ -2,6 +2,7 @@ name: Deploy Dispatcher Worker
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy:
@@ -23,7 +24,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        working-directory: cloud-agent
+        working-directory: cloudflare-deploy-infra/dispatcher
         run: pnpm install --frozen-lockfile
 
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/deploy-git-token-service.yml
+++ b/.github/workflows/deploy-git-token-service.yml
@@ -2,6 +2,7 @@ name: Deploy Git Token Service
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for cloud-agent changes
         uses: dorny/paths-filter@v3
@@ -183,7 +183,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for session-ingest changes
         uses: dorny/paths-filter@v3
@@ -209,7 +209,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for o11y changes
         uses: dorny/paths-filter@v3
@@ -235,7 +235,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for git-token-service changes
         uses: dorny/paths-filter@v3
@@ -259,7 +259,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for deployment-dispatcher changes
         uses: dorny/paths-filter@v3
@@ -283,7 +283,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for deployment-builder changes
         uses: dorny/paths-filter@v3
@@ -307,7 +307,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for app-builder changes
         uses: dorny/paths-filter@v3

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -154,7 +154,7 @@ jobs:
   check-cloud-agent-changes:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.changes.outputs.cloud-agent }}
+      changed: ${{ steps.changes.outputs['cloud-agent'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -230,7 +230,7 @@ jobs:
   check-git-token-service-changes:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.changes.outputs.git-token-service }}
+      changed: ${{ steps.changes.outputs['git-token-service'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -254,7 +254,7 @@ jobs:
   check-deployment-dispatcher-changes:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.changes.outputs.deployment-dispatcher }}
+      changed: ${{ steps.changes.outputs['deployment-dispatcher'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -278,7 +278,7 @@ jobs:
   check-deployment-builder-changes:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.changes.outputs.deployment-builder }}
+      changed: ${{ steps.changes.outputs['deployment-builder'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -302,7 +302,7 @@ jobs:
   check-app-builder-changes:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.changes.outputs.app-builder }}
+      changed: ${{ steps.changes.outputs['app-builder'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -226,3 +226,99 @@ jobs:
     secrets: inherit
     with:
       environment: prod
+
+  check-git-token-service-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.git-token-service }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for git-token-service changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            git-token-service:
+              - 'cloudflare-git-token-service/**'
+
+  deploy-git-token-service:
+    needs: [check-git-token-service-changes]
+    if: needs.check-git-token-service-changes.outputs.changed == 'true'
+    uses: ./.github/workflows/deploy-git-token-service.yml
+    secrets: inherit
+
+  check-deployment-dispatcher-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.deployment-dispatcher }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for deployment-dispatcher changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            deployment-dispatcher:
+              - 'cloudflare-deploy-infra/dispatcher/**'
+
+  deploy-deployment-dispatcher:
+    needs: [check-deployment-dispatcher-changes]
+    if: needs.check-deployment-dispatcher-changes.outputs.changed == 'true'
+    uses: ./.github/workflows/deploy-deployment-dispatcher.yml
+    secrets: inherit
+
+  check-deployment-builder-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.deployment-builder }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for deployment-builder changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            deployment-builder:
+              - 'cloudflare-deploy-infra/builder/**'
+
+  deploy-deployment-builder:
+    needs: [check-deployment-builder-changes]
+    if: needs.check-deployment-builder-changes.outputs.changed == 'true'
+    uses: ./.github/workflows/deploy-deployment-builder.yml
+    secrets: inherit
+
+  check-app-builder-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.app-builder }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for app-builder changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            app-builder:
+              - 'cloudflare-app-builder/**'
+
+  deploy-app-builder:
+    needs: [check-app-builder-changes]
+    if: needs.check-app-builder-changes.outputs.changed == 'true'
+    uses: ./.github/workflows/deploy-app-builder.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Auto-deploy four additional Cloudflare workers when merged to main with path-based change detection: Git Token Service, Deployment Dispatcher, Deployment Builder, and App Builder.
- Add `workflow_call` trigger to each worker's deploy workflow so `deploy-production.yml` can invoke them.
- Fix incorrect `working-directory` for dependency install in Dispatcher and Builder workflows — they were installing from `cloud-agent/` instead of their own directories (`cloudflare-deploy-infra/dispatcher` and `cloudflare-deploy-infra/builder`).

## Path filters

| Worker | Watched path |
|---|---|
| Git Token Service | `cloudflare-git-token-service/**` |
| Deployment Dispatcher | `cloudflare-deploy-infra/dispatcher/**` |
| Deployment Builder | `cloudflare-deploy-infra/builder/**` |
| App Builder | `cloudflare-app-builder/**` |