### PR TITLE
fix: Update limits on promoted models

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -49,5 +49,5 @@ export const FREE_MODEL_MAX_REQUESTS_PER_WINDOW = 200;
 // Stripe publishable key (client-side, inlined at build time)
 export const STRIPE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
 
-export const PROMOTION_MAX_REQUESTS = 10000;
+export const PROMOTION_MAX_REQUESTS = 400;
 export const PROMOTION_WINDOW_HOURS = 24;


### PR DESCRIPTION
Set usage limit for promotion models to 400 calls / day