### PR TITLE
use originalModelIdLowerCased instead of reading requestBodyParsed.model

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -357,7 +357,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       mode: request.headers.get('x-kilocode-mode')?.trim() || undefined,
       provider: provider.id,
       requestedModel: requestedModelLowerCased,
-      resolvedModel: requestBodyParsed.model.toLowerCase(),
+      resolvedModel: originalModelIdLowerCased,
       toolsAvailable,
       toolsUsed,
       ttfbMs,


### PR DESCRIPTION
this is because requestBodyParsed gets mutated when applying provider-specific settings