### PR TITLE
Recover from Fly 412 insufficient resources by replacing stranded volumes

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -28,6 +28,9 @@ export const DEFAULT_MACHINE_GUEST = {
 /** Default Fly Volume size in GB */
 export const DEFAULT_VOLUME_SIZE_GB = 10;
 
+/** Default Fly region priority list when FLY_REGION env var is not set */
+export const DEFAULT_FLY_REGION = 'dfw,yyz,cdg';
+
 // Alarm cadence by instance status
 /** Running machines: fast health checks */
 export const ALARM_INTERVAL_RUNNING_MS = 5 * 60 * 1000; // 5 min

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -28,12 +28,14 @@ vi.mock('cloudflare:workers', () => ({
 }));
 
 // -- Mock fly client --
-// Keep real isFlyNotFound + FlyApiError; mock all API functions.
+// Keep real isFlyNotFound, isFlyInsufficientResources + FlyApiError; mock all API functions.
 vi.mock('../fly/client', async () => {
-  const { FlyApiError, isFlyNotFound } = await vi.importActual('../fly/client');
+  const { FlyApiError, isFlyNotFound, isFlyInsufficientResources } =
+    await vi.importActual('../fly/client');
   return {
     FlyApiError,
     isFlyNotFound,
+    isFlyInsufficientResources,
     createMachine: vi.fn(),
     getMachine: vi.fn(),
     startMachine: vi.fn(),
@@ -630,7 +632,7 @@ describe('createNewMachine: persist ID before waitForState', () => {
 // selectRecoveryCandidate (pure function, no mocks needed)
 // ============================================================================
 
-import { selectRecoveryCandidate } from './kiloclaw-instance';
+import { selectRecoveryCandidate, reverseRegionPriority } from './kiloclaw-instance';
 import type { FlyMachine } from '../fly/types';
 
 function fakeMachine(overrides: Partial<FlyMachine>): FlyMachine {
@@ -828,5 +830,269 @@ describe('updateChannels', () => {
 
     expect(result.telegram).toBe(true);
     expect(result.discord).toBe(true);
+  });
+});
+
+// ============================================================================
+// reverseRegionPriority (pure function)
+// ============================================================================
+
+describe('reverseRegionPriority', () => {
+  it('reverses a comma-separated region list', () => {
+    expect(reverseRegionPriority('dfw,yyz,cdg')).toBe('cdg,yyz,dfw');
+  });
+
+  it('handles a single region', () => {
+    expect(reverseRegionPriority('iad')).toBe('iad');
+  });
+
+  it('handles two regions', () => {
+    expect(reverseRegionPriority('us,eu')).toBe('eu,us');
+  });
+});
+
+// ============================================================================
+// Volume region validation before machine creation
+// ============================================================================
+
+describe('start: volume region validation', () => {
+  it('corrects flyRegion when it drifts from actual volume region', async () => {
+    const { instance, storage } = createInstance();
+    // DO thinks volume is in 'iad', but actual volume is in 'cdg'
+    await seedProvisioned(storage, { flyMachineId: null, flyRegion: 'iad' });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'cdg' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'cdg' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.start('user-1');
+
+    // flyRegion should be corrected to actual volume region
+    expect(storage._store.get('flyRegion')).toBe('cdg');
+    // Machine should be created (region passed from corrected flyRegion)
+    expect(flyClient.createMachine).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ region: 'cdg' })
+    );
+  });
+
+  it('handles volume gone (404) during region check by creating a new volume', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { flyMachineId: null });
+
+    // Volume is gone
+    (flyClient.getVolume as Mock).mockRejectedValue(new FlyApiError('not found', 404, '{}'));
+    // ensureVolume creates a replacement
+    (flyClient.createVolume as Mock).mockResolvedValue({ id: 'vol-new', region: 'dfw' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'dfw' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.start('user-1');
+
+    expect(storage._store.get('flyVolumeId')).toBe('vol-new');
+    expect(storage._store.get('flyRegion')).toBe('dfw');
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('skips region check when machine already exists', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { status: 'stopped' });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'stopped' });
+    (flyClient.updateMachine as Mock).mockResolvedValue({ id: 'machine-1' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.start('user-1');
+
+    // getVolume should only be called by ensureVolume (which is a no-op since
+    // flyVolumeId is set), NOT for region validation (because flyMachineId exists)
+    // Actually getVolume is NOT called by ensureVolume when flyVolumeId is set.
+    // The region validation also skips because flyMachineId is set.
+    expect(flyClient.getVolume).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// 412 insufficient resources recovery
+// ============================================================================
+
+describe('start: 412 insufficient resources recovery', () => {
+  it('fresh provision (never started): deletes volume and creates fresh in reversed region', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { flyMachineId: null, lastStartedAt: null });
+
+    // First createMachine fails with 412
+    (flyClient.createMachine as Mock)
+      .mockRejectedValueOnce(
+        new FlyApiError('insufficient resources', 412, '{"error":"insufficient resources"}')
+      )
+      .mockResolvedValueOnce({ id: 'machine-retry', region: 'cdg' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+    (flyClient.createVolume as Mock).mockResolvedValue({ id: 'vol-new', region: 'cdg' });
+
+    await instance.start('user-1');
+
+    // Old volume was deleted
+    expect(flyClient.deleteVolume).toHaveBeenCalledWith(expect.anything(), 'vol-1');
+    // New volume was created with reversed region (no source_volume_id since never started)
+    expect(flyClient.createVolume).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        region: 'eu,us', // reversed from FLY_REGION='us,eu' in fake env
+      })
+    );
+    // source_volume_id should NOT be set for fresh provision
+    const createVolumeCall = (flyClient.createVolume as Mock).mock.calls[0][1];
+    expect(createVolumeCall.source_volume_id).toBeUndefined();
+
+    // Machine was created on retry
+    expect(flyClient.createMachine).toHaveBeenCalledTimes(2);
+    expect(storage._store.get('flyMachineId')).toBe('machine-retry');
+    expect(storage._store.get('flyVolumeId')).toBe('vol-new');
+    expect(storage._store.get('flyRegion')).toBe('cdg');
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('existing instance (has user data): forks volume to preserve data', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      flyMachineId: null,
+      lastStartedAt: Date.now() - 60_000,
+    });
+
+    // First createMachine fails with 412
+    (flyClient.createMachine as Mock)
+      .mockRejectedValueOnce(
+        new FlyApiError('insufficient resources', 412, '{"error":"insufficient resources"}')
+      )
+      .mockResolvedValueOnce({ id: 'machine-retry', region: 'cdg' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+    // Fork succeeds
+    (flyClient.createVolume as Mock).mockResolvedValue({ id: 'vol-forked', region: 'cdg' });
+
+    await instance.start('user-1');
+
+    // Volume was forked (source_volume_id set)
+    expect(flyClient.createVolume).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        region: 'eu,us', // reversed from FLY_REGION='us,eu' in fake env
+        source_volume_id: 'vol-1',
+      })
+    );
+    // Old volume was deleted
+    expect(flyClient.deleteVolume).toHaveBeenCalledWith(expect.anything(), 'vol-1');
+    // Machine was retried
+    expect(storage._store.get('flyMachineId')).toBe('machine-retry');
+    expect(storage._store.get('flyVolumeId')).toBe('vol-forked');
+  });
+
+  it('existing instance: falls back to fresh volume when fork fails', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      flyMachineId: null,
+      lastStartedAt: Date.now() - 60_000,
+    });
+
+    // First createMachine fails with 412
+    (flyClient.createMachine as Mock)
+      .mockRejectedValueOnce(
+        new FlyApiError('insufficient resources', 412, '{"error":"insufficient resources"}')
+      )
+      .mockResolvedValueOnce({ id: 'machine-retry', region: 'yyz' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+    // Fork fails, then fresh create succeeds
+    (flyClient.createVolume as Mock)
+      .mockRejectedValueOnce(new FlyApiError('fork failed', 500, 'fail'))
+      .mockResolvedValueOnce({ id: 'vol-fresh', region: 'yyz' });
+
+    await instance.start('user-1');
+
+    // createVolume called twice: fork attempt + fresh
+    expect(flyClient.createVolume).toHaveBeenCalledTimes(2);
+    // Second call should NOT have source_volume_id
+    const secondCall = (flyClient.createVolume as Mock).mock.calls[1][1];
+    expect(secondCall.source_volume_id).toBeUndefined();
+
+    expect(storage._store.get('flyMachineId')).toBe('machine-retry');
+    expect(storage._store.get('flyVolumeId')).toBe('vol-fresh');
+  });
+
+  it('destroys existing machine when 412 hits on updateMachine in startExistingMachine', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { status: 'stopped', lastStartedAt: Date.now() - 60_000 });
+
+    // getMachine returns stopped, updateMachine throws 412
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'stopped' });
+    (flyClient.updateMachine as Mock).mockRejectedValue(
+      new FlyApiError('insufficient resources', 412, '{"error":"insufficient resources"}')
+    );
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+    (flyClient.createVolume as Mock).mockResolvedValue({ id: 'vol-new', region: 'cdg' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-new', region: 'cdg' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.start('user-1');
+
+    // Old machine was destroyed
+    expect(flyClient.destroyMachine).toHaveBeenCalledWith(expect.anything(), 'machine-1');
+    // Volume was forked (has user data)
+    expect(flyClient.createVolume).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ source_volume_id: 'vol-1' })
+    );
+    // New machine was created
+    expect(storage._store.get('flyMachineId')).toBe('machine-new');
+    expect(storage._store.get('flyVolumeId')).toBe('vol-new');
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('propagates non-412 errors without recovery', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { flyMachineId: null });
+
+    (flyClient.createMachine as Mock).mockRejectedValue(
+      new FlyApiError('server error', 500, 'internal')
+    );
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await expect(instance.start('user-1')).rejects.toThrow('server error');
+
+    // Volume should NOT have been replaced
+    expect(flyClient.deleteVolume).not.toHaveBeenCalled();
+    expect(flyClient.createVolume).not.toHaveBeenCalled();
+    expect(storage._store.get('flyVolumeId')).toBe('vol-1');
+  });
+
+  it('propagates error when 412 retry also fails', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { flyMachineId: null, lastStartedAt: null });
+
+    // Both attempts fail
+    (flyClient.createMachine as Mock)
+      .mockRejectedValueOnce(
+        new FlyApiError('insufficient resources', 412, '{"error":"insufficient resources"}')
+      )
+      .mockRejectedValueOnce(new FlyApiError('still no resources', 500, '{"error":"no capacity"}'));
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+    (flyClient.createVolume as Mock).mockResolvedValue({ id: 'vol-new', region: 'cdg' });
+
+    await expect(instance.start('user-1')).rejects.toThrow('still no resources');
+
+    // Volume was replaced (during recovery attempt)
+    expect(storage._store.get('flyVolumeId')).toBe('vol-new');
+    // But machine was NOT created (retry failed)
+    expect(storage._store.get('flyMachineId')).toBeNull();
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -1426,7 +1426,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    * Replace a stranded volume whose host has no capacity (Fly 412).
    *
    * For existing instances (lastStartedAt set): forks the volume to preserve
-   * user data, falling back to a fresh volume if the fork fails.
+   * user data. If the fork fails, the error propagates to the caller.
    * For fresh provisions (never started): deletes and creates a new empty volume.
    *
    * Uses reversed FLY_REGION priority so we prefer different regions.

--- a/kiloclaw/src/fly/client.test.ts
+++ b/kiloclaw/src/fly/client.test.ts
@@ -25,63 +25,45 @@ describe('isFlyNotFound', () => {
 });
 
 describe('isFlyInsufficientResources', () => {
-  // -- Capacity signals: should return true --
+  // -- Confirmed production payload --
 
-  it('matches exact production payload (insufficient resources + existing volume)', () => {
+  it('matches production payload: insufficient resources + existing volume', () => {
     const body =
       '{"error":"insufficient resources to create new machine with existing volume \'vol_4y5gkog8p5kj839r\'"}';
     const err = new FlyApiError(`Fly API createMachine failed (412): ${body}`, 412, body);
     expect(isFlyInsufficientResources(err)).toBe(true);
   });
 
-  it('matches insufficient_capacity in json.status field', () => {
-    const body = '{"status":"insufficient_capacity","error":"no hosts available"}';
-    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
-    expect(isFlyInsufficientResources(err)).toBe(true);
-  });
-
-  it('matches "no capacity" in json.error field', () => {
-    const body = '{"error":"no capacity in region iad"}';
-    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
-    expect(isFlyInsufficientResources(err)).toBe(true);
-  });
-
-  it('matches "at capacity" in json.error field', () => {
-    const body = '{"error":"host at capacity"}';
-    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
-    expect(isFlyInsufficientResources(err)).toBe(true);
-  });
-
-  it('matches capacity markers case-insensitively', () => {
+  it('matches capacity marker case-insensitively', () => {
     const body = '{"error":"Insufficient Resources for volume"}';
     const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
     expect(isFlyInsufficientResources(err)).toBe(true);
   });
 
-  it('matches capacity markers in non-JSON body text', () => {
+  it('matches capacity marker in non-JSON body text', () => {
     const body = 'insufficient resources to create machine';
     const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
     expect(isFlyInsufficientResources(err)).toBe(true);
   });
 
-  // -- Version/precondition signals: should return false --
+  // -- Version/precondition 412s: must NOT trigger recovery --
 
-  it('returns false for min_secrets_version mismatch', () => {
-    const body = '{"error":"min_secrets_version 3 is not yet available on this app"}';
-    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
-    expect(isFlyInsufficientResources(err)).toBe(false);
-  });
+  it('returns false for version/precondition 412s', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-  it('returns false for machine_version mismatch', () => {
-    const body = '{"error":"machine_version mismatch: expected 5, got 4"}';
-    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
-    expect(isFlyInsufficientResources(err)).toBe(false);
-  });
+    // These are hypothetical but represent the class of 412s we must NOT match
+    const preconditionBodies = [
+      '{"error":"min_secrets_version 3 is not yet available on this app"}',
+      '{"error":"machine_version mismatch: expected 5, got 4"}',
+      '{"error":"precondition failed: current_version does not match"}',
+    ];
 
-  it('returns false for generic precondition failure', () => {
-    const body = '{"error":"precondition failed: current_version does not match"}';
-    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
-    expect(isFlyInsufficientResources(err)).toBe(false);
+    for (const body of preconditionBodies) {
+      const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+      expect(isFlyInsufficientResources(err)).toBe(false);
+    }
+
+    warnSpy.mockRestore();
   });
 
   // -- Unclassified 412: should return false and warn --
@@ -99,7 +81,7 @@ describe('isFlyInsufficientResources', () => {
     warnSpy.mockRestore();
   });
 
-  // -- Non-412 and non-FlyApiError: should return false --
+  // -- Non-412 and non-FlyApiError --
 
   it('returns false for non-412 status', () => {
     expect(isFlyInsufficientResources(new FlyApiError('not found', 404, '{}'))).toBe(false);

--- a/kiloclaw/src/fly/client.test.ts
+++ b/kiloclaw/src/fly/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { FlyApiError, isFlyNotFound, isFlyInsufficientResources } from './client';
 
 describe('isFlyNotFound', () => {
@@ -25,12 +25,83 @@ describe('isFlyNotFound', () => {
 });
 
 describe('isFlyInsufficientResources', () => {
-  it('returns true for FlyApiError with status 412', () => {
-    const err = new FlyApiError('insufficient resources', 412, '{}');
+  // -- Capacity signals: should return true --
+
+  it('matches exact production payload (insufficient resources + existing volume)', () => {
+    const body =
+      '{"error":"insufficient resources to create new machine with existing volume \'vol_4y5gkog8p5kj839r\'"}';
+    const err = new FlyApiError(`Fly API createMachine failed (412): ${body}`, 412, body);
     expect(isFlyInsufficientResources(err)).toBe(true);
   });
 
-  it('returns false for FlyApiError with non-412 status', () => {
+  it('matches insufficient_capacity in json.status field', () => {
+    const body = '{"status":"insufficient_capacity","error":"no hosts available"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  it('matches "no capacity" in json.error field', () => {
+    const body = '{"error":"no capacity in region iad"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  it('matches "at capacity" in json.error field', () => {
+    const body = '{"error":"host at capacity"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  it('matches capacity markers case-insensitively', () => {
+    const body = '{"error":"Insufficient Resources for volume"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  it('matches capacity markers in non-JSON body text', () => {
+    const body = 'insufficient resources to create machine';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  // -- Version/precondition signals: should return false --
+
+  it('returns false for min_secrets_version mismatch', () => {
+    const body = '{"error":"min_secrets_version 3 is not yet available on this app"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(false);
+  });
+
+  it('returns false for machine_version mismatch', () => {
+    const body = '{"error":"machine_version mismatch: expected 5, got 4"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(false);
+  });
+
+  it('returns false for generic precondition failure', () => {
+    const body = '{"error":"precondition failed: current_version does not match"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+    expect(isFlyInsufficientResources(err)).toBe(false);
+  });
+
+  // -- Unclassified 412: should return false and warn --
+
+  it('returns false and logs warning for unclassified 412', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const body = '{"error":"some unknown 412 reason"}';
+    const err = new FlyApiError(`Fly API failed (412): ${body}`, 412, body);
+
+    expect(isFlyInsufficientResources(err)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[fly] Unclassified 412 error (not treated as capacity):',
+      body
+    );
+    warnSpy.mockRestore();
+  });
+
+  // -- Non-412 and non-FlyApiError: should return false --
+
+  it('returns false for non-412 status', () => {
     expect(isFlyInsufficientResources(new FlyApiError('not found', 404, '{}'))).toBe(false);
     expect(isFlyInsufficientResources(new FlyApiError('server error', 500, '{}'))).toBe(false);
   });

--- a/kiloclaw/src/fly/client.test.ts
+++ b/kiloclaw/src/fly/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { FlyApiError, isFlyNotFound } from './client';
+import { FlyApiError, isFlyNotFound, isFlyInsufficientResources } from './client';
 
 describe('isFlyNotFound', () => {
   it('returns true for FlyApiError with status 404', () => {
@@ -21,5 +21,27 @@ describe('isFlyNotFound', () => {
     expect(isFlyNotFound(null)).toBe(false);
     expect(isFlyNotFound(undefined)).toBe(false);
     expect(isFlyNotFound(42)).toBe(false);
+  });
+});
+
+describe('isFlyInsufficientResources', () => {
+  it('returns true for FlyApiError with status 412', () => {
+    const err = new FlyApiError('insufficient resources', 412, '{}');
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  it('returns false for FlyApiError with non-412 status', () => {
+    expect(isFlyInsufficientResources(new FlyApiError('not found', 404, '{}'))).toBe(false);
+    expect(isFlyInsufficientResources(new FlyApiError('server error', 500, '{}'))).toBe(false);
+  });
+
+  it('returns false for generic Error', () => {
+    expect(isFlyInsufficientResources(new Error('something'))).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isFlyInsufficientResources('string')).toBe(false);
+    expect(isFlyInsufficientResources(null)).toBe(false);
+    expect(isFlyInsufficientResources(undefined)).toBe(false);
   });
 });

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -212,6 +212,16 @@ export function isFlyNotFound(err: unknown): boolean {
 }
 
 /**
+ * Check if an error is a Fly API 412 (insufficient resources).
+ * This typically means the physical host where a volume is pinned has no
+ * capacity to launch a new machine. Recovery requires replacing the volume
+ * in a different region/host.
+ */
+export function isFlyInsufficientResources(err: unknown): boolean {
+  return err instanceof FlyApiError && err.status === 412;
+}
+
+/**
  * List machines in the app, optionally filtered by metadata key-value pairs.
  *
  * Metadata filtering (?metadata.{key}=value) is documented in the Fly Machines

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -228,10 +228,10 @@ const CAPACITY_MARKERS = ['insufficient resources'];
  * issue (host where a volume is pinned has no room for a machine).
  *
  * Fly overloads 412 for both capacity issues AND precondition/version mismatches
- * (e.g. min_secrets_version, machine_version). We only want to trigger
- * destructive recovery (volume replacement) for genuine capacity problems.
+ * (e.g. min_secrets_version, machine_version). We only trigger volume
+ * replacement recovery for genuine capacity problems — version/precondition
+ * 412s should surface to the caller as-is.
  *
- * Returns false for version/precondition 412s to avoid accidental data loss.
  * Logs a warning for unclassified 412s so we can tune matching.
  */
 export function isFlyInsufficientResources(err: unknown): boolean {

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -214,14 +214,14 @@ export function isFlyNotFound(err: unknown): boolean {
 /**
  * Capacity-related markers in Fly 412 error bodies. Matched case-insensitively
  * against the JSON body fields (error, status) and raw body text.
+ *
+ * Confirmed from production: "insufficient resources to create new machine
+ * with existing volume 'vol_xxx'"
+ *
+ * Add new markers here when the unclassified-412 warning log reveals new
+ * capacity error formats from Fly.
  */
-const CAPACITY_MARKERS = [
-  'insufficient resources',
-  'insufficient_capacity',
-  'no capacity',
-  'at capacity',
-  'existing volume',
-];
+const CAPACITY_MARKERS = ['insufficient resources'];
 
 /**
  * Check if a Fly API 412 error is specifically a capacity/resource exhaustion

--- a/kiloclaw/src/fly/types.ts
+++ b/kiloclaw/src/fly/types.ts
@@ -87,6 +87,17 @@ export type FlyVolume = {
   created_at: string;
 };
 
+/**
+ * Hint to Fly about the expected machine spec that will attach to this volume.
+ * When provided, Fly places the volume on a host with capacity for the machine,
+ * reducing the chance of a 412 "insufficient resources" on subsequent machine creation.
+ */
+export type VolumeComputeHint = {
+  cpu_kind?: 'shared' | 'performance';
+  cpus?: number;
+  memory_mb?: number;
+};
+
 export type CreateVolumeRequest = {
   name: string;
   region: string;
@@ -94,6 +105,8 @@ export type CreateVolumeRequest = {
   snapshot_retention?: number;
   /** Fork an existing volume. Creates a copy on a different host/region. */
   source_volume_id?: string;
+  /** Expected machine spec — helps Fly pick a host with capacity. */
+  compute?: VolumeComputeHint;
 };
 
 // -- Exec types --

--- a/kiloclaw/src/fly/types.ts
+++ b/kiloclaw/src/fly/types.ts
@@ -92,6 +92,8 @@ export type CreateVolumeRequest = {
   region: string;
   size_gb: number;
   snapshot_retention?: number;
+  /** Fork an existing volume. Creates a copy on a different host/region. */
+  source_volume_id?: string;
 };
 
 // -- Exec types --


### PR DESCRIPTION
## Summary

- When a Fly volume's host has no capacity for a new machine (412 error), automatically recover by replacing the volume in a different region
- For existing instances with user data: fork the volume to preserve workspace files; if fork fails, surface the error (no silent data loss)
- For fresh provisions (never started): delete and recreate volume in a different region
- Narrow 412 detection to only match capacity-related errors, not version/precondition mismatches (`min_secrets_version`, `machine_version`, etc.)
- Pass compute hints (cpu/memory spec) when creating volumes so Fly picks a host with capacity for the expected machine
- Walk the region list explicitly on volume creation — Fly doesn't support meta-regions for volumes, so on capacity 412 we try the next region
- Add pre-flight volume region validation on `start()` to catch `flyRegion` drift before machine creation
- Unify fallback region strings into `DEFAULT_FLY_REGION` constant

## Context

Users hitting `FlyApiError: Fly API createMachine failed (412): {"error":"insufficient resources to create new machine with existing volume"}` — the physical host where their volume is pinned ran out of capacity. Previously this was unrecoverable without manual intervention.

Fly support recommended passing `--vm-size`/`--vm-cpus`/`--memory` when creating volumes so the scheduler picks a host with capacity for both the volume and the machine. They also confirmed meta-regions aren't supported for volume creation, so we walk the region list ourselves.

## 412 Classification

Fly overloads 412 for both capacity exhaustion and precondition/version mismatches. We only trigger recovery for capacity signals:

| Fly 412 body | Classified as | Recovery? |
|---|---|---|
| `"insufficient resources to create new machine with existing volume 'vol_xxx'"` | Capacity | Yes — fork/replace volume |
| `"min_secrets_version 3 is not yet available"` | Precondition | No — re-thrown |
| `"machine_version mismatch"` | Precondition | No — re-thrown |
| Unknown 412 | Unclassified | No — re-thrown + warning logged |

## Volume Creation Strategy

All volume creation now goes through `createVolumeWithFallback` which:
1. Accepts an explicit list of regions (parsed from `FLY_REGION`)
2. Passes a `compute` hint matching the expected machine spec
3. Tries each region in order; on capacity 412, logs a warning and tries the next
4. On non-capacity errors, throws immediately (no fallthrough)

For 412 recovery, `deprioritizeRegion` moves the failed region to the end of the list so other regions are tried first.

## Recovery Strategy

| Scenario | Action |
|---|---|
| Fresh provision (never started, empty volume) | Delete volume, create fresh in deprioritized regions |
| Existing instance (has user data) | Fork volume to new region, delete old |
| Fork fails on existing instance | Error surfaces to caller (no silent data loss) |

## Changes

| File | What |
|------|------|
| `src/fly/types.ts` | `VolumeComputeHint` type, `compute` + `source_volume_id` on `CreateVolumeRequest` |
| `src/fly/client.ts` | `isFlyInsufficientResources()` (capacity-aware 412), `createVolumeWithFallback()` (region walking) |
| `src/config.ts` | `DEFAULT_FLY_REGION` constant |
| `src/durable-objects/kiloclaw-instance.ts` | `parseRegions()`, `deprioritizeRegion()`, `replaceStrandedVolume()`, 412 recovery in `start()`, pre-flight region validation, compute hints on all volume creation |
| `src/fly/client.test.ts` | Tests for 412 classification, `createVolumeWithFallback` (region walking, compute passthrough) |
| `src/durable-objects/kiloclaw-instance.test.ts` | Tests for `parseRegions`, `deprioritizeRegion`, 412 recovery, region validation |

## Test plan

- 245 tests passing (`pnpm typecheck && pnpm test && pnpm lint` all clean)
- Covers: fresh provision 412, existing instance fork, fork failure propagation, updateMachine 412, non-412 passthrough, retry failure propagation, region drift correction, volume 404 during region check, production payload matching, version mismatch rejection, unclassified 412 warning, region walking (first region 412 → fallback), all regions exhausted, non-capacity error no-fallthrough, compute hint passthrough