### PR TITLE
Make OpenRouter description prevail over Kilo free model description

### DIFF
--- a/src/lib/providers/openrouter/sync-providers.ts
+++ b/src/lib/providers/openrouter/sync-providers.ts
@@ -267,7 +267,7 @@ export async function syncProviders() {
         console.log(
           `Found existing ${provider} provider from OpenRouter, adding extra model ${extraModel.model.slug}`
         );
-        providerData.models.push(extraModel.model);
+        providerData.models.splice(0, 0, extraModel.model);
       }
     }
   }


### PR DESCRIPTION
otherwise you get shit like this:

<img width="721" height="132" alt="CleanShot 2026-02-10 at 17 28 13" src="https://github.com/user-attachments/assets/13c33c77-885f-4723-9863-d7fe0edead63" />
