### PR TITLE
Deployments - Add back-to-App Builder navigation link

### DIFF
--- a/src/components/deployments/DeploymentContext.tsx
+++ b/src/components/deployments/DeploymentContext.tsx
@@ -6,6 +6,7 @@ import type { DeploymentQueries, DeploymentMutations } from '@/lib/user-deployme
 type DeploymentContextValue = {
   queries: DeploymentQueries;
   mutations: DeploymentMutations;
+  organizationId?: string;
 };
 
 const DeploymentContext = createContext<DeploymentContextValue | null>(null);
@@ -29,14 +30,16 @@ export function useDeploymentQueries() {
 export function DeploymentProvider({
   queries,
   mutations,
+  organizationId,
   children,
 }: {
   queries: DeploymentQueries;
   mutations: DeploymentMutations;
+  organizationId?: string;
   children: ReactNode;
 }) {
   return (
-    <DeploymentContext.Provider value={{ queries, mutations }}>
+    <DeploymentContext.Provider value={{ queries, mutations, organizationId }}>
       {children}
     </DeploymentContext.Provider>
   );

--- a/src/components/deployments/DeploymentDetails.tsx
+++ b/src/components/deployments/DeploymentDetails.tsx
@@ -10,10 +10,11 @@ import { EnvironmentSettings } from './EnvironmentSettings';
 import { PasswordSettings } from './PasswordSettings';
 import { SlugEditor } from './SlugEditor';
 import { Button } from '@/components/Button';
-import { Loader2, AlertCircle, Trash2, RotateCw, XCircle } from 'lucide-react';
+import { Loader2, AlertCircle, Trash2, RotateCw, XCircle, ArrowLeft } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { isDeploymentFinished, isDeploymentInProgress } from '@/lib/user-deployments/types';
 import { toast } from 'sonner';
+import Link from 'next/link';
 
 type DeploymentDetailsProps = {
   deploymentId: string;
@@ -23,7 +24,7 @@ type DeploymentDetailsProps = {
 
 export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentDetailsProps) {
   const [activeTab, setActiveTab] = useState<'overview' | 'environment' | 'password'>('overview');
-  const { queries, mutations } = useDeploymentQueries();
+  const { queries, mutations, organizationId } = useDeploymentQueries();
 
   // Check if password features are available (org-only)
   const hasPasswordFeature = !!mutations.setPassword;
@@ -41,6 +42,7 @@ export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentD
 
   const deployment = deploymentData?.deployment;
   const latestBuild = deploymentData?.latestBuild;
+  const appBuilderProjectId = deploymentData?.appBuilderProjectId ?? null;
   const deploymentStatus = latestBuild?.status || 'queued';
   const showActionButtons = isDeploymentFinished(deploymentStatus);
   const showCancelButton = latestBuild && isDeploymentInProgress(deploymentStatus);
@@ -102,6 +104,19 @@ export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentD
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
         <DialogHeader>
+          {appBuilderProjectId && (
+            <Link
+              href={
+                organizationId
+                  ? `/organizations/${organizationId}/app-builder/${appBuilderProjectId}`
+                  : `/app-builder/${appBuilderProjectId}`
+              }
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm transition-colors"
+            >
+              <ArrowLeft className="size-4" />
+              App Builder
+            </Link>
+          )}
           <DialogTitle>Deployment Details</DialogTitle>
         </DialogHeader>
 

--- a/src/components/deployments/DeploymentDetails.tsx
+++ b/src/components/deployments/DeploymentDetails.tsx
@@ -10,7 +10,8 @@ import { EnvironmentSettings } from './EnvironmentSettings';
 import { PasswordSettings } from './PasswordSettings';
 import { SlugEditor } from './SlugEditor';
 import { Button } from '@/components/Button';
-import { Loader2, AlertCircle, Trash2, RotateCw, XCircle, ArrowLeft } from 'lucide-react';
+import { Loader2, AlertCircle, Trash2, RotateCw, XCircle, Blocks } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 import { formatDistanceToNow } from 'date-fns';
 import { isDeploymentFinished, isDeploymentInProgress } from '@/lib/user-deployments/types';
 import { toast } from 'sonner';
@@ -104,19 +105,6 @@ export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentD
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
         <DialogHeader>
-          {appBuilderProjectId && (
-            <Link
-              href={
-                organizationId
-                  ? `/organizations/${organizationId}/app-builder/${appBuilderProjectId}`
-                  : `/app-builder/${appBuilderProjectId}`
-              }
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm transition-colors"
-            >
-              <ArrowLeft className="size-4" />
-              App Builder
-            </Link>
-          )}
           <DialogTitle>Deployment Details</DialogTitle>
         </DialogHeader>
 
@@ -162,7 +150,23 @@ export function DeploymentDetails({ deploymentId, isOpen, onClose }: DeploymentD
                     currentSlug={deployment.deployment_slug}
                     deploymentUrl={deployment.deployment_url}
                   />
-                  <StatusBadge status={deploymentStatus} className="shrink-0" />
+                  <div className="flex shrink-0 items-center gap-2">
+                    {appBuilderProjectId && (
+                      <Link
+                        href={
+                          organizationId
+                            ? `/organizations/${organizationId}/app-builder/${appBuilderProjectId}`
+                            : `/app-builder/${appBuilderProjectId}`
+                        }
+                      >
+                        <Badge className="border-purple-600/30 bg-purple-600/20 text-purple-400">
+                          <Blocks className="size-3" />
+                          App Builder
+                        </Badge>
+                      </Link>
+                    )}
+                    <StatusBadge status={deploymentStatus} />
+                  </div>
                 </div>
 
                 <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">

--- a/src/components/deployments/OrgDeploymentProvider.tsx
+++ b/src/components/deployments/OrgDeploymentProvider.tsx
@@ -358,7 +358,7 @@ export function OrgDeploymentProvider({ organizationId, children }: OrgDeploymen
   };
 
   return (
-    <DeploymentProvider queries={queries} mutations={mutations}>
+    <DeploymentProvider queries={queries} mutations={mutations} organizationId={organizationId}>
       {children}
     </DeploymentProvider>
   );

--- a/src/lib/user-deployments/deployments-service.ts
+++ b/src/lib/user-deployments/deployments-service.ts
@@ -95,9 +95,11 @@ export async function listDeployments(owner: Owner) {
     .select({
       deployment: deployments,
       latestBuild: deployment_builds,
+      appBuilderProjectId: app_builder_projects.id,
     })
     .from(deployments)
     .leftJoin(deployment_builds, eq(deployments.last_build_id, deployment_builds.id))
+    .leftJoin(app_builder_projects, eq(app_builder_projects.deployment_id, deployments.id))
     .where(ownershipCondition)
     .orderBy(desc(deployments.created_at))
     .limit(100);
@@ -107,6 +109,7 @@ export async function listDeployments(owner: Owner) {
     data: userDeployments.map(row => ({
       deployment: row.deployment,
       latestBuild: row.latestBuild,
+      appBuilderProjectId: row.appBuilderProjectId,
     })),
   };
 }
@@ -124,9 +127,11 @@ export async function getDeployment(deploymentId: string, owner: Owner) {
     .select({
       deployment: deployments,
       latestBuild: deployment_builds,
+      appBuilderProjectId: app_builder_projects.id,
     })
     .from(deployments)
     .leftJoin(deployment_builds, eq(deployments.last_build_id, deployment_builds.id))
+    .leftJoin(app_builder_projects, eq(app_builder_projects.deployment_id, deployments.id))
     .where(and(eq(deployments.id, deploymentId), ownershipCondition))
     .limit(1);
 
@@ -141,6 +146,7 @@ export async function getDeployment(deploymentId: string, owner: Owner) {
     success: true,
     deployment: result[0].deployment,
     latestBuild: result[0].latestBuild,
+    appBuilderProjectId: result[0].appBuilderProjectId,
   };
 }
 

--- a/src/lib/user-deployments/router-types.ts
+++ b/src/lib/user-deployments/router-types.ts
@@ -37,6 +37,7 @@ export type ListDeploymentsResponse = {
   data: Array<{
     deployment: Deployment;
     latestBuild: DeploymentBuild | null;
+    appBuilderProjectId: string | null;
   }>;
 };
 
@@ -47,6 +48,7 @@ export type GetDeploymentResponse = {
   success: boolean;
   deployment: Deployment;
   latestBuild: DeploymentBuild | null;
+  appBuilderProjectId: string | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds a "Back to App Builder" link in the deployment details dialog when the deployment is associated with an app builder project.
- Joins `app_builder_projects` in `listDeployments` and `getDeployment` queries to retrieve the linked project ID.
- Threads `organizationId` through `DeploymentContext` so the link resolves to the correct org-scoped or user-scoped App Builder route.
- Updates `ListDeploymentsResponse` and `GetDeploymentResponse` types with the new `appBuilderProjectId` field.

<img width="1025" height="334" alt="Screenshot 2026-02-19 at 10 37 23" src="https://github.com/user-attachments/assets/b26f99de-183a-4c89-8202-b853bca83c00" />
