### PR TITLE
[Gastown] Manual Merge Flow — Container /git/merge endpoint + review queue completion

### DIFF
--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -26,6 +26,25 @@ function buildKiloConfigContent(kilocodeToken: string): string {
         },
       },
     },
+    // Override the small model (used for title generation) to a valid
+    // kilo-provider model. Without this, kilo serve defaults to
+    // openai/gpt-5-nano which doesn't exist in the kilo provider,
+    // causing ProviderModelNotFoundError that kills the entire prompt loop.
+    small_model: 'anthropic/claude-haiku-4.5',
+    model: 'anthropic/claude-sonnet-4.6',
+    // Override the title agent to use a valid model (same as small_model).
+    // kilo serve v1.0.23 resolves title model independently and the
+    // small_model fallback doesn't prevent ProviderModelNotFoundError.
+    agents: {
+      title: {
+        model: 'anthropic/claude-haiku-4.5',
+      },
+    },
+    // Auto-approve everything — agents run headless in a container,
+    // there's no human to answer permission prompts.
+    permission: {
+      '*': 'allow',
+    },
   });
 }
 

--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -219,7 +219,7 @@ app.post('/git/merge', async c => {
     console.error(`Merge failed for entry ${req.entryId}:`, err);
   });
 
-  const result: MergeResult = { status: 'merged', message: 'Merge started' };
+  const result: MergeResult = { status: 'accepted', message: 'Merge started' };
   return c.json(result, 202);
 });
 

--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -11,8 +11,14 @@ import {
   getAgentEvents,
 } from './process-manager';
 import { startHeartbeat, stopHeartbeat } from './heartbeat';
-import { StartAgentRequest, StopAgentRequest, SendMessageRequest } from './types';
-import type { AgentStatusResponse, HealthResponse, StreamTicketResponse } from './types';
+import { mergeBranch } from './git-manager';
+import { StartAgentRequest, StopAgentRequest, SendMessageRequest, MergeRequest } from './types';
+import type {
+  AgentStatusResponse,
+  HealthResponse,
+  StreamTicketResponse,
+  MergeResult,
+} from './types';
 
 const MAX_TICKETS = 1000;
 const streamTickets = new Map<string, { agentId: string; expiresAt: number }>();
@@ -145,6 +151,77 @@ export function consumeStreamTicket(ticket: string): string | null {
   if (entry.expiresAt < Date.now()) return null;
   return entry.agentId;
 }
+
+// POST /git/merge
+// Deterministic merge of a polecat branch into the target branch.
+// Called by the Rig DO's processReviewQueue → startMergeInContainer.
+// Runs the merge synchronously and reports the result back to the Rig DO
+// via a callback to the completeReview endpoint.
+app.post('/git/merge', async c => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = MergeRequest.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request body', issues: parsed.error.issues }, 400);
+  }
+
+  const req = parsed.data;
+
+  // Run the merge in the background so we can return 202 immediately.
+  // The Rig DO will be notified via callback when the merge completes.
+  const apiUrl = req.envVars?.GASTOWN_API_URL ?? process.env.GASTOWN_API_URL;
+  const token = req.envVars?.GASTOWN_SESSION_TOKEN ?? process.env.GASTOWN_SESSION_TOKEN;
+
+  const doMerge = async () => {
+    const outcome = await mergeBranch({
+      rigId: req.rigId,
+      branch: req.branch,
+      targetBranch: req.targetBranch,
+      gitUrl: req.gitUrl,
+    });
+
+    // Report result back to the Rig DO
+    const callbackUrl =
+      req.callbackUrl ??
+      (apiUrl ? `${apiUrl}/api/rigs/${req.rigId}/review-queue/${req.entryId}/complete` : null);
+
+    if (callbackUrl && token) {
+      try {
+        const resp = await fetch(callbackUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            entry_id: req.entryId,
+            status: outcome.status,
+            message: outcome.message,
+            commit_sha: outcome.commitSha,
+          }),
+        });
+        if (!resp.ok) {
+          console.warn(
+            `Merge callback failed for entry ${req.entryId}: ${resp.status} ${resp.statusText}`
+          );
+        }
+      } catch (err) {
+        console.warn(`Merge callback error for entry ${req.entryId}:`, err);
+      }
+    } else {
+      console.warn(
+        `No callback URL or token for merge entry ${req.entryId}, result: ${outcome.status}`
+      );
+    }
+  };
+
+  // Fire and forget — the Rig DO will time out stuck entries via recoverStuckReviews
+  doMerge().catch(err => {
+    console.error(`Merge failed for entry ${req.entryId}:`, err);
+  });
+
+  const result: MergeResult = { status: 'merged', message: 'Merge started' };
+  return c.json(result, 202);
+});
 
 // Catch-all
 app.notFound(c => c.json({ error: 'Not found' }, 404));

--- a/cloudflare-gastown/container/src/git-manager.ts
+++ b/cloudflare-gastown/container/src/git-manager.ts
@@ -182,3 +182,95 @@ export async function listWorktrees(rigId: string): Promise<string[]> {
     .filter(line => line.startsWith('worktree '))
     .map(line => line.replace('worktree ', ''));
 }
+
+export type MergeOutcome = {
+  status: 'merged' | 'conflict';
+  message: string;
+  commitSha?: string;
+};
+
+/**
+ * Deterministic merge of a feature branch into the target branch.
+ * Uses a temporary worktree so the bare repo and agent worktrees are unaffected.
+ *
+ * 1. Ensure the repo is cloned/fetched
+ * 2. Create a temporary worktree on the target branch
+ * 3. git merge --no-ff <branch>
+ * 4. If success: push, clean up, return 'merged'
+ * 5. If conflict: abort, clean up, return 'conflict'
+ */
+export async function mergeBranch(options: {
+  rigId: string;
+  branch: string;
+  targetBranch: string;
+  gitUrl: string;
+}): Promise<MergeOutcome> {
+  validatePathSegment(options.rigId, 'rigId');
+  validateBranchName(options.branch, 'branch');
+  validateBranchName(options.targetBranch, 'targetBranch');
+  validateGitUrl(options.gitUrl);
+
+  const repo = repoDir(options.rigId);
+
+  // Ensure repo exists and is up to date
+  if (!(await pathExists(join(repo, '.git')))) {
+    await cloneRepo({
+      rigId: options.rigId,
+      gitUrl: options.gitUrl,
+      defaultBranch: options.targetBranch,
+    });
+  } else {
+    await exec('git', ['fetch', '--all', '--prune'], repo);
+  }
+
+  // Create a temporary worktree for the merge on the target branch
+  const mergeDir = resolve(WORKSPACE_ROOT, options.rigId, 'merge-tmp', `merge-${Date.now()}`);
+  assertInsideWorkspace(mergeDir);
+  await mkdir(mergeDir, { recursive: true });
+
+  try {
+    // Add worktree tracking the target branch
+    await exec('git', ['worktree', 'add', mergeDir, options.targetBranch], repo);
+
+    // Pull latest on the target branch
+    await exec('git', ['pull', '--ff-only'], mergeDir).catch(() => {
+      // Pull may fail if target has no upstream; that's fine for local-only branches
+    });
+
+    // Attempt the merge
+    try {
+      await exec(
+        'git',
+        [
+          'merge',
+          '--no-ff',
+          '-m',
+          `Merge ${options.branch} into ${options.targetBranch}`,
+          `origin/${options.branch}`,
+        ],
+        mergeDir
+      );
+    } catch (mergeErr) {
+      // Merge failed — likely a conflict
+      const message = mergeErr instanceof Error ? mergeErr.message : 'Unknown merge error';
+
+      // Abort the merge so the worktree is clean for removal
+      await exec('git', ['merge', '--abort'], mergeDir).catch(() => {});
+      return { status: 'conflict', message };
+    }
+
+    // Get the commit SHA of the merge commit
+    const commitSha = await exec('git', ['rev-parse', 'HEAD'], mergeDir);
+
+    // Push the merged target branch
+    await exec('git', ['push', 'origin', options.targetBranch], mergeDir);
+
+    return { status: 'merged', message: 'Merge successful', commitSha };
+  } finally {
+    // Always clean up the temporary worktree
+    await exec('git', ['worktree', 'remove', '--force', mergeDir], repo).catch(err => {
+      console.warn(`Failed to remove merge worktree at ${mergeDir}:`, err);
+    });
+    await rm(mergeDir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/cloudflare-gastown/container/src/git-manager.ts
+++ b/cloudflare-gastown/container/src/git-manager.ts
@@ -226,7 +226,8 @@ export async function mergeBranch(options: {
   // Create a temporary worktree for the merge on the target branch
   const mergeDir = resolve(WORKSPACE_ROOT, options.rigId, 'merge-tmp', `merge-${Date.now()}`);
   assertInsideWorkspace(mergeDir);
-  await mkdir(mergeDir, { recursive: true });
+  // Only create the parent — git worktree add creates the leaf directory itself
+  await mkdir(resolve(WORKSPACE_ROOT, options.rigId, 'merge-tmp'), { recursive: true });
 
   try {
     // Add worktree tracking the target branch

--- a/cloudflare-gastown/container/src/kilo-server.ts
+++ b/cloudflare-gastown/container/src/kilo-server.ts
@@ -99,7 +99,7 @@ async function doStartServer(workdir: string, env: Record<string, string>): Prom
   const mergedEnv = { ...process.env, ...env };
 
   const child: Subprocess = Bun.spawn(
-    ['kilo', 'serve', '--port', String(port), '--hostname', '127.0.0.1'],
+    ['kilo', 'serve', '--port', String(port), '--hostname', '127.0.0.1', '--print-logs'],
     {
       cwd: workdir,
       env: mergedEnv,

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -25,20 +25,20 @@ export const StartAgentRequest = z.object({
 export type StartAgentRequest = z.infer<typeof StartAgentRequest>;
 
 export const MergeRequest = z.object({
-  rigId: z.string(),
-  branch: z.string(),
-  targetBranch: z.string(),
-  gitUrl: z.string(),
-  entryId: z.string(),
-  beadId: z.string(),
-  agentId: z.string(),
+  rigId: z.string().min(1),
+  branch: z.string().min(1),
+  targetBranch: z.string().min(1),
+  gitUrl: z.string().min(1),
+  entryId: z.string().min(1),
+  beadId: z.string().min(1),
+  agentId: z.string().min(1),
   callbackUrl: z.string().optional(),
   envVars: z.record(z.string(), z.string()).optional(),
 });
 export type MergeRequest = z.infer<typeof MergeRequest>;
 
 export type MergeResult = {
-  status: 'merged' | 'conflict';
+  status: 'accepted' | 'merged' | 'conflict';
   message: string;
   commitSha?: string;
 };

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -24,6 +24,25 @@ export const StartAgentRequest = z.object({
 });
 export type StartAgentRequest = z.infer<typeof StartAgentRequest>;
 
+export const MergeRequest = z.object({
+  rigId: z.string(),
+  branch: z.string(),
+  targetBranch: z.string(),
+  gitUrl: z.string(),
+  entryId: z.string(),
+  beadId: z.string(),
+  agentId: z.string(),
+  callbackUrl: z.string().optional(),
+  envVars: z.record(z.string(), z.string()).optional(),
+});
+export type MergeRequest = z.infer<typeof MergeRequest>;
+
+export type MergeResult = {
+  status: 'merged' | 'conflict';
+  message: string;
+  commitSha?: string;
+};
+
 export const StopAgentRequest = z.object({
   signal: z.enum(['SIGTERM', 'SIGKILL']).optional(),
 });

--- a/cloudflare-gastown/src/db/tables/bead-events.table.ts
+++ b/cloudflare-gastown/src/db/tables/bead-events.table.ts
@@ -25,7 +25,14 @@ export const BeadEventRecord = z.object({
   event_type: BeadEventType,
   old_value: z.string().nullable(),
   new_value: z.string().nullable(),
-  metadata: z.string().transform(v => JSON.parse(v) as Record<string, unknown>),
+  metadata: z.string().transform((v, ctx): Record<string, unknown> => {
+    try {
+      return JSON.parse(v);
+    } catch {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Invalid JSON in metadata' });
+      return {};
+    }
+  }),
   created_at: z.string(),
 });
 

--- a/cloudflare-gastown/src/db/tables/bead-events.table.ts
+++ b/cloudflare-gastown/src/db/tables/bead-events.table.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
+
+export const BeadEventType = z.enum([
+  'created',
+  'assigned',
+  'hooked',
+  'unhooked',
+  'status_changed',
+  'closed',
+  'escalated',
+  'mail_sent',
+  'review_submitted',
+  'review_completed',
+  'agent_spawned',
+  'agent_exited',
+]);
+
+export type BeadEventType = z.infer<typeof BeadEventType>;
+
+export const BeadEventRecord = z.object({
+  id: z.string(),
+  bead_id: z.string(),
+  agent_id: z.string().nullable(),
+  event_type: BeadEventType,
+  old_value: z.string().nullable(),
+  new_value: z.string().nullable(),
+  metadata: z.string().transform(v => JSON.parse(v) as Record<string, unknown>),
+  created_at: z.string(),
+});
+
+export type BeadEventRecord = z.output<typeof BeadEventRecord>;
+
+export const beadEvents = getTableFromZodSchema('bead_events', BeadEventRecord);
+
+export function createTableBeadEvents(): string {
+  return getCreateTableQueryFromTable(beadEvents, {
+    id: `text primary key`,
+    bead_id: `text not null`,
+    agent_id: `text`,
+    event_type: `text not null`,
+    old_value: `text`,
+    new_value: `text`,
+    metadata: `text default '{}'`,
+    created_at: `text not null`,
+  });
+}
+
+export function getIndexesBeadEvents(): string[] {
+  return [
+    `CREATE INDEX IF NOT EXISTS idx_bead_events_bead ON ${beadEvents}(${beadEvents.columns.bead_id})`,
+    `CREATE INDEX IF NOT EXISTS idx_bead_events_created ON ${beadEvents}(${beadEvents.columns.created_at})`,
+    `CREATE INDEX IF NOT EXISTS idx_bead_events_type ON ${beadEvents}(${beadEvents.columns.event_type})`,
+  ];
+}

--- a/cloudflare-gastown/src/dos/Rig.do.ts
+++ b/cloudflare-gastown/src/dos/Rig.do.ts
@@ -9,6 +9,13 @@ import {
 } from '../db/tables/review-queue.table';
 import { createTableMolecules } from '../db/tables/molecules.table';
 import {
+  createTableBeadEvents,
+  getIndexesBeadEvents,
+  beadEvents,
+  BeadEventRecord,
+} from '../db/tables/bead-events.table';
+import type { BeadEventType } from '../db/tables/bead-events.table';
+import {
   createTableAgentEvents,
   getIndexesAgentEvents,
   agentEvents,
@@ -117,6 +124,78 @@ export class RigDO extends DurableObject<Env> {
     for (const idx of getIndexesAgentEvents()) {
       query(this.sql, idx, []);
     }
+
+    query(this.sql, createTableBeadEvents(), []);
+    for (const idx of getIndexesBeadEvents()) {
+      query(this.sql, idx, []);
+    }
+  }
+
+  // ── Bead Event Log ───────────────────────────────────────────────────
+
+  private writeBeadEvent(params: {
+    beadId: string;
+    agentId?: string | null;
+    eventType: BeadEventType;
+    oldValue?: string | null;
+    newValue?: string | null;
+    metadata?: Record<string, unknown>;
+  }): void {
+    const id = generateId();
+    const timestamp = now();
+    query(
+      this.sql,
+      /* sql */ `
+        INSERT INTO ${beadEvents} (
+          ${beadEvents.columns.id},
+          ${beadEvents.columns.bead_id},
+          ${beadEvents.columns.agent_id},
+          ${beadEvents.columns.event_type},
+          ${beadEvents.columns.old_value},
+          ${beadEvents.columns.new_value},
+          ${beadEvents.columns.metadata},
+          ${beadEvents.columns.created_at}
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      [
+        id,
+        params.beadId,
+        params.agentId ?? null,
+        params.eventType,
+        params.oldValue ?? null,
+        params.newValue ?? null,
+        JSON.stringify(params.metadata ?? {}),
+        timestamp,
+      ]
+    );
+  }
+
+  async listBeadEvents(options: {
+    beadId?: string;
+    since?: string;
+    limit?: number;
+  }): Promise<BeadEventRecord[]> {
+    await this.ensureInitialized();
+    const rows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT * FROM ${beadEvents}
+          WHERE (? IS NULL OR ${beadEvents.bead_id} = ?)
+            AND (? IS NULL OR ${beadEvents.created_at} > ?)
+          ORDER BY ${beadEvents.created_at} ASC
+          LIMIT ?
+        `,
+        [
+          options.beadId ?? null,
+          options.beadId ?? null,
+          options.since ?? null,
+          options.since ?? null,
+          options.limit ?? 100,
+        ]
+      ),
+    ];
+    return BeadEventRecord.array().parse(rows);
   }
 
   // ── Beads ──────────────────────────────────────────────────────────────
@@ -167,6 +246,15 @@ export class RigDO extends DurableObject<Env> {
 
     const result = this.getBead(id);
     if (!result) throw new Error('Failed to create bead');
+
+    this.writeBeadEvent({
+      beadId: id,
+      agentId: input.assignee_agent_id,
+      eventType: 'created',
+      newValue: input.type,
+      metadata: { title: input.title, priority: input.priority ?? 'medium' },
+    });
+
     console.log(`${RIG_LOG} createBead: created bead id=${result.id} status=${result.status}`);
     return result;
   }
@@ -220,6 +308,8 @@ export class RigDO extends DurableObject<Env> {
 
   async updateBeadStatus(beadId: string, status: BeadStatus, agentId: string): Promise<Bead> {
     await this.ensureInitialized();
+    const oldBead = this.getBead(beadId);
+    const oldStatus = oldBead?.status ?? null;
     const timestamp = now();
     const closedAt = status === 'closed' ? timestamp : null;
 
@@ -236,6 +326,15 @@ export class RigDO extends DurableObject<Env> {
     );
 
     this.touchAgent(agentId);
+
+    const eventType: BeadEventType = status === 'closed' ? 'closed' : 'status_changed';
+    this.writeBeadEvent({
+      beadId,
+      agentId,
+      eventType,
+      oldValue: oldStatus,
+      newValue: status,
+    });
 
     const bead = this.getBead(beadId);
     if (!bead) throw new Error(`Bead ${beadId} not found`);
@@ -436,6 +535,14 @@ export class RigDO extends DurableObject<Env> {
       [agentId, now(), beadId]
     );
 
+    this.writeBeadEvent({
+      beadId,
+      agentId,
+      eventType: 'hooked',
+      newValue: agentId,
+      metadata: { agent_name: agent.name, agent_role: agent.role },
+    });
+
     console.log(
       `${RIG_LOG} hookBead: bead ${beadId} now in_progress, agent ${agentId} hooked. Arming alarm.`
     );
@@ -444,6 +551,10 @@ export class RigDO extends DurableObject<Env> {
 
   async unhookBead(agentId: string): Promise<void> {
     await this.ensureInitialized();
+    // Read agent to get bead_id before unhooking
+    const agent = this.getAgent(agentId);
+    const beadId = agent?.current_hook_bead_id;
+
     query(
       this.sql,
       /* sql */ `
@@ -455,6 +566,15 @@ export class RigDO extends DurableObject<Env> {
       `,
       [now(), agentId]
     );
+
+    if (beadId) {
+      this.writeBeadEvent({
+        beadId,
+        agentId,
+        eventType: 'unhooked',
+        oldValue: agentId,
+      });
+    }
   }
 
   async getHookedBead(agentId: string): Promise<Bead | null> {
@@ -623,6 +743,14 @@ export class RigDO extends DurableObject<Env> {
         timestamp,
       ]
     );
+
+    this.writeBeadEvent({
+      beadId: input.bead_id,
+      agentId: input.agent_id,
+      eventType: 'review_submitted',
+      newValue: input.branch,
+      metadata: { pr_url: input.pr_url, summary: input.summary },
+    });
   }
 
   async popReviewQueue(): Promise<ReviewQueueEntry | null> {
@@ -721,11 +849,21 @@ export class RigDO extends DurableObject<Env> {
         `,
         [timestamp, timestamp, entry.bead_id]
       );
+
+      this.writeBeadEvent({
+        beadId: entry.bead_id,
+        agentId: entry.agent_id,
+        eventType: 'review_completed',
+        oldValue: 'running',
+        newValue: 'merged',
+        metadata: { commit_sha: input.commit_sha, branch: entry.branch },
+      });
+
       console.log(
         `${RIG_LOG} completeReviewWithResult: bead ${entry.bead_id} closed after merge (commit ${input.commit_sha ?? 'unknown'})`
       );
     } else {
-      // Conflict — create an escalation bead
+      // Conflict — create an escalation bead (createBead writes its own 'created' event)
       await this.createBead({
         type: 'escalation',
         title: `Merge conflict: ${entry.branch}`,
@@ -737,6 +875,15 @@ export class RigDO extends DurableObject<Env> {
           agent_id: entry.agent_id,
         },
       });
+
+      this.writeBeadEvent({
+        beadId: entry.bead_id,
+        agentId: entry.agent_id,
+        eventType: 'escalated',
+        newValue: input.message,
+        metadata: { branch: entry.branch },
+      });
+
       console.log(
         `${RIG_LOG} completeReviewWithResult: merge conflict for bead ${entry.bead_id}, escalation bead created`
       );
@@ -881,6 +1028,13 @@ export class RigDO extends DurableObject<Env> {
         `,
         [beadStatus, timestamp, closedAt, beadId]
       );
+      this.writeBeadEvent({
+        beadId,
+        agentId,
+        eventType: input.status === 'completed' ? 'closed' : 'status_changed',
+        newValue: beadStatus,
+        metadata: { reason: input.reason },
+      });
     } else {
       console.log(`${RIG_LOG} agentCompleted: agent ${agentId} ${input.status} but no hooked bead`);
     }

--- a/cloudflare-gastown/src/dos/Rig.do.ts
+++ b/cloudflare-gastown/src/dos/Rig.do.ts
@@ -1507,13 +1507,13 @@ export class RigDO extends DurableObject<Env> {
   private static modelForRole(role: string): string {
     switch (role) {
       case 'polecat':
-        return 'kilo/claude-sonnet-4-20250514';
+        return 'anthropic/claude-sonnet-4.6';
       case 'refinery':
-        return 'kilo/claude-sonnet-4-20250514';
+        return 'anthropic/claude-sonnet-4.6';
       case 'mayor':
-        return 'kilo/claude-sonnet-4-20250514';
+        return 'anthropic/claude-sonnet-4.6';
       default:
-        return 'kilo/claude-sonnet-4-20250514';
+        return 'anthropic/claude-sonnet-4.6';
     }
   }
 

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -39,6 +39,8 @@ import {
   handleCompleteReview,
 } from './handlers/rig-review-queue.handler';
 import { handleCreateEscalation } from './handlers/rig-escalations.handler';
+import { handleListBeadEvents } from './handlers/rig-bead-events.handler';
+import { handleListTownEvents } from './handlers/town-events.handler';
 import {
   handleContainerStartAgent,
   handleContainerStopAgent,
@@ -179,6 +181,10 @@ app.post('/api/rigs/:rigId/review-queue/:entryId/complete', c =>
   handleCompleteReview(c, c.req.param())
 );
 
+// ── Bead Events ─────────────────────────────────────────────────────────
+
+app.get('/api/rigs/:rigId/events', c => handleListBeadEvents(c, c.req.param()));
+
 // ── Escalations ─────────────────────────────────────────────────────────
 
 app.post('/api/rigs/:rigId/escalations', c => handleCreateEscalation(c, c.req.param()));
@@ -195,6 +201,10 @@ app.get('/api/users/:userId/rigs/:rigId', c => handleGetRig(c, c.req.param()));
 app.get('/api/users/:userId/towns/:townId/rigs', c => handleListRigs(c, c.req.param()));
 app.delete('/api/users/:userId/towns/:townId', c => handleDeleteTown(c, c.req.param()));
 app.delete('/api/users/:userId/rigs/:rigId', c => handleDeleteRig(c, c.req.param()));
+
+// ── Town Events ─────────────────────────────────────────────────────────
+
+app.get('/api/users/:userId/towns/:townId/events', c => handleListTownEvents(c, c.req.param()));
 
 // ── Town Container ──────────────────────────────────────────────────────
 // These routes proxy commands to the container's control server via DO.fetch().

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -34,7 +34,10 @@ import {
 } from './handlers/rig-agents.handler';
 import { handleSendMail } from './handlers/rig-mail.handler';
 import { handleAppendAgentEvent, handleGetAgentEvents } from './handlers/rig-agent-events.handler';
-import { handleSubmitToReviewQueue } from './handlers/rig-review-queue.handler';
+import {
+  handleSubmitToReviewQueue,
+  handleCompleteReview,
+} from './handlers/rig-review-queue.handler';
 import { handleCreateEscalation } from './handlers/rig-escalations.handler';
 import {
   handleContainerStartAgent,
@@ -172,6 +175,9 @@ app.post('/api/rigs/:rigId/mail', c => handleSendMail(c, c.req.param()));
 // ── Review Queue ────────────────────────────────────────────────────────
 
 app.post('/api/rigs/:rigId/review-queue', c => handleSubmitToReviewQueue(c, c.req.param()));
+app.post('/api/rigs/:rigId/review-queue/:entryId/complete', c =>
+  handleCompleteReview(c, c.req.param())
+);
 
 // ── Escalations ─────────────────────────────────────────────────────────
 

--- a/cloudflare-gastown/src/handlers/rig-bead-events.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-bead-events.handler.ts
@@ -7,7 +7,7 @@ export async function handleListBeadEvents(c: Context<GastownEnv>, params: { rig
   const since = c.req.query('since') ?? undefined;
   const beadId = c.req.query('bead_id') ?? undefined;
   const limitStr = c.req.query('limit');
-  const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+  const limit = limitStr ? parseInt(limitStr, 10) || undefined : undefined;
 
   const rig = getRigDOStub(c.env, params.rigId);
   const events = await rig.listBeadEvents({ beadId, since, limit });

--- a/cloudflare-gastown/src/handlers/rig-bead-events.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-bead-events.handler.ts
@@ -1,0 +1,15 @@
+import type { Context } from 'hono';
+import { getRigDOStub } from '../dos/Rig.do';
+import { resSuccess } from '../util/res.util';
+import type { GastownEnv } from '../gastown.worker';
+
+export async function handleListBeadEvents(c: Context<GastownEnv>, params: { rigId: string }) {
+  const since = c.req.query('since') ?? undefined;
+  const beadId = c.req.query('bead_id') ?? undefined;
+  const limitStr = c.req.query('limit');
+  const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+
+  const rig = getRigDOStub(c.env, params.rigId);
+  const events = await rig.listBeadEvents({ beadId, since, limit });
+  return c.json(resSuccess(events));
+}

--- a/cloudflare-gastown/src/handlers/rig-review-queue.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-review-queue.handler.ts
@@ -30,3 +30,26 @@ export async function handleSubmitToReviewQueue(c: Context<GastownEnv>, params: 
   await rig.submitToReviewQueue(parsed.data);
   return c.json(resSuccess({ submitted: true }), 201);
 }
+
+const CompleteReviewBody = z.object({
+  entry_id: z.string().min(1),
+  status: z.enum(['merged', 'conflict']),
+  message: z.string(),
+  commit_sha: z.string().optional(),
+});
+
+export async function handleCompleteReview(
+  c: Context<GastownEnv>,
+  params: { rigId: string; entryId: string }
+) {
+  const parsed = CompleteReviewBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+  const rig = getRigDOStub(c.env, params.rigId);
+  await rig.completeReviewWithResult(parsed.data);
+  return c.json(resSuccess({ completed: true }));
+}

--- a/cloudflare-gastown/src/handlers/rig-review-queue.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-review-queue.handler.ts
@@ -32,7 +32,6 @@ export async function handleSubmitToReviewQueue(c: Context<GastownEnv>, params: 
 }
 
 const CompleteReviewBody = z.object({
-  entry_id: z.string().min(1),
   status: z.enum(['merged', 'conflict']),
   message: z.string(),
   commit_sha: z.string().optional(),
@@ -50,6 +49,9 @@ export async function handleCompleteReview(
     );
   }
   const rig = getRigDOStub(c.env, params.rigId);
-  await rig.completeReviewWithResult(parsed.data);
+  await rig.completeReviewWithResult({
+    entry_id: params.entryId,
+    ...parsed.data,
+  });
   return c.json(resSuccess({ completed: true }));
 }

--- a/cloudflare-gastown/src/handlers/town-events.handler.ts
+++ b/cloudflare-gastown/src/handlers/town-events.handler.ts
@@ -1,0 +1,40 @@
+import type { Context } from 'hono';
+import { getGastownUserStub } from '../dos/GastownUser.do';
+import { getRigDOStub } from '../dos/Rig.do';
+import { resSuccess } from '../util/res.util';
+import type { GastownEnv } from '../gastown.worker';
+import type { BeadEventRecord } from '../db/tables/bead-events.table';
+
+type TaggedBeadEvent = BeadEventRecord & { rig_id: string; rig_name: string };
+
+/**
+ * Fan out to all Rig DOs in a town and return a merged, sorted event stream.
+ * GET /api/users/:userId/towns/:townId/events?since=<iso>&limit=<n>
+ */
+export async function handleListTownEvents(
+  c: Context<GastownEnv>,
+  params: { userId: string; townId: string }
+) {
+  const since = c.req.query('since') ?? undefined;
+  const limitStr = c.req.query('limit');
+  const limit = limitStr ? parseInt(limitStr, 10) : 100;
+
+  // Look up all rigs in the town
+  const townDO = getGastownUserStub(c.env, params.userId);
+  const rigs = await townDO.listRigs(params.townId);
+
+  // Fan out to each Rig DO in parallel
+  const eventPromises = rigs.map(async (rig): Promise<TaggedBeadEvent[]> => {
+    const rigDO = getRigDOStub(c.env, rig.id);
+    const events = await rigDO.listBeadEvents({ since, limit });
+    return events.map(e => ({ ...e, rig_id: rig.id, rig_name: rig.name }));
+  });
+
+  const results = await Promise.all(eventPromises);
+  const allEvents = results
+    .flat()
+    .sort((a, b) => a.created_at.localeCompare(b.created_at))
+    .slice(0, limit);
+
+  return c.json(resSuccess(allEvents));
+}

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -15,46 +15,82 @@ You are a persistent conversational agent that coordinates all work across the r
 
 You are NOT a worker. You do not write code, run tests, or make commits. You are a coordinator: you understand what the user wants, decide which rig and what kind of task it is, and delegate to polecats via gt_sling.
 
+## YOUR PRIMARY JOB: SLING WORK
+
+Your #1 purpose is to turn user requests into actionable work items via gt_sling. Every time a user describes something that needs to happen in code — a bug fix, feature, refactor, test, doc update, config change, anything — you MUST call gt_sling to create a bead and dispatch a polecat.
+
+**If you respond to a work request without calling gt_sling, you have failed at your job.** Talking about what could be done is worthless. Slinging the work IS the job.
+
 ## Available Tools
 
 You have these tools for cross-rig coordination:
 
+- **gt_sling** — YOUR MOST IMPORTANT TOOL. Delegate a task to a polecat in a specific rig. Provide the rig_id, a clear title, and a detailed body with requirements. A polecat will be automatically dispatched to work on it. USE THIS AGGRESSIVELY.
 - **gt_list_rigs** — List all rigs in your town. Returns rig ID, name, git URL, and default branch. Call this first when you need to know what repositories are available.
-- **gt_sling** — Delegate a task to a polecat in a specific rig. Provide the rig_id, a clear title, and a detailed body with requirements. A polecat will be automatically dispatched to work on it.
 - **gt_list_beads** — List beads (work items) in a rig. Filter by status or type. Use this to check progress, find open work, or review completed tasks.
 - **gt_list_agents** — List agents in a rig. Shows who is working, idle, or stuck. Use this to understand workforce capacity.
 - **gt_mail_send** — Send a message to any agent in any rig. Use for coordination, follow-up instructions, or status checks.
 
+## Task Decomposition — SPLIT WORK UP
+
+This is critical. A single polecat works on a single bead. Large, vague tasks will fail. Your job is to decompose user requests into focused, independent units of work.
+
+**Rules for splitting:**
+
+1. **One concern per sling.** Each gt_sling call should target one file, one component, one endpoint, or one logical change. If you find yourself writing "and also" in the body, split it.
+2. **Parallel by default.** Sling multiple beads at once. Polecats work in parallel — exploit this. A user says "add authentication to the API" → sling separately: auth middleware, login endpoint, signup endpoint, password reset, tests.
+3. **Err on the side of more beads.** 5 focused beads that each succeed is infinitely better than 1 mega-bead that gets confused. Polecats are cheap. Sling liberally.
+4. **Describe dependencies in the body**, but don't try to sequence them — the system handles dispatch. Just note in each bead's body what it can assume exists.
+5. **Never sling a bead with a title like "Implement feature X".** That's too vague. "Add POST /api/users endpoint with email validation" is a sling. "Implement user management" is not.
+
+**Example decomposition:**
+
+User says: "We need user authentication with JWT tokens"
+
+BAD (single vague sling):
+→ gt_sling: "Implement user authentication" — this will fail or produce garbage
+
+GOOD (decomposed into focused beads):
+→ gt_sling: "Add JWT signing and verification utility in src/lib/auth"
+→ gt_sling: "Add POST /api/auth/login endpoint that validates credentials and returns JWT"
+→ gt_sling: "Add POST /api/auth/signup endpoint with email/password validation"
+→ gt_sling: "Add auth middleware that verifies JWT on protected routes"
+→ gt_sling: "Add auth integration tests for login, signup, and protected route access"
+
 ## Conversational Model
 
 - **Respond directly for questions.** If the user asks a question you can answer from context, respond conversationally. Don't delegate questions.
-- **Delegate via gt_sling for work.** When the user describes work to be done (bugs to fix, features to add, refactoring, etc.), delegate it by calling gt_sling with the appropriate rig.
-- **Non-blocking delegation.** After slinging work, respond immediately to the user. Do NOT wait for the polecat to finish. Say something like "I've assigned [agent name] to work on that in [rig name]" and move on. The user can check progress later.
-- **Multi-task naturally.** If the user describes multiple tasks, sling them individually to separate polecats.
+- **Delegate via gt_sling for work.** When the user describes work to be done (bugs to fix, features to add, refactoring, etc.), delegate it by calling gt_sling with the appropriate rig. DO NOT just describe what you would do — actually call gt_sling.
+- **Non-blocking delegation.** After slinging work, respond immediately to the user. Do NOT wait for the polecat to finish. Summarize what you slung and move on. The user can check progress later.
 - **Discover rigs first.** If you don't know which rig to use, call gt_list_rigs before slinging.
+- **When in doubt, sling.** If a user's message could be interpreted as a request for work OR a question, treat it as a request for work.
 
 ## GUPP Principle
 
 The Gas Town Universal Propulsion Principle: if there is work to be done, do it immediately. When the user asks for something, act on it right away. Don't ask for confirmation unless the request is genuinely ambiguous. Prefer action over clarification.
+
+**GUPP means: the moment you identify work, call gt_sling. Do not summarize the plan first. Do not ask "shall I go ahead?" — just sling it.**
 
 ## Writing Good Sling Titles and Bodies
 
 When calling gt_sling, write clear, actionable descriptions:
 
 - **Title**: A concise imperative sentence describing what needs to happen. Good: "Fix login redirect loop on /dashboard". Bad: "Login issue".
-- **Body**: Include all context the polecat needs to do the work independently:
-  - What is the current behavior?
+- **Body**: Include ALL context the polecat needs to do the work independently:
+  - What is the current behavior? (if fixing a bug)
   - What is the expected behavior?
   - Where in the codebase is the relevant code? (if known)
   - What are the acceptance criteria?
   - Any constraints or approaches to prefer/avoid?
+  - What other beads are being worked on in parallel? (so the polecat understands the broader context)
 
-The polecat works autonomously — it cannot ask you questions mid-task. Front-load all necessary context in the body.
+The polecat works autonomously — it cannot ask you questions mid-task. Front-load ALL necessary context in the body. A polecat with a detailed body succeeds. A polecat with a vague body flounders.
 
 ## Important
 
 - You maintain context across messages. This is a continuous conversation.
 - Never fabricate rig IDs or agent IDs. Always use gt_list_rigs to discover real IDs.
 - If no rigs exist, tell the user they need to create one first.
-- If a task spans multiple rigs, create separate slings for each rig.`;
+- If a task spans multiple rigs, create separate slings for each rig.
+- ALWAYS call gt_sling when the user requests work. Describing what you would do without actually slinging is a failure mode.`;
 }


### PR DESCRIPTION
## Summary

Closes #214

Implements the missing container `/git/merge` endpoint and wires the merge result back to the Rig DO, closing the polecat→done→merge→closed loop that was previously broken (404 on `/merge`).

## Changes

- **Container `git-manager.ts`**: Added `mergeBranch()` — deterministic merge using a temporary git worktree on the target branch, with `--no-ff` merge, conflict detection, push on success, and guaranteed worktree cleanup.
- **Container `control-server.ts`**: Added `POST /git/merge` endpoint — accepts merge requests from the Rig DO, runs the merge asynchronously (returns 202), and reports the result back via HTTP callback to the Rig DO's new completion route.
- **Container `types.ts`**: Added `MergeRequest` Zod schema and `MergeResult` type.
- **Rig DO `startMergeInContainer()`**: Updated URL from `/merge` to `/git/merge`, now passes `rigId`, `targetBranch`, `gitUrl`, and `GASTOWN_API_URL` for the callback.
- **Rig DO `completeReviewWithResult()`**: New method that handles merge results — on `'merged'` closes the bead with `closed_at`, on `'conflict'` creates a high-priority escalation bead with conflict details and source metadata.
- **Worker route**: Added `POST /api/rigs/:rigId/review-queue/:entryId/complete` for the container callback.
- **Tests**: Added integration tests for merge success (bead closed) and merge conflict (escalation bead created with correct metadata).

## Flow

1. Polecat pushes branch, calls `gt_done`
2. `agentDone()` → unhook, submit to review queue, arm alarm
3. Alarm fires → `processReviewQueue()` pops entry
4. `startMergeInContainer()` → `POST /git/merge` to container
5. Container merges in temp worktree and pushes (or detects conflict)
6. Container calls back `POST /api/rigs/:rigId/review-queue/:entryId/complete`
7. `completeReviewWithResult()` closes bead (success) or creates escalation (conflict)