### PR TITLE
AppBuilder - Prevent git repository corruption on failed pack indexing

### DIFF
--- a/cloudflare-app-builder/package.json
+++ b/cloudflare-app-builder/package.json
@@ -8,6 +8,7 @@
     "deploy": "wrangler deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv worker-configuration.d.ts",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "test:git": "tsx src/_integration_tests/test-git-integration.ts"
   },
   "dependencies": {
@@ -18,13 +19,14 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.9",
     "@cloudflare/containers": "^0.0.30",
     "@cloudflare/sandbox": "0.6.7",
     "@cloudflare/workers-types": "^4.20251014.0",
+    "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.10.1",
     "tsx": "^4.7.0",
     "typescript": "^5.9.3",
+    "vitest": "^4.0.18",
     "wrangler": "^4.61.0"
   }
 }

--- a/cloudflare-app-builder/src/git/git-receive-pack-service.test.ts
+++ b/cloudflare-app-builder/src/git/git-receive-pack-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { deflateSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
+import git from '@ashishkumar472/cf-git';
 import { GitReceivePackService } from './git-receive-pack-service';
 import { MemFS } from './memfs';
 import { MAX_OBJECT_SIZE } from './constants';
@@ -388,5 +389,308 @@ describe('GitReceivePackService', () => {
 
       expect(result.errors.filter(e => e.includes('packfile'))).toHaveLength(0);
     });
+
+    it('reports ng for all refs when packfile exceeds size limit', async () => {
+      const fs = new MemFS();
+      const oversizedPack = new Uint8Array(MAX_OBJECT_SIZE + 1);
+      oversizedPack[0] = 0x50;
+      oversizedPack[1] = 0x41;
+      oversizedPack[2] = 0x43;
+      oversizedPack[3] = 0x4b;
+
+      const requestData = buildPushRequest(
+        [
+          { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' },
+          { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/feature' },
+        ],
+        oversizedPack
+      );
+
+      const { response } = await GitReceivePackService.handleReceivePack(fs, requestData);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('error');
+      expect(status.refs).toEqual([
+        {
+          status: 'ng',
+          refName: 'refs/heads/main',
+          message: expect.stringContaining('Packfile too large'),
+        },
+        {
+          status: 'ng',
+          refName: 'refs/heads/feature',
+          message: expect.stringContaining('Packfile too large'),
+        },
+      ]);
+    });
+
+    it('reports ng for all refs when indexPack fails', async () => {
+      const fs = new MemFS();
+      const requestData = buildPushRequest(
+        [
+          { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' },
+          { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/feature' },
+        ],
+        buildCorruptPackfile()
+      );
+
+      const { response } = await GitReceivePackService.handleReceivePack(fs, requestData);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('error');
+      expect(status.refs).toEqual([
+        {
+          status: 'ng',
+          refName: 'refs/heads/main',
+          message: expect.stringContaining('Failed to index packfile'),
+        },
+        {
+          status: 'ng',
+          refName: 'refs/heads/feature',
+          message: expect.stringContaining('Failed to index packfile'),
+        },
+      ]);
+    });
+  });
+
+  describe('HEAD symbolic ref', () => {
+    it('creates a symbolic HEAD on first push to main', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('hello');
+
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+      expect(result.success).toBe(true);
+
+      // HEAD should be a symbolic ref, not a detached OID
+      const headContent = String(await fs.readFile('.git/HEAD', { encoding: 'utf8' })).trim();
+      expect(headContent).toBe('ref: refs/heads/main');
+
+      // resolveRef should follow the symref to the branch OID
+      const resolved = await git.resolveRef({ fs, dir: '/', ref: 'HEAD' });
+      expect(resolved).toBe(blobOid);
+    });
+
+    it('does not overwrite HEAD on subsequent pushes to main', async () => {
+      const fs = new MemFS();
+      const { packBytes: firstPack, blobOid: firstOid } = buildValidPackfile('first');
+
+      // First push — sets HEAD
+      const firstRequest = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: firstOid, refName: 'refs/heads/main' }],
+        firstPack
+      );
+      await GitReceivePackService.handleReceivePack(fs, firstRequest);
+
+      const headAfterFirst = String(await fs.readFile('.git/HEAD', { encoding: 'utf8' })).trim();
+      expect(headAfterFirst).toBe('ref: refs/heads/main');
+
+      // Second push — HEAD should remain symbolic, not be rewritten
+      const { packBytes: secondPack, blobOid: secondOid } = buildValidPackfile('second');
+      const secondRequest = buildPushRequest(
+        [{ oldOid: firstOid, newOid: secondOid, refName: 'refs/heads/main' }],
+        secondPack
+      );
+      await GitReceivePackService.handleReceivePack(fs, secondRequest);
+
+      const headAfterSecond = String(await fs.readFile('.git/HEAD', { encoding: 'utf8' })).trim();
+      expect(headAfterSecond).toBe('ref: refs/heads/main');
+
+      // HEAD should resolve to the new OID via the symref
+      const resolved = await git.resolveRef({ fs, dir: '/', ref: 'HEAD' });
+      expect(resolved).toBe(secondOid);
+    });
+
+    it('creates symbolic HEAD for master branch too', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('hello');
+
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/master' }],
+        packBytes
+      );
+
+      await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      const headContent = String(await fs.readFile('.git/HEAD', { encoding: 'utf8' })).trim();
+      expect(headContent).toBe('ref: refs/heads/master');
+    });
+
+    it('does not set HEAD when pushing a non-default branch', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('hello');
+
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/feature' }],
+        packBytes
+      );
+
+      await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      // HEAD should not exist — no main/master was pushed
+      await expect(fs.readFile('.git/HEAD')).rejects.toThrow('ENOENT');
+    });
+  });
+
+  describe('generateReportStatus', () => {
+    it('reports unpack ok and ok for all refs when no errors', () => {
+      const commands = [
+        { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' },
+        { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/feature' },
+      ];
+
+      const response = GitReceivePackService.generateReportStatus(commands, []);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('ok');
+      expect(status.refs).toEqual([
+        { status: 'ok', refName: 'refs/heads/main' },
+        { status: 'ok', refName: 'refs/heads/feature' },
+      ]);
+    });
+
+    it('marks all refs ng when a global error exists', () => {
+      const commands = [
+        { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' },
+        { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/feature' },
+      ];
+      const errors = [{ kind: 'global' as const, message: 'Packfile too large' }];
+
+      const response = GitReceivePackService.generateReportStatus(commands, errors);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('error');
+      expect(status.refs).toEqual([
+        { status: 'ng', refName: 'refs/heads/main', message: 'Packfile too large' },
+        { status: 'ng', refName: 'refs/heads/feature', message: 'Packfile too large' },
+      ]);
+    });
+
+    it('marks only the matched ref ng for a per-ref error', () => {
+      const commands = [
+        { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' },
+        { oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/feature' },
+      ];
+      const errors = [
+        { kind: 'ref' as const, refName: 'refs/heads/feature', message: 'object missing' },
+      ];
+
+      const response = GitReceivePackService.generateReportStatus(commands, errors);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('ok');
+      expect(status.refs).toEqual([
+        { status: 'ok', refName: 'refs/heads/main' },
+        { status: 'ng', refName: 'refs/heads/feature', message: 'object missing' },
+      ]);
+    });
+
+    it('global error takes precedence over per-ref status', () => {
+      const commands = [{ oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' }];
+      const errors = [
+        { kind: 'global' as const, message: 'index failed' },
+        { kind: 'ref' as const, refName: 'refs/heads/main', message: 'specific error' },
+      ];
+
+      const response = GitReceivePackService.generateReportStatus(commands, errors);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('error');
+      // Global error should apply to all refs
+      expect(status.refs).toEqual([
+        { status: 'ng', refName: 'refs/heads/main', message: 'index failed' },
+      ]);
+    });
+
+    it('returns unpack ok with no ref lines when commands array is empty', () => {
+      const response = GitReceivePackService.generateReportStatus([], []);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('ok');
+      expect(status.refs).toEqual([]);
+    });
+
+    it('handles global error with empty commands (catch-all path)', () => {
+      const errors = [{ kind: 'global' as const, message: 'Unknown error' }];
+
+      const response = GitReceivePackService.generateReportStatus([], errors);
+      const status = parseReportStatus(response);
+
+      expect(status.unpack).toBe('error');
+      expect(status.refs).toEqual([]);
+    });
   });
 });
+
+// Parse the sideband-wrapped report-status binary response into structured data.
+// Format: each sideband-1 packet contains a pkt-line; lines are "unpack ok/error"
+// followed by "ok <ref>" or "ng <ref> <message>" lines, ending with a flush.
+type RefStatus =
+  | { status: 'ok'; refName: string }
+  | { status: 'ng'; refName: string; message: string };
+
+function parseReportStatus(data: Uint8Array): { unpack: string; refs: RefStatus[] } {
+  const decoder = new TextDecoder();
+  let offset = 0;
+  const lines: string[] = [];
+
+  // Read sideband packets until we hit the final flush (0000)
+  while (offset < data.length) {
+    const hexLen = decoder.decode(data.subarray(offset, offset + 4));
+    if (hexLen === '0000') {
+      offset += 4;
+      // Could be the inner flush (inside sideband) or the outer flush.
+      // If we've already collected lines and the next 4 bytes are also 0000, that's the outer flush.
+      continue;
+    }
+    const pktLen = parseInt(hexLen, 16);
+    if (pktLen === 0 || isNaN(pktLen)) break;
+
+    // byte at offset+4 is the sideband band number
+    const band = data[offset + 4];
+    const payload = data.subarray(offset + 5, offset + pktLen);
+
+    if (band === 1) {
+      // The payload is itself a pkt-line (or flush)
+      const payloadStr = decoder.decode(payload);
+      // Could be a pkt-line "XXXX<content>" or "0000" (inner flush)
+      if (payloadStr === '0000') {
+        offset += pktLen;
+        continue;
+      }
+      const innerHex = payloadStr.substring(0, 4);
+      const innerLen = parseInt(innerHex, 16);
+      if (innerLen > 4) {
+        const line = payloadStr.substring(4, innerLen).replace(/\n$/, '');
+        lines.push(line);
+      }
+    }
+    offset += pktLen;
+  }
+
+  // First line should be "unpack ok" or "unpack error"
+  let unpack = 'unknown';
+  const refs: RefStatus[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('unpack ')) {
+      unpack = line.substring('unpack '.length);
+    } else if (line.startsWith('ok ')) {
+      refs.push({ status: 'ok', refName: line.substring('ok '.length) });
+    } else if (line.startsWith('ng ')) {
+      const rest = line.substring('ng '.length);
+      const spaceIdx = rest.indexOf(' ');
+      refs.push({
+        status: 'ng',
+        refName: rest.substring(0, spaceIdx),
+        message: rest.substring(spaceIdx + 1),
+      });
+    }
+  }
+
+  return { unpack, refs };
+}

--- a/cloudflare-app-builder/src/git/git-receive-pack-service.test.ts
+++ b/cloudflare-app-builder/src/git/git-receive-pack-service.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from 'vitest';
+import { deflateSync } from 'node:zlib';
+import { createHash } from 'node:crypto';
+import { GitReceivePackService } from './git-receive-pack-service';
+import { MemFS } from './memfs';
+import { MAX_OBJECT_SIZE } from './constants';
+
+// Helper to build a git pkt-line push request with a packfile payload
+function buildPushRequest(
+  refs: Array<{ oldOid: string; newOid: string; refName: string }>,
+  packfileBytes: Uint8Array
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+
+  for (let i = 0; i < refs.length; i++) {
+    const { oldOid, newOid, refName } = refs[i];
+    let line = `${oldOid} ${newOid} ${refName}`;
+    if (i === 0) {
+      line += '\0 report-status';
+    }
+    line += '\n';
+    const lengthHex = (line.length + 4).toString(16).padStart(4, '0');
+    chunks.push(encoder.encode(lengthHex + line));
+  }
+
+  // Flush packet
+  chunks.push(encoder.encode('0000'));
+
+  // Append packfile bytes
+  chunks.push(packfileBytes);
+
+  // Concatenate
+  const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+const fakeNewOid = 'a'.repeat(40);
+const zeroOid = '0'.repeat(40);
+
+// A truncated packfile: valid PACK magic so the header scanner finds it,
+// but too short for cf-git's indexPack to parse — causes a real error.
+function buildCorruptPackfile(): Uint8Array {
+  return new Uint8Array([0x50, 0x41, 0x43, 0x4b]); // just "PACK", no version/count
+}
+
+// Build a valid packfile containing a single blob object.
+// cf-git's indexPack will succeed on this and return the blob's OID.
+// The OID is SHA1("blob <size>\0<content>").
+function buildValidPackfile(blobContent: string): { packBytes: Uint8Array; blobOid: string } {
+  const content = Buffer.from(blobContent);
+
+  // Compute the git object OID: SHA1("blob <len>\0<content>")
+  const gitObjectHeader = Buffer.from(`blob ${content.length}\0`);
+  const blobOid = createHash('sha1')
+    .update(Buffer.concat([gitObjectHeader, content]))
+    .digest('hex');
+
+  // PACK header: magic + version 2 + 1 object
+  const header = Buffer.alloc(12);
+  header.write('PACK', 0);
+  header.writeUInt32BE(2, 4);
+  header.writeUInt32BE(1, 8);
+
+  // Object header byte: type=3 (blob) in bits 6-4, size in bits 3-0.
+  // For content <= 15 bytes, no continuation bit needed.
+  if (content.length > 15)
+    throw new Error('buildValidPackfile: content too long for simple header');
+  const objHeader = Buffer.from([(3 << 4) | content.length]);
+
+  // Zlib-deflate the content
+  const deflated = deflateSync(content);
+
+  // Assemble pack body (everything before the checksum)
+  const packBody = Buffer.concat([header, objHeader, deflated]);
+
+  // 20-byte SHA-1 checksum of the body
+  const checksum = createHash('sha1').update(packBody).digest();
+  const packBytes = new Uint8Array(Buffer.concat([packBody, checksum]));
+
+  return { packBytes, blobOid };
+}
+
+describe('GitReceivePackService', () => {
+  describe('parsePktLines', () => {
+    it('parses a single ref update command', () => {
+      const oldOid = 'a'.repeat(40);
+      const newOid = 'b'.repeat(40);
+      const line = `${oldOid} ${newOid} refs/heads/main\0 report-status\n`;
+      const lengthHex = (line.length + 4).toString(16).padStart(4, '0');
+      const pktLine = lengthHex + line + '0000';
+      const data = new TextEncoder().encode(pktLine);
+
+      const { commands, packfileStart } = GitReceivePackService.parsePktLines(data);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toEqual({
+        oldOid,
+        newOid,
+        refName: 'refs/heads/main',
+      });
+      expect(packfileStart).toBe(pktLine.length);
+    });
+
+    it('parses multiple ref update commands', () => {
+      const encoder = new TextEncoder();
+      const chunks: string[] = [];
+
+      const line1 = `${'a'.repeat(40)} ${'b'.repeat(40)} refs/heads/main\0 report-status\n`;
+      chunks.push((line1.length + 4).toString(16).padStart(4, '0') + line1);
+
+      const line2 = `${'c'.repeat(40)} ${'d'.repeat(40)} refs/heads/feature\n`;
+      chunks.push((line2.length + 4).toString(16).padStart(4, '0') + line2);
+
+      chunks.push('0000');
+
+      const data = encoder.encode(chunks.join(''));
+      const { commands } = GitReceivePackService.parsePktLines(data);
+
+      expect(commands).toHaveLength(2);
+      expect(commands[0].refName).toBe('refs/heads/main');
+      expect(commands[1].refName).toBe('refs/heads/feature');
+    });
+
+    it('returns empty commands for flush-only data', () => {
+      const data = new TextEncoder().encode('0000');
+      const { commands, packfileStart } = GitReceivePackService.parsePktLines(data);
+
+      expect(commands).toHaveLength(0);
+      expect(packfileStart).toBe(4);
+    });
+
+    it('ignores malformed lines (too few parts)', () => {
+      const line = `${'a'.repeat(40)} refs/heads/main\n`;
+      const lengthHex = (line.length + 4).toString(16).padStart(4, '0');
+      const pktLine = lengthHex + line + '0000';
+      const data = new TextEncoder().encode(pktLine);
+
+      const { commands } = GitReceivePackService.parsePktLines(data);
+      expect(commands).toHaveLength(0);
+    });
+
+    it('sets packfileStart after flush packet', () => {
+      const line = `${'a'.repeat(40)} ${'b'.repeat(40)} refs/heads/main\n`;
+      const lengthHex = (line.length + 4).toString(16).padStart(4, '0');
+      const pktPart = lengthHex + line;
+      const flush = '0000';
+      const packData = 'PACKsomedata';
+      const full = pktPart + flush + packData;
+      const data = new TextEncoder().encode(full);
+
+      const { packfileStart } = GitReceivePackService.parsePktLines(data);
+      expect(packfileStart).toBe(pktPart.length + flush.length);
+    });
+  });
+
+  describe('handleReceivePack', () => {
+    it('rejects packfiles exceeding MAX_OBJECT_SIZE', async () => {
+      const fs = new MemFS();
+      const oversizedPack = new Uint8Array(MAX_OBJECT_SIZE + 1);
+      oversizedPack[0] = 0x50;
+      oversizedPack[1] = 0x41;
+      oversizedPack[2] = 0x43;
+      oversizedPack[3] = 0x4b;
+
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' }],
+        oversizedPack
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Packfile too large');
+    });
+
+    it('does not update refs when packfile size validation fails', async () => {
+      const fs = new MemFS();
+      const oversizedPack = new Uint8Array(MAX_OBJECT_SIZE + 1);
+      oversizedPack[0] = 0x50;
+      oversizedPack[1] = 0x41;
+      oversizedPack[2] = 0x43;
+      oversizedPack[3] = 0x4b;
+
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' }],
+        oversizedPack
+      );
+
+      await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      await expect(fs.readFile('.git/refs/heads/main')).rejects.toThrow('ENOENT');
+    });
+
+    it('returns early with error on indexPack failure', async () => {
+      const fs = new MemFS();
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' }],
+        buildCorruptPackfile()
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Failed to index packfile');
+    });
+
+    it('does not update refs when indexPack fails', async () => {
+      const fs = new MemFS();
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' }],
+        buildCorruptPackfile()
+      );
+
+      await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      await expect(fs.readFile('.git/refs/heads/main')).rejects.toThrow('ENOENT');
+    });
+
+    it('cleans up .pack file from filesystem on indexPack failure', async () => {
+      const fs = new MemFS();
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: fakeNewOid, refName: 'refs/heads/main' }],
+        buildCorruptPackfile()
+      );
+
+      await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      const packDir = await fs.readdir('.git/objects/pack').catch(() => []);
+      const packFiles = packDir.filter((f: string) => f.endsWith('.pack'));
+      expect(packFiles).toHaveLength(0);
+    });
+
+    it('rejects ref update when newOid is not in the indexed pack', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid: _blobOid } = buildValidPackfile('hello');
+
+      // Push with a ref pointing to an OID that does NOT exist in the pack
+      const bogusOid = 'dead'.repeat(10);
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: bogusOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('does not write ref file when newOid is not in the indexed pack', async () => {
+      const fs = new MemFS();
+      const { packBytes } = buildValidPackfile('hello');
+
+      const bogusOid = 'dead'.repeat(10);
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: bogusOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      // The ref should NOT exist — writing it would corrupt the repo
+      await expect(fs.readFile('.git/refs/heads/main')).rejects.toThrow('ENOENT');
+    });
+
+    it('allows ref update when newOid IS in the indexed pack', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('hello');
+
+      const requestData = buildPushRequest(
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('rejects only the refs with missing OIDs, not the entire push', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('hello');
+
+      const bogusOid = 'dead'.repeat(10);
+      const requestData = buildPushRequest(
+        [
+          { oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/good' },
+          { oldOid: zeroOid, newOid: bogusOid, refName: 'refs/heads/bad' },
+        ],
+        packBytes
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      // The good ref should have been written
+      const goodRef = await fs.readFile('.git/refs/heads/good', { encoding: 'utf8' });
+      expect(String(goodRef)).toContain(blobOid);
+
+      // The bad ref should NOT exist
+      await expect(fs.readFile('.git/refs/heads/bad')).rejects.toThrow('ENOENT');
+
+      // Should report an error for the bad ref
+      expect(result.errors.some(e => e.includes('refs/heads/bad'))).toBe(true);
+    });
+
+    it('handles push with no packfile data (delete-only)', async () => {
+      const fs = new MemFS();
+      await fs.writeFile('.git/refs/heads/feature', fakeNewOid);
+
+      const requestData = buildPushRequest(
+        [{ oldOid: fakeNewOid, newOid: zeroOid, refName: 'refs/heads/feature' }],
+        new Uint8Array(0)
+      );
+
+      const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+
+      expect(result.errors.filter(e => e.includes('packfile'))).toHaveLength(0);
+    });
+  });
+});

--- a/cloudflare-app-builder/vitest.config.ts
+++ b/cloudflare-app-builder/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text'],
+      exclude: ['node_modules/', '**/*.test.ts'],
+    },
+  },
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -32,6 +32,7 @@ const config: Config = {
   testPathIgnorePatterns: [
     '<rootDir>/cloud-agent/',
     '<rootDir>/cloud-agent-next/',
+    '<rootDir>/cloudflare-app-builder/',
     '<rootDir>/cloudflare-webhook-agent-ingest/',
     '<rootDir>/cloudflare-session-ingest/',
     '<rootDir>/kiloclaw/',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 15.5.11(@mdx-js/loader@3.1.1(webpack@5.102.1(@swc/core@1.12.5)(esbuild@0.25.12)))(@mdx-js/react@3.1.1(@types/react@19.2.2)(react@19.2.0))
       '@next/third-parties':
         specifier: ^15.5.10
-        version: 15.5.11(next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 15.5.11(next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@octokit/auth-app':
         specifier: ^8.1.2
         version: 8.1.2
@@ -128,7 +128,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@sentry/nextjs':
         specifier: ^10.29.0
-        version: 10.29.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.102.1(@swc/core@1.12.5)(esbuild@0.25.12))
+        version: 10.29.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.102.1(@swc/core@1.12.5)(esbuild@0.25.12))
       '@sentry/opentelemetry':
         specifier: ^10.29.0
         version: 10.29.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
@@ -212,10 +212,10 @@ importers:
         version: 3.0.6
       jotai:
         specifier: ^2.15.1
-        version: 2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
+        version: 2.15.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
       jotai-minidb:
         specifier: ^0.0.8
-        version: 0.0.8(jotai@2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0))
+        version: 0.0.8(jotai@2.15.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0))
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -233,10 +233,10 @@ importers:
         version: 12.23.24(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next:
         specifier: ^15.5.10
-        version: 15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.24.13(next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       openai:
         specifier: ^6.8.1
         version: 6.8.1(ws@8.18.2)(zod@4.3.4)
@@ -414,7 +414,7 @@ importers:
         version: 4.1.17
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -677,6 +677,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       wrangler:
         specifier: ^4.61.0
         version: 4.61.1(@cloudflare/workers-types@4.20251014.0)
@@ -841,7 +844,7 @@ importers:
         version: 9.0.10
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@22.19.11)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))
+        version: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -4933,9 +4936,6 @@ packages:
   '@speed-highlight/core@1.2.9':
     resolution: {integrity: sha512-4Zxu0O1UN7cfN62Hv5RqcuqcIb93qkIKhl3Mv9gzmFcAf7Ilow/kwS6CXZhvJeAQu8QuyX4kIHUhbag+UfnIxA==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -5593,9 +5593,6 @@ packages:
 
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
-
-  '@types/node@22.19.11':
-    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
   '@types/node@25.2.0':
     resolution: {integrity: sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==}
@@ -12995,20 +12992,44 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
@@ -13025,15 +13046,33 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
@@ -13045,40 +13084,88 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
@@ -14410,7 +14497,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.2.0(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))':
+  '@jest/core@30.2.0(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -14425,7 +14512,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -14885,9 +14972,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@next/third-parties@15.5.11(next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@next/third-parties@15.5.11(next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
-      next: 15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       third-party-capital: 1.0.20
 
@@ -15867,7 +15954,7 @@ snapshots:
 
   '@reduxjs/toolkit@2.9.1(react-redux@9.2.0(@types/react@19.2.2)(react@19.2.0)(redux@5.0.1))(react@19.2.0)':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
       immer: 10.1.3
       redux: 5.0.1
@@ -16164,7 +16251,7 @@ snapshots:
 
   '@sentry/core@10.29.0': {}
 
-  '@sentry/nextjs@10.29.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.102.1(@swc/core@1.12.5)(esbuild@0.25.12))':
+  '@sentry/nextjs@10.29.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(webpack@5.102.1(@swc/core@1.12.5)(esbuild@0.25.12))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -16177,7 +16264,7 @@ snapshots:
       '@sentry/react': 10.29.0(react@19.2.0)
       '@sentry/vercel-edge': 10.29.0
       '@sentry/webpack-plugin': 4.6.1(webpack@5.102.1(@swc/core@1.12.5)(esbuild@0.25.12))
-      next: 15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       resolve: 1.22.8
       rollup: 4.53.3
       stacktrace-parser: 0.1.11
@@ -16676,8 +16763,6 @@ snapshots:
       tslib: 2.8.1
 
   '@speed-highlight/core@1.2.9': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -17702,11 +17787,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.19.11':
-    dependencies:
-      undici-types: 6.21.0
-    optional: true
-
   '@types/node@25.2.0':
     dependencies:
       undici-types: 7.16.0
@@ -17812,10 +17892,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.3
       '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -18756,6 +18836,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@30.2.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 30.2.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.2.0(@babel/core@7.28.4)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-jest@30.2.0(@babel/core@7.28.5):
     dependencies:
       '@babel/core': 7.28.5
@@ -18831,6 +18925,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
+    optional: true
+
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
     dependencies:
       '@babel/core': 7.28.5
@@ -18855,6 +18969,13 @@ snapshots:
       '@babel/core': 7.28.5
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+
+  babel-preset-jest@30.2.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      babel-plugin-jest-hoist: 30.2.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
+    optional: true
 
   babel-preset-jest@30.2.0(@babel/core@7.28.5):
     dependencies:
@@ -20038,8 +20159,8 @@ snapshots:
       '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.1(jiti@2.6.1))
@@ -20062,7 +20183,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -20073,18 +20194,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -20099,7 +20220,7 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-compat-utils: 0.5.1(eslint@9.39.1(jiti@2.6.1))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20110,7 +20231,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -21476,15 +21597,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.2.0(@types/node@22.19.11)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3)):
+  jest-cli@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))
+      '@jest/core': 30.2.0(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@22.19.11)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -21625,7 +21746,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -21654,12 +21775,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
       esbuild-register: 3.6.0(esbuild@0.27.0)
-      ts-node: 10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@22.19.11)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -21686,9 +21807,9 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       esbuild-register: 3.6.0(esbuild@0.27.0)
-      ts-node: 10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22274,12 +22395,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.2.0(@types/node@22.19.11)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3)):
+  jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))
+      '@jest/core': 30.2.0(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@22.19.11)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3))
+      jest-cli: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.0))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22305,15 +22426,15 @@ snapshots:
 
   jose@6.1.3: {}
 
-  jotai-minidb@0.0.8(jotai@2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)):
+  jotai-minidb@0.0.8(jotai@2.15.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)):
     dependencies:
       '@rocicorp/resolver': 1.0.2
       idb-keyval: 6.2.2
-      jotai: 2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
+      jotai: 2.15.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0)
 
-  jotai@2.15.1(@babel/core@7.28.5)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0):
+  jotai@2.15.1(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.2.2)(react@19.2.0):
     optionalDependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.4
       '@babel/template': 7.27.2
       '@types/react': 19.2.2
       react: 19.2.0
@@ -23235,13 +23356,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@4.24.13(next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next-auth@4.24.13(next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.28.3
@@ -23249,6 +23370,31 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       uuid: 8.3.2
+
+  next@15.5.11(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 15.5.11
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001760
+      postcss: 8.4.31
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.7
+      '@next/swc-darwin-x64': 15.5.7
+      '@next/swc-linux-arm64-gnu': 15.5.7
+      '@next/swc-linux-arm64-musl': 15.5.7
+      '@next/swc-linux-x64-gnu': 15.5.7
+      '@next/swc-linux-x64-musl': 15.5.7
+      '@next/swc-win32-arm64-msvc': 15.5.7
+      '@next/swc-win32-x64-msvc': 15.5.7
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.57.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   next@15.5.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -24992,6 +25138,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
+  styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.2.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.0
+    optionalDependencies:
+      '@babel/core': 7.28.4
+
   styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.0):
     dependencies:
       client-only: 0.0.1
@@ -25158,12 +25311,12 @@ snapshots:
       '@ts-graphviz/common': 2.1.5
       '@ts-graphviz/core': 2.0.7
 
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3))
+      jest: 30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25172,19 +25325,19 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.4
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.5)
+      babel-jest: 30.2.0(@babel/core@7.28.4)
       esbuild: 0.25.12
       jest-util: 30.2.0
 
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25242,14 +25395,14 @@ snapshots:
       '@swc/core': 1.12.5
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.12.5)(@types/node@22.19.11)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.12.5)(@types/node@25.2.3)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -25373,7 +25526,7 @@ snapshots:
 
   typescript-eslint@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- **Early return on indexPack failure**: `handleReceivePack` now returns an error response immediately when `indexPack` throws, instead of silently continuing to apply ref updates against corrupt/missing objects.
- **Packfile cleanup**: On `indexPack` failure, both the `.pack` and `.idx` artifacts are removed to avoid leaving partial data in the repository.
- **OID validation for ref updates**: Captures the OIDs returned by `indexPack` and rejects any ref update whose target OID was not actually indexed. This catches cases where `cf-git` silently skips corrupt objects during indexing.
- **Structured error logging**: `indexPack` failures now log packfile size, pack path, affected ref names, and error stack.
- **Tests**: 15 vitest unit tests covering pack indexing failure, corrupted packfiles, OID mismatch, oversized packs, and normal push flows. Uses real `cf-git` indexPack and real MemFS (no mocks).