### PR TITLE
Deployments - Generate human-friendly slugs for App Builder deployments

### DIFF
--- a/src/lib/user-deployments/deployments-service.ts
+++ b/src/lib/user-deployments/deployments-service.ts
@@ -17,6 +17,7 @@ import { generateGitToken as generateAppBuilderGitToken } from '@/lib/app-builde
 import { getCredentials as getAppBuilderDbCredentials } from '@/lib/app-builder/app-builder-db-proxy-client';
 import * as z from 'zod';
 import { eventSchema } from '@/lib/user-deployments/types';
+import { generateDeploymentSlug } from '@/lib/user-deployments/slug-generator';
 import type {
   Provider,
   DeploymentSource,
@@ -666,9 +667,9 @@ export async function createDeployment(params: {
 
   const resolved = await resolveSource(owner, source);
 
-  // Generate deployment slug from repository name + random suffix
-  const randomSuffix = Math.random().toString(36).substring(2, 8);
-  const deploymentSlug = `${resolved.repoName}-${randomSuffix}`.toLowerCase();
+  const deploymentSlug = generateDeploymentSlug(
+    source.type === 'app-builder' ? null : resolved.repoName
+  );
 
   // Encrypt user-provided env vars first
   const encryptedUserEnvVars = envVars && envVars.length > 0 ? encryptEnvVars(envVars) : [];

--- a/src/lib/user-deployments/deployments-service.ts
+++ b/src/lib/user-deployments/deployments-service.ts
@@ -723,11 +723,11 @@ export async function createDeployment(params: {
 
   const deploymentUrl = `https://${deploymentSlug}.${DEFAULT_DEPLOYMENT_DOMAIN}`;
 
-  // Point the public slug at the internal worker
-  await dispatcherClient.setSlugMapping(internalWorkerName, deploymentSlug);
-
   let deploymentId: string;
   try {
+    // Point the public slug at the internal worker
+    await dispatcherClient.setSlugMapping(internalWorkerName, deploymentSlug);
+
     deploymentId = await db.transaction(async tx => {
       const [deployment] = await tx
         .insert(deployments)

--- a/src/lib/user-deployments/slug-generator.test.ts
+++ b/src/lib/user-deployments/slug-generator.test.ts
@@ -1,0 +1,136 @@
+import { generateDeploymentSlug } from './slug-generator';
+import { slugSchema } from './validation';
+
+describe('generateDeploymentSlug', () => {
+  describe('app-builder deployments (repoName is null)', () => {
+    it('generates a slug matching adjective-noun-NNNN pattern', () => {
+      const slug = generateDeploymentSlug(null);
+      expect(slug).toMatch(/^[a-z]+-[a-z]+-\d{4}$/);
+    });
+
+    it('passes slugSchema validation', () => {
+      for (let i = 0; i < 100; i++) {
+        const slug = generateDeploymentSlug(null);
+        const result = slugSchema.safeParse(slug);
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('generates different slugs on repeated calls', () => {
+      const slugs = new Set(Array.from({ length: 50 }, () => generateDeploymentSlug(null)));
+      // With ~120 adjectives * ~150 nouns * 10000 numbers, collisions in 50 tries
+      // are astronomically unlikely
+      expect(slugs.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe('regular deployments (repoName provided)', () => {
+    it('generates a slug with repoName prefix and 4-digit suffix', () => {
+      const slug = generateDeploymentSlug('owner-repo');
+      expect(slug).toMatch(/^owner-repo-\d{4}$/);
+    });
+
+    it('lowercases the repo name', () => {
+      const slug = generateDeploymentSlug('Owner-Repo');
+      expect(slug).toMatch(/^owner-repo-\d{4}$/);
+    });
+
+    it('passes slugSchema validation', () => {
+      for (let i = 0; i < 100; i++) {
+        const slug = generateDeploymentSlug('my-project');
+        const result = slugSchema.safeParse(slug);
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('replaces invalid characters with hyphens', () => {
+      const slug = generateDeploymentSlug('my_project.name');
+      expect(slug).toMatch(/^my-project-name-\d{4}$/);
+    });
+
+    it('collapses consecutive hyphens from replacements', () => {
+      const slug = generateDeploymentSlug('my--project');
+      expect(slug).toMatch(/^my-project-\d{4}$/);
+    });
+
+    it('strips leading and trailing hyphens from repo name', () => {
+      const slug = generateDeploymentSlug('-my-project-');
+      expect(slug).toMatch(/^my-project-\d{4}$/);
+    });
+  });
+
+  describe('long repo name truncation', () => {
+    it('truncates long repo names to fit within 63-char limit', () => {
+      const longName = 'a'.repeat(100);
+      const slug = generateDeploymentSlug(longName);
+      expect(slug.length).toBeLessThanOrEqual(63);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    });
+
+    it('does not leave a trailing hyphen after truncation', () => {
+      // 58 chars: 57 a's + hyphen at the end — truncation to 58 then strip trailing hyphen
+      const name = 'a'.repeat(57) + '-b';
+      const slug = generateDeploymentSlug(name);
+      expect(slug).not.toMatch(/--/);
+      expect(slug.length).toBeLessThanOrEqual(63);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    });
+
+    it('handles repo name exactly at the max prefix length', () => {
+      const name = 'a'.repeat(58); // exactly max prefix length
+      const slug = generateDeploymentSlug(name);
+      expect(slug.length).toBeLessThanOrEqual(63);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    });
+
+    it('handles truncation at a hyphen boundary', () => {
+      // Create a name where the 58th char is a hyphen
+      const name = 'a'.repeat(57) + '-' + 'b'.repeat(10);
+      const slug = generateDeploymentSlug(name);
+      expect(slug).not.toMatch(/--/);
+      expect(slug).not.toMatch(/-$/);
+      expect(slug.length).toBeLessThanOrEqual(63);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('falls back to pronounceable name when repo name is empty after sanitization', () => {
+      const slug = generateDeploymentSlug('---');
+      // Should fall back to adjective-noun-NNNN
+      expect(slug).toMatch(/^[a-z]+-[a-z]+-\d{4}$/);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    });
+
+    it('falls back to pronounceable name for all-invalid-char repo name', () => {
+      const slug = generateDeploymentSlug('!!!');
+      expect(slug).toMatch(/^[a-z]+-[a-z]+-\d{4}$/);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    });
+
+    it('never exceeds 63 characters', () => {
+      const testCases = [
+        null,
+        'short',
+        'a'.repeat(100),
+        'owner-with-many-segments-in-the-repo-name-that-goes-on-and-on-forever',
+      ];
+      for (const repoName of testCases) {
+        for (let i = 0; i < 20; i++) {
+          const slug = generateDeploymentSlug(repoName);
+          expect(slug.length).toBeLessThanOrEqual(63);
+        }
+      }
+    });
+
+    it('never contains consecutive hyphens', () => {
+      const testCases = [null, 'my-project', 'a--b', 'x-', '-y', '---'];
+      for (const repoName of testCases) {
+        for (let i = 0; i < 20; i++) {
+          const slug = generateDeploymentSlug(repoName);
+          expect(slug).not.toMatch(/--/);
+        }
+      }
+    });
+  });
+});

--- a/src/lib/user-deployments/slug-generator.test.ts
+++ b/src/lib/user-deployments/slug-generator.test.ts
@@ -15,13 +15,6 @@ describe('generateDeploymentSlug', () => {
         expect(result.success).toBe(true);
       }
     });
-
-    it('generates different slugs on repeated calls', () => {
-      const slugs = new Set(Array.from({ length: 50 }, () => generateDeploymentSlug(null)));
-      // With ~120 adjectives * ~150 nouns * 10000 numbers, collisions in 50 tries
-      // are astronomically unlikely
-      expect(slugs.size).toBeGreaterThan(1);
-    });
   });
 
   describe('regular deployments (repoName provided)', () => {

--- a/src/lib/user-deployments/slug-generator.ts
+++ b/src/lib/user-deployments/slug-generator.ts
@@ -1,0 +1,360 @@
+import { slugSchema } from './validation';
+
+// Mixed-theme word lists: nature/poetic, neutral, and tech
+// All words kept short (≤10 chars) to stay well within the 63-char slug limit.
+
+const adjectives = [
+  // nature / poetic
+  'autumn',
+  'bitter',
+  'bold',
+  'calm',
+  'cold',
+  'cool',
+  'crimson',
+  'damp',
+  'dark',
+  'dawn',
+  'dry',
+  'dusty',
+  'empty',
+  'fading',
+  'falling',
+  'floral',
+  'frosty',
+  'gentle',
+  'golden',
+  'green',
+  'hidden',
+  'hollow',
+  'icy',
+  'lush',
+  'misty',
+  'morning',
+  'muddy',
+  'mute',
+  'pale',
+  'plain',
+  'proud',
+  'quiet',
+  'rapid',
+  'rough',
+  'round',
+  'royal',
+  'rustic',
+  'shy',
+  'silent',
+  'snowy',
+  'soft',
+  'solitary',
+  'spring',
+  'steep',
+  'still',
+  'summer',
+  'sweet',
+  'tiny',
+  'twilight',
+  'wandering',
+  'warm',
+  'white',
+  'wild',
+  'winter',
+  'young',
+  // neutral / general
+  'bright',
+  'broad',
+  'clean',
+  'clear',
+  'cosmic',
+  'deep',
+  'early',
+  'even',
+  'firm',
+  'flat',
+  'free',
+  'fresh',
+  'grand',
+  'great',
+  'keen',
+  'late',
+  'lean',
+  'light',
+  'long',
+  'lucky',
+  'neat',
+  'next',
+  'noble',
+  'odd',
+  'open',
+  'prime',
+  'rare',
+  'real',
+  'rich',
+  'sharp',
+  'shiny',
+  'short',
+  'slim',
+  'smart',
+  'smooth',
+  'solid',
+  'stark',
+  'steady',
+  'true',
+  'vast',
+  // tech / computing
+  'active',
+  'agile',
+  'async',
+  'atomic',
+  'binary',
+  'cubic',
+  'cyber',
+  'dual',
+  'dynamic',
+  'fast',
+  'hyper',
+  'linear',
+  'live',
+  'lunar',
+  'mega',
+  'micro',
+  'neural',
+  'nimble',
+  'polar',
+  'swift',
+  'sonic',
+  'super',
+  'synced',
+  'turbo',
+  'ultra',
+  'wired',
+] as const;
+
+const nouns = [
+  // nature / poetic
+  'birch',
+  'bloom',
+  'breeze',
+  'brook',
+  'cedar',
+  'cliff',
+  'cloud',
+  'cove',
+  'creek',
+  'dale',
+  'dawn',
+  'dew',
+  'dune',
+  'elm',
+  'ember',
+  'fern',
+  'field',
+  'flame',
+  'flint',
+  'fog',
+  'frost',
+  'glade',
+  'grove',
+  'haze',
+  'hill',
+  'lake',
+  'leaf',
+  'marsh',
+  'meadow',
+  'mist',
+  'moon',
+  'moss',
+  'oak',
+  'peak',
+  'pine',
+  'pond',
+  'rain',
+  'reed',
+  'ridge',
+  'river',
+  'shade',
+  'shore',
+  'sky',
+  'snow',
+  'star',
+  'stone',
+  'storm',
+  'sun',
+  'tide',
+  'vale',
+  'wave',
+  'wind',
+  'wood',
+  // neutral / general
+  'arch',
+  'band',
+  'base',
+  'bell',
+  'bolt',
+  'bond',
+  'bridge',
+  'cap',
+  'core',
+  'crest',
+  'crown',
+  'drum',
+  'edge',
+  'forge',
+  'gate',
+  'guild',
+  'harbor',
+  'hatch',
+  'haven',
+  'helm',
+  'hub',
+  'key',
+  'lance',
+  'lens',
+  'link',
+  'loom',
+  'mark',
+  'mill',
+  'mint',
+  'nest',
+  'orbit',
+  'path',
+  'port',
+  'prism',
+  'quest',
+  'relay',
+  'rune',
+  'sail',
+  'scope',
+  'seal',
+  'shell',
+  'shard',
+  'signal',
+  'spark',
+  'spire',
+  'summit',
+  'tower',
+  'trail',
+  'vault',
+  'wing',
+  // tech / computing
+  'bit',
+  'block',
+  'buffer',
+  'byte',
+  'cache',
+  'cell',
+  'chip',
+  'clock',
+  'codec',
+  'coil',
+  'cycle',
+  'data',
+  'delta',
+  'disk',
+  'fiber',
+  'flux',
+  'frame',
+  'grid',
+  'hash',
+  'index',
+  'ion',
+  'kernel',
+  'latch',
+  'matrix',
+  'node',
+  'null',
+  'oxide',
+  'packet',
+  'pixel',
+  'probe',
+  'pulse',
+  'queue',
+  'rack',
+  'ray',
+  'rotor',
+  'sector',
+  'servo',
+  'stack',
+  'sync',
+  'tensor',
+  'token',
+  'vector',
+  'voxel',
+  'wire',
+] as const;
+
+const MAX_SLUG_LENGTH = 63;
+// "-" separator + 4-digit number
+const SUFFIX_LENGTH = 1 + 4;
+
+function cryptoRandomInt(max: number): number {
+  const array = new Uint32Array(1);
+  crypto.getRandomValues(array);
+  // Uint32Array(1) always has index 0 after getRandomValues
+  const value = array[0] ?? 0;
+  return value % max;
+}
+
+function pickRandom<T>(list: readonly T[]): T {
+  const index = cryptoRandomInt(list.length);
+  const value = list[index];
+  if (value === undefined) {
+    throw new Error(`pickRandom: index ${index} out of bounds for list of length ${list.length}`);
+  }
+  return value;
+}
+
+function generate4DigitNumber(): string {
+  return String(cryptoRandomInt(10000)).padStart(4, '0');
+}
+
+function sanitizePrefix(raw: string): string {
+  let prefix = raw
+    .toLowerCase()
+    // Replace anything that isn't a-z, 0-9, or hyphen
+    .replace(/[^a-z0-9-]/g, '-')
+    // Collapse consecutive hyphens
+    .replace(/-{2,}/g, '-')
+    // Strip leading/trailing hyphens
+    .replace(/^-+|-+$/g, '');
+
+  const maxPrefixLength = MAX_SLUG_LENGTH - SUFFIX_LENGTH;
+  prefix = prefix.slice(0, maxPrefixLength);
+  // Truncation may leave a trailing hyphen
+  prefix = prefix.replace(/-+$/, '');
+
+  return prefix;
+}
+
+/**
+ * Generate a pronounceable deployment slug.
+ *
+ * - App-builder deployments (repoName is null): `adjective-noun-NNNN`
+ * - Regular deployments: `repoName-NNNN` (repoName truncated to fit 63-char limit)
+ */
+export function generateDeploymentSlug(repoName: string | null): string {
+  const number = generate4DigitNumber();
+
+  let slug: string;
+  if (repoName === null) {
+    const adj = pickRandom(adjectives);
+    const noun = pickRandom(nouns);
+    slug = `${adj}-${noun}-${number}`;
+  } else {
+    const prefix = sanitizePrefix(repoName);
+    slug = prefix
+      ? `${prefix}-${number}`
+      : `${pickRandom(adjectives)}-${pickRandom(nouns)}-${number}`;
+  }
+
+  // Safety: if the generated slug doesn't pass validation (shouldn't happen
+  // with curated word lists, but just in case), fall back to a simple pattern.
+  const result = slugSchema.safeParse(slug);
+  if (!result.success) {
+    const adj = pickRandom(adjectives);
+    const noun = pickRandom(nouns);
+    slug = `${adj}-${noun}-${number}`;
+  }
+
+  return slug;
+}


### PR DESCRIPTION
## Summary

- Extract deployment slug generation from `createDeployment` into a dedicated `slug-generator` module
- App-builder deployments now get human-friendly `adjective-noun-NNNN` slugs (e.g. `calm-brook-0742`) instead of repo-name based slugs
- Regular deployments continue using sanitized repo name with a 4-digit suffix
- Use `crypto.getRandomValues` instead of `Math.random` for better randomness
- Add schema validation with fallback and comprehensive tests