### PR TITLE
Add KiloClaw Instances admin page

### DIFF
--- a/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
+++ b/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
@@ -14,6 +14,7 @@ const baseStatus: KiloClawDashboardStatus = {
   envVarCount: 1,
   secretCount: 2,
   channelCount: 3,
+  flyAppName: null,
   flyMachineId: null,
   flyVolumeId: null,
   flyRegion: null,

--- a/src/app/admin/components/AppSidebar.tsx
+++ b/src/app/admin/components/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
   UserX,
   Upload,
   Bell,
+  Server,
 } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import type { Session } from 'next-auth';
@@ -120,6 +121,11 @@ const productEngineeringItems: MenuItem[] = [
     title: () => 'App Builder',
     url: '/admin/app-builder',
     icon: () => <Blocks />,
+  },
+  {
+    title: () => 'KiloClaw Instances',
+    url: '/admin/kiloclaw-instances',
+    icon: () => <Server />,
   },
   {
     title: () => 'Managed Indexing',

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import { useState } from 'react';
+import AdminPage from '@/app/admin/components/AdminPage';
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import {
+  User,
+  Calendar,
+  Loader2,
+  Server,
+  Globe,
+  HardDrive,
+  AlertTriangle,
+  ExternalLink,
+  Trash2,
+  BarChart,
+} from 'lucide-react';
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+import { toast } from 'sonner';
+
+function formatRelativeTime(timestamp: string | null): string {
+  if (!timestamp) return '—';
+  return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+}
+
+function formatAbsoluteTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function formatEpochTime(epoch: number | null): string {
+  if (epoch === null) return '—';
+  return new Date(epoch).toLocaleString();
+}
+
+type DetailPageWrapperProps = {
+  children: React.ReactNode;
+  subtitle: string | undefined;
+};
+
+function DetailPageWrapper({ children, subtitle }: DetailPageWrapperProps) {
+  const breadcrumbs = (
+    <>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="/admin/kiloclaw-instances">KiloClaw Instances</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage>{subtitle ?? 'Instance Details'}</BreadcrumbPage>
+      </BreadcrumbItem>
+    </>
+  );
+
+  return <AdminPage breadcrumbs={breadcrumbs}>{children}</AdminPage>;
+}
+
+function StatusBadge({ status }: { status: string | null }) {
+  switch (status) {
+    case 'running':
+      return <Badge className="bg-green-600">Running</Badge>;
+    case 'stopped':
+      return <Badge variant="secondary">Stopped</Badge>;
+    case 'provisioned':
+      return <Badge className="bg-blue-600">Provisioned</Badge>;
+    case 'destroying':
+      return <Badge variant="destructive">Destroying</Badge>;
+    default:
+      return <Badge variant="outline">Unknown</Badge>;
+  }
+}
+
+function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}
+
+export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [destroyDialogOpen, setDestroyDialogOpen] = useState(false);
+
+  const { data, isLoading, error } = useQuery(
+    trpc.admin.kiloclawInstances.get.queryOptions({ id: instanceId })
+  );
+
+  const { mutateAsync: destroyInstance, isPending: isDestroying } = useMutation(
+    trpc.admin.kiloclawInstances.destroy.mutationOptions({
+      onSuccess: () => {
+        toast.success('Instance destroyed successfully');
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.list.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.stats.queryKey(),
+        });
+        setDestroyDialogOpen(false);
+      },
+      onError: err => {
+        toast.error(`Failed to destroy instance: ${err.message}`);
+      },
+    })
+  );
+
+  if (isLoading) {
+    return (
+      <DetailPageWrapper subtitle={undefined}>
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span>Loading instance details...</span>
+        </div>
+      </DetailPageWrapper>
+    );
+  }
+
+  if (error) {
+    return (
+      <DetailPageWrapper subtitle={undefined}>
+        <Alert variant="destructive">
+          <AlertDescription>
+            {error instanceof Error ? error.message : 'Failed to load instance'}
+          </AlertDescription>
+        </Alert>
+      </DetailPageWrapper>
+    );
+  }
+
+  if (!data) {
+    return (
+      <DetailPageWrapper subtitle={undefined}>
+        <Alert variant="destructive">
+          <AlertDescription>Instance not found</AlertDescription>
+        </Alert>
+      </DetailPageWrapper>
+    );
+  }
+
+  const isActive = data.destroyed_at === null;
+
+  return (
+    <DetailPageWrapper subtitle={data.user_email ?? data.user_id}>
+      <div className="flex w-full flex-col gap-6">
+        {/* Instance Information */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Instance Information</CardTitle>
+                <CardDescription>Database record for this KiloClaw instance</CardDescription>
+              </div>
+              <div className="flex items-center gap-3">
+                {isActive ? (
+                  <>
+                    <Badge className="bg-green-600">Active</Badge>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setDestroyDialogOpen(true)}
+                    >
+                      <Trash2 className="mr-1 h-4 w-4" />
+                      Destroy Instance
+                    </Button>
+                  </>
+                ) : (
+                  <Badge variant="secondary">Destroyed</Badge>
+                )}
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-2">
+            <div className="flex items-center gap-2">
+              <User className="text-muted-foreground h-4 w-4 shrink-0" />
+              <DetailField label="User">
+                <Link
+                  href={`/admin/users/${data.user_id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  {data.user_email ?? data.user_id}
+                </Link>
+              </DetailField>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+              <DetailField label="Sandbox ID">
+                <code className="text-sm">{data.sandbox_id}</code>
+              </DetailField>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Calendar className="text-muted-foreground h-4 w-4 shrink-0" />
+              <DetailField label="Created">
+                <span title={formatAbsoluteTime(data.created_at)}>
+                  {formatRelativeTime(data.created_at)}
+                </span>
+              </DetailField>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Calendar className="text-muted-foreground h-4 w-4 shrink-0" />
+              <DetailField label="Destroyed">
+                {data.destroyed_at ? (
+                  <span title={formatAbsoluteTime(data.destroyed_at)}>
+                    {formatRelativeTime(data.destroyed_at)}
+                  </span>
+                ) : (
+                  '—'
+                )}
+              </DetailField>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Technical Details */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Technical Details</CardTitle>
+            <CardDescription>Internal identifiers</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-2">
+            <DetailField label="Instance ID">
+              <code className="text-sm">{data.id}</code>
+            </DetailField>
+            <DetailField label="User ID">
+              <code className="text-sm">{data.user_id}</code>
+            </DetailField>
+          </CardContent>
+        </Card>
+
+        {/* Worker Status (active instances only) */}
+        {isActive && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Live Worker Status</CardTitle>
+              <CardDescription>Real-time status from the KiloClaw Durable Object</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {data.workerStatusError && (
+                <Alert className="mb-4">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>{data.workerStatusError}</AlertDescription>
+                </Alert>
+              )}
+              {data.workerStatus ? (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  <DetailField label="DO Status">
+                    <StatusBadge status={data.workerStatus.status} />
+                  </DetailField>
+
+                  <div className="flex items-center gap-2">
+                    <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                    <DetailField label="Fly Machine ID">
+                      {data.workerStatus.flyMachineId && data.workerStatus.flyAppName ? (
+                        <a
+                          href={`https://fly.io/apps/${data.workerStatus.flyAppName}/machines/${data.workerStatus.flyMachineId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+                        >
+                          <code className="text-sm">{data.workerStatus.flyMachineId}</code>
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : (
+                        <code className="text-sm">{data.workerStatus.flyMachineId ?? '—'}</code>
+                      )}
+                    </DetailField>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <Globe className="text-muted-foreground h-4 w-4 shrink-0" />
+                    <DetailField label="Fly Region">
+                      {data.workerStatus.flyRegion ?? '—'}
+                    </DetailField>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <HardDrive className="text-muted-foreground h-4 w-4 shrink-0" />
+                    <DetailField label="Fly Volume ID">
+                      <code className="text-sm">{data.workerStatus.flyVolumeId ?? '—'}</code>
+                    </DetailField>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                    <DetailField label="Fly App">
+                      {data.workerStatus.flyAppName ? (
+                        <a
+                          href={`https://fly.io/apps/${data.workerStatus.flyAppName}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+                        >
+                          <code className="text-sm">{data.workerStatus.flyAppName}</code>
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : (
+                        '—'
+                      )}
+                    </DetailField>
+                  </div>
+
+                  {data.workerStatus.flyAppName && data.workerStatus.flyMachineId && (
+                    <div className="flex items-center gap-2">
+                      <BarChart className="text-muted-foreground h-4 w-4 shrink-0" />
+                      <DetailField label="Metrics">
+                        <a
+                          href={`https://fly-metrics.net/d/fly-instance/fly-instance?from=now-1h&orgId=1480569&to=now&var-app=${data.workerStatus.flyAppName}&var-instance=${data.workerStatus.flyMachineId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+                        >
+                          <span className="text-sm">View Grafana Dashboard</span>
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </DetailField>
+                    </div>
+                  )}
+
+                  <DetailField label="Provisioned At">
+                    {formatEpochTime(data.workerStatus.provisionedAt)}
+                  </DetailField>
+
+                  <DetailField label="Last Started At">
+                    {formatEpochTime(data.workerStatus.lastStartedAt)}
+                  </DetailField>
+
+                  <DetailField label="Last Stopped At">
+                    {formatEpochTime(data.workerStatus.lastStoppedAt)}
+                  </DetailField>
+
+                  <DetailField label="Env Vars">{data.workerStatus.envVarCount}</DetailField>
+
+                  <DetailField label="Secrets">{data.workerStatus.secretCount}</DetailField>
+
+                  <DetailField label="Channels">{data.workerStatus.channelCount}</DetailField>
+                </div>
+              ) : !data.workerStatusError ? (
+                <p className="text-muted-foreground text-sm">No worker status available</p>
+              ) : null}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Destroyed notice */}
+        {!isActive && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Live Worker Status</CardTitle>
+              <CardDescription>Real-time status from the KiloClaw Durable Object</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground text-sm">
+                Worker status is not available for destroyed instances.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+        {/* Destroy Confirmation Dialog */}
+        <Dialog open={destroyDialogOpen} onOpenChange={setDestroyDialogOpen}>
+          <DialogContent className="sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle className="text-destructive flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5" />
+                Destroy Instance
+              </DialogTitle>
+              <DialogDescription className="pt-3">
+                Are you sure you want to destroy this KiloClaw instance?
+                <span className="text-foreground mt-2 block font-medium">
+                  User: {data.user_email ?? data.user_id}
+                </span>
+                <span className="mt-2 block">
+                  This will stop the Fly machine and mark the instance as destroyed. The user will
+                  need to re-provision to use KiloClaw again.
+                </span>
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <DialogClose asChild>
+                <Button variant="secondary" disabled={isDestroying}>
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                variant="destructive"
+                onClick={() => void destroyInstance({ id: data.id })}
+                disabled={isDestroying}
+              >
+                {isDestroying ? 'Destroying...' : 'Destroy Instance'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </DetailPageWrapper>
+  );
+}

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -1,0 +1,522 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import Link from 'next/link';
+import { formatDistanceToNow, format, parseISO } from 'date-fns';
+import {
+  ComposedChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+type SortField = 'created_at' | 'destroyed_at';
+type SortOrder = 'asc' | 'desc';
+type StatusFilter = 'all' | 'active' | 'destroyed';
+
+function toSortedSearchParams(obj: Record<string, unknown>): URLSearchParams {
+  const params = new URLSearchParams();
+  const keys = Object.keys(obj).sort();
+  for (const key of keys) {
+    const value = obj[key];
+    if (value) params.set(key, String(value));
+  }
+  return params;
+}
+
+function formatRelativeTime(timestamp: string | null): string {
+  if (!timestamp) return '—';
+  return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+}
+
+function formatLifespan(minutes: number | null): string {
+  if (minutes === null) return '—';
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  if (minutes < 1440) return `${Math.round(minutes / 60)}h`;
+  return `${Math.round(minutes / 1440)}d`;
+}
+
+// --- Overview Stats Cards ---
+
+type OverviewData = {
+  totalInstances: number;
+  activeInstances: number;
+  destroyedInstances: number;
+  uniqueUsers: number;
+  last24hCreated: number;
+  last7dCreated: number;
+  activeUsers7d: number;
+  avgLifespanMinutes: number | null;
+};
+
+function OverviewStatsCards({ data }: { data: OverviewData }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Total Instances</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{data.totalInstances.toLocaleString()}</div>
+          <p className="text-muted-foreground text-xs">
+            {data.last24hCreated} last 24h &middot; {data.last7dCreated} last 7d
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Active Instances</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{data.activeInstances.toLocaleString()}</div>
+          <p className="text-muted-foreground text-xs">
+            {data.destroyedInstances.toLocaleString()} destroyed
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Unique Users</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{data.uniqueUsers.toLocaleString()}</div>
+          <p className="text-muted-foreground text-xs">{data.activeUsers7d} active in last 7d</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Avg Lifespan</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{formatLifespan(data.avgLifespanMinutes)}</div>
+          <p className="text-muted-foreground text-xs">Average time before destroyed</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// --- Daily Chart ---
+
+type DailyChartData = {
+  date: string;
+  created: number;
+  destroyed: number;
+};
+
+type TooltipPayload = {
+  dataKey: string;
+  value: number;
+};
+
+type CustomTooltipProps = {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  label?: string;
+};
+
+function DailyChart({ data }: { data: DailyChartData[] }) {
+  const chartData = data.map(item => ({
+    date: format(parseISO(item.date), 'MM/dd'),
+    created: item.created,
+    destroyed: item.destroyed,
+  }));
+
+  const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+    if (active && payload && payload.length) {
+      const created = payload.find(p => p.dataKey === 'created')?.value || 0;
+      const destroyed = payload.find(p => p.dataKey === 'destroyed')?.value || 0;
+
+      return (
+        <div className="bg-background rounded-lg border p-3 shadow-sm">
+          <p className="text-sm font-medium">{label}</p>
+          <div className="mt-2 space-y-1">
+            <p className="text-sm">
+              <span className="text-muted-foreground">Created:</span>{' '}
+              <span className="font-medium">{created}</span>
+            </p>
+            <p className="text-sm">
+              <span className="text-muted-foreground">Destroyed:</span>{' '}
+              <span className="font-medium">{destroyed}</span>
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const maxVal = Math.max(...chartData.map(d => Math.max(d.created, d.destroyed)), 1);
+  const yAxisMax = Math.ceil(maxVal * 1.1) || 10;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Daily Instances</CardTitle>
+        <CardDescription>Instances created and destroyed per day (last 30 days)</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-[300px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 60 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis
+                dataKey="date"
+                angle={-45}
+                textAnchor="end"
+                height={60}
+                className="text-xs"
+                tick={{ fontSize: 10 }}
+              />
+              <YAxis domain={[0, yAxisMax]} tick={{ fontSize: 10 }} />
+              <Tooltip content={<CustomTooltip />} />
+              <Bar dataKey="created" fill="#22c55e" name="Created" />
+              <Bar dataKey="destroyed" fill="#ef4444" name="Destroyed" />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="mt-4 flex items-center justify-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-sm bg-green-500" />
+            <span className="text-muted-foreground">Created</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-sm bg-red-500" />
+            <span className="text-muted-foreground">Destroyed</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- Main Page ---
+
+export function KiloclawInstancesPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const trpc = useTRPC();
+
+  const queryStringState = useMemo(
+    () => ({
+      page: parseInt(searchParams.get('page') || '1'),
+      limit: parseInt(searchParams.get('limit') || '20'),
+      sortBy: (searchParams.get('sortBy') || 'created_at') as SortField,
+      sortOrder: (searchParams.get('sortOrder') || 'desc') as SortOrder,
+      search: searchParams.get('search') || '',
+      status: (searchParams.get('status') || 'all') as StatusFilter,
+    }),
+    [searchParams]
+  );
+
+  const [searchInput, setSearchInput] = useState(queryStringState.search);
+
+  const offset = (queryStringState.page - 1) * queryStringState.limit;
+
+  const { data, isLoading, error, isFetching } = useQuery(
+    trpc.admin.kiloclawInstances.list.queryOptions({
+      offset,
+      limit: queryStringState.limit,
+      sortBy: queryStringState.sortBy,
+      sortOrder: queryStringState.sortOrder,
+      search: queryStringState.search,
+      status: queryStringState.status,
+    })
+  );
+
+  const { data: statsData } = useQuery(
+    trpc.admin.kiloclawInstances.stats.queryOptions({ days: 30 })
+  );
+
+  type QueryStringState = typeof queryStringState;
+
+  const pushWith = useCallback(
+    (overrides: Partial<QueryStringState>) => {
+      const queryString = toSortedSearchParams({
+        ...queryStringState,
+        ...overrides,
+      });
+      router.push(`/admin/kiloclaw-instances?${queryString.toString()}`);
+    },
+    [router, queryStringState]
+  );
+
+  const handleSearchSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      pushWith({ search: searchInput, page: 1 });
+    },
+    [pushWith, searchInput]
+  );
+
+  const handleClearSearch = useCallback(() => {
+    setSearchInput('');
+    pushWith({ search: '', page: 1 });
+  }, [pushWith]);
+
+  const handleStatusChange = useCallback(
+    (status: StatusFilter) => {
+      pushWith({ status, page: 1 });
+    },
+    [pushWith]
+  );
+
+  const handleSort = useCallback(
+    (field: SortField) => {
+      const newDirection =
+        queryStringState.sortBy === field && queryStringState.sortOrder === 'asc' ? 'desc' : 'asc';
+      pushWith({ sortBy: field, sortOrder: newDirection, page: 1 });
+    },
+    [queryStringState.sortBy, queryStringState.sortOrder, pushWith]
+  );
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      pushWith({ page });
+    },
+    [pushWith]
+  );
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Error</CardTitle>
+          <CardDescription>Failed to load KiloClaw instances</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            {error instanceof Error ? error.message : 'An error occurred'}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const instances = data?.instances || [];
+  const pagination = data?.pagination || {
+    offset: 0,
+    limit: 20,
+    total: 0,
+    totalPages: 1,
+  };
+
+  const currentPage = Math.floor(pagination.offset / pagination.limit) + 1;
+
+  return (
+    <div className="flex w-full flex-col gap-y-6">
+      {/* Dashboard Section */}
+      {statsData && (
+        <>
+          <OverviewStatsCards data={statsData.overview} />
+          {statsData.dailyChart.length > 0 && <DailyChart data={statsData.dailyChart} />}
+        </>
+      )}
+
+      {/* Filters */}
+      <div className="flex items-center gap-4">
+        <form onSubmit={handleSearchSubmit} className="flex flex-1 gap-2">
+          <div className="relative max-w-md flex-1">
+            <Input
+              placeholder="Search by user ID, sandbox ID, or instance ID..."
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+              className="pr-8"
+            />
+            {(searchInput || queryStringState.search) && (
+              <button
+                type="button"
+                onClick={handleClearSearch}
+                className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+                aria-label="Clear search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          <Button type="submit" disabled={isFetching}>
+            Search
+          </Button>
+        </form>
+
+        <Select value={queryStringState.status} onValueChange={handleStatusChange}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Instances</SelectItem>
+            <SelectItem value="active">Active Only</SelectItem>
+            <SelectItem value="destroyed">Destroyed Only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>Sandbox ID</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead
+                className="hover:bg-muted/50 cursor-pointer"
+                onClick={() => handleSort('created_at')}
+              >
+                Created
+                {queryStringState.sortBy === 'created_at' && (
+                  <span className="ml-1">{queryStringState.sortOrder === 'asc' ? '↑' : '↓'}</span>
+                )}
+              </TableHead>
+              <TableHead
+                className="hover:bg-muted/50 cursor-pointer"
+                onClick={() => handleSort('destroyed_at')}
+              >
+                Destroyed
+                {queryStringState.sortBy === 'destroyed_at' && (
+                  <span className="ml-1">{queryStringState.sortOrder === 'asc' ? '↑' : '↓'}</span>
+                )}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} className="h-24 text-center">
+                  Loading instances...
+                </TableCell>
+              </TableRow>
+            ) : instances.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="h-24 text-center">
+                  No instances found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              instances.map(instance => (
+                <TableRow
+                  key={instance.id}
+                  className="hover:bg-muted/50 cursor-pointer"
+                  tabIndex={0}
+                  role="link"
+                  onClick={() => router.push(`/admin/kiloclaw-instances/${instance.id}`)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      router.push(`/admin/kiloclaw-instances/${instance.id}`);
+                    }
+                  }}
+                >
+                  <TableCell>
+                    <Link
+                      href={`/admin/users/${instance.user_id}`}
+                      className="text-blue-600 hover:underline"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      {instance.user_email || instance.user_id}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="font-mono text-sm">
+                    <span
+                      className="block truncate"
+                      style={{ maxWidth: '200px' }}
+                      title={instance.sandbox_id}
+                    >
+                      {instance.sandbox_id}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    {instance.destroyed_at === null ? (
+                      <Badge variant="default" className="bg-green-600">
+                        Active
+                      </Badge>
+                    ) : (
+                      <Badge variant="secondary">Destroyed</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell
+                    className="text-muted-foreground text-sm"
+                    title={new Date(instance.created_at).toLocaleString()}
+                  >
+                    {formatRelativeTime(instance.created_at)}
+                  </TableCell>
+                  <TableCell
+                    className="text-muted-foreground text-sm"
+                    title={
+                      instance.destroyed_at
+                        ? new Date(instance.destroyed_at).toLocaleString()
+                        : undefined
+                    }
+                  >
+                    {formatRelativeTime(instance.destroyed_at)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <div className="text-muted-foreground text-sm">
+          Showing {instances.length > 0 ? pagination.offset + 1 : 0} to{' '}
+          {Math.min(pagination.offset + pagination.limit, pagination.total)} of {pagination.total}{' '}
+          instances
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage <= 1 || isFetching}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Button>
+          <div className="text-sm">
+            Page {currentPage} of {pagination.totalPages}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage >= pagination.totalPages || isFetching}
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/kiloclaw-instances/[id]/page.tsx
+++ b/src/app/admin/kiloclaw-instances/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { getUserFromAuth } from '@/lib/user.server';
+import { KiloclawInstanceDetail } from '../../components/KiloclawInstances/KiloclawInstanceDetail';
+
+export default async function KiloclawInstanceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) {
+    redirect('/admin/unauthorized');
+  }
+
+  const { id } = await params;
+  const instanceId = decodeURIComponent(id);
+
+  return (
+    <Suspense fallback={<div>Loading instance details...</div>}>
+      <KiloclawInstanceDetail instanceId={instanceId} />
+    </Suspense>
+  );
+}

--- a/src/app/admin/kiloclaw-instances/page.tsx
+++ b/src/app/admin/kiloclaw-instances/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react';
+import AdminPage from '../components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+import { KiloclawInstancesPage } from '../components/KiloclawInstances/KiloclawInstancesPage';
+
+const breadcrumbs = (
+  <>
+    <BreadcrumbItem>
+      <BreadcrumbPage>KiloClaw Instances</BreadcrumbPage>
+    </BreadcrumbItem>
+  </>
+);
+
+export default async function KiloclawInstancesAdminPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <Suspense fallback={<div>Loading KiloClaw instances...</div>}>
+        <KiloclawInstancesPage />
+      </Suspense>
+    </AdminPage>
+  );
+}

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -46,6 +46,7 @@ export type PlatformStatusResponse = {
   envVarCount: number;
   secretCount: number;
   channelCount: number;
+  flyAppName: string | null;
   flyMachineId: string | null;
   flyVolumeId: string | null;
   flyRegion: string | null;

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,0 +1,301 @@
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { db } from '@/lib/drizzle';
+import { kiloclaw_instances, kilocode_users } from '@/db/schema';
+import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import {
+  markActiveInstanceDestroyed,
+  restoreDestroyedInstance,
+} from '@/lib/kiloclaw/instance-registry';
+import type { PlatformStatusResponse } from '@/lib/kiloclaw/types';
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+import { eq, and, or, desc, asc, isNull, isNotNull, sql, gte, type SQL } from 'drizzle-orm';
+
+const ListInstancesSchema = z.object({
+  offset: z.number().min(0).default(0),
+  limit: z.number().min(1).max(100).default(25),
+  sortBy: z.enum(['created_at', 'destroyed_at']).default('created_at'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+  search: z.string().optional(),
+  status: z.enum(['all', 'active', 'destroyed']).default('all'),
+});
+
+const GetInstanceSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const DestroyInstanceSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const StatsSchema = z.object({
+  days: z.number().min(1).max(365).default(30),
+});
+
+export type AdminKiloclawInstance = {
+  id: string;
+  user_id: string;
+  sandbox_id: string;
+  created_at: string;
+  destroyed_at: string | null;
+  user_email: string | null;
+};
+
+export type AdminKiloclawInstanceDetail = AdminKiloclawInstance & {
+  workerStatus: PlatformStatusResponse | null;
+  workerStatusError: string | null;
+};
+
+export const adminKiloclawInstancesRouter = createTRPCRouter({
+  get: adminProcedure.input(GetInstanceSchema).query(async ({ input }) => {
+    const [result] = await db
+      .select({
+        instance: kiloclaw_instances,
+        user_email: kilocode_users.google_user_email,
+      })
+      .from(kiloclaw_instances)
+      .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
+      .where(eq(kiloclaw_instances.id, input.id))
+      .limit(1);
+
+    if (!result) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Instance not found' });
+    }
+
+    const instance: AdminKiloclawInstance = {
+      id: result.instance.id,
+      user_id: result.instance.user_id,
+      sandbox_id: result.instance.sandbox_id,
+      created_at: result.instance.created_at,
+      destroyed_at: result.instance.destroyed_at,
+      user_email: result.user_email,
+    };
+
+    // Fetch live worker status for active instances
+    let workerStatus: PlatformStatusResponse | null = null;
+    let workerStatusError: string | null = null;
+
+    if (instance.destroyed_at === null) {
+      try {
+        const client = new KiloClawInternalClient();
+        workerStatus = await client.getStatus(instance.user_id);
+      } catch (err) {
+        workerStatusError = err instanceof Error ? err.message : 'Failed to fetch worker status';
+      }
+    }
+
+    return { ...instance, workerStatus, workerStatusError } satisfies AdminKiloclawInstanceDetail;
+  }),
+
+  list: adminProcedure.input(ListInstancesSchema).query(async ({ input }) => {
+    const { offset, limit, sortBy, sortOrder, search, status } = input;
+    const searchTerm = search?.trim() || '';
+
+    const conditions: SQL[] = [];
+
+    if (searchTerm) {
+      const searchConditions: SQL[] = [
+        eq(kiloclaw_instances.user_id, searchTerm),
+        eq(kiloclaw_instances.sandbox_id, searchTerm),
+      ];
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (uuidRegex.test(searchTerm)) {
+        searchConditions.push(eq(kiloclaw_instances.id, searchTerm));
+      }
+
+      const searchCondition = or(...searchConditions);
+      if (searchCondition) {
+        conditions.push(searchCondition);
+      }
+    }
+
+    if (status === 'active') {
+      conditions.push(isNull(kiloclaw_instances.destroyed_at));
+    } else if (status === 'destroyed') {
+      conditions.push(isNotNull(kiloclaw_instances.destroyed_at));
+    }
+
+    const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const orderFunction = sortOrder === 'asc' ? asc : desc;
+    const orderCondition = orderFunction(kiloclaw_instances[sortBy]);
+
+    const instancesResult = await db
+      .select({
+        instance: kiloclaw_instances,
+        user_email: kilocode_users.google_user_email,
+      })
+      .from(kiloclaw_instances)
+      .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
+      .where(whereCondition)
+      .orderBy(orderCondition)
+      .limit(limit)
+      .offset(offset);
+
+    const totalCountResult = await db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(kiloclaw_instances)
+      .where(whereCondition);
+
+    const totalCount = totalCountResult[0]?.count || 0;
+    const totalPages = Math.ceil(totalCount / limit);
+
+    const instances: AdminKiloclawInstance[] = instancesResult.map(row => ({
+      id: row.instance.id,
+      user_id: row.instance.user_id,
+      sandbox_id: row.instance.sandbox_id,
+      created_at: row.instance.created_at,
+      destroyed_at: row.instance.destroyed_at,
+      user_email: row.user_email,
+    }));
+
+    return {
+      instances,
+      pagination: {
+        offset,
+        limit,
+        total: totalCount,
+        totalPages,
+      },
+    };
+  }),
+
+  stats: adminProcedure.input(StatsSchema).query(async ({ input }) => {
+    const { days } = input;
+
+    // Overview counts
+    const [overview] = await db
+      .select({
+        total_instances: sql<number>`COUNT(*)::int`,
+        active_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL THEN 1 END)::int`,
+        destroyed_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NOT NULL THEN 1 END)::int`,
+        unique_users: sql<number>`COUNT(DISTINCT ${kiloclaw_instances.user_id})::int`,
+      })
+      .from(kiloclaw_instances);
+
+    // Time-windowed counts
+    const [last24h] = await db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(kiloclaw_instances)
+      .where(sql`${kiloclaw_instances.created_at} >= NOW() - INTERVAL '24 hours'`);
+
+    const [last7d] = await db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(kiloclaw_instances)
+      .where(sql`${kiloclaw_instances.created_at} >= NOW() - INTERVAL '7 days'`);
+
+    const [activeUsers7d] = await db
+      .select({
+        count: sql<number>`COUNT(DISTINCT ${kiloclaw_instances.user_id})::int`,
+      })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          isNull(kiloclaw_instances.destroyed_at),
+          gte(kiloclaw_instances.created_at, sql`NOW() - INTERVAL '7 days'`)
+        )
+      );
+
+    // Average lifespan of destroyed instances
+    const [lifespan] = await db
+      .select({
+        avg_lifespan_minutes: sql<
+          number | null
+        >`AVG(EXTRACT(EPOCH FROM (${kiloclaw_instances.destroyed_at}::timestamp - ${kiloclaw_instances.created_at}::timestamp)) / 60)`,
+      })
+      .from(kiloclaw_instances)
+      .where(isNotNull(kiloclaw_instances.destroyed_at));
+
+    // Daily stats for chart
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - days);
+
+    const dailyStats = await db
+      .select({
+        date: sql<string>`DATE(${kiloclaw_instances.created_at})`.as('date'),
+        created: sql<number>`COUNT(*)::int`.as('created'),
+      })
+      .from(kiloclaw_instances)
+      .where(gte(kiloclaw_instances.created_at, startDate.toISOString()))
+      .groupBy(sql`DATE(${kiloclaw_instances.created_at})`)
+      .orderBy(sql`DATE(${kiloclaw_instances.created_at})`);
+
+    const dailyDestroyed = await db
+      .select({
+        date: sql<string>`DATE(${kiloclaw_instances.destroyed_at})`.as('date'),
+        destroyed: sql<number>`COUNT(*)::int`.as('destroyed'),
+      })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          isNotNull(kiloclaw_instances.destroyed_at),
+          gte(kiloclaw_instances.destroyed_at, startDate.toISOString())
+        )
+      )
+      .groupBy(sql`DATE(${kiloclaw_instances.destroyed_at})`)
+      .orderBy(sql`DATE(${kiloclaw_instances.destroyed_at})`);
+
+    // Merge created and destroyed into a single daily series
+    const destroyedByDate = new Map(dailyDestroyed.map(d => [d.date, d.destroyed]));
+    const createdByDate = new Map(dailyStats.map(d => [d.date, d.created]));
+
+    const allDates = new Set([...createdByDate.keys(), ...destroyedByDate.keys()]);
+    const dailyChart = [...allDates].sort().map(date => ({
+      date,
+      created: createdByDate.get(date) ?? 0,
+      destroyed: destroyedByDate.get(date) ?? 0,
+    }));
+
+    return {
+      overview: {
+        totalInstances: overview?.total_instances ?? 0,
+        activeInstances: overview?.active_instances ?? 0,
+        destroyedInstances: overview?.destroyed_instances ?? 0,
+        uniqueUsers: overview?.unique_users ?? 0,
+        last24hCreated: last24h?.count ?? 0,
+        last7dCreated: last7d?.count ?? 0,
+        activeUsers7d: activeUsers7d?.count ?? 0,
+        avgLifespanMinutes: lifespan?.avg_lifespan_minutes ?? null,
+      },
+      dailyChart,
+    };
+  }),
+
+  destroy: adminProcedure.input(DestroyInstanceSchema).mutation(async ({ input, ctx }) => {
+    const [instance] = await db
+      .select({
+        id: kiloclaw_instances.id,
+        user_id: kiloclaw_instances.user_id,
+        destroyed_at: kiloclaw_instances.destroyed_at,
+      })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, input.id))
+      .limit(1);
+
+    if (!instance) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Instance not found' });
+    }
+
+    if (instance.destroyed_at !== null) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Instance is already destroyed' });
+    }
+
+    console.log(
+      `[admin-kiloclaw] Destroy triggered by admin ${ctx.user.id} (${ctx.user.google_user_email}) for instance ${instance.id} (user: ${instance.user_id})`
+    );
+
+    const destroyedRow = await markActiveInstanceDestroyed(instance.user_id);
+    const client = new KiloClawInternalClient();
+    try {
+      await client.destroy(instance.user_id);
+    } catch (error) {
+      if (destroyedRow) {
+        await restoreDestroyedInstance(destroyedRow.id);
+      }
+      throw error;
+    }
+
+    return { success: true };
+  }),
+});

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -94,7 +94,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     const conditions: SQL[] = [];
 
     if (searchTerm) {
-      const ilikePattern = `%${searchTerm}%`;
+      const escapedTerm = searchTerm.replace(/[%_\\]/g, '\\$&');
+      const ilikePattern = `%${escapedTerm}%`;
       const searchConditions: SQL[] = [
         ilike(kiloclaw_instances.sandbox_id, ilikePattern),
         ilike(kilocode_users.google_user_email, ilikePattern),

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -12,6 +12,7 @@ import {
 } from '@/db/schema';
 import { adminAppBuilderRouter } from '@/routers/admin-app-builder-router';
 import { adminDeploymentsRouter } from '@/routers/admin-deployments-router';
+import { adminKiloclawInstancesRouter } from '@/routers/admin-kiloclaw-instances-router';
 import { adminFeatureInterestRouter } from '@/routers/admin-feature-interest-router';
 import { adminCodeReviewsRouter } from '@/routers/admin-code-reviews-router';
 import { adminAIAttributionRouter } from '@/routers/admin-ai-attribution-router';
@@ -683,6 +684,7 @@ export const adminRouter = createTRPCRouter({
       }),
   }),
   appBuilder: adminAppBuilderRouter,
+  kiloclawInstances: adminKiloclawInstancesRouter,
   aiAttribution: adminAIAttributionRouter,
   ossSponsorship: ossSponsorshipRouter,
   bulkUserCredits: bulkUserCreditsRouter,


### PR DESCRIPTION
## Summary

- Adds a new **KiloClaw Instances** page under Product & Engineering in the admin dashboard
- Dashboard with overview stats (total/active/destroyed instances, unique users, avg lifespan) and daily created/destroyed chart
- Filterable, paginated table with search by user ID, sandbox ID, or instance UUID, and status filter (all/active/destroyed)
- Detail page per instance showing DB record + live worker status (Fly machine ID, app, region, volume, DO status)
- Links to Fly dashboard and Grafana metrics for each instance
- Destroy instance action with confirmation dialog and admin audit logging
- Adds `flyAppName` to `PlatformStatusResponse` type (already returned by the worker, type was missing it)
