### PR TITLE
AppBuilder - Tag sessions with app-builder platform identifier

### DIFF
--- a/cloud-agent/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent/src/persistence/CloudAgentSession.ts
@@ -670,6 +670,7 @@ export class CloudAgentSession extends DurableObject {
     condenseOnComplete?: boolean;
     appendSystemPrompt?: string;
     upstreamBranch?: string;
+    createdOnPlatform?: string;
     callbackTarget?: CallbackTarget;
     images?: Images;
   }): Promise<OperationResult> {

--- a/cloud-agent/src/persistence/schemas.ts
+++ b/cloud-agent/src/persistence/schemas.ts
@@ -160,7 +160,7 @@ export const MetadataSchema = z.object({
     })
     .optional(),
   upstreamBranch: branchNameSchema.optional(),
-  createdOnPlatform: z.string().optional(),
+  createdOnPlatform: z.string().max(100).optional(),
   kiloSessionId: z.string().uuid().optional(),
 
   // Execution params

--- a/cloud-agent/src/persistence/schemas.ts
+++ b/cloud-agent/src/persistence/schemas.ts
@@ -160,6 +160,7 @@ export const MetadataSchema = z.object({
     })
     .optional(),
   upstreamBranch: branchNameSchema.optional(),
+  createdOnPlatform: z.string().optional(),
   kiloSessionId: z.string().uuid().optional(),
 
   // Execution params

--- a/cloud-agent/src/router/handlers/session-init.ts
+++ b/cloud-agent/src/router/handlers/session-init.ts
@@ -572,6 +572,7 @@ export function createSessionInitHandlers() {
                     setupCommands: metadata.setupCommands,
                     mcpServers: metadata.mcpServers,
                     botId: ctx.botId,
+                    createdOnPlatform: metadata.createdOnPlatform,
                     // Skip linking - backend already linked during prepareSession
                     skipLinking: true,
                     // Pass existing metadata to preserve preparedAt, initiatedAt, prompt, mode, model, autoCommit

--- a/cloud-agent/src/router/handlers/session-prepare.ts
+++ b/cloud-agent/src/router/handlers/session-prepare.ts
@@ -156,7 +156,8 @@ const prepareSessionHandler = internalApiProtectedProcedure
           input.kilocodeOrganizationId,
           input.mode,
           input.model,
-          gitUrlForBackend
+          gitUrlForBackend,
+          input.createdOnPlatform
         );
       } catch (error) {
         logger
@@ -198,6 +199,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
         setupCommands: input.setupCommands,
         mcpServers: input.mcpServers,
         upstreamBranch: input.upstreamBranch,
+        createdOnPlatform: input.createdOnPlatform,
         autoCommit: input.autoCommit,
         condenseOnComplete: input.condenseOnComplete,
         appendSystemPrompt: input.appendSystemPrompt,

--- a/cloud-agent/src/router/schemas.ts
+++ b/cloud-agent/src/router/schemas.ts
@@ -440,6 +440,15 @@ export const PrepareSessionInput = z
       'Optional callback target configuration for execution completion notifications'
     ),
 
+    // Platform identifier
+    createdOnPlatform: z
+      .string()
+      .max(100)
+      .optional()
+      .describe(
+        'Platform identifier for session creation (e.g., "app-builder"). Defaults to "cloud-agent" if not specified.'
+      ),
+
     // Organization context
     kilocodeOrganizationId: z
       .string()

--- a/cloud-agent/src/session-service.ts
+++ b/cloud-agent/src/session-service.ts
@@ -1460,12 +1460,13 @@ export class SessionService {
     organizationId?: string,
     lastMode?: string,
     lastModel?: string,
-    gitUrl?: string
+    gitUrl?: string,
+    createdOnPlatform?: string
   ): Promise<string> {
     const backendUrl = env.KILOCODE_BACKEND_BASE_URL || DEFAULT_BACKEND_URL;
 
     const input = {
-      created_on_platform: 'cloud-agent',
+      created_on_platform: createdOnPlatform ?? 'cloud-agent',
       organization_id: organizationId ?? null,
       cloud_agent_session_id: cloudAgentSessionId,
       version: 2,

--- a/src/lib/app-builder/app-builder-service.ts
+++ b/src/lib/app-builder/app-builder-service.ts
@@ -118,6 +118,7 @@ export async function createProject(input: CreateProjectInput): Promise<CreatePr
       kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,
       images,
       appendSystemPrompt: APP_BUILDER_APPEND_SYSTEM_PROMPT,
+      createdOnPlatform: 'app-builder',
     });
 
     // Save session ID and track it atomically
@@ -510,6 +511,7 @@ export async function sendMessage(input: SendMessageInput): Promise<InitiateSess
         kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,
         images,
         appendSystemPrompt: APP_BUILDER_APPEND_SYSTEM_PROMPT,
+        createdOnPlatform: 'app-builder',
       });
 
       const result = await client.initiateFromKilocodeSessionV2({

--- a/src/lib/cloud-agent/cloud-agent-client.ts
+++ b/src/lib/cloud-agent/cloud-agent-client.ts
@@ -173,6 +173,7 @@ export type PrepareSessionInput = {
   condenseOnComplete?: boolean;
   /** Custom text to append to the system prompt */
   appendSystemPrompt?: string;
+  createdOnPlatform?: string;
   /** Image attachments for the prompt */
   images?: Images;
   /** Callback configuration for execution completion events */

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -27,7 +27,7 @@ export const BLOB_TYPES = [
 ] as const satisfies readonly FileName[];
 
 /** Known platform values that have dedicated filters. "Extension" is everything else. */
-export const KNOWN_PLATFORMS = ['cloud-agent', 'cli', 'agent-manager'] as const;
+export const KNOWN_PLATFORMS = ['cloud-agent', 'cli', 'agent-manager', 'app-builder'] as const;
 
 const PAGE_SIZE = 10;
 


### PR DESCRIPTION
## Summary
- Thread `createdOnPlatform` through the `prepareSession` flow so App Builder sessions are tagged as `'app-builder'` instead of the hardcoded `'cloud-agent'` default.
- Add `'app-builder'` to `KNOWN_PLATFORMS` for filtering in the CLI sessions list.

## Changes
- **cloud-agent/src/router/schemas.ts**: Add `createdOnPlatform` to `PrepareSessionInput` schema (optional string, max 100 chars).
- **cloud-agent/src/persistence/schemas.ts**: Add `createdOnPlatform` to `MetadataSchema`.
- **cloud-agent/src/persistence/CloudAgentSession.ts**: Add `createdOnPlatform` to `prepare()` input type.
- **cloud-agent/src/session-service.ts**: Accept `createdOnPlatform` in `createKiloSessionInBackend()`, defaulting to `'cloud-agent'`.
- **cloud-agent/src/router/handlers/session-prepare.ts**: Pass `createdOnPlatform` to both backend session creation and DO preparation.
- **cloud-agent/src/router/handlers/session-init.ts**: Forward `createdOnPlatform` from metadata into session init options.
- **src/lib/cloud-agent/cloud-agent-client.ts**: Add `createdOnPlatform` to client-side `PrepareSessionInput` type.
- **src/lib/app-builder/app-builder-service.ts**: Set `createdOnPlatform: 'app-builder'` in both `createProject` and `sendMessage` flows.
- **src/routers/cli-sessions-router.ts**: Add `'app-builder'` to `KNOWN_PLATFORMS`.