### PR TITLE
chore: Bump vercel routing to 100% for openrouter incident

### DIFF
--- a/src/lib/providers/vercel.ts
+++ b/src/lib/providers/vercel.ts
@@ -16,7 +16,7 @@ import type {
 import { zai_glm47_free_model, zai_glm5_free_model } from '@/lib/providers/zai';
 import * as crypto from 'crypto';
 
-const VERCEL_ROUTING_PERCENTAGE = 10;
+const VERCEL_ROUTING_PERCENTAGE = 100;
 
 const VERCEL_ROUTING_ALLOW_LIST = [
   'arcee-ai/trinity-large-preview:free',


### PR DESCRIPTION
Ongoing openrouter incident:

<img width="1892" height="1217" alt="image" src="https://github.com/user-attachments/assets/af32bf05-7057-42b8-b66a-60c521076c57" />
