### PR TITLE
AppBuilder - Rewrite system prompt, add preview awareness and clickable preview links

### DIFF
--- a/src/components/app-builder/AppBuilderPreview.tsx
+++ b/src/components/app-builder/AppBuilderPreview.tsx
@@ -441,6 +441,24 @@ export const AppBuilderPreview = memo(function AppBuilderPreview({
     manager.setCurrentIframeUrl(null);
   }, [previewUrl, manager]);
 
+  // Register a preview navigation handler so chat links can navigate the iframe
+  useEffect(() => {
+    return manager.onPreviewNavigate(path => {
+      if (!previewUrl || !iframeRef.current?.contentWindow) return;
+      try {
+        const targetUrl = new URL(previewUrl);
+        targetUrl.pathname = path;
+        targetUrl.search = '';
+        iframeRef.current.contentWindow.postMessage(
+          { type: 'kilo-preview-navigate', url: targetUrl.toString() },
+          targetUrl.origin
+        );
+      } catch {
+        // Invalid URL, ignore
+      }
+    });
+  }, [manager, previewUrl]);
+
   // Get tRPC for queries
   const trpc = useTRPC();
 

--- a/src/components/app-builder/ProjectManager.ts
+++ b/src/components/app-builder/ProjectManager.ts
@@ -198,6 +198,29 @@ export class ProjectManager {
     this.store.setState({ gitRepoFullName: repoFullName });
   }
 
+  private previewNavigateHandler: ((path: string) => void) | null = null;
+
+  /**
+   * Register a callback that navigates the preview iframe.
+   * Called by AppBuilderPreview on mount; returns an unregister function.
+   */
+  onPreviewNavigate(handler: (path: string) => void): () => void {
+    this.previewNavigateHandler = handler;
+    return () => {
+      if (this.previewNavigateHandler === handler) {
+        this.previewNavigateHandler = null;
+      }
+    };
+  }
+
+  /**
+   * Navigate the preview iframe to a relative path.
+   * No-op if the preview hasn't registered a handler (e.g., iframe not ready).
+   */
+  navigatePreview(path: string): void {
+    this.previewNavigateHandler?.(path);
+  }
+
   /**
    * Deploy the project to production.
    * @returns Promise resolving to deployment result with URL or error

--- a/src/components/app-builder/project-manager/streaming.ts
+++ b/src/components/app-builder/project-manager/streaming.ts
@@ -122,11 +122,25 @@ export function createStreamingCoordinator(
   /**
    * Calls the appropriate mutation to send a message.
    */
+  /**
+   * Extract pathname from a full URL, returning '/' on failure.
+   */
+  function getPreviewPath(): string | undefined {
+    const currentIframeUrl = store.getState().currentIframeUrl;
+    if (!currentIframeUrl) return undefined;
+    try {
+      return new URL(currentIframeUrl).pathname;
+    } catch {
+      return undefined;
+    }
+  }
+
   async function callSendMessage(
     message: string,
     images?: Images,
     model?: string
   ): Promise<string> {
+    const previewPath = getPreviewPath();
     if (organizationId) {
       const result = await trpcClient.organizations.appBuilder.sendMessage.mutate({
         projectId,
@@ -134,6 +148,7 @@ export function createStreamingCoordinator(
         message,
         images,
         model,
+        previewPath,
       });
       return result.cloudAgentSessionId;
     } else {
@@ -142,6 +157,7 @@ export function createStreamingCoordinator(
         message,
         images,
         model,
+        previewPath,
       });
       return result.cloudAgentSessionId;
     }

--- a/src/lib/app-builder/constants.ts
+++ b/src/lib/app-builder/constants.ts
@@ -77,23 +77,68 @@ export const APP_BUILDER_TEMPLATE_ASK_PROMPT =
  * System prompt appended to cloud agent sessions for App Builder.
  * Guides the AI's communication style and workflow when helping users build websites.
  */
-export const APP_BUILDER_APPEND_SYSTEM_PROMPT = `You are Kilo, a friendly website builder assistant helping users create their website through chat.
+export const APP_BUILDER_APPEND_SYSTEM_PROMPT = `You are Kilo, a website design partner helping users create their website through chat.
+The user sees a live preview of their website next to this chat. When they send a
+message, you'll see which page they're currently viewing.
+
+## How to Talk to the User
+- Default to non-technical language: describe changes in visual/content terms
+  ("I updated your homepage header", "I changed the background color")
+- Don't mention file names, code, or framework terms unless the user explicitly
+  asks about technical details — then answer honestly
+- When something goes wrong, say "Something didn't work as expected, let me fix that"
+  — no error types, build failures, or line numbers
+- You can briefly acknowledge work happening behind the scenes ("Let me make some
+  changes...") but don't get specific about code or files
+
+## Vocabulary Guide (defaults — override if user asks technical questions)
+Avoid → Use instead:
+- component, module, file → "section", "part of the page", "your [page name]"
+- CSS, styles, Tailwind, className → "the design", "how it looks"
+- deploy → "publish", "make it live"
+- build, compile → "get things ready"
+- repository, git, commit → don't mention
+- framework, Next.js, React → don't mention
+- HTML, JavaScript, TypeScript → don't mention
+- responsive → "works well on phones too"
+- route, routing, URL path → "page", "link"
+- npm, bun, package → don't mention
+
+## Preview Awareness
+- The user is viewing a live preview alongside this chat
+- Messages include which page they're currently viewing — prioritize changes
+  visible on that page
+- After making changes, include a markdown link to the relevant page so the user
+  can see the result: "I updated your About page — [take a look](/about)!"
+- If your changes affect a different page than the one they're viewing, link to it:
+  "I made some updates — [check out your About page](/about) to see!"
+- Always use relative paths for these links (e.g., [link text](/path))
+
+## Project Conventions
+- Understand the project you're working in and follow its framework's conventions
+- Create pages, routes, and files the way the framework expects
+- Never create files that conflict with the framework's routing or build system
+  (e.g., don't create static HTML files in a framework that uses its own routing)
+- If unsure, read the project structure first before creating new files
 
 ## Communication Style
 - Be conversational, concise, and encouraging
-- Skip technical jargon — explain concepts simply when needed
-- Ask clarifying questions if the request is vague
-- Celebrate progress ("Great choice!" "Looking good!")
-- Proactively suggest next steps or improvements
+- Ask clarifying questions when the request is vague
+- Celebrate progress naturally
+- One change at a time — don't overwhelm
+- When they seem stuck, offer 2-3 concrete options focused on visual/content choices
 
-## User Awareness
-- Assume the user is NOT technical unless they demonstrate otherwise
-- Never overwhelm with multiple changes at once — focus on one thing at a time
-- When showing code changes, briefly explain what changed and why
-- If something might break, warn them kindly before proceeding
+## After Each Change
+- Briefly confirm what changed in visual terms
+- Link to the relevant preview page
+- Suggest a natural next step: "Want to update the colors next?"
 
-## Workflow
-- After each change, briefly confirm what you did
-- Suggest related improvements they might want ("Want me to add a contact form next?")
-- If they seem stuck, offer 2-3 concrete options to choose from
-- Keep the conversation moving forward — don't wait for them to know what to ask`;
+## Examples
+Bad: "I updated the Hero component in page.tsx with a gradient using Tailwind's bg-gradient-to-r utility class"
+Good: "I gave your homepage header a smooth color gradient — [take a look](/)"
+
+Bad: "There's a TypeScript compilation error on line 42 of layout.tsx"
+Good: "Something didn't work as expected. Let me fix that real quick."
+
+Bad: "I created a new React component for the contact form and added it to the app router"
+Good: "I added a contact form to your site — [check it out](/contact)!"`;

--- a/src/lib/app-builder/types.ts
+++ b/src/lib/app-builder/types.ts
@@ -49,6 +49,8 @@ export type SendMessageInput = {
   images?: Images;
   /** Optional model override - if provided, updates the project's model_id */
   model?: string;
+  /** Current preview path the user is viewing (e.g., "/about") */
+  previewPath?: string;
 };
 
 /**

--- a/src/routers/app-builder-router.ts
+++ b/src/routers/app-builder-router.ts
@@ -198,6 +198,7 @@ export const appBuilderRouter = createTRPCRouter({
       authToken,
       images: input.images,
       model: input.model,
+      previewPath: input.previewPath,
     });
 
     return { cloudAgentSessionId: result.cloudAgentSessionId };

--- a/src/routers/app-builder/schemas.ts
+++ b/src/routers/app-builder/schemas.ts
@@ -27,6 +27,13 @@ export const sendMessageBaseSchema = z.object({
   images: imagesSchema,
   /** Optional model override - if provided, updates the project's model_id */
   model: z.string().min(1).optional(),
+  /** Current preview path the user is viewing (e.g., "/about") */
+  previewPath: z
+    .string()
+    .startsWith('/')
+    .max(2048)
+    .regex(/^[^\s]*$/, 'Must not contain whitespace')
+    .optional(),
 });
 
 // Common extension for organizationId

--- a/src/routers/organizations/organization-app-builder-router.ts
+++ b/src/routers/organizations/organization-app-builder-router.ts
@@ -236,6 +236,7 @@ export const organizationAppBuilderRouter = createTRPCRouter({
         authToken,
         images: input.images,
         model: input.model,
+        previewPath: input.previewPath,
       });
 
       return { cloudAgentSessionId: result.cloudAgentSessionId };


### PR DESCRIPTION
## Summary
- Rewrites the App Builder system prompt to use non-technical, user-friendly language with a vocabulary guide, preview awareness instructions, and good/bad response examples
- Sends the current preview path (the page the user is viewing) with each message so the LLM can prioritize changes visible on that page
- Makes relative links in assistant messages (e.g. `[take a look](/about)`) clickable to navigate the preview iframe via `postMessage`

## Details

**System prompt** (`constants.ts`): Replaces the old prompt with sections for how to talk to the user, a vocabulary guide (avoid technical terms by default), preview awareness (link to relevant pages after changes), project conventions, and concrete good/bad examples.

**Preview path plumbing**: `streaming.ts` reads the current iframe URL from the store and extracts the pathname. This is passed as `previewPath` through the tRPC schema → service layer, where it's prepended to the user's message as `[The user is currently viewing: /path]`. Schema validates it must start with `/`, contain no whitespace, and be ≤2048 chars.

**Clickable preview links** (`MessageContent.tsx`, `AppBuilderChat.tsx`, `AppBuilderPreview.tsx`, `ProjectManager.ts`): Relative links in markdown are intercepted and routed through `manager.navigatePreview(path)`, which calls a handler registered by `AppBuilderPreview` that posts a navigation message to the iframe. Uses a direct callback pattern — no state stored; if the iframe isn't ready, the click is a no-op and the user can click again.