### PR TITLE
Deployments - Send email on build failure

### DIFF
--- a/src/app/api/user-deployments/webhook/route.ts
+++ b/src/app/api/user-deployments/webhook/route.ts
@@ -6,6 +6,9 @@ import { USER_DEPLOYMENTS_API_AUTH_KEY } from '@/lib/config.server';
 import { eq } from 'drizzle-orm';
 import * as z from 'zod';
 import { webhookPayloadSchema, type WebhookPayload } from '@/lib/user-deployments/types';
+import { sendDeploymentFailedEmail } from '@/lib/email';
+import { findUserById } from '@/lib/user';
+import { getOrganizationMembers } from '@/lib/organizations/organizations';
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get('Authorization');
@@ -81,6 +84,14 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           })
           .where(eq(deployments.id, updatedBuild.deployment_id));
       }
+
+      // If failed, send an email notification to the deployment creator
+      const isFailed = lastStatusChangeEvent.payload.status === 'failed';
+      if (isFailed && updatedBuild) {
+        sendDeploymentFailureNotification(updatedBuild.deployment_id).catch(error => {
+          console.error('Failed to send deployment failure email:', error);
+        });
+      }
     }
   } catch (error) {
     console.error('Failed to process deployment events:', error);
@@ -88,4 +99,48 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   return new NextResponse(null, { status: 200 });
+}
+
+async function resolveRecipientEmails(deployment: {
+  created_by_user_id: string | null;
+  owned_by_organization_id: string | null;
+}): Promise<string[]> {
+  // Try the deployment creator first
+  if (deployment.created_by_user_id) {
+    const creator = await findUserById(deployment.created_by_user_id);
+    if (creator) {
+      return [creator.google_user_email];
+    }
+  }
+
+  // Fall back to org owners for org-owned deployments
+  if (deployment.owned_by_organization_id) {
+    const members = await getOrganizationMembers(deployment.owned_by_organization_id);
+    return members.filter(m => m.role === 'owner').map(m => m.email);
+  }
+
+  return [];
+}
+
+async function sendDeploymentFailureNotification(deploymentId: string) {
+  const deployment = await db.query.deployments.findFirst({
+    where: eq(deployments.id, deploymentId),
+  });
+
+  if (!deployment) {
+    return;
+  }
+
+  const emails = await resolveRecipientEmails(deployment);
+
+  await Promise.all(
+    emails.map(email =>
+      sendDeploymentFailedEmail({
+        to: email,
+        deployment_name: deployment.deployment_slug,
+        deployment_url: deployment.deployment_url,
+        repository: deployment.repository_source,
+      })
+    )
+  );
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -52,6 +52,7 @@ const teamplates = {
   ossInviteNewUser: '18',
   ossInviteExistingUser: '19',
   ossExistingOrgProvisioned: '20',
+  deployFailed: '21',
 } as const;
 
 type Template = (typeof teamplates)[keyof typeof teamplates];
@@ -163,6 +164,29 @@ export async function sendAutoTopUpFailedEmail(to: string, props: { reason: stri
     },
     identifiers: {
       email: to,
+    },
+    reply_to: 'hi@kilocode.ai',
+  });
+}
+
+type SendDeploymentFailedEmailProps = {
+  to: string;
+  deployment_name: string;
+  deployment_url: string;
+  repository: string;
+};
+
+export async function sendDeploymentFailedEmail(props: SendDeploymentFailedEmailProps) {
+  return send({
+    transactional_message_id: teamplates.deployFailed,
+    to: props.to,
+    message_data: {
+      deployment_name: props.deployment_name,
+      deployment_url: props.deployment_url,
+      repository: props.repository,
+    },
+    identifiers: {
+      email: props.to,
     },
     reply_to: 'hi@kilocode.ai',
   });


### PR DESCRIPTION
## Summary

- When the deployment webhook handler receives a `failed` status change, sends an email notification via Customer.io
- Recipient resolution: tries `created_by_user_id` first; for org-owned deployments, falls back to org owners if creator is unknown
- Email is fire-and-forget (doesn't block the webhook response)

## Changes

- `src/lib/email.ts`: Added `deployFailed` template ID (placeholder `'21'`) and `sendDeploymentFailedEmail()` function
- `src/app/api/user-deployments/webhook/route.ts`: Added failure detection + `sendDeploymentFailureNotification()` with `resolveRecipientEmails()` helper

## Follow-up

- Create the Customer.io transactional email template with variables: `deployment_name`, `deployment_url`, `repository`
- Update the placeholder template ID `'21'` with the actual one