### PR TITLE
fix: reset isSessionInitiated in preflight to prevent sendMessageV2 on non-initiated sessions

### DIFF
--- a/src/components/cloud-agent/CloudChatContainer.tsx
+++ b/src/components/cloud-agent/CloudChatContainer.tsx
@@ -452,6 +452,10 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
     preflightedCloudAgentSessionRef.current = cloudAgentSessionId;
     setNeedsLegacyPrepare(false);
     setPreflightComplete(false);
+    // Reset to false so the DO's initiatedAt is the authoritative source.
+    // Without this, hasSessionBlobs() can eagerly set it to true during DB load
+    // even when the DO has not been initiated (e.g. prepared-but-not-initiated sessions).
+    setIsSessionInitiated(false);
 
     const runPreflight = async () => {
       try {


### PR DESCRIPTION
## Summary

Fixes a bug where sending a follow-up message to certain Cloud agent sessions (notably those created by the Security agent) fails with **"Session has not been initiated yet"** (HTTP 500 / `INTERNAL_SERVER_ERROR`).

## Root Cause Investigation

### Symptom

When viewing an older Cloud agent session (created via Security agent analysis) at `/organizations/{orgId}/cloud/chat?sessionId={id}` and sending a new message, the `sendMessageV2` tRPC call returns:

```json
{
  "error": {
    "message": "Session has not been initiated yet",
    "code": -32603,
    "data": { "code": "INTERNAL_SERVER_ERROR" }
  }
}
```

### How sessions are created

Security agent sessions are created via the **V1 `initiateSessionStream`** flow in the `cloud-agent` worker. This flow:
- Creates a Durable Object (DO) with session metadata
- Does **NOT** set `preparedAt` or `initiatedAt` on the DO metadata (these fields are part of the newer V2 prepare/initiate flow)
- The Kilo CLI execution completes and syncs blob URLs (`ui_messages_blob_url`, `api_conversation_history_blob_url`, etc.) to the `cli_sessions` DB record

### The state inconsistency

At some point (likely a previous visit to this session), the `prepareLegacySession` endpoint was called, which set `preparedAt` on the DO. However, the subsequent `initiateFromPreparedSession` call either failed or was interrupted, leaving the DO in a **prepared-but-not-initiated** state:

```
DO metadata: { preparedAt: 1771193381593, initiatedAt: undefined }
DB record:   { blob URLs: all set, last_model: "anthropic/claude-sonnet-4.5" }
```

### The bug: two conflicting sources of truth for `isSessionInitiated`

When loading an existing session, two code paths independently set `isSessionInitiated`:

1. **DB load effect (line 391)** — eagerly sets `isSessionInitiated = true` based on whether blob URLs exist via `hasSessionBlobs()`:
   ```ts
   setIsSessionInitiated(hasSessionBlobs(sessionData));
   ```
   Since all 4 blob URLs are present, this sets `isSessionInitiated = true`.

2. **Preflight effect (line 442–479)** — queries the DO's `getSession` endpoint and is supposed to be the authoritative check:
   ```ts
   if (session.initiatedAt) {
     setIsSessionInitiated(true);  // only ever sets to true, never false!
   }
   ```
   Since `initiatedAt` is missing, this branch is skipped — but `isSessionInitiated` remains `true` from step 1.

### How this leads to the error

With `isSessionInitiated = true` (from blobs) and `needsLegacyPrepare = false` (because `preparedAt` exists):

1. **Chat input**: `(cloudAgentSessionId && !isSessionInitiated)` → `false` → input is **enabled**
2. **`handleSendMessage`**: `needsLegacyPrepare` is `false` → skips the legacy prepare + initiate path → falls through to `sendMessageV2`
3. **DO**: checks `metadata.initiatedAt` → missing → returns `"Session has not been initiated yet"`

### Why some sessions work and others don't

- **Working sessions** (newer): Created via V2 prepare/initiate flow → DO has both `preparedAt` and `initiatedAt` → preflight confirms `isSessionInitiated = true` → `sendMessageV2` succeeds
- **Broken sessions** (older, security agent): Created via V1 flow → DO has `preparedAt` (from a previous legacy prepare attempt) but no `initiatedAt` → preflight doesn't override the eager blob-based `isSessionInitiated = true` → `sendMessageV2` fails

## Fix

Reset `isSessionInitiated` to `false` at the start of the preflight effect, alongside the existing `needsLegacyPrepare` and `preflightComplete` resets. This makes the DO's `initiatedAt` the authoritative source for whether the chat input is enabled.

```ts
preflightedCloudAgentSessionRef.current = cloudAgentSessionId;
setNeedsLegacyPrepare(false);
setPreflightComplete(false);
setIsSessionInitiated(false);  // ← added
```

For properly initiated sessions, the preflight completes quickly and re-enables the input. There may be a brief "Initializing session..." placeholder visible while the preflight `getSession` call is in flight, which is correct behavior — the input is now properly gated on the DO confirming session state.

For broken sessions (prepared but not initiated), the input stays disabled and the auto-initiation or legacy prepare flow handles the session correctly.

## Verification

Confirmed via production data:

- **DB query**: Session has all 4 blob URLs set (triggering `hasSessionBlobs() = true`)
- **DO query**: `preparedAt` is set but `initiatedAt` is missing — confirming the prepared-but-not-initiated state