### PR TITLE
Deploy Infra - Add wrangler v4 to dispatcher worker

### DIFF
--- a/cloudflare-deploy-infra/dispatcher/http-requests/dispatcher.http
+++ b/cloudflare-deploy-infra/dispatcher/http-requests/dispatcher.http
@@ -26,6 +26,7 @@
 # === WORKER SETTINGS ===
 @workerName = demo-app
 @password = TestPassword123
+@slug = super-awesome-app
 
 ###
 
@@ -52,6 +53,27 @@ Content-Type: application/json
 
 ### Remove password protection
 DELETE {{baseUrl}}/api/password/{{workerName}}
+Authorization: Bearer {{authToken}}
+
+###
+
+# =============================================================================
+# SLUG MAPPING API (apex domain: d.kiloapps.io/api)
+# =============================================================================
+
+### Set slug mapping (maps slug to worker)
+PUT {{baseUrl}}/api/slug-mapping/{{workerName}}
+Authorization: Bearer {{authToken}}
+Content-Type: application/json
+
+{
+  "slug": "{{slug}}"
+}
+
+###
+
+### Delete slug mapping
+DELETE {{baseUrl}}/api/slug-mapping/{{workerName}}
 Authorization: Bearer {{authToken}}
 
 ###

--- a/cloudflare-deploy-infra/dispatcher/package.json
+++ b/cloudflare-deploy-infra/dispatcher/package.json
@@ -14,7 +14,8 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "jest": "^30.2.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "wrangler": "^4.61.0"
   },
   "dependencies": {
     "hono": "^4.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      wrangler:
+        specifier: ^4.61.0
+        version: 4.61.1(@cloudflare/workers-types@4.20260130.0)
 
   cloudflare-git-token-service:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `wrangler` (`^4.61.0`) to `devDependencies` in `cloudflare-deploy-infra/dispatcher/package.json`

The dispatcher worker was the only worker package missing `wrangler` from its dependencies. This caused the `cloudflare/wrangler-action@v3` GitHub Action to fall back to installing wrangler 3.90.0 instead of using v4, which every other worker already uses.