### PR TITLE
fix(security-agent): use org-aware URLs for cloud chat session links

### DIFF
--- a/src/components/security-agent/AnalysisJobsCard.tsx
+++ b/src/components/security-agent/AnalysisJobsCard.tsx
@@ -302,7 +302,11 @@ export function AnalysisJobsCard({ organizationId, onGitHubError }: AnalysisJobs
                   {job.cli_session_id && (
                     <div className="mt-1">
                       <Link
-                        href={`/cloud/chat?sessionId=${job.cli_session_id}`}
+                        href={
+                          organizationId
+                            ? `/organizations/${organizationId}/cloud/chat?sessionId=${job.cli_session_id}`
+                            : `/cloud/chat?sessionId=${job.cli_session_id}`
+                        }
                         className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
                       >
                         <ExternalLink className="h-3 w-3" />

--- a/src/components/security-agent/FindingDetailDialog.tsx
+++ b/src/components/security-agent/FindingDetailDialog.tsx
@@ -264,7 +264,11 @@ export function FindingDetailDialog({
                 {cliSessionId && (
                   <div className="mt-2">
                     <Link
-                      href={`/cloud/chat?sessionId=${cliSessionId}`}
+                      href={
+                        organizationId
+                          ? `/organizations/${organizationId}/cloud/chat?sessionId=${cliSessionId}`
+                          : `/cloud/chat?sessionId=${cliSessionId}`
+                      }
                       className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm transition-colors"
                     >
                       <ExternalLink className="h-4 w-4" />
@@ -306,7 +310,11 @@ export function FindingDetailDialog({
                 {cliSessionId && (
                   <div className="mt-2">
                     <Link
-                      href={`/cloud/chat?sessionId=${cliSessionId}`}
+                      href={
+                        organizationId
+                          ? `/organizations/${organizationId}/cloud/chat?sessionId=${cliSessionId}`
+                          : `/cloud/chat?sessionId=${cliSessionId}`
+                      }
                       className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
                     >
                       <ExternalLink className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- Session links in `AnalysisJobsCard` and `FindingDetailDialog` were hardcoded to `/cloud/chat?sessionId=...` (the personal route), causing the app to switch from the org profile to the personal profile when clicked from the Security Agent pages.
- Updated all 3 link instances to use the `organizationId` prop (already available) to build org-aware URLs, matching the pattern used throughout the rest of the codebase.

## Files Changed
- `src/components/security-agent/AnalysisJobsCard.tsx` — 1 link
- `src/components/security-agent/FindingDetailDialog.tsx` — 2 links