### PR TITLE
Explicitly pick regions with capacity

### DIFF
--- a/kiloclaw/wrangler.jsonc
+++ b/kiloclaw/wrangler.jsonc
@@ -69,7 +69,7 @@
     "FLY_REGISTRY_APP": "kiloclaw-machines", // Shared Docker image registry
     "FLY_ORG_SLUG": "kilo-679", // Org for creating per-user Fly apps
     "FLY_IMAGE_TAG": "latest",
-    "FLY_REGION": "us,eu",
+    "FLY_REGION": "dfw,yyz,cdg",
     "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",
   },
   // Secrets (set via wrangler secret put):


### PR DESCRIPTION
We're see'ing provisioning failures in prod that look like capacity issues, we're being mostly placed in IAD with the current config and IAD looks over provisioned if the api can be trusted. 

https://kilo-code.slack.com/archives/C0AD0MJGANT/p1771523884845279?thread_ts=1771523075.643569&cid=C0AD0MJGANT