### PR TITLE
[Gastown] PR 8.5: Mayor Tools — Cross-Rig Delegation

### DIFF
--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -1,4 +1,17 @@
-import type { ApiResponse, Bead, BeadPriority, GastownEnv, Mail, PrimeContext } from './types';
+import type {
+  Agent,
+  ApiResponse,
+  Bead,
+  BeadPriority,
+  BeadStatus,
+  BeadType,
+  GastownEnv,
+  Mail,
+  MayorGastownEnv,
+  PrimeContext,
+  Rig,
+  SlingResult,
+} from './types';
 
 function isApiResponse(value: unknown): value is ApiResponse<unknown> {
   return (
@@ -130,6 +143,114 @@ export class GastownClient {
   }
 }
 
+/**
+ * Mayor-scoped client for town-level cross-rig operations.
+ * Uses `/api/mayor/:townId/tools/*` routes authenticated via townId-scoped JWT.
+ */
+export class MayorGastownClient {
+  private baseUrl: string;
+  private token: string;
+  private agentId: string;
+  private townId: string;
+
+  constructor(env: MayorGastownEnv) {
+    this.baseUrl = env.apiUrl.replace(/\/+$/, '');
+    this.token = env.sessionToken;
+    this.agentId = env.agentId;
+    this.townId = env.townId;
+  }
+
+  private mayorPath(path: string): string {
+    return `${this.baseUrl}/api/mayor/${this.townId}/tools${path}`;
+  }
+
+  private async request<T>(url: string, init?: RequestInit): Promise<T> {
+    const headers = new Headers(init?.headers);
+    headers.set('Content-Type', 'application/json');
+    headers.set('Authorization', `Bearer ${this.token}`);
+
+    let response: Response;
+    try {
+      response = await fetch(url, { ...init, headers });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new GastownApiError(`Network error: ${message}`, 0);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new GastownApiError(`Invalid JSON response (HTTP ${response.status})`, response.status);
+    }
+
+    if (!isApiResponse(body)) {
+      throw new GastownApiError(
+        `Unexpected response shape (HTTP ${response.status})`,
+        response.status
+      );
+    }
+
+    if (!body.success) {
+      throw new GastownApiError((body as { error: string }).error, response.status);
+    }
+
+    return (body as { data: T }).data;
+  }
+
+  // -- Mayor tool endpoints --
+
+  async sling(input: {
+    rig_id: string;
+    title: string;
+    body?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<SlingResult> {
+    return this.request<SlingResult>(this.mayorPath('/sling'), {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async listRigs(): Promise<Rig[]> {
+    return this.request<Rig[]>(this.mayorPath('/rigs'));
+  }
+
+  async listBeads(
+    rigId: string,
+    filter?: { status?: BeadStatus; type?: BeadType }
+  ): Promise<Bead[]> {
+    const params = new URLSearchParams();
+    if (filter?.status) params.set('status', filter.status);
+    if (filter?.type) params.set('type', filter.type);
+    const qs = params.toString();
+    return this.request<Bead[]>(this.mayorPath(`/rigs/${rigId}/beads${qs ? `?${qs}` : ''}`));
+  }
+
+  async listAgents(rigId: string): Promise<Agent[]> {
+    return this.request<Agent[]>(this.mayorPath(`/rigs/${rigId}/agents`));
+  }
+
+  async sendMail(input: {
+    rig_id: string;
+    to_agent_id: string;
+    subject: string;
+    body: string;
+  }): Promise<void> {
+    await this.request<void>(this.mayorPath('/mail'), {
+      method: 'POST',
+      body: JSON.stringify({
+        ...input,
+        from_agent_id: this.agentId,
+      }),
+    });
+  }
+}
+
 export class GastownApiError extends Error {
   readonly status: number;
 
@@ -157,4 +278,23 @@ export function createClientFromEnv(): GastownClient {
   }
 
   return new GastownClient({ apiUrl, sessionToken, agentId, rigId });
+}
+
+export function createMayorClientFromEnv(): MayorGastownClient {
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const sessionToken = process.env.GASTOWN_SESSION_TOKEN;
+  const agentId = process.env.GASTOWN_AGENT_ID;
+  const townId = process.env.GASTOWN_TOWN_ID;
+
+  if (!apiUrl || !sessionToken || !agentId || !townId) {
+    const missing = [
+      !apiUrl && 'GASTOWN_API_URL',
+      !sessionToken && 'GASTOWN_SESSION_TOKEN',
+      !agentId && 'GASTOWN_AGENT_ID',
+      !townId && 'GASTOWN_TOWN_ID',
+    ].filter(Boolean);
+    throw new Error(`Missing required mayor environment variables: ${missing.join(', ')}`);
+  }
+
+  return new MayorGastownClient({ apiUrl, sessionToken, agentId, townId });
 }

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -1,0 +1,145 @@
+import { tool } from '@opencode-ai/plugin';
+import type { MayorGastownClient } from './client';
+
+function parseJsonObject(value: string, label: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`Invalid JSON in "${label}"`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      `"${label}" must be a JSON object, got ${Array.isArray(parsed) ? 'array' : typeof parsed}`
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Mayor-specific tools for cross-rig delegation.
+ * These are only registered when `GASTOWN_AGENT_ROLE=mayor`.
+ */
+export function createMayorTools(client: MayorGastownClient) {
+  return {
+    gt_sling: tool({
+      description:
+        'Delegate a task to a polecat agent in a specific rig. ' +
+        'Creates a bead (work item), assigns a polecat, and arms the dispatch alarm. ' +
+        'The polecat will be started automatically and begin working on the task. ' +
+        'You must specify which rig the work belongs to — use gt_list_rigs first if unsure.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig to assign work to'),
+        title: tool.schema.string().describe('Short title describing the task'),
+        body: tool.schema
+          .string()
+          .describe(
+            'Detailed description of the work to be done. Include requirements, context, acceptance criteria.'
+          )
+          .optional(),
+        metadata: tool.schema
+          .string()
+          .describe('JSON-encoded metadata object for additional context')
+          .optional(),
+      },
+      async execute(args) {
+        const metadata = args.metadata ? parseJsonObject(args.metadata, 'metadata') : undefined;
+        const result = await client.sling({
+          rig_id: args.rig_id,
+          title: args.title,
+          body: args.body,
+          metadata,
+        });
+        return [
+          `Task slung successfully.`,
+          `Bead: ${result.bead.id} — "${result.bead.title}"`,
+          `Assigned to: ${result.agent.name} (${result.agent.role}, id: ${result.agent.id})`,
+          `Status: ${result.bead.status}`,
+          `The polecat will be dispatched automatically by the alarm scheduler.`,
+        ].join('\n');
+      },
+    }),
+
+    gt_list_rigs: tool({
+      description:
+        'List all rigs (repositories) in your town. ' +
+        'Returns the rig ID, name, git URL, and default branch for each rig. ' +
+        'Use this to discover available rigs before delegating work with gt_sling.',
+      args: {},
+      async execute() {
+        const rigs = await client.listRigs();
+        if (rigs.length === 0) {
+          return 'No rigs configured in this town. A rig must be created before work can be delegated.';
+        }
+        return JSON.stringify(rigs, null, 2);
+      },
+    }),
+
+    gt_list_beads: tool({
+      description:
+        'List beads (work items) in a specific rig. ' +
+        'Optionally filter by status (open, in_progress, closed, failed) or type (issue, message, escalation, merge_request). ' +
+        'Use this to check what work exists in a rig, what is in progress, and what has been completed.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig to list beads from'),
+        status: tool.schema
+          .enum(['open', 'in_progress', 'closed', 'failed'])
+          .describe('Filter by bead status')
+          .optional(),
+        type: tool.schema
+          .enum(['issue', 'message', 'escalation', 'merge_request'])
+          .describe('Filter by bead type')
+          .optional(),
+      },
+      async execute(args) {
+        const beads = await client.listBeads(args.rig_id, {
+          status: args.status,
+          type: args.type,
+        });
+        if (beads.length === 0) {
+          return 'No beads found matching the filter.';
+        }
+        return JSON.stringify(beads, null, 2);
+      },
+    }),
+
+    gt_list_agents: tool({
+      description:
+        'List all agents in a specific rig. ' +
+        'Returns agent ID, role, name, status, and current hook (assigned bead). ' +
+        'Use this to see which agents are active, idle, or working on what.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig to list agents from'),
+      },
+      async execute(args) {
+        const agents = await client.listAgents(args.rig_id);
+        if (agents.length === 0) {
+          return 'No agents registered in this rig.';
+        }
+        return JSON.stringify(agents, null, 2);
+      },
+    }),
+
+    gt_mail_send: tool({
+      description:
+        'Send a mail message to an agent in any rig. ' +
+        'Use this for cross-rig coordination, instructions, or status requests. ' +
+        'The recipient must be identified by their agent UUID and rig UUID.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig the recipient agent belongs to'),
+        to_agent_id: tool.schema.string().describe('The UUID of the recipient agent'),
+        subject: tool.schema.string().describe('Subject line for the mail'),
+        body: tool.schema.string().describe('Body content of the mail'),
+      },
+      async execute(args) {
+        await client.sendMail({
+          rig_id: args.rig_id,
+          to_agent_id: args.to_agent_id,
+          subject: args.subject,
+          body: args.body,
+        });
+        return `Mail sent to agent ${args.to_agent_id} in rig ${args.rig_id}.`;
+      },
+    }),
+  };
+}

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -1,7 +1,7 @@
 // Types mirroring the Rig DO domain model.
 // These are the API response shapes — the plugin never touches SQLite directly.
 
-export type BeadStatus = 'open' | 'in_progress' | 'closed';
+export type BeadStatus = 'open' | 'in_progress' | 'closed' | 'failed';
 export type BeadType = 'issue' | 'message' | 'escalation' | 'merge_request';
 export type BeadPriority = 'low' | 'medium' | 'high' | 'critical';
 
@@ -60,10 +60,35 @@ export type ApiSuccess<T> = { success: true; data: T };
 export type ApiError = { success: false; error: string };
 export type ApiResponse<T> = ApiSuccess<T> | ApiError;
 
-// Environment variable config for the plugin
+// Rig metadata (from GastownUserDO)
+export type Rig = {
+  id: string;
+  town_id: string;
+  name: string;
+  git_url: string;
+  default_branch: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// Sling result (bead + assigned agent)
+export type SlingResult = {
+  bead: Bead;
+  agent: Agent;
+};
+
+// Environment variable config for the plugin (rig-scoped agents)
 export type GastownEnv = {
   apiUrl: string;
   sessionToken: string;
   agentId: string;
   rigId: string;
+};
+
+// Environment variable config for the mayor (town-scoped)
+export type MayorGastownEnv = {
+  apiUrl: string;
+  sessionToken: string;
+  agentId: string;
+  townId: string;
 };

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -59,6 +59,14 @@ import {
   handleMayorCompleted,
   handleDestroyMayor,
 } from './handlers/mayor.handler';
+import {
+  handleMayorSling,
+  handleMayorListRigs,
+  handleMayorListBeads,
+  handleMayorListAgents,
+  handleMayorSendMail,
+} from './handlers/mayor-tools.handler';
+import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 
 export { RigDO } from './dos/Rig.do';
 export { GastownUserDO } from './dos/GastownUser.do';
@@ -201,6 +209,22 @@ app.post('/api/towns/:townId/mayor/message', c => handleSendMayorMessage(c, c.re
 app.get('/api/towns/:townId/mayor/status', c => handleGetMayorStatus(c, c.req.param()));
 app.post('/api/towns/:townId/mayor/completed', c => handleMayorCompleted(c, c.req.param()));
 app.post('/api/towns/:townId/mayor/destroy', c => handleDestroyMayor(c, c.req.param()));
+
+// ── Mayor Tools ──────────────────────────────────────────────────────────
+// Tool endpoints called by the mayor's kilo serve session via the Gastown plugin.
+// Authenticated via mayor JWT (townId-scoped, no rigId restriction).
+
+app.use('/api/mayor/:townId/tools/*', async (c, next) =>
+  c.env.ENVIRONMENT === 'development' ? next() : mayorAuthMiddleware(c, next)
+);
+
+app.post('/api/mayor/:townId/tools/sling', c => handleMayorSling(c, c.req.param()));
+app.get('/api/mayor/:townId/tools/rigs', c => handleMayorListRigs(c, c.req.param()));
+app.get('/api/mayor/:townId/tools/rigs/:rigId/beads', c => handleMayorListBeads(c, c.req.param()));
+app.get('/api/mayor/:townId/tools/rigs/:rigId/agents', c =>
+  handleMayorListAgents(c, c.req.param())
+);
+app.post('/api/mayor/:townId/tools/mail', c => handleMayorSendMail(c, c.req.param()));
 
 // ── Error handling ──────────────────────────────────────────────────────
 

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -1,0 +1,180 @@
+import type { Context } from 'hono';
+import { z } from 'zod';
+import { getRigDOStub } from '../dos/Rig.do';
+import { getGastownUserStub } from '../dos/GastownUser.do';
+import { resSuccess, resError } from '../util/res.util';
+import { parseJsonBody } from '../util/parse-json-body.util';
+import { BeadStatus, BeadType } from '../types';
+import type { GastownEnv } from '../gastown.worker';
+
+const HANDLER_LOG = '[mayor-tools.handler]';
+
+// ── Schemas ──────────────────────────────────────────────────────────────
+
+const MayorSlingBody = z.object({
+  rig_id: z.string().min(1),
+  title: z.string().min(1),
+  body: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const MayorMailBody = z.object({
+  rig_id: z.string().min(1),
+  to_agent_id: z.string().min(1),
+  subject: z.string().min(1),
+  body: z.string().min(1),
+  from_agent_id: z.string().min(1),
+});
+
+const NonNegativeInt = z.coerce.number().int().nonnegative();
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the userId for the town by reading the JWT payload.
+ * The mayor's JWT contains the userId that owns the town.
+ */
+function getUserIdFromJWT(c: Context<GastownEnv>): string | null {
+  const jwt = c.get('agentJWT');
+  return jwt?.userId ?? null;
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/mayor/:townId/tools/sling
+ * Sling a task to a polecat in a specific rig. Creates a bead, assigns
+ * an agent, and arms the alarm for dispatch.
+ */
+export async function handleMayorSling(c: Context<GastownEnv>, params: { townId: string }) {
+  const parsed = MayorSlingBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorSling: townId=${params.townId} rigId=${parsed.data.rig_id} title="${parsed.data.title.slice(0, 80)}"`
+  );
+
+  const rig = getRigDOStub(c.env, parsed.data.rig_id);
+  const result = await rig.slingBead({
+    title: parsed.data.title,
+    body: parsed.data.body,
+    metadata: parsed.data.metadata,
+  });
+
+  console.log(
+    `${HANDLER_LOG} handleMayorSling: completed, result=${JSON.stringify(result).slice(0, 300)}`
+  );
+
+  return c.json(resSuccess(result), 201);
+}
+
+/**
+ * GET /api/mayor/:townId/tools/rigs
+ * List all rigs in the town. Requires userId from JWT to route to the
+ * correct GastownUserDO instance.
+ */
+export async function handleMayorListRigs(c: Context<GastownEnv>, params: { townId: string }) {
+  const userId = getUserIdFromJWT(c);
+  if (!userId) {
+    return c.json(resError('Missing userId in token'), 401);
+  }
+
+  console.log(`${HANDLER_LOG} handleMayorListRigs: townId=${params.townId} userId=${userId}`);
+
+  const userDO = getGastownUserStub(c.env, userId);
+  const rigs = await userDO.listRigs(params.townId);
+
+  return c.json(resSuccess(rigs));
+}
+
+/**
+ * GET /api/mayor/:townId/tools/rigs/:rigId/beads
+ * List beads in a specific rig. Supports status and type filtering.
+ */
+export async function handleMayorListBeads(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  const limitRaw = c.req.query('limit');
+  const offsetRaw = c.req.query('offset');
+  const limit = limitRaw !== undefined ? NonNegativeInt.safeParse(limitRaw) : undefined;
+  const offset = offsetRaw !== undefined ? NonNegativeInt.safeParse(offsetRaw) : undefined;
+  if ((limit && !limit.success) || (offset && !offset.success)) {
+    return c.json(resError('limit and offset must be non-negative integers'), 400);
+  }
+
+  const statusRaw = c.req.query('status');
+  const typeRaw = c.req.query('type');
+  const status = statusRaw !== undefined ? BeadStatus.safeParse(statusRaw) : undefined;
+  const type = typeRaw !== undefined ? BeadType.safeParse(typeRaw) : undefined;
+  if ((status && !status.success) || (type && !type.success)) {
+    return c.json(resError('Invalid status or type filter'), 400);
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorListBeads: townId=${params.townId} rigId=${params.rigId} status=${statusRaw ?? 'all'} type=${typeRaw ?? 'all'}`
+  );
+
+  const rig = getRigDOStub(c.env, params.rigId);
+  const beads = await rig.listBeads({
+    status: status?.data,
+    type: type?.data,
+    assignee_agent_id: c.req.query('assignee_agent_id'),
+    convoy_id: c.req.query('convoy_id'),
+    limit: limit?.data,
+    offset: offset?.data,
+  });
+
+  return c.json(resSuccess(beads));
+}
+
+/**
+ * GET /api/mayor/:townId/tools/rigs/:rigId/agents
+ * List agents in a specific rig.
+ */
+export async function handleMayorListAgents(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  console.log(
+    `${HANDLER_LOG} handleMayorListAgents: townId=${params.townId} rigId=${params.rigId}`
+  );
+
+  const rig = getRigDOStub(c.env, params.rigId);
+  const agents = await rig.listAgents({});
+
+  return c.json(resSuccess(agents));
+}
+
+/**
+ * POST /api/mayor/:townId/tools/mail
+ * Send mail to an agent in any rig. The mayor can communicate cross-rig.
+ */
+export async function handleMayorSendMail(c: Context<GastownEnv>, params: { townId: string }) {
+  const parsed = MayorMailBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorSendMail: townId=${params.townId} rigId=${parsed.data.rig_id} to=${parsed.data.to_agent_id} subject="${parsed.data.subject.slice(0, 80)}"`
+  );
+
+  const rig = getRigDOStub(c.env, parsed.data.rig_id);
+  await rig.sendMail({
+    from_agent_id: parsed.data.from_agent_id,
+    to_agent_id: parsed.data.to_agent_id,
+    subject: parsed.data.subject,
+    body: parsed.data.body,
+  });
+
+  return c.json(resSuccess({ sent: true }));
+}

--- a/cloudflare-gastown/src/middleware/mayor-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/mayor-auth.middleware.ts
@@ -1,5 +1,5 @@
 import { createMiddleware } from 'hono/factory';
-import { verifyAgentJWT, type AgentJWTPayload } from '../util/jwt.util';
+import { verifyAgentJWT } from '../util/jwt.util';
 import { resError } from '../util/res.util';
 import type { GastownEnv } from '../gastown.worker';
 

--- a/cloudflare-gastown/src/middleware/mayor-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/mayor-auth.middleware.ts
@@ -1,0 +1,54 @@
+import { createMiddleware } from 'hono/factory';
+import { verifyAgentJWT, type AgentJWTPayload } from '../util/jwt.util';
+import { resError } from '../util/res.util';
+import type { GastownEnv } from '../gastown.worker';
+
+/**
+ * Resolves a secret value from either a `SecretsStoreSecret` (production, has `.get()`)
+ * or a plain string (test env vars set in wrangler.test.jsonc).
+ */
+async function resolveSecret(binding: SecretsStoreSecret | string): Promise<string> {
+  if (typeof binding === 'string') return binding;
+  return binding.get();
+}
+
+/**
+ * Auth middleware for mayor tool routes. Validates a Gastown agent JWT
+ * and checks that the JWT's `townId` matches the `:townId` route param.
+ *
+ * Unlike the rig-scoped `authMiddleware` (which checks `rigId` match),
+ * this validates `townId` — the mayor operates cross-rig.
+ *
+ * Sets `agentJWT` on the Hono context.
+ */
+export const mayorAuthMiddleware = createMiddleware<GastownEnv>(async (c, next) => {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader?.toLowerCase().startsWith('bearer ')) {
+    return c.json(resError('Authentication required'), 401);
+  }
+
+  const token = authHeader.slice(7).trim();
+  if (!token) {
+    return c.json(resError('Missing token'), 401);
+  }
+
+  const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
+  if (!secret) {
+    console.error('[mayor-auth] GASTOWN_JWT_SECRET not configured');
+    return c.json(resError('Internal server error'), 500);
+  }
+
+  const result = verifyAgentJWT(token, secret);
+  if (!result.success) {
+    return c.json(resError(result.error), 401);
+  }
+
+  // Verify the townId in the JWT matches the route param
+  const townId = c.req.param('townId');
+  if (townId && result.payload.townId !== townId) {
+    return c.json(resError('Token townId does not match route'), 403);
+  }
+
+  c.set('agentJWT', result.payload);
+  return next();
+});

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -1,0 +1,60 @@
+/**
+ * Build the system prompt for the Mayor agent.
+ *
+ * The prompt establishes identity, the mayor's role as town coordinator,
+ * available tools, the conversational model, delegation instructions, and
+ * the GUPP principle.
+ */
+export function buildMayorSystemPrompt(params: { identity: string; townId: string }): string {
+  return `You are the Mayor of Gastown town "${params.townId}".
+Your identity: ${params.identity}
+
+## Role
+
+You are a persistent conversational agent that coordinates all work across the rigs (repositories) in your town. Users talk to you in natural language. You respond conversationally and delegate work to polecat agents when needed.
+
+You are NOT a worker. You do not write code, run tests, or make commits. You are a coordinator: you understand what the user wants, decide which rig and what kind of task it is, and delegate to polecats via gt_sling.
+
+## Available Tools
+
+You have these tools for cross-rig coordination:
+
+- **gt_list_rigs** — List all rigs in your town. Returns rig ID, name, git URL, and default branch. Call this first when you need to know what repositories are available.
+- **gt_sling** — Delegate a task to a polecat in a specific rig. Provide the rig_id, a clear title, and a detailed body with requirements. A polecat will be automatically dispatched to work on it.
+- **gt_list_beads** — List beads (work items) in a rig. Filter by status or type. Use this to check progress, find open work, or review completed tasks.
+- **gt_list_agents** — List agents in a rig. Shows who is working, idle, or stuck. Use this to understand workforce capacity.
+- **gt_mail_send** — Send a message to any agent in any rig. Use for coordination, follow-up instructions, or status checks.
+
+## Conversational Model
+
+- **Respond directly for questions.** If the user asks a question you can answer from context, respond conversationally. Don't delegate questions.
+- **Delegate via gt_sling for work.** When the user describes work to be done (bugs to fix, features to add, refactoring, etc.), delegate it by calling gt_sling with the appropriate rig.
+- **Non-blocking delegation.** After slinging work, respond immediately to the user. Do NOT wait for the polecat to finish. Say something like "I've assigned [agent name] to work on that in [rig name]" and move on. The user can check progress later.
+- **Multi-task naturally.** If the user describes multiple tasks, sling them individually to separate polecats.
+- **Discover rigs first.** If you don't know which rig to use, call gt_list_rigs before slinging.
+
+## GUPP Principle
+
+The Gas Town Universal Propulsion Principle: if there is work to be done, do it immediately. When the user asks for something, act on it right away. Don't ask for confirmation unless the request is genuinely ambiguous. Prefer action over clarification.
+
+## Writing Good Sling Titles and Bodies
+
+When calling gt_sling, write clear, actionable descriptions:
+
+- **Title**: A concise imperative sentence describing what needs to happen. Good: "Fix login redirect loop on /dashboard". Bad: "Login issue".
+- **Body**: Include all context the polecat needs to do the work independently:
+  - What is the current behavior?
+  - What is the expected behavior?
+  - Where in the codebase is the relevant code? (if known)
+  - What are the acceptance criteria?
+  - Any constraints or approaches to prefer/avoid?
+
+The polecat works autonomously — it cannot ask you questions mid-task. Front-load all necessary context in the body.
+
+## Important
+
+- You maintain context across messages. This is a continuous conversation.
+- Never fabricate rig IDs or agent IDs. Always use gt_list_rigs to discover real IDs.
+- If no rigs exist, tell the user they need to create one first.
+- If a task spans multiple rigs, create separate slings for each rig.`;
+}


### PR DESCRIPTION
## Summary

- Add 5 mayor-specific tools (`gt_sling`, `gt_list_rigs`, `gt_list_beads`, `gt_list_agents`, `gt_mail_send`) so the Mayor agent can delegate work across rigs
- New `/api/mayor/:townId/tools/*` worker routes with townId-scoped JWT auth (no rigId restriction)
- Detailed mayor system prompt with tool documentation, GUPP principle, and delegation best practices
- Conditional plugin loading: `GASTOWN_AGENT_ROLE=mayor` loads mayor tools, otherwise rig tools

Closes #339

## Architecture

```
User → Mayor Chat → MayorDO → Container (kilo serve + Gastown plugin)
                                    ↓ GASTOWN_AGENT_ROLE=mayor
                              MayorGastownClient
                                    ↓
                        /api/mayor/:townId/tools/*
                                    ↓
                    mayorAuthMiddleware (townId JWT validation)
                                    ↓
              ┌─── GastownUserDO (list rigs)
              └─── RigDO (sling, beads, agents, mail)
```

## Changes

### Worker (`cloudflare-gastown/src/`)
- **`handlers/mayor-tools.handler.ts`** (new) — 5 handlers: `handleMayorSling`, `handleMayorListRigs`, `handleMayorListBeads`, `handleMayorListAgents`, `handleMayorSendMail`
- **`middleware/mayor-auth.middleware.ts`** (new) — JWT middleware that validates `townId` match (cross-rig, no rigId constraint)
- **`prompts/mayor-system.prompt.ts`** (new) — `buildMayorSystemPrompt()` with role, tool docs, conversational model, GUPP
- **`gastown.worker.ts`** — 5 new routes under `/api/mayor/:townId/tools/*`
- **`dos/Mayor.do.ts`** — Uses `buildMayorSystemPrompt()`, passes `GASTOWN_AGENT_ROLE=mayor`, `GASTOWN_TOWN_ID`, `GASTOWN_API_URL` env vars to container

### Plugin (`cloudflare-gastown/container/plugin/`)
- **`mayor-tools.ts`** (new) — `createMayorTools()` with 5 tools for cross-rig delegation
- **`client.ts`** — `MayorGastownClient` class + `createMayorClientFromEnv()` for town-scoped API calls
- **`types.ts`** — `Rig`, `SlingResult`, `MayorGastownEnv` types; fixed `BeadStatus` to include `'failed'`
- **`index.ts`** — Conditional tool loading based on `GASTOWN_AGENT_ROLE`; guarded prime/checkpoint for mayor

## Testing

- Both worker and container typechecks pass clean
- All 34 existing plugin tests pass