### PR TITLE
CloudAgent - Add R2 log upload for CLI and wrapper logs

### DIFF
--- a/cloud-agent/src/index.ts
+++ b/cloud-agent/src/index.ts
@@ -212,7 +212,13 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
         if (authResult.userId !== userId) {
           return new Response('Token does not match session user', { status: 403 });
         }
-        await this.env.R2_BUCKET.put(`logs/${sessionId}/${executionId}/${filename}`, request.body);
+        if (!request.body) {
+          return new Response('Missing request body', { status: 400 });
+        }
+        await this.env.R2_BUCKET.put(
+          `logs/${userId}/${sessionId}/${executionId}/${filename}`,
+          request.body
+        );
         return new Response(null, { status: 204 });
       }
 

--- a/cloud-agent/src/index.ts
+++ b/cloud-agent/src/index.ts
@@ -191,7 +191,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
         /^\/sessions\/([^/]+)\/([^/]+)\/logs\/([^/]+)\/([^/]+)$/
       );
       if (logsMatch && request.method === 'PUT') {
-        const allowedFilenames = new Set(['cli.txt', 'wrapper.log']);
+        const allowedFilenames = new Set(['logs.tar.gz']);
         let userId: string, sessionId: string, executionId: string, filename: string;
         try {
           userId = decodeURIComponent(logsMatch[1]);
@@ -216,7 +216,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
           return new Response('Missing request body', { status: 400 });
         }
         await this.env.R2_BUCKET.put(
-          `logs/${userId}/${sessionId}/${executionId}/${filename}`,
+          `logs/${userId}/${sessionId}/${executionId}/logs.tar.gz`,
           request.body
         );
         return new Response(null, { status: 204 });

--- a/cloud-agent/src/queue/consumer-core.ts
+++ b/cloud-agent/src/queue/consumer-core.ts
@@ -30,7 +30,7 @@ import type {
 import type { CloudAgentSession } from '../persistence/CloudAgentSession.js';
 import { SessionService, type PreparedSession } from '../session-service.js';
 import { logger } from '../logger.js';
-import { updateGitRemoteToken } from '../workspace.js';
+import { getKilocodeLogFilePath, updateGitRemoteToken } from '../workspace.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -373,6 +373,7 @@ async function processMessage(msg: ExecutionMessage, env: Env, deps: ConsumerDep
     UPSTREAM_BRANCH: upstreamBranch,
     INGEST_URL: doUrl,
     WORKSPACE_PATH: prepared.context.workspacePath,
+    CLI_LOG_PATH: getKilocodeLogFilePath(prepared.context.sessionHome),
   };
 
   logger.withFields({ promptFile }).info('Starting wrapper process');

--- a/cloud-agent/src/router.test.ts
+++ b/cloud-agent/src/router.test.ts
@@ -282,6 +282,7 @@ describe('router sessionId validation', () => {
                 send: vi.fn().mockResolvedValue(undefined),
               } as unknown as TRPCContext['env']['EXECUTION_QUEUE'],
               NEXTAUTH_SECRET: 'test-secret',
+              R2_BUCKET: {} as unknown as TRPCContext['env']['R2_BUCKET'],
             },
           };
           cloudAgentSession = mockContext.env.CLOUD_AGENT_SESSION as unknown as MockCAS;
@@ -629,6 +630,7 @@ describe('router sessionId validation', () => {
               send: vi.fn().mockResolvedValue(undefined),
             } as unknown as TRPCContext['env']['EXECUTION_QUEUE'],
             NEXTAUTH_SECRET: 'test-secret',
+            R2_BUCKET: {} as unknown as TRPCContext['env']['R2_BUCKET'],
           },
         };
 
@@ -838,6 +840,7 @@ describe('router sessionId validation', () => {
               send: vi.fn().mockResolvedValue(undefined),
             } as unknown as TRPCContext['env']['EXECUTION_QUEUE'],
             NEXTAUTH_SECRET: 'test-secret',
+            R2_BUCKET: {} as unknown as TRPCContext['env']['R2_BUCKET'],
           },
         };
         cloudAgentSession = mockContext.env.CLOUD_AGENT_SESSION as unknown as MockCAS;

--- a/cloud-agent/src/types.ts
+++ b/cloud-agent/src/types.ts
@@ -133,6 +133,8 @@ export type Env = {
    * Used for looking up GitHub installation IDs from the database.
    */
   HYPERDRIVE?: { connectionString: string };
+  /** R2 bucket for object storage */
+  R2_BUCKET: R2Bucket;
 };
 
 /** tRPC context passed to all procedures */

--- a/cloud-agent/wrapper/src/log-uploader.ts
+++ b/cloud-agent/wrapper/src/log-uploader.ts
@@ -19,7 +19,14 @@ type LogUploader = {
   stop: () => void;
 };
 
-function createTarStream(files: Array<string>): ReadableStream<Uint8Array> | undefined {
+const UPLOAD_TIMEOUT_MS = 15_000;
+
+type TarStream = {
+  stream: ReadableStream<Uint8Array>;
+  kill: () => void;
+};
+
+function createTarStream(files: Array<string>): TarStream | undefined {
   const existing = files.filter(f => existsSync(f));
   if (existing.length === 0) return undefined;
 
@@ -40,36 +47,52 @@ function createTarStream(files: Array<string>): ReadableStream<Uint8Array> | und
     if (code !== 0) logToFile(`tar exited with code ${code}: ${stderr}`);
   });
 
-  return new ReadableStream({
+  const stream = new ReadableStream({
     start(controller) {
       stdout.on('data', (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
       stdout.on('end', () => controller.close());
       stdout.on('error', err => controller.error(err));
+      proc.on('error', err => {
+        logToFile(`tar spawn error: ${err.message}`);
+        controller.error(err);
+      });
     },
   });
+
+  return { stream, kill: () => proc.kill() };
 }
 
 export function createLogUploader(opts: LogUploaderOpts): LogUploader {
   let intervalId: ReturnType<typeof setInterval> | undefined;
 
   async function uploadNow(): Promise<void> {
-    try {
-      const stream = createTarStream([opts.cliLogPath, opts.wrapperLogPath]);
-      if (!stream) return;
+    const tar = createTarStream([opts.cliLogPath, opts.wrapperLogPath]);
+    if (!tar) return;
 
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), UPLOAD_TIMEOUT_MS);
+    try {
       const url = `${opts.workerBaseUrl}/sessions/${encodeURIComponent(opts.userId)}/${encodeURIComponent(opts.sessionId)}/logs/${encodeURIComponent(opts.executionId)}/logs.tar.gz`;
       const response = await fetch(url, {
         method: 'PUT',
         headers: { Authorization: `Bearer ${opts.kilocodeToken}` },
-        body: stream,
+        body: tar.stream,
         // @ts-expect-error -- Node/Bun fetch supports duplex for streaming request bodies
         duplex: 'half',
+        signal: abort.signal,
       });
       if (!response.ok) {
         logToFile(`Log upload failed: ${response.status} ${response.statusText}`);
       }
     } catch (error) {
-      logToFile(`Log upload error: ${error instanceof Error ? error.message : String(error)}`);
+      if (abort.signal.aborted) {
+        logToFile(`Log upload timed out after ${UPLOAD_TIMEOUT_MS}ms`);
+      } else {
+        logToFile(`Log upload error: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } finally {
+      clearTimeout(timer);
+      tar.kill();
     }
   }
 

--- a/cloud-agent/wrapper/src/log-uploader.ts
+++ b/cloud-agent/wrapper/src/log-uploader.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { logToFile } from './utils.js';
+
+type LogUploaderOpts = {
+  workerBaseUrl: string;
+  sessionId: string;
+  executionId: string;
+  userId: string;
+  kilocodeToken: string;
+  cliLogPath: string;
+  wrapperLogPath: string;
+};
+
+type LogUploader = {
+  start: (intervalMs?: number) => void;
+  uploadNow: () => Promise<void>;
+  stop: () => void;
+};
+
+function readFileIfExists(path: string): string | undefined {
+  try {
+    const content = readFileSync(path, 'utf-8');
+    return content.length > 0 ? content : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function uploadLogFile(
+  baseUrl: string,
+  userId: string,
+  sessionId: string,
+  executionId: string,
+  token: string,
+  filename: string,
+  content: string
+): Promise<void> {
+  const url = `${baseUrl}/sessions/${encodeURIComponent(userId)}/${encodeURIComponent(sessionId)}/logs/${encodeURIComponent(executionId)}/${filename}`;
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}` },
+    body: content,
+  });
+  if (!response.ok) {
+    logToFile(`Log upload failed for ${filename}: ${response.status} ${response.statusText}`);
+  }
+}
+
+export function createLogUploader(opts: LogUploaderOpts): LogUploader {
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  async function uploadNow(): Promise<void> {
+    try {
+      const uploads: Array<{ filename: string; path: string }> = [
+        { filename: 'cli.txt', path: opts.cliLogPath },
+        { filename: 'wrapper.log', path: opts.wrapperLogPath },
+      ];
+      for (const { filename, path } of uploads) {
+        const content = readFileIfExists(path);
+        if (content === undefined) {
+          continue;
+        }
+        await uploadLogFile(
+          opts.workerBaseUrl,
+          opts.userId,
+          opts.sessionId,
+          opts.executionId,
+          opts.kilocodeToken,
+          filename,
+          content
+        );
+      }
+    } catch (error) {
+      logToFile(`Log upload error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  function start(intervalMs = 30_000): void {
+    stop();
+    intervalId = setInterval(() => {
+      uploadNow().catch(() => {});
+    }, intervalMs);
+  }
+
+  function stop(): void {
+    if (intervalId !== undefined) {
+      clearInterval(intervalId);
+      intervalId = undefined;
+    }
+  }
+
+  return { start, uploadNow, stop };
+}


### PR DESCRIPTION
## Summary

- Adds a new `PUT /sessions/:userId/:sessionId/logs/:executionId/:filename` endpoint to the cloud-agent worker that accepts log file uploads and stores them in R2 under `logs/{sessionId}/{executionId}/{filename}`. The endpoint validates auth tokens and restricts filenames to `cli.txt` and `wrapper.log`.
- Introduces `log-uploader.ts` in the wrapper, which periodically (every 30s) uploads CLI and wrapper log files to R2 via the new endpoint. Final uploads are performed on normal exit, shutdown signals, and fatal errors.
- Passes `CLI_LOG_PATH` env var from the queue consumer to the wrapper process and adds `R2_BUCKET` binding to the `Env` type.