### PR TITLE
feat: add /install redirect to Kilo CLI install script

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -73,6 +73,12 @@ const nextConfig = {
   redirects: async () => {
     return [
       {
+        source: '/cli/install',
+        destination:
+          'https://raw.githubusercontent.com/Kilo-Org/kilo/refs/heads/dev/install',
+        permanent: false,
+      },
+      {
         source: '/users/sign_up',
         destination: '/get-started',
         permanent: true,


### PR DESCRIPTION
## Summary

- Adds a 302 redirect from `kilo.ai/cli/install` to the raw `install` script on GitHub (`raw.githubusercontent.com/Kilo-Org/kilo/refs/heads/dev/install`)
- Uses temporary (302) redirect so the destination can be changed later without browser cache issues
- Enables `curl -fsSL https://kilo.ai/cli/install | bash` for users

Companion PR: https://github.com/Kilo-Org/kilo/pull/266