### PR TITLE
Deploy - Fix build log horizontal overflow in deployment details dialog

### DIFF
--- a/src/components/deployments/BuildLogViewer.tsx
+++ b/src/components/deployments/BuildLogViewer.tsx
@@ -105,7 +105,7 @@ export function BuildLogViewer({ deploymentId, buildId, status, className }: Bui
   }
 
   return (
-    <div className="relative">
+    <div className="relative overflow-hidden">
       {isActiveBuild && (
         <div className="absolute top-4 right-4 z-10 flex items-center gap-2 rounded-md bg-gray-900/90 px-3 py-1.5 text-xs text-gray-400 backdrop-blur-sm">
           <Loader2 className="size-3 animate-spin" />
@@ -115,7 +115,7 @@ export function BuildLogViewer({ deploymentId, buildId, status, className }: Bui
       <pre
         ref={scrollRef}
         className={cn(
-          'max-h-96 overflow-auto rounded-lg bg-gray-950 p-4 font-mono text-sm break-words whitespace-pre-wrap text-gray-300',
+          'max-h-96 min-w-0 overflow-auto rounded-lg bg-gray-950 p-4 font-mono text-sm break-all whitespace-pre-wrap text-gray-300',
           className
         )}
       >

--- a/src/components/deployments/BuildLogViewer.tsx
+++ b/src/components/deployments/BuildLogViewer.tsx
@@ -115,7 +115,7 @@ export function BuildLogViewer({ deploymentId, buildId, status, className }: Bui
       <pre
         ref={scrollRef}
         className={cn(
-          'max-h-96 min-w-0 overflow-auto rounded-lg bg-gray-950 p-4 font-mono text-sm break-all whitespace-pre-wrap text-gray-300',
+          'max-h-96 w-0 min-w-full overflow-auto rounded-lg bg-gray-950 p-4 font-mono text-sm whitespace-pre-wrap text-gray-300',
           className
         )}
       >


### PR DESCRIPTION
## Summary

Before the change the whole dialog and not only build logs became scrollable. 

- Fix horizontal overflow in the Deployment Details dialog caused by long unbreakable strings (e.g. minified CSS, long URLs) in build logs
- Add `overflow-hidden` to the build log wrapper and `min-w-0` to the `<pre>` element to constrain it within the dialog
- Switch from `break-words` to `break-all` to force-break long strings at any character boundary


<img width="1007" height="1046" alt="Screenshot 2026-02-18 at 13 05 37" src="https://github.com/user-attachments/assets/dbd5c98a-01e3-41b6-a24a-0a56182e318d" />
