### PR TITLE
Deployments - Add explicit createdFrom param for payment check

### DIFF
--- a/src/lib/app-builder/app-builder-service.ts
+++ b/src/lib/app-builder/app-builder-service.ts
@@ -325,6 +325,7 @@ export async function deployProject(
     source,
     branch: 'main',
     createdByUserId,
+    createdFrom: 'app-builder',
   });
 
   if (!result.success) {

--- a/src/lib/user-deployments/deployments-service.ts
+++ b/src/lib/user-deployments/deployments-service.ts
@@ -650,12 +650,13 @@ export async function createDeployment(params: {
   source: DeploymentSource;
   branch: string;
   createdByUserId: string;
+  createdFrom: 'deploy' | 'app-builder';
   envVars?: PlaintextEnvVar[];
 }): Promise<CreateDeploymentResult> {
-  const { owner, source, branch, createdByUserId, envVars } = params;
+  const { owner, source, branch, createdByUserId, createdFrom, envVars } = params;
 
-  // Temporary: skip payment check for app builder sites
-  if (source.type !== 'app-builder') {
+  // App Builder sites are free to deploy; only check payment for the deploy page
+  if (createdFrom !== 'app-builder') {
     const paymentCheck = await checkOwnerHasEverPaid(owner);
     if (!paymentCheck.hasPaid) {
       return {

--- a/src/routers/deployments-router.ts
+++ b/src/routers/deployments-router.ts
@@ -88,6 +88,7 @@ export const deploymentsRouter = createTRPCRouter({
         },
         branch: input.branch,
         createdByUserId: ctx.user.id,
+        createdFrom: 'deploy',
         envVars: input.envVars,
       });
     }),

--- a/src/routers/organizations/organization-deployments-router.ts
+++ b/src/routers/organizations/organization-deployments-router.ts
@@ -125,6 +125,7 @@ export const organizationDeploymentsRouter = createTRPCRouter({
         },
         branch: input.branch,
         createdByUserId: ctx.user.id,
+        createdFrom: 'deploy',
         envVars: input.envVars,
       });
     }),


### PR DESCRIPTION
Replaces the implicit `source.type !== 'app-builder'` check with an explicit `createdFrom` parameter on `createDeployment` to control whether payment validation runs.

- Add `createdFrom: 'deploy' | 'app-builder'` param to `createDeployment`
- App Builder callers pass `createdFrom: 'app-builder'` to skip payment checks
- Deploy page and org deploy routers pass `createdFrom: 'deploy'` to enforce payment checks
- This prevents App Builder sites deployed via the deploy page from bypassing payment validation