### PR TITLE
feat(kiloclaw): encrypt sensitive env vars in Fly machine config

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -8,6 +8,8 @@ GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
 WORKER_ENV=development
 
 # Optional: Override KiloCode base URL (dev)
+# In dev you'll want to use ngrok or cloudflare tunnel to route back to your nextjs app
+# e.g.: `cloudflared tunnel --url http://localhost:3000`
 # KILOCODE_API_BASE_URL=https://api.kilo.ai/api/openrouter/
 
 # Fly.io Machines API
@@ -33,7 +35,9 @@ FLY_APP_NAME=kiloclaw-machines
 
 # Allowed origins for the OpenClaw Control UI WebSocket (comma-separated).
 # Must include the origins that the browser connects from.
-OPENCLAW_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8795
+# NOTE: wrangler dev rewrites the Origin header to match the custom domain route
+# (claw.kilosessions.ai), so that origin must be included for local dev.
+OPENCLAW_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8795,http://claw.kilosessions.ai
 
 # Encryption (for user secrets)
 # AGENT_ENV_VARS_PRIVATE_KEY=...

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-13-v42-allowed-origins
+# Build cache bust: 2026-02-16-v43-env-encryption
 RUN echo "4"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 RUN chmod +x /usr/local/bin/start-openclaw.sh

--- a/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
@@ -32,8 +32,19 @@ vi.mock('../fly/apps', async () => {
   };
 });
 
+// -- Mock fly/secrets --
+vi.mock('../fly/secrets', () => ({
+  setAppSecret: vi.fn().mockResolvedValue({ version: 1 }),
+}));
+
+// -- Mock utils/env-encryption (deterministic key for testing) --
+vi.mock('../utils/env-encryption', () => ({
+  generateEnvKey: vi.fn().mockReturnValue('dGVzdC1rZXktMzItYnl0ZXMtcGFkZGVkLi4uLg=='),
+}));
+
 import { KiloClawApp } from './kiloclaw-app';
 import * as appsClient from '../fly/apps';
+import * as secretsClient from '../fly/secrets';
 import { FlyApiError } from '../fly/client';
 
 // ============================================================================
@@ -108,7 +119,7 @@ beforeEach(() => {
 });
 
 describe('ensureApp', () => {
-  it('creates app and allocates both IPs on first call', async () => {
+  it('creates app, allocates both IPs, and sets env key on first call', async () => {
     const { appDO, storage } = createAppDO();
 
     const result = await appDO.ensureApp('user-1');
@@ -124,6 +135,14 @@ describe('ensureApp', () => {
     expect(appsClient.allocateIP).toHaveBeenCalledWith('test-token', result.appName, 'shared_v4');
     expect(storage._store.get('ipv4Allocated')).toBe(true);
     expect(storage._store.get('ipv6Allocated')).toBe(true);
+    // Env key was set
+    expect(secretsClient.setAppSecret).toHaveBeenCalledWith(
+      { apiToken: 'test-token', appName: result.appName },
+      'KILOCLAW_ENV_KEY',
+      expect.any(String)
+    );
+    expect(storage._store.get('envKeySet')).toBe(true);
+    expect(storage._store.get('envKey')).toBeTruthy();
   });
 
   it('skips creation if app already exists', async () => {
@@ -147,6 +166,7 @@ describe('ensureApp', () => {
     expect(appsClient.createApp).not.toHaveBeenCalled();
     expect(appsClient.getApp).not.toHaveBeenCalled();
     expect(appsClient.allocateIP).not.toHaveBeenCalled();
+    expect(secretsClient.setAppSecret).not.toHaveBeenCalled();
   });
 
   it('resumes from partial state — IPv6 done, IPv4 pending', async () => {
@@ -300,6 +320,7 @@ describe('alarm retry', () => {
     storage._store.set('flyAppName', 'acct-test');
     storage._store.set('ipv6Allocated', false);
     storage._store.set('ipv4Allocated', false);
+    storage._store.set('envKeySet', false);
 
     (appsClient.getApp as Mock).mockRejectedValue(new FlyApiError('timeout', 503, 'retry'));
 
@@ -315,11 +336,120 @@ describe('alarm retry', () => {
     storage._store.set('flyAppName', 'acct-test');
     storage._store.set('ipv6Allocated', true);
     storage._store.set('ipv4Allocated', true);
+    storage._store.set('envKeySet', true);
+    storage._store.set('envKey', 'test-key');
 
     const { appDO } = createAppDO(storage);
     await appDO.alarm();
 
     expect(appsClient.getApp).not.toHaveBeenCalled();
     expect(appsClient.allocateIP).not.toHaveBeenCalled();
+    expect(secretsClient.setAppSecret).not.toHaveBeenCalled();
+  });
+
+  it('retries env key setup when IPs allocated but key missing', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+    storage._store.set('ipv6Allocated', true);
+    storage._store.set('ipv4Allocated', true);
+    storage._store.set('envKeySet', false);
+
+    // App exists
+    (appsClient.getApp as Mock).mockResolvedValue({ id: 'existing', created_at: 100 });
+
+    const { appDO } = createAppDO(storage);
+    await appDO.alarm();
+
+    // Should only set the env key, not allocate IPs
+    expect(appsClient.allocateIP).not.toHaveBeenCalled();
+    expect(secretsClient.setAppSecret).toHaveBeenCalled();
+    expect(storage._store.get('envKeySet')).toBe(true);
+  });
+});
+
+describe('ensureEnvKey', () => {
+  it('always re-sets Fly secret (self-healing) even when key exists', async () => {
+    const { appDO } = createAppDO();
+    await appDO.ensureApp('user-1');
+    vi.clearAllMocks();
+
+    const { key, secretsVersion } = await appDO.ensureEnvKey('user-1');
+
+    expect(key).toBeTruthy();
+    expect(secretsVersion).toBe(1);
+    // setAppSecret is always called to self-heal deleted Fly secrets
+    expect(secretsClient.setAppSecret).toHaveBeenCalledWith(
+      expect.objectContaining({ apiToken: 'test-token' }),
+      'KILOCLAW_ENV_KEY',
+      key
+    );
+  });
+
+  it('is idempotent — two calls return the same key', async () => {
+    const { appDO } = createAppDO();
+    await appDO.ensureApp('user-1');
+    vi.clearAllMocks();
+
+    const result1 = await appDO.ensureEnvKey('user-1');
+    const result2 = await appDO.ensureEnvKey('user-1');
+
+    expect(result1.key).toBe(result2.key);
+    // Called twice (once per ensureEnvKey call) but with same key
+    expect(secretsClient.setAppSecret).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates key for legacy app that has no key yet', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+    storage._store.set('ipv4Allocated', true);
+    storage._store.set('ipv6Allocated', true);
+    storage._store.set('envKeySet', false);
+
+    const { appDO } = createAppDO(storage);
+    const key = await appDO.ensureEnvKey('user-1');
+
+    expect(key).toBeTruthy();
+    expect(secretsClient.setAppSecret).toHaveBeenCalledWith(
+      { apiToken: 'test-token', appName: 'acct-test' },
+      'KILOCLAW_ENV_KEY',
+      expect.any(String)
+    );
+    expect(storage._store.get('envKeySet')).toBe(true);
+  });
+
+  it('throws on userId mismatch', async () => {
+    const { appDO } = createAppDO();
+    await appDO.ensureApp('user-1');
+
+    await expect(appDO.ensureEnvKey('user-2')).rejects.toThrow('userId mismatch');
+  });
+});
+
+describe('getEnvKey', () => {
+  it('returns key after ensureApp', async () => {
+    const { appDO } = createAppDO();
+    await appDO.ensureApp('user-1');
+
+    const key = await appDO.getEnvKey('user-1');
+    expect(key).toBeTruthy();
+  });
+
+  it('returns null when key not yet set', async () => {
+    const storage = createFakeStorage();
+    storage._store.set('userId', 'user-1');
+    storage._store.set('flyAppName', 'acct-test');
+
+    const { appDO } = createAppDO(storage);
+    const key = await appDO.getEnvKey('user-1');
+    expect(key).toBeNull();
+  });
+
+  it('throws on userId mismatch', async () => {
+    const { appDO } = createAppDO();
+    await appDO.ensureApp('user-1');
+
+    await expect(appDO.getEnvKey('user-2')).rejects.toThrow('userId mismatch');
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -56,7 +56,16 @@ vi.mock('../db', () => ({
 
 // -- Mock gateway/env --
 vi.mock('../gateway/env', () => ({
-  buildEnvVars: vi.fn().mockResolvedValue({ KILOCODE_API_KEY: 'test' }),
+  buildEnvVars: vi.fn().mockResolvedValue({
+    env: { AUTO_APPROVE_DEVICES: 'true' },
+    sensitive: { KILOCODE_API_KEY: 'test', OPENCLAW_GATEWAY_TOKEN: 'gw-token' },
+  }),
+}));
+
+// -- Mock utils/env-encryption --
+vi.mock('../utils/env-encryption', () => ({
+  ENCRYPTED_ENV_PREFIX: 'KILOCLAW_ENC_',
+  encryptEnvValue: vi.fn((_key: string, value: string) => `enc:v1:fake_${value}`),
 }));
 
 import { KiloClawInstance } from './kiloclaw-instance';
@@ -107,13 +116,27 @@ function createFakeStorage() {
   };
 }
 
+function createFakeAppStub() {
+  return {
+    ensureEnvKey: vi.fn().mockResolvedValue({
+      key: 'dGVzdC1rZXktMzItYnl0ZXMtcGFkZGVkLi4uLg==',
+      secretsVersion: 1,
+    }),
+  };
+}
+
 function createFakeEnv() {
+  const appStub = createFakeAppStub();
   return {
     FLY_API_TOKEN: 'test-token',
     FLY_APP_NAME: 'test-app',
     FLY_REGION: 'us,eu',
     GATEWAY_TOKEN_SECRET: 'test-secret',
     KILOCLAW_INSTANCE: {} as unknown,
+    KILOCLAW_APP: {
+      idFromName: vi.fn().mockReturnValue('fake-do-id'),
+      get: vi.fn().mockReturnValue(appStub),
+    } as unknown,
     HYPERDRIVE: { connectionString: '' } as unknown,
   };
 }

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -65,13 +65,14 @@ async function assertOk(resp: Response, context: string): Promise<void> {
 export async function createMachine(
   config: FlyClientConfig,
   machineConfig: FlyMachineConfig,
-  options?: { name?: string; region?: string; skipLaunch?: boolean }
+  options?: { name?: string; region?: string; skipLaunch?: boolean; minSecretsVersion?: number }
 ): Promise<FlyMachine> {
-  const body: CreateMachineRequest = {
+  const body: CreateMachineRequest & { min_secrets_version?: number } = {
     config: machineConfig,
     name: options?.name,
     region: options?.region,
     skip_launch: options?.skipLaunch,
+    min_secrets_version: options?.minSecretsVersion,
   };
   const resp = await flyFetch(config, '/machines', {
     method: 'POST',
@@ -149,11 +150,16 @@ export async function waitForState(
 export async function updateMachine(
   config: FlyClientConfig,
   machineId: string,
-  machineConfig: FlyMachineConfig
+  machineConfig: FlyMachineConfig,
+  options?: { minSecretsVersion?: number }
 ): Promise<FlyMachine> {
+  const body: { config: FlyMachineConfig; min_secrets_version?: number } = {
+    config: machineConfig,
+    min_secrets_version: options?.minSecretsVersion,
+  };
   const resp = await flyFetch(config, `/machines/${machineId}`, {
     method: 'POST',
-    body: JSON.stringify({ config: machineConfig }),
+    body: JSON.stringify(body),
   });
   await assertOk(resp, 'updateMachine');
   return resp.json();

--- a/kiloclaw/src/fly/secrets.test.ts
+++ b/kiloclaw/src/fly/secrets.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setAppSecret, deleteAppSecret, listAppSecrets } from './secrets';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const config = { apiToken: 'test-token', appName: 'test-app' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('setAppSecret', () => {
+  it('calls POST /secrets/{name} with value and returns version', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ name: 'MY_SECRET', version: 3 }), { status: 201 })
+    );
+
+    const result = await setAppSecret(config, 'MY_SECRET', 'secret-value');
+
+    expect(result.version).toBe(3);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.machines.dev/v1/apps/test-app/secrets/MY_SECRET',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ value: 'secret-value' }),
+      })
+    );
+  });
+
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValue(new Response('{"error":"bad"}', { status: 400 }));
+
+    await expect(setAppSecret(config, 'BAD', 'val')).rejects.toThrow('setAppSecret failed');
+  });
+});
+
+describe('deleteAppSecret', () => {
+  it('calls DELETE /secrets/{name}', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await deleteAppSecret(config, 'MY_SECRET');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.machines.dev/v1/apps/test-app/secrets/MY_SECRET',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('treats 404 as success (already gone)', async () => {
+    mockFetch.mockResolvedValue(new Response('', { status: 404 }));
+    await expect(deleteAppSecret(config, 'GONE')).resolves.toBeUndefined();
+  });
+});
+
+describe('listAppSecrets', () => {
+  it('returns secret names and digests', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          secrets: [
+            { name: 'KEY_A', digest: 'abc123' },
+            { name: 'KEY_B', digest: 'def456' },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+
+    const secrets = await listAppSecrets(config);
+    expect(secrets).toEqual([
+      { name: 'KEY_A', digest: 'abc123' },
+      { name: 'KEY_B', digest: 'def456' },
+    ]);
+  });
+});

--- a/kiloclaw/src/fly/secrets.ts
+++ b/kiloclaw/src/fly/secrets.ts
@@ -1,0 +1,92 @@
+/**
+ * Fly.io App Secrets REST API client.
+ *
+ * Manages per-app secrets stored in Fly's encrypted vault.
+ * Secrets are injected as environment variables at machine boot.
+ *
+ * API docs: https://docs.machines.dev/swagger/index.html
+ */
+
+import { FlyApiError } from './client';
+
+const FLY_API_BASE = 'https://api.machines.dev';
+
+type FlySecretsConfig = {
+  apiToken: string;
+  appName: string;
+};
+
+type AppSecret = {
+  name: string;
+  digest: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+async function secretsFetch(
+  config: FlySecretsConfig,
+  path: string,
+  init?: RequestInit
+): Promise<Response> {
+  const url = `${FLY_API_BASE}/v1/apps/${encodeURIComponent(config.appName)}${path}`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${config.apiToken}`,
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  });
+}
+
+async function assertOk(resp: Response, context: string): Promise<void> {
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new FlyApiError(`Fly API ${context} failed (${resp.status}): ${body}`, resp.status, body);
+  }
+}
+
+/**
+ * Set a single app secret. Returns the secrets version, which should be
+ * passed as `min_secrets_version` to createMachine/updateMachine to ensure
+ * the machine boots with this secret version available.
+ *
+ * POST /v1/apps/{app}/secrets/{name}
+ */
+export async function setAppSecret(
+  config: FlySecretsConfig,
+  name: string,
+  value: string
+): Promise<{ version: number }> {
+  const resp = await secretsFetch(config, `/secrets/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    body: JSON.stringify({ value }),
+  });
+  await assertOk(resp, 'setAppSecret');
+  const data: { version?: number } = await resp.json();
+  return { version: data.version ?? 0 };
+}
+
+/**
+ * Delete an app secret.
+ * DELETE /v1/apps/{app}/secrets/{name}
+ */
+export async function deleteAppSecret(config: FlySecretsConfig, name: string): Promise<void> {
+  const resp = await secretsFetch(config, `/secrets/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+  if (resp.status === 404) return; // already gone
+  await assertOk(resp, 'deleteAppSecret');
+}
+
+/**
+ * List app secret names and digests.
+ * Values are not readable via the API.
+ * GET /v1/apps/{app}/secrets
+ */
+export async function listAppSecrets(config: FlySecretsConfig): Promise<AppSecret[]> {
+  const resp = await secretsFetch(config, '/secrets');
+  await assertOk(resp, 'listAppSecrets');
+  const data: { secrets: AppSecret[] } = await resp.json();
+  return data.secrets ?? [];
+}

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -2,6 +2,7 @@ import type { KiloClawEnv } from '../types';
 import type { EncryptedEnvelope, EncryptedChannelTokens } from '../schemas/instance-config';
 import { deriveGatewayToken } from '../auth/gateway-token';
 import { mergeEnvVarsWithSecrets, decryptChannelTokens } from '../utils/encryption';
+import { validateUserEnvVarName } from '../utils/env-encryption';
 
 /**
  * User-provided configuration for building container environment variables.
@@ -17,6 +18,30 @@ export type UserConfig = {
 };
 
 /**
+ * Result of buildEnvVars: split into non-sensitive env vars and sensitive values
+ * that will be encrypted before placement in config.env.
+ */
+export type EnvVarsBuild = {
+  /** Non-sensitive vars — placed in config.env as-is. */
+  env: Record<string, string>;
+  /** Sensitive vars — encrypted and prefixed with KILOCLAW_ENC_ before config.env. */
+  sensitive: Record<string, string>;
+};
+
+/**
+ * Env var names that are always classified as sensitive.
+ * Values for these keys go into the `sensitive` bucket.
+ */
+const SENSITIVE_KEYS = new Set([
+  'KILOCODE_API_KEY',
+  'OPENCLAW_GATEWAY_TOKEN',
+  'TELEGRAM_BOT_TOKEN',
+  'DISCORD_BOT_TOKEN',
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+]);
+
+/**
  * Build environment variables to pass to the OpenClaw container process.
  *
  * Layering order:
@@ -26,58 +51,91 @@ export type UserConfig = {
  * 4. Decrypted channel tokens (mapped to container env var names)
  * 5. Reserved system vars (cannot be overridden by any user config)
  *
+ * Returns a split result: non-sensitive vars in `env`, sensitive vars in `sensitive`.
+ * User-provided plaintext env vars go to `env` unless they match SENSITIVE_KEYS.
+ * User-provided encrypted secrets always go to `sensitive`.
+ *
  * @param env - Worker environment bindings
  * @param sandboxId - Per-user sandbox ID
  * @param gatewayTokenSecret - Secret for deriving per-sandbox gateway tokens
  * @param userConfig - User-provided env vars, encrypted secrets, and channel tokens
- * @returns Environment variables record
+ * @returns Split env vars: `env` (plaintext) and `sensitive` (to be encrypted)
  */
 export async function buildEnvVars(
   env: KiloClawEnv,
   sandboxId: string,
   gatewayTokenSecret: string,
   userConfig?: UserConfig
-): Promise<Record<string, string>> {
-  // Layer 1: Worker-level defaults
-  const envVars: Record<string, string> = {};
+): Promise<EnvVarsBuild> {
+  // Layer 1: Worker-level defaults (non-sensitive)
+  const plainEnv: Record<string, string> = {};
 
-  if (env.DEV_MODE) envVars.OPENCLAW_DEV_MODE = env.DEV_MODE;
-  if (env.KILOCODE_API_BASE_URL) envVars.KILOCODE_API_BASE_URL = env.KILOCODE_API_BASE_URL;
+  if (env.DEV_MODE) plainEnv.OPENCLAW_DEV_MODE = env.DEV_MODE;
+  if (env.KILOCODE_API_BASE_URL) plainEnv.KILOCODE_API_BASE_URL = env.KILOCODE_API_BASE_URL;
+
+  // Collect all sensitive values
+  const sensitive: Record<string, string> = {};
 
   // Layer 2 + 3: User env vars merged with decrypted secrets.
   if (userConfig) {
+    // Validate user-provided env var names
+    if (userConfig.envVars) {
+      for (const name of Object.keys(userConfig.envVars)) {
+        validateUserEnvVarName(name);
+      }
+    }
+    if (userConfig.encryptedSecrets) {
+      for (const name of Object.keys(userConfig.encryptedSecrets)) {
+        validateUserEnvVarName(name);
+      }
+    }
+
     const userEnv = mergeEnvVarsWithSecrets(
       userConfig.envVars,
       userConfig.encryptedSecrets,
       env.AGENT_ENV_VARS_PRIVATE_KEY
     );
-    Object.assign(envVars, userEnv);
+
+    // User-provided decrypted secrets are sensitive (they came from encrypted envelopes).
+    // User-provided plaintext env vars: classify based on SENSITIVE_KEYS.
+    for (const [key, value] of Object.entries(userEnv)) {
+      if (SENSITIVE_KEYS.has(key)) {
+        sensitive[key] = value;
+      } else if (userConfig.encryptedSecrets?.[key]) {
+        // Was an encrypted secret — treat as sensitive
+        sensitive[key] = value;
+      } else {
+        plainEnv[key] = value;
+      }
+    }
 
     if (userConfig.kilocodeApiKey) {
-      envVars.KILOCODE_API_KEY = userConfig.kilocodeApiKey;
+      sensitive.KILOCODE_API_KEY = userConfig.kilocodeApiKey;
     }
     if (userConfig.kilocodeDefaultModel) {
-      envVars.KILOCODE_DEFAULT_MODEL = userConfig.kilocodeDefaultModel;
+      plainEnv.KILOCODE_DEFAULT_MODEL = userConfig.kilocodeDefaultModel;
     }
     if (userConfig.kilocodeModels) {
-      envVars.KILOCODE_MODELS_JSON = JSON.stringify(userConfig.kilocodeModels);
+      plainEnv.KILOCODE_MODELS_JSON = JSON.stringify(userConfig.kilocodeModels);
     }
 
     // Layer 4: Decrypt channel tokens and map to container env var names
     if (userConfig.channels && env.AGENT_ENV_VARS_PRIVATE_KEY) {
       const channelEnv = decryptChannelTokens(userConfig.channels, env.AGENT_ENV_VARS_PRIVATE_KEY);
-      Object.assign(envVars, channelEnv);
+      // All channel tokens are sensitive
+      Object.assign(sensitive, channelEnv);
     }
   }
 
-  // Worker-level passthrough
-  if (env.TELEGRAM_DM_POLICY) envVars.TELEGRAM_DM_POLICY = env.TELEGRAM_DM_POLICY;
-  if (env.DISCORD_DM_POLICY) envVars.DISCORD_DM_POLICY = env.DISCORD_DM_POLICY;
-  if (env.OPENCLAW_ALLOWED_ORIGINS) envVars.OPENCLAW_ALLOWED_ORIGINS = env.OPENCLAW_ALLOWED_ORIGINS;
+  // Worker-level passthrough (non-sensitive)
+  if (env.TELEGRAM_DM_POLICY) plainEnv.TELEGRAM_DM_POLICY = env.TELEGRAM_DM_POLICY;
+  if (env.DISCORD_DM_POLICY) plainEnv.DISCORD_DM_POLICY = env.DISCORD_DM_POLICY;
+  if (env.OPENCLAW_ALLOWED_ORIGINS)
+    plainEnv.OPENCLAW_ALLOWED_ORIGINS = env.OPENCLAW_ALLOWED_ORIGINS;
 
   // Layer 5: Reserved system vars (cannot be overridden by any user config)
-  envVars.OPENCLAW_GATEWAY_TOKEN = await deriveGatewayToken(sandboxId, gatewayTokenSecret);
-  envVars.AUTO_APPROVE_DEVICES = 'true';
+  sensitive.OPENCLAW_GATEWAY_TOKEN = await deriveGatewayToken(sandboxId, gatewayTokenSecret);
+  plainEnv.AUTO_APPROVE_DEVICES = 'true';
 
-  return envVars;
+  return { env: plainEnv, sensitive };
 }

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -19,9 +19,22 @@ const MachineSizeSchema = z.object({
 
 export type MachineSize = z.infer<typeof MachineSizeSchema>;
 
+/**
+ * Valid env var name: must be a valid shell identifier and must not use
+ * reserved prefixes (KILOCLAW_ENC_, KILOCLAW_ENV_) which are reserved
+ * for the env var encryption system.
+ */
+const envVarNameSchema = z
+  .string()
+  .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'Must be a valid shell identifier')
+  .refine(
+    s => !s.startsWith('KILOCLAW_ENC_') && !s.startsWith('KILOCLAW_ENV_'),
+    'Uses reserved prefix (KILOCLAW_ENC_ or KILOCLAW_ENV_)'
+  );
+
 export const InstanceConfigSchema = z.object({
-  envVars: z.record(z.string(), z.string()).optional(),
-  encryptedSecrets: z.record(z.string(), EncryptedEnvelopeSchema).optional(),
+  envVars: z.record(envVarNameSchema, z.string()).optional(),
+  encryptedSecrets: z.record(envVarNameSchema, EncryptedEnvelopeSchema).optional(),
   kilocodeApiKey: z.string().nullable().optional(),
   kilocodeApiKeyExpiresAt: z.string().nullable().optional(),
   kilocodeDefaultModel: z.string().nullable().optional(),

--- a/kiloclaw/src/utils/env-encryption.test.ts
+++ b/kiloclaw/src/utils/env-encryption.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateEnvKey,
+  encryptEnvValue,
+  decryptEnvValue,
+  isEncryptedEnvValue,
+  validateUserEnvVarName,
+  ENCRYPTED_ENV_PREFIX,
+} from './env-encryption';
+
+describe('generateEnvKey', () => {
+  it('produces a base64 string that decodes to 32 bytes', () => {
+    const key = generateEnvKey();
+    const buf = Buffer.from(key, 'base64');
+    expect(buf.length).toBe(32);
+  });
+});
+
+describe('encryptEnvValue / decryptEnvValue', () => {
+  it('round-trips: encrypt then decrypt returns original value', () => {
+    const key = generateEnvKey();
+    const plaintext = 'sk-test-api-key-12345';
+    const encrypted = encryptEnvValue(key, plaintext);
+    const decrypted = decryptEnvValue(key, encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('handles empty string', () => {
+    const key = generateEnvKey();
+    const encrypted = encryptEnvValue(key, '');
+    expect(decryptEnvValue(key, encrypted)).toBe('');
+  });
+
+  it('handles values with special characters', () => {
+    const key = generateEnvKey();
+    const value = 'token=\'with"special\nchars&stuff';
+    const encrypted = encryptEnvValue(key, value);
+    expect(decryptEnvValue(key, encrypted)).toBe(value);
+  });
+});
+
+describe('isEncryptedEnvValue', () => {
+  it('returns true for enc:v1: prefixed strings', () => {
+    expect(isEncryptedEnvValue('enc:v1:abc123')).toBe(true);
+  });
+
+  it('returns false for plain strings', () => {
+    expect(isEncryptedEnvValue('plain-value')).toBe(false);
+    expect(isEncryptedEnvValue('')).toBe(false);
+    expect(isEncryptedEnvValue('enc:v2:wrong-version')).toBe(false);
+  });
+});
+
+describe('validateUserEnvVarName', () => {
+  it('accepts valid shell identifiers', () => {
+    expect(() => validateUserEnvVarName('MY_VAR')).not.toThrow();
+    expect(() => validateUserEnvVarName('_private')).not.toThrow();
+    expect(() => validateUserEnvVarName('var123')).not.toThrow();
+  });
+
+  it('rejects KILOCLAW_ENC_ prefix', () => {
+    expect(() => validateUserEnvVarName('KILOCLAW_ENC_FOO')).toThrow('reserved prefix');
+  });
+
+  it('rejects KILOCLAW_ENV_ prefix', () => {
+    expect(() => validateUserEnvVarName('KILOCLAW_ENV_KEY')).toThrow('reserved prefix');
+  });
+
+  it('rejects names with hyphens', () => {
+    expect(() => validateUserEnvVarName('MY-VAR')).toThrow('valid shell identifier');
+  });
+
+  it('rejects names starting with digit', () => {
+    expect(() => validateUserEnvVarName('123VAR')).toThrow('valid shell identifier');
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validateUserEnvVarName('')).toThrow('valid shell identifier');
+  });
+});
+
+describe('ENCRYPTED_ENV_PREFIX', () => {
+  it('is KILOCLAW_ENC_', () => {
+    expect(ENCRYPTED_ENV_PREFIX).toBe('KILOCLAW_ENC_');
+  });
+});

--- a/kiloclaw/src/utils/env-encryption.ts
+++ b/kiloclaw/src/utils/env-encryption.ts
@@ -1,0 +1,88 @@
+/**
+ * AES-256-GCM encryption for environment variable values.
+ *
+ * Used to encrypt sensitive env var values in the CF Worker before placing
+ * them in Fly Machine config.env. Decrypted at boot by start-openclaw.sh
+ * using the KILOCLAW_ENV_KEY (stored as a Fly app secret).
+ *
+ * Ciphertext format: "enc:v1:{base64(12-byte-iv + ciphertext + 16-byte-tag)}"
+ */
+
+import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
+
+/** Prefix added to env var names in config.env for encrypted values. */
+export const ENCRYPTED_ENV_PREFIX = 'KILOCLAW_ENC_';
+
+/** Prefix on encrypted values (format version marker). */
+const ENCRYPTED_VALUE_PREFIX = 'enc:v1:';
+
+/** Prefixes reserved for the encryption system. User env vars must not use these. */
+export const RESERVED_PREFIXES = ['KILOCLAW_ENC_', 'KILOCLAW_ENV_'] as const;
+
+/** Valid shell identifier: letters, digits, underscores. Must start with letter or underscore. */
+const SHELL_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Generate a random 256-bit AES key, returned as base64. */
+export function generateEnvKey(): string {
+  return randomBytes(32).toString('base64');
+}
+
+/** Encrypt a plaintext value. Returns "enc:v1:{base64(iv + ciphertext + authTag)}". */
+export function encryptEnvValue(keyBase64: string, plaintext: string): string {
+  const key = Buffer.from(keyBase64, 'base64');
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const combined = Buffer.concat([iv, encrypted, tag]);
+  return ENCRYPTED_VALUE_PREFIX + combined.toString('base64');
+}
+
+/** Decrypt an encrypted value. Input must start with "enc:v1:". */
+export function decryptEnvValue(keyBase64: string, encoded: string): string {
+  if (!encoded.startsWith(ENCRYPTED_VALUE_PREFIX)) {
+    throw new Error('Invalid encrypted value: missing enc:v1: prefix');
+  }
+
+  const key = Buffer.from(keyBase64, 'base64');
+  const data = Buffer.from(encoded.slice(ENCRYPTED_VALUE_PREFIX.length), 'base64');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(data.length - 16);
+  const ciphertext = data.subarray(12, data.length - 16);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  let decrypted = decipher.update(ciphertext, undefined, 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}
+
+/** Check if a string looks like an encrypted env value. */
+export function isEncryptedEnvValue(value: string): boolean {
+  return value.startsWith(ENCRYPTED_VALUE_PREFIX);
+}
+
+/**
+ * Validate that an env var name is a valid shell identifier.
+ * Returns true if the name matches /^[A-Za-z_][A-Za-z0-9_]*$/.
+ */
+export function isValidShellIdentifier(name: string): boolean {
+  return SHELL_IDENTIFIER_RE.test(name);
+}
+
+/**
+ * Validate that a user-provided env var name doesn't use reserved prefixes
+ * and is a valid shell identifier.
+ * Throws if validation fails.
+ */
+export function validateUserEnvVarName(name: string): void {
+  for (const prefix of RESERVED_PREFIXES) {
+    if (name.startsWith(prefix)) {
+      throw new Error(`Env var name '${name}' uses reserved prefix '${prefix}'`);
+    }
+  }
+  if (!isValidShellIdentifier(name)) {
+    throw new Error(
+      `Env var name '${name}' is not a valid shell identifier (must match /^[A-Za-z_][A-Za-z0-9_]*$/)`
+    );
+  }
+}

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Startup script for OpenClaw on Fly.io Machines
 # This script:
-# 1. Runs openclaw onboard --non-interactive to configure from env vars (first run only)
-# 2. Patches config for features onboard doesn't cover (channels, gateway auth)
-# 3. Starts the gateway
+# 1. Decrypts KILOCLAW_ENC_* environment variables (if encryption key is present)
+# 2. Runs openclaw onboard --non-interactive to configure from env vars (first run only)
+# 3. Patches config for features onboard doesn't cover (channels, gateway auth)
+# 4. Starts the gateway
 
 set -e
 
@@ -21,6 +22,93 @@ echo "Config directory: $CONFIG_DIR"
 mkdir -p "$CONFIG_DIR"
 mkdir -p "$WORKSPACE_DIR"
 cd "$WORKSPACE_DIR"
+
+# ============================================================
+# DECRYPT ENCRYPTED ENV VARS
+# ============================================================
+# Encrypted env vars use KILOCLAW_ENC_ prefix in config.env.
+# The decryption key (KILOCLAW_ENV_KEY) is a Fly app secret
+# injected at boot, never in config.env.
+KILOCLAW_DECRYPT_FILE="/tmp/.kiloclaw-decrypted-env.sh"
+
+# Fail closed: if KILOCLAW_ENC_* vars exist, KILOCLAW_ENV_KEY must be set
+if env | grep -q '^KILOCLAW_ENC_' && [ -z "${KILOCLAW_ENV_KEY:-}" ]; then
+    echo "FATAL: Encrypted env vars (KILOCLAW_ENC_*) found but KILOCLAW_ENV_KEY is not set"
+    exit 1
+fi
+
+if [ -n "${KILOCLAW_ENV_KEY:-}" ]; then
+    echo "Decrypting encrypted environment variables..."
+    node << 'EOFDECRYPT'
+const crypto = require('crypto');
+const fs = require('fs');
+
+const key = Buffer.from(process.env.KILOCLAW_ENV_KEY, 'base64');
+const ENC_PREFIX = 'KILOCLAW_ENC_';
+const VALUE_PREFIX = 'enc:v1:';
+const VALID_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const lines = [];
+let count = 0;
+
+for (const [envName, value] of Object.entries(process.env)) {
+    if (!envName.startsWith(ENC_PREFIX)) continue;
+
+    const name = envName.slice(ENC_PREFIX.length);
+
+    // Validate stripped name is a safe shell identifier
+    if (!VALID_NAME.test(name)) {
+        console.error('FATAL: Invalid env var name after stripping prefix: ' + name);
+        process.exit(1);
+    }
+
+    // Validate value has the expected format prefix
+    if (!value.startsWith(VALUE_PREFIX)) {
+        console.error('FATAL: ' + envName + ' does not start with ' + VALUE_PREFIX);
+        process.exit(1);
+    }
+
+    const data = Buffer.from(value.slice(VALUE_PREFIX.length), 'base64');
+    const iv = data.subarray(0, 12);
+    const tag = data.subarray(data.length - 16);
+    const ciphertext = data.subarray(12, data.length - 16);
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(tag);
+    let plain = decipher.update(ciphertext, undefined, 'utf8');
+    plain += decipher.final('utf8');
+
+    // Shell-safe: single-quote value, escape inner single quotes
+    const escaped = plain.replace(/'/g, "'\\''");
+    lines.push("export " + name + "='" + escaped + "'");
+    count++;
+}
+
+fs.writeFileSync('/tmp/.kiloclaw-decrypted-env.sh', lines.join('\n') + '\n');
+console.log('Decrypted ' + count + ' encrypted environment variables');
+EOFDECRYPT
+
+    # Source decrypted values into shell environment, then immediately delete
+    . "$KILOCLAW_DECRYPT_FILE"
+    rm -f "$KILOCLAW_DECRYPT_FILE"
+
+    # Post-decrypt presence check: critical vars must exist after decryption
+    if [ -z "${KILOCODE_API_KEY:-}" ]; then
+        echo "FATAL: KILOCODE_API_KEY missing after decryption"
+        exit 1
+    fi
+    if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
+        echo "FATAL: OPENCLAW_GATEWAY_TOKEN missing after decryption"
+        exit 1
+    fi
+
+    # Clean up encryption artifacts — don't leak key material to openclaw process
+    unset KILOCLAW_ENV_KEY 2>/dev/null || true
+    for _enc_var in "${!KILOCLAW_ENC_@}"; do
+        unset "$_enc_var"
+    done
+    unset _enc_var 2>/dev/null || true
+else
+    echo "No KILOCLAW_ENV_KEY found, using env vars as-is"
+fi
 
 # ============================================================
 # ONBOARD (only if no config exists yet)


### PR DESCRIPTION
## Summary

Sensitive environment variables (API keys, gateway tokens, channel tokens) are now AES-256-GCM encrypted before placement in Fly machine `config.env`. Previously these were stored as plaintext, visible in Fly API responses (`getMachine`) and the Fly control plane.

## How it works

### Background

KiloClaw uses two Durable Objects per user:
- **`KiloClawApp` (App DO)** — manages the per-user Fly App lifecycle (one Fly app per user). Handles app creation, IP allocation, and now env encryption key management.
- **`KiloClawInstance` (Instance DO)** — manages the machine lifecycle (create, start, stop, destroy). Builds environment variables and creates/updates Fly Machines.

The worker builds env vars via `buildEnvVars()`, which layers platform defaults, user config, decrypted secrets, and channel tokens into a single record that gets passed to the Fly Machines API as `config.env`.

### Encryption flow

```
CF Worker (kiloclaw)                          Fly Machine (start-openclaw.sh)
─────────────────────                         ──────────────────────────────
1. App DO generates AES-256 key               3. KILOCLAW_ENV_KEY injected by Fly
   → stored as Fly app secret                    from encrypted vault
   (KILOCLAW_ENV_KEY)
                                              4. Decrypt block iterates KILOCLAW_ENC_*
2. Instance DO encrypts sensitive vars           → strips prefix, decrypts value
   → KILOCLAW_ENC_KILOCODE_API_KEY=enc:v1:…     → exports KILOCODE_API_KEY=plaintext
   → KILOCLAW_ENC_OPENCLAW_GATEWAY_TOKEN=…       → exports OPENCLAW_GATEWAY_TOKEN=…
   → non-sensitive vars stay as-is
                                              5. Unsets KILOCLAW_ENV_KEY + KILOCLAW_ENC_*
   min_secrets_version passed to                 (key material not inherited by openclaw)
   createMachine/updateMachine
                                              6. Post-decrypt presence check:
                                                 KILOCODE_API_KEY + OPENCLAW_GATEWAY_TOKEN
                                                 must exist, else exit 1

                                              7. PATCH CONFIG + exec gateway as before
```

### Key design decisions

- **`KILOCLAW_ENC_` prefix** on encrypted env var names prevents "encrypted blob used as plaintext" failures. If the decrypt block doesn't run (old image), `KILOCODE_API_KEY` simply doesn't exist and the existing check catches it cleanly.
- **`min_secrets_version`** threaded from `setAppSecret` response through to `createMachine`/`updateMachine`. Fly's REST API stages secrets without deploying — this field ensures the machine won't boot until the secret has propagated.
- **Fail closed everywhere**: missing key with `KILOCLAW_ENC_*` vars → exit 1. Any decrypt error → exit 1. Invalid env var name → exit 1.
- **Single key-write path**: all key generation goes through `ensureEnvKey()`. The key is persisted to memory + storage before the `setAppSecret` await, so interleaved DO calls reuse the same key (DOs are single-threaded but non-storage awaits can interleave).
- **Self-healing**: `ensureEnvKey` always calls `setAppSecret` (idempotent) to re-create the Fly secret if it was deleted externally.

### What's encrypted vs plaintext

| Encrypted (`KILOCLAW_ENC_*`) | Plaintext |
|---|---|
| `KILOCODE_API_KEY` | `KILOCODE_DEFAULT_MODEL` |
| `OPENCLAW_GATEWAY_TOKEN` | `KILOCODE_MODELS_JSON` |
| `TELEGRAM_BOT_TOKEN` | `KILOCODE_API_BASE_URL` |
| `DISCORD_BOT_TOKEN` | `AUTO_APPROVE_DEVICES` |
| `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` | `OPENCLAW_DEV_MODE` |
| User-provided encrypted secrets | DM policies, allowed origins |

## Other changes in this branch

- Fixes pre-existing bug: `kilocodeModels` was not passed through `buildUserEnvVars` to `buildEnvVars`, so `KILOCODE_MODELS_JSON` was never set from persisted DO config (broken since the Fly migration in `d1219a7`)

---

<img width="1045" height="337" alt="SCR-20260216-rlsq" src="https://github.com/user-attachments/assets/ba67beb8-ca09-4f8d-a840-bab2df428812" />
