### PR TITLE
[Gastown] PR 7.5: Agent Lifecycle & Container Reliability Fixes

### DIFF
--- a/cloudflare-gastown/container/Dockerfile.dev
+++ b/cloudflare-gastown/container/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM oven/bun:1-slim
+FROM --platform=linux/arm64 oven/bun:1-slim
 
 # Install git, gh CLI, and Node.js (required by @kilocode/cli which uses #!/usr/bin/env node)
 RUN apt-get update && \
@@ -17,7 +17,7 @@ RUN apt-get update && \
 # Install Kilo CLI globally via npm (needs real Node.js runtime).
 # npm's global install does not resolve optionalDependencies, so we must
 # explicitly install the platform-specific binary package alongside the CLI.
-RUN npm install -g @kilocode/cli @kilocode/cli-linux-x64
+RUN npm install -g @kilocode/cli @kilocode/cli-linux-arm64
 
 # Create workspace directories
 RUN mkdir -p /workspace/rigs /app

--- a/cloudflare-gastown/container/src/completion-reporter.ts
+++ b/cloudflare-gastown/container/src/completion-reporter.ts
@@ -16,11 +16,11 @@ export async function reportAgentCompleted(
   status: 'completed' | 'failed',
   reason?: string
 ): Promise<void> {
-  const apiUrl = process.env.GASTOWN_API_URL;
-  const token = process.env.GASTOWN_SESSION_TOKEN;
+  const apiUrl = agent.gastownApiUrl;
+  const token = agent.gastownSessionToken;
   if (!apiUrl || !token) {
     console.warn(
-      `Cannot report agent ${agent.agentId} completion: GASTOWN_API_URL or GASTOWN_SESSION_TOKEN not set`
+      `Cannot report agent ${agent.agentId} completion: no API credentials on agent record`
     );
     return;
   }

--- a/cloudflare-gastown/container/src/completion-reporter.ts
+++ b/cloudflare-gastown/container/src/completion-reporter.ts
@@ -1,0 +1,49 @@
+/**
+ * Reports agent completion/failure back to the Rig DO via the Gastown
+ * worker API. This closes the bead and unhooks the agent, preventing
+ * the infinite retry loop where witnessPatrol resets the agent to idle
+ * and schedulePendingWork re-dispatches it.
+ */
+
+import type { ManagedAgent } from './types';
+
+/**
+ * Notify the Rig DO that an agent session has completed or failed.
+ * Best-effort: errors are logged but do not propagate.
+ */
+export async function reportAgentCompleted(
+  agent: ManagedAgent,
+  status: 'completed' | 'failed',
+  reason?: string
+): Promise<void> {
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const token = process.env.GASTOWN_SESSION_TOKEN;
+  if (!apiUrl || !token) {
+    console.warn(
+      `Cannot report agent ${agent.agentId} completion: GASTOWN_API_URL or GASTOWN_SESSION_TOKEN not set`
+    );
+    return;
+  }
+
+  const url = `${apiUrl}/api/rigs/${agent.rigId}/agents/${agent.agentId}/completed`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status, reason }),
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `Failed to report agent ${agent.agentId} completion: ${response.status} ${response.statusText}`
+      );
+    } else {
+      console.log(`Reported agent ${agent.agentId} ${status} to Rig DO`);
+    }
+  } catch (err) {
+    console.warn(`Error reporting agent ${agent.agentId} completion:`, err);
+  }
+}

--- a/cloudflare-gastown/container/src/git-manager.ts
+++ b/cloudflare-gastown/container/src/git-manager.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rm, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { CloneOptions, WorktreeOptions } from './types';
 
@@ -71,7 +71,12 @@ async function exec(cmd: string, args: string[], cwd?: string): Promise<string> 
 }
 
 async function pathExists(p: string): Promise<boolean> {
-  return Bun.file(p).exists();
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function repoDir(rigId: string): string {

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -57,6 +57,8 @@ export async function startAgent(
     activeTools: [],
     messageCount: 0,
     exitReason: null,
+    gastownApiUrl: request.envVars?.GASTOWN_API_URL ?? process.env.GASTOWN_API_URL ?? null,
+    gastownSessionToken: request.envVars?.GASTOWN_SESSION_TOKEN ?? null,
   };
   agents.set(request.agentId, agent);
 

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -16,6 +16,7 @@ import {
 } from './kilo-server';
 import { createKiloClient } from './kilo-client';
 import { createSSEConsumer, isCompletionEvent, type SSEConsumer } from './sse-consumer';
+import { reportAgentCompleted } from './completion-reporter';
 
 const agents = new Map<string, ManagedAgent>();
 const sseConsumers = new Map<string, SSEConsumer>();
@@ -93,6 +94,7 @@ export async function startAgent(
         if (isCompletionEvent(evt)) {
           agent.status = 'exited';
           agent.exitReason = 'completed';
+          void reportAgentCompleted(agent, 'completed');
         }
       },
       onActivity: () => {
@@ -102,6 +104,7 @@ export async function startAgent(
         if (agent.status === 'running') {
           agent.status = 'failed';
           agent.exitReason = `SSE stream closed: ${reason}`;
+          void reportAgentCompleted(agent, 'failed', reason);
         }
       },
     });

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -68,6 +68,10 @@ export type ManagedAgent = {
   messageCount: number;
   /** Exit reason if status is 'exited' or 'failed' */
   exitReason: string | null;
+  /** Gastown worker API URL for completion callbacks */
+  gastownApiUrl: string | null;
+  /** Agent-scoped JWT for authenticating callbacks to the Gastown worker */
+  gastownSessionToken: string | null;
 };
 
 export type AgentStatusResponse = {

--- a/cloudflare-gastown/src/db/tables/agents.table.ts
+++ b/cloudflare-gastown/src/db/tables/agents.table.ts
@@ -11,6 +11,7 @@ export const AgentRecord = z.object({
   identity: z.string(),
   status: AgentStatus,
   current_hook_bead_id: z.string().nullable(),
+  dispatch_attempts: z.number().default(0),
   last_activity_at: z.string().nullable(),
   checkpoint: z
     .string()
@@ -32,6 +33,7 @@ export function createTableAgents(): string {
     identity: `text not null unique`,
     status: `text not null default 'idle' check(status in ('idle', 'working', 'blocked', 'dead'))`,
     current_hook_bead_id: `text references beads(id)`,
+    dispatch_attempts: `integer not null default 0`,
     last_activity_at: `text`,
     checkpoint: `text`,
     created_at: `text not null`,

--- a/cloudflare-gastown/src/db/tables/beads.table.ts
+++ b/cloudflare-gastown/src/db/tables/beads.table.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
 
 const BeadType = z.enum(['issue', 'message', 'escalation', 'merge_request']);
-const BeadStatus = z.enum(['open', 'in_progress', 'closed']);
+const BeadStatus = z.enum(['open', 'in_progress', 'closed', 'failed']);
 const BeadPriority = z.enum(['low', 'medium', 'high', 'critical']);
 
 export const BeadRecord = z.object({
@@ -30,7 +30,7 @@ export function createTableBeads(): string {
   return getCreateTableQueryFromTable(beads, {
     id: `text primary key`,
     type: `text not null check(type in ('issue', 'message', 'escalation', 'merge_request'))`,
-    status: `text not null default 'open' check(status in ('open', 'in_progress', 'closed'))`,
+    status: `text not null default 'open' check(status in ('open', 'in_progress', 'closed', 'failed'))`,
     title: `text not null`,
     body: `text`,
     assignee_agent_id: `text`,

--- a/cloudflare-gastown/src/dos/GastownUser.do.ts
+++ b/cloudflare-gastown/src/dos/GastownUser.do.ts
@@ -3,6 +3,8 @@ import { createTableTowns, towns, TownRecord } from '../db/tables/towns.table';
 import { createTableRigs, rigs, RigRecord } from '../db/tables/rigs.table';
 import { query } from '../util/query.util';
 
+const USER_LOG = '[GastownUser.do]';
+
 function generateId(): string {
   return crypto.randomUUID();
 }
@@ -55,6 +57,7 @@ export class GastownUserDO extends DurableObject<Env> {
     await this.ensureInitialized();
     const id = generateId();
     const timestamp = now();
+    console.log(`${USER_LOG} createTown: id=${id} name=${input.name} owner=${input.owner_user_id}`);
 
     query(
       this.sql,
@@ -72,6 +75,7 @@ export class GastownUserDO extends DurableObject<Env> {
 
     const town = this.getTown(id);
     if (!town) throw new Error('Failed to create town');
+    console.log(`${USER_LOG} createTown: created town id=${town.id}`);
     return town;
   }
 
@@ -111,10 +115,16 @@ export class GastownUserDO extends DurableObject<Env> {
     default_branch: string;
   }): Promise<RigRecord> {
     await this.ensureInitialized();
+    console.log(
+      `${USER_LOG} createRig: town_id=${input.town_id} name=${input.name} git_url=${input.git_url} default_branch=${input.default_branch}`
+    );
 
     // Verify town exists
     const town = this.getTown(input.town_id);
-    if (!town) throw new Error(`Town ${input.town_id} not found`);
+    if (!town) {
+      console.error(`${USER_LOG} createRig: town ${input.town_id} not found`);
+      throw new Error(`Town ${input.town_id} not found`);
+    }
 
     const id = generateId();
     const timestamp = now();
@@ -137,6 +147,7 @@ export class GastownUserDO extends DurableObject<Env> {
 
     const rig = this.getRig(id);
     if (!rig) throw new Error('Failed to create rig');
+    console.log(`${USER_LOG} createRig: created rig id=${rig.id}`);
     return rig;
   }
 

--- a/cloudflare-gastown/src/dos/Rig.do.ts
+++ b/cloudflare-gastown/src/dos/Rig.do.ts
@@ -30,6 +30,8 @@ import type {
   PatrolResult,
 } from '../types';
 
+const RIG_LOG = '[Rig.do]';
+
 function generateId(): string {
   return crypto.randomUUID();
 }
@@ -55,6 +57,7 @@ const TOWN_ID_KEY = 'townId';
 const RIG_CONFIG_KEY = 'rigConfig';
 
 type RigConfig = {
+  rigId?: string;
   townId: string;
   gitUrl: string;
   defaultBranch: string;
@@ -107,6 +110,10 @@ export class RigDO extends DurableObject<Env> {
     const labelsJson = JSON.stringify(input.labels ?? []);
     const metadataJson = JSON.stringify(input.metadata ?? {});
 
+    console.log(
+      `${RIG_LOG} createBead: id=${id} type=${input.type} title="${input.title?.slice(0, 80)}" assignee_agent_id=${input.assignee_agent_id ?? 'none'}`
+    );
+
     query(
       this.sql,
       /* sql */ `
@@ -142,6 +149,7 @@ export class RigDO extends DurableObject<Env> {
 
     const result = this.getBead(id);
     if (!result) throw new Error('Failed to create bead');
+    console.log(`${RIG_LOG} createBead: created bead id=${result.id} status=${result.status}`);
     return result;
   }
 
@@ -246,6 +254,10 @@ export class RigDO extends DurableObject<Env> {
     const id = generateId();
     const timestamp = now();
 
+    console.log(
+      `${RIG_LOG} registerAgent: id=${id} role=${input.role} name=${input.name} identity=${input.identity}`
+    );
+
     query(
       this.sql,
       /* sql */ `
@@ -264,6 +276,9 @@ export class RigDO extends DurableObject<Env> {
 
     const agent = this.getAgent(id);
     if (!agent) throw new Error('Failed to register agent');
+    console.log(
+      `${RIG_LOG} registerAgent: created agent id=${agent.id} role=${agent.role} name=${agent.name} status=${agent.status}`
+    );
     return agent;
   }
 
@@ -355,17 +370,27 @@ export class RigDO extends DurableObject<Env> {
 
   async hookBead(agentId: string, beadId: string): Promise<void> {
     await this.ensureInitialized();
+    console.log(`${RIG_LOG} hookBead: agentId=${agentId} beadId=${beadId}`);
 
     // Verify bead exists
     const bead = this.getBead(beadId);
     if (!bead) throw new Error(`Bead ${beadId} not found`);
+    console.log(
+      `${RIG_LOG} hookBead: bead exists, type=${bead.type} status=${bead.status} assignee=${bead.assignee_agent_id}`
+    );
 
     // Verify agent exists
     const agent = this.getAgent(agentId);
     if (!agent) throw new Error(`Agent ${agentId} not found`);
+    console.log(
+      `${RIG_LOG} hookBead: agent exists, role=${agent.role} status=${agent.status} current_hook=${agent.current_hook_bead_id}`
+    );
 
     // Check agent isn't already hooked to another bead
     if (agent.current_hook_bead_id && agent.current_hook_bead_id !== beadId) {
+      console.error(
+        `${RIG_LOG} hookBead: CONFLICT - agent ${agentId} already hooked to ${agent.current_hook_bead_id}`
+      );
       throw new Error(`Agent ${agentId} is already hooked to bead ${agent.current_hook_bead_id}`);
     }
 
@@ -392,6 +417,9 @@ export class RigDO extends DurableObject<Env> {
       [agentId, now(), beadId]
     );
 
+    console.log(
+      `${RIG_LOG} hookBead: bead ${beadId} now in_progress, agent ${agentId} hooked. Arming alarm.`
+    );
     await this.armAlarmIfNeeded();
   }
 
@@ -661,6 +689,9 @@ export class RigDO extends DurableObject<Env> {
     metadata?: Record<string, unknown>;
   }): Promise<{ bead: Bead; agent: Agent }> {
     await this.ensureInitialized();
+    console.log(
+      `${RIG_LOG} slingBead: title="${input.title?.slice(0, 80)}" metadata=${JSON.stringify(input.metadata)}`
+    );
 
     // Create the bead
     const bead = await this.createBead({
@@ -669,18 +700,24 @@ export class RigDO extends DurableObject<Env> {
       body: input.body,
       metadata: input.metadata,
     });
+    console.log(`${RIG_LOG} slingBead: bead created id=${bead.id}`);
 
     // Find an idle polecat or create one
     const agent = await this.getOrCreateAgent('polecat');
+    console.log(`${RIG_LOG} slingBead: agent=${agent.id} role=${agent.role} name=${agent.name}`);
 
     // Hook them together (also arms the alarm)
     await this.hookBead(agent.id, bead.id);
+    console.log(`${RIG_LOG} slingBead: hooked agent ${agent.id} to bead ${bead.id}`);
 
     const updatedBead = await this.getBeadAsync(bead.id);
     const updatedAgent = this.getAgent(agent.id);
     if (!updatedBead || !updatedAgent) {
       throw new Error(`slingBead: failed to re-fetch bead ${bead.id} or agent ${agent.id}`);
     }
+    console.log(
+      `${RIG_LOG} slingBead: complete bead.status=${updatedBead.status} agent.status=${updatedAgent.status} agent.current_hook=${updatedAgent.current_hook_bead_id}`
+    );
     return { bead: updatedBead, agent: updatedAgent };
   }
 
@@ -698,6 +735,7 @@ export class RigDO extends DurableObject<Env> {
 
   async getOrCreateAgent(role: AgentRole): Promise<Agent> {
     await this.ensureInitialized();
+    console.log(`${RIG_LOG} getOrCreateAgent: role=${role}`);
 
     const existing = [
       ...query(
@@ -715,11 +753,22 @@ export class RigDO extends DurableObject<Env> {
 
     if (existing.length > 0) {
       const agent = AgentRecord.parse(existing[0]);
+      console.log(
+        `${RIG_LOG} getOrCreateAgent: found existing agent id=${agent.id} name=${agent.name} role=${agent.role} status=${agent.status} current_hook=${agent.current_hook_bead_id}`
+      );
       // Singleton roles: return existing agent regardless of status
-      if (agent.status === 'idle' || RigDO.SINGLETON_ROLES.has(role)) return agent;
+      if (agent.status === 'idle' || RigDO.SINGLETON_ROLES.has(role)) {
+        console.log(
+          `${RIG_LOG} getOrCreateAgent: returning existing agent (idle=${agent.status === 'idle'}, singleton=${RigDO.SINGLETON_ROLES.has(role)})`
+        );
+        return agent;
+      }
+    } else {
+      console.log(`${RIG_LOG} getOrCreateAgent: no existing agent found for role=${role}`);
     }
 
     // No idle agent found (polecat) or no agent at all — create a new one
+    console.log(`${RIG_LOG} getOrCreateAgent: creating new agent for role=${role}`);
     return this.registerAgent({
       role,
       name: `${role}-${Date.now()}`,
@@ -730,7 +779,13 @@ export class RigDO extends DurableObject<Env> {
   // ── Rig configuration (links this rig to its town + git repo) ────────
 
   async configureRig(config: RigConfig): Promise<void> {
-    await this.ctx.storage.put(RIG_CONFIG_KEY, config);
+    // Auto-populate rigId from the DO name if not provided by the caller
+    const rigId = config.rigId ?? this.ctx.id.name ?? undefined;
+    const enriched = { ...config, rigId };
+    console.log(
+      `${RIG_LOG} configureRig: rigId=${rigId} townId=${config.townId} gitUrl=${config.gitUrl} defaultBranch=${config.defaultBranch} userId=${config.userId}`
+    );
+    await this.ctx.storage.put(RIG_CONFIG_KEY, enriched);
     // Also store townId under the legacy key for backward compat
     await this.ctx.storage.put(TOWN_ID_KEY, config.townId);
     await this.armAlarmIfNeeded();
@@ -768,17 +823,35 @@ export class RigDO extends DurableObject<Env> {
 
   async alarm(): Promise<void> {
     await this.ensureInitialized();
+    console.log(`${RIG_LOG} alarm: fired at ${now()}`);
 
     // witnessPatrol first: resets dead-container agents to idle so
     // schedulePendingWork can re-dispatch them in the same tick
-    await this.witnessPatrol();
-    await this.schedulePendingWork();
-    await this.processReviewQueue();
+    console.log(`${RIG_LOG} alarm: running witnessPatrol`);
+    const patrolResult = await this.witnessPatrol();
+    console.log(
+      `${RIG_LOG} alarm: witnessPatrol done dead=${patrolResult.dead_agents.length} stale=${patrolResult.stale_agents.length} orphaned=${patrolResult.orphaned_beads.length}`
+    );
+
+    console.log(`${RIG_LOG} alarm: running schedulePendingWork`);
+    const scheduled = await this.schedulePendingWork();
+    console.log(
+      `${RIG_LOG} alarm: schedulePendingWork done, scheduled ${scheduled.length} agents: [${scheduled.join(', ')}]`
+    );
+
+    console.log(`${RIG_LOG} alarm: running processReviewQueue`);
+    const reviewProcessed = await this.processReviewQueue();
+    console.log(`${RIG_LOG} alarm: processReviewQueue done, processed=${reviewProcessed}`);
 
     // Only re-arm if there's active work; armAlarmIfNeeded() restarts
     // the loop when new work arrives
-    if (this.hasActiveWork()) {
+    const active = this.hasActiveWork();
+    console.log(`${RIG_LOG} alarm: hasActiveWork=${active}`);
+    if (active) {
+      console.log(`${RIG_LOG} alarm: re-arming alarm for ${ACTIVE_ALARM_INTERVAL_MS}ms`);
       await this.ctx.storage.setAlarm(Date.now() + ACTIVE_ALARM_INTERVAL_MS);
+    } else {
+      console.log(`${RIG_LOG} alarm: no active work, NOT re-arming`);
     }
   }
 
@@ -788,8 +861,15 @@ export class RigDO extends DurableObject<Env> {
    */
   private async armAlarmIfNeeded(): Promise<void> {
     const currentAlarm = await this.ctx.storage.getAlarm();
-    if (!currentAlarm) {
+    if (!currentAlarm || currentAlarm < Date.now()) {
+      console.log(
+        `${RIG_LOG} armAlarmIfNeeded: ${currentAlarm ? `stale alarm at ${new Date(currentAlarm).toISOString()}, re-arming` : 'no current alarm, arming'} for 5s from now`
+      );
       await this.ctx.storage.setAlarm(Date.now() + 5_000);
+    } else {
+      console.log(
+        `${RIG_LOG} armAlarmIfNeeded: alarm already set for ${new Date(currentAlarm).toISOString()}`
+      );
     }
   }
 
@@ -834,6 +914,9 @@ export class RigDO extends DurableObject<Env> {
     const pendingBeads = Number(pendingBeadRows[0]?.cnt ?? 0);
     const pendingReviews = Number(pendingReviewRows[0]?.cnt ?? 0);
 
+    console.log(
+      `${RIG_LOG} hasActiveWork: activeAgents=${activeAgents} pendingBeads=${pendingBeads} pendingReviews=${pendingReviews}`
+    );
     return activeAgents > 0 || pendingBeads > 0 || pendingReviews > 0;
   }
 
@@ -857,14 +940,28 @@ export class RigDO extends DurableObject<Env> {
       ),
     ];
     const pendingAgents = AgentRecord.array().parse(rows);
+    console.log(
+      `${RIG_LOG} schedulePendingWork: found ${pendingAgents.length} idle agents with hooked beads`
+    );
 
     if (pendingAgents.length === 0) return [];
 
+    for (const agent of pendingAgents) {
+      console.log(
+        `${RIG_LOG} schedulePendingWork: agent id=${agent.id} role=${agent.role} name=${agent.name} status=${agent.status} hook=${agent.current_hook_bead_id}`
+      );
+    }
+
     const config = await this.getRigConfig();
     if (!config?.townId) {
-      console.warn('schedulePendingWork: rig not configured, skipping container dispatch');
+      console.warn(
+        `${RIG_LOG} schedulePendingWork: rig not configured (no townId), skipping container dispatch`
+      );
       return [];
     }
+    console.log(
+      `${RIG_LOG} schedulePendingWork: rig config townId=${config.townId} gitUrl=${config.gitUrl} defaultBranch=${config.defaultBranch}`
+    );
 
     const scheduledAgentIds: string[] = [];
 
@@ -872,8 +969,16 @@ export class RigDO extends DurableObject<Env> {
       const beadId = agent.current_hook_bead_id;
       if (!beadId) continue;
       const bead = this.getBead(beadId);
-      if (!bead) continue;
+      if (!bead) {
+        console.warn(
+          `${RIG_LOG} schedulePendingWork: bead ${beadId} not found for agent ${agent.id}, skipping`
+        );
+        continue;
+      }
 
+      console.log(
+        `${RIG_LOG} schedulePendingWork: dispatching agent ${agent.id} (${agent.role}/${agent.name}) to container for bead "${bead.title?.slice(0, 60)}"`
+      );
       const started = await this.startAgentInContainer(config, {
         agentId: agent.id,
         agentName: agent.name,
@@ -886,6 +991,9 @@ export class RigDO extends DurableObject<Env> {
       });
 
       if (started) {
+        console.log(
+          `${RIG_LOG} schedulePendingWork: agent ${agent.id} started in container, marking as 'working'`
+        );
         query(
           this.sql,
           /* sql */ `
@@ -897,6 +1005,10 @@ export class RigDO extends DurableObject<Env> {
           [now(), agent.id]
         );
         scheduledAgentIds.push(agent.id);
+      } else {
+        console.error(
+          `${RIG_LOG} schedulePendingWork: FAILED to start agent ${agent.id} in container`
+        );
       }
     }
 
@@ -929,9 +1041,9 @@ export class RigDO extends DurableObject<Env> {
     const secret = await this.resolveJWTSecret();
     if (!secret) return null;
 
-    const rigId = this.ctx.id.name;
+    const rigId = this.ctx.id.name ?? config.rigId;
     if (!rigId) {
-      console.error('mintAgentToken: DO has no name (rigId)');
+      console.error('mintAgentToken: DO has no name (rigId) and config has no rigId');
       return null;
     }
 
@@ -1020,17 +1132,32 @@ export class RigDO extends DurableObject<Env> {
       checkpoint: unknown;
     }
   ): Promise<boolean> {
+    console.log(
+      `${RIG_LOG} startAgentInContainer: agentId=${params.agentId} role=${params.role} name=${params.agentName} beadId=${params.beadId} townId=${config.townId}`
+    );
     try {
       const token = await this.mintAgentToken(params.agentId, config);
+      console.log(`${RIG_LOG} startAgentInContainer: JWT minted=${!!token}`);
 
       const envVars: Record<string, string> = {};
       if (token) {
         envVars.GASTOWN_SESSION_TOKEN = token;
       }
 
-      const rigId = this.ctx.id.name ?? '';
+      const rigId = this.ctx.id.name ?? config.rigId ?? '';
+      console.log(
+        `${RIG_LOG} startAgentInContainer: rigId=${rigId} gitUrl=${config.gitUrl} branch=${RigDO.branchForAgent(params.agentName)}`
+      );
+
+      const prompt = RigDO.buildPrompt({
+        beadTitle: params.beadTitle,
+        beadBody: params.beadBody,
+        checkpoint: params.checkpoint,
+      });
+      console.log(`${RIG_LOG} startAgentInContainer: prompt="${prompt.slice(0, 200)}"`);
 
       const container = getTownContainerStub(this.env, config.townId);
+      console.log(`${RIG_LOG} startAgentInContainer: sending POST to container /agents/start`);
       const response = await container.fetch('http://container/agents/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1041,11 +1168,7 @@ export class RigDO extends DurableObject<Env> {
           role: params.role,
           name: params.agentName,
           identity: params.identity,
-          prompt: RigDO.buildPrompt({
-            beadTitle: params.beadTitle,
-            beadBody: params.beadBody,
-            checkpoint: params.checkpoint,
-          }),
+          prompt,
           model: RigDO.modelForRole(params.role),
           systemPrompt: RigDO.systemPromptForRole(params.role, params.identity),
           gitUrl: config.gitUrl,
@@ -1054,9 +1177,19 @@ export class RigDO extends DurableObject<Env> {
           envVars,
         }),
       });
+      console.log(
+        `${RIG_LOG} startAgentInContainer: response status=${response.status} ok=${response.ok}`
+      );
+      if (!response.ok) {
+        const text = await response.text().catch(() => '(unreadable)');
+        console.error(`${RIG_LOG} startAgentInContainer: error response: ${text.slice(0, 500)}`);
+      }
       return response.ok;
     } catch (err) {
-      console.error(`Failed to start agent ${params.agentId} in container:`, err);
+      console.error(
+        `${RIG_LOG} startAgentInContainer: EXCEPTION for agent ${params.agentId}:`,
+        err
+      );
       return false;
     }
   }
@@ -1141,6 +1274,7 @@ export class RigDO extends DurableObject<Env> {
 
   async witnessPatrol(): Promise<PatrolResult> {
     await this.ensureInitialized();
+    console.log(`${RIG_LOG} witnessPatrol: starting`);
 
     const staleThreshold = new Date(Date.now() - STALE_THRESHOLD_MS).toISOString();
     const guppThreshold = new Date(Date.now() - GUPP_THRESHOLD_MS).toISOString();
@@ -1216,10 +1350,19 @@ export class RigDO extends DurableObject<Env> {
 
       const MailId = MailRecord.pick({ id: true });
 
+      console.log(
+        `${RIG_LOG} witnessPatrol: checking ${workingAgents.length} working/blocked agents in container`
+      );
       for (const working of workingAgents) {
         const containerStatus = await this.checkAgentContainerStatus(townId, working.id);
+        console.log(
+          `${RIG_LOG} witnessPatrol: agent ${working.id} container status=${containerStatus}`
+        );
 
         if (containerStatus === 'not_found' || containerStatus === 'exited') {
+          console.log(
+            `${RIG_LOG} witnessPatrol: agent ${working.id} process gone (${containerStatus}), resetting to idle`
+          );
           // Agent process is gone — reset to idle so schedulePendingWork()
           // can re-dispatch on the next alarm tick
           query(
@@ -1293,6 +1436,18 @@ export class RigDO extends DurableObject<Env> {
     await this.ensureInitialized();
     this.touchAgent(agentId);
     await this.armAlarmIfNeeded();
+  }
+
+  // ── Cleanup ────────────────────────────────────────────────────────────
+
+  /**
+   * Delete all storage and cancel alarms. Called when the rig is deleted
+   * to prevent orphaned alarms from firing indefinitely.
+   */
+  async destroy(): Promise<void> {
+    console.log(`${RIG_LOG} destroy: clearing all storage and alarms`);
+    await this.ctx.storage.deleteAlarm();
+    await this.ctx.storage.deleteAll();
   }
 
   // ── Private helpers ────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -24,6 +24,7 @@ import {
   handleUnhookBead,
   handlePrime,
   handleAgentDone,
+  handleAgentCompleted,
   handleWriteCheckpoint,
   handleCheckMail,
   handleHeartbeat,
@@ -131,6 +132,7 @@ app.post('/api/rigs/:rigId/agents/:agentId/hook', c => handleHookBead(c, c.req.p
 app.delete('/api/rigs/:rigId/agents/:agentId/hook', c => handleUnhookBead(c, c.req.param()));
 app.get('/api/rigs/:rigId/agents/:agentId/prime', c => handlePrime(c, c.req.param()));
 app.post('/api/rigs/:rigId/agents/:agentId/done', c => handleAgentDone(c, c.req.param()));
+app.post('/api/rigs/:rigId/agents/:agentId/completed', c => handleAgentCompleted(c, c.req.param()));
 app.post('/api/rigs/:rigId/agents/:agentId/checkpoint', c =>
   handleWriteCheckpoint(c, c.req.param())
 );

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -64,6 +64,19 @@ export type GastownEnv = {
 
 const app = new Hono<GastownEnv>();
 
+const WORKER_LOG = '[gastown-worker]';
+
+// ── Request logging ─────────────────────────────────────────────────────
+app.use('*', async (c, next) => {
+  const method = c.req.method;
+  const path = c.req.path;
+  const startTime = Date.now();
+  console.log(`${WORKER_LOG} --> ${method} ${path}`);
+  await next();
+  const elapsed = Date.now() - startTime;
+  console.log(`${WORKER_LOG} <-- ${method} ${path} ${c.res.status} (${elapsed}ms)`);
+});
+
 // ── Cloudflare Access ───────────────────────────────────────────────────
 // Validate Cloudflare Access JWT for all requests; skip in development.
 

--- a/cloudflare-gastown/src/handlers/town-container.handler.ts
+++ b/cloudflare-gastown/src/handlers/town-container.handler.ts
@@ -4,6 +4,8 @@ import { getTownContainerStub } from '../dos/TownContainer.do';
 import { resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
 
+const CONTAINER_LOG = '[town-container.handler]';
+
 /**
  * Proxy a request to the town container's control server and return the response.
  * Preserves the original status code and JSON body.
@@ -13,12 +15,25 @@ async function proxyToContainer(
   path: string,
   init?: RequestInit
 ): Promise<Response> {
-  const response = await container.fetch(`http://container${path}`, init);
-  const data = await response.text();
-  return new Response(data, {
-    status: response.status,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  const method = init?.method ?? 'GET';
+  console.log(`${CONTAINER_LOG} proxyToContainer: ${method} ${path}`);
+  if (init?.body) {
+    console.log(`${CONTAINER_LOG} proxyToContainer: body=${String(init.body).slice(0, 300)}`);
+  }
+  try {
+    const response = await container.fetch(`http://container${path}`, init);
+    const data = await response.text();
+    console.log(
+      `${CONTAINER_LOG} proxyToContainer: ${method} ${path} -> ${response.status} body=${data.slice(0, 300)}`
+    );
+    return new Response(data, {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error(`${CONTAINER_LOG} proxyToContainer: EXCEPTION for ${method} ${path}:`, err);
+    throw err;
+  }
 }
 
 /**

--- a/cloudflare-gastown/src/handlers/towns.handler.ts
+++ b/cloudflare-gastown/src/handlers/towns.handler.ts
@@ -17,6 +17,7 @@ const CreateRigBody = z.object({
   name: z.string().min(1).max(64),
   git_url: z.string().url(),
   default_branch: z.string().min(1).default('main'),
+  kilocode_token: z.string().min(1).optional(),
 });
 
 /**
@@ -81,6 +82,7 @@ export async function handleCreateRig(c: Context<GastownEnv>, params: { userId: 
       gitUrl: parsed.data.git_url,
       defaultBranch: parsed.data.default_branch,
       userId: params.userId,
+      kilocodeToken: parsed.data.kilocode_token,
     });
     console.log(`${TOWNS_LOG} handleCreateRig: Rig DO configured successfully`);
   } catch (err) {

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -7,7 +7,7 @@ import type { MoleculeRecord } from './db/tables/molecules.table';
 
 // -- Beads --
 
-export const BeadStatus = z.enum(['open', 'in_progress', 'closed']);
+export const BeadStatus = z.enum(['open', 'in_progress', 'closed', 'failed']);
 export type BeadStatus = z.infer<typeof BeadStatus>;
 
 export const BeadType = z.enum(['issue', 'message', 'escalation', 'merge_request']);

--- a/cloudflare-gastown/worker-configuration.d.ts
+++ b/cloudflare-gastown/worker-configuration.d.ts
@@ -8,6 +8,7 @@ declare namespace Cloudflare {
   }
   interface DevEnv {
     GASTOWN_JWT_SECRET: SecretsStoreSecret;
+    KILO_API_URL: string;
     ENVIRONMENT: 'development';
     CF_ACCESS_TEAM: 'engineering-e11';
     CF_ACCESS_AUD: 'f30e3fd893df52fa3ffc50fbdb5ee6a4f111625ae92234233429684e1429d809';
@@ -18,6 +19,7 @@ declare namespace Cloudflare {
   }
   interface Env {
     GASTOWN_JWT_SECRET: SecretsStoreSecret;
+    KILO_API_URL: string;
     ENVIRONMENT: 'development' | 'production';
     CF_ACCESS_TEAM: 'engineering-e11';
     CF_ACCESS_AUD: 'f30e3fd893df52fa3ffc50fbdb5ee6a4f111625ae92234233429684e1429d809';

--- a/cloudflare-gastown/wrangler.jsonc
+++ b/cloudflare-gastown/wrangler.jsonc
@@ -41,6 +41,7 @@
     "ENVIRONMENT": "production",
     "CF_ACCESS_TEAM": "engineering-e11",
     "CF_ACCESS_AUD": "f30e3fd893df52fa3ffc50fbdb5ee6a4f111625ae92234233429684e1429d809",
+    "KILO_API_URL": "https://api.kilo.ai",
   },
 
   // PRODUCTION Secrets Store (shared Kilo secrets store)
@@ -58,6 +59,7 @@
         "ENVIRONMENT": "development",
         "CF_ACCESS_TEAM": "engineering-e11",
         "CF_ACCESS_AUD": "f30e3fd893df52fa3ffc50fbdb5ee6a4f111625ae92234233429684e1429d809",
+        "KILO_API_URL": "https://api.kilo.ai",
       },
       "containers": [
         {

--- a/cloudflare-gastown/wrangler.jsonc
+++ b/cloudflare-gastown/wrangler.jsonc
@@ -63,7 +63,7 @@
         {
           "name": "gastown-dev-TownContainerDO",
           "class_name": "TownContainerDO",
-          "image": "./container/Dockerfile",
+          "image": "./container/Dockerfile.dev",
           "instance_type": "standard-4",
           "max_instances": 50,
         },

--- a/src/lib/config.server.ts
+++ b/src/lib/config.server.ts
@@ -142,7 +142,7 @@ export const AGENT_ENV_VARS_PUBLIC_KEY = getEnvVariable('AGENT_ENV_VARS_PUBLIC_K
 // Gastown Service
 export const GASTOWN_SERVICE_URL =
   getEnvVariable('GASTOWN_SERVICE_URL') ||
-  (process.env.NODE_ENV === 'production' ? 'https://gastown.kiloapps.io' : null);
+  (process.env.NODE_ENV === 'production' ? 'https://gastown.kiloapps.io' : 'http://localhost:8787');
 export const GASTOWN_CF_ACCESS_CLIENT_ID = getEnvVariable('GASTOWN_CF_ACCESS_CLIENT_ID');
 export const GASTOWN_CF_ACCESS_CLIENT_SECRET = getEnvVariable('GASTOWN_CF_ACCESS_CLIENT_SECRET');
 

--- a/src/lib/gastown/gastown-client.ts
+++ b/src/lib/gastown/gastown-client.ts
@@ -123,9 +123,13 @@ async function gastownFetch(path: string, init?: RequestInit): Promise<unknown> 
   const method = init?.method ?? 'GET';
   console.log(`${CLIENT_LOG} ${method} ${url}`);
   if (init?.body) {
-    console.log(
-      `${CLIENT_LOG}   body: ${typeof init.body === 'string' ? init.body.slice(0, 500) : '[non-string body]'}`
-    );
+    const safeBody =
+      typeof init.body === 'string'
+        ? init.body
+            .replace(/"kilocode_token":"[^"]*"/g, '"kilocode_token":"[REDACTED]"')
+            .slice(0, 500)
+        : '[non-string body]';
+    console.log(`${CLIENT_LOG}   body: ${safeBody}`);
   }
 
   const startTime = Date.now();

--- a/src/lib/gastown/gastown-client.ts
+++ b/src/lib/gastown/gastown-client.ts
@@ -39,7 +39,7 @@ export type Rig = z.output<typeof RigSchema>;
 export const BeadSchema = z.object({
   id: z.string(),
   type: z.enum(['issue', 'message', 'escalation', 'merge_request']),
-  status: z.enum(['open', 'in_progress', 'closed']),
+  status: z.enum(['open', 'in_progress', 'closed', 'failed']),
   title: z.string(),
   body: z.string().nullable(),
   assignee_agent_id: z.string().nullable(),
@@ -73,6 +73,7 @@ export const AgentSchema = z.object({
   identity: z.string(),
   status: z.enum(['idle', 'working', 'blocked', 'dead']),
   current_hook_bead_id: z.string().nullable(),
+  dispatch_attempts: z.number().default(0),
   last_activity_at: z.string(),
   checkpoint: z.string().nullable(),
   created_at: z.string(),
@@ -188,7 +189,13 @@ export async function getTown(userId: string, townId: string): Promise<Town> {
 
 export async function createRig(
   userId: string,
-  input: { town_id: string; name: string; git_url: string; default_branch: string }
+  input: {
+    town_id: string;
+    name: string;
+    git_url: string;
+    default_branch: string;
+    kilocode_token?: string;
+  }
 ): Promise<Rig> {
   const body = await gastownFetch(`/api/users/${userId}/rigs`, {
     method: 'POST',


### PR DESCRIPTION
## Summary

Fixes three reliability issues discovered during local dev testing that cause the agent dispatch loop to retry indefinitely, waste resources, and prevent agents from completing real work.

Closes #335

## Changes

### 1. Pass API credentials to kilo serve

- **Next.js router** (`gastown-router.ts`): generates a `kilocodeToken` via `generateApiToken(ctx.user)` at rig creation time
- **Gastown worker** (`towns.handler.ts`, `Rig.do.ts`): accepts `kilocode_token` in `CreateRigBody`, stores in `RigConfig`, passes as `KILOCODE_TOKEN` env var at agent dispatch
- **Container** (`agent-runner.ts`): builds `KILO_CONFIG_CONTENT` JSON (matching cloud-agent-next's pattern) so kilo serve can authenticate LLM calls through the Kilo gateway
- **Wrangler**: adds `KILO_API_URL` var for the gateway endpoint

### 2. Dispatch retry limit (circuit breaker)

- Adds `dispatch_attempts` column to the agents table (integer, default 0)
- `schedulePendingWork()` increments attempts before each dispatch, resets to 0 on success
- After 5 consecutive failed dispatches (`MAX_DISPATCH_ATTEMPTS`), marks the bead as `failed` and unhooks the agent
- `hookBead()` resets `dispatch_attempts` to 0 so fresh assignments start clean
- Adds `failed` status to the bead state machine (`open → in_progress → closed | failed`)

### 3. Agent completion closes the bead

- Adds `agentCompleted()` RPC on Rig DO — transitions hooked bead to `closed` (on completion) or `failed` (on error), then unhooks the agent
- Adds `POST /api/rigs/:rigId/agents/:agentId/completed` endpoint
- New `completion-reporter.ts` module in the container — called by the process manager when SSE detects `isCompletionEvent` or stream failure, reports back to the Rig DO
- `witnessPatrol()` now checks `exitReason` from the container status response — auto-closes beads for agents that completed (`exitReason = 'completed'`) instead of blindly resetting to idle

## Testing

- All 75 integration tests pass
- Typecheck clean
- Retry limit visible in test output (dispatch attempts 1/5, 2/5, etc.)