### PR TITLE
Organization Switcher skeleton loader

### DIFF
--- a/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Check, ChevronDown } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
@@ -51,7 +52,17 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
   if (isLoading) {
     return (
       <div className="mt-1">
-        <div className="h-[62px] w-full animate-pulse rounded-lg border border-gray-700 bg-gray-800" />
+        <Button
+          variant="ghost"
+          disabled
+          className="h-auto w-full justify-between rounded-lg border border-gray-700 p-3 text-left"
+        >
+          <div className="flex flex-col items-start">
+            <Skeleton className="h-5 w-24" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+          <ChevronDown className="h-4 w-4 text-gray-500" />
+        </Button>
       </div>
     );
   }

--- a/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -48,7 +48,7 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
   const currentOrg = organizations?.find(org => org.organizationId === organizationId);
   const hasOrganizations = organizations && organizations.length > 0;
 
-  // Show loading skeleton while fetching (only when no cached data)
+  // Show loading skeleton on initial load (before any data is available)
   if (isPending) {
     return (
       <div className="mt-1">

--- a/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -23,7 +23,15 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
   const router = useRouter();
 
   // Fetch user organizations
-  const { data: organizations, isPending } = useQuery(trpc.organizations.list.queryOptions());
+  const { data: organizations, isPending } = useQuery(
+    trpc.organizations.list.queryOptions(undefined, {
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+    })
+  );
 
   const handleOrganizationSwitch = (orgId: string | null) => {
     if (orgId) {

--- a/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -22,7 +22,7 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
   const router = useRouter();
 
   // Fetch user organizations
-  const { data: organizations } = useQuery(trpc.organizations.list.queryOptions());
+  const { data: organizations, isLoading } = useQuery(trpc.organizations.list.queryOptions());
 
   const handleOrganizationSwitch = (orgId: string | null) => {
     if (orgId) {
@@ -46,6 +46,15 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
 
   const currentOrg = organizations?.find(org => org.organizationId === organizationId);
   const hasOrganizations = organizations && organizations.length > 0;
+
+  // Show loading skeleton while fetching
+  if (isLoading) {
+    return (
+      <div className="mt-1">
+        <div className="h-[62px] w-full animate-pulse rounded-lg border border-gray-700 bg-gray-800" />
+      </div>
+    );
+  }
 
   // Don't render if no organizations
   if (!hasOrganizations) {

--- a/src/app/(app)/components/OrganizationSwitcher.tsx
+++ b/src/app/(app)/components/OrganizationSwitcher.tsx
@@ -23,7 +23,7 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
   const router = useRouter();
 
   // Fetch user organizations
-  const { data: organizations, isLoading } = useQuery(trpc.organizations.list.queryOptions());
+  const { data: organizations, isPending } = useQuery(trpc.organizations.list.queryOptions());
 
   const handleOrganizationSwitch = (orgId: string | null) => {
     if (orgId) {
@@ -48,8 +48,8 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
   const currentOrg = organizations?.find(org => org.organizationId === organizationId);
   const hasOrganizations = organizations && organizations.length > 0;
 
-  // Show loading skeleton while fetching
-  if (isLoading) {
+  // Show loading skeleton while fetching (only when no cached data)
+  if (isPending) {
     return (
       <div className="mt-1">
         <Button
@@ -57,8 +57,8 @@ export default function OrganizationSwitcher({ organizationId = null }: Organiza
           disabled
           className="h-auto w-full justify-between rounded-lg border border-gray-700 p-3 text-left"
         >
-          <div className="flex flex-col items-start">
-            <Skeleton className="h-5 w-24" />
+          <div className="flex flex-col items-start gap-1">
+            <Skeleton className="h-4 w-24" />
             <Skeleton className="h-4 w-16" />
           </div>
           <ChevronDown className="h-4 w-4 text-gray-500" />

--- a/src/app/(app)/components/PrefetchedOrganizations.tsx
+++ b/src/app/(app)/components/PrefetchedOrganizations.tsx
@@ -1,0 +1,29 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { createCallerFactory, createTRPCContext } from '@/lib/trpc/init';
+import { rootRouter } from '@/routers/root-router';
+
+const createCaller = createCallerFactory(rootRouter);
+
+/**
+ * Server component that prefetches the organizations list on the server,
+ * so the OrganizationSwitcher can render immediately without a loading skeleton.
+ *
+ * The query key must match what tRPC generates for `trpc.organizations.list.queryOptions()`.
+ * Verified with @trpc/tanstack-react-query@^11.9.0 — key format: [["organizations", "list"], { type: "query" }]
+ * If this breaks after a tRPC upgrade, check the key with `trpc.organizations.list.queryKey()` in a client component.
+ */
+export async function PrefetchedOrganizations({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient();
+
+  try {
+    const ctx = await createTRPCContext();
+    const caller = createCaller(ctx);
+    const organizations = await caller.organizations.list();
+    queryClient.setQueryData([['organizations', 'list'], { type: 'query' }], organizations);
+  } catch {
+    // If prefetch fails (e.g. user not authenticated), just render children without prefetched data.
+    // The client-side query will handle fetching.
+  }
+
+  return <HydrationBoundary state={dehydrate(queryClient)}>{children}</HydrationBoundary>;
+}

--- a/src/app/(app)/components/PrefetchedOrganizations.tsx
+++ b/src/app/(app)/components/PrefetchedOrganizations.tsx
@@ -1,27 +1,25 @@
+import type { ReactNode } from 'react';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
-import { createCallerFactory, createTRPCContext } from '@/lib/trpc/init';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import { createTRPCContext } from '@/lib/trpc/init';
 import { rootRouter } from '@/routers/root-router';
 
-const createCaller = createCallerFactory(rootRouter);
-
 /**
- * Server component that prefetches the organizations list on the server,
- * so the OrganizationSwitcher can render immediately without a loading skeleton.
+ * Server component that prefetches the organizations list during SSR,
+ * so the OrganizationSwitcher renders immediately without a loading skeleton.
  *
- * The query key must match what tRPC generates for `trpc.organizations.list.queryOptions()`.
- * Verified with @trpc/tanstack-react-query@^11.9.0 — key format: [["organizations", "list"], { type: "query" }]
- * If this breaks after a tRPC upgrade, check the key with `trpc.organizations.list.queryKey()` in a client component.
+ * Uses tRPC's createTRPCOptionsProxy to generate the correct query key,
+ * matching what the client-side `trpc.organizations.list.queryOptions()` produces.
  */
-export async function PrefetchedOrganizations({ children }: { children: React.ReactNode }) {
+export async function PrefetchedOrganizations({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient();
 
   try {
     const ctx = await createTRPCContext();
-    const caller = createCaller(ctx);
-    const organizations = await caller.organizations.list();
-    queryClient.setQueryData([['organizations', 'list'], { type: 'query' }], organizations);
+    const trpc = createTRPCOptionsProxy({ router: rootRouter, ctx, queryClient });
+    await queryClient.prefetchQuery(trpc.organizations.list.queryOptions());
   } catch {
-    // If prefetch fails (e.g. user not authenticated), just render children without prefetched data.
+    // If prefetch fails (e.g. user not authenticated), render children without prefetched data.
     // The client-side query will handle fetching.
   }
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,23 +3,26 @@ import AppSidebar from './components/AppSidebar';
 import { SidebarProvider, SidebarTrigger, SidebarInset } from '@/components/ui/sidebar';
 import { RoleTestingProvider } from '@/contexts/RoleTestingContext';
 import { AdminOmnibox } from '@/components/admin-omnibox';
+import { PrefetchedOrganizations } from './components/PrefetchedOrganizations';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <RoleTestingProvider>
       <SidebarProvider>
-        <div className="flex min-h-screen w-full">
-          <AppSidebar />
-          <SidebarInset>
-            {/* Mobile header with sidebar trigger */}
-            <header className="bg-background sticky top-0 z-10 flex h-18 items-center justify-between gap-4 border-b p-4 md:hidden">
-              <AnimatedLogo />
-              <SidebarTrigger />
-            </header>
-            {/* Main content */}
-            <main className="bg-background w-full flex-1">{children}</main>
-          </SidebarInset>
-        </div>
+        <PrefetchedOrganizations>
+          <div className="flex min-h-screen w-full">
+            <AppSidebar />
+            <SidebarInset>
+              {/* Mobile header with sidebar trigger */}
+              <header className="bg-background sticky top-0 z-10 flex h-18 items-center justify-between gap-4 border-b p-4 md:hidden">
+                <AnimatedLogo />
+                <SidebarTrigger />
+              </header>
+              {/* Main content */}
+              <main className="bg-background w-full flex-1">{children}</main>
+            </SidebarInset>
+          </div>
+        </PrefetchedOrganizations>
       </SidebarProvider>
       <AdminOmnibox />
     </RoleTestingProvider>

--- a/src/hooks/useUrlOrganizationId.ts
+++ b/src/hooks/useUrlOrganizationId.ts
@@ -1,24 +1,20 @@
 import { usePathname } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
+
+const ORG_PATH_REGEX =
+  /^\/organizations\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
 
 /**
  * Hook to extract organization ID from the current URL pathname.
  * Returns null if not viewing an organization page.
+ *
+ * Uses useMemo (not useEffect) so the org ID is available on the first render,
+ * avoiding a flash of "Personal Workspace" before the org name appears.
  */
 export function useUrlOrganizationId(): string | null {
   const pathname = usePathname();
-  const [currentOrgId, setCurrentOrgId] = useState<string | null>(null);
-
-  useEffect(() => {
-    const orgMatch = pathname.match(
-      /^\/organizations\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
-    );
-    if (orgMatch) {
-      setCurrentOrgId(orgMatch[1]);
-    } else {
-      setCurrentOrgId(null);
-    }
+  return useMemo(() => {
+    const orgMatch = pathname.match(ORG_PATH_REGEX);
+    return orgMatch ? orgMatch[1] : null;
   }, [pathname]);
-
-  return currentOrgId;
 }


### PR DESCRIPTION
## Summary
The OrganizationSwitcher in the sidebar was taking randomly a long time to load. Navigating to an organization page also briefly flashed "Personal Workspace" before showing the correct org name.

## Changes
- Show skeleton UI while organizations list is loading
- Prevents layout shift by matching skeleton dimensions to actual button
- Uses existing Skeleton component from UI library
- Server-side prefetch (PrefetchedOrganizations.tsx): New server component that prefetches the org list during SSR via tRPC server caller + React Query's HydrationBoundary. The OrganizationSwitcher now renders with data immediately instead of showing a skeleton.
- Synchronous URL parsing (useUrlOrganizationId.ts): Replaced useState/useEffect with useMemo so the org ID is available on the first render, eliminating the "Personal Workspace" flash.
- Layout integration (layout.tsx): Wrapped the app sidebar content with PrefetchedOrganizations.

## Root Causes
- Client-side waterfall: The organizations.list query only fired after the client-side React tree mounted, causing a visible loading state on every page navigation.
- Deferred URL parsing: useUrlOrganizationId used useState + useEffect to extract the org ID from the URL, so organizationId was null on the first render — causing a flash of "Personal Workspace".
