### PR TITLE
[Gastown] PR 5.5: Container — Adopt kilo serve for Agent Management

### DIFF
--- a/cloudflare-gastown/AGENTS.md
+++ b/cloudflare-gastown/AGENTS.md
@@ -9,6 +9,11 @@
 
 - Each DO module must export a `get{ClassName}Stub` helper function (e.g. `getRigDOStub`) that centralizes how that DO namespace creates instances. Callers should use this helper instead of accessing the namespace binding directly.
 
+## IO boundaries
+
+- Always validate data at IO boundaries (HTTP responses, JSON.parse results, SSE event payloads, subprocess output) with Zod schemas. Return `unknown` from raw fetch/parse helpers and `.parse()` in the caller.
+- Never use `as` to cast IO data. If the shape is known, define a Zod schema; if not, use `.passthrough()` or a catch-all schema.
+
 ## SQL queries
 
 - Use the type-safe `query()` helper from `util/query.util.ts` for all SQL queries.

--- a/cloudflare-gastown/container/src/heartbeat.ts
+++ b/cloudflare-gastown/container/src/heartbeat.ts
@@ -1,4 +1,4 @@
-import { listProcesses } from './process-manager';
+import { listAgents } from './process-manager';
 import type { HeartbeatPayload } from './types';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -41,7 +41,7 @@ export function stopHeartbeat(): void {
 async function sendHeartbeats(): Promise<void> {
   if (!gastownApiUrl || !sessionToken) return;
 
-  const active = listProcesses().filter(p => p.status === 'running' || p.status === 'starting');
+  const active = listAgents().filter(a => a.status === 'running' || a.status === 'starting');
 
   for (const agent of active) {
     const payload: HeartbeatPayload = {

--- a/cloudflare-gastown/container/src/kilo-client.ts
+++ b/cloudflare-gastown/container/src/kilo-client.ts
@@ -1,0 +1,89 @@
+/**
+ * HTTP client for talking to a kilo serve instance.
+ *
+ * Modeled after cloud-agent-next/wrapper/src/kilo-client.ts but simplified
+ * for the gastown container use-case (no sandbox indirection, direct fetch).
+ */
+
+import type { KiloSession } from './types';
+
+type TextPart = { type: 'text'; text: string };
+
+type SendPromptBody = {
+  parts: TextPart[];
+  agent?: string;
+  model?: { providerID: string; modelID: string };
+  system?: string;
+  tools?: Record<string, boolean>;
+};
+
+export type KiloClient = {
+  checkHealth: () => Promise<{ healthy: boolean; version: string }>;
+  createSession: () => Promise<KiloSession>;
+  getSession: (sessionId: string) => Promise<KiloSession>;
+  sendPromptAsync: (
+    sessionId: string,
+    opts: {
+      prompt: string;
+      model?: string;
+      systemPrompt?: string;
+      agent?: string;
+    }
+  ) => Promise<void>;
+  abortSession: (sessionId: string) => Promise<void>;
+};
+
+/**
+ * Create a client for interacting with a kilo serve instance on the given port.
+ */
+export function createKiloClient(port: number): KiloClient {
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`kilo API ${method} ${path}: ${res.status} ${res.statusText} — ${text}`);
+    }
+
+    // 204 No Content
+    if (res.status === 204) return undefined as T;
+
+    return res.json() as Promise<T>;
+  }
+
+  return {
+    checkHealth: () => request<{ healthy: boolean; version: string }>('GET', '/global/health'),
+
+    createSession: () => request<KiloSession>('POST', '/session', {}),
+
+    getSession: (sessionId: string) => request<KiloSession>('GET', `/session/${sessionId}`),
+
+    sendPromptAsync: async (sessionId, opts) => {
+      const body: SendPromptBody = {
+        parts: [{ type: 'text', text: opts.prompt }],
+      };
+
+      if (opts.model) {
+        body.model = { providerID: 'kilo', modelID: opts.model };
+      }
+      if (opts.systemPrompt) {
+        body.system = opts.systemPrompt;
+      }
+      if (opts.agent) {
+        body.agent = opts.agent;
+      }
+
+      await request<void>('POST', `/session/${sessionId}/prompt_async`, body);
+    },
+
+    abortSession: async (sessionId: string) => {
+      await request<unknown>('POST', `/session/${sessionId}/abort`);
+    },
+  };
+}

--- a/cloudflare-gastown/container/src/kilo-server.ts
+++ b/cloudflare-gastown/container/src/kilo-server.ts
@@ -62,6 +62,9 @@ async function waitForHealthy(port: number, timeoutMs = HEALTH_CHECK_TIMEOUT_MS)
 export async function ensureServer(workdir: string, env: Record<string, string>): Promise<number> {
   const existing = servers.get(workdir);
   if (existing?.healthy) {
+    // The server was started with the env from the first agent in this workdir.
+    // Subsequent agents share the same server process — their env vars only
+    // affect the kilo serve session (via prompt/system-prompt), not the server.
     return existing.port;
   }
 

--- a/cloudflare-gastown/container/src/kilo-server.ts
+++ b/cloudflare-gastown/container/src/kilo-server.ts
@@ -1,0 +1,225 @@
+/**
+ * Kilo Server Manager
+ *
+ * Manages kilo serve instances inside the town container. Each worktree gets
+ * its own kilo serve process (since a server is scoped to one project dir).
+ * Multiple agents sharing a worktree share one server with separate sessions.
+ *
+ * Port allocation: starting at 4096, incrementing. The control server on 8080
+ * is unaffected.
+ */
+
+import type { Subprocess } from 'bun';
+import type { KiloServerInstance } from './types';
+
+const KILO_SERVER_START_PORT = 4096;
+const HEALTH_CHECK_INTERVAL_MS = 500;
+const HEALTH_CHECK_TIMEOUT_MS = 60_000;
+
+/** workdir -> KiloServerInstance */
+const servers = new Map<string, KiloServerInstance>();
+
+let nextPort = KILO_SERVER_START_PORT;
+
+function allocatePort(): number {
+  const usedPorts = new Set([...servers.values()].map(s => s.port));
+  while (usedPorts.has(nextPort)) {
+    nextPort++;
+  }
+  const port = nextPort;
+  nextPort++;
+  return port;
+}
+
+/**
+ * Wait for a kilo serve instance to respond to GET /global/health.
+ */
+async function waitForHealthy(port: number, timeoutMs = HEALTH_CHECK_TIMEOUT_MS): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const url = `http://127.0.0.1:${port}/global/health`;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (res.ok) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise(r => setTimeout(r, HEALTH_CHECK_INTERVAL_MS));
+  }
+
+  throw new Error(`kilo serve on port ${port} did not become healthy within ${timeoutMs}ms`);
+}
+
+/**
+ * Get or start a kilo serve instance for the given workdir.
+ *
+ * If a healthy server already exists for this workdir it is reused.
+ * Otherwise a new `kilo serve` process is spawned.
+ *
+ * @returns The port the server is listening on.
+ */
+export async function ensureServer(workdir: string, env: Record<string, string>): Promise<number> {
+  const existing = servers.get(workdir);
+  if (existing?.healthy) {
+    return existing.port;
+  }
+
+  // If there's a dead/unhealthy server entry, clean it up
+  if (existing) {
+    try {
+      existing.process.kill();
+    } catch {
+      /* already dead */
+    }
+    servers.delete(workdir);
+  }
+
+  const port = allocatePort();
+
+  const mergedEnv = { ...process.env, ...env };
+
+  const child: Subprocess = Bun.spawn(
+    ['kilo', 'serve', '--port', String(port), '--hostname', '127.0.0.1'],
+    {
+      cwd: workdir,
+      env: mergedEnv,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    }
+  );
+
+  const instance: KiloServerInstance = {
+    port,
+    workdir,
+    process: child,
+    sessionIds: new Set(),
+    healthy: false,
+  };
+
+  servers.set(workdir, instance);
+
+  // Stream stdout/stderr for visibility
+  const stdout = child.stdout;
+  if (stdout && typeof stdout !== 'number') {
+    void (async () => {
+      const reader = stdout.getReader();
+      const decoder = new TextDecoder();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          process.stdout.write(`[kilo-serve:${port}] ${decoder.decode(value)}`);
+        }
+      } catch {
+        /* stream closed */
+      }
+    })();
+  }
+
+  const stderr = child.stderr;
+  if (stderr && typeof stderr !== 'number') {
+    void (async () => {
+      const reader = stderr.getReader();
+      const decoder = new TextDecoder();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          process.stderr.write(`[kilo-serve:${port}:err] ${decoder.decode(value)}`);
+        }
+      } catch {
+        /* stream closed */
+      }
+    })();
+  }
+
+  // Monitor process exit
+  void child.exited.then(exitCode => {
+    instance.healthy = false;
+    console.log(`kilo serve on port ${port} exited: code=${exitCode}`);
+  });
+
+  await waitForHealthy(port);
+  instance.healthy = true;
+
+  console.log(`kilo serve started on port ${port} for workdir ${workdir} (pid=${child.pid})`);
+  return port;
+}
+
+/**
+ * Track a session ID on a server (for bookkeeping / shutdown decisions).
+ */
+export function registerSession(workdir: string, sessionId: string): void {
+  const server = servers.get(workdir);
+  if (server) {
+    server.sessionIds.add(sessionId);
+  }
+}
+
+/**
+ * Unregister a session. If the server has no remaining sessions, stop it.
+ */
+export async function unregisterSession(workdir: string, sessionId: string): Promise<void> {
+  const server = servers.get(workdir);
+  if (!server) return;
+
+  server.sessionIds.delete(sessionId);
+
+  if (server.sessionIds.size === 0) {
+    await stopServer(workdir);
+  }
+}
+
+/**
+ * Stop a kilo serve instance for the given workdir.
+ */
+export async function stopServer(workdir: string): Promise<void> {
+  const server = servers.get(workdir);
+  if (!server) return;
+
+  server.healthy = false;
+
+  try {
+    server.process.kill(15); // SIGTERM
+
+    const timeout = new Promise<'timeout'>(r => setTimeout(() => r('timeout'), 10_000));
+    const result = await Promise.race([
+      server.process.exited.then(() => 'exited' as const),
+      timeout,
+    ]);
+    if (result === 'timeout') {
+      server.process.kill(9); // SIGKILL
+    }
+  } catch {
+    /* already dead */
+  }
+
+  servers.delete(workdir);
+  console.log(`Stopped kilo serve for workdir ${workdir}`);
+}
+
+/**
+ * Stop all running kilo serve instances. Used during container shutdown.
+ */
+export async function stopAllServers(): Promise<void> {
+  await Promise.allSettled([...servers.keys()].map(workdir => stopServer(workdir)));
+}
+
+/**
+ * Get the port for a server by workdir, or null if none exists.
+ */
+export function getServerPort(workdir: string): number | null {
+  return servers.get(workdir)?.port ?? null;
+}
+
+/**
+ * Count of active (healthy) server instances.
+ */
+export function activeServerCount(): number {
+  let count = 0;
+  for (const s of servers.values()) {
+    if (s.healthy) count++;
+  }
+  return count;
+}

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -114,7 +114,12 @@ export async function startAgent(
       systemPrompt: request.systemPrompt,
     });
 
-    agent.status = 'running';
+    // Only transition to 'running' if the SSE consumer hasn't already
+    // moved us to a terminal state (e.g. a fast completion event arrived
+    // between subscription and here).
+    if (agent.status === 'starting') {
+      agent.status = 'running';
+    }
     agent.messageCount = 1;
 
     console.log(

--- a/cloudflare-gastown/container/src/sse-consumer.ts
+++ b/cloudflare-gastown/container/src/sse-consumer.ts
@@ -1,0 +1,184 @@
+/**
+ * SSE consumer for kilo serve /event endpoint.
+ *
+ * Subscribes to the server-sent event stream and forwards structured events
+ * to a callback. Used for observability (heartbeat enrichment, future
+ * WebSocket streaming to the dashboard).
+ */
+
+import type { KiloSSEEvent } from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export type SSEConsumerOptions = {
+  /** Port of the kilo serve instance */
+  port: number;
+  /** Called for each meaningful event (excludes heartbeats) */
+  onEvent: (event: KiloSSEEvent) => void;
+  /** Called on any SSE activity (including heartbeats) — for last-activity tracking */
+  onActivity?: () => void;
+  /** Called when the SSE stream ends or errors */
+  onClose?: (reason: string) => void;
+};
+
+export type SSEConsumer = {
+  stop: () => void;
+  isActive: () => boolean;
+};
+
+/**
+ * Parse SSE text format into event objects.
+ *
+ * SSE format:
+ *   event: <name>\n
+ *   data: <json>\n
+ *   \n
+ *
+ * kilo serve may also omit the `event:` line and embed the type inside the
+ * data payload as `{ "type": "event.name", "properties": {...} }`.
+ */
+function parseSSEChunk(chunk: string, flush = false): KiloSSEEvent[] {
+  const events: KiloSSEEvent[] = [];
+  const lines = chunk.split('\n');
+
+  let currentEvent: string | null = null;
+  let currentData: string[] = [];
+
+  const emit = () => {
+    if (currentData.length === 0) {
+      currentEvent = null;
+      return;
+    }
+
+    const raw = currentData.join('\n');
+    let data: unknown;
+    try {
+      data = raw ? JSON.parse(raw) : {};
+    } catch {
+      data = raw;
+    }
+
+    let eventName = currentEvent;
+    if (eventName === null && isRecord(data) && typeof data.type === 'string') {
+      eventName = data.type;
+    }
+
+    if (eventName !== null) {
+      events.push({ event: eventName, data });
+    }
+
+    currentEvent = null;
+    currentData = [];
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('event:')) {
+      currentEvent = line.slice(6).trim();
+    } else if (line.startsWith('data:')) {
+      currentData.push(line.slice(5).trim());
+    } else if (line === '' && currentData.length > 0) {
+      emit();
+    }
+  }
+
+  if (flush) emit();
+
+  return events;
+}
+
+/** Events that indicate the agent finished its current task. */
+const COMPLETION_EVENTS = new Set([
+  'session.completed',
+  'session.idle',
+  'message.completed',
+  'assistant.completed',
+]);
+
+export function isCompletionEvent(event: KiloSSEEvent): boolean {
+  return COMPLETION_EVENTS.has(event.event);
+}
+
+/**
+ * Create an SSE consumer that connects to `GET /event` on a kilo serve
+ * instance and forwards parsed events.
+ */
+export function createSSEConsumer(opts: SSEConsumerOptions): SSEConsumer {
+  const url = `http://127.0.0.1:${opts.port}/event`;
+  let active = true;
+  const controller = new AbortController();
+
+  void (async () => {
+    try {
+      const res = await fetch(url, {
+        headers: { Accept: 'text/event-stream' },
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`SSE connection failed: ${res.status} ${res.statusText}`);
+      }
+
+      if (!res.body) {
+        throw new Error('SSE response has no body');
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (active) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          // Flush remaining buffer
+          if (buffer.trim()) {
+            for (const evt of parseSSEChunk(buffer, true)) {
+              opts.onActivity?.();
+              if (evt.event !== 'server.connected' && evt.event !== 'server.heartbeat') {
+                opts.onEvent(evt);
+              }
+            }
+          }
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete events (separated by blank lines)
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+
+        for (const part of parts) {
+          if (!part.trim()) continue;
+          for (const evt of parseSSEChunk(part + '\n\n')) {
+            opts.onActivity?.();
+            if (evt.event !== 'server.connected' && evt.event !== 'server.heartbeat') {
+              opts.onEvent(evt);
+            }
+          }
+        }
+      }
+
+      opts.onClose?.('stream ended');
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        opts.onClose?.('aborted');
+      } else {
+        console.error('SSE error:', err instanceof Error ? err.message : String(err));
+        opts.onClose?.(`error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  })();
+
+  return {
+    stop: () => {
+      if (active) {
+        active = false;
+        controller.abort();
+      }
+    },
+    isActive: () => active,
+  };
+}

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -34,38 +34,89 @@ export const SendMessageRequest = z.object({
 });
 export type SendMessageRequest = z.infer<typeof SendMessageRequest>;
 
-// ── Process lifecycle ───────────────────────────────────────────────────
+// ── Agent lifecycle ─────────────────────────────────────────────────────
 
-export const ProcessStatus = z.enum(['starting', 'running', 'stopping', 'exited', 'failed']);
-export type ProcessStatus = z.infer<typeof ProcessStatus>;
+export const AgentStatus = z.enum(['starting', 'running', 'stopping', 'exited', 'failed']);
+export type AgentStatus = z.infer<typeof AgentStatus>;
 
-export type AgentProcess = {
+// Kept for backward compat — external callers (DO, heartbeat) still reference this name.
+export const ProcessStatus = AgentStatus;
+export type ProcessStatus = AgentStatus;
+
+/**
+ * Tracks a managed agent: a kilo serve session backed by an SSE subscription.
+ * Replaces the old AgentProcess (raw child process + stdin pipe).
+ */
+export type ManagedAgent = {
   agentId: string;
   rigId: string;
   townId: string;
   role: AgentRole;
   name: string;
-  pid: number | null;
-  status: ProcessStatus;
-  exitCode: number | null;
+  status: AgentStatus;
+  /** Port of the kilo serve instance this agent's session lives on */
+  serverPort: number;
+  /** Session ID within the kilo serve instance */
+  sessionId: string;
+  /** Working directory (git worktree) */
   workdir: string;
   startedAt: string;
   lastActivityAt: string;
+  /** Last known active tool calls (populated from SSE events) */
+  activeTools: string[];
+  /** Total messages sent to this agent */
+  messageCount: number;
+  /** Exit reason if status is 'exited' or 'failed' */
+  exitReason: string | null;
 };
 
 export type AgentStatusResponse = {
   agentId: string;
-  status: ProcessStatus;
-  pid: number | null;
-  exitCode: number | null;
+  status: AgentStatus;
+  serverPort: number;
+  sessionId: string;
   startedAt: string;
   lastActivityAt: string;
+  activeTools: string[];
+  messageCount: number;
+  exitReason: string | null;
 };
 
 export type HealthResponse = {
   status: 'ok' | 'degraded';
   agents: number;
+  servers: number;
   uptime: number;
+};
+
+// ── Kilo serve instance ─────────────────────────────────────────────────
+
+export type KiloServerInstance = {
+  /** Port the kilo serve process is listening on */
+  port: number;
+  /** Working directory (project root) the server was started in */
+  workdir: string;
+  /** The Bun subprocess handle */
+  process: import('bun').Subprocess;
+  /** Agent IDs with sessions on this server */
+  sessionIds: Set<string>;
+  /** Tracks whether the server is healthy (responded to /global/health) */
+  healthy: boolean;
+};
+
+/**
+ * Session info returned by kilo serve POST /session.
+ */
+export type KiloSession = {
+  id: string;
+  title?: string;
+};
+
+// ── SSE events ──────────────────────────────────────────────────────────
+
+export type KiloSSEEvent = {
+  event: string;
+  data: unknown;
 };
 
 // ── Git manager ─────────────────────────────────────────────────────────
@@ -87,7 +138,7 @@ export type HeartbeatPayload = {
   agentId: string;
   rigId: string;
   townId: string;
-  status: ProcessStatus;
+  status: AgentStatus;
   timestamp: string;
 };
 


### PR DESCRIPTION
## Summary

Replace stdin/stdout-based agent process management in the Town Container with `kilo serve` HTTP server instances. Agents become sessions within kilo serve processes, enabling structured HTTP messaging, SSE event observability, and clean abort via API.

Closes #305

## Changes

### New modules
- **`kilo-server.ts`** — Manages `kilo serve` subprocess lifecycle: one server per worktree, port allocation (starting at 4096), health-check polling, graceful shutdown (SIGTERM → SIGKILL fallback)
- **`kilo-client.ts`** — HTTP client for the kilo serve API: `POST /session` (create), `POST /session/:id/prompt_async` (send message), `POST /session/:id/abort` (clean abort), `GET /global/health`
- **`sse-consumer.ts`** — Connects to `GET /event` on kilo serve instances, parses SSE text format, extracts typed events, detects completion/idle events

### Updated modules
- **`process-manager.ts`** — Fully rewritten: agents tracked as `ManagedAgent` (session ID, server port, active tools, message count) instead of `ManagedProcess` (PID, stdin pipe). Start/stop/message operations route through kilo client HTTP API
- **`agent-runner.ts`** — After git clone + worktree setup, starts a kilo serve instance (or reuses existing), creates a session, sends the initial prompt via HTTP
- **`control-server.ts`** — Same external endpoint contract; internals now use session-based agent management. Health response includes `servers` count
- **`heartbeat.ts`** — Reports session-level agent status instead of process-level
- **`types.ts`** — New types: `ManagedAgent`, `KiloServerInstance`, `KiloSession`, `KiloSSEEvent`. `AgentProcess` removed. `AgentStatusResponse` enriched with `sessionId`, `serverPort`, `activeTools`, `messageCount`, `exitReason`

## Architecture (before → after)

```
BEFORE:
  Control Server (port 8080)
    └── Bun.spawn('kilo code --non-interactive') × N agents
        └── stdin/stdout pipes

AFTER:
  Control Server (port 8080)
    └── kilo serve (port 4096+N) × M servers (one per worktree)
        └── HTTP API: POST /session/:id/prompt_async, GET /event (SSE), etc.
```

## Acceptance criteria
- [x] Container starts `kilo serve` instances instead of `kilo code --non-interactive` processes
- [x] Agents are managed as sessions within kilo server instances
- [x] Follow-up messages use HTTP API instead of stdin pipes
- [x] Agent status reflects session-level detail (active tools, message count, exit reason)
- [x] SSE event subscription wired up for observability
- [x] Clean abort via server API works
- [x] Control server endpoints maintain same external contract (no breaking changes for TownContainer DO)
- [x] Typecheck passes