### PR TITLE
[Gastown] Dashboard UI Overhaul — Phase 1: Activity Feed, Split-Pane Town Home, Event Procedures (#346)

### DIFF
--- a/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/src/app/(app)/gastown/TownListPageClient.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateTownDialog } from '@/components/gastown/CreateTownDialog';
+import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
 import { Plus, Factory, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -25,7 +26,7 @@ export function TownListPageClient() {
   const deleteTown = useMutation(
     trpc.gastown.deleteTown.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listTowns.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listTowns.queryKey() });
         toast.success('Town deleted');
       },
       onError: err => {
@@ -36,31 +37,61 @@ export function TownListPageClient() {
 
   return (
     <PageContainer>
-      <div className="mb-8">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-3xl font-bold text-gray-100">Gastown</h1>
-              <Badge variant="beta">beta</Badge>
+      <GastownBackdrop contentClassName="p-5 md:p-7">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-3">
+                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gastown</h1>
+                <Badge variant="beta">beta</Badge>
+              </div>
+              <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
+                A chat-first orchestration console for towns, rigs, beads, and agents. Built for
+                radical transparency: every object is clickable; every outcome is attributable.
+              </p>
             </div>
-            <p className="text-gray-400">Manage your towns and rigs</p>
+
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => setIsCreateOpen(true)}
+              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+            >
+              <Plus className="size-5" />
+              New Town
+            </Button>
           </div>
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => setIsCreateOpen(true)}
-            className="gap-2"
-          >
-            <Plus className="size-5" />
-            New Town
-          </Button>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+              <div className="text-[11px] tracking-wider text-white/40 uppercase">Towns</div>
+              <div className="mt-0.5 text-lg font-semibold text-white/85">
+                {townsQuery.isLoading ? '…' : (townsQuery.data ?? []).length}
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+              <div className="text-[11px] tracking-wider text-white/40 uppercase">Mode</div>
+              <div className="mt-1 inline-flex items-center gap-2 text-sm text-white/70">
+                <span className="size-2 rounded-full bg-emerald-400" />
+                Live
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+              <div className="text-[11px] tracking-wider text-white/40 uppercase">Core</div>
+              <div className="mt-1 text-sm text-white/70">MEOW · GUPP · NDI</div>
+            </div>
+            <div className="hidden rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 sm:block">
+              <div className="text-[11px] tracking-wider text-white/40 uppercase">Promise</div>
+              <div className="mt-1 text-sm text-white/70">Discover, don’t track</div>
+            </div>
+          </div>
         </div>
-      </div>
+      </GastownBackdrop>
 
       {townsQuery.isLoading && (
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <Card key={i}>
+            <Card key={i} className="border-white/10 bg-white/[0.03]">
               <CardContent className="p-4">
                 <Skeleton className="h-6 w-48" />
                 <Skeleton className="mt-2 h-4 w-32" />
@@ -71,20 +102,25 @@ export function TownListPageClient() {
       )}
 
       {townsQuery.data && townsQuery.data.length === 0 && (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-700 py-16">
-          <Factory className="mb-4 size-12 text-gray-500" />
-          <h3 className="text-lg font-medium text-gray-300">No towns yet</h3>
-          <p className="mt-1 text-sm text-gray-500">Create a town to get started with Gastown</p>
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => setIsCreateOpen(true)}
-            className="mt-4 gap-2"
-          >
-            <Plus className="size-5" />
-            Create your first town
-          </Button>
-        </div>
+        <GastownBackdrop>
+          <div className="flex flex-col items-center justify-center px-6 py-14 text-center">
+            <Factory className="mb-4 size-12 text-white/40" />
+            <h3 className="text-lg font-semibold text-white/85">No towns yet</h3>
+            <p className="mt-2 max-w-md text-sm text-white/55">
+              Create a town to spawn the Mayor and begin delegating work. Your town becomes the
+              command center for every rig.
+            </p>
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => setIsCreateOpen(true)}
+              className="mt-5 gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+            >
+              <Plus className="size-5" />
+              Create your first town
+            </Button>
+          </div>
+        </GastownBackdrop>
       )}
 
       {townsQuery.data && townsQuery.data.length > 0 && (
@@ -92,13 +128,13 @@ export function TownListPageClient() {
           {townsQuery.data.map(town => (
             <Card
               key={town.id}
-              className="cursor-pointer transition-colors hover:bg-gray-800/50"
-              onClick={() => router.push(`/gastown/${town.id}`)}
+              className="cursor-pointer border-white/10 bg-white/[0.03] transition-[border-color,background-color,transform] hover:bg-white/[0.05]"
+              onClick={() => void router.push(`/gastown/${town.id}`)}
             >
               <CardContent className="flex items-center justify-between p-4">
                 <div>
-                  <h3 className="text-lg font-medium text-gray-100">{town.name}</h3>
-                  <p className="text-sm text-gray-500">
+                  <h3 className="text-lg font-medium text-white/90">{town.name}</h3>
+                  <p className="text-sm text-white/50">
                     Created {formatDistanceToNow(new Date(town.created_at), { addSuffix: true })}
                   </p>
                 </div>
@@ -111,7 +147,7 @@ export function TownListPageClient() {
                       deleteTown.mutate({ townId: town.id });
                     }
                   }}
-                  className="rounded p-1.5 text-gray-500 hover:bg-red-500/10 hover:text-red-400"
+                  className="rounded p-1.5 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
                 >
                   <Trash2 className="size-4" />
                 </button>

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateRigDialog } from '@/components/gastown/CreateRigDialog';
 import { MayorChat } from '@/components/gastown/MayorChat';
-import { ActivityFeed } from '@/components/gastown/ActivityFeed';
+import { ActivityFeedView } from '@/components/gastown/ActivityFeed';
 import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
 import { ArrowLeft, Plus, GitBranch, Trash2, Activity, Bot, Users } from 'lucide-react';
 import { toast } from 'sonner';
@@ -240,7 +240,11 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
             </h2>
             <GastownBackdrop>
               <div className="p-0">
-                <ActivityFeed townId={townId} />
+                <ActivityFeedView
+                  townId={townId}
+                  events={(townEventsQuery.data ?? []).slice(-50)}
+                  isLoading={townEventsQuery.isLoading}
+                />
               </div>
             </GastownBackdrop>
           </div>

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -9,7 +9,10 @@ import { Button } from '@/components/Button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateRigDialog } from '@/components/gastown/CreateRigDialog';
-import { ArrowLeft, Plus, GitBranch, Trash2 } from 'lucide-react';
+import { MayorChat } from '@/components/gastown/MayorChat';
+import { ActivityFeed } from '@/components/gastown/ActivityFeed';
+import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
+import { ArrowLeft, Plus, GitBranch, Trash2, Activity, Bot, Users } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -25,11 +28,19 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
   const queryClient = useQueryClient();
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+  const townEventsQuery = useQuery({
+    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 80 }),
+    refetchInterval: 5_000,
+  });
+
+  const escalationsCount = (townEventsQuery.data ?? []).filter(
+    e => e.event_type === 'escalated'
+  ).length;
 
   const deleteRig = useMutation(
     trpc.gastown.deleteRig.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listRigs.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listRigs.queryKey() });
         toast.success('Rig deleted');
       },
       onError: err => {
@@ -40,111 +51,201 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
 
   return (
     <PageContainer>
-      <div className="mb-8">
-        <button
-          onClick={() => router.push('/gastown')}
-          className="mb-4 flex items-center gap-1 text-sm text-gray-400 hover:text-gray-200"
-        >
-          <ArrowLeft className="size-4" />
-          Back to towns
-        </button>
+      <GastownBackdrop contentClassName="p-5 md:p-7">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              onClick={() => void router.push('/gastown')}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-white/60 transition-colors hover:bg-white/5 hover:text-white/85"
+            >
+              <ArrowLeft className="size-4" />
+              Back to towns
+            </button>
 
-        <div className="flex items-center justify-between">
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => setIsCreateRigOpen(true)}
+              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+            >
+              <Plus className="size-5" />
+              New Rig
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <div>
+              {townQuery.isLoading ? (
+                <>
+                  <Skeleton className="h-9 w-56" />
+                  <Skeleton className="mt-2 h-4 w-40" />
+                </>
+              ) : (
+                <>
+                  <h1 className="text-3xl font-semibold tracking-tight text-balance text-white/95">
+                    {townQuery.data?.name}
+                  </h1>
+                  <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
+                    Chat-first command center with radical transparency. Everything here is a live
+                    object: rigs, agents, beads, events.
+                  </p>
+                </>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+                <div className="text-[11px] tracking-wider text-white/40 uppercase">Rigs</div>
+                <div className="mt-0.5 text-lg font-semibold text-white/85">
+                  {(rigsQuery.data ?? []).length}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+                <div className="text-[11px] tracking-wider text-white/40 uppercase">
+                  Escalations
+                </div>
+                <div className="mt-0.5 text-lg font-semibold text-white/85">{escalationsCount}</div>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+                <div className="text-[11px] tracking-wider text-white/40 uppercase">
+                  Events (80)
+                </div>
+                <div className="mt-0.5 text-lg font-semibold text-white/85">
+                  {townEventsQuery.isLoading ? '…' : (townEventsQuery.data ?? []).length}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+                <div className="text-[11px] tracking-wider text-white/40 uppercase">System</div>
+                <div className="mt-1 inline-flex items-center gap-2 text-sm text-white/70">
+                  <span className="size-2 rounded-full bg-emerald-400" />
+                  Live
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </GastownBackdrop>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <div className="lg:col-span-5">
+          <div className="mb-3">
+            <div className="flex items-center gap-2">
+              <Bot className="size-4 text-[color:oklch(95%_0.15_108_/_0.95)]" />
+              <h2 className="text-sm font-medium tracking-wide text-white/70">Mayor</h2>
+            </div>
+            <p className="mt-0.5 text-xs text-white/45">
+              The orchestrator. Describe intent; watch the machine route it into beads and agents.
+            </p>
+          </div>
+          <GastownBackdrop>
+            <div className="p-4">
+              <MayorChat townId={townId} />
+            </div>
+          </GastownBackdrop>
+        </div>
+
+        <div className="space-y-4 lg:col-span-7">
+          {/* Rig Cards */}
           <div>
-            {townQuery.isLoading ? (
-              <>
-                <Skeleton className="h-8 w-48" />
-                <Skeleton className="mt-2 h-4 w-32" />
-              </>
-            ) : (
-              <>
-                <h1 className="text-3xl font-bold text-gray-100">{townQuery.data?.name}</h1>
-                <p className="text-gray-400">Rigs in this town</p>
-              </>
+            <h2 className="mb-2 flex items-center gap-2 text-sm font-medium text-white/70">
+              <Users className="size-4" />
+              Rigs
+            </h2>
+
+            {rigsQuery.isLoading && (
+              <div className="space-y-3">
+                {Array.from({ length: 2 }).map((_, i) => (
+                  <Card key={i}>
+                    <CardContent className="p-3">
+                      <Skeleton className="h-5 w-40" />
+                      <Skeleton className="mt-1.5 h-3.5 w-56" />
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {rigsQuery.data && rigsQuery.data.length === 0 && (
+              <GastownBackdrop>
+                <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
+                  <GitBranch className="size-9 text-white/40" />
+                  <div>
+                    <div className="text-sm font-medium text-white/75">No rigs yet</div>
+                    <div className="mt-1 text-xs text-white/45">
+                      Connect a repo to create a rig; agents will spawn inside the town container.
+                    </div>
+                  </div>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => setIsCreateRigOpen(true)}
+                    className="gap-1 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+                  >
+                    <Plus className="size-4" />
+                    Create rig
+                  </Button>
+                </div>
+              </GastownBackdrop>
+            )}
+
+            {rigsQuery.data && rigsQuery.data.length > 0 && (
+              <div className="space-y-2">
+                {rigsQuery.data.map(rig => (
+                  <Card
+                    key={rig.id}
+                    className="cursor-pointer border-white/10 bg-white/[0.03] transition-[border-color,background-color,transform] hover:bg-white/[0.05]"
+                    onClick={() => void router.push(`/gastown/${townId}/rigs/${rig.id}`)}
+                  >
+                    <CardContent className="flex items-center justify-between p-3">
+                      <div className="min-w-0">
+                        <h3 className="font-medium text-white/85">{rig.name}</h3>
+                        <div className="mt-0.5 flex items-center gap-2 text-xs text-white/55">
+                          <span className="flex items-center gap-1">
+                            <GitBranch className="size-3" />
+                            {rig.default_branch}
+                          </span>
+                          <span className="max-w-[260px] truncate font-mono text-[11px] text-white/45">
+                            {rig.git_url}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <span className="text-xs text-white/45">
+                          {formatDistanceToNow(new Date(rig.created_at), { addSuffix: true })}
+                        </span>
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            if (confirm(`Delete rig "${rig.name}"?`)) {
+                              deleteRig.mutate({ rigId: rig.id });
+                            }
+                          }}
+                          className="rounded p-1 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
+                        >
+                          <Trash2 className="size-3.5" />
+                        </button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             )}
           </div>
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => setIsCreateRigOpen(true)}
-            className="gap-2"
-          >
-            <Plus className="size-5" />
-            New Rig
-          </Button>
+
+          {/* Activity Feed */}
+          <div>
+            <h2 className="mb-2 flex items-center gap-2 text-sm font-medium text-white/70">
+              <Activity className="size-4" />
+              Activity
+            </h2>
+            <GastownBackdrop>
+              <div className="p-0">
+                <ActivityFeed townId={townId} />
+              </div>
+            </GastownBackdrop>
+          </div>
         </div>
       </div>
-
-      {rigsQuery.isLoading && (
-        <div className="space-y-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <Card key={i}>
-              <CardContent className="p-4">
-                <Skeleton className="h-6 w-48" />
-                <Skeleton className="mt-2 h-4 w-64" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
-
-      {rigsQuery.data && rigsQuery.data.length === 0 && (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-700 py-16">
-          <GitBranch className="mb-4 size-12 text-gray-500" />
-          <h3 className="text-lg font-medium text-gray-300">No rigs yet</h3>
-          <p className="mt-1 text-sm text-gray-500">Create a rig to connect a git repository</p>
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => setIsCreateRigOpen(true)}
-            className="mt-4 gap-2"
-          >
-            <Plus className="size-5" />
-            Create your first rig
-          </Button>
-        </div>
-      )}
-
-      {rigsQuery.data && rigsQuery.data.length > 0 && (
-        <div className="space-y-3">
-          {rigsQuery.data.map(rig => (
-            <Card
-              key={rig.id}
-              className="cursor-pointer transition-colors hover:bg-gray-800/50"
-              onClick={() => router.push(`/gastown/${townId}/rigs/${rig.id}`)}
-            >
-              <CardContent className="flex items-center justify-between p-4">
-                <div>
-                  <h3 className="text-lg font-medium text-gray-100">{rig.name}</h3>
-                  <div className="mt-1 flex items-center gap-3 text-sm text-gray-500">
-                    <span className="flex items-center gap-1">
-                      <GitBranch className="size-3.5" />
-                      {rig.default_branch}
-                    </span>
-                    <span className="max-w-xs truncate">{rig.git_url}</span>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className="text-sm text-gray-500">
-                    {formatDistanceToNow(new Date(rig.created_at), { addSuffix: true })}
-                  </span>
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      if (confirm(`Delete rig "${rig.name}"?`)) {
-                        deleteRig.mutate({ rigId: rig.id });
-                      }
-                    }}
-                    className="rounded p-1.5 text-gray-500 hover:bg-red-500/10 hover:text-red-400"
-                  >
-                    <Trash2 className="size-4" />
-                  </button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
 
       <CreateRigDialog
         townId={townId}

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -13,6 +13,8 @@ import { AgentCard } from '@/components/gastown/AgentCard';
 import { AgentStream } from '@/components/gastown/AgentStream';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
 import { MayorChat } from '@/components/gastown/MayorChat';
+import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
+import { GastownBeadDetailSheet } from '@/components/gastown/GastownBeadDetailSheet';
 import { ArrowLeft, Plus, GitBranch } from 'lucide-react';
 
 type RigDetailPageClientProps = {
@@ -25,6 +27,7 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
   const trpc = useTRPC();
   const [isSlingOpen, setIsSlingOpen] = useState(false);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [selectedBeadId, setSelectedBeadId] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
   const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId }));
@@ -33,10 +36,17 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
 
   const rig = rigQuery.data;
 
+  const agentNameById = (agentsQuery.data ?? []).reduce<Record<string, string>>((acc, a) => {
+    acc[a.id] = a.name;
+    return acc;
+  }, {});
+
+  const selectedBead = (beadsQuery.data ?? []).find(b => b.id === selectedBeadId) ?? null;
+
   const deleteBead = useMutation(
     trpc.gastown.deleteBead.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listBeads.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listBeads.queryKey() });
         toast.success('Bead deleted');
       },
       onError: err => toast.error(err.message),
@@ -46,7 +56,7 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
   const deleteAgent = useMutation(
     trpc.gastown.deleteAgent.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listAgents.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listAgents.queryKey() });
         setSelectedAgentId(null);
         toast.success('Agent deleted');
       },
@@ -56,101 +66,166 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
 
   return (
     <PageContainer>
-      <div className="mb-8">
-        <button
-          onClick={() => router.push(`/gastown/${townId}`)}
-          className="mb-4 flex items-center gap-1 text-sm text-gray-400 hover:text-gray-200"
-        >
-          <ArrowLeft className="size-4" />
-          Back to town
-        </button>
+      <GastownBackdrop contentClassName="p-5 md:p-7">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              onClick={() => void router.push(`/gastown/${townId}`)}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-white/60 transition-colors hover:bg-white/5 hover:text-white/85"
+            >
+              <ArrowLeft className="size-4" />
+              Back to town
+            </button>
 
-        <div className="flex items-center justify-between">
-          <div>
-            {rigQuery.isLoading ? (
-              <>
-                <Skeleton className="h-8 w-48" />
-                <Skeleton className="mt-2 h-4 w-64" />
-              </>
-            ) : (
-              <>
-                <h1 className="text-3xl font-bold text-gray-100">{rig?.name}</h1>
-                {rig && (
-                  <div className="mt-1 flex items-center gap-3 text-sm text-gray-400">
-                    <span className="flex items-center gap-1">
-                      <GitBranch className="size-3.5" />
-                      {rig.default_branch}
-                    </span>
-                    <span className="max-w-sm truncate">{rig.git_url}</span>
-                  </div>
-                )}
-              </>
-            )}
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => setIsSlingOpen(true)}
+              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+            >
+              <Plus className="size-5" />
+              Sling Work
+            </Button>
           </div>
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => setIsSlingOpen(true)}
-            className="gap-2"
-          >
-            <Plus className="size-5" />
-            Sling Work
-          </Button>
-        </div>
-      </div>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* Bead Board — takes 2 columns */}
-        <div className="lg:col-span-2">
-          <h2 className="mb-4 text-lg font-semibold text-gray-200">Beads</h2>
-          <BeadBoard
-            beads={beadsQuery.data ?? []}
-            isLoading={beadsQuery.isLoading}
-            onDeleteBead={beadId => {
-              if (confirm('Delete this bead?')) {
-                deleteBead.mutate({ rigId, beadId });
-              }
-            }}
-          />
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              {rigQuery.isLoading ? (
+                <>
+                  <Skeleton className="h-9 w-56" />
+                  <Skeleton className="mt-2 h-4 w-80" />
+                </>
+              ) : (
+                <>
+                  <h1 className="text-3xl font-semibold tracking-tight text-balance text-white/95">
+                    {rig?.name}
+                  </h1>
+                  {rig && (
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-white/60">
+                      <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-1">
+                        <GitBranch className="size-3.5" />
+                        {rig.default_branch}
+                      </span>
+                      <span className="max-w-[560px] truncate rounded-full border border-white/10 bg-black/25 px-3 py-1 font-mono text-[12px] text-white/55">
+                        {rig.git_url}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+
+            <div className="hidden shrink-0 items-center gap-3 lg:flex">
+              <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
+                <div className="text-[11px] tracking-wider text-white/40 uppercase">Beads</div>
+                <div className="mt-0.5 text-sm font-medium text-white/80">
+                  {(beadsQuery.data ?? []).length}
+                </div>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
+                <div className="text-[11px] tracking-wider text-white/40 uppercase">Agents</div>
+                <div className="mt-0.5 text-sm font-medium text-white/80">
+                  {(agentsQuery.data ?? []).length}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </GastownBackdrop>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <div className="lg:col-span-8">
+          <div className="mb-3 flex items-end justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-medium tracking-wide text-white/70">Bead Board</h2>
+              <p className="mt-0.5 text-xs text-white/45">
+                Read-only kanban view with click-through details.
+              </p>
+            </div>
+            <div className="hidden text-xs text-white/45 md:block">
+              Tip: click a bead to open the ledger.
+            </div>
+          </div>
+
+          <GastownBackdrop>
+            <div className="p-4">
+              <BeadBoard
+                beads={beadsQuery.data ?? []}
+                isLoading={beadsQuery.isLoading}
+                onDeleteBead={beadId => {
+                  if (confirm('Delete this bead?')) {
+                    deleteBead.mutate({ rigId, beadId });
+                  }
+                }}
+                onSelectBead={bead => {
+                  setSelectedBeadId(bead.id);
+                }}
+                selectedBeadId={selectedBeadId}
+                agentNameById={agentNameById}
+              />
+            </div>
+          </GastownBackdrop>
         </div>
 
-        {/* Agents sidebar */}
-        <div>
-          <h2 className="mb-4 text-lg font-semibold text-gray-200">Agents</h2>
-          {agentsQuery.isLoading && (
-            <div className="space-y-3">
-              {Array.from({ length: 2 }).map((_, i) => (
-                <Skeleton key={i} className="h-24 w-full rounded-lg" />
-              ))}
+        <div className="lg:col-span-4">
+          <div className="mb-3">
+            <h2 className="text-sm font-medium tracking-wide text-white/70">Agent Roster</h2>
+            <p className="mt-0.5 text-xs text-white/45">
+              Live identities with hook + last activity.
+            </p>
+          </div>
+
+          <GastownBackdrop>
+            <div className="p-4">
+              {agentsQuery.isLoading && (
+                <div className="space-y-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-24 w-full rounded-lg" />
+                  ))}
+                </div>
+              )}
+
+              {agentsQuery.data && agentsQuery.data.length === 0 && (
+                <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4 text-sm text-white/55">
+                  No agents yet. Sling work to spawn a polecat.
+                </div>
+              )}
+
+              {agentsQuery.data && agentsQuery.data.length > 0 && (
+                <div className="space-y-3">
+                  {agentsQuery.data.map(agent => (
+                    <AgentCard
+                      key={agent.id}
+                      agent={agent}
+                      isSelected={selectedAgentId === agent.id}
+                      onSelect={() =>
+                        setSelectedAgentId(prev => (prev === agent.id ? null : agent.id))
+                      }
+                      onDelete={() => {
+                        if (confirm(`Delete agent "${agent.name}"?`)) {
+                          deleteAgent.mutate({ rigId, agentId: agent.id });
+                        }
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
-          )}
-          {agentsQuery.data && agentsQuery.data.length === 0 && (
-            <p className="text-sm text-gray-500">No agents yet. Sling work to create one.</p>
-          )}
-          {agentsQuery.data && agentsQuery.data.length > 0 && (
-            <div className="space-y-3">
-              {agentsQuery.data.map(agent => (
-                <AgentCard
-                  key={agent.id}
-                  agent={agent}
-                  isSelected={selectedAgentId === agent.id}
-                  onSelect={() => setSelectedAgentId(prev => (prev === agent.id ? null : agent.id))}
-                  onDelete={() => {
-                    if (confirm(`Delete agent "${agent.name}"?`)) {
-                      deleteAgent.mutate({ rigId, agentId: agent.id });
-                    }
-                  }}
-                />
-              ))}
-            </div>
-          )}
+          </GastownBackdrop>
         </div>
       </div>
 
       {/* Agent Stream */}
       {selectedAgentId && (
         <div className="mt-6">
-          <h2 className="mb-4 text-lg font-semibold text-gray-200">Agent Stream</h2>
+          <div className="mb-3 flex items-end justify-between">
+            <div>
+              <h2 className="text-sm font-medium tracking-wide text-white/70">Agent Stream</h2>
+              <p className="mt-0.5 text-xs text-white/45">
+                Real-time tool calls, diffs, and narrative output.
+              </p>
+            </div>
+          </div>
           <AgentStream
             townId={townId}
             agentId={selectedAgentId}
@@ -161,9 +236,38 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
 
       {/* Mayor Chat */}
       <div className="mt-6">
-        <h2 className="mb-4 text-lg font-semibold text-gray-200">Mayor Chat</h2>
-        <MayorChat townId={townId} />
+        <div className="mb-3">
+          <h2 className="text-sm font-medium tracking-wide text-white/70">Mayor Chat</h2>
+          <p className="mt-0.5 text-xs text-white/45">
+            Delegate work to the town-level coordinator.
+          </p>
+        </div>
+        <GastownBackdrop>
+          <div className="p-4">
+            <MayorChat townId={townId} />
+          </div>
+        </GastownBackdrop>
       </div>
+
+      <GastownBeadDetailSheet
+        open={Boolean(selectedBeadId)}
+        onOpenChange={open => {
+          if (!open) setSelectedBeadId(null);
+        }}
+        bead={selectedBead}
+        rigId={rigId}
+        agentNameById={agentNameById}
+        onDelete={
+          selectedBead
+            ? () => {
+                if (confirm('Delete this bead?')) {
+                  deleteBead.mutate({ rigId, beadId: selectedBead.id });
+                  setSelectedBeadId(null);
+                }
+              }
+            : undefined
+        }
+      />
 
       <SlingDialog rigId={rigId} isOpen={isSlingOpen} onClose={() => setIsSlingOpen(false)} />
     </PageContainer>

--- a/src/components/gastown/ActivityFeed.tsx
+++ b/src/components/gastown/ActivityFeed.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  Activity,
+  GitMerge,
+  AlertTriangle,
+  CheckCircle,
+  PlayCircle,
+  PauseCircle,
+  Mail,
+} from 'lucide-react';
+
+const EVENT_ICONS: Record<string, typeof Activity> = {
+  created: PlayCircle,
+  hooked: PlayCircle,
+  unhooked: PauseCircle,
+  status_changed: Activity,
+  closed: CheckCircle,
+  escalated: AlertTriangle,
+  review_submitted: GitMerge,
+  review_completed: GitMerge,
+  mail_sent: Mail,
+};
+
+const EVENT_COLORS: Record<string, string> = {
+  created: 'text-blue-500',
+  hooked: 'text-green-500',
+  unhooked: 'text-yellow-500',
+  status_changed: 'text-purple-500',
+  closed: 'text-green-600',
+  escalated: 'text-red-500',
+  review_submitted: 'text-indigo-500',
+  review_completed: 'text-green-600',
+  mail_sent: 'text-sky-500',
+};
+
+function eventDescription(event: {
+  event_type: string;
+  old_value: string | null;
+  new_value: string | null;
+  metadata: Record<string, unknown>;
+  rig_name?: string;
+}): string {
+  const rigPrefix = event.rig_name ? `[${event.rig_name}] ` : '';
+  switch (event.event_type) {
+    case 'created': {
+      const title = event.metadata?.title;
+      return `${rigPrefix}Bead created: ${typeof title === 'string' ? title : (event.new_value ?? 'unknown')}`;
+    }
+    case 'hooked':
+      return `${rigPrefix}Agent hooked to bead`;
+    case 'unhooked':
+      return `${rigPrefix}Agent unhooked from bead`;
+    case 'status_changed':
+      return `${rigPrefix}Status: ${event.old_value ?? '?'} → ${event.new_value ?? '?'}`;
+    case 'closed':
+      return `${rigPrefix}Bead closed`;
+    case 'escalated':
+      return `${rigPrefix}Escalation created`;
+    case 'review_submitted':
+      return `${rigPrefix}Submitted for review: ${event.new_value ?? ''}`;
+    case 'review_completed':
+      return `${rigPrefix}Review ${event.new_value ?? 'completed'}`;
+    case 'mail_sent':
+      return `${rigPrefix}Mail sent`;
+    default:
+      return `${rigPrefix}${event.event_type}`;
+  }
+}
+
+export function ActivityFeed({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+  const { data: events, isLoading } = useQuery({
+    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 50 }),
+    refetchInterval: 5000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 p-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex animate-pulse items-center gap-2">
+            <div className="bg-muted h-4 w-4 rounded-full" />
+            <div className="bg-muted h-3 flex-1 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!events?.length) {
+    return (
+      <div className="text-muted-foreground flex flex-col items-center justify-center p-6 text-sm">
+        <Activity className="mb-2 h-8 w-8 opacity-40" />
+        <p>No activity yet</p>
+      </div>
+    );
+  }
+
+  // Show newest first
+  const sorted = [...events].reverse();
+
+  return (
+    <div className="max-h-[420px] space-y-1 overflow-y-auto p-2">
+      {sorted.map(event => {
+        const Icon = EVENT_ICONS[event.event_type] ?? Activity;
+        const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
+
+        return (
+          <div
+            key={event.id}
+            className="flex items-start gap-2 rounded-xl px-2 py-1.5 text-sm transition-colors hover:bg-white/[0.05]"
+          >
+            <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${color}`} />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-white/85">
+                {eventDescription(event as Parameters<typeof eventDescription>[0])}
+              </p>
+              <p className="text-xs text-white/40">
+                {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+              </p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function BeadEventTimeline({ rigId, beadId }: { rigId: string; beadId: string }) {
+  const trpc = useTRPC();
+  const { data: events, isLoading } = useQuery({
+    ...trpc.gastown.getBeadEvents.queryOptions({ rigId, beadId }),
+    refetchInterval: 5000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 p-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex animate-pulse items-center gap-2">
+            <div className="bg-muted h-3 w-3 rounded-full" />
+            <div className="bg-muted h-2.5 flex-1 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!events?.length) {
+    return <p className="text-muted-foreground p-2 text-xs">No events</p>;
+  }
+
+  return (
+    <div className="space-y-1 p-2">
+      {events.map(event => {
+        const Icon = EVENT_ICONS[event.event_type] ?? Activity;
+        const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
+
+        return (
+          <div key={event.id} className="flex items-start gap-2 py-1 text-xs">
+            <Icon className={`mt-0.5 h-3 w-3 shrink-0 ${color}`} />
+            <div className="min-w-0 flex-1">
+              <span className="text-foreground">
+                {eventDescription(event as Parameters<typeof eventDescription>[0])}
+              </span>
+              <span className="text-muted-foreground ml-1">
+                {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/gastown/AgentCard.tsx
+++ b/src/components/gastown/AgentCard.tsx
@@ -33,7 +33,7 @@ const roleIcons: Record<string, React.ElementType> = {
 };
 
 const statusColors: Record<string, string> = {
-  idle: 'bg-gray-500',
+  idle: 'bg-white/30',
   working: 'bg-green-500',
   blocked: 'bg-yellow-500',
   dead: 'bg-red-500',
@@ -45,36 +45,40 @@ export function AgentCard({ agent, isSelected, onSelect, onDelete }: AgentCardPr
   return (
     <Card
       className={cn(
-        'cursor-pointer border transition-colors',
-        isSelected ? 'border-blue-500/50 bg-blue-500/5' : 'border-gray-700 hover:bg-gray-800/50'
+        'cursor-pointer border transition-[border-color,background-color]',
+        'hover:bg-white/[0.05]',
+        isSelected
+          ? 'border-[color:oklch(95%_0.15_108_/_0.45)] bg-[color:oklch(95%_0.15_108_/_0.06)]'
+          : 'border-white/10 bg-white/[0.03]'
       )}
       onClick={onSelect}
     >
       <CardContent className="p-3">
         <div className="flex items-center gap-3">
-          <div className="flex size-9 items-center justify-center rounded-full bg-gray-700">
-            <Icon className="size-4 text-gray-300" />
+          <div className="flex size-9 items-center justify-center rounded-full border border-white/10 bg-black/30">
+            <Icon className="size-4 text-white/70" />
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <span className="truncate text-sm font-medium text-gray-200">{agent.name}</span>
+              <span className="truncate text-sm font-medium text-white/85">{agent.name}</span>
               <div className={cn('size-2 shrink-0 rounded-full', statusColors[agent.status])} />
             </div>
             <div className="flex items-center gap-2">
               <Badge variant="outline" className="text-xs">
                 {agent.role}
               </Badge>
-              <span className="text-xs text-gray-500">{agent.status}</span>
+              <span className="text-xs text-white/50">{agent.status}</span>
             </div>
           </div>
         </div>
         {agent.current_hook_bead_id && (
-          <p className="mt-2 text-xs text-gray-500">
-            Hooked: {agent.current_hook_bead_id.slice(0, 8)}...
+          <p className="mt-2 text-xs text-white/55">
+            Hooked:{' '}
+            <span className="font-mono text-[11px]">{agent.current_hook_bead_id.slice(0, 8)}…</span>
           </p>
         )}
         <div className="mt-1 flex items-center justify-between">
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-white/40">
             Active {formatDistanceToNow(new Date(agent.last_activity_at), { addSuffix: true })}
           </p>
           {onDelete && (
@@ -83,7 +87,7 @@ export function AgentCard({ agent, isSelected, onSelect, onDelete }: AgentCardPr
                 e.stopPropagation();
                 onDelete();
               }}
-              className="rounded p-1 text-gray-600 hover:bg-red-500/10 hover:text-red-400"
+              className="rounded p-1 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
             >
               <Trash2 className="size-3.5" />
             </button>

--- a/src/components/gastown/AgentStream.tsx
+++ b/src/components/gastown/AgentStream.tsx
@@ -232,13 +232,13 @@ export function AgentStream({ townId, agentId, onClose }: AgentStreamProps) {
   }, [entries]);
 
   return (
-    <Card className="border-gray-700">
+    <Card className="border-white/10 bg-white/[0.02]">
       <CardHeader className="flex flex-row items-center justify-between pb-3">
         <div className="flex items-center gap-2">
           <CardTitle className="text-sm">Agent Stream</CardTitle>
           <div className="flex items-center gap-1">
-            <Radio className={`size-3 ${connected ? 'text-green-400' : 'text-gray-500'}`} />
-            <span className="text-xs text-gray-500">{status}</span>
+            <Radio className={`size-3 ${connected ? 'text-emerald-300' : 'text-white/35'}`} />
+            <span className="text-xs text-white/45">{status}</span>
           </div>
         </div>
         <Button variant="secondary" size="icon" onClick={onClose}>
@@ -248,9 +248,9 @@ export function AgentStream({ townId, agentId, onClose }: AgentStreamProps) {
       <CardContent>
         <div
           ref={scrollRef}
-          className="h-80 overflow-y-auto rounded-md bg-gray-900 p-3 text-sm leading-relaxed"
+          className="h-80 overflow-y-auto rounded-xl border border-white/10 bg-black/40 p-3 text-sm leading-relaxed"
         >
-          {entries.length === 0 && <p className="text-xs text-gray-600">Waiting for events...</p>}
+          {entries.length === 0 && <p className="text-xs text-white/35">Waiting for events...</p>}
           {entries.map(entry => (
             <EntryLine key={entry.id} entry={entry} />
           ))}
@@ -268,7 +268,7 @@ function EntryLine({ entry }: { entry: StreamEntry }) {
           {entry.meta === 'thinking' && (
             <span className="text-xs text-purple-400 italic">thinking: </span>
           )}
-          <span className="whitespace-pre-wrap text-gray-200">{entry.content}</span>
+          <span className="whitespace-pre-wrap text-white/85">{entry.content}</span>
         </div>
       );
 
@@ -278,12 +278,12 @@ function EntryLine({ entry }: { entry: StreamEntry }) {
           <span className="rounded bg-blue-900/50 px-1.5 py-0.5 text-blue-300">
             {entry.content}
           </span>
-          <span className="text-gray-500">{entry.meta}</span>
+          <span className="text-white/45">{entry.meta}</span>
         </div>
       );
 
     case 'status':
-      return <div className="my-2 text-center text-xs text-gray-600">— {entry.content} —</div>;
+      return <div className="my-2 text-center text-xs text-white/35">— {entry.content} —</div>;
 
     case 'error':
       return <div className="mb-1 text-xs text-red-400">Error: {entry.content}</div>;

--- a/src/components/gastown/BeadBoard.tsx
+++ b/src/components/gastown/BeadBoard.tsx
@@ -24,6 +24,9 @@ type BeadBoardProps = {
   beads: Bead[];
   isLoading: boolean;
   onDeleteBead?: (beadId: string) => void;
+  onSelectBead?: (bead: Bead) => void;
+  selectedBeadId?: string | null;
+  agentNameById?: Record<string, string>;
 };
 
 const statusColumns = ['open', 'in_progress', 'closed'] as const;
@@ -41,55 +44,104 @@ const statusColors: Record<string, string> = {
 };
 
 const priorityColors: Record<string, string> = {
-  low: 'text-gray-400',
-  medium: 'text-blue-400',
-  high: 'text-orange-400',
-  critical: 'text-red-400',
+  low: 'text-white/55',
+  medium: 'text-sky-300',
+  high: 'text-amber-300',
+  critical: 'text-red-300',
 };
 
-function BeadCard({ bead, onDelete }: { bead: Bead; onDelete?: () => void }) {
+function BeadCard({
+  bead,
+  onDelete,
+  onSelect,
+  isSelected,
+  agentNameById,
+}: {
+  bead: Bead;
+  onDelete?: () => void;
+  onSelect?: () => void;
+  isSelected?: boolean;
+  agentNameById?: Record<string, string>;
+}) {
+  const assigneeName = bead.assignee_agent_id ? agentNameById?.[bead.assignee_agent_id] : null;
   return (
-    <Card className="border-gray-700 bg-gray-800/50">
-      <CardContent className="p-3">
-        <div className="mb-2 flex items-start justify-between gap-2">
-          <h4 className="line-clamp-2 text-sm font-medium text-gray-200">{bead.title}</h4>
-          <div className="flex shrink-0 items-center gap-1">
-            <span className={cn('text-xs font-medium', priorityColors[bead.priority])}>
-              {bead.priority}
+    <Card
+      className={cn(
+        'group border-white/10 bg-white/[0.03] transition-[border-color,background-color,transform] hover:bg-white/[0.05]',
+        onSelect ? 'cursor-pointer' : 'cursor-default',
+        isSelected
+          ? 'border-[color:oklch(95%_0.15_108_/_0.45)] bg-[color:oklch(95%_0.15_108_/_0.06)]'
+          : ''
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        disabled={!onSelect}
+        className={cn(
+          'w-full text-left disabled:cursor-default',
+          'focus-visible:ring-2 focus-visible:ring-[color:oklch(95%_0.15_108_/_0.35)] focus-visible:ring-offset-0 focus-visible:outline-none'
+        )}
+      >
+        <CardContent className="p-3">
+          <div className="mb-2 flex items-start justify-between gap-2">
+            <h4 className="line-clamp-2 text-sm font-medium text-white/90">{bead.title}</h4>
+            <div className="flex shrink-0 items-center gap-1">
+              <span className={cn('text-xs font-medium', priorityColors[bead.priority])}>
+                {bead.priority}
+              </span>
+              {onDelete && (
+                <button
+                  type="button"
+                  onClick={e => {
+                    e.stopPropagation();
+                    onDelete();
+                  }}
+                  className="rounded p-0.5 text-white/40 transition-colors hover:bg-red-500/10 hover:text-red-300"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="text-xs">
+              {bead.type}
+            </Badge>
+            <span className="text-xs text-white/50">
+              {formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}
             </span>
-            {onDelete && (
-              <button
-                onClick={onDelete}
-                className="rounded p-0.5 text-gray-600 hover:bg-red-500/10 hover:text-red-400"
-              >
-                <Trash2 className="size-3" />
-              </button>
+            {assigneeName && (
+              <span className="text-xs text-white/50">
+                <span className="text-white/30">assigned</span> {assigneeName}
+              </span>
             )}
           </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant="outline" className="text-xs">
-            {bead.type}
-          </Badge>
-          <span className="text-xs text-gray-500">
-            {formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}
-          </span>
-        </div>
-        {bead.labels.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
-            {bead.labels.map(label => (
-              <Badge key={label} variant="secondary" className="text-xs">
-                {label}
-              </Badge>
-            ))}
-          </div>
-        )}
-      </CardContent>
+
+          {bead.labels.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {bead.labels.map(label => (
+                <Badge key={label} variant="secondary" className="text-xs">
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </button>
     </Card>
   );
 }
 
-export function BeadBoard({ beads, isLoading, onDeleteBead }: BeadBoardProps) {
+export function BeadBoard({
+  beads,
+  isLoading,
+  onDeleteBead,
+  onSelectBead,
+  selectedBeadId,
+  agentNameById,
+}: BeadBoardProps) {
   if (isLoading) {
     return (
       <div className="grid grid-cols-3 gap-4">
@@ -121,17 +173,20 @@ export function BeadBoard({ beads, isLoading, onDeleteBead }: BeadBoardProps) {
               >
                 {statusLabels[status]}
               </span>
-              <span className="text-xs text-gray-500">{columnBeads.length}</span>
+              <span className="text-xs text-white/45">{columnBeads.length}</span>
             </div>
             <div className="space-y-2">
               {columnBeads.length === 0 && (
-                <p className="py-4 text-center text-xs text-gray-600">No beads</p>
+                <p className="py-4 text-center text-xs text-white/35">No beads</p>
               )}
               {columnBeads.map(bead => (
                 <BeadCard
                   key={bead.id}
                   bead={bead}
                   onDelete={onDeleteBead ? () => onDeleteBead(bead.id) : undefined}
+                  onSelect={onSelectBead ? () => onSelectBead(bead) : undefined}
+                  isSelected={selectedBeadId === bead.id}
+                  agentNameById={agentNameById}
                 />
               ))}
             </div>

--- a/src/components/gastown/BeadBoard.tsx
+++ b/src/components/gastown/BeadBoard.tsx
@@ -64,6 +64,17 @@ function BeadCard({
   agentNameById?: Record<string, string>;
 }) {
   const assigneeName = bead.assignee_agent_id ? agentNameById?.[bead.assignee_agent_id] : null;
+
+  // Use a non-interactive wrapper (div) + interactive elements inside.
+  // Avoid nesting <button> inside <button> (invalid HTML, a11y issues).
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onSelect) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect();
+    }
+  };
+
   return (
     <Card
       className={cn(
@@ -74,13 +85,17 @@ function BeadCard({
           : ''
       )}
     >
-      <button
-        type="button"
+      <div
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
         onClick={onSelect}
-        disabled={!onSelect}
+        onKeyDown={handleKeyDown}
         className={cn(
-          'w-full text-left disabled:cursor-default',
-          'focus-visible:ring-2 focus-visible:ring-[color:oklch(95%_0.15_108_/_0.35)] focus-visible:ring-offset-0 focus-visible:outline-none'
+          'w-full text-left',
+          onSelect
+            ? 'focus-visible:ring-2 focus-visible:ring-[color:oklch(95%_0.15_108_/_0.35)]'
+            : '',
+          'focus-visible:ring-offset-0 focus-visible:outline-none'
         )}
       >
         <CardContent className="p-3">
@@ -129,7 +144,7 @@ function BeadCard({
             </div>
           )}
         </CardContent>
-      </button>
+      </div>
     </Card>
   );
 }

--- a/src/components/gastown/CreateRigDialog.tsx
+++ b/src/components/gastown/CreateRigDialog.tsx
@@ -30,7 +30,7 @@ export function CreateRigDialog({ townId, isOpen, onClose }: CreateRigDialogProp
   const createRig = useMutation(
     trpc.gastown.createRig.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listRigs.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listRigs.queryKey() });
         toast.success('Rig created');
         setName('');
         setGitUrl('');
@@ -56,35 +56,38 @@ export function CreateRigDialog({ townId, isOpen, onClose }: CreateRigDialogProp
 
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
-      <DialogContent>
+      <DialogContent className="border-white/10 bg-[color:oklch(0.155_0_0)]">
         <DialogHeader>
           <DialogTitle>Create Rig</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">Rig Name</label>
+              <label className="mb-2 block text-sm font-medium text-white/70">Rig Name</label>
               <Input
                 value={name}
                 onChange={e => setName(e.target.value)}
                 placeholder="my-project"
                 autoFocus
+                className="border-white/10 bg-black/25"
               />
             </div>
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">Git URL</label>
+              <label className="mb-2 block text-sm font-medium text-white/70">Git URL</label>
               <Input
                 value={gitUrl}
                 onChange={e => setGitUrl(e.target.value)}
                 placeholder="https://github.com/org/repo.git"
+                className="border-white/10 bg-black/25"
               />
             </div>
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">Default Branch</label>
+              <label className="mb-2 block text-sm font-medium text-white/70">Default Branch</label>
               <Input
                 value={defaultBranch}
                 onChange={e => setDefaultBranch(e.target.value)}
                 placeholder="main"
+                className="border-white/10 bg-black/25"
               />
             </div>
           </div>
@@ -97,6 +100,7 @@ export function CreateRigDialog({ townId, isOpen, onClose }: CreateRigDialogProp
               size="md"
               type="submit"
               disabled={!name.trim() || !gitUrl.trim() || createRig.isPending}
+              className="bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
             >
               {createRig.isPending ? 'Creating...' : 'Create'}
             </Button>

--- a/src/components/gastown/CreateTownDialog.tsx
+++ b/src/components/gastown/CreateTownDialog.tsx
@@ -27,7 +27,7 @@ export function CreateTownDialog({ isOpen, onClose }: CreateTownDialogProps) {
   const createTown = useMutation(
     trpc.gastown.createTown.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listTowns.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listTowns.queryKey() });
         toast.success('Town created');
         setName('');
         onClose();
@@ -46,18 +46,19 @@ export function CreateTownDialog({ isOpen, onClose }: CreateTownDialogProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
-      <DialogContent>
+      <DialogContent className="border-white/10 bg-[color:oklch(0.155_0_0)]">
         <DialogHeader>
           <DialogTitle>Create Town</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="py-4">
-            <label className="mb-2 block text-sm font-medium text-gray-300">Town Name</label>
+            <label className="mb-2 block text-sm font-medium text-white/70">Town Name</label>
             <Input
               value={name}
               onChange={e => setName(e.target.value)}
               placeholder="My Town"
               autoFocus
+              className="border-white/10 bg-black/25"
             />
           </div>
           <DialogFooter>
@@ -69,6 +70,7 @@ export function CreateTownDialog({ isOpen, onClose }: CreateTownDialogProps) {
               size="md"
               type="submit"
               disabled={!name.trim() || createTown.isPending}
+              className="bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
             >
               {createTown.isPending ? 'Creating...' : 'Create'}
             </Button>

--- a/src/components/gastown/GastownBackdrop.tsx
+++ b/src/components/gastown/GastownBackdrop.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+type GastownBackdropProps = {
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+};
+
+export function GastownBackdrop({ children, className, contentClassName }: GastownBackdropProps) {
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-b from-white/[0.06] to-black/25 shadow-[0_30px_120px_-70px_rgba(0,0,0,0.9)]',
+        className
+      )}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-90 [background:radial-gradient(circle_at_18%_0%,rgba(237,255,0,0.14),transparent_48%),radial-gradient(circle_at_84%_22%,rgba(56,189,248,0.12),transparent_44%),radial-gradient(circle_at_60%_120%,rgba(34,197,94,0.10),transparent_46%),linear-gradient(to_bottom,rgba(255,255,255,0.06),transparent_35%)]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-30 mix-blend-overlay [background:repeating-linear-gradient(90deg,rgba(255,255,255,0.06)_0px,rgba(255,255,255,0.06)_1px,transparent_1px,transparent_10px)]"
+      />
+      <div className={cn('relative', contentClassName)}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/gastown/GastownBeadDetailSheet.tsx
+++ b/src/components/gastown/GastownBeadDetailSheet.tsx
@@ -11,21 +11,13 @@ import {
 } from '@/components/ui/sheet';
 import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
 import { cn } from '@/lib/utils';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
 import { formatDistanceToNow } from 'date-fns';
 import { Clock, Flag, Hash, Tags, User } from 'lucide-react';
 
-type Bead = {
-  id: string;
-  type: string;
-  status: string;
-  title: string;
-  body: string | null;
-  assignee_agent_id: string | null;
-  priority: string;
-  labels: string[];
-  created_at: string;
-  closed_at: string | null;
-};
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Bead = RouterOutputs['gastown']['listBeads'][number];
 
 type GastownBeadDetailSheetProps = {
   open: boolean;

--- a/src/components/gastown/GastownBeadDetailSheet.tsx
+++ b/src/components/gastown/GastownBeadDetailSheet.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/Button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
+import { cn } from '@/lib/utils';
+import { formatDistanceToNow } from 'date-fns';
+import { Clock, Flag, Hash, Tags, User } from 'lucide-react';
+
+type Bead = {
+  id: string;
+  type: string;
+  status: string;
+  title: string;
+  body: string | null;
+  assignee_agent_id: string | null;
+  priority: string;
+  labels: string[];
+  created_at: string;
+  closed_at: string | null;
+};
+
+type GastownBeadDetailSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bead: Bead | null;
+  rigId: string;
+  agentNameById?: Record<string, string>;
+  onDelete?: () => void;
+};
+
+function MetaRow({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <Icon className="mt-0.5 size-4 text-white/40" />
+      <div className="min-w-0">
+        <div className="text-xs text-white/45">{label}</div>
+        <div className="truncate text-sm text-white/85">{value}</div>
+      </div>
+    </div>
+  );
+}
+
+export function GastownBeadDetailSheet({
+  open,
+  onOpenChange,
+  bead,
+  rigId,
+  agentNameById,
+  onDelete,
+}: GastownBeadDetailSheetProps) {
+  const assigneeName = bead?.assignee_agent_id ? agentNameById?.[bead.assignee_agent_id] : null;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className={cn(
+          'w-[540px] max-w-[92vw] border-white/10 bg-[color:oklch(0.155_0_0)]',
+          'shadow-[0_30px_120px_-70px_rgba(0,0,0,0.95)]'
+        )}
+      >
+        <SheetHeader className="gap-2">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <SheetTitle className="truncate text-base text-white/90">
+                {bead?.title ?? 'Bead'}
+              </SheetTitle>
+              <SheetDescription className="mt-1 text-xs text-white/45">
+                Click-through audit trail: events, status changes, hooks, and mail.
+              </SheetDescription>
+            </div>
+            {onDelete && bead && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={onDelete}
+                className="shrink-0 border border-red-500/25 bg-red-500/10 text-red-200 hover:bg-red-500/15"
+              >
+                Delete
+              </Button>
+            )}
+          </div>
+
+          {bead && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="text-xs">
+                {bead.type}
+              </Badge>
+              <Badge variant="secondary" className="text-xs">
+                {bead.status}
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                <Flag className="size-3" />
+                {bead.priority}
+              </Badge>
+            </div>
+          )}
+        </SheetHeader>
+
+        <div className="space-y-4 px-4">
+          {!bead ? (
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-sm text-white/50">
+              Select a bead to inspect details.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                <MetaRow icon={Hash} label="Bead ID" value={bead.id} />
+                <MetaRow
+                  icon={Clock}
+                  label="Created"
+                  value={formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}
+                />
+                <MetaRow
+                  icon={User}
+                  label="Assignee"
+                  value={
+                    assigneeName ?? (bead.assignee_agent_id ? bead.assignee_agent_id : 'Unassigned')
+                  }
+                />
+                <MetaRow
+                  icon={Tags}
+                  label="Labels"
+                  value={bead.labels.length ? bead.labels.join(', ') : 'None'}
+                />
+              </div>
+
+              {bead.body && bead.body.trim().length > 0 && (
+                <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                  <div className="text-xs font-medium tracking-wide text-white/55">Body</div>
+                  <div className="mt-2 text-sm leading-relaxed whitespace-pre-wrap text-white/80">
+                    {bead.body}
+                  </div>
+                </div>
+              )}
+
+              <div className="rounded-2xl border border-white/10 bg-white/[0.02]">
+                <div className="border-b border-white/10 px-4 py-3">
+                  <div className="text-xs font-medium tracking-wide text-white/55">
+                    Event Timeline
+                  </div>
+                  <div className="mt-1 text-xs text-white/40">
+                    Append-only ledger for this bead.
+                  </div>
+                </div>
+                <BeadEventTimeline rigId={rigId} beadId={bead.id} />
+              </div>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/gastown/MayorChat.tsx
+++ b/src/components/gastown/MayorChat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Card, CardContent } from '@/components/ui/card';
@@ -25,7 +25,9 @@ function SessionStatusBadge({ status }: { status: string }) {
   return (
     <span
       className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
-        isActive ? 'bg-green-900/40 text-green-400' : 'bg-gray-800 text-gray-400'
+        isActive
+          ? 'bg-emerald-500/10 text-emerald-200 ring-1 ring-emerald-400/20'
+          : 'bg-white/5 text-white/55 ring-1 ring-white/10'
       }`}
     >
       <Radio className={`size-2.5 ${isActive ? 'animate-pulse' : ''}`} />
@@ -53,7 +55,7 @@ export function MayorChat({ townId }: MayorChatProps) {
   const sendMessage = useMutation(
     trpc.gastown.sendMessage.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({
+        void queryClient.invalidateQueries({
           queryKey: trpc.gastown.getMayorStatus.queryKey(),
         });
         toast.success('Message sent to Mayor');
@@ -98,13 +100,13 @@ export function MayorChat({ townId }: MayorChatProps) {
 
   return (
     <div className="space-y-4">
-      <Card className="border-gray-700">
+      <Card className="border-white/10 bg-transparent shadow-none">
         <CardContent className="p-4">
           {/* Status indicator */}
           {session && (
             <div className="mb-3 flex items-center justify-between text-sm">
               <SessionStatusBadge status={session.status} />
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-white/45">
                 Last activity: {new Date(session.lastActivityAt).toLocaleTimeString()}
               </span>
             </div>
@@ -117,14 +119,14 @@ export function MayorChat({ townId }: MayorChatProps) {
               onChange={e => setMessage(e.target.value)}
               placeholder="Send a message to the Mayor..."
               disabled={sendMessage.isPending}
-              className="flex-1"
+              className="flex-1 border-white/10 bg-black/25"
             />
             <Button
               variant="primary"
               size="md"
               type="submit"
               disabled={!message.trim() || sendMessage.isPending}
-              className="gap-2"
+              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
             >
               <Send className="size-4" />
               {sendMessage.isPending ? 'Sending...' : 'Send'}

--- a/src/components/gastown/SlingDialog.tsx
+++ b/src/components/gastown/SlingDialog.tsx
@@ -46,9 +46,9 @@ export function SlingDialog({ rigId, isOpen, onClose }: SlingDialogProps) {
   const sling = useMutation(
     trpc.gastown.sling.mutationOptions({
       onSuccess: result => {
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listBeads.queryKey() });
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listAgents.queryKey() });
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.getRig.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listBeads.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.listAgents.queryKey() });
+        void queryClient.invalidateQueries({ queryKey: trpc.gastown.getRig.queryKey() });
         toast.success(`Work slung to ${result.agent.name}`);
         setTitle('');
         setBody('');
@@ -74,23 +74,24 @@ export function SlingDialog({ rigId, isOpen, onClose }: SlingDialogProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
-      <DialogContent>
+      <DialogContent className="border-white/10 bg-[color:oklch(0.155_0_0)]">
         <DialogHeader>
           <DialogTitle>Sling Work</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">Title</label>
+              <label className="mb-2 block text-sm font-medium text-white/70">Title</label>
               <Input
                 value={title}
                 onChange={e => setTitle(e.target.value)}
                 placeholder="What needs to be done?"
                 autoFocus
+                className="border-white/10 bg-black/25"
               />
             </div>
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">
+              <label className="mb-2 block text-sm font-medium text-white/70">
                 Description (optional)
               </label>
               <Textarea
@@ -98,10 +99,11 @@ export function SlingDialog({ rigId, isOpen, onClose }: SlingDialogProps) {
                 onChange={e => setBody(e.target.value)}
                 placeholder="Additional context or requirements..."
                 rows={4}
+                className="border-white/10 bg-black/25"
               />
             </div>
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">Model</label>
+              <label className="mb-2 block text-sm font-medium text-white/70">Model</label>
               <Select value={model} onValueChange={setModel}>
                 <SelectTrigger>
                   <SelectValue />
@@ -125,6 +127,7 @@ export function SlingDialog({ rigId, isOpen, onClose }: SlingDialogProps) {
               size="md"
               type="submit"
               disabled={!title.trim() || sling.isPending}
+              className="bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
             >
               {sling.isPending ? 'Slinging...' : 'Sling'}
             </Button>

--- a/src/lib/gastown/gastown-client.ts
+++ b/src/lib/gastown/gastown-client.ts
@@ -50,14 +50,14 @@ export const BeadSchema = z.object({
     z.array(z.string()),
     z
       .string()
-      .transform(v => JSON.parse(v))
+      .transform(v => JSON.parse(v) as unknown)
       .pipe(z.array(z.string())),
   ]),
   metadata: z.union([
     z.record(z.string(), z.unknown()),
     z
       .string()
-      .transform(v => JSON.parse(v))
+      .transform(v => JSON.parse(v) as unknown)
       .pipe(z.record(z.string(), z.unknown())),
   ]),
   created_at: z.string(),
@@ -314,6 +314,60 @@ export async function deleteBead(rigId: string, beadId: string): Promise<void> {
 
 export async function deleteAgent(rigId: string, agentId: string): Promise<void> {
   await gastownFetch(`/api/rigs/${rigId}/agents/${agentId}`, { method: 'DELETE' });
+}
+
+// ── Event operations ──────────────────────────────────────────────────────
+
+export const BeadEventSchema = z.object({
+  id: z.string(),
+  bead_id: z.string(),
+  agent_id: z.string().nullable(),
+  event_type: z.string(),
+  old_value: z.string().nullable(),
+  new_value: z.string().nullable(),
+  metadata: z.union([
+    z.record(z.string(), z.unknown()),
+    z
+      .string()
+      .transform(v => JSON.parse(v) as unknown)
+      .pipe(z.record(z.string(), z.unknown())),
+  ]),
+  created_at: z.string(),
+});
+export type BeadEvent = z.output<typeof BeadEventSchema>;
+
+export const TaggedBeadEventSchema = BeadEventSchema.extend({
+  rig_id: z.string(),
+  rig_name: z.string(),
+});
+export type TaggedBeadEvent = z.output<typeof TaggedBeadEventSchema>;
+
+export async function listBeadEvents(
+  rigId: string,
+  options?: { beadId?: string; since?: string; limit?: number }
+): Promise<BeadEvent[]> {
+  const params = new URLSearchParams();
+  if (options?.beadId) params.set('bead_id', options.beadId);
+  if (options?.since) params.set('since', options.since);
+  if (options?.limit) params.set('limit', String(options.limit));
+  const qs = params.toString();
+  const path = `/api/rigs/${rigId}/events${qs ? `?${qs}` : ''}`;
+  const body = await gastownFetch(path);
+  return parseSuccessData(body, BeadEventSchema.array());
+}
+
+export async function listTownEvents(
+  userId: string,
+  townId: string,
+  options?: { since?: string; limit?: number }
+): Promise<TaggedBeadEvent[]> {
+  const params = new URLSearchParams();
+  if (options?.since) params.set('since', options.since);
+  if (options?.limit) params.set('limit', String(options.limit));
+  const qs = params.toString();
+  const path = `/api/users/${userId}/towns/${townId}/events${qs ? `?${qs}` : ''}`;
+  const body = await gastownFetch(path);
+  return parseSuccessData(body, TaggedBeadEventSchema.array());
 }
 
 // ── Container operations (via Town Container DO) ──────────────────────────


### PR DESCRIPTION
## Summary

Closes #346 (Phase 1)

Phase 1 of the dashboard UI overhaul — adds the event-driven activity feed and restructures the town overview into a split-pane layout.

## Changes

### Backend (gastown-client + tRPC)
- **`gastown-client.ts`**: Added `BeadEventSchema`, `TaggedBeadEventSchema`, `listBeadEvents()`, `listTownEvents()` server-side fetch functions
- **`gastown-router.ts`**: Added `getBeadEvents` and `getTownEvents` tRPC procedures with ownership checks, pagination, and `since` timestamp filtering

### Frontend Components
- **`ActivityFeed.tsx`**: New component that polls town events every 5s, renders a timeline with typed icons (PlayCircle, CheckCircle, AlertTriangle, GitMerge, etc.) and color-coded event types. Shows newest-first. Includes `BeadEventTimeline` for per-bead detail panels.
- **`TownOverviewPageClient.tsx`**: Restructured into split-pane layout:
  - **Left pane (2/5)**: Mayor chat with descriptive header
  - **Right pane (3/5)**: Rig cards + live activity feed
  - Responsive — stacks on mobile, side-by-side on `lg+`

### Depends On
- PR #353 (Manual Merge Flow + Event Log) for the `bead_events` table and `/events` endpoints