### PR TITLE
fix: reduce KiloClaw stale status from ~30min to ~30s and prevent Fly auto restart

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -40,3 +40,7 @@ export const ALARM_JITTER_MS = 60 * 1000; // 0-60s
 
 /** Consecutive failed health checks before marking a running instance as stopped */
 export const SELF_HEAL_THRESHOLD = 5;
+
+/** Minimum interval between live Fly API checks in getStatus() (30 seconds).
+ *  At 10s UI poll interval, only ~1 in 3 polls will hit Fly. */
+export const LIVE_CHECK_THROTTLE_MS = 30 * 1000;

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -78,6 +78,7 @@ import {
   ALARM_INTERVAL_IDLE_MS,
   ALARM_JITTER_MS,
   SELF_HEAL_THRESHOLD,
+  LIVE_CHECK_THROTTLE_MS,
 } from '../config';
 
 // ============================================================================
@@ -145,13 +146,23 @@ function createFakeEnv() {
 function createInstance(
   storage = createFakeStorage(),
   env = createFakeEnv()
-): { instance: KiloClawInstance; storage: ReturnType<typeof createFakeStorage> } {
-  const ctx = { storage } as unknown;
+): {
+  instance: KiloClawInstance;
+  storage: ReturnType<typeof createFakeStorage>;
+  waitUntilPromises: Promise<unknown>[];
+} {
+  const waitUntilPromises: Promise<unknown>[] = [];
+  const ctx = {
+    storage,
+    waitUntil: (p: Promise<unknown>) => {
+      waitUntilPromises.push(p);
+    },
+  } as unknown;
   const instance = new KiloClawInstance(
     ctx as ConstructorParameters<typeof KiloClawInstance>[0],
     env as ConstructorParameters<typeof KiloClawInstance>[1]
   );
-  return { instance, storage };
+  return { instance, storage, waitUntilPromises };
 }
 
 /** Seed DO storage with a provisioned instance and trigger loadState. */
@@ -828,5 +839,181 @@ describe('updateChannels', () => {
 
     expect(result.telegram).toBe(true);
     expect(result.discord).toBe(true);
+  });
+});
+
+// ============================================================================
+// Live check in getStatus()
+// ============================================================================
+
+describe('getStatus: throttled live Fly check', () => {
+  it('confirms running when Fly says started', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'started', config: {} });
+
+    const result = await instance.getStatus();
+
+    // Fire-and-forget: wait for the background check to complete
+    await Promise.all(waitUntilPromises);
+
+    expect(result.status).toBe('running');
+    expect(flyClient.getMachine).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips to stopped in-memory when Fly says stopped', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'stopped', config: {} });
+
+    // First call: fires the live check (fire-and-forget), returns cached 'running'
+    const result1 = await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+
+    // Status was updated in-memory by the background check
+    // Second call should return 'stopped' (and not fire another check since status != running)
+    const result2 = await instance.getStatus();
+
+    expect(result1.status).toBe('running'); // fire-and-forget: first call returns cached
+    expect(result2.status).toBe('stopped'); // next call sees updated in-memory state
+    // No persistence — alarm loop owns that
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('leaves status as running for transitional states (starting)', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'starting', config: {} });
+
+    await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+
+    // Second call: status should still be running
+    const result = await instance.getStatus();
+    expect(result.status).toBe('running');
+  });
+
+  it('leaves status as running for transitional states (stopping)', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'stopping', config: {} });
+
+    await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+
+    const result = await instance.getStatus();
+    expect(result.status).toBe('running');
+  });
+
+  it('flips to stopped on 404 (machine gone)', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockRejectedValue(new FlyApiError('not found', 404, '{}'));
+
+    await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+
+    const result = await instance.getStatus();
+    expect(result.status).toBe('stopped');
+    // No persistence
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('preserves cached status on transient Fly error', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockRejectedValue(new FlyApiError('timeout', 503, 'retry'));
+
+    await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+
+    const result = await instance.getStatus();
+    expect(result.status).toBe('running');
+  });
+
+  it('respects throttle — does not call Fly within window', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'started', config: {} });
+
+    // First call triggers live check
+    await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+    expect(flyClient.getMachine).toHaveBeenCalledTimes(1);
+
+    // Second call within throttle window — should NOT call Fly again
+    await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+    expect(flyClient.getMachine).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire live check when status is not running', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'stopped', flyMachineId: 'machine-1' });
+
+    await instance.getStatus();
+
+    expect(flyClient.getMachine).not.toHaveBeenCalled();
+  });
+
+  it('does not fire live check when flyMachineId is null', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { flyMachineId: null });
+
+    await instance.getStatus();
+
+    expect(flyClient.getMachine).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// stop() error handling
+// ============================================================================
+
+describe('stop: error propagation', () => {
+  it('propagates non-404 Fly errors', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.stopMachineAndWait as Mock).mockRejectedValue(
+      new FlyApiError('server error', 500, 'internal')
+    );
+
+    await expect(instance.stop()).rejects.toThrow('server error');
+
+    // Status should NOT have been written to stopped
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('treats 404 as success (machine already gone)', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.stopMachineAndWait as Mock).mockRejectedValue(
+      new FlyApiError('not found', 404, '{}')
+    );
+
+    await instance.stop();
+
+    expect(storage._store.get('status')).toBe('stopped');
+  });
+
+  it('succeeds when Fly stop completes normally', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.stopMachineAndWait as Mock).mockResolvedValue(undefined);
+
+    await instance.stop();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('lastStoppedAt')).toBeDefined();
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -78,7 +78,6 @@ import {
   ALARM_INTERVAL_IDLE_MS,
   ALARM_JITTER_MS,
   SELF_HEAL_THRESHOLD,
-  LIVE_CHECK_THROTTLE_MS,
 } from '../config';
 
 // ============================================================================

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -44,6 +44,7 @@ import {
   ALARM_INTERVAL_IDLE_MS,
   ALARM_JITTER_MS,
   SELF_HEAL_THRESHOLD,
+  LIVE_CHECK_THROTTLE_MS,
 } from '../config';
 import type { FlyClientConfig } from '../fly/client';
 import type { FlyMachineConfig, FlyMachine, FlyMachineState } from '../fly/types';
@@ -127,6 +128,8 @@ function buildMachineConfig(
         ports: [{ port: 443, handlers: ['tls', 'http'] }],
         internal_port: OPENCLAW_PORT,
         protocol: 'tcp' as const,
+        autostart: false,
+        autostop: 'off',
       },
     ],
     mounts: flyVolumeId ? [{ volume: flyVolumeId, path: '/root' }] : [],
@@ -166,6 +169,15 @@ const METADATA_RECOVERY_COOLDOWN_MS = ALARM_INTERVAL_IDLE_MS;
 
 /** States that indicate the machine is dead and should be ignored for recovery. */
 const DEAD_STATES: ReadonlySet<FlyMachineState> = new Set(['destroyed', 'destroying']);
+
+/** Terminal non-running states for live check. Transitional states (starting, stopping, replacing)
+ *  are intentionally excluded to avoid UI flicker during normal operations. */
+const TERMINAL_STOPPED_STATES: ReadonlySet<string> = new Set([
+  'stopped',
+  'created',
+  'destroyed',
+  'suspended',
+]);
 
 /**
  * Priority order for picking a machine to recover.
@@ -241,6 +253,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private pendingDestroyMachineId: string | null = null;
   private pendingDestroyVolumeId: string | null = null;
   private lastMetadataRecoveryAt: number | null = null;
+
+  // In-memory only (not persisted to SQLite) — throttles live Fly checks in getStatus()
+  private lastLiveCheckAt: number | null = null;
 
   // ---- State loading ----
 
@@ -738,7 +753,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       try {
         await fly.stopMachineAndWait(flyConfig, this.flyMachineId);
       } catch (err) {
-        console.error('[DO] Failed to stop machine:', err);
+        if (!fly.isFlyNotFound(err)) {
+          // Real error — don't write 'stopped' when we don't know the actual state
+          throw err;
+        }
+        // 404 = machine already gone, safe to mark stopped
+        console.log('[DO] Machine already gone (404), marking stopped');
       }
     }
 
@@ -821,6 +841,19 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     flyRegion: string | null;
   }> {
     await this.loadState();
+
+    // Fire-and-forget live check: when DO thinks the machine is running, verify
+    // with Fly in the background. Updates in-memory state for the *next* poll.
+    // This keeps getStatus() latency consistently low (~0ms) instead of blocking
+    // on a Fly API round-trip (~1-5s) every throttle window.
+    if (
+      this.status === 'running' &&
+      this.flyMachineId &&
+      (this.lastLiveCheckAt === null || Date.now() - this.lastLiveCheckAt >= LIVE_CHECK_THROTTLE_MS)
+    ) {
+      this.lastLiveCheckAt = Date.now();
+      this.ctx.waitUntil(this.syncStatusFromLiveCheck());
+    }
 
     return {
       userId: this.userId,
@@ -1120,6 +1153,42 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           })
         );
       }
+    }
+  }
+
+  /**
+   * Lightweight live check called from getStatus() via waitUntil (fire-and-forget).
+   * Updates in-memory status only — the alarm loop owns persistence.
+   * Silently falls back to cached state on transient errors.
+   * lastLiveCheckAt is set by the caller before dispatching.
+   */
+  private async syncStatusFromLiveCheck(): Promise<void> {
+    try {
+      const flyConfig = this.getFlyConfig();
+      const machine = await fly.getMachine(flyConfig, this.flyMachineId!);
+
+      if (machine.state === 'started') {
+        // Confirmed running — reset in-memory fail count
+        this.healthCheckFailCount = 0;
+        return;
+      }
+
+      if (TERMINAL_STOPPED_STATES.has(machine.state)) {
+        console.log('[DO] Live check: Fly state is', machine.state, '— marking stopped in-memory');
+        this.status = 'stopped';
+      } else {
+        // Transitional state — leave status as running, reset fail count
+        this.healthCheckFailCount = 0;
+      }
+    } catch (err) {
+      if (fly.isFlyNotFound(err)) {
+        // Machine gone (404) — flip in-memory status to stopped
+        console.log('[DO] Live check: machine 404 — marking stopped in-memory');
+        this.status = 'stopped';
+        return;
+      }
+      // Transient error — silently fall back to cached state
+      console.warn('[DO] Live check failed, using cached status:', err);
     }
   }
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -1163,9 +1163,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    * lastLiveCheckAt is set by the caller before dispatching.
    */
   private async syncStatusFromLiveCheck(): Promise<void> {
+    if (!this.flyMachineId) return;
+
     try {
       const flyConfig = this.getFlyConfig();
-      const machine = await fly.getMachine(flyConfig, this.flyMachineId!);
+      const machine = await fly.getMachine(flyConfig, this.flyMachineId);
 
       if (machine.state === 'started') {
         // Confirmed running — reset in-memory fail count

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -172,7 +172,7 @@ const DEAD_STATES: ReadonlySet<FlyMachineState> = new Set(['destroyed', 'destroy
 
 /** Terminal non-running states for live check. Transitional states (starting, stopping, replacing)
  *  are intentionally excluded to avoid UI flicker during normal operations. */
-const TERMINAL_STOPPED_STATES: ReadonlySet<string> = new Set([
+const TERMINAL_STOPPED_STATES: ReadonlySet<FlyMachineState> = new Set([
   'stopped',
   'created',
   'destroyed',


### PR DESCRIPTION


  - Add LIVE_CHECK_THROTTLE_MS (30s) constant to config
  - Add fire-and-forget syncStatusFromLiveCheck() via ctx.waitUntil() that queries Fly on getStatus() polls when DO thinks machine is running
  - Only flip to stopped for terminal Fly states; transitional states (starting, stopping, replacing) leave status as running
  - Fix stop() to propagate Fly API errors instead of silently writing stopped (404 still treated as success)
  - Disable Fly autostart/autostop on machine services so stopped machines stay stopped when WebSocket proxy requests hit them
  - Add 11 tests covering live check and stop() error handling