### PR TITLE
fix(auth): support IDP-initiated SSO by disabling OAuth state check for WorkOS

### DIFF
--- a/src/lib/user.server.ts
+++ b/src/lib/user.server.ts
@@ -323,6 +323,7 @@ const authOptions: NextAuthOptions = {
       client: {
         token_endpoint_auth_method: 'client_secret_post',
       },
+      checks: [],
     }),
     // Email provider for magic link authentication using CredentialsProvider
     // We use CredentialsProvider because EmailProvider requires a database adapter,


### PR DESCRIPTION
## Summary
- Adds `checks: []` to the WorkOS OAuth provider config in NextAuth to support IDP-initiated SSO flows
- Without this, IDP-initiated SSO fails because the OAuth state parameter is missing when the IdP initiates the login flow

## Source
Polecat: rust (branch `polecat/rust/hq-cv-6xp6g@mlmwvyry`)
MR: ki-n2f

## Test plan
- [x] Rebased cleanly on main
- [ ] CI checks (build + test) — auto-merge enabled