### PR TITLE
fix(auth): hardcode secure cookie flag for production (AF-6)

### DIFF
--- a/kiloclaw/src/routes/access-gateway.ts
+++ b/kiloclaw/src/routes/access-gateway.ts
@@ -230,7 +230,7 @@ accessGatewayRoutes.post('/kilo-access-gateway', async c => {
   setCookie(c, KILOCLAW_AUTH_COOKIE, token, {
     path: '/',
     httpOnly: true,
-    secure: new URL(c.req.url).protocol === 'https:',
+    secure: c.env.WORKER_ENV !== 'development',
     sameSite: 'Lax',
     maxAge: KILOCLAW_AUTH_COOKIE_MAX_AGE,
   });


### PR DESCRIPTION
The old code checked if the request URL was https: to decide the Secure flag. That works in production (always behind Cloudflare, always HTTPS), but it's fragile because it relies on the request protocol rather than an explicit environment signal.

The new code uses WORKER_ENV !== 'development' — so the cookie is Secure in every environment except local dev. This means:

- Production (WORKER_ENV = 'production' or any non-'development' value): secure: true
- Local dev (WORKER_ENV = 'development'): secure: false (so HTTP still works locally)

This matches how the rest of kiloclaw already uses WORKER_ENV for environment detection (e.g., the dev- prefix logic in kiloclaw-app.ts:100).

The practical difference is small — production behavior is identical. It just removes the dependency on protocol sniffing, which AF-6 flagged as potentially risky if the worker ever received a non-HTTPS request in production.