### PR TITLE
App Builder - Extract shared git protocol utils and fix byte-length bug

### DIFF
--- a/cloudflare-app-builder/src/git/git-clone-service.test.ts
+++ b/cloudflare-app-builder/src/git/git-clone-service.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from 'vitest';
+import { deflateSync } from 'node:zlib';
+import { createHash } from 'node:crypto';
+import { GitCloneService } from './git-clone-service';
+import { GitReceivePackService } from './git-receive-pack-service';
+import { MemFS } from './memfs';
+
+// ---------------------------------------------------------------------------
+// Helpers copied from git-receive-pack-service.test.ts
+// ---------------------------------------------------------------------------
+
+function buildPushRequest(
+  refs: Array<{ oldOid: string; newOid: string; refName: string }>,
+  packfileBytes: Uint8Array
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+
+  for (let i = 0; i < refs.length; i++) {
+    const { oldOid, newOid, refName } = refs[i];
+    let line = `${oldOid} ${newOid} ${refName}`;
+    if (i === 0) {
+      line += '\0 report-status';
+    }
+    line += '\n';
+    const lengthHex = (line.length + 4).toString(16).padStart(4, '0');
+    chunks.push(encoder.encode(lengthHex + line));
+  }
+
+  chunks.push(encoder.encode('0000'));
+  chunks.push(packfileBytes);
+
+  const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+const zeroOid = '0'.repeat(40);
+
+function buildValidPackfile(blobContent: string): { packBytes: Uint8Array; blobOid: string } {
+  const content = Buffer.from(blobContent);
+  const gitObjectHeader = Buffer.from(`blob ${content.length}\0`);
+  const blobOid = createHash('sha1')
+    .update(Buffer.concat([gitObjectHeader, content]))
+    .digest('hex');
+
+  const header = Buffer.alloc(12);
+  header.write('PACK', 0);
+  header.writeUInt32BE(2, 4);
+  header.writeUInt32BE(1, 8);
+
+  if (content.length > 15)
+    throw new Error('buildValidPackfile: content too long for simple header');
+  const objHeader = Buffer.from([(3 << 4) | content.length]);
+
+  const deflated = deflateSync(content);
+  const packBody = Buffer.concat([header, objHeader, deflated]);
+  const checksum = createHash('sha1').update(packBody).digest();
+  const packBytes = new Uint8Array(Buffer.concat([packBody, checksum]));
+
+  return { packBytes, blobOid };
+}
+
+// ---------------------------------------------------------------------------
+// Push helper: uses GitReceivePackService to populate a MemFS with real objects
+// ---------------------------------------------------------------------------
+
+async function pushToRepo(
+  fs: MemFS,
+  refs: Array<{ oldOid: string; newOid: string; refName: string }>,
+  packBytes: Uint8Array
+): Promise<void> {
+  const requestData = buildPushRequest(refs, packBytes);
+  const { result } = await GitReceivePackService.handleReceivePack(fs, requestData);
+  if (!result.success) {
+    throw new Error(`Push failed: ${result.errors.join(', ')}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers for smart HTTP info/refs responses
+// ---------------------------------------------------------------------------
+
+type ParsedInfoRefs = {
+  service: string;
+  headOid: string;
+  capabilities: string;
+  refs: Array<{ oid: string; refName: string }>;
+};
+
+/** Parse a git smart HTTP info/refs response into structured data. */
+function parseInfoRefsResponse(response: string): ParsedInfoRefs {
+  let offset = 0;
+
+  // Read service announcement pkt-line
+  const serviceHex = response.substring(offset, offset + 4);
+  const serviceLen = parseInt(serviceHex, 16);
+  const serviceLine = response.substring(offset + 4, offset + serviceLen);
+  offset += serviceLen;
+
+  // Skip flush packet
+  if (response.substring(offset, offset + 4) === '0000') {
+    offset += 4;
+  }
+
+  let headOid = '';
+  let capabilities = '';
+  const refs: Array<{ oid: string; refName: string }> = [];
+
+  while (offset < response.length) {
+    const hex = response.substring(offset, offset + 4);
+    if (hex === '0000') break;
+
+    const len = parseInt(hex, 16);
+    const lineContent = response.substring(offset + 4, offset + len);
+    offset += len;
+
+    const trimmed = lineContent.replace(/\n$/, '');
+
+    if (trimmed.includes('\0')) {
+      // HEAD line with capabilities
+      const [refPart, capsPart] = trimmed.split('\0');
+      const spaceIdx = refPart.indexOf(' ');
+      headOid = refPart.substring(0, spaceIdx);
+      capabilities = capsPart;
+    } else {
+      const spaceIdx = trimmed.indexOf(' ');
+      refs.push({
+        oid: trimmed.substring(0, spaceIdx),
+        refName: trimmed.substring(spaceIdx + 1),
+      });
+    }
+  }
+
+  return { service: serviceLine.trim(), headOid, capabilities, refs };
+}
+
+/**
+ * Walk pkt-lines in a response string and verify that each hex-length prefix
+ * correctly represents the UTF-8 byte length of the line (including the 4-byte
+ * prefix itself). Skips flush packets (0000).
+ */
+function verifyPktLineLengths(response: string): void {
+  const encoder = new TextEncoder();
+  let offset = 0;
+
+  while (offset < response.length) {
+    const hex = response.substring(offset, offset + 4);
+    if (hex === '0000') {
+      offset += 4;
+      continue;
+    }
+
+    const declaredLen = parseInt(hex, 16);
+    if (isNaN(declaredLen) || declaredLen < 4) {
+      throw new Error(`Invalid pkt-line hex at offset ${offset}: "${hex}"`);
+    }
+
+    // The content after the hex prefix up to declaredLen bytes total
+    const lineContent = response.substring(offset + 4, offset + declaredLen);
+    const byteLen = encoder.encode(lineContent).length + 4;
+
+    expect(declaredLen).toBe(byteLen);
+
+    offset += declaredLen;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitCloneService', () => {
+  describe('handleInfoRefs', () => {
+    it('advertises symref=HEAD:refs/heads/main when HEAD is symbolic', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('hello');
+
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const response = await GitCloneService.handleInfoRefs(fs);
+      const parsed = parseInfoRefsResponse(response);
+
+      expect(parsed.capabilities).toContain('symref=HEAD:refs/heads/main');
+    });
+
+    it('advertises symref=HEAD:refs/heads/main when HEAD is a raw OID matching main (legacy repo)', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('legacy');
+
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      // Read the OID that refs/heads/main points to
+      const mainOid = String(
+        await fs.readFile('.git/refs/heads/main', { encoding: 'utf8' })
+      ).trim();
+
+      // Overwrite HEAD with the raw OID (simulating pre-PR#203 state)
+      await fs.writeFile('.git/HEAD', mainOid);
+
+      const response = await GitCloneService.handleInfoRefs(fs);
+      const parsed = parseInfoRefsResponse(response);
+
+      expect(parsed.capabilities).toContain('symref=HEAD:refs/heads/main');
+    });
+
+    it('does not advertise symref when HEAD is a raw OID matching no branch', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('orphan');
+
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      // Overwrite HEAD with an OID that doesn't match any branch
+      await fs.writeFile('.git/HEAD', 'b'.repeat(40));
+
+      const response = await GitCloneService.handleInfoRefs(fs);
+      const parsed = parseInfoRefsResponse(response);
+
+      expect(parsed.capabilities).not.toContain('symref=');
+    });
+
+    it('advertises all branch refs', async () => {
+      const fs = new MemFS();
+
+      const { packBytes: pack1, blobOid: oid1 } = buildValidPackfile('one');
+      await pushToRepo(fs, [{ oldOid: zeroOid, newOid: oid1, refName: 'refs/heads/main' }], pack1);
+
+      const { packBytes: pack2, blobOid: oid2 } = buildValidPackfile('two');
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: oid2, refName: 'refs/heads/feature' }],
+        pack2
+      );
+
+      const response = await GitCloneService.handleInfoRefs(fs);
+      const parsed = parseInfoRefsResponse(response);
+
+      const refNames = parsed.refs.map(r => r.refName);
+      expect(refNames).toContain('refs/heads/main');
+      expect(refNames).toContain('refs/heads/feature');
+    });
+
+    it('HEAD line OID matches refs/heads/main OID', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('match');
+
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const response = await GitCloneService.handleInfoRefs(fs);
+      const parsed = parseInfoRefsResponse(response);
+
+      // Read the OID from refs/heads/main
+      const mainOid = String(
+        await fs.readFile('.git/refs/heads/main', { encoding: 'utf8' })
+      ).trim();
+
+      expect(parsed.headOid).toBe(mainOid);
+    });
+  });
+
+  describe('formatPacketLine', () => {
+    it('pkt-line hex lengths match UTF-8 byte lengths', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('pkt');
+
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const response = await GitCloneService.handleInfoRefs(fs);
+
+      // Verify every pkt-line in the response has correct hex lengths
+      verifyPktLineLengths(response);
+    });
+  });
+
+  describe('handleUploadPack', () => {
+    it('returns data starting with NAK', async () => {
+      const fs = new MemFS();
+      const { packBytes, blobOid } = buildValidPackfile('nak');
+
+      await pushToRepo(
+        fs,
+        [{ oldOid: zeroOid, newOid: blobOid, refName: 'refs/heads/main' }],
+        packBytes
+      );
+
+      const result = await GitCloneService.handleUploadPack(fs);
+
+      // First 8 bytes should be "0008NAK\n"
+      const first8 = new TextDecoder().decode(result.slice(0, 8));
+      expect(first8).toBe('0008NAK\n');
+    });
+  });
+});

--- a/cloudflare-app-builder/src/git/git-protocol-utils.test.ts
+++ b/cloudflare-app-builder/src/git/git-protocol-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { formatPacketLine } from './git-protocol-utils';
+
+describe('formatPacketLine', () => {
+  it('length prefix counts UTF-8 bytes, not JS string length', () => {
+    // '€' is U+20AC — 3 bytes in UTF-8 but 1 JS char.
+    // Data: "€\n" → 4 UTF-8 bytes.  Packet = 4 (prefix) + 4 (data) = 0008.
+    const line = '€\n';
+    const result = formatPacketLine(line);
+    const declaredLen = parseInt(result.substring(0, 4), 16);
+    const actualByteLen = new TextEncoder().encode(line).length + 4;
+
+    expect(declaredLen).toBe(actualByteLen); // 8, not 6
+  });
+
+  it('length prefix is correct for ASCII-only data', () => {
+    const line = 'hello\n';
+    const result = formatPacketLine(line);
+    const declaredLen = parseInt(result.substring(0, 4), 16);
+
+    // "hello\n" = 6 bytes + 4 prefix = 10
+    expect(declaredLen).toBe(10);
+    expect(result).toBe('000ahello\n');
+  });
+});

--- a/cloudflare-app-builder/src/git/git-protocol-utils.ts
+++ b/cloudflare-app-builder/src/git/git-protocol-utils.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared utilities for the git HTTP protocol (upload-pack & receive-pack).
+ */
+
+import type { MemFS } from './memfs';
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Determine which branch HEAD points to, for the symref capability.
+ * Returns the full ref (e.g. "refs/heads/main") or null if HEAD is detached
+ * with no matching branch.
+ */
+export async function resolveHeadSymref(fs: MemFS, branches: string[]): Promise<string | null> {
+  try {
+    const headContent = String(await fs.readFile('.git/HEAD', { encoding: 'utf8' })).trim();
+
+    // Symbolic ref: "ref: refs/heads/main"
+    if (headContent.startsWith('ref: ')) {
+      return headContent.slice('ref: '.length);
+    }
+
+    // Raw OID (legacy repo): find a branch whose OID matches HEAD
+    const headOid = headContent;
+
+    // Prefer main > master > first match
+    const preferred = ['main', 'master'];
+    for (const name of preferred) {
+      if (!branches.includes(name)) continue;
+      try {
+        const branchOid = String(
+          await fs.readFile(`.git/refs/heads/${name}`, { encoding: 'utf8' })
+        ).trim();
+        if (branchOid === headOid) return `refs/heads/${name}`;
+      } catch {
+        // branch file missing
+      }
+    }
+
+    for (const name of branches) {
+      if (preferred.includes(name)) continue;
+      try {
+        const branchOid = String(
+          await fs.readFile(`.git/refs/heads/${name}`, { encoding: 'utf8' })
+        ).trim();
+        if (branchOid === headOid) return `refs/heads/${name}`;
+      } catch {
+        // branch file missing
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format git packet line (4-byte hex length prefix + data).
+ * The length counts UTF-8 encoded bytes (not JS string length) per the git protocol spec.
+ */
+export function formatPacketLine(data: string): string {
+  const byteLength = textEncoder.encode(data).length;
+  const hexLength = (byteLength + 4).toString(16).padStart(4, '0');
+  return hexLength + data;
+}

--- a/cloudflare-app-builder/src/handlers/git-protocol.ts
+++ b/cloudflare-app-builder/src/handlers/git-protocol.ts
@@ -6,6 +6,7 @@
 
 import { GitCloneService } from '../git/git-clone-service';
 import { GitReceivePackService } from '../git/git-receive-pack-service';
+import { formatPacketLine } from '../git/git-protocol-utils';
 import { MAX_OBJECT_SIZE } from '../git/constants';
 import { logger, formatError } from '../utils/logger';
 import { verifyGitAuth } from '../utils/auth';
@@ -152,15 +153,6 @@ async function handleInfoRefs(
     logger.error('Git info/refs error', formatError(error));
     return new Response('Internal server error', { status: 500 });
   }
-}
-
-/**
- * Format git packet line (4-byte hex length + data)
- */
-function formatPacketLine(data: string): string {
-  const length = data.length + 4;
-  const hexLength = length.toString(16).padStart(4, '0');
-  return hexLength + data;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract duplicated `resolveHeadSymref` and `formatPacketLine` into a shared `git-protocol-utils.ts` module, removing identical copies from `git-clone-service.ts`, `git-receive-pack-service.ts`, and `handlers/git-protocol.ts`
- Add `symref=HEAD:<branch>` capability advertisement to both upload-pack and receive-pack `info/refs` responses, so git clients can detect the default branch on clone/push
- Fix `formatPacketLine` in `handlers/git-protocol.ts` which was using JS string length instead of UTF-8 byte length for the pkt-line hex prefix (incorrect for multi-byte characters)

## Changes
- **New:** `cloudflare-app-builder/src/git/git-protocol-utils.ts` — shared module with `resolveHeadSymref` and `formatPacketLine` (hoisted `TextEncoder`)
- **New:** `cloudflare-app-builder/src/git/git-protocol-utils.test.ts` — unit tests for `formatPacketLine` including a multi-byte UTF-8 test that catches the string-length bug
- **New:** `cloudflare-app-builder/src/git/git-clone-service.test.ts` — integration tests for `handleInfoRefs` symref advertisement and pkt-line correctness
- **Modified:** `git-clone-service.ts`, `git-receive-pack-service.ts` — import shared functions, remove private static duplicates, add symref capability
- **Modified:** `handlers/git-protocol.ts` — replace buggy local `formatPacketLine` with shared import