### PR TITLE
CloudAgent - Fix session.idle handling for child sessions

### DIFF
--- a/cloud-agent-next/test/unit/wrapper/connection.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/connection.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for connection module.
+ *
+ * Tests the isSessionIdleEvent type guard and session.idle filtering logic.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isSessionIdleEvent } from '../../../wrapper/src/connection.js';
+
+// ---------------------------------------------------------------------------
+// isSessionIdleEvent
+// ---------------------------------------------------------------------------
+
+describe('isSessionIdleEvent', () => {
+  it('returns true for a valid session.idle event with sessionID', () => {
+    const data = {
+      event: 'session.idle',
+      properties: { sessionID: 'sess_root_123' },
+    };
+    expect(isSessionIdleEvent(data)).toBe(true);
+  });
+
+  it('narrows properties.sessionID to string', () => {
+    const data: unknown = {
+      event: 'session.idle',
+      properties: { sessionID: 'sess_abc' },
+    };
+    if (isSessionIdleEvent(data)) {
+      // TypeScript should narrow this — verify at runtime
+      expect(data.properties.sessionID).toBe('sess_abc');
+    } else {
+      expect.unreachable('should have matched');
+    }
+  });
+
+  it('returns false when event is not session.idle', () => {
+    const data = {
+      event: 'message.updated',
+      properties: { sessionID: 'sess_123' },
+    };
+    expect(isSessionIdleEvent(data)).toBe(false);
+  });
+
+  it('returns false when data is null', () => {
+    expect(isSessionIdleEvent(null)).toBe(false);
+  });
+
+  it('returns false when data is not an object', () => {
+    expect(isSessionIdleEvent('session.idle')).toBe(false);
+    expect(isSessionIdleEvent(42)).toBe(false);
+    expect(isSessionIdleEvent(undefined)).toBe(false);
+  });
+
+  it('returns false when properties is missing', () => {
+    const data = { event: 'session.idle' };
+    expect(isSessionIdleEvent(data)).toBe(false);
+  });
+
+  it('returns false when properties is null', () => {
+    const data = { event: 'session.idle', properties: null };
+    expect(isSessionIdleEvent(data)).toBe(false);
+  });
+
+  it('returns false when sessionID is missing from properties', () => {
+    const data = { event: 'session.idle', properties: {} };
+    expect(isSessionIdleEvent(data)).toBe(false);
+  });
+
+  it('returns false when sessionID is not a string', () => {
+    const data = { event: 'session.idle', properties: { sessionID: 123 } };
+    expect(isSessionIdleEvent(data)).toBe(false);
+  });
+});

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -89,7 +89,9 @@ function isMessageUpdatedEvent(
   if (!isRecord(data)) return false;
   if (data.event !== 'message.updated') return false;
   const props = data.properties;
-  return isRecord(props) && isRecord(props.info);
+  if (!isRecord(props)) return false;
+  const info = props.info;
+  return isRecord(info) && typeof info.role === 'string' && isRecord(info.time);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Filter `session.idle` events by `sessionID` so only the root session's idle event triggers job completion — child sessions (subagents) are now ignored.
- Add `isSessionIdleEvent` type guard with backwards-compatible fallback for payloads missing `sessionID`.
- Add unit tests for the new type guard covering valid events, invalid shapes, and edge cases.