### PR TITLE
Remove payment requirement from Emilie Valentine Experiment promo code

### DIFF
--- a/src/lib/promoCreditCategories.ts
+++ b/src/lib/promoCreditCategories.ts
@@ -567,7 +567,6 @@ const encryptedSelfServicePromos: readonly EncryptedSelfServicePromoCreditCatego
     promotion_ends_at: new Date('2026-03-01'),
     description: 'Emilie Valentine Experiment',
     total_redemptions_allowed: 5000,
-    customer_requirement: has_Payment,
   },
   {
     encrypted_credit_category: 'C3wdUIGcWvHqGKkb+S1caw==:y0x+2EPqORv/Cj/0iJRAoQ==:8mc/1wDaNo0=',


### PR DESCRIPTION
## Summary
- Removed the `customer_requirement: has_Payment` constraint from the Emilie Valentine Experiment promo code
- This allows all users to redeem the promo code without needing to have made a payment first

## Changes
- Modified `src/lib/promoCreditCategories.ts` to remove the payment requirement from the promo code (line 570)
- All type checks pass successfully