### PR TITLE
fix(kiloclaw): detect app name hash collisions on Fly app creation

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
@@ -128,7 +128,9 @@ describe('ensureApp', () => {
     expect(appsClient.createApp).toHaveBeenCalledWith(
       { apiToken: 'test-token' },
       result.appName,
-      'test-org'
+      'test-org',
+      'user-1',
+      'kiloclaw_user_id'
     );
     expect(appsClient.allocateIP).toHaveBeenCalledTimes(2);
     expect(appsClient.allocateIP).toHaveBeenCalledWith('test-token', result.appName, 'v6');

--- a/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -20,6 +20,7 @@ import type { KiloClawEnv } from '../types';
 import * as apps from '../fly/apps';
 import { setAppSecret } from '../fly/secrets';
 import { generateEnvKey } from '../utils/env-encryption';
+import { METADATA_KEY_USER_ID } from './kiloclaw-instance';
 
 // -- Persisted state schema --
 
@@ -114,7 +115,7 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
       if (!this.ipv4Allocated || !this.ipv6Allocated) {
         const existing = await apps.getApp({ apiToken }, appName);
         if (!existing) {
-          await apps.createApp({ apiToken }, appName, orgSlug);
+          await apps.createApp({ apiToken }, appName, orgSlug, userId, METADATA_KEY_USER_ID);
           console.log('[AppDO] Created Fly App:', appName);
         }
       }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -483,8 +483,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
-    console.log('[DO] DEBUG envVars keys:', Object.keys(envVars));
-    console.log('[DO] DEBUG minSecretsVersion:', minSecretsVersion);
     const guest = guestFromSize(this.machineSize);
     const imageTag = this.env.FLY_IMAGE_TAG ?? 'latest';
     const identity = { userId: this.userId, sandboxId: this.sandboxId };

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -483,6 +483,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
+    console.log('[DO] DEBUG envVars keys:', Object.keys(envVars));
+    console.log('[DO] DEBUG minSecretsVersion:', minSecretsVersion);
     const guest = guestFromSize(this.machineSize);
     const imageTag = this.env.FLY_IMAGE_TAG ?? 'latest';
     const identity = { userId: this.userId, sandboxId: this.sandboxId };

--- a/kiloclaw/src/fly/apps.test.ts
+++ b/kiloclaw/src/fly/apps.test.ts
@@ -104,7 +104,8 @@ function mockFetchSequence(responses: Array<[number, unknown]>): void {
   const fn = vi.fn();
   for (const [status, body] of responses) {
     const responseBody = typeof body === 'string' ? body : JSON.stringify(body);
-    const headers = typeof body === 'string' ? {} : { 'Content-Type': 'application/json' };
+    const headers: HeadersInit =
+      typeof body === 'string' ? {} : { 'Content-Type': 'application/json' };
     fn.mockResolvedValueOnce(new Response(responseBody, { status, headers }));
   }
   vi.stubGlobal('fetch', fn);


### PR DESCRIPTION
On 409 (app already exists), verify ownership by listing machines and checking userId metadata. 
Throws AppNameCollisionError if the existing app belongs to a different user, preventing silent network namespace sharing from SHA-256 truncation collisions.

Fails open if machine listing errors to preserve existing retry behavior. Legacy machines without metadata are treated as safe (no false positives).