### PR TITLE
Explicitly set a few OpenClaw settings

### DIFF
--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -156,6 +156,14 @@ config.agents.defaults = config.agents.defaults || {};
 config.agents.defaults.model = { primary: defaultModel };
 console.log('KiloCode provider configured with base URL ' + baseUrl);
 
+// Explicitly lock down exec tool security (defense-in-depth).
+// OpenClaw defaults to these values, but pinning them here prevents
+// silent regression if upstream defaults change in a future version.
+config.tools = config.tools || {};
+config.tools.exec = config.tools.exec || {};
+config.tools.exec.security = 'deny';
+config.tools.exec.ask = 'on-miss';
+
 // Telegram configuration
 if (process.env.TELEGRAM_BOT_TOKEN) {
     const dmPolicy = process.env.TELEGRAM_DM_POLICY || 'pairing';


### PR DESCRIPTION
- Explicitly set tools.exec.security = "deny" (exec requires approval)
- Explicitly set tools.exec.ask = "on-miss" (prompt user on first exec use)

These settings were implied, but if the upstream ever changes their behavior, we want to ensure they are explicitly controlled