### PR TITLE
Auth - Add missing auth checks and fix redirect behavior across app pages

### DIFF
--- a/src/app/(app)/byok/layout.tsx
+++ b/src/app/(app)/byok/layout.tsx
@@ -1,0 +1,6 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+
+export default async function BYOKLayout({ children }: { children: React.ReactNode }) {
+  await getUserFromAuthOrRedirect();
+  return <>{children}</>;
+}

--- a/src/app/(app)/claw/layout.tsx
+++ b/src/app/(app)/claw/layout.tsx
@@ -1,10 +1,9 @@
 import { redirect } from 'next/navigation';
-import { getUserFromAuth } from '@/lib/user.server';
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
 
 export default async function ClawLayout({ children }: { children: React.ReactNode }) {
-  const { user } = await getUserFromAuth({ adminOnly: false });
-  if (!user) redirect('/sign-in');
+  const user = await getUserFromAuthOrRedirect();
 
   const isKiloClawEnabled = await isReleaseToggleEnabled('kiloclaw', user.id);
   const isDevelopment = process.env.NODE_ENV === 'development';

--- a/src/app/(app)/cloud/sessions/layout.tsx
+++ b/src/app/(app)/cloud/sessions/layout.tsx
@@ -1,0 +1,6 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+
+export default async function CloudSessionsLayout({ children }: { children: React.ReactNode }) {
+  await getUserFromAuthOrRedirect();
+  return <>{children}</>;
+}

--- a/src/app/(app)/cloud/webhooks/layout.tsx
+++ b/src/app/(app)/cloud/webhooks/layout.tsx
@@ -1,0 +1,6 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+
+export default async function CloudWebhooksLayout({ children }: { children: React.ReactNode }) {
+  await getUserFromAuthOrRedirect();
+  return <>{children}</>;
+}

--- a/src/app/(app)/deploy/[deploymentId]/page.tsx
+++ b/src/app/(app)/deploy/[deploymentId]/page.tsx
@@ -8,7 +8,7 @@ export default async function DeploymentDetailPage({
 }: {
   params: Promise<{ deploymentId: string }>;
 }) {
-  await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/deploy');
+  await getUserFromAuthOrRedirect();
 
   if (!ENABLE_DEPLOY_FEATURE) {
     return notFound();

--- a/src/app/(app)/organizations/[id]/app-builder/[projectId]/page.tsx
+++ b/src/app/(app)/organizations/[id]/app-builder/[projectId]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { AppBuilderPage } from '@/components/app-builder/AppBuilderPage';
 import { getAuthorizedOrgContext } from '@/lib/organizations/organization-auth';
+import { signInUrlWithCallbackPath } from '@/lib/user.server';
 
 type Props = {
   params: Promise<{ id: string; projectId: string }>;
@@ -10,9 +11,11 @@ export default async function OrgAppBuilderProjectPage({ params }: Props) {
   const { id, projectId } = await params;
   const organizationId = decodeURIComponent(id);
 
-  // Auth check - redirect if not authorized
-  const { success } = await getAuthorizedOrgContext(organizationId);
-  if (!success) {
+  const result = await getAuthorizedOrgContext(organizationId);
+  if (!result.success) {
+    if (result.nextResponse.status === 401) {
+      redirect(await signInUrlWithCallbackPath());
+    }
     redirect('/profile');
   }
 

--- a/src/app/(app)/organizations/[id]/cloud/chat/page.tsx
+++ b/src/app/(app)/organizations/[id]/cloud/chat/page.tsx
@@ -3,6 +3,7 @@ import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { CloudChatPageWrapper } from './CloudChatPageWrapper';
 import { CloudChatPageWrapperNext } from './CloudChatPageWrapperNext';
 import { getAuthorizedOrgContext } from '@/lib/organizations/organization-auth';
+import { signInUrlWithCallbackPath } from '@/lib/user.server';
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -13,8 +14,11 @@ export default async function OrganizationCloudChatPage({ params, searchParams }
   const { id } = await params;
   const organizationId = decodeURIComponent(id);
 
-  const { success } = await getAuthorizedOrgContext(organizationId);
-  if (!success) {
+  const result = await getAuthorizedOrgContext(organizationId);
+  if (!result.success) {
+    if (result.nextResponse.status === 401) {
+      redirect(await signInUrlWithCallbackPath());
+    }
     redirect('/profile');
   }
 

--- a/src/app/(app)/organizations/[id]/security-agent/page.tsx
+++ b/src/app/(app)/organizations/[id]/security-agent/page.tsx
@@ -1,6 +1,6 @@
 import { SecurityAgentPageClient } from '@/components/security-agent';
 import { PageContainer } from '@/components/layouts/PageContainer';
-import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
 
 export const metadata = {
   title: 'Security Agent | Kilo Code',
@@ -12,12 +12,14 @@ type PageProps = {
 };
 
 export default async function OrganizationSecurityAgentPage({ params }: PageProps) {
-  const { id: organizationId } = await params;
-  const user = await getUserFromAuthOrRedirect('/users/sign_in');
-
   return (
-    <PageContainer>
-      <SecurityAgentPageClient organizationId={organizationId} isAdmin={user.is_admin} />
-    </PageContainer>
+    <OrganizationByPageLayout
+      params={params}
+      render={({ role, organization }) => (
+        <PageContainer>
+          <SecurityAgentPageClient organizationId={organization.id} isAdmin={role === 'owner'} />
+        </PageContainer>
+      )}
+    />
   );
 }

--- a/src/app/(app)/organizations/[id]/security-agent/page.tsx
+++ b/src/app/(app)/organizations/[id]/security-agent/page.tsx
@@ -15,9 +15,9 @@ export default async function OrganizationSecurityAgentPage({ params }: PageProp
   return (
     <OrganizationByPageLayout
       params={params}
-      render={({ role, organization }) => (
+      render={({ organization, isGlobalAdmin }) => (
         <PageContainer>
-          <SecurityAgentPageClient organizationId={organization.id} isAdmin={role === 'owner'} />
+          <SecurityAgentPageClient organizationId={organization.id} isAdmin={isGlobalAdmin} />
         </PageContainer>
       )}
     />

--- a/src/app/(app)/organizations/[id]/welcome/layout.tsx
+++ b/src/app/(app)/organizations/[id]/welcome/layout.tsx
@@ -1,16 +1,16 @@
-import { redirect } from 'next/navigation';
-import { AppBuilderPage } from '@/components/app-builder/AppBuilderPage';
 import { getAuthorizedOrgContext } from '@/lib/organizations/organization-auth';
 import { signInUrlWithCallbackPath } from '@/lib/user.server';
+import { redirect } from 'next/navigation';
 
-type Props = {
+export default async function WelcomeLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
   params: Promise<{ id: string }>;
-};
-
-export default async function OrgAppBuilderPage({ params }: Props) {
+}) {
   const { id } = await params;
   const organizationId = decodeURIComponent(id);
-
   const result = await getAuthorizedOrgContext(organizationId);
   if (!result.success) {
     if (result.nextResponse.status === 401) {
@@ -18,6 +18,5 @@ export default async function OrgAppBuilderPage({ params }: Props) {
     }
     redirect('/profile');
   }
-
-  return <AppBuilderPage organizationId={organizationId} projectId={undefined} />;
+  return <>{children}</>;
 }

--- a/src/app/payments/kilo-pass/awarding/page.tsx
+++ b/src/app/payments/kilo-pass/awarding/page.tsx
@@ -2,7 +2,7 @@ import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { KiloPassAwardingCreditsClient } from './KiloPassAwardingCreditsClient';
 
 export default async function KiloPassAwardingCreditsPage() {
-  await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/profile');
+  await getUserFromAuthOrRedirect();
 
   return <KiloPassAwardingCreditsClient />;
 }

--- a/src/app/payments/subscriptions/success/page.tsx
+++ b/src/app/payments/subscriptions/success/page.tsx
@@ -8,7 +8,7 @@ export default async function Page({
 }: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
-  await getUserFromAuthOrRedirect('/');
+  await getUserFromAuthOrRedirect();
   const params = await searchParams;
   const sessionId = params[STRIPE_SUB_QUERY_STRING_KEY];
   const organizationId = params['organizationId'];

--- a/src/app/payments/topup/success/layout.tsx
+++ b/src/app/payments/topup/success/layout.tsx
@@ -1,0 +1,6 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+
+export default async function TopUpSuccessLayout({ children }: { children: React.ReactNode }) {
+  await getUserFromAuthOrRedirect();
+  return <>{children}</>;
+}

--- a/src/components/organizations/OrganizationByPageLayout.tsx
+++ b/src/components/organizations/OrganizationByPageLayout.tsx
@@ -1,5 +1,6 @@
 'use server';
 import { getAuthorizedOrgContext } from '@/lib/organizations/organization-auth';
+import { signInUrlWithCallbackPath } from '@/lib/user.server';
 import type { OrganizationRole } from '@/lib/organizations/organization-types';
 import type { Organization } from '@/db/schema';
 import { redirect } from 'next/navigation';
@@ -21,11 +22,14 @@ export async function OrganizationByPageLayout({
 }) {
   const { id } = await params;
   const organizationId = decodeURIComponent(id);
-  const { success, data } = await getAuthorizedOrgContext(organizationId);
-  if (!success) {
+  const result = await getAuthorizedOrgContext(organizationId);
+  if (!result.success) {
+    if (result.nextResponse.status === 401) {
+      redirect(await signInUrlWithCallbackPath());
+    }
     redirect('/profile');
   }
-  const { user, organization } = data;
+  const { user, organization } = result.data;
   const role = user.is_admin ? 'owner' : user.role;
   return (
     <OrganizationTrialWrapper organizationId={organization.id}>

--- a/src/components/organizations/OrganizationByPageLayout.tsx
+++ b/src/components/organizations/OrganizationByPageLayout.tsx
@@ -15,9 +15,11 @@ export async function OrganizationByPageLayout({
   render: ({
     role,
     organization,
+    isGlobalAdmin,
   }: {
     role: OrganizationRole;
     organization: Organization;
+    isGlobalAdmin: boolean;
   }) => JSX.Element;
 }) {
   const { id } = await params;
@@ -33,7 +35,7 @@ export async function OrganizationByPageLayout({
   const role = user.is_admin ? 'owner' : user.role;
   return (
     <OrganizationTrialWrapper organizationId={organization.id}>
-      {render({ role, organization })}
+      {render({ role, organization, isGlobalAdmin: user.is_admin })}
     </OrganizationTrialWrapper>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,16 @@
+import type { NextRequestWithAuth } from 'next-auth/middleware';
 import { NextResponse } from 'next/server';
 import { withAuthenticatedAdminApiRoutes } from './middleware/withAuthenticatedAdminApiRoutes';
 import { withKiloEditorCookie } from './middleware/withKiloEditorCookie';
 
-export function defaultMiddleware() {
-  return NextResponse.next();
+export function defaultMiddleware(request: NextRequestWithAuth) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-pathname', request.nextUrl.pathname);
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
 }
 
 export default withAuthenticatedAdminApiRoutes(withKiloEditorCookie(defaultMiddleware));


### PR DESCRIPTION
## Summary

- Adds missing server-side auth checks to 8 unprotected pages (byok, cloud/sessions, cloud/webhooks/*, org welcome, payments/topup/success)
- Update `/organizations/:id/security-agent` security check
- Fixes ~25 org pages that redirected unauthenticated users to `/profile` instead of `/users/sign_in`
- Fixes ~16 pages missing `callbackPath` in their sign-in redirect, plus 2 with incorrect values

## Changes

### Infrastructure (Phase 1)
- **`src/middleware.ts`**: Propagates `x-pathname` request header so server components can read the current path
- **`src/lib/user.server.ts`**: `getUserFromAuthOrRedirect()` now defaults to `/users/sign_in` and auto-appends `?callbackPath=<current-path>` from the `x-pathname` header. New `signInUrlWithCallbackPath()` helper exported for use by org auth flows
- **`src/components/organizations/OrganizationByPageLayout.tsx`**: Distinguishes 401 (not authenticated → sign-in) from 404 (not a member → /profile)
- **`src/app/(app)/claw/layout.tsx`**: Replaced broken `redirect('/sign-in')` with `getUserFromAuthOrRedirect()`

### Missing auth (Phase 2)
- Created auth guard layouts for `/byok`, `/cloud/sessions`, `/cloud/webhooks/*`, `/payments/topup/success`
- Created auth + org membership layout for `/organizations/:id/welcome`
- Migrated `/organizations/:id/security-agent` to `OrganizationByPageLayout` for org membership enforcement
- Fixed `/payments/subscriptions/success` redirecting to `/` instead of sign-in

### Incorrect callbackPaths (Phase 3)
- `/deploy/:deploymentId` and `/payments/kilo-pass/awarding` now use auto-detected callbackPath

### Direct getAuthorizedOrgContext callers (Phase 4)
- `organizations/[id]/app-builder/page.tsx`, `organizations/[id]/app-builder/[projectId]/page.tsx`, `organizations/[id]/cloud/chat/page.tsx` now redirect 401s to sign-in instead of `/profile`