### PR TITLE
Coerce errorRate to number in gateway error parsing

### DIFF
--- a/src/lib/providers/gateway-error-rate.ts
+++ b/src/lib/providers/gateway-error-rate.ts
@@ -20,7 +20,7 @@ const getGatewayErrorRate_cached = unstable_cache(
       .array(
         z.object({
           gateway: z.string(),
-          errorRate: z.number(),
+          errorRate: z.coerce.number(),
         })
       )
       .parse(rows);


### PR DESCRIPTION
Postgres can return a string here, but only sometimes 🤷 