### PR TITLE
fix(auth): use constant-time comparison for internal API secret validation

### DIFF
--- a/kiloclaw/src/auth/middleware.ts
+++ b/kiloclaw/src/auth/middleware.ts
@@ -112,12 +112,14 @@ export async function internalApiMiddleware(c: Context<AppEnv>, next: Next) {
 }
 
 function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+
+  if (aBytes.length !== bBytes.length) {
+    // Compare a against itself so the timing is constant regardless of length mismatch
+    crypto.subtle.timingSafeEqual(aBytes, aBytes);
     return false;
   }
-  let result = 0;
-  for (let i = 0; i < a.length; i++) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return result === 0;
+  return crypto.subtle.timingSafeEqual(aBytes, bBytes);
 }

--- a/kiloclaw/src/auth/middleware.ts
+++ b/kiloclaw/src/auth/middleware.ts
@@ -104,9 +104,20 @@ export async function internalApiMiddleware(c: Context<AppEnv>, next: Next) {
     return c.json({ error: 'Forbidden' }, 403);
   }
 
-  if (apiKey !== secret) {
+  if (!timingSafeEqual(apiKey, secret)) {
     return c.json({ error: 'Forbidden' }, 403);
   }
 
   return next();
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
 }

--- a/kiloclaw/src/test-setup.ts
+++ b/kiloclaw/src/test-setup.ts
@@ -1,0 +1,17 @@
+import { timingSafeEqual } from 'node:crypto';
+
+// Polyfill crypto.subtle.timingSafeEqual for Vitest (Node environment).
+// This API is available natively in Cloudflare Workers but not in Node.js.
+if (!crypto.subtle.timingSafeEqual) {
+  Object.defineProperty(crypto.subtle, 'timingSafeEqual', {
+    value(a: ArrayBuffer | ArrayBufferView, b: ArrayBuffer | ArrayBufferView): boolean {
+      const bufA = ArrayBuffer.isView(a)
+        ? Buffer.from(a.buffer, a.byteOffset, a.byteLength)
+        : Buffer.from(a);
+      const bufB = ArrayBuffer.isView(b)
+        ? Buffer.from(b.buffer, b.byteOffset, b.byteLength)
+        : Buffer.from(b);
+      return timingSafeEqual(bufA, bufB);
+    },
+  });
+}

--- a/kiloclaw/vitest.config.ts
+++ b/kiloclaw/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     name: 'unit',
     globals: true,
     environment: 'node',
+    setupFiles: ['src/test-setup.ts'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
fix(auth): use constant-time comparison for internal API secret validation (AF-5)

Replace short-circuit !== string comparison with timing-safe XOR-based comparison for INTERNAL_API_SECRET in kiloclaw to prevent theoretical timing side channel attacks