### PR TITLE
feat(api): add gateway route alias for openrouter

### DIFF
--- a/src/app/api/gateway/[...path]/route.ts
+++ b/src/app/api/gateway/[...path]/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/openrouter/[...path]/route';

--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -85,7 +85,9 @@ function resolveAutoModel(modeHeader: string | null) {
 }
 
 function validatePath(url: URL) {
-  const path = stripRequiredPrefix(url.pathname, '/api/openrouter');
+  const path =
+    stripRequiredPrefix(url.pathname, '/api/gateway') ??
+    stripRequiredPrefix(url.pathname, '/api/openrouter');
 
   return path === '/chat/completions' ? { path } : { errorResponse: invalidPathResponse() };
 }


### PR DESCRIPTION
Introduce a new `/api/gateway` endpoint that proxies requests to the existing OpenRouter API logic. This change includes updating the path validation to support both the new gateway prefix and the original openrouter prefix.