### PR TITLE
fix(kiloclaw): pass instance_id when waiting for machine stopped state

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -38,6 +38,7 @@ vi.mock('../fly/client', async () => {
     getMachine: vi.fn(),
     startMachine: vi.fn(),
     stopMachine: vi.fn(),
+    stopMachineAndWait: vi.fn(),
     destroyMachine: vi.fn(),
     waitForState: vi.fn(),
     updateMachine: vi.fn(),
@@ -439,7 +440,7 @@ describe('status guards', () => {
 
     // Status unchanged
     expect(storage._store.get('status')).toBe('destroying');
-    expect(flyClient.stopMachine).not.toHaveBeenCalled();
+    expect(flyClient.stopMachineAndWait).not.toHaveBeenCalled();
   });
 });
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -538,8 +538,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     if (this.flyMachineId) {
       const flyConfig = this.getFlyConfig();
       try {
-        await fly.stopMachine(flyConfig, this.flyMachineId);
-        await fly.waitForState(flyConfig, this.flyMachineId, 'stopped', 60);
+        await fly.stopMachineAndWait(flyConfig, this.flyMachineId);
       } catch (err) {
         console.error('[DO] Failed to stop machine:', err);
       }
@@ -670,8 +669,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     try {
       const flyConfig = this.getFlyConfig();
-      await fly.stopMachine(flyConfig, this.flyMachineId);
-      await fly.waitForState(flyConfig, this.flyMachineId, 'stopped', 60);
+      await fly.stopMachineAndWait(flyConfig, this.flyMachineId);
 
       const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
       const guest = guestFromSize(this.machineSize);
@@ -950,8 +948,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     if (!this.flyMachineId) return;
 
-    await fly.stopMachine(flyConfig, this.flyMachineId);
-    await fly.waitForState(flyConfig, this.flyMachineId, 'stopped', 60);
+    await fly.stopMachineAndWait(flyConfig, this.flyMachineId);
     await fly.updateMachine(flyConfig, this.flyMachineId, {
       ...machine.config,
       mounts: [{ volume: this.flyVolumeId, path: '/root' }],

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -102,6 +102,21 @@ export async function stopMachine(config: FlyClientConfig, machineId: string): P
   await assertOk(resp, 'stopMachine');
 }
 
+/**
+ * Stop a machine and wait for it to reach the 'stopped' state.
+ * Fly requires instance_id when waiting for 'stopped', so this fetches
+ * the current machine state after issuing the stop to get the instance_id.
+ */
+export async function stopMachineAndWait(
+  config: FlyClientConfig,
+  machineId: string,
+  timeoutSeconds = 60
+): Promise<void> {
+  await stopMachine(config, machineId);
+  const machine = await getMachine(config, machineId);
+  await waitForState(config, machineId, 'stopped', timeoutSeconds, machine.instance_id);
+}
+
 export async function destroyMachine(
   config: FlyClientConfig,
   machineId: string,


### PR DESCRIPTION
## Summary

- Fly API requires `instance_id` when calling `/machines/{id}/wait?state=stopped`, otherwise returns 400
- Added `stopMachineAndWait` helper in `fly/client.ts` that fetches the current `instance_id` via `getMachine` after issuing the stop, then passes it to `waitForState`
- Replaced all 3 manual `stopMachine` + `waitForState('stopped')` call sites in `kiloclaw-instance.ts` (`stop()`, `restartGateway()`, `reconcileMachineMount()`)