### PR TITLE
feat(kiloclaw): per-user Fly apps with network isolation

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -11,15 +11,12 @@ WORKER_ENV=development
 # KILOCODE_API_BASE_URL=https://api.kilo.ai/api/openrouter/
 
 # Fly.io Machines API
-# Get an org-scoped token: fly tokens create org
+# Get a token (run: `fly tokens create some-name-for-this-dev-token`)
 FLY_API_TOKEN=fo1_...
 # Your Fly org slug (run: `fly orgs list`)
 FLY_ORG_SLUG=personal
 # Shared Docker image registry app (images are pushed here, referenced by all per-user apps)
 FLY_REGISTRY_APP=kiloclaw-machines-dev
-# Legacy fallback for existing instances without per-user apps.
-# New instances get per-user apps (acct-{hash}) created automatically.
-FLY_APP_NAME=kiloclaw-machines
 # Default region for new users. Comma-separated priority list of region codes or aliases.
 # Fly tries the first region, falls back to the next if unavailable.
 # Examples: "us,eu" (try US first, then Europe), "lhr,fra" (London first, then Frankfurt)
@@ -29,6 +26,10 @@ FLY_REGION=us,eu
 # In dev, use "latest" or run scripts/push-dev.sh which sets a timestamped tag.
 # In production, pin to a version (e.g., v40, sha-abc1234).
 FLY_IMAGE_TAG=latest
+
+# Legacy fallback for existing instances without per-user apps.
+# New instances get per-user apps (acct-{hash}) created automatically.
+FLY_APP_NAME=kiloclaw-machines
 
 # Allowed origins for the OpenClaw Control UI WebSocket (comma-separated).
 # Must include the origins that the browser connects from.

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -13,7 +13,7 @@ WORKER_ENV=development
 # Fly.io Machines API
 # Get an org-scoped token: fly tokens create org
 FLY_API_TOKEN=fo1_...
-# Your Fly org slug (run: fly orgs list)
+# Your Fly org slug (run: `fly orgs list`)
 FLY_ORG_SLUG=personal
 # Shared Docker image registry app (images are pushed here, referenced by all per-user apps)
 FLY_REGISTRY_APP=kiloclaw-machines-dev

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -11,15 +11,21 @@ WORKER_ENV=development
 # KILOCODE_API_BASE_URL=https://api.kilo.ai/api/openrouter/
 
 # Fly.io Machines API
-# Get your API token from: https://fly.io/docs/flyctl/tokens/
+# Get an org-scoped token: fly tokens create org
 FLY_API_TOKEN=fo1_...
+# Your Fly org slug (run: fly orgs list)
+FLY_ORG_SLUG=personal
+# Shared Docker image registry app (images are pushed here, referenced by all per-user apps)
+FLY_REGISTRY_APP=kiloclaw-machines-dev
+# Legacy fallback for existing instances without per-user apps.
+# New instances get per-user apps (acct-{hash}) created automatically.
 FLY_APP_NAME=kiloclaw-machines
 # Default region for new users. Comma-separated priority list of region codes or aliases.
 # Fly tries the first region, falls back to the next if unavailable.
 # Examples: "us,eu" (try US first, then Europe), "lhr,fra" (London first, then Frankfurt)
 # The platform API can override per-user at provision time.
 FLY_REGION=us,eu
-# Docker image tag on registry.fly.io/{FLY_APP_NAME}:{tag}.
+# Docker image tag on registry.fly.io/{FLY_REGISTRY_APP}:{tag}.
 # In dev, use "latest" or run scripts/push-dev.sh which sets a timestamped tag.
 # In production, pin to a version (e.g., v40, sha-abc1234).
 FLY_IMAGE_TAG=latest

--- a/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for KiloClawApp DO.
+ *
+ * Mocks cloudflare:workers and the fly/apps module.
+ * Verifies idempotent app creation, IP allocation, alarm retry,
+ * and destroy behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// -- Mock cloudflare:workers --
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class FakeDurableObject {
+    ctx: { storage: unknown };
+    env: unknown;
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx as { storage: unknown };
+      this.env = env;
+    }
+  },
+}));
+
+// -- Mock fly/apps --
+vi.mock('../fly/apps', async () => {
+  const { appNameFromUserId } = await vi.importActual('../fly/apps');
+  return {
+    appNameFromUserId,
+    createApp: vi.fn().mockResolvedValue({ id: 'app-id', created_at: 1234567890 }),
+    getApp: vi.fn().mockResolvedValue(null), // default: app doesn't exist yet
+    deleteApp: vi.fn().mockResolvedValue(undefined),
+    allocateIP: vi.fn().mockResolvedValue({ address: '::1', type: 'v6' }),
+  };
+});
+
+import { KiloClawApp } from './kiloclaw-app';
+import * as appsClient from '../fly/apps';
+import { FlyApiError } from '../fly/client';
+
+// ============================================================================
+// Test harness
+// ============================================================================
+
+function createFakeStorage() {
+  const store = new Map<string, unknown>();
+  let alarmTime: number | null = null;
+
+  return {
+    get(keys: string[]): Map<string, unknown> {
+      const result = new Map<string, unknown>();
+      for (const k of keys) {
+        if (store.has(k)) result.set(k, store.get(k));
+      }
+      return result;
+    },
+    put(entries: Record<string, unknown>): void {
+      for (const [k, v] of Object.entries(entries)) {
+        store.set(k, v);
+      }
+    },
+    deleteAll(): void {
+      store.clear();
+      alarmTime = null;
+    },
+    setAlarm(time: number): void {
+      alarmTime = time;
+    },
+    deleteAlarm(): void {
+      alarmTime = null;
+    },
+    _store: store,
+    _getAlarm: () => alarmTime,
+  };
+}
+
+function createFakeEnv() {
+  return {
+    FLY_API_TOKEN: 'test-token',
+    FLY_ORG_SLUG: 'test-org',
+  };
+}
+
+function createAppDO(
+  storage = createFakeStorage(),
+  env = createFakeEnv()
+): { appDO: KiloClawApp; storage: ReturnType<typeof createFakeStorage> } {
+  const ctx = { storage } as unknown;
+  const appDO = new KiloClawApp(
+    ctx as ConstructorParameters<typeof KiloClawApp>[0],
+    env as ConstructorParameters<typeof KiloClawApp>[1]
+  );
+  return { appDO, storage };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  // Reset default mock behaviors
+  (appsClient.getApp as Mock).mockResolvedValue(null);
+  (appsClient.createApp as Mock).mockResolvedValue({ id: 'app-id', created_at: 1234567890 });
+  (appsClient.allocateIP as Mock).mockResolvedValue({ address: '::1', type: 'v6' });
+});
+
+describe('ensureApp', () => {
+  it('creates app and allocates both IPs on first call', async () => {
+    const { appDO, storage } = createAppDO();
+
+    const result = await appDO.ensureApp('user-1');
+
+    expect(result.appName).toMatch(/^acct-[0-9a-f]{20}$/);
+    expect(appsClient.createApp).toHaveBeenCalledWith(
+      { apiToken: 'test-token' },
+      result.appName,
+      'test-org'
+    );
+    expect(appsClient.allocateIP).toHaveBeenCalledTimes(2);
+    expect(appsClient.allocateIP).toHaveBeenCalledWith('test-token', result.appName, 'v6');
+    expect(appsClient.allocateIP).toHaveBeenCalledWith('test-token', result.appName, 'shared_v4');
+    expect(storage._store.get('ipv4Allocated')).toBe(true);
+    expect(storage._store.get('ipv6Allocated')).toBe(true);
+  });
+
+  it('skips creation if app already exists', async () => {
+    (appsClient.getApp as Mock).mockResolvedValue({ id: 'existing', created_at: 100 });
+
+    const { appDO } = createAppDO();
+    await appDO.ensureApp('user-1');
+
+    expect(appsClient.createApp).not.toHaveBeenCalled();
+    expect(appsClient.allocateIP).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent — second call is a no-op', async () => {
+    const { appDO } = createAppDO();
+
+    const result1 = await appDO.ensureApp('user-1');
+    vi.clearAllMocks();
+    const result2 = await appDO.ensureApp('user-1');
+
+    expect(result1.appName).toBe(result2.appName);
+    expect(appsClient.createApp).not.toHaveBeenCalled();
+    expect(appsClient.getApp).not.toHaveBeenCalled();
+    expect(appsClient.allocateIP).not.toHaveBeenCalled();
+  });
+
+  it('resumes from partial state — IPv6 done, IPv4 pending', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+    storage._store.set('ipv6Allocated', true);
+    storage._store.set('ipv4Allocated', false);
+
+    // App already exists (since we already created it)
+    (appsClient.getApp as Mock).mockResolvedValue({ id: 'existing', created_at: 100 });
+
+    const { appDO } = createAppDO(storage);
+    await appDO.ensureApp('user-1');
+
+    // Should only allocate IPv4
+    expect(appsClient.allocateIP).toHaveBeenCalledTimes(1);
+    expect(appsClient.allocateIP).toHaveBeenCalledWith('test-token', 'acct-test', 'shared_v4');
+  });
+
+  it('arms retry alarm and rethrows on partial failure', async () => {
+    // IPv6 allocation will fail
+    (appsClient.allocateIP as Mock).mockRejectedValue(new FlyApiError('timeout', 503, 'retry'));
+
+    const { appDO, storage } = createAppDO();
+
+    await expect(appDO.ensureApp('user-1')).rejects.toThrow('timeout');
+
+    // App name was persisted (partial state saved before failure)
+    expect(storage._store.get('flyAppName')).toMatch(/^acct-/);
+    // IPs NOT allocated
+    expect(storage._store.get('ipv6Allocated')).not.toBe(true);
+    expect(storage._store.get('ipv4Allocated')).not.toBe(true);
+    // Retry alarm armed
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('arms retry alarm when IPv4 allocation fails after IPv6 succeeds', async () => {
+    let callCount = 0;
+    (appsClient.allocateIP as Mock).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ address: '::1', type: 'v6' });
+      return Promise.reject(new FlyApiError('rate limit', 429, 'slow down'));
+    });
+
+    const { appDO, storage } = createAppDO();
+
+    await expect(appDO.ensureApp('user-1')).rejects.toThrow('rate limit');
+
+    // IPv6 was persisted, IPv4 was not
+    expect(storage._store.get('ipv6Allocated')).toBe(true);
+    expect(storage._store.get('ipv4Allocated')).not.toBe(true);
+    // Retry alarm armed
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('uses dev- prefix when WORKER_ENV is development', async () => {
+    const env = {
+      FLY_API_TOKEN: 'test-token',
+      FLY_ORG_SLUG: 'test-org',
+      WORKER_ENV: 'development',
+    };
+    const { appDO } = createAppDO(createFakeStorage(), env);
+
+    const result = await appDO.ensureApp('user-1');
+
+    expect(result.appName).toMatch(/^dev-[0-9a-f]{20}$/);
+  });
+
+  it('uses acct- prefix when WORKER_ENV is not development', async () => {
+    const env = { FLY_API_TOKEN: 'test-token', FLY_ORG_SLUG: 'test-org', WORKER_ENV: 'production' };
+    const { appDO } = createAppDO(createFakeStorage(), env);
+
+    const result = await appDO.ensureApp('user-1');
+
+    expect(result.appName).toMatch(/^acct-[0-9a-f]{20}$/);
+  });
+
+  it('uses acct- prefix when WORKER_ENV is unset', async () => {
+    const { appDO } = createAppDO();
+
+    const result = await appDO.ensureApp('user-1');
+
+    expect(result.appName).toMatch(/^acct-[0-9a-f]{20}$/);
+  });
+
+  it('throws when FLY_API_TOKEN is missing', async () => {
+    const { appDO } = createAppDO(createFakeStorage(), { FLY_API_TOKEN: '', FLY_ORG_SLUG: 'org' });
+    await expect(appDO.ensureApp('user-1')).rejects.toThrow('FLY_API_TOKEN is not configured');
+  });
+
+  it('throws when FLY_ORG_SLUG is missing', async () => {
+    const { appDO } = createAppDO(createFakeStorage(), { FLY_API_TOKEN: 'tok', FLY_ORG_SLUG: '' });
+    await expect(appDO.ensureApp('user-1')).rejects.toThrow('FLY_ORG_SLUG is not configured');
+  });
+});
+
+describe('getAppName', () => {
+  it('returns null when no app has been created', async () => {
+    const { appDO } = createAppDO();
+    expect(await appDO.getAppName()).toBeNull();
+  });
+
+  it('returns the app name after ensureApp', async () => {
+    const { appDO } = createAppDO();
+    const { appName } = await appDO.ensureApp('user-1');
+    expect(await appDO.getAppName()).toBe(appName);
+  });
+});
+
+describe('destroyApp', () => {
+  it('deletes the Fly app and clears all state', async () => {
+    const { appDO, storage } = createAppDO();
+    await appDO.ensureApp('user-1');
+
+    await appDO.destroyApp();
+
+    expect(appsClient.deleteApp).toHaveBeenCalled();
+    expect(storage._store.size).toBe(0);
+    expect(await appDO.getAppName()).toBeNull();
+  });
+
+  it('is a no-op when no app exists', async () => {
+    const { appDO } = createAppDO();
+    await appDO.destroyApp();
+    expect(appsClient.deleteApp).not.toHaveBeenCalled();
+  });
+});
+
+describe('alarm retry', () => {
+  it('retries incomplete IP allocation on alarm', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+    storage._store.set('ipv6Allocated', true);
+    storage._store.set('ipv4Allocated', false);
+
+    // App exists
+    (appsClient.getApp as Mock).mockResolvedValue({ id: 'existing', created_at: 100 });
+
+    const { appDO } = createAppDO(storage);
+    await appDO.alarm();
+
+    expect(appsClient.allocateIP).toHaveBeenCalledWith('test-token', 'acct-test', 'shared_v4');
+    expect(storage._store.get('ipv4Allocated')).toBe(true);
+  });
+
+  it('reschedules alarm if retry fails', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+    storage._store.set('ipv6Allocated', false);
+    storage._store.set('ipv4Allocated', false);
+
+    (appsClient.getApp as Mock).mockRejectedValue(new FlyApiError('timeout', 503, 'retry'));
+
+    const { appDO } = createAppDO(storage);
+    await appDO.alarm();
+
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('does nothing on alarm when fully set up', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+    storage._store.set('ipv6Allocated', true);
+    storage._store.set('ipv4Allocated', true);
+
+    const { appDO } = createAppDO(storage);
+    await appDO.alarm();
+
+    expect(appsClient.getApp).not.toHaveBeenCalled();
+    expect(appsClient.allocateIP).not.toHaveBeenCalled();
+  });
+});

--- a/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -1,0 +1,181 @@
+/**
+ * KiloClawApp Durable Object
+ *
+ * Manages the per-user Fly App lifecycle: creation, IP allocation, and deletion.
+ * Keyed by userId: env.KILOCLAW_APP.idFromName(userId) — one per user.
+ *
+ * Separate from KiloClawInstance to support future multi-instance per user,
+ * where one Fly App contains multiple instances (machines + volumes).
+ *
+ * The App DO ensures that each user has a Fly App with allocated IPs before
+ * any machines are created. ensureApp() is idempotent: safe to call multiple
+ * times, only creates the app + IPs on first call.
+ *
+ * If allocation partially fails, the alarm retries.
+ */
+
+import { DurableObject } from 'cloudflare:workers';
+import { z } from 'zod';
+import type { KiloClawEnv } from '../types';
+import * as apps from '../fly/apps';
+
+// -- Persisted state schema --
+
+const AppStateSchema = z.object({
+  userId: z.string().default(''),
+  flyAppName: z.string().nullable().default(null),
+  ipv4Allocated: z.boolean().default(false),
+  ipv6Allocated: z.boolean().default(false),
+});
+
+type AppState = z.infer<typeof AppStateSchema>;
+
+const STORAGE_KEYS = Object.keys(AppStateSchema.shape);
+
+/** How often to retry incomplete setup (IP allocation failures). */
+const RETRY_ALARM_MS = 60 * 1000; // 1 min
+
+// -- DO --
+
+export class KiloClawApp extends DurableObject<KiloClawEnv> {
+  private loaded = false;
+  private userId: string | null = null;
+  private flyAppName: string | null = null;
+  private ipv4Allocated = false;
+  private ipv6Allocated = false;
+
+  private async loadState(): Promise<void> {
+    if (this.loaded) return;
+
+    const entries = await this.ctx.storage.get(STORAGE_KEYS);
+    const raw = Object.fromEntries(entries.entries());
+    const parsed = AppStateSchema.safeParse(raw);
+
+    if (parsed.success) {
+      const s = parsed.data;
+      this.userId = s.userId || null;
+      this.flyAppName = s.flyAppName;
+      this.ipv4Allocated = s.ipv4Allocated;
+      this.ipv6Allocated = s.ipv6Allocated;
+    }
+
+    this.loaded = true;
+  }
+
+  /**
+   * Ensure a Fly App exists for this user with IPs allocated.
+   * Idempotent: creates the app only if it doesn't exist yet.
+   * Returns the app name for callers to cache.
+   */
+  async ensureApp(userId: string): Promise<{ appName: string }> {
+    await this.loadState();
+
+    const apiToken = this.env.FLY_API_TOKEN;
+    if (!apiToken) throw new Error('FLY_API_TOKEN is not configured');
+    const orgSlug = this.env.FLY_ORG_SLUG;
+    if (!orgSlug) throw new Error('FLY_ORG_SLUG is not configured');
+
+    // Derive app name (deterministic from userId, with env prefix in dev)
+    const prefix = this.env.WORKER_ENV === 'development' ? 'dev' : undefined;
+    const appName = this.flyAppName ?? (await apps.appNameFromUserId(userId, prefix));
+
+    // Persist userId + appName early so we can retry on partial failure
+    if (!this.userId || !this.flyAppName) {
+      this.userId = userId;
+      this.flyAppName = appName;
+      await this.ctx.storage.put({
+        userId,
+        flyAppName: appName,
+      } satisfies Partial<AppState>);
+    }
+
+    try {
+      // Step 1: Create app if it doesn't exist
+      if (!this.ipv4Allocated || !this.ipv6Allocated) {
+        const existing = await apps.getApp({ apiToken }, appName);
+        if (!existing) {
+          await apps.createApp({ apiToken }, appName, orgSlug);
+          console.log('[AppDO] Created Fly App:', appName);
+        }
+      }
+
+      // Step 2: Allocate IPv6 if not done
+      if (!this.ipv6Allocated) {
+        await apps.allocateIP(apiToken, appName, 'v6');
+        this.ipv6Allocated = true;
+        await this.ctx.storage.put({ ipv6Allocated: true } satisfies Partial<AppState>);
+        console.log('[AppDO] Allocated IPv6 for:', appName);
+      }
+
+      // Step 3: Allocate shared IPv4 if not done
+      if (!this.ipv4Allocated) {
+        await apps.allocateIP(apiToken, appName, 'shared_v4');
+        this.ipv4Allocated = true;
+        await this.ctx.storage.put({ ipv4Allocated: true } satisfies Partial<AppState>);
+        console.log('[AppDO] Allocated shared IPv4 for:', appName);
+      }
+    } catch (err) {
+      // Partial state persisted above — arm a retry alarm so the DO self-heals
+      // even if the caller doesn't retry.
+      if (!this.ipv4Allocated || !this.ipv6Allocated) {
+        await this.ctx.storage.setAlarm(Date.now() + RETRY_ALARM_MS);
+        console.error('[AppDO] Partial failure, retry alarm armed for:', appName, err);
+      }
+      throw err;
+    }
+
+    return { appName };
+  }
+
+  /**
+   * Get the stored app name, or null if not yet created.
+   */
+  async getAppName(): Promise<string | null> {
+    await this.loadState();
+    return this.flyAppName;
+  }
+
+  /**
+   * Delete the Fly App entirely.
+   * For future use (e.g. account deletion). Not called on instance destroy.
+   */
+  async destroyApp(): Promise<void> {
+    await this.loadState();
+
+    if (!this.flyAppName) return;
+
+    const apiToken = this.env.FLY_API_TOKEN;
+    if (!apiToken) throw new Error('FLY_API_TOKEN is not configured');
+
+    await apps.deleteApp({ apiToken }, this.flyAppName);
+    console.log('[AppDO] Deleted Fly App:', this.flyAppName);
+
+    await this.ctx.storage.deleteAlarm();
+    await this.ctx.storage.deleteAll();
+
+    this.userId = null;
+    this.flyAppName = null;
+    this.ipv4Allocated = false;
+    this.ipv6Allocated = false;
+    this.loaded = false;
+  }
+
+  /**
+   * Alarm: retry incomplete IP allocation.
+   */
+  override async alarm(): Promise<void> {
+    await this.loadState();
+
+    if (!this.userId || !this.flyAppName) return;
+    if (this.ipv4Allocated && this.ipv6Allocated) return;
+
+    console.log('[AppDO] Retrying incomplete setup for:', this.flyAppName);
+
+    try {
+      await this.ensureApp(this.userId);
+    } catch (err) {
+      console.error('[AppDO] Retry failed, rescheduling:', err);
+      await this.ctx.storage.setAlarm(Date.now() + RETRY_ALARM_MS);
+    }
+  }
+}

--- a/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -70,6 +70,10 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
   async ensureApp(userId: string): Promise<{ appName: string }> {
     await this.loadState();
 
+    if (this.userId && this.userId !== userId) {
+      throw new Error(`userId mismatch: DO has ${this.userId}, caller passed ${userId}`);
+    }
+
     const apiToken = this.env.FLY_API_TOKEN;
     if (!apiToken) throw new Error('FLY_API_TOKEN is not configured');
     const orgSlug = this.env.FLY_ORG_SLUG;

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -109,7 +109,7 @@ export const METADATA_KEY_SANDBOX_ID = 'kiloclaw_sandbox_id';
 type MachineIdentity = { userId: string; sandboxId: string };
 
 function buildMachineConfig(
-  appName: string,
+  registryApp: string,
   imageTag: string,
   envVars: Record<string, string>,
   guest: FlyMachineConfig['guest'],
@@ -117,7 +117,7 @@ function buildMachineConfig(
   identity: MachineIdentity
 ): FlyMachineConfig {
   return {
-    image: `registry.fly.io/${appName}:${imageTag}`,
+    image: `registry.fly.io/${registryApp}:${imageTag}`,
     env: envVars,
     guest,
     services: [
@@ -230,6 +230,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private provisionedAt: number | null = null;
   private lastStartedAt: number | null = null;
   private lastStoppedAt: number | null = null;
+  private flyAppName: string | null = null;
   private flyMachineId: string | null = null;
   private flyVolumeId: string | null = null;
   private flyRegion: string | null = null;
@@ -263,6 +264,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.provisionedAt = s.provisionedAt;
       this.lastStartedAt = s.lastStartedAt;
       this.lastStoppedAt = s.lastStoppedAt;
+      this.flyAppName = s.flyAppName;
       this.flyMachineId = s.flyMachineId;
       this.flyVolumeId = s.flyVolumeId;
       this.flyRegion = s.flyRegion;
@@ -302,6 +304,18 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const sandboxId = sandboxIdFromUserId(userId);
     const isNew = !this.status;
 
+    // Ensure per-user Fly App exists on first provision only.
+    // Legacy instances (flyAppName = null with existing flyMachineId/flyVolumeId)
+    // must NOT be reassigned: their resources live in the legacy FLY_APP_NAME app.
+    // They get a per-user app only after a full destroy + fresh provision cycle.
+    if (isNew && !this.flyAppName) {
+      const appStub = this.env.KILOCLAW_APP.get(this.env.KILOCLAW_APP.idFromName(userId));
+      const { appName } = await appStub.ensureApp(userId);
+      this.flyAppName = appName;
+      await this.ctx.storage.put(storageUpdate({ flyAppName: appName }));
+      console.log('[DO] Per-user Fly App ensured:', appName);
+    }
+
     // Create Fly Volume on first provision
     if (isNew && !this.flyVolumeId) {
       const flyConfig = this.getFlyConfig();
@@ -336,6 +350,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           provisionedAt: Date.now(),
           lastStartedAt: null,
           lastStoppedAt: null,
+          flyAppName: this.flyAppName,
           flyMachineId: this.flyMachineId,
           flyVolumeId: this.flyVolumeId,
           flyRegion: this.flyRegion,
@@ -468,7 +483,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const imageTag = this.env.FLY_IMAGE_TAG ?? 'latest';
     const identity = { userId: this.userId, sandboxId: this.sandboxId };
     const machineConfig = buildMachineConfig(
-      flyConfig.appName,
+      this.getRegistryApp(),
       imageTag,
       envVars,
       guest,
@@ -599,6 +614,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     envVarCount: number;
     secretCount: number;
     channelCount: number;
+    flyAppName: string | null;
     flyMachineId: string | null;
     flyVolumeId: string | null;
     flyRegion: string | null;
@@ -615,6 +631,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       envVarCount: this.envVars ? Object.keys(this.envVars).length : 0,
       secretCount: this.encryptedSecrets ? Object.keys(this.encryptedSecrets).length : 0,
       channelCount: this.channels ? Object.values(this.channels).filter(Boolean).length : 0,
+      flyAppName: this.flyAppName,
       flyMachineId: this.flyMachineId,
       flyVolumeId: this.flyVolumeId,
       flyRegion: this.flyRegion,
@@ -657,7 +674,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       const imageTag = this.env.FLY_IMAGE_TAG ?? 'latest';
       const identity = { userId: this.userId ?? '', sandboxId: this.sandboxId ?? '' };
       const machineConfig = buildMachineConfig(
-        flyConfig.appName,
+        this.getRegistryApp(),
         imageTag,
         envVars,
         guest,
@@ -1069,6 +1086,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.provisionedAt = null;
     this.lastStartedAt = null;
     this.lastStoppedAt = null;
+    this.flyAppName = null;
     this.flyMachineId = null;
     this.flyVolumeId = null;
     this.flyRegion = null;
@@ -1086,16 +1104,26 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   // Infrastructure helpers
   // ========================================================================
 
+  /**
+   * Shared Docker image registry app name.
+   * Images are pushed to this app's registry and referenced by all per-user apps.
+   */
+  private getRegistryApp(): string {
+    return this.env.FLY_REGISTRY_APP ?? this.env.FLY_APP_NAME ?? 'kiloclaw-machines';
+  }
+
   private getFlyConfig(): FlyClientConfig {
     if (!this.env.FLY_API_TOKEN) {
       throw new Error('FLY_API_TOKEN is not configured');
     }
-    if (!this.env.FLY_APP_NAME) {
-      throw new Error('FLY_APP_NAME is not configured');
+    // Per-user app name, with legacy fallback for existing instances
+    const appName = this.flyAppName ?? this.env.FLY_APP_NAME;
+    if (!appName) {
+      throw new Error('No Fly app name: flyAppName not set and FLY_APP_NAME not configured');
     }
     return {
       apiToken: this.env.FLY_API_TOKEN,
-      appName: this.env.FLY_APP_NAME,
+      appName,
     };
   }
 
@@ -1212,6 +1240,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       const encryptedSecrets: Record<string, EncryptedEnvelope> | null = null;
       const channels = null;
 
+      // Recover flyAppName from the App DO (which persists independently).
+      // If the user has a per-user app, the App DO still knows about it.
+      // If not (legacy user), getAppName() returns null and getFlyConfig()
+      // falls back to env.FLY_APP_NAME.
+      const appStub = this.env.KILOCLAW_APP.get(this.env.KILOCLAW_APP.idFromName(userId));
+      const recoveredAppName = await appStub.getAppName();
+
       await this.ctx.storage.put(
         storageUpdate({
           userId,
@@ -1223,6 +1258,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           provisionedAt: Date.now(),
           lastStartedAt: null,
           lastStoppedAt: null,
+          flyAppName: recoveredAppName,
           flyMachineId: null,
           flyVolumeId: null,
           flyRegion: null,
@@ -1242,6 +1278,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.provisionedAt = Date.now();
       this.lastStartedAt = null;
       this.lastStoppedAt = null;
+      this.flyAppName = recoveredAppName;
       this.flyMachineId = null;
       this.flyVolumeId = null;
       this.flyRegion = null;

--- a/kiloclaw/src/fly/apps.test.ts
+++ b/kiloclaw/src/fly/apps.test.ts
@@ -220,6 +220,22 @@ describe('allocateIP', () => {
     expect(sentBody.type).toBe('shared_v4');
   });
 
+  it('treats 409 as success (IP already allocated)', async () => {
+    mockFetchText(409, 'already allocated');
+
+    const result = await allocateIP(TOKEN, 'acct-test', 'v6');
+
+    expect(result.shared).toBe(false);
+  });
+
+  it('treats 422 as success (IP already allocated)', async () => {
+    mockFetchText(422, 'already allocated');
+
+    const result = await allocateIP(TOKEN, 'acct-test', 'shared_v4');
+
+    expect(result.shared).toBe(true);
+  });
+
   it('throws FlyApiError on 404 (app not found)', async () => {
     mockFetchText(404, 'app not found');
 

--- a/kiloclaw/src/fly/apps.test.ts
+++ b/kiloclaw/src/fly/apps.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { appNameFromUserId, createApp, getApp, deleteApp, allocateIP } from './apps';
+import { FlyApiError } from './client';
+
+// ============================================================================
+// appNameFromUserId (pure, no mocking needed)
+// ============================================================================
+
+describe('appNameFromUserId', () => {
+  it('returns a deterministic app name', async () => {
+    const name1 = await appNameFromUserId('user-123');
+    const name2 = await appNameFromUserId('user-123');
+    expect(name1).toBe(name2);
+  });
+
+  it('starts with acct- prefix', async () => {
+    const name = await appNameFromUserId('user-123');
+    expect(name).toMatch(/^acct-/);
+  });
+
+  it('is exactly 25 chars (acct- + 20 hex chars)', async () => {
+    const name = await appNameFromUserId('user-123');
+    expect(name).toHaveLength(25);
+  });
+
+  it('only contains lowercase hex chars after prefix', async () => {
+    const name = await appNameFromUserId('user-123');
+    const hex = name.slice(5);
+    expect(hex).toMatch(/^[0-9a-f]{20}$/);
+  });
+
+  it('produces different names for different userIds', async () => {
+    const name1 = await appNameFromUserId('user-1');
+    const name2 = await appNameFromUserId('user-2');
+    expect(name1).not.toBe(name2);
+  });
+
+  it('handles empty string userId', async () => {
+    const name = await appNameFromUserId('');
+    expect(name).toMatch(/^acct-[0-9a-f]{20}$/);
+  });
+
+  it('handles unicode userId', async () => {
+    const name = await appNameFromUserId('user-\u00e9\u00e8\u00ea');
+    expect(name).toMatch(/^acct-[0-9a-f]{20}$/);
+  });
+
+  it('uses prefix when provided', async () => {
+    const name = await appNameFromUserId('user-123', 'dev');
+    expect(name).toMatch(/^dev-[0-9a-f]{20}$/);
+  });
+
+  it('prefix changes the name but not the hash', async () => {
+    const plain = await appNameFromUserId('user-123');
+    const prefixed = await appNameFromUserId('user-123', 'dev');
+    // Same hash portion, different prefix
+    expect(plain.slice(5)).toBe(prefixed.slice(4));
+  });
+
+  it('omits acct- prefix when custom prefix is provided', async () => {
+    const name = await appNameFromUserId('user-123', 'stg');
+    expect(name).toMatch(/^stg-[0-9a-f]{20}$/);
+    expect(name).not.toContain('acct');
+  });
+});
+
+// ============================================================================
+// REST API functions (fetch-mocked)
+// ============================================================================
+
+const TOKEN = 'test-token';
+const CONFIG = { apiToken: TOKEN };
+
+function mockFetch(status: number, body: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+  );
+}
+
+function mockFetchText(status: number, body: string): void {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(body, { status })));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createApp', () => {
+  it('returns FlyApp on 201', async () => {
+    mockFetch(201, { id: 'app-123', created_at: 1234567890 });
+
+    const result = await createApp(CONFIG, 'acct-test', 'test-org');
+
+    expect(result).toEqual({ id: 'app-123', created_at: 1234567890 });
+
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[0]).toBe('https://api.machines.dev/v1/apps');
+    expect(fetchCall[1].method).toBe('POST');
+    const sentBody = JSON.parse(fetchCall[1].body);
+    expect(sentBody).toEqual({ app_name: 'acct-test', org_slug: 'test-org', network: 'acct-test' });
+  });
+
+  it('passes network param matching app name for isolation', async () => {
+    mockFetch(201, { id: 'app-123', created_at: 0 });
+
+    await createApp(CONFIG, 'acct-abc123', 'org');
+
+    const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(sentBody.network).toBe('acct-abc123');
+  });
+
+  it('treats 409 as success (app already exists)', async () => {
+    mockFetchText(409, 'app already exists');
+
+    const result = await createApp(CONFIG, 'acct-dup', 'org');
+
+    expect(result).toEqual({ id: 'acct-dup', created_at: 0 });
+  });
+
+  it('throws FlyApiError on non-OK response', async () => {
+    mockFetchText(422, 'app name taken');
+
+    try {
+      await createApp(CONFIG, 'acct-bad', 'org');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FlyApiError);
+      expect((err as FlyApiError).status).toBe(422);
+      expect((err as FlyApiError).body).toBe('app name taken');
+    }
+  });
+});
+
+describe('getApp', () => {
+  it('returns FlyApp on 200', async () => {
+    mockFetch(200, { id: 'app-123', created_at: 100 });
+
+    const result = await getApp(CONFIG, 'acct-test');
+
+    expect(result).toEqual({ id: 'app-123', created_at: 100 });
+  });
+
+  it('returns null on 404', async () => {
+    mockFetchText(404, 'not found');
+
+    const result = await getApp(CONFIG, 'acct-nonexistent');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws FlyApiError on other error status', async () => {
+    mockFetchText(500, 'internal error');
+
+    await expect(getApp(CONFIG, 'acct-test')).rejects.toThrow(FlyApiError);
+  });
+});
+
+describe('deleteApp', () => {
+  it('succeeds silently on 200', async () => {
+    mockFetchText(200, 'ok');
+
+    await expect(deleteApp(CONFIG, 'acct-test')).resolves.toBeUndefined();
+  });
+
+  it('succeeds silently on 404 (already gone)', async () => {
+    mockFetchText(404, 'not found');
+
+    await expect(deleteApp(CONFIG, 'acct-gone')).resolves.toBeUndefined();
+  });
+
+  it('throws FlyApiError on other error status', async () => {
+    mockFetchText(500, 'internal error');
+
+    await expect(deleteApp(CONFIG, 'acct-test')).rejects.toThrow(FlyApiError);
+  });
+});
+
+// ============================================================================
+// IP allocation (REST)
+// ============================================================================
+
+describe('allocateIP', () => {
+  it('returns IPAssignment on success', async () => {
+    mockFetch(200, {
+      ip: '2a09:8280:1::1',
+      region: 'global',
+      created_at: '2026-01-01T00:00:00Z',
+      shared: false,
+    });
+
+    const result = await allocateIP(TOKEN, 'acct-test', 'v6');
+
+    expect(result.ip).toBe('2a09:8280:1::1');
+    expect(result.region).toBe('global');
+
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[0]).toBe('https://api.machines.dev/v1/apps/acct-test/ip_assignments');
+    expect(fetchCall[1].method).toBe('POST');
+    const sentBody = JSON.parse(fetchCall[1].body);
+    expect(sentBody).toEqual({ type: 'v6' });
+  });
+
+  it('sends shared_v4 type for IPv4', async () => {
+    mockFetch(200, {
+      ip: '137.66.1.1',
+      region: 'global',
+      created_at: '2026-01-01T00:00:00Z',
+      shared: true,
+    });
+
+    await allocateIP(TOKEN, 'acct-test', 'shared_v4');
+
+    const sentBody = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(sentBody.type).toBe('shared_v4');
+  });
+
+  it('throws FlyApiError on 404 (app not found)', async () => {
+    mockFetchText(404, 'app not found');
+
+    try {
+      await allocateIP(TOKEN, 'acct-nonexistent', 'v6');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FlyApiError);
+      expect((err as FlyApiError).status).toBe(404);
+    }
+  });
+
+  it('throws FlyApiError on 401 (unauthorized)', async () => {
+    mockFetchText(401, 'unauthorized');
+
+    try {
+      await allocateIP(TOKEN, 'acct-test', 'v6');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FlyApiError);
+      expect((err as FlyApiError).status).toBe(401);
+    }
+  });
+
+  it('throws FlyApiError on 500', async () => {
+    mockFetchText(500, 'internal error');
+
+    await expect(allocateIP(TOKEN, 'acct-test', 'v6')).rejects.toThrow(FlyApiError);
+  });
+
+  it('encodes app name in URL path', async () => {
+    mockFetch(200, {
+      ip: '::1',
+      region: 'global',
+      created_at: '2026-01-01T00:00:00Z',
+      shared: false,
+    });
+
+    await allocateIP(TOKEN, 'acct-test', 'v6');
+
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[0]).toContain('/v1/apps/acct-test/ip_assignments');
+  });
+});

--- a/kiloclaw/src/fly/apps.ts
+++ b/kiloclaw/src/fly/apps.ts
@@ -138,6 +138,10 @@ export async function allocateIP(
     method: 'POST',
     body: JSON.stringify({ type: ipType }),
   });
+  // 409/422 = IP already allocated (safe to treat as success during retries)
+  if (resp.status === 409 || resp.status === 422) {
+    return { ip: '', region: '', created_at: '', shared: ipType === 'shared_v4' };
+  }
   await assertOk(resp, 'allocateIP');
   return resp.json();
 }

--- a/kiloclaw/src/fly/apps.ts
+++ b/kiloclaw/src/fly/apps.ts
@@ -1,0 +1,143 @@
+/**
+ * Fly.io Apps + IP allocation REST API.
+ *
+ * Manages per-user Fly Apps: creation, existence checks, deletion,
+ * and IP address allocation (IPv4 shared + IPv6).
+ * All calls use the Machines REST API (https://api.machines.dev).
+ *
+ * App naming: `acct-{first 20 hex chars of SHA-256(userId)}`
+ */
+
+import { FlyApiError } from './client';
+
+const FLY_API_BASE = 'https://api.machines.dev';
+
+// -- App name derivation --
+
+/**
+ * Derive a deterministic Fly app name from a userId.
+ *
+ * Production: `acct-{first 20 hex chars of SHA-256(userId)}` (25 chars)
+ * With prefix: `{prefix}-{first 20 hex chars}` (e.g. `dev-{hash}` = 24 chars)
+ *
+ * The hash portion is the same regardless of prefix, so you can compare
+ * across environments by stripping the prefix.
+ *
+ * @param prefix - Environment prefix (e.g. "dev" for WORKER_ENV=development). Omit for production.
+ */
+export async function appNameFromUserId(userId: string, prefix?: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(userId);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = new Uint8Array(hashBuffer);
+  const hex = Array.from(hashArray.slice(0, 10))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  return prefix ? `${prefix}-${hex}` : `acct-${hex}`;
+}
+
+// -- REST API helpers --
+
+type FlyAppConfig = {
+  apiToken: string;
+};
+
+type FlyApp = {
+  id: string;
+  created_at: number;
+};
+
+async function apiFetch(apiToken: string, path: string, init?: RequestInit): Promise<Response> {
+  const url = `${FLY_API_BASE}${path}`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  });
+}
+
+async function assertOk(resp: Response, context: string): Promise<void> {
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new FlyApiError(`Fly API ${context} failed (${resp.status}): ${body}`, resp.status, body);
+  }
+}
+
+// -- Apps resource --
+
+/**
+ * Create a Fly App with its own isolated private network.
+ * POST /v1/apps — returns 201 on success.
+ *
+ * Each per-user app gets `network: appName` so machines in different
+ * user apps cannot reach each other over Fly's internal `.internal` DNS.
+ */
+export async function createApp(
+  config: FlyAppConfig,
+  appName: string,
+  orgSlug: string
+): Promise<FlyApp> {
+  const resp = await apiFetch(config.apiToken, '/v1/apps', {
+    method: 'POST',
+    body: JSON.stringify({ app_name: appName, org_slug: orgSlug, network: appName }),
+  });
+  // 409 = app already exists (race with alarm retry or Fly API eventual consistency)
+  if (resp.status === 409) return { id: appName, created_at: 0 };
+  await assertOk(resp, 'createApp');
+  return resp.json();
+}
+
+/**
+ * Check if a Fly App exists.
+ * GET /v1/apps/{app_name} — returns the app or null if 404.
+ */
+export async function getApp(config: FlyAppConfig, appName: string): Promise<FlyApp | null> {
+  const resp = await apiFetch(config.apiToken, `/v1/apps/${encodeURIComponent(appName)}`);
+  if (resp.status === 404) return null;
+  await assertOk(resp, 'getApp');
+  return resp.json();
+}
+
+/**
+ * Delete a Fly App.
+ * DELETE /v1/apps/{app_name}
+ */
+export async function deleteApp(config: FlyAppConfig, appName: string): Promise<void> {
+  const resp = await apiFetch(config.apiToken, `/v1/apps/${encodeURIComponent(appName)}`, {
+    method: 'DELETE',
+  });
+  if (resp.status === 404) return; // already gone
+  await assertOk(resp, 'deleteApp');
+}
+
+// -- IP allocation --
+
+/** Fly REST API response shape for POST /v1/apps/{app}/ip_assignments */
+type IPAssignment = {
+  ip: string;
+  region: string;
+  created_at: string;
+  shared: boolean;
+};
+
+/**
+ * Allocate an IP address for a Fly App.
+ * POST /v1/apps/{app_name}/ip_assignments
+ *
+ * @param ipType - "v6" for dedicated IPv6, "shared_v4" for shared IPv4
+ */
+export async function allocateIP(
+  apiToken: string,
+  appName: string,
+  ipType: 'v6' | 'shared_v4'
+): Promise<IPAssignment> {
+  const resp = await apiFetch(apiToken, `/v1/apps/${encodeURIComponent(appName)}/ip_assignments`, {
+    method: 'POST',
+    body: JSON.stringify({ type: ipType }),
+  });
+  await assertOk(resp, 'allocateIP');
+  return resp.json();
+}

--- a/kiloclaw/src/index.ts
+++ b/kiloclaw/src/index.ts
@@ -47,8 +47,6 @@ function validateRequiredEnv(env: KiloClawEnv): string[] {
   if (!env.NEXTAUTH_SECRET) missing.push('NEXTAUTH_SECRET');
   if (!env.GATEWAY_TOKEN_SECRET) missing.push('GATEWAY_TOKEN_SECRET');
   if (!env.FLY_API_TOKEN) missing.push('FLY_API_TOKEN');
-  if (!env.FLY_ORG_SLUG) missing.push('FLY_ORG_SLUG');
-  if (!env.FLY_REGISTRY_APP) missing.push('FLY_REGISTRY_APP');
   return missing;
 }
 
@@ -95,8 +93,6 @@ async function requireEnvVars(c: Context<AppEnv>, next: Next) {
     if (!c.env.HYPERDRIVE?.connectionString) missing.push('HYPERDRIVE');
     if (!c.env.GATEWAY_TOKEN_SECRET) missing.push('GATEWAY_TOKEN_SECRET');
     if (!c.env.FLY_API_TOKEN) missing.push('FLY_API_TOKEN');
-    if (!c.env.FLY_ORG_SLUG) missing.push('FLY_ORG_SLUG');
-    if (!c.env.FLY_REGISTRY_APP) missing.push('FLY_REGISTRY_APP');
     if (missing.length > 0) {
       console.error('[CONFIG] Platform route missing bindings:', missing.join(', '));
       return c.json({ error: 'Configuration error', missing }, 503);

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -90,7 +90,8 @@ export const PersistedStateSchema = z.object({
   provisionedAt: z.number().nullable().default(null),
   lastStartedAt: z.number().nullable().default(null),
   lastStoppedAt: z.number().nullable().default(null),
-  // Fly.io machine/volume identifiers
+  // Fly.io app/machine/volume identifiers
+  flyAppName: z.string().nullable().default(null),
   flyMachineId: z.string().nullable().default(null),
   flyVolumeId: z.string().nullable().default(null),
   flyRegion: z.string().nullable().default(null),

--- a/kiloclaw/src/test-utils.ts
+++ b/kiloclaw/src/test-utils.ts
@@ -10,6 +10,7 @@ import type { KiloClawEnv } from './types';
 export function createMockEnv(overrides: Partial<KiloClawEnv> = {}): KiloClawEnv {
   return {
     KILOCLAW_INSTANCE: {} as unknown as KiloClawEnv['KILOCLAW_INSTANCE'],
+    KILOCLAW_APP: {} as unknown as KiloClawEnv['KILOCLAW_APP'],
     HYPERDRIVE: {} as unknown as KiloClawEnv['HYPERDRIVE'],
     ...overrides,
   };

--- a/kiloclaw/src/types.ts
+++ b/kiloclaw/src/types.ts
@@ -1,10 +1,12 @@
 import type { KiloClawInstance } from './durable-objects/kiloclaw-instance';
+import type { KiloClawApp } from './durable-objects/kiloclaw-app';
 
 /**
  * Environment bindings for the KiloClaw Worker
  */
 export type KiloClawEnv = {
   KILOCLAW_INSTANCE: DurableObjectNamespace<KiloClawInstance>;
+  KILOCLAW_APP: DurableObjectNamespace<KiloClawApp>;
   HYPERDRIVE: Hyperdrive;
 
   // Auth secrets
@@ -29,7 +31,9 @@ export type KiloClawEnv = {
 
   // Fly.io configuration
   FLY_API_TOKEN?: string;
-  FLY_APP_NAME?: string;
+  FLY_APP_NAME?: string; // Legacy: fallback for existing instances without per-user apps
+  FLY_ORG_SLUG?: string; // Org for creating new per-user Fly apps
+  FLY_REGISTRY_APP?: string; // Shared app for Docker image registry
   FLY_REGION?: string;
   FLY_IMAGE_TAG?: string;
 

--- a/kiloclaw/wrangler.jsonc
+++ b/kiloclaw/wrangler.jsonc
@@ -26,6 +26,10 @@
         "class_name": "KiloClawInstance",
         "name": "KILOCLAW_INSTANCE",
       },
+      {
+        "class_name": "KiloClawApp",
+        "name": "KILOCLAW_APP",
+      },
     ],
   },
   "migrations": [
@@ -41,6 +45,10 @@
       "deleted_classes": ["KiloClawSandbox"],
       "tag": "v4",
     },
+    {
+      "new_sqlite_classes": ["KiloClawApp"],
+      "tag": "v5",
+    },
   ],
   // Hyperdrive binding for Postgres (pepper validation, instance registry)
   "hyperdrive": [
@@ -51,7 +59,9 @@
     },
   ],
   "vars": {
-    "FLY_APP_NAME": "kiloclaw-machines",
+    "FLY_APP_NAME": "kiloclaw-machines", // Legacy fallback for existing instances
+    "FLY_REGISTRY_APP": "kiloclaw-machines", // Shared Docker image registry
+    "FLY_ORG_SLUG": "kilo-679", // Org for creating per-user Fly apps
     "FLY_IMAGE_TAG": "latest",
     "FLY_REGION": "us,eu",
     "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",


### PR DESCRIPTION
Create a dedicated Fly App per user instead of sharing a single app. Each user's app gets its own isolated private network, preventing cross-user lateral movement over Fly's internal DNS, and also means we can start using App Secrets. (app per user is also recommended by Fly for this scenario - https://fly.io/docs/machines/guides-examples/one-app-per-user-why/)

New KiloClawApp Durable Object manages per-user app lifecycle:
- Idempotent app creation with retry alarm on partial failure
- IPv4 (shared) + IPv6 allocation via Machines REST API (i think we probably don't need to keep provisioning ipv4 addrs , so i'll probably remove in a follow up)
- Network isolation via app-scoped private network
- Environment-aware naming: dev-{hash} / acct-{hash}

Key changes:
- Apps REST API client (create, get, delete, IP assignment)
- KiloClawInstance calls App DO on first provision, caches flyAppName
- Proxy routes to per-user {flyAppName}.fly.dev with legacy fallback
- Docker images stay in shared FLY_REGISTRY_APP, referenced by all apps (which is great, means we just ship one image to `fly-machines`)
- Postgres restore recovers flyAppName from App DO (persists independently)
