### PR TITLE
Cloud Agent - Add interactive question answering and rejecting

### DIFF
--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -363,7 +363,7 @@ describe('WrapperClient', () => {
       );
       const client = new WrapperClient({ session, port: defaultPort });
 
-      const result = await client.answerQuestion('q_123', ['Yes']);
+      const result = await client.answerQuestion('q_123', [['Yes']]);
 
       expect(result.success).toBe(true);
     });
@@ -374,7 +374,7 @@ describe('WrapperClient', () => {
       );
       const client = new WrapperClient({ session, port: defaultPort });
 
-      await client.answerQuestion('q_456', ['Option A', 'Option B']);
+      await client.answerQuestion('q_456', [['Option A', 'Option B']]);
 
       const execCall = (session.exec as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(execCall).toContain('/job/answer-question');

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -376,7 +376,7 @@ export class WrapperClient {
   /**
    * Answer a question.
    */
-  async answerQuestion(questionId: string, answers: string[]): Promise<{ success: boolean }> {
+  async answerQuestion(questionId: string, answers: string[][]): Promise<{ success: boolean }> {
     const result = await this.request<{
       status: string;
       success: boolean;

--- a/cloud-agent-next/src/router.ts
+++ b/cloud-agent-next/src/router.ts
@@ -8,11 +8,13 @@ import { router } from './router/auth.js';
 import { createSessionManagementHandlers } from './router/handlers/session-management.js';
 import { createSessionPrepareHandlers } from './router/handlers/session-prepare.js';
 import { createSessionExecutionV2Handlers } from './router/handlers/session-execution.js';
+import { createSessionQuestionHandlers } from './router/handlers/session-questions.js';
 
 export const appRouter = router({
   ...createSessionManagementHandlers(),
   ...createSessionPrepareHandlers(),
   ...createSessionExecutionV2Handlers(),
+  ...createSessionQuestionHandlers(),
 });
 
 export type AppRouter = typeof appRouter;

--- a/cloud-agent-next/src/router/handlers/session-questions.ts
+++ b/cloud-agent-next/src/router/handlers/session-questions.ts
@@ -1,0 +1,156 @@
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+import { getSandbox } from '@cloudflare/sandbox';
+import { logger, withLogTags } from '../../logger.js';
+import { generateSandboxId } from '../../sandbox-id.js';
+import type { SessionId, SandboxId } from '../../types.js';
+import { SessionService, fetchSessionMetadata } from '../../session-service.js';
+import { protectedProcedure } from '../auth.js';
+import { sessionIdSchema } from '../schemas.js';
+import { findWrapperForSession } from '../../kilo/wrapper-manager.js';
+import { WrapperClient } from '../../kilo/wrapper-client.js';
+
+export function createSessionQuestionHandlers() {
+  return {
+    answerQuestion: protectedProcedure
+      .input(
+        z.object({
+          sessionId: sessionIdSchema,
+          questionId: z.string().min(1),
+          answers: z.array(z.array(z.string())),
+        })
+      )
+      .mutation(async ({ input, ctx }) => {
+        return withLogTags({ source: 'answerQuestion' }, async () => {
+          const sessionId = input.sessionId as SessionId;
+          const { userId, env } = ctx;
+
+          logger.setTags({ userId, sessionId });
+          logger.info('Answering question', { questionId: input.questionId });
+
+          try {
+            const metadata = await fetchSessionMetadata(env, userId, sessionId);
+            if (!metadata) {
+              throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
+            }
+
+            const sandboxId: SandboxId = await generateSandboxId(
+              metadata.orgId,
+              userId,
+              metadata.botId
+            );
+            const sandbox = getSandbox(env.Sandbox, sandboxId);
+
+            const wrapperInfo = await findWrapperForSession(sandbox, sessionId);
+            if (!wrapperInfo) {
+              throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: 'No wrapper found for session',
+              });
+            }
+
+            const sessionService = new SessionService();
+            const context = sessionService.buildContext({
+              sandboxId,
+              orgId: metadata.orgId,
+              userId,
+              sessionId,
+              upstreamBranch: metadata.upstreamBranch,
+              botId: metadata.botId,
+            });
+
+            const session = await sessionService.getOrCreateSession(
+              sandbox,
+              context,
+              env,
+              ctx.authToken,
+              metadata.orgId
+            );
+
+            const wrapperClient = new WrapperClient({ session, port: wrapperInfo.port });
+            const result = await wrapperClient.answerQuestion(input.questionId, input.answers);
+
+            return { success: result.success };
+          } catch (error) {
+            if (error instanceof TRPCError) throw error;
+            const errorMsg = error instanceof Error ? error.message : String(error);
+            logger.withFields({ error: errorMsg }).error('Failed to answer question');
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: `Failed to answer question: ${errorMsg}`,
+            });
+          }
+        });
+      }),
+
+    rejectQuestion: protectedProcedure
+      .input(
+        z.object({
+          sessionId: sessionIdSchema,
+          questionId: z.string().min(1),
+        })
+      )
+      .mutation(async ({ input, ctx }) => {
+        return withLogTags({ source: 'rejectQuestion' }, async () => {
+          const sessionId = input.sessionId as SessionId;
+          const { userId, env } = ctx;
+
+          logger.setTags({ userId, sessionId });
+          logger.info('Rejecting question', { questionId: input.questionId });
+
+          try {
+            const metadata = await fetchSessionMetadata(env, userId, sessionId);
+            if (!metadata) {
+              throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
+            }
+
+            const sandboxId: SandboxId = await generateSandboxId(
+              metadata.orgId,
+              userId,
+              metadata.botId
+            );
+            const sandbox = getSandbox(env.Sandbox, sandboxId);
+
+            const wrapperInfo = await findWrapperForSession(sandbox, sessionId);
+            if (!wrapperInfo) {
+              throw new TRPCError({
+                code: 'NOT_FOUND',
+                message: 'No wrapper found for session',
+              });
+            }
+
+            const sessionService = new SessionService();
+            const context = sessionService.buildContext({
+              sandboxId,
+              orgId: metadata.orgId,
+              userId,
+              sessionId,
+              upstreamBranch: metadata.upstreamBranch,
+              botId: metadata.botId,
+            });
+
+            const session = await sessionService.getOrCreateSession(
+              sandbox,
+              context,
+              env,
+              ctx.authToken,
+              metadata.orgId
+            );
+
+            const wrapperClient = new WrapperClient({ session, port: wrapperInfo.port });
+            const result = await wrapperClient.rejectQuestion(input.questionId);
+
+            return { success: result.success };
+          } catch (error) {
+            if (error instanceof TRPCError) throw error;
+            const errorMsg = error instanceof Error ? error.message : String(error);
+            logger.withFields({ error: errorMsg }).error('Failed to reject question');
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: `Failed to reject question: ${errorMsg}`,
+            });
+          }
+        });
+      }),
+  };
+}

--- a/cloud-agent-next/src/router/handlers/session-questions.ts
+++ b/cloud-agent-next/src/router/handlers/session-questions.ts
@@ -3,12 +3,54 @@ import * as z from 'zod';
 import { getSandbox } from '@cloudflare/sandbox';
 import { logger, withLogTags } from '../../logger.js';
 import { generateSandboxId } from '../../sandbox-id.js';
-import type { SessionId, SandboxId } from '../../types.js';
+import type { SessionId, SandboxId, Env } from '../../types.js';
 import { SessionService, fetchSessionMetadata } from '../../session-service.js';
 import { protectedProcedure } from '../auth.js';
 import { sessionIdSchema } from '../schemas.js';
 import { findWrapperForSession } from '../../kilo/wrapper-manager.js';
 import { WrapperClient } from '../../kilo/wrapper-client.js';
+
+async function resolveWrapperClient(opts: {
+  sessionId: SessionId;
+  userId: string;
+  env: Env;
+  authToken: string;
+}): Promise<WrapperClient> {
+  const { sessionId, userId, env, authToken } = opts;
+
+  const metadata = await fetchSessionMetadata(env, userId, sessionId);
+  if (!metadata) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
+  }
+
+  const sandboxId: SandboxId = await generateSandboxId(metadata.orgId, userId, metadata.botId);
+  const sandbox = getSandbox(env.Sandbox, sandboxId);
+
+  const wrapperInfo = await findWrapperForSession(sandbox, sessionId);
+  if (!wrapperInfo) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'No wrapper found for session' });
+  }
+
+  const sessionService = new SessionService();
+  const context = sessionService.buildContext({
+    sandboxId,
+    orgId: metadata.orgId,
+    userId,
+    sessionId,
+    upstreamBranch: metadata.upstreamBranch,
+    botId: metadata.botId,
+  });
+
+  const session = await sessionService.getOrCreateSession(
+    sandbox,
+    context,
+    env,
+    authToken,
+    metadata.orgId
+  );
+
+  return new WrapperClient({ session, port: wrapperInfo.port });
+}
 
 export function createSessionQuestionHandlers() {
   return {
@@ -29,47 +71,13 @@ export function createSessionQuestionHandlers() {
           logger.info('Answering question', { questionId: input.questionId });
 
           try {
-            const metadata = await fetchSessionMetadata(env, userId, sessionId);
-            if (!metadata) {
-              throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
-            }
-
-            const sandboxId: SandboxId = await generateSandboxId(
-              metadata.orgId,
-              userId,
-              metadata.botId
-            );
-            const sandbox = getSandbox(env.Sandbox, sandboxId);
-
-            const wrapperInfo = await findWrapperForSession(sandbox, sessionId);
-            if (!wrapperInfo) {
-              throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: 'No wrapper found for session',
-              });
-            }
-
-            const sessionService = new SessionService();
-            const context = sessionService.buildContext({
-              sandboxId,
-              orgId: metadata.orgId,
-              userId,
+            const wrapperClient = await resolveWrapperClient({
               sessionId,
-              upstreamBranch: metadata.upstreamBranch,
-              botId: metadata.botId,
-            });
-
-            const session = await sessionService.getOrCreateSession(
-              sandbox,
-              context,
+              userId,
               env,
-              ctx.authToken,
-              metadata.orgId
-            );
-
-            const wrapperClient = new WrapperClient({ session, port: wrapperInfo.port });
+              authToken: ctx.authToken,
+            });
             const result = await wrapperClient.answerQuestion(input.questionId, input.answers);
-
             return { success: result.success };
           } catch (error) {
             if (error instanceof TRPCError) throw error;
@@ -99,47 +107,13 @@ export function createSessionQuestionHandlers() {
           logger.info('Rejecting question', { questionId: input.questionId });
 
           try {
-            const metadata = await fetchSessionMetadata(env, userId, sessionId);
-            if (!metadata) {
-              throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
-            }
-
-            const sandboxId: SandboxId = await generateSandboxId(
-              metadata.orgId,
-              userId,
-              metadata.botId
-            );
-            const sandbox = getSandbox(env.Sandbox, sandboxId);
-
-            const wrapperInfo = await findWrapperForSession(sandbox, sessionId);
-            if (!wrapperInfo) {
-              throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: 'No wrapper found for session',
-              });
-            }
-
-            const sessionService = new SessionService();
-            const context = sessionService.buildContext({
-              sandboxId,
-              orgId: metadata.orgId,
-              userId,
+            const wrapperClient = await resolveWrapperClient({
               sessionId,
-              upstreamBranch: metadata.upstreamBranch,
-              botId: metadata.botId,
-            });
-
-            const session = await sessionService.getOrCreateSession(
-              sandbox,
-              context,
+              userId,
               env,
-              ctx.authToken,
-              metadata.orgId
-            );
-
-            const wrapperClient = new WrapperClient({ session, port: wrapperInfo.port });
+              authToken: ctx.authToken,
+            });
             const result = await wrapperClient.rejectQuestion(input.questionId);
-
             return { success: result.success };
           } catch (error) {
             if (error instanceof TRPCError) throw error;

--- a/cloud-agent-next/wrapper/src/kilo-client.ts
+++ b/cloud-agent-next/wrapper/src/kilo-client.ts
@@ -90,7 +90,7 @@ export type KiloClient = {
   /** Answer a permission request */
   answerPermission: (permissionId: string, response: PermissionResponse) => Promise<boolean>;
   /** Answer a question */
-  answerQuestion: (questionId: string, answers: string[]) => Promise<boolean>;
+  answerQuestion: (questionId: string, answers: string[][]) => Promise<boolean>;
   /** Reject a question */
   rejectQuestion: (questionId: string) => Promise<boolean>;
 };
@@ -191,7 +191,7 @@ export function createKiloClient(baseUrl: string): KiloClient {
       return true;
     },
 
-    answerQuestion: async (questionId: string, answers: string[]) => {
+    answerQuestion: async (questionId: string, answers: string[][]) => {
       // Question answers go to POST /question/:questionId/reply
       await requestNoContent('POST', `/question/${questionId}/reply`, { answers });
       return true;

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -72,7 +72,7 @@ type AnswerPermissionBody = {
 
 type AnswerQuestionBody = {
   questionId: string;
-  answers: string[];
+  answers: string[][];
 };
 
 type RejectQuestionBody = {

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -41,6 +41,7 @@ import {
 import { useCloudAgentStream } from './useCloudAgentStream';
 import { useAutoScroll } from './hooks/useAutoScroll';
 import { useCelebrationSound } from '@/hooks/useCelebrationSound';
+import { useNotificationSound } from '@/hooks/useNotificationSound';
 import { useSidebarSessions } from './hooks/useSidebarSessions';
 import { useOrganizationModels } from './hooks/useOrganizationModels';
 import { useSessionDeletion } from './hooks/useSessionDeletion';
@@ -190,6 +191,9 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   // Celebration sound
   const { play: playCelebrationSound, soundEnabled, setSoundEnabled } = useCelebrationSound();
 
+  // Notification chime for agent questions
+  const { playNotification } = useNotificationSound();
+
   // Toggle sound handler
   const handleToggleSound = useCallback(() => {
     setSoundEnabled(prev => !prev);
@@ -246,6 +250,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
     onComplete: handleStreamComplete,
     onKiloSessionCreated: handleKiloSessionCreated,
     onSessionInitiated: handleSessionInitiated,
+    onQuestionAsked: playNotification,
   });
 
   // Wrapper for sendMessage that doesn't use sessionIdOverride

--- a/src/components/cloud-agent-next/QuestionToolCard.tsx
+++ b/src/components/cloud-agent-next/QuestionToolCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
-import { ChevronDown, Loader2, XCircle, Check, Send, X } from 'lucide-react';
+import { ChevronDown, Loader2, XCircle, Check, Send, X, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRawTRPCClient } from '@/lib/trpc/utils';
 import {
@@ -111,15 +111,19 @@ function InteractiveQuestionContent({
   question,
   selectedLabels,
   customInput,
+  customSelected,
   onToggleOption,
   onCustomInputChange,
+  onToggleCustom,
   showHeader = true,
 }: {
   question: QuestionInfo;
   selectedLabels: string[];
   customInput: string;
+  customSelected: boolean;
   onToggleOption: (label: string) => void;
   onCustomInputChange: (value: string) => void;
+  onToggleCustom: () => void;
   showHeader?: boolean;
 }) {
   const isMultiple = question.multiple === true;
@@ -132,56 +136,87 @@ function InteractiveQuestionContent({
       )}
       <div className="text-sm font-medium">{question.question}</div>
 
-      {question.options && question.options.length > 0 && (
-        <div className="space-y-1.5">
-          {question.options.map((option, idx) => {
-            const isSelected = selectedLabels.includes(option.label);
-            return (
+      <div className="space-y-1.5">
+        {question.options?.map((option, idx) => {
+          const isSelected = selectedLabels.includes(option.label);
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => onToggleOption(option.label)}
+              className={cn(
+                'w-full rounded-md border px-3 py-2 text-left text-xs transition-colors',
+                isSelected
+                  ? 'bg-primary/15 border-primary/60 ring-primary/30 ring-1'
+                  : 'border-muted bg-muted/20 hover:bg-muted/40 hover:border-muted-foreground/30'
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <div
+                  className={cn(
+                    'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                    isMultiple ? 'rounded' : 'rounded-full',
+                    isSelected
+                      ? 'bg-primary border-primary text-primary-foreground'
+                      : 'border-muted-foreground/40'
+                  )}
+                >
+                  {isSelected && <Check className="h-2.5 w-2.5" />}
+                </div>
+                <span className={cn('font-medium', isSelected && 'text-primary')}>
+                  {option.label}
+                </span>
+              </div>
+              {option.description && (
+                <div className="text-muted-foreground mt-1 pl-6">{option.description}</div>
+              )}
+            </button>
+          );
+        })}
+
+        {allowCustom && (
+          <div
+            role="button"
+            tabIndex={-1}
+            onClick={() => {
+              if (!customSelected) onToggleCustom();
+            }}
+            className={cn(
+              'w-full rounded-md border px-3 py-2 text-left text-xs transition-colors',
+              customSelected
+                ? 'bg-primary/15 border-primary/60 ring-primary/30 ring-1'
+                : 'border-muted bg-muted/20 hover:bg-muted/40 hover:border-muted-foreground/30'
+            )}
+          >
+            <div className="flex items-center gap-2">
               <button
-                key={idx}
                 type="button"
-                onClick={() => onToggleOption(option.label)}
+                onClick={e => {
+                  e.stopPropagation();
+                  onToggleCustom();
+                }}
                 className={cn(
-                  'w-full rounded-md border px-3 py-2 text-left text-xs transition-colors',
-                  isSelected
-                    ? 'bg-primary/15 border-primary/60 ring-primary/30 ring-1'
-                    : 'border-muted bg-muted/20 hover:bg-muted/40 hover:border-muted-foreground/30'
+                  'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                  isMultiple ? 'rounded' : 'rounded-full',
+                  customSelected
+                    ? 'bg-primary border-primary text-primary-foreground'
+                    : 'border-muted-foreground/40'
                 )}
               >
-                <div className="flex items-center gap-2">
-                  <div
-                    className={cn(
-                      'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
-                      isMultiple ? 'rounded' : 'rounded-full',
-                      isSelected
-                        ? 'bg-primary border-primary text-primary-foreground'
-                        : 'border-muted-foreground/40'
-                    )}
-                  >
-                    {isSelected && <Check className="h-2.5 w-2.5" />}
-                  </div>
-                  <span className={cn('font-medium', isSelected && 'text-primary')}>
-                    {option.label}
-                  </span>
-                </div>
-                {option.description && (
-                  <div className="text-muted-foreground mt-1 pl-6">{option.description}</div>
-                )}
+                {customSelected && <Check className="h-2.5 w-2.5" />}
               </button>
-            );
-          })}
-        </div>
-      )}
-
-      {allowCustom && (
-        <input
-          type="text"
-          value={customInput}
-          onChange={e => onCustomInputChange(e.target.value)}
-          placeholder="Type your own answer..."
-          className="border-muted bg-background placeholder:text-muted-foreground/50 focus:border-primary/60 focus:ring-primary/30 w-full rounded-md border px-3 py-2 text-xs focus:ring-1 focus:outline-none"
-        />
-      )}
+              <input
+                type="text"
+                value={customInput}
+                onClick={e => e.stopPropagation()}
+                onChange={e => onCustomInputChange(e.target.value)}
+                placeholder="Type your own answer..."
+                className="placeholder:text-muted-foreground/50 min-w-0 flex-1 bg-transparent font-medium outline-none"
+              />
+            </div>
+          </div>
+        )}
+      </div>
 
       {isMultiple && (
         <div className="flex gap-2 text-[10px]">
@@ -222,7 +257,7 @@ function QuestionTab({
           : 'bg-muted/50 text-muted-foreground hover:bg-muted'
       )}
     >
-      {total > 1 ? `Q${index + 1}` : question.header || 'Question'}
+      {total > 1 ? question.header || `Q${index + 1}` : question.header || 'Question'}
       {hasAnswers && <Check className="ml-1 inline h-3 w-3" />}
     </button>
   );
@@ -238,6 +273,7 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
   const [activeTab, setActiveTab] = useState(0);
   const [selectedAnswers, setSelectedAnswers] = useState<string[][]>(() => questions.map(() => []));
   const [customInputs, setCustomInputs] = useState<string[]>(() => questions.map(() => ''));
+  const [customSelected, setCustomSelected] = useState<boolean[]>(() => questions.map(() => false));
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -265,47 +301,106 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
 
   const handleToggleOption = useCallback(
     (questionIndex: number, label: string) => {
+      const question = questions[questionIndex];
+      const isMultiple = question?.multiple === true;
+
       setSelectedAnswers(prev => {
         const updated = [...prev];
         const current = updated[questionIndex] ?? [];
-        const question = questions[questionIndex];
-        const isMultiple = question?.multiple === true;
 
         if (isMultiple) {
           updated[questionIndex] = current.includes(label)
             ? current.filter(l => l !== label)
             : [...current, label];
         } else {
-          // Single select: toggle off if already selected, otherwise replace
           updated[questionIndex] = current.includes(label) ? [] : [label];
         }
         return updated;
       });
+
+      // Single-select: picking an option deselects custom
+      if (!isMultiple) {
+        setCustomSelected(prev => {
+          const updated = [...prev];
+          updated[questionIndex] = false;
+          return updated;
+        });
+      }
     },
     [questions]
   );
 
-  const handleCustomInputChange = useCallback((questionIndex: number, value: string) => {
-    setCustomInputs(prev => {
-      const updated = [...prev];
-      updated[questionIndex] = value;
-      return updated;
-    });
-  }, []);
+  const handleToggleCustom = useCallback(
+    (questionIndex: number) => {
+      const question = questions[questionIndex];
+      const isMultiple = question?.multiple === true;
 
-  const hasAnyAnswer = selectedAnswers.some(
-    (labels, i) => labels.length > 0 || (customInputs[i] ?? '').trim().length > 0
+      setCustomSelected(prev => {
+        const updated = [...prev];
+        const wasSelected = updated[questionIndex] ?? false;
+        updated[questionIndex] = !wasSelected;
+        return updated;
+      });
+
+      // Single-select: selecting custom deselects options
+      if (!isMultiple) {
+        setSelectedAnswers(prev => {
+          const updated = [...prev];
+          updated[questionIndex] = [];
+          return updated;
+        });
+      }
+    },
+    [questions]
   );
+
+  const handleCustomInputChange = useCallback(
+    (questionIndex: number, value: string) => {
+      setCustomInputs(prev => {
+        const updated = [...prev];
+        updated[questionIndex] = value;
+        return updated;
+      });
+      // Auto-select custom when user types
+      if (value.length > 0) {
+        setCustomSelected(prev => {
+          if (prev[questionIndex]) return prev;
+          const updated = [...prev];
+          updated[questionIndex] = true;
+          return updated;
+        });
+        // Single-select: auto-selecting custom deselects options
+        const question = questions[questionIndex];
+        if (question?.multiple !== true) {
+          setSelectedAnswers(prev => {
+            if ((prev[questionIndex] ?? []).length === 0) return prev;
+            const updated = [...prev];
+            updated[questionIndex] = [];
+            return updated;
+          });
+        }
+      }
+    },
+    [questions]
+  );
+
+  /** Compute effective answers for a given question index */
+  const getEffectiveAnswers = useCallback(
+    (questionIndex: number) => {
+      const labels = selectedAnswers[questionIndex] ?? [];
+      const isCustom = customSelected[questionIndex] ?? false;
+      const custom = isCustom ? (customInputs[questionIndex] ?? '').trim() : '';
+      return custom ? [...labels, custom] : [...labels];
+    },
+    [selectedAnswers, customSelected, customInputs]
+  );
+
+  const hasAnyAnswer = questions.some((_, i) => getEffectiveAnswers(i).length > 0);
 
   const handleSubmit = useCallback(async () => {
     if (!requestId || !sessionId || isSubmitting) return;
 
-    // Build answers: for each question, combine selected labels + custom input
-    const answers: string[][] = questions.map((_, i) => {
-      const labels = selectedAnswers[i] ?? [];
-      const custom = (customInputs[i] ?? '').trim();
-      return custom ? [...labels, custom] : [...labels];
-    });
+    const answers: string[][] = questions.map((_, i) => getEffectiveAnswers(i));
 
     setIsSubmitting(true);
     setSubmitError(null);
@@ -332,8 +427,7 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
     sessionId,
     organizationId,
     questions,
-    selectedAnswers,
-    customInputs,
+    getEffectiveAnswers,
     isSubmitting,
     trpcClient,
   ]);
@@ -381,64 +475,120 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
                 <QuestionTab
                   key={idx}
                   question={q}
-                  answers={selectedAnswers[idx]}
+                  answers={getEffectiveAnswers(idx)}
                   isActive={activeTab === idx}
                   onClick={() => setActiveTab(idx)}
                   index={idx}
                   total={questionCount}
                 />
               ))}
+              {/* Confirm tab */}
+              <button
+                type="button"
+                onClick={() => setActiveTab(questionCount)}
+                className={cn(
+                  'shrink-0 rounded-md px-2 py-1 text-xs transition-colors',
+                  activeTab === questionCount
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+                )}
+              >
+                Confirm
+              </button>
             </div>
           )}
 
           {/* Active question — interactive */}
-          {questions[activeTab] && (
+          {activeTab < questionCount && questions[activeTab] && (
             <InteractiveQuestionContent
               question={questions[activeTab]}
               selectedLabels={selectedAnswers[activeTab] ?? []}
               customInput={customInputs[activeTab] ?? ''}
+              customSelected={customSelected[activeTab] ?? false}
               onToggleOption={label => handleToggleOption(activeTab, label)}
               onCustomInputChange={value => handleCustomInputChange(activeTab, value)}
-              showHeader={questionCount > 1}
+              onToggleCustom={() => handleToggleCustom(activeTab)}
+              showHeader={false}
             />
+          )}
+
+          {/* Confirm tab — compact recap + submit */}
+          {questionCount > 1 && activeTab === questionCount && (
+            <div className="space-y-2">
+              <div className="text-muted-foreground text-xs font-medium">Review your answers</div>
+              {questions.map((q, idx) => {
+                const allAnswers = getEffectiveAnswers(idx);
+                const answered = allAnswers.length > 0;
+
+                return (
+                  <button
+                    key={idx}
+                    type="button"
+                    onClick={() => setActiveTab(idx)}
+                    className={cn(
+                      'w-full rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors',
+                      answered
+                        ? 'border-muted bg-muted/20 hover:bg-muted/40'
+                        : 'border-yellow-500/40 bg-yellow-500/5 hover:bg-yellow-500/10'
+                    )}
+                  >
+                    <div className="flex items-center gap-1.5">
+                      {answered ? (
+                        <Check className="h-3 w-3 shrink-0 text-green-500" />
+                      ) : (
+                        <AlertCircle className="h-3 w-3 shrink-0 text-yellow-500" />
+                      )}
+                      <span className="font-medium">{q.header || `Q${idx + 1}`}</span>
+                    </div>
+                    <div className="text-muted-foreground mt-0.5 truncate pl-[18px]">
+                      {answered ? allAnswers.join(', ') : 'No answer yet'}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
           )}
 
           {/* Submit error */}
           {submitError && <div className="mt-2 text-xs text-red-500">{submitError}</div>}
 
-          {/* Action buttons */}
-          <div className="mt-3 flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={!hasAnyAnswer || isSubmitting || !requestId}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                hasAnyAnswer && requestId && !isSubmitting
-                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                  : 'bg-muted text-muted-foreground cursor-not-allowed'
+          {/* Action buttons — single question: always visible; multi-question: only on Confirm tab */}
+          {(questionCount === 1 || activeTab === questionCount) && (
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!hasAnyAnswer || isSubmitting || !requestId}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                  hasAnyAnswer && requestId && !isSubmitting
+                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                    : 'bg-muted text-muted-foreground cursor-not-allowed'
+                )}
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Send className="h-3 w-3" />
+                )}
+                Submit
+              </button>
+              <button
+                type="button"
+                onClick={handleDismiss}
+                disabled={isSubmitting || !requestId}
+                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <X className="h-3 w-3" />
+                Dismiss
+              </button>
+              {!requestId && (
+                <span className="text-muted-foreground text-[10px]">
+                  Waiting for question ID...
+                </span>
               )}
-            >
-              {isSubmitting ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <Send className="h-3 w-3" />
-              )}
-              Submit
-            </button>
-            <button
-              type="button"
-              onClick={handleDismiss}
-              disabled={isSubmitting || !requestId}
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <X className="h-3 w-3" />
-              Dismiss
-            </button>
-            {!requestId && (
-              <span className="text-muted-foreground text-[10px]">Waiting for question ID...</span>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -480,11 +630,11 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
             </div>
           )}
 
-          {questions[activeTab] && (
+          {questions[activeTab < questionCount ? activeTab : 0] && (
             <CompletedQuestionContent
-              question={questions[activeTab]}
-              answers={completedAnswers[activeTab]}
-              showHeader={questionCount > 1}
+              question={questions[activeTab < questionCount ? activeTab : 0]}
+              answers={completedAnswers[activeTab < questionCount ? activeTab : 0]}
+              showHeader={false}
             />
           )}
 

--- a/src/components/cloud-agent-next/QuestionToolCard.tsx
+++ b/src/components/cloud-agent-next/QuestionToolCard.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import { useState } from 'react';
-import { ChevronDown, Loader2, XCircle, Check } from 'lucide-react';
+import { useState, useCallback } from 'react';
+import { useAtomValue } from 'jotai';
+import { ChevronDown, Loader2, XCircle, Check, Send, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useRawTRPCClient } from '@/lib/trpc/utils';
+import {
+  questionRequestIdsAtom,
+  currentSessionIdAtom,
+  sessionOrganizationIdAtom,
+} from './store/atoms';
 import type { ToolPart } from './types';
 import type { QuestionInfo } from '@/types/opencode.gen';
 
@@ -30,6 +37,161 @@ function getStatusIndicator(status: 'pending' | 'running' | 'completed' | 'error
     default:
       return <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-500" />;
   }
+}
+
+/** Read-only view of a completed question's answers */
+function CompletedQuestionContent({
+  question,
+  answers,
+  showHeader = true,
+}: {
+  question: QuestionInfo;
+  answers?: string[];
+  showHeader?: boolean;
+}) {
+  const hasAnswers = answers && answers.length > 0;
+  const customAnswers = hasAnswers
+    ? answers.filter(a => !question.options?.some(opt => opt.label === a))
+    : [];
+
+  return (
+    <div className="space-y-2">
+      {showHeader && question.header && (
+        <div className="text-muted-foreground text-xs font-medium">{question.header}</div>
+      )}
+      <div className="text-sm">{question.question}</div>
+
+      {question.options && question.options.length > 0 && (
+        <div className="space-y-1">
+          {question.options.map((option, idx) => {
+            const isSelected = hasAnswers && answers.includes(option.label);
+            return (
+              <div
+                key={idx}
+                className={cn(
+                  'rounded-md px-2 py-1 text-xs',
+                  isSelected ? 'bg-primary/20 border-primary/50 border' : 'bg-muted/30'
+                )}
+              >
+                <div className="flex items-center gap-1">
+                  {isSelected && <Check className="h-3 w-3 text-green-500" />}
+                  <span className={cn('font-medium', isSelected && 'text-primary')}>
+                    {option.label}
+                  </span>
+                </div>
+                {option.description && (
+                  <div className="text-muted-foreground mt-0.5">{option.description}</div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {customAnswers.length > 0 && (
+        <div className="space-y-1">
+          {customAnswers.map((answer, idx) => (
+            <div
+              key={idx}
+              className="flex items-center gap-1 rounded-md border border-blue-500/50 bg-blue-500/20 px-2 py-1 text-xs"
+            >
+              <Check className="h-3 w-3 text-green-500" />
+              <span className="font-medium">{answer}</span>
+              <span className="text-muted-foreground text-[10px]">(custom)</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Interactive view for answering a question */
+function InteractiveQuestionContent({
+  question,
+  selectedLabels,
+  customInput,
+  onToggleOption,
+  onCustomInputChange,
+  showHeader = true,
+}: {
+  question: QuestionInfo;
+  selectedLabels: string[];
+  customInput: string;
+  onToggleOption: (label: string) => void;
+  onCustomInputChange: (value: string) => void;
+  showHeader?: boolean;
+}) {
+  const isMultiple = question.multiple === true;
+  const allowCustom = question.custom !== false;
+
+  return (
+    <div className="space-y-3">
+      {showHeader && question.header && (
+        <div className="text-muted-foreground text-xs font-medium">{question.header}</div>
+      )}
+      <div className="text-sm font-medium">{question.question}</div>
+
+      {question.options && question.options.length > 0 && (
+        <div className="space-y-1.5">
+          {question.options.map((option, idx) => {
+            const isSelected = selectedLabels.includes(option.label);
+            return (
+              <button
+                key={idx}
+                type="button"
+                onClick={() => onToggleOption(option.label)}
+                className={cn(
+                  'w-full rounded-md border px-3 py-2 text-left text-xs transition-colors',
+                  isSelected
+                    ? 'bg-primary/15 border-primary/60 ring-primary/30 ring-1'
+                    : 'border-muted bg-muted/20 hover:bg-muted/40 hover:border-muted-foreground/30'
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <div
+                    className={cn(
+                      'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                      isMultiple ? 'rounded' : 'rounded-full',
+                      isSelected
+                        ? 'bg-primary border-primary text-primary-foreground'
+                        : 'border-muted-foreground/40'
+                    )}
+                  >
+                    {isSelected && <Check className="h-2.5 w-2.5" />}
+                  </div>
+                  <span className={cn('font-medium', isSelected && 'text-primary')}>
+                    {option.label}
+                  </span>
+                </div>
+                {option.description && (
+                  <div className="text-muted-foreground mt-1 pl-6">{option.description}</div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {allowCustom && (
+        <input
+          type="text"
+          value={customInput}
+          onChange={e => onCustomInputChange(e.target.value)}
+          placeholder="Type your own answer..."
+          className="border-muted bg-background placeholder:text-muted-foreground/50 focus:border-primary/60 focus:ring-primary/30 w-full rounded-md border px-3 py-2 text-xs focus:ring-1 focus:outline-none"
+        />
+      )}
+
+      {isMultiple && (
+        <div className="flex gap-2 text-[10px]">
+          <span className="bg-muted/50 text-muted-foreground rounded px-1.5 py-0.5">
+            Select multiple
+          </span>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function QuestionTab({
@@ -66,113 +228,225 @@ function QuestionTab({
   );
 }
 
-function QuestionContent({ question, answers }: { question: QuestionInfo; answers?: string[] }) {
-  const hasAnswers = answers && answers.length > 0;
-
-  // Find custom answers (not matching any option label)
-  const customAnswers = hasAnswers
-    ? answers.filter(a => !question.options?.some(opt => opt.label === a))
-    : [];
-
-  return (
-    <div className="space-y-2">
-      {/* Question header and text */}
-      {question.header && (
-        <div className="text-muted-foreground text-xs font-medium">{question.header}</div>
-      )}
-      <div className="text-sm">{question.question}</div>
-
-      {/* Options with selected highlighting */}
-      {question.options && question.options.length > 0 && (
-        <div className="space-y-1">
-          {question.options.map((option, idx) => {
-            const isSelected = hasAnswers && answers.includes(option.label);
-            return (
-              <div
-                key={idx}
-                className={cn(
-                  'rounded-md px-2 py-1 text-xs',
-                  isSelected ? 'bg-primary/20 border-primary/50 border' : 'bg-muted/30'
-                )}
-              >
-                <div className="flex items-center gap-1">
-                  {isSelected && <Check className="h-3 w-3 text-green-500" />}
-                  <span className={cn('font-medium', isSelected && 'text-primary')}>
-                    {option.label}
-                  </span>
-                </div>
-                {option.description && (
-                  <div className="text-muted-foreground mt-0.5">{option.description}</div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {/* Show custom answers (not in options list) */}
-      {customAnswers.length > 0 && (
-        <div className="space-y-1">
-          {customAnswers.map((answer, idx) => (
-            <div
-              key={idx}
-              className="flex items-center gap-1 rounded-md border border-blue-500/50 bg-blue-500/20 px-2 py-1 text-xs"
-            >
-              <Check className="h-3 w-3 text-green-500" />
-              <span className="font-medium">{answer}</span>
-              <span className="text-muted-foreground text-[10px]">(custom)</span>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Show info badges only when not answered */}
-      {!hasAnswers && (
-        <div className="flex gap-2 text-[10px]">
-          {question.multiple && (
-            <span className="bg-muted/50 text-muted-foreground rounded px-1.5 py-0.5">
-              Multiple selection
-            </span>
-          )}
-          {question.custom !== false && (
-            <span className="bg-muted/50 text-muted-foreground rounded px-1.5 py-0.5">
-              Custom allowed
-            </span>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [activeTab, setActiveTab] = useState(0);
-
   const state = toolPart.state;
   const input = state.input as QuestionInput;
   const questions = input.questions || [];
+  const isRunning = state.status === 'running';
 
-  // Get answers from metadata (completed/running states have metadata)
-  let answers: string[][] = [];
-  if (state.status === 'completed' || state.status === 'running') {
-    const metadata = state.metadata as QuestionMetadata | undefined;
-    answers = metadata?.answers || [];
-  }
+  const [isExpanded, setIsExpanded] = useState(isRunning);
+  const [activeTab, setActiveTab] = useState(0);
+  const [selectedAnswers, setSelectedAnswers] = useState<string[][]>(() => questions.map(() => []));
+  const [customInputs, setCustomInputs] = useState<string[]>(() => questions.map(() => ''));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const trpcClient = useRawTRPCClient();
+  const questionRequestIds = useAtomValue(questionRequestIdsAtom);
+  const sessionId = useAtomValue(currentSessionIdAtom);
+  const organizationId = useAtomValue(sessionOrganizationIdAtom);
+
+  const requestId = toolPart.callID ? questionRequestIds.get(toolPart.callID) : undefined;
+
+  // Get answers from metadata for completed state
+  const completedAnswers: string[][] =
+    state.status === 'completed'
+      ? ((state.metadata as QuestionMetadata | undefined)?.answers ?? [])
+      : [];
 
   const error = state.status === 'error' ? state.error : undefined;
   const questionCount = questions.length;
-  const answeredCount = answers.filter(a => a && a.length > 0).length;
+  const answeredCount = completedAnswers.filter(a => a && a.length > 0).length;
 
-  // Compact header text
   const headerText =
     questionCount === 1
       ? questions[0]?.header || 'Question'
       : `${questionCount} questions${answeredCount > 0 ? ` (${answeredCount} answered)` : ''}`;
 
+  const handleToggleOption = useCallback(
+    (questionIndex: number, label: string) => {
+      setSelectedAnswers(prev => {
+        const updated = [...prev];
+        const current = updated[questionIndex] ?? [];
+        const question = questions[questionIndex];
+        const isMultiple = question?.multiple === true;
+
+        if (isMultiple) {
+          updated[questionIndex] = current.includes(label)
+            ? current.filter(l => l !== label)
+            : [...current, label];
+        } else {
+          // Single select: toggle off if already selected, otherwise replace
+          updated[questionIndex] = current.includes(label) ? [] : [label];
+        }
+        return updated;
+      });
+    },
+    [questions]
+  );
+
+  const handleCustomInputChange = useCallback((questionIndex: number, value: string) => {
+    setCustomInputs(prev => {
+      const updated = [...prev];
+      updated[questionIndex] = value;
+      return updated;
+    });
+  }, []);
+
+  const hasAnyAnswer = selectedAnswers.some(
+    (labels, i) => labels.length > 0 || (customInputs[i] ?? '').trim().length > 0
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!requestId || !sessionId || isSubmitting) return;
+
+    // Build answers: for each question, combine selected labels + custom input
+    const answers: string[][] = questions.map((_, i) => {
+      const labels = selectedAnswers[i] ?? [];
+      const custom = (customInputs[i] ?? '').trim();
+      return custom ? [...labels, custom] : [...labels];
+    });
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      if (organizationId) {
+        await trpcClient.organizations.cloudAgentNext.answerQuestion.mutate(
+          { sessionId, questionId: requestId, answers, organizationId },
+          { context: { skipBatch: true } }
+        );
+      } else {
+        await trpcClient.cloudAgentNext.answerQuestion.mutate(
+          { sessionId, questionId: requestId, answers },
+          { context: { skipBatch: true } }
+        );
+      }
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to submit answer');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    requestId,
+    sessionId,
+    organizationId,
+    questions,
+    selectedAnswers,
+    customInputs,
+    isSubmitting,
+    trpcClient,
+  ]);
+
+  const handleDismiss = useCallback(async () => {
+    if (!requestId || !sessionId || isSubmitting) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      if (organizationId) {
+        await trpcClient.organizations.cloudAgentNext.rejectQuestion.mutate(
+          { sessionId, questionId: requestId, organizationId },
+          { context: { skipBatch: true } }
+        );
+      } else {
+        await trpcClient.cloudAgentNext.rejectQuestion.mutate(
+          { sessionId, questionId: requestId },
+          { context: { skipBatch: true } }
+        );
+      }
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to dismiss question');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [requestId, sessionId, organizationId, isSubmitting, trpcClient]);
+
+  // Running state: always expanded, interactive
+  if (isRunning) {
+    return (
+      <div className="border-primary/40 bg-muted/30 rounded-md border border-l-4">
+        {/* Header */}
+        <div className="flex items-center gap-2 px-3 py-2">
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-500" />
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">{headerText}</span>
+        </div>
+
+        <div className="border-muted border-t px-3 py-2">
+          {/* Tabs for multiple questions */}
+          {questionCount > 1 && (
+            <div className="mb-3 flex gap-1 overflow-x-auto pb-1">
+              {questions.map((q, idx) => (
+                <QuestionTab
+                  key={idx}
+                  question={q}
+                  answers={selectedAnswers[idx]}
+                  isActive={activeTab === idx}
+                  onClick={() => setActiveTab(idx)}
+                  index={idx}
+                  total={questionCount}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Active question — interactive */}
+          {questions[activeTab] && (
+            <InteractiveQuestionContent
+              question={questions[activeTab]}
+              selectedLabels={selectedAnswers[activeTab] ?? []}
+              customInput={customInputs[activeTab] ?? ''}
+              onToggleOption={label => handleToggleOption(activeTab, label)}
+              onCustomInputChange={value => handleCustomInputChange(activeTab, value)}
+              showHeader={questionCount > 1}
+            />
+          )}
+
+          {/* Submit error */}
+          {submitError && <div className="mt-2 text-xs text-red-500">{submitError}</div>}
+
+          {/* Action buttons */}
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!hasAnyAnswer || isSubmitting || !requestId}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                hasAnyAnswer && requestId && !isSubmitting
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'bg-muted text-muted-foreground cursor-not-allowed'
+              )}
+            >
+              {isSubmitting ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Send className="h-3 w-3" />
+              )}
+              Submit
+            </button>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              disabled={isSubmitting || !requestId}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <X className="h-3 w-3" />
+              Dismiss
+            </button>
+            {!requestId && (
+              <span className="text-muted-foreground text-[10px]">Waiting for question ID...</span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Non-running states: collapsible
   return (
     <div className="border-muted bg-muted/30 rounded-md border">
-      {/* Collapsed header */}
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
@@ -188,17 +462,15 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
         />
       </button>
 
-      {/* Expanded content */}
       {isExpanded && (
         <div className="border-muted border-t px-3 py-2">
-          {/* Tabs for multiple questions */}
           {questionCount > 1 && (
             <div className="mb-3 flex gap-1 overflow-x-auto pb-1">
               {questions.map((q, idx) => (
                 <QuestionTab
                   key={idx}
                   question={q}
-                  answers={answers[idx]}
+                  answers={completedAnswers[idx]}
                   isActive={activeTab === idx}
                   onClick={() => setActiveTab(idx)}
                   index={idx}
@@ -208,12 +480,14 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
             </div>
           )}
 
-          {/* Active question content */}
           {questions[activeTab] && (
-            <QuestionContent question={questions[activeTab]} answers={answers[activeTab]} />
+            <CompletedQuestionContent
+              question={questions[activeTab]}
+              answers={completedAnswers[activeTab]}
+              showHeader={questionCount > 1}
+            />
           )}
 
-          {/* Error */}
           {error && (
             <div className="mt-2">
               <div className="text-muted-foreground mb-1 text-xs">Error:</div>
@@ -223,12 +497,6 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
             </div>
           )}
 
-          {/* Running state */}
-          {state.status === 'running' && (
-            <div className="text-muted-foreground mt-2 text-xs italic">Waiting for answer...</div>
-          )}
-
-          {/* Pending state */}
           {state.status === 'pending' && (
             <div className="text-muted-foreground mt-2 text-xs italic">Preparing question...</div>
           )}

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -132,6 +132,7 @@ export const clearMessagesAtom = atom(null, (_get, set) => {
   set(errorAtom, null);
   set(messagesMapAtom, new Map());
   set(partsMapAtom, new Map());
+  set(questionRequestIdsAtom, new Map());
 });
 
 // ============================================================================
@@ -297,19 +298,6 @@ export const addUserMessageAtom = atom(
     set(partsMapAtom, partsMap);
   }
 );
-
-/**
- * Clear all streaming state atoms.
- * Resets messagesMapAtom, partsMapAtom, childSessionsMapAtom, and sessionStatusAtom to initial state.
- */
-export const clearStreamingStateAtom = atom(null, (_get, set) => {
-  set(messagesMapAtom, new Map());
-  set(partsMapAtom, new Map());
-  set(childSessionsMapAtom, new Map());
-  set(questionRequestIdsAtom, new Map());
-  set(sessionOrganizationIdAtom, null);
-  set(sessionStatusAtom, { type: 'idle' });
-});
 
 /**
  * Update a message in a child session.

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -33,6 +33,25 @@ export const partsMapAtom = atom<Map<string, { messageId: string; part: Part }>>
 export const childSessionsMapAtom = atom<Map<string, StoredMessage[]>>(new Map());
 
 /**
+ * Map of tool callID -> question requestId.
+ * Populated from question.asked events. Used by QuestionToolCard
+ * to know which requestId to send when answering/rejecting.
+ */
+export const questionRequestIdsAtom = atom<Map<string, string>>(new Map());
+
+/**
+ * Record a callID -> requestId mapping from a question.asked event.
+ */
+export const setQuestionRequestIdAtom = atom(
+  null,
+  (get, set, payload: { callId: string; requestId: string }) => {
+    const map = new Map(get(questionRequestIdsAtom));
+    map.set(payload.callId, payload.requestId);
+    set(questionRequestIdsAtom, map);
+  }
+);
+
+/**
  * Session status from session.status events
  * Can be 'idle', 'busy', or 'retry' with additional metadata
  */
@@ -47,6 +66,8 @@ export const sessionStatusAtom = atom<
 // ============================================================================
 
 export const currentSessionIdAtom = atom<string | null>(null);
+/** Organization ID for the current session (null for personal sessions) */
+export const sessionOrganizationIdAtom = atom<string | null>(null);
 export const sessionConfigAtom = atom<SessionConfig | null>(null);
 export const isStreamingAtom = atom(false);
 export const errorAtom = atom<string | null>(null);
@@ -107,6 +128,7 @@ export const totalCostAtom = atom(get => {
 export const clearMessagesAtom = atom(null, (_get, set) => {
   set(isStreamingAtom, false);
   set(currentSessionIdAtom, null);
+  set(sessionOrganizationIdAtom, null);
   set(errorAtom, null);
   set(messagesMapAtom, new Map());
   set(partsMapAtom, new Map());
@@ -284,6 +306,8 @@ export const clearStreamingStateAtom = atom(null, (_get, set) => {
   set(messagesMapAtom, new Map());
   set(partsMapAtom, new Map());
   set(childSessionsMapAtom, new Map());
+  set(questionRequestIdsAtom, new Map());
+  set(sessionOrganizationIdAtom, null);
   set(sessionStatusAtom, { type: 'idle' });
 });
 

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -35,6 +35,8 @@ import {
   updateChildSessionMessageAtom,
   updateChildSessionPartAtom,
   removeChildSessionPartAtom,
+  setQuestionRequestIdAtom,
+  sessionOrganizationIdAtom,
 } from './store/atoms';
 import {
   updateHighWaterMarkAtom,
@@ -108,6 +110,12 @@ export function useCloudAgentStream({
   const updateChildSessionPart = useSetAtom(updateChildSessionPartAtom);
   const removeChildSessionPart = useSetAtom(removeChildSessionPartAtom);
 
+  // Atom for question tracking
+  const setQuestionRequestId = useSetAtom(setQuestionRequestIdAtom);
+
+  // Atom for organization ID (used by QuestionToolCard for tRPC calls)
+  const setSessionOrganizationId = useSetAtom(sessionOrganizationIdAtom);
+
   // Common atoms
   const setCurrentSessionId = useSetAtom(currentSessionIdAtom);
   const setIsStreaming = useSetAtom(isStreamingAtom);
@@ -155,7 +163,8 @@ export function useCloudAgentStream({
 
   useEffect(() => {
     organizationIdRef.current = organizationId;
-  }, [organizationId]);
+    setSessionOrganizationId(organizationId ?? null);
+  }, [organizationId, setSessionOrganizationId]);
 
   /**
    * Create the event processor with callbacks wired to Jotai atoms and IndexedDB.
@@ -287,6 +296,10 @@ export function useCloudAgentStream({
           onCompleteRef.current?.();
         }
       },
+
+      onQuestionAsked: (requestId, callId) => {
+        setQuestionRequestId({ callId, requestId });
+      },
     }),
     [
       updateMessage,
@@ -303,6 +316,7 @@ export function useCloudAgentStream({
       updateChildSessionPart,
       removeChildSessionPart,
       setError,
+      setQuestionRequestId,
     ]
   );
 

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -60,6 +60,8 @@ export type UseCloudAgentStreamOptions = {
   onKiloSessionCreated?: (kiloSessionId: string) => void;
   /** Callback when session is confirmed initiated (first session_synced event) */
   onSessionInitiated?: () => void;
+  /** Callback when the agent asks a question */
+  onQuestionAsked?: () => void;
 };
 
 export type UseCloudAgentStreamReturn = {
@@ -96,6 +98,7 @@ export function useCloudAgentStream({
   onComplete,
   onKiloSessionCreated,
   onSessionInitiated,
+  onQuestionAsked,
 }: UseCloudAgentStreamOptions): UseCloudAgentStreamReturn {
   const trpcClient = useRawTRPCClient();
 
@@ -144,6 +147,7 @@ export function useCloudAgentStream({
   const onCompleteRef = useRef(onComplete);
   const onKiloSessionCreatedRef = useRef(onKiloSessionCreated);
   const onSessionInitiatedRef = useRef(onSessionInitiated);
+  const onQuestionAskedRef = useRef(onQuestionAsked);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -156,6 +160,10 @@ export function useCloudAgentStream({
   useEffect(() => {
     onSessionInitiatedRef.current = onSessionInitiated;
   }, [onSessionInitiated]);
+
+  useEffect(() => {
+    onQuestionAskedRef.current = onQuestionAsked;
+  }, [onQuestionAsked]);
 
   useEffect(() => {
     cloudAgentSessionIdRef.current = cloudAgentSessionIdProp ?? null;
@@ -299,6 +307,7 @@ export function useCloudAgentStream({
 
       onQuestionAsked: (requestId, callId) => {
         setQuestionRequestId({ callId, requestId });
+        onQuestionAskedRef.current?.();
       },
     }),
     [

--- a/src/hooks/useNotificationSound.ts
+++ b/src/hooks/useNotificationSound.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { SOUND_NOTIFICATIONS_KEY } from '@/hooks/useCelebrationSound';
+
+/**
+ * Play a single tone with exponential decay.
+ */
+function playTone(
+  audioCtx: AudioContext,
+  frequency: number,
+  startTime: number,
+  duration: number,
+  volume: number
+) {
+  const oscillator = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(frequency, startTime);
+
+  gain.gain.setValueAtTime(volume, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+
+  oscillator.connect(gain);
+  gain.connect(audioCtx.destination);
+
+  oscillator.start(startTime);
+  oscillator.stop(startTime + duration);
+}
+
+/**
+ * Two-tone "ding-ding" chime — audible but not jarring.
+ */
+function playChime(audioCtx: AudioContext) {
+  const now = audioCtx.currentTime;
+  playTone(audioCtx, 660, now, 0.4, 0.35);
+  playTone(audioCtx, 880, now + 0.18, 0.4, 0.35);
+}
+
+/**
+ * Hook for playing a notification chime when the agent asks a question.
+ * Uses Web Audio API synthesis (no binary asset needed).
+ * Respects the same sound-notifications localStorage toggle as useCelebrationSound.
+ */
+export function useNotificationSound() {
+  const [soundEnabled] = useLocalStorage(SOUND_NOTIFICATIONS_KEY, true);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const playNotification = useCallback(() => {
+    if (!soundEnabled) return;
+
+    try {
+      if (!audioCtxRef.current) {
+        audioCtxRef.current = new AudioContext();
+      }
+      // Resume context if suspended (browser autoplay policy)
+      if (audioCtxRef.current.state === 'suspended') {
+        void audioCtxRef.current.resume();
+      }
+      playChime(audioCtxRef.current);
+    } catch {
+      // Web Audio API unavailable or blocked — silently ignore
+    }
+  }, [soundEnabled]);
+
+  return { playNotification };
+}

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -241,6 +241,17 @@ export type InterruptResult = {
   message: string;
 };
 
+export type AnswerQuestionInput = {
+  sessionId: string;
+  questionId: string;
+  answers: string[][];
+};
+
+export type RejectQuestionInput = {
+  sessionId: string;
+  questionId: string;
+};
+
 /** Output from health procedure */
 export type HealthOutput = {
   status: string;
@@ -320,6 +331,12 @@ type CloudAgentNextTRPCClient = {
   };
   sendMessageV2: {
     mutate: (input: SendMessageInput) => Promise<InitiateSessionOutput>;
+  };
+  answerQuestion: {
+    mutate: (input: AnswerQuestionInput) => Promise<{ success: boolean }>;
+  };
+  rejectQuestion: {
+    mutate: (input: RejectQuestionInput) => Promise<{ success: boolean }>;
   };
 };
 
@@ -543,6 +560,30 @@ export class CloudAgentNextClient {
       captureException(error, {
         tags: { source: 'cloud-agent-next-client', endpoint: 'sendMessage' },
         extra: { input },
+      });
+      throw error;
+    }
+  }
+
+  async answerQuestion(input: AnswerQuestionInput): Promise<{ success: boolean }> {
+    try {
+      return await this.client.answerQuestion.mutate(input);
+    } catch (error) {
+      captureException(error, {
+        tags: { source: 'cloud-agent-next-client', endpoint: 'answerQuestion' },
+        extra: { sessionId: input.sessionId, questionId: input.questionId },
+      });
+      throw error;
+    }
+  }
+
+  async rejectQuestion(input: RejectQuestionInput): Promise<{ success: boolean }> {
+    try {
+      return await this.client.rejectQuestion.mutate(input);
+    } catch (error) {
+      captureException(error, {
+        tags: { source: 'cloud-agent-next-client', endpoint: 'rejectQuestion' },
+        extra: { sessionId: input.sessionId, questionId: input.questionId },
       });
       throw error;
     }

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -44,6 +44,7 @@ const HANDLED_EVENT_TYPES = new Set([
   'session.updated',
   'session.error',
   'session.idle',
+  'question.asked',
 ]);
 
 function isHandledEventType(type: string): boolean {
@@ -361,6 +362,17 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   }
 
   /**
+   * Handle question.asked events — extract the callID→requestId mapping.
+   */
+  function handleQuestionAsked(data: { id: string; tool?: { callID: string } }): void {
+    const requestId = data.id;
+    const callId = data.tool?.callID;
+    if (requestId && callId) {
+      callbacks.onQuestionAsked?.(requestId, callId);
+    }
+  }
+
+  /**
    * Handle session.idle events.
    * Completes all pending user messages since they don't have their own completion signals.
    */
@@ -425,6 +437,10 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
       case 'session.idle':
         handleSessionIdle();
+        break;
+
+      case 'question.asked':
+        handleQuestionAsked(data as { id: string; tool?: { callID: string } });
         break;
     }
   }

--- a/src/lib/cloud-agent-next/processor/types.ts
+++ b/src/lib/cloud-agent-next/processor/types.ts
@@ -83,6 +83,9 @@ export type EventProcessorCallbacks = {
 
   /** Called when streaming state changes */
   onStreamingChanged?: (isStreaming: boolean) => void;
+
+  /** Called when a question.asked event maps a tool callID to a requestId */
+  onQuestionAsked?: (requestId: string, callId: string) => void;
 };
 
 /**

--- a/src/routers/cloud-agent-next-router.ts
+++ b/src/routers/cloud-agent-next-router.ts
@@ -29,6 +29,8 @@ import {
   baseInterruptSessionNextSchema,
   baseGetSessionNextSchema,
   baseGetSessionNextOutputSchema,
+  baseAnswerQuestionNextSchema,
+  baseRejectQuestionNextSchema,
 } from './cloud-agent-next-schemas';
 import * as z from 'zod';
 import { PLATFORM } from '@/lib/integrations/core/constants';
@@ -181,6 +183,24 @@ export const cloudAgentNextRouter = createTRPCRouter({
       const client = createCloudAgentNextClient(authToken);
 
       return await client.interruptSession(input.sessionId);
+    }),
+
+  answerQuestion: baseProcedure
+    .input(baseAnswerQuestionNextSchema)
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const authToken = generateApiToken(ctx.user);
+      const client = createCloudAgentNextClient(authToken);
+      return await client.answerQuestion(input);
+    }),
+
+  rejectQuestion: baseProcedure
+    .input(baseRejectQuestionNextSchema)
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const authToken = generateApiToken(ctx.user);
+      const client = createCloudAgentNextClient(authToken);
+      return await client.rejectQuestion(input);
     }),
 
   /**

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -194,6 +194,19 @@ export const baseGetSessionNextOutputSchema = z.object({
   version: z.number(),
 });
 
+// Schema for answering a question
+export const baseAnswerQuestionNextSchema = z.object({
+  sessionId: z.string(),
+  questionId: z.string().min(1),
+  answers: z.array(z.array(z.string())),
+});
+
+// Schema for rejecting a question
+export const baseRejectQuestionNextSchema = z.object({
+  sessionId: z.string(),
+  questionId: z.string().min(1),
+});
+
 // Output schema for V2 initiation/message procedures
 export const baseInitiateSessionNextOutputSchema = z.object({
   cloudAgentSessionId: z.string(),

--- a/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -30,6 +30,8 @@ import {
   baseInterruptSessionNextSchema,
   baseGetSessionNextSchema,
   baseGetSessionNextOutputSchema,
+  baseAnswerQuestionNextSchema,
+  baseRejectQuestionNextSchema,
 } from '../cloud-agent-next-schemas';
 import * as z from 'zod';
 import { PLATFORM } from '@/lib/integrations/core/constants';
@@ -54,6 +56,14 @@ const InterruptSessionInput = baseInterruptSessionNextSchema.extend({
 });
 
 const GetSessionInput = baseGetSessionNextSchema.extend({
+  organizationId: z.uuid(),
+});
+
+const AnswerQuestionInput = baseAnswerQuestionNextSchema.extend({
+  organizationId: z.uuid(),
+});
+
+const RejectQuestionInput = baseRejectQuestionNextSchema.extend({
   organizationId: z.uuid(),
 });
 
@@ -226,6 +236,31 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       const client = createCloudAgentNextClient(authToken);
 
       return await client.interruptSession(input.sessionId);
+    }),
+
+  answerQuestion: organizationMemberProcedure
+    .input(AnswerQuestionInput)
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const authToken = generateApiToken(ctx.user);
+      const client = createCloudAgentNextClient(authToken);
+      return await client.answerQuestion({
+        sessionId: input.sessionId,
+        questionId: input.questionId,
+        answers: input.answers,
+      });
+    }),
+
+  rejectQuestion: organizationMemberProcedure
+    .input(RejectQuestionInput)
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const authToken = generateApiToken(ctx.user);
+      const client = createCloudAgentNextClient(authToken);
+      return await client.rejectQuestion({
+        sessionId: input.sessionId,
+        questionId: input.questionId,
+      });
     }),
 
   /**


### PR DESCRIPTION
## Summary

- Add `answerQuestion` and `rejectQuestion` tRPC mutations in the cloud-agent-next worker, with new session-questions handler
- Fix `answers` type from `string[]` to `string[][]` across the full wrapper chain (wrapper server, kilo-client, wrapper-client, tests) to match the Kilo serve API contract
- Add personal and organization proxy endpoints with Zod validation schemas
- Track `question.asked` SSE events to map tool `callID` → `requestId`, enabling the UI to target the correct question
- Rewrite `QuestionToolCard` with an interactive UI: selectable options (single/multi), custom text input, submit and dismiss buttons, loading/error states
- Add `questionRequestIdsAtom` and `sessionOrganizationIdAtom` to Jotai store; wire them through `useCloudAgentStream` and clear on session reset