### PR TITLE
Make Sonnet 4.6 default reviewer and make it free for one week in review mode

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -58,6 +58,7 @@ import {
 import { customLlmRequest } from '@/lib/custom-llm/customLlmRequest';
 import { normalizeModelId } from '@/lib/model-utils';
 import { isRateLimitedToDeath } from '@/lib/rate-limited-models';
+import { isActiveReviewPromo } from '@/lib/code-reviews/core/constants';
 
 const MAX_TOKENS_LIMIT = 99999999999; // GPT4.1 default is ~32k
 
@@ -177,12 +178,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     authFailedResponse,
     organizationId: authOrganizationId,
     internalApiUse: authInternalApiUse,
+    botId: authBotId,
   } = await getUserFromAuth({ adminOnly: false });
   authSpan.end();
 
   let user: typeof maybeUser | AnonymousUserContext;
   let organizationId: string | undefined = authOrganizationId;
   let internalApiUse: boolean | undefined = authInternalApiUse;
+  let botId: string | undefined = authBotId;
 
   if (authFailedResponse) {
     // No valid auth
@@ -194,6 +197,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     user = createAnonymousContext(ipAddress);
     organizationId = undefined;
     internalApiUse = false;
+    botId = undefined;
   } else {
     user = maybeUser;
   }
@@ -274,6 +278,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     machine_id: extractHeaderAndLimitLength(request, 'x-kilocode-machineid'),
     user_byok: !!userByok,
     has_tools: (requestBodyParsed.tools?.length ?? 0) > 0,
+    botId,
   };
 
   setTag('ui.ai_model', requestBodyParsed.model);
@@ -282,7 +287,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   if (!isAnonymousContext(user) && !customLlm) {
     const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user);
 
-    if (balance <= 0 && !isFreeModel(originalModelIdLowerCased) && !userByok) {
+    if (
+      balance <= 0 &&
+      !isFreeModel(originalModelIdLowerCased) &&
+      !userByok &&
+      !isActiveReviewPromo(botId, originalModelIdLowerCased)
+    ) {
       return await usageLimitExceededResponse(user, balance);
     }
 

--- a/src/lib/code-reviews/core/constants.ts
+++ b/src/lib/code-reviews/core/constants.ts
@@ -8,16 +8,29 @@
 // Review Configuration
 // ============================================================================
 
-/**
- * Default model for code reviews
- * Using Claude Sonnet 4.5 as specified in the plan
- */
-export const DEFAULT_CODE_REVIEW_MODEL = 'anthropic/claude-sonnet-4.5';
+/** Default model for code reviews */
+export const DEFAULT_CODE_REVIEW_MODEL = 'anthropic/claude-sonnet-4.6';
 
 /**
  * Default mode for cloud agent sessions
  */
 export const DEFAULT_CODE_REVIEW_MODE = 'code' as const;
+
+// ============================================================================
+// Sonnet 4.6 Review Promotion
+// ============================================================================
+
+export const REVIEW_PROMO_MODEL = 'anthropic/claude-sonnet-4.6';
+export const REVIEW_PROMO_START = '2026-02-18T14:00:00Z'; // used only for admin logging
+export const REVIEW_PROMO_END = '2026-02-25T14:00:00Z';
+
+/** Single source of truth: is the free-review promo active for this request? */
+export function isActiveReviewPromo(botId: string | undefined, model: string): boolean {
+  if (botId !== 'reviewer') return false;
+  if (model !== REVIEW_PROMO_MODEL) return false;
+
+  return Date.now() < Date.parse(REVIEW_PROMO_END);
+}
 
 // ============================================================================
 // Pagination

--- a/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -37,7 +37,13 @@ import type {
 } from '../prompts/generate-prompt';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
 import { getCodeReviewById } from '../db/code-reviews';
-import { DEFAULT_CODE_REVIEW_MODEL, DEFAULT_CODE_REVIEW_MODE } from '../core/constants';
+import {
+  DEFAULT_CODE_REVIEW_MODEL,
+  DEFAULT_CODE_REVIEW_MODE,
+  isActiveReviewPromo,
+  REVIEW_PROMO_START,
+  REVIEW_PROMO_END,
+} from '../core/constants';
 import type { Owner } from '../core';
 import { generateReviewPrompt } from '../prompts/generate-prompt';
 import type { CodeReviewAgentConfig } from '@/lib/agent-config/core/types';
@@ -355,11 +361,28 @@ export async function prepareReviewPayload(
             upstreamBranch: review.head_ref,
           };
 
+    if (isActiveReviewPromo('reviewer', sessionInput.model)) {
+      logExceptInTest('[prepareReviewPayload] Promotional model selected for code review', {
+        reviewId,
+        owner,
+        model: sessionInput.model,
+        promoStart: REVIEW_PROMO_START,
+        promoEnd: REVIEW_PROMO_END,
+      });
+    }
+
     // Log the session input for GitLab
     if (platform === PLATFORM.GITLAB) {
       logExceptInTest('[prepareReviewPayload] GitLab session input prepared', {
         gitUrl: sessionInput.gitUrl,
         hasGitToken: !!sessionInput.gitToken,
+        upstreamBranch: sessionInput.upstreamBranch,
+        model: sessionInput.model,
+      });
+    } else {
+      logExceptInTest('[prepareReviewPayload] GitHub session input prepared', {
+        githubRepo: sessionInput.githubRepo,
+        hasGithubToken: !!sessionInput.githubToken,
         upstreamBranch: sessionInput.upstreamBranch,
         model: sessionInput.model,
       });

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -126,5 +126,6 @@ export function validateAuthorizationHeader(headers: Headers) {
     organizationRole: payload.organizationRole,
     internalApiUse: payload.internalApiUse,
     createdOnPlatform: payload.createdOnPlatform,
+    botId: payload.botId,
   };
 }

--- a/src/lib/user.server.ts
+++ b/src/lib/user.server.ts
@@ -643,6 +643,7 @@ type GetAuthResponse =
       isNewUser?: undefined;
       organizationId?: undefined;
       internalApiUse?: undefined;
+      botId?: undefined;
     }
   | {
       user: User;
@@ -650,6 +651,7 @@ type GetAuthResponse =
       isNewUser?: boolean;
       organizationId?: Organization['id'];
       internalApiUse?: boolean;
+      botId?: string;
     };
 
 export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAuthResponse> {
@@ -675,6 +677,7 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
 
     const organizationId = headersList.get(ORGANIZATION_ID_HEADER) || undefined;
     const internalApiUse = authorizationValidationResult.internalApiUse;
+    const botId = authorizationValidationResult.botId;
 
     return await validateUserAuthorization(
       authorizationValidationResult.kiloUserId,
@@ -683,7 +686,8 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
       false,
       organizationId,
       internalApiUse,
-      readDb
+      readDb,
+      botId
     );
   }
 
@@ -733,7 +737,8 @@ async function validateUserAuthorization(
   isNewUser?: boolean,
   organizationId?: Organization['id'],
   internalApiUse?: boolean,
-  fromDb: typeof db = db
+  fromDb: typeof db = db,
+  botId?: string
 ): Promise<GetAuthResponse> {
   if (!user) {
     return authError(401, 'User not found', kiloUserId);
@@ -756,7 +761,7 @@ async function validateUserAuthorization(
     }
   }
 
-  return { user, authFailedResponse: null, isNewUser, organizationId, internalApiUse };
+  return { user, authFailedResponse: null, isNewUser, organizationId, internalApiUse, botId };
 }
 
 export const isUserBlacklistedByDomain = (existingUser: Pick<User, 'google_user_email'>) =>

--- a/src/scripts/test-sonnet-46-review-promo.ts
+++ b/src/scripts/test-sonnet-46-review-promo.ts
@@ -1,0 +1,263 @@
+/**
+ * Test script: verify Sonnet 4.6 free code review promotion.
+ *
+ * Generates a reviewer JWT matching actual prepare-review-payload.ts behavior
+ * (botId: 'reviewer', no internalApiUse) and exercises the promo logic.
+ *
+ * Run with:
+ *   pnpm script src/scripts/test-sonnet-46-review-promo.ts
+ */
+
+import pg from 'pg';
+import jwt from 'jsonwebtoken';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import {
+  isActiveReviewPromo,
+  REVIEW_PROMO_MODEL,
+  REVIEW_PROMO_END,
+} from '@/lib/code-reviews/core/constants';
+
+const root = path.resolve(__dirname, '../../');
+dotenv.config({ path: path.join(root, '.env') });
+dotenv.config({ path: path.join(root, '.env.local'), override: true });
+
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET;
+const POSTGRES_URL = process.env.POSTGRES_URL;
+
+if (!NEXTAUTH_SECRET) throw new Error('NEXTAUTH_SECRET not set');
+if (!POSTGRES_URL) throw new Error('POSTGRES_URL not set');
+
+const JWT_TOKEN_VERSION = 3;
+const BASE_URL = 'http://localhost:3000';
+const secret: string = NEXTAUTH_SECRET;
+
+type TestResult = { name: string; passed: boolean; detail: string };
+const results: TestResult[] = [];
+
+function mintToken(
+  userId: string,
+  pepper: string,
+  overrides: Record<string, unknown> = {}
+): string {
+  return jwt.sign(
+    {
+      env: process.env.NODE_ENV ?? 'development',
+      kiloUserId: userId,
+      apiTokenPepper: pepper,
+      version: JWT_TOKEN_VERSION,
+      ...overrides,
+    },
+    secret,
+    { algorithm: 'HS256', expiresIn: 300 }
+  );
+}
+
+async function chatRequest(token: string, model: string) {
+  return fetch(`${BASE_URL}/api/openrouter/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-forwarded-for': '127.0.0.1',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: 'Say "ok" and nothing else.' }],
+      stream: false,
+      max_tokens: 10,
+    }),
+  });
+}
+
+function record(name: string, passed: boolean, detail: string) {
+  results.push({ name, passed, detail });
+  console.log(`${passed ? '✅ PASS' : '❌ FAIL'} [${name}] ${detail}`);
+}
+
+async function main() {
+  const client = new pg.Client({ connectionString: POSTGRES_URL });
+  await client.connect();
+
+  const { rows } = await client.query<{
+    id: string;
+    api_token_pepper: string;
+    google_user_email: string;
+  }>('SELECT id, api_token_pepper, google_user_email FROM kilocode_users LIMIT 1');
+
+  const user = rows[0];
+  if (!user) throw new Error('No users found in DB');
+  console.log(`Using user: ${user.id} (${user.google_user_email})\n`);
+
+  // ─── Test 1: Promo model accepted ────────────────────────────────────
+  {
+    const token = mintToken(user.id, user.api_token_pepper, { botId: 'reviewer' });
+    const res = await chatRequest(token, REVIEW_PROMO_MODEL);
+    record('Promo model accepted', res.status === 200, `HTTP ${res.status} (expected 200)`);
+  }
+
+  // ─── Test 2: Cost is zeroed ──────────────────────────────────────────
+  {
+    // Small delay so the usage row has been written
+    await new Promise(r => setTimeout(r, 3000));
+    const { rows: usageRows } = await client.query<{ cost: string }>(
+      `SELECT cost FROM microdollar_usage
+       WHERE kilo_user_id = $1
+         AND requested_model = $2
+       ORDER BY created_at DESC LIMIT 1`,
+      [user.id, REVIEW_PROMO_MODEL]
+    );
+    const cost = usageRows[0] ? Number(usageRows[0].cost) : -1;
+    record('Cost is zeroed', cost === 0, `cost = ${cost} (expected 0)`);
+  }
+
+  // ─── Test 3: Non-promo model not free ────────────────────────────────
+  {
+    const token = mintToken(user.id, user.api_token_pepper, { botId: 'reviewer' });
+    const res = await chatRequest(token, 'anthropic/claude-opus-4.6');
+    // Should either work (cost > 0) or be balance-gated (402)
+    await new Promise(r => setTimeout(r, 3000));
+    const { rows: usageRows } = await client.query<{ cost: string }>(
+      `SELECT cost FROM microdollar_usage
+       WHERE kilo_user_id = $1
+         AND requested_model = 'anthropic/claude-opus-4.6'
+       ORDER BY created_at DESC LIMIT 1`,
+      [user.id]
+    );
+    const cost = usageRows[0] ? Number(usageRows[0].cost) : -1;
+    const passed = res.status === 402 || cost > 0;
+    record('Non-promo model not free', passed, `HTTP ${res.status}, cost = ${cost}`);
+  }
+
+  // ─── Test 4: Non-reviewer botId not free ─────────────────────────────
+  {
+    const token = mintToken(user.id, user.api_token_pepper, { botId: 'other' });
+    const res = await chatRequest(token, REVIEW_PROMO_MODEL);
+    await new Promise(r => setTimeout(r, 3000));
+    const { rows: usageRows } = await client.query<{ cost: string }>(
+      `SELECT cost FROM microdollar_usage
+       WHERE kilo_user_id = $1
+         AND requested_model = $2
+       ORDER BY created_at DESC LIMIT 1`,
+      [user.id, REVIEW_PROMO_MODEL]
+    );
+    const cost = usageRows[0] ? Number(usageRows[0].cost) : -1;
+    // If the promo window is active, a non-reviewer botId should still pay
+    const passed = res.status === 402 || cost > 0;
+    record('Non-reviewer botId not free', passed, `HTTP ${res.status}, cost = ${cost}`);
+  }
+
+  // ─── Test 5: No botId not free ───────────────────────────────────────
+  {
+    const token = mintToken(user.id, user.api_token_pepper);
+    const res = await chatRequest(token, REVIEW_PROMO_MODEL);
+    await new Promise(r => setTimeout(r, 3000));
+    const { rows: usageRows } = await client.query<{ cost: string }>(
+      `SELECT cost FROM microdollar_usage
+       WHERE kilo_user_id = $1
+         AND requested_model = $2
+       ORDER BY created_at DESC LIMIT 1`,
+      [user.id, REVIEW_PROMO_MODEL]
+    );
+    const cost = usageRows[0] ? Number(usageRows[0].cost) : -1;
+    const passed = res.status === 402 || cost > 0;
+    record('No botId not free', passed, `HTTP ${res.status}, cost = ${cost}`);
+  }
+
+  // ─── Test 6: Balance gate bypass ─────────────────────────────────────
+  {
+    // Temporarily set user balance to 0 for this test
+    await client.query(
+      `UPDATE kilocode_users SET microdollars_used = microdollars_lifetime_total WHERE id = $1`,
+      [user.id]
+    );
+    const token = mintToken(user.id, user.api_token_pepper, { botId: 'reviewer' });
+    const res = await chatRequest(token, REVIEW_PROMO_MODEL);
+    // Restore balance
+    await client.query(`UPDATE kilocode_users SET microdollars_used = 0 WHERE id = $1`, [user.id]);
+    record(
+      'Balance gate bypass',
+      res.status === 200,
+      `HTTP ${res.status} with 0 balance (expected 200)`
+    );
+  }
+
+  // ─── Test 7: isActiveReviewPromo unit test ───────────────────────────
+  {
+    const now = Date.now();
+    const inWindow = now < Date.parse(REVIEW_PROMO_END);
+
+    const resultTrue = isActiveReviewPromo('reviewer', REVIEW_PROMO_MODEL);
+    const resultWrongBot = isActiveReviewPromo('other', REVIEW_PROMO_MODEL);
+    const resultWrongModel = isActiveReviewPromo('reviewer', 'anthropic/claude-opus-4.6');
+    const resultUndefined = isActiveReviewPromo(undefined, REVIEW_PROMO_MODEL);
+
+    const allCorrect =
+      resultTrue === inWindow &&
+      resultWrongBot === false &&
+      resultWrongModel === false &&
+      resultUndefined === false;
+
+    record(
+      'isActiveReviewPromo unit',
+      allCorrect,
+      `inWindow=${inWindow}, reviewer+promo=${resultTrue}, other+promo=${resultWrongBot}, reviewer+opus=${resultWrongModel}, undefined+promo=${resultUndefined}`
+    );
+  }
+
+  // ─── Test 8: Admin stats endpoint ────────────────────────────────────
+  {
+    // Make user admin temporarily
+    await client.query(`UPDATE kilocode_users SET is_admin = true WHERE id = $1`, [user.id]);
+    const token = mintToken(user.id, user.api_token_pepper);
+    try {
+      const res = await fetch(`${BASE_URL}/api/trpc/adminCodeReviews.getReviewPromotionStats`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const body = await res.json();
+      const data = body?.result?.data;
+      const hasShape =
+        data &&
+        typeof data.promoActive === 'boolean' &&
+        typeof data.promoStart === 'string' &&
+        typeof data.promoEnd === 'string' &&
+        typeof data.totalRequests === 'number' &&
+        typeof data.uniqueUsers === 'number' &&
+        typeof data.uniqueOrgs === 'number' &&
+        Array.isArray(data.daily);
+
+      record(
+        'Admin stats endpoint',
+        res.status === 200 && hasShape,
+        `HTTP ${res.status}, hasShape=${hasShape}`
+      );
+    } finally {
+      await client.query(`UPDATE kilocode_users SET is_admin = false WHERE id = $1`, [user.id]);
+    }
+  }
+
+  await client.end();
+
+  // ─── Summary ─────────────────────────────────────────────────────────
+  console.log('\n┌─────────────────────────────────────────────┐');
+  console.log('│         SONNET 4.6 REVIEW PROMO TESTS       │');
+  console.log('├──────┬──────────────────────────────────────┤');
+  for (const r of results) {
+    const status = r.passed ? 'PASS' : 'FAIL';
+    console.log(`│ ${status} │ ${r.name.padEnd(40)}│`);
+  }
+  console.log('├──────┴──────────────────────────────────────┤');
+  const passed = results.filter(r => r.passed).length;
+  console.log(`│ ${passed}/${results.length} tests passed${' '.repeat(30)}│`);
+  console.log('└─────────────────────────────────────────────┘');
+
+  if (passed < results.length) process.exit(1);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

1. Make sonnet 4.6 default reviewer - is already in `https://app.kilo.ai/organizations/.../code-reviews`. Has same costs as sonnet 4.5 [per docs](https://platform.claude.com/docs/en/about-claude/pricing)
2. Time-boxed promotion (2026-02-18T14:00Z → 2026-02-25T14:00Z) making `sonnet 4.6` free for automated code reviews. After the window closes, the promo silently stops — no cleanup needed.

### How it works

A single predicate `isActiveReviewPromo(botId, model)` is the sole source of truth. It returns `true` only when all three conditions hold:

1. `botId === 'reviewer'` (set in the JWT by `prepare-review-payload.ts`)
2. `model === 'anthropic/claude-sonnet-4.6'`
3. Current time is before the promo end date

This predicate is checked in two places:
- **Balance gate** (`route.ts`): skips the 402 "insufficient credits" rejection
- **Cost recording** (`processUsage.ts`): zeros `cost_mUsd` so the user isn't charged

### Changes

**Auth stack — thread `botId` from JWT to usage context:**
- `tokens.ts`: return `botId` from `validateAuthorizationHeader` (was missing despite being in `JWTTokenExtraPayload`)
- `user.server.ts`: add `botId` to `GetAuthResponse` type and thread through `getUserFromAuth` → `validateUserAuthorization`
- `route.ts`: destructure `botId` from auth, add to `usageContext`, add `isActiveReviewPromo` to balance gate condition

**Promo logic:**
- `constants.ts`: add `REVIEW_PROMO_MODEL`, `REVIEW_PROMO_START`, `REVIEW_PROMO_END`, and `isActiveReviewPromo()` predicate. Update `DEFAULT_CODE_REVIEW_MODEL` to `anthropic/claude-sonnet-4.6`.
- `processUsage.ts`: add `botId?: string` to `MicrodollarUsageContext`; extend cost-zeroing condition with `isActiveReviewPromo`
- `prepare-review-payload.ts`: add promo logging when `isActiveReviewPromo` returns true

**Admin visibility:**
- `admin-code-reviews-router.ts`: add `getReviewPromotionStats` query — aggregate + daily breakdown from `microdollar_usage` joined with `microdollar_usage_metadata`, filtered to zero-cost non-BYOK sonnet-4.6 requests within the promo window

**Integration tests:**
- `test-sonnet-46-review-promo.ts`: 8 tests covering promo accepted, cost zeroed, non-promo model not free, wrong botId, no botId, balance gate bypass with zero balance, `isActiveReviewPromo` unit test, admin stats query shape validation

### What this does NOT change

- No new model slugs, no `KiloFreeModel` entries, no DB migrations
- No changes to `isFreeModel`/`kiloFreeModels`/free model rate limiter
- No changes to model picker UI or FIM route
- `prepare-review-payload.ts` JWT creation already sets `botId: 'reviewer'` — unchanged

### Testing

```
pnpm script src/scripts/test-sonnet-46-review-promo.ts
```