### PR TITLE
Deploy - Route deployment details by URL

### DIFF
--- a/src/app/(app)/deploy/DeployPageClient.tsx
+++ b/src/app/(app)/deploy/DeployPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { DeploymentsList } from '@/components/deployments/DeploymentsList';
 import { DeploymentDetails } from '@/components/deployments/DeploymentDetails';
 import { NewDeploymentDialog } from '@/components/deployments/NewDeploymentDialog';
@@ -10,17 +10,24 @@ import { Button } from '@/components/Button';
 import { Badge } from '@/components/ui/badge';
 import { ExternalLink, Plus } from 'lucide-react';
 import { PageContainer } from '@/components/layouts/PageContainer';
+import { useState } from 'react';
 
-export function DeployPageClient() {
-  const [selectedDeploymentId, setSelectedDeploymentId] = useState<string | null>(null);
+type DeployPageClientProps = {
+  initialDeploymentId?: string;
+};
+
+export function DeployPageClient({ initialDeploymentId }: DeployPageClientProps) {
+  const router = useRouter();
   const [isNewDeploymentOpen, setIsNewDeploymentOpen] = useState(false);
 
+  const basePath = '/deploy';
+
   const handleViewDetails = (deploymentId: string) => {
-    setSelectedDeploymentId(deploymentId);
+    router.push(`${basePath}/${deploymentId}`);
   };
 
   const handleCloseDetails = () => {
-    setSelectedDeploymentId(null);
+    router.push(basePath);
   };
 
   const handleNewDeployment = () => {
@@ -62,10 +69,10 @@ export function DeployPageClient() {
 
           <DeploymentsList onViewDetails={handleViewDetails} />
 
-          {selectedDeploymentId && (
+          {initialDeploymentId && (
             <DeploymentDetails
-              deploymentId={selectedDeploymentId}
-              isOpen={selectedDeploymentId !== null}
+              deploymentId={initialDeploymentId}
+              isOpen={true}
               onClose={handleCloseDetails}
             />
           )}

--- a/src/app/(app)/deploy/[deploymentId]/page.tsx
+++ b/src/app/(app)/deploy/[deploymentId]/page.tsx
@@ -1,0 +1,20 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { DeployPageClient } from '../DeployPageClient';
+import { notFound } from 'next/navigation';
+import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
+
+export default async function DeploymentDetailPage({
+  params,
+}: {
+  params: Promise<{ deploymentId: string }>;
+}) {
+  await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/deploy');
+
+  if (!ENABLE_DEPLOY_FEATURE) {
+    return notFound();
+  }
+
+  const { deploymentId } = await params;
+
+  return <DeployPageClient initialDeploymentId={deploymentId} />;
+}

--- a/src/app/(app)/organizations/[id]/deploy/DeployPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/deploy/DeployPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { DeploymentsList } from '@/components/deployments/DeploymentsList';
 import { DeploymentDetails } from '@/components/deployments/DeploymentDetails';
 import { NewDeploymentDialog } from '@/components/deployments/NewDeploymentDialog';
@@ -9,21 +9,25 @@ import { OrgGitHubAppsProvider } from '@/components/integrations/OrgGitHubAppsPr
 import { Button } from '@/components/Button';
 import { Badge } from '@/components/ui/badge';
 import { ExternalLink, Plus } from 'lucide-react';
+import { useState } from 'react';
 
 type DeployPageClientProps = {
   organizationId: string;
+  initialDeploymentId?: string;
 };
 
-export function DeployPageClient({ organizationId }: DeployPageClientProps) {
-  const [selectedDeploymentId, setSelectedDeploymentId] = useState<string | null>(null);
+export function DeployPageClient({ organizationId, initialDeploymentId }: DeployPageClientProps) {
+  const router = useRouter();
   const [isNewDeploymentOpen, setIsNewDeploymentOpen] = useState(false);
 
+  const basePath = `/organizations/${organizationId}/deploy`;
+
   const handleViewDetails = (deploymentId: string) => {
-    setSelectedDeploymentId(deploymentId);
+    router.push(`${basePath}/${deploymentId}`);
   };
 
   const handleCloseDetails = () => {
-    setSelectedDeploymentId(null);
+    router.push(basePath);
   };
 
   const handleNewDeployment = () => {
@@ -64,10 +68,10 @@ export function DeployPageClient({ organizationId }: DeployPageClientProps) {
 
         <DeploymentsList onViewDetails={handleViewDetails} />
 
-        {selectedDeploymentId && (
+        {initialDeploymentId && (
           <DeploymentDetails
-            deploymentId={selectedDeploymentId}
-            isOpen={selectedDeploymentId !== null}
+            deploymentId={initialDeploymentId}
+            isOpen={true}
             onClose={handleCloseDetails}
           />
         )}

--- a/src/app/(app)/organizations/[id]/deploy/[deploymentId]/page.tsx
+++ b/src/app/(app)/organizations/[id]/deploy/[deploymentId]/page.tsx
@@ -1,0 +1,28 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { DeployPageClient } from '../DeployPageClient';
+import { notFound } from 'next/navigation';
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
+
+export default async function OrgDeploymentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; deploymentId: string }>;
+}) {
+  await getUserFromAuthOrRedirect('/users/sign_in');
+
+  if (!ENABLE_DEPLOY_FEATURE) {
+    return notFound();
+  }
+
+  const { deploymentId } = await params;
+
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={({ organization }) => (
+        <DeployPageClient organizationId={organization.id} initialDeploymentId={deploymentId} />
+      )}
+    />
+  );
+}

--- a/src/components/app-builder/AppBuilderPreview.tsx
+++ b/src/components/app-builder/AppBuilderPreview.tsx
@@ -301,7 +301,20 @@ const statusLabels: Record<BuildStatus, string> = {
   cancelled: 'Cancelled',
 };
 
-function DeploymentControls({ state, onDeploy }: { state: DeploymentState; onDeploy: () => void }) {
+function deploymentPageUrl(organizationId: string | undefined, deploymentId: string) {
+  const base = organizationId ? `/organizations/${organizationId}/deploy` : '/deploy';
+  return `${base}/${deploymentId}`;
+}
+
+function DeploymentControls({
+  state,
+  onDeploy,
+  organizationId,
+}: {
+  state: DeploymentState;
+  onDeploy: () => void;
+  organizationId?: string;
+}) {
   switch (state.kind) {
     case 'creating':
       return (
@@ -313,7 +326,7 @@ function DeploymentControls({ state, onDeploy }: { state: DeploymentState; onDep
     case 'in-progress':
       return (
         <Button size="sm" variant="outline" asChild>
-          <Link href={`/deploy/`} target="_blank">
+          <Link href={deploymentPageUrl(organizationId, state.deploymentId)} target="_blank">
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             {statusLabels[state.buildStatus]}...
           </Link>
@@ -331,7 +344,7 @@ function DeploymentControls({ state, onDeploy }: { state: DeploymentState; onDep
     case 'failed':
       return (
         <Button size="sm" variant="outline" className="text-red-400" asChild>
-          <Link href={`/deploy/`} target="_blank">
+          <Link href={deploymentPageUrl(organizationId, state.deploymentId)} target="_blank">
             <AlertCircle className="mr-2 h-4 w-4" />
             Failed - View Logs
           </Link>
@@ -562,7 +575,11 @@ export const AppBuilderPreview = memo(function AppBuilderPreview({
 
         <div className="flex items-center gap-2">
           {projectId && <CloneDialog projectId={projectId} organizationId={organizationId} />}
-          <DeploymentControls state={deploymentState} onDeploy={handleDeploy} />
+          <DeploymentControls
+            state={deploymentState}
+            onDeploy={handleDeploy}
+            organizationId={organizationId}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Route deploy detail views via URL segments for personal and org pages
- Pass deployment IDs from new [deploymentId] routes into DeployPageClient
- Link preview status actions directly to the deployment detail page