### PR TITLE
fix(o11y): await Pipeline send and improve alert error logging

### DIFF
--- a/cloudflare-o11y/src/alerting/evaluate.ts
+++ b/cloudflare-o11y/src/alerting/evaluate.ts
@@ -260,6 +260,13 @@ export async function evaluateAlerts(env: Env): Promise<void> {
 	}
 
 	if (errors.length > 0) {
-		throw new AggregateError(errors, `Alert evaluation failed with ${errors.length} error(s)`);
+		const details = errors
+			.map((e) => {
+				const msg = e instanceof Error ? e.message : String(e);
+				const cause = e instanceof Error && e.cause instanceof Error ? `: ${e.cause.message}` : '';
+				return `  - ${msg}${cause}`;
+			})
+			.join('\n');
+		throw new AggregateError(errors, `Alert evaluation failed with ${errors.length} error(s):\n${details}`);
 	}
 }

--- a/cloudflare-o11y/src/index.ts
+++ b/cloudflare-o11y/src/index.ts
@@ -26,6 +26,6 @@ export default class extends WorkerEntrypoint<Env> {
 	/** RPC method called by session-ingest via service binding. */
 	async ingestSessionMetrics(params: SessionMetricsParams): Promise<void> {
 		const parsed = SessionMetricsParamsSchema.parse(params);
-		writeSessionMetricsDataPoint(parsed, this.env, (p) => this.ctx.waitUntil(p));
+		await writeSessionMetricsDataPoint(parsed, this.env);
 	}
 }

--- a/cloudflare-o11y/src/session-metrics-analytics.ts
+++ b/cloudflare-o11y/src/session-metrics-analytics.ts
@@ -23,7 +23,7 @@ import type { SessionMetricsParams } from './session-metrics-schema';
  *   double10 = autoCompactionCount
  *   double11 = ingestVersion
  */
-export function writeSessionMetricsDataPoint(params: SessionMetricsParams, env: Env, waitUntil: (p: Promise<unknown>) => void): void {
+export async function writeSessionMetricsDataPoint(params: SessionMetricsParams, env: Env): Promise<void> {
 	const totalTokensSum =
 		params.totalTokens.input +
 		params.totalTokens.output +
@@ -49,26 +49,24 @@ export function writeSessionMetricsDataPoint(params: SessionMetricsParams, env: 
 		],
 	});
 
-	waitUntil(
-		env.SESSION_METRICS_STREAM.send([
-			{
-				platform: params.platform,
-				termination_reason: params.terminationReason,
-				organization_id: params.organizationId,
-				kilo_user_id: params.kiloUserId,
-				model: params.model,
-				session_duration_ms: params.sessionDurationMs,
-				time_to_first_response_ms: params.timeToFirstResponseMs ?? -1,
-				total_turns: params.totalTurns,
-				total_steps: params.totalSteps,
-				total_errors: params.totalErrors,
-				total_tokens: totalTokensSum,
-				total_cost: params.totalCost,
-				compaction_count: params.compactionCount,
-				stuck_tool_call_count: params.stuckToolCallCount,
-				auto_compaction_count: params.autoCompactionCount,
-				ingest_version: params.ingestVersion,
-			},
-		]),
-	);
+	await env.SESSION_METRICS_STREAM.send([
+		{
+			platform: params.platform,
+			termination_reason: params.terminationReason,
+			organization_id: params.organizationId,
+			kilo_user_id: params.kiloUserId,
+			model: params.model,
+			session_duration_ms: params.sessionDurationMs,
+			time_to_first_response_ms: params.timeToFirstResponseMs ?? -1,
+			total_turns: params.totalTurns,
+			total_steps: params.totalSteps,
+			total_errors: params.totalErrors,
+			total_tokens: totalTokensSum,
+			total_cost: params.totalCost,
+			compaction_count: params.compactionCount,
+			stuck_tool_call_count: params.stuckToolCallCount,
+			auto_compaction_count: params.autoCompactionCount,
+			ingest_version: params.ingestVersion,
+		},
+	]);
 }


### PR DESCRIPTION
## Summary

- **Await Pipeline send instead of `waitUntil`** — `ingestSessionMetrics` was firing the Pipeline write (`SESSION_METRICS_STREAM.send()`) via `ctx.waitUntil()`, but the RPC invocation context ends as soon as the method returns, giving `waitUntil` tasks only a limited grace period. If the Pipeline write is slow, the task gets cancelled. Since the only caller is a DO alarm (with plenty of time budget and no user-facing latency), awaiting inline is strictly more reliable.

- **Include inner error details in `evaluateAlerts` log output** — Cloudflare logs the top-level `.message` of a thrown error but doesn't traverse `AggregateError.errors` or `Error.cause` chains. The alert evaluation was throwing `AggregateError` with nested causes that were invisible in logs. Now the per-window error messages and their causes are inlined into the top-level message.