### PR TITLE
fix(o11y): add resolvedModel as Analytics Engine index for api metrics

### DIFF
--- a/cloudflare-o11y/src/o11y-analytics.ts
+++ b/cloudflare-o11y/src/o11y-analytics.ts
@@ -7,6 +7,7 @@ type ApiMetricsParams = z.infer<typeof ApiMetricsParamsSchema>;
  * Write an API metrics data point to Analytics Engine for alerting queries.
  *
  * Schema:
+ *   index1  = resolvedModel (sampling key — ensures equitable sampling per model)
  *   blob1   = provider
  *   blob2   = resolvedModel
  *   blob3   = clientName
@@ -18,6 +19,7 @@ type ApiMetricsParams = z.infer<typeof ApiMetricsParamsSchema>;
  */
 export function writeApiMetricsDataPoint(params: ApiMetricsParams, clientName: string, env: Env): void {
 	env.O11Y_API_METRICS.writeDataPoint({
+		indexes: [params.resolvedModel],
 		blobs: [params.provider, params.resolvedModel, clientName, params.statusCode >= 400 ? '1' : '0', params.inferenceProvider],
 		doubles: [params.ttfbMs, params.completeRequestMs, params.statusCode],
 	});

--- a/cloudflare-o11y/test/index.spec.ts
+++ b/cloudflare-o11y/test/index.spec.ts
@@ -120,6 +120,7 @@ describe('o11y worker', () => {
 
 		expect(aeSpy.writeDataPoint).toHaveBeenCalledOnce();
 		const call = aeSpy.writeDataPoint.mock.calls[0][0];
+		expect(call.indexes).toEqual(['anthropic/claude-sonnet-4.5']);
 		expect(call.blobs).toEqual(['openai', 'anthropic/claude-sonnet-4.5', 'kilo-gateway', '0', 'openai']);
 		expect(call.doubles).toEqual([45, 123, 200]);
 	});


### PR DESCRIPTION
## Summary

- **Adds `resolvedModel` as the Analytics Engine index** for the `o11y_api_metrics` dataset. Without an index, all data points share a single sampling bucket, causing Cloudflare's equitable sampling to discard low-volume model data indiscriminately. This makes per-model alerting queries (error rate baselines, TTFB baselines) inaccurate for rarely-used models.
- Updates existing test to assert the new index field is written correctly.

## Context

Cloudflare Analytics Engine uses the `indexes` field as the sampling key for [equitable sampling](https://developers.cloudflare.com/analytics/analytics-engine/sampling/). All 4 alerting queries in `query.ts` GROUP BY or filter on `blob2` (model), so `resolvedModel` is the natural choice — it ensures each model retains a proportional share of data even under high write volumes.