### PR TITLE
Remove Kilo: Auto from Providers and Models page

### DIFF
--- a/src/app/api/openrouter/hooks.ts
+++ b/src/app/api/openrouter/hooks.ts
@@ -13,12 +13,6 @@ import {
   type OpenRouterModel,
 } from '@/lib/providers/openrouter/openrouter-types';
 import * as z from 'zod';
-import {
-  KILO_AUTO_MODEL_CONTEXT_LENGTH,
-  KILO_AUTO_MODEL_DESCRIPTION,
-  KILO_AUTO_MODEL_ID,
-  KILO_AUTO_MODEL_NAME,
-} from '@/lib/kilo-auto-model';
 
 interface OpenRouterProvider {
   name: string;
@@ -76,38 +70,6 @@ interface OpenRouterData {
   total_providers: number;
   total_models: number;
   generated_at: string;
-}
-
-function buildKiloAutoModel(): OpenRouterModel {
-  const epochIso = new Date(0).toISOString();
-  return {
-    slug: KILO_AUTO_MODEL_ID,
-    hf_slug: null,
-    updated_at: epochIso,
-    created_at: epochIso,
-    hf_updated_at: null,
-    name: KILO_AUTO_MODEL_NAME,
-    short_name: KILO_AUTO_MODEL_NAME,
-    author: 'Kilo',
-    description: KILO_AUTO_MODEL_DESCRIPTION,
-    model_version_group_id: null,
-    context_length: KILO_AUTO_MODEL_CONTEXT_LENGTH,
-    input_modalities: ['text', 'image'],
-    output_modalities: ['text'],
-    has_text_output: true,
-    group: 'other',
-    instruct_type: null,
-    default_system: null,
-    default_stops: [],
-    hidden: false,
-    router: null,
-    warning_message: null,
-    permaslug: KILO_AUTO_MODEL_ID,
-    reasoning_config: null,
-    features: null,
-    default_parameters: null,
-    endpoint: null,
-  };
 }
 
 export function useOpenRouterModels() {
@@ -233,8 +195,7 @@ export function useOpenRouterModelsAndProviders() {
     }
 
     const modelsWithEndpoints = [...modelBySlug.values()];
-    const hasAutoAlready = modelsWithEndpoints.some(model => model.slug === KILO_AUTO_MODEL_ID);
-    return hasAutoAlready ? modelsWithEndpoints : [buildKiloAutoModel(), ...modelsWithEndpoints];
+    return modelsWithEndpoints;
   }, [query.data]);
 
   return {


### PR DESCRIPTION
I don't think it makes sense for it be there, enabling/disabling it doesn't do anything.

<img width="1129" height="849" alt="CleanShot 2026-02-11 at 20 40 50" src="https://github.com/user-attachments/assets/92c6fa76-4e93-4ae6-8d98-cf8606435b43" />

My guess it was added because Cloud agents use the same list, but that's fixed in: https://github.com/Kilo-Org/cloud/pull/136, https://github.com/Kilo-Org/cloud/pull/140