### PR TITLE
feat(gastown): Sandbox Docker Image

### DIFF
--- a/gastown-sandbox/Dockerfile
+++ b/gastown-sandbox/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Pinned versions for reproducible builds
 ENV NODE_VERSION=22.13.1
 ENV DOLT_VERSION=1.35.0
-ENV KILO_CLI_VERSION=latest
+ENV KILO_CLI_VERSION=1.0.23
 
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/gastown-sandbox/Dockerfile
+++ b/gastown-sandbox/Dockerfile
@@ -1,0 +1,108 @@
+FROM ubuntu:22.04
+
+# Pinned versions for reproducible builds
+ENV NODE_VERSION=22.13.1
+ENV DOLT_VERSION=1.35.0
+ENV KILO_CLI_VERSION=latest
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies.
+# git-core PPA provides >=2.40 (Ubuntu 22.04 default is 2.34).
+# tmux from source provides >=3.3 (Ubuntu 22.04 default is 3.2a).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       curl \
+       git \
+       jq \
+       xz-utils \
+       unzip \
+       openssh-client \
+       # tmux build deps
+       libevent-dev libncurses-dev build-essential bison pkg-config autoconf automake \
+    && rm -rf /var/lib/apt/lists/*
+
+# Verify git version (>=2.40 required for worktree support)
+RUN git_major=$(git --version | sed 's/git version //' | cut -d. -f1) \
+    && git_minor=$(git --version | sed 's/git version //' | cut -d. -f2) \
+    && if [ "$git_major" -lt 2 ] || { [ "$git_major" -eq 2 ] && [ "$git_minor" -lt 40 ]; }; then \
+         echo "FATAL: git $(git --version) is too old, need >=2.40" >&2; exit 1; \
+       fi \
+    && echo "git version OK: $(git --version)"
+
+# Build tmux >=3.3 from source (Ubuntu 22.04 only ships 3.2a)
+ENV TMUX_VERSION=3.4
+RUN curl -fsSL "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" -o /tmp/tmux.tar.gz \
+    && tar -xzf /tmp/tmux.tar.gz -C /tmp \
+    && cd /tmp/tmux-${TMUX_VERSION} \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && rm -rf /tmp/tmux* \
+    && tmux -V
+
+# Clean up build dependencies no longer needed at runtime
+RUN apt-get purge -y build-essential bison pkg-config autoconf automake software-properties-common \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js (required by Kilo CLI and gastown.js plugin)
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "${ARCH}" in \
+         amd64) NODE_ARCH="x64" ;; \
+         arm64) NODE_ARCH="arm64" ;; \
+         *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz \
+    && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
+    && rm /tmp/node.tar.xz \
+    && node --version \
+    && npm --version
+
+# Install Dolt (per-rig SQL database)
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-${ARCH}.tar.gz" -o /tmp/dolt.tar.gz \
+    && tar -xzf /tmp/dolt.tar.gz -C /tmp \
+    && mv /tmp/dolt-linux-*/bin/dolt /usr/local/bin/dolt \
+    && rm -rf /tmp/dolt* \
+    && dolt version
+
+# Install gt (gastown binary)
+# The gt binary must be provided as a build artifact in bin/.
+# CI/CD should download the correct platform binary before building.
+# TODO: Replace with a goreleaser download URL once release artifacts are published.
+COPY --chmod=755 bin/gt /usr/local/bin/gt
+
+# Install Kilo CLI
+RUN npm install -g @kilocode/cli@${KILO_CLI_VERSION} \
+    && kilo --version
+
+# Create gt user and home directory structure
+ENV GT_HOME=/home/gt
+RUN useradd -m -d /home/gt -s /bin/bash gt \
+    && mkdir -p /home/gt/.gt/settings
+
+# Copy town config and fix ownership
+COPY town-config.json /home/gt/.gt/settings/config.json
+RUN chown -R gt:gt /home/gt/.gt
+
+# Copy startup script
+COPY --chmod=755 startup.sh /usr/local/bin/startup.sh
+
+# Data volume mount point (50GB persistent volume on Fly.io)
+VOLUME /home/gt/data
+
+# Internal API port (control plane, built in PR 3)
+EXPOSE 8080
+
+# Switch to gt user
+USER gt
+WORKDIR /home/gt
+
+ENTRYPOINT ["/usr/local/bin/startup.sh"]

--- a/gastown-sandbox/startup.sh
+++ b/gastown-sandbox/startup.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Startup script for Gastown Sandbox on Fly.io Machines
+#
+# This script:
+# 1. Sets environment from provisioned secrets
+# 2. Restores from R2 if backup exists and volume is empty (PR 4)
+# 3. Runs `gt up` to start the gastown daemon
+# 4. Starts R2 sync daemon in background (PR 4)
+# 5. Starts internal API server in background (PR 3)
+# 6. Starts terminal proxy in background (PR 7)
+# 7. Handles SIGTERM for graceful shutdown
+# 8. Keeps container alive
+
+set -uo pipefail
+
+GT_HOME="${GT_HOME:-/home/gt}"
+DATA_DIR="${GT_HOME}/data"
+LOG_DIR="${GT_HOME}/logs"
+
+mkdir -p "$DATA_DIR" "$LOG_DIR"
+
+# ============================================================
+# LOGGING
+# ============================================================
+log() {
+    echo "[gastown-sandbox] $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"
+}
+
+log "Starting gastown sandbox..."
+log "GT_HOME=$GT_HOME"
+log "DATA_DIR=$DATA_DIR"
+
+# ============================================================
+# ENVIRONMENT
+# ============================================================
+# Required env vars are set by the provisioning system:
+#   KILO_API_URL  — gateway URL for LLM calls
+#   KILO_JWT      — per-user gateway auth token
+#   TOWN_ID       — unique town identifier
+#   INTERNAL_API_KEY — shared secret for internal API auth
+#
+# Optional (added by later PRs):
+#   R2_BUCKET, R2_ACCESS_KEY, R2_SECRET_KEY, R2_ENDPOINT
+
+if [ -z "${KILO_API_URL:-}" ]; then
+    log "WARNING: KILO_API_URL not set. LLM calls will fail."
+fi
+
+if [ -z "${TOWN_ID:-}" ]; then
+    log "WARNING: TOWN_ID not set."
+fi
+
+# Export for gt and kilo-cli
+export KILO_API_URL="${KILO_API_URL:-}"
+export KILO_JWT="${KILO_JWT:-}"
+
+# ============================================================
+# CHILD PID TRACKING
+# ============================================================
+CHILD_PIDS=()
+
+# ============================================================
+# SIGTERM HANDLER
+# ============================================================
+shutdown() {
+    log "Received shutdown signal, starting graceful shutdown..."
+
+    # Trigger final R2 backup if sync daemon is available
+    if [ -x /usr/local/bin/r2-sync-daemon.sh ]; then
+        log "Flushing to R2 before shutdown..."
+        /usr/local/bin/r2-sync-daemon.sh --flush 2>&1 | while read -r line; do log "r2-flush: $line"; done || true
+    fi
+
+    # Stop gt daemon
+    log "Stopping gt daemon..."
+    /usr/local/bin/gt down 2>&1 | while read -r line; do log "gt-down: $line"; done || true
+
+    # Terminate background processes
+    for pid in "${CHILD_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            log "Terminating PID $pid..."
+            kill -TERM "$pid" 2>/dev/null || true
+        fi
+    done
+
+    # Wait briefly for children to exit
+    for pid in "${CHILD_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            timeout 5 tail --pid="$pid" -f /dev/null 2>/dev/null || true
+        fi
+    done
+
+    log "Shutdown complete."
+    exit 0
+}
+
+trap shutdown SIGTERM SIGINT
+
+# ============================================================
+# R2 RESTORE (PR 4 — optional, resilient to absence)
+# ============================================================
+if [ -x /usr/local/bin/r2-restore.sh ]; then
+    log "Checking if R2 restore is needed..."
+    /usr/local/bin/r2-restore.sh 2>&1 | while read -r line; do log "r2-restore: $line"; done || {
+        log "WARNING: R2 restore failed (non-fatal, continuing with empty volume)"
+    }
+else
+    log "r2-restore.sh not found, skipping R2 restore"
+fi
+
+# ============================================================
+# START GT DAEMON
+# ============================================================
+log "Starting gt daemon..."
+if /usr/local/bin/gt up 2>&1 | while read -r line; do log "gt-up: $line"; done; then
+    log "gt daemon started"
+else
+    log "ERROR: gt up failed. Continuing so sandbox remains reachable for debugging."
+fi
+
+# ============================================================
+# R2 SYNC DAEMON (PR 4 — optional, resilient to absence)
+# ============================================================
+if [ -x /usr/local/bin/r2-sync-daemon.sh ]; then
+    log "Starting R2 sync daemon..."
+    /usr/local/bin/r2-sync-daemon.sh >> "$LOG_DIR/r2-sync.log" 2>&1 &
+    CHILD_PIDS+=($!)
+    log "R2 sync daemon started (PID $!)"
+else
+    log "r2-sync-daemon.sh not found, skipping R2 sync"
+fi
+
+# ============================================================
+# INTERNAL API SERVER (PR 3 — optional, resilient to absence)
+# ============================================================
+if [ -x /usr/local/bin/internal-api ]; then
+    log "Starting internal API server..."
+    /usr/local/bin/internal-api >> "$LOG_DIR/internal-api.log" 2>&1 &
+    CHILD_PIDS+=($!)
+    log "Internal API server started (PID $!)"
+elif [ -f /usr/local/lib/internal-api/server.js ]; then
+    log "Starting internal API server (Node.js)..."
+    node /usr/local/lib/internal-api/server.js >> "$LOG_DIR/internal-api.log" 2>&1 &
+    CHILD_PIDS+=($!)
+    log "Internal API server started (PID $!)"
+else
+    log "Internal API server not found, skipping"
+fi
+
+# ============================================================
+# TERMINAL PROXY (PR 7 — optional, resilient to absence)
+# ============================================================
+if [ -x /usr/local/bin/terminal-proxy ]; then
+    log "Starting terminal proxy..."
+    /usr/local/bin/terminal-proxy >> "$LOG_DIR/terminal-proxy.log" 2>&1 &
+    CHILD_PIDS+=($!)
+    log "Terminal proxy started (PID $!)"
+else
+    log "terminal-proxy not found, skipping"
+fi
+
+# ============================================================
+# KEEP ALIVE
+# ============================================================
+log "Sandbox ready. Waiting for shutdown signal..."
+
+# Use wait instead of sleep infinity so we can respond to signals
+while true; do
+    sleep 60 &
+    SLEEP_PID=$!
+    wait $SLEEP_PID 2>/dev/null || true
+done

--- a/gastown-sandbox/town-config.json
+++ b/gastown-sandbox/town-config.json
@@ -1,0 +1,3 @@
+{
+  "default_agent": "opencode"
+}


### PR DESCRIPTION
## Summary

Closes #281

Fly.io machine image with all gastown dependencies pre-installed for the sandbox-per-town hosted gastown (Proposal A).

- **Ubuntu 22.04 base** with git >=2.40 (via git-core PPA), tmux 3.4 (built from source), Node.js 22.13.1, Dolt 1.35.0, jq
- **gt binary** placeholder (COPY from `bin/` — CI must provide the build artifact)
- **Kilo CLI** installed globally via npm
- **Pre-configured** `default_agent: "opencode"` via `town-config.json`
- **startup.sh**: R2 restore (if available) → `gt up` → background services (R2 sync, internal API, terminal proxy) → SIGTERM graceful shutdown
- Resilient to missing optional components from later PRs (#283, #284, #287)
- Runs as non-root `gt` user with persistent volume at `/home/gt/data`

## Files

- `gastown-sandbox/Dockerfile` — Multi-step build with version-pinned binaries
- `gastown-sandbox/startup.sh` — Entrypoint with signal handling and service orchestration
- `gastown-sandbox/town-config.json` — Default gastown configuration
- `gastown-sandbox/bin/.gitkeep` — Placeholder for gt binary build artifact

## Notes

- The `gt` binary must be placed in `gastown-sandbox/bin/gt` before building. This will be handled by CI/CD once goreleaser artifacts are published.
- Git version is validated at build time (fails if <2.40)
- tmux is built from source since Ubuntu 22.04 only ships 3.2a
- Build deps (gcc, make, etc.) are purged after tmux compilation to reduce image size