### PR TITLE
fix(openrouter): strip unsupported models field from requests

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -122,6 +122,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return invalidRequestResponse();
   }
 
+  delete requestBodyParsed.models; // OpenRouter specific field we do not support
   if (!requestBodyParsed.model) {
     return modelDoesNotExistResponse();
   }

--- a/src/lib/providers/openrouter/types.ts
+++ b/src/lib/providers/openrouter/types.ts
@@ -50,6 +50,10 @@ export type OpenRouterChatCompletionRequest = OpenAI.Chat.ChatCompletionCreatePa
   reasoning_split?: boolean;
 
   thinking?: { type?: 'enabled' | 'disabled' };
+
+  // OpenRouter specific field we do not support
+  // https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#request.body.models
+  models?: string[];
 };
 
 export type OpenRouterAssistantMessage = OpenAI.ChatCompletionAssistantMessageParam & {


### PR DESCRIPTION
OpenRouter accepts a 'models' field in chat completion requests that we don't support. Remove this field from the request body before processing to prevent issues with unsupported parameters.