### PR TITLE
feat(admin): add session_id to usage data in heuristic abuse page

### DIFF
--- a/src/app/(app)/claw/page.tsx
+++ b/src/app/(app)/claw/page.tsx
@@ -512,12 +512,12 @@ export default function ClawPage() {
               </PopoverContent>
             )}
           </Popover>
-          <a href={gatewayUrl} target="_blank" rel="noopener noreferrer">
-            <Button variant="outline">
+          <Button variant="outline" asChild>
+            <a href={gatewayUrl} target="_blank" rel="noopener noreferrer">
               <ExternalLink className="mr-2 h-4 w-4" />
               Open
-            </Button>
-          </a>
+            </a>
+          </Button>
         </>
       )}
     </div>

--- a/src/app/(app)/claw/page.tsx
+++ b/src/app/(app)/claw/page.tsx
@@ -512,12 +512,12 @@ export default function ClawPage() {
               </PopoverContent>
             )}
           </Popover>
-          <Button variant="outline" asChild>
-            <a href={gatewayUrl} target="_blank" rel="noopener noreferrer">
+          <a href={gatewayUrl} target="_blank" rel="noopener noreferrer">
+            <Button variant="outline">
               <ExternalLink className="mr-2 h-4 w-4" />
               Open
-            </a>
-          </Button>
+            </Button>
+          </a>
         </>
       )}
     </div>

--- a/src/app/admin/api/users/heuristic-analysis/grouped/route.ts
+++ b/src/app/admin/api/users/heuristic-analysis/grouped/route.ts
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<HeuristicA
         SUM(cost) / 1000000.0 as cost_dollars,
         SUM(input_tokens) as input_tokens,
         SUM(output_tokens) as output_tokens
-      FROM microdollar_usage_view
+      FROM microdollar_usage_view_with_session
       CROSS JOIN LATERAL (
         SELECT
           CASE

--- a/src/app/admin/api/users/heuristic-analysis/types.ts
+++ b/src/app/admin/api/users/heuristic-analysis/types.ts
@@ -1,10 +1,11 @@
-import type { MicrodollarUsageView } from '@/db/schema';
+import { microdollar_usage_view_with_session } from '@/db/schema';
 import type { PaginationMetadata } from '@/types/pagination';
 
 export type ApiResponse = GroupedDataResponse | PaginatedRawDataResponse;
-export type UsageForTableDisplay = MicrodollarUsageView & {
-  is_ja4_whitelisted: boolean;
-};
+export type UsageForTableDisplay = Omit<
+  typeof microdollar_usage_view_with_session.$inferSelect & { is_ja4_whitelisted: boolean },
+  'organization_id' | 'inference_provider'
+> & { organization_id: string | null; inference_provider: string | null };
 
 export type GroupByDimension = 'day' | 'week' | 'month' | 'userAgent' | 'model';
 

--- a/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
@@ -286,6 +286,12 @@ const createMicrodollarUsageColumns = (): TableColumn<UsageForTableDisplay>[] =>
   { key: 'id', title: 'ID', render: row => row.id, visible: false },
   { key: 'message_id', title: 'Message ID', render: row => row.message_id ?? '', visible: false },
   {
+    key: 'session_id',
+    title: 'Session ID',
+    render: row => row.session_id || 'N/A',
+    visible: true,
+  },
+  {
     key: 'upstream_id',
     title: 'Upstream ID',
     render: row => row.upstream_id || 'N/A',


### PR DESCRIPTION
## Summary
- Adds a new database view `microdollar_usage_view_with_session` that joins usage data with session information via `app_builder_project_sessions` and `cli_sessions` tables
- Updates the heuristic abuse page API routes to use the new view
- Adds a Session ID column to the raw data table in the admin UI

This allows admins to see which CLI session (if any) generated each usage record when the usage is associated with an active app builder project.