### PR TITLE
fix: handle deleted repos gracefully in security alerts sync

### DIFF
--- a/src/lib/security-agent/core/types.ts
+++ b/src/lib/security-agent/core/types.ts
@@ -316,4 +316,6 @@ export type SyncResult = {
   created: number;
   updated: number;
   errors: number;
+  /** Repos that returned 404 from GitHub (deleted/transferred) */
+  staleRepos: string[];
 };


### PR DESCRIPTION
## Summary
- Handle HTTP 404 from GitHub Dependabot API gracefully when repos have been deleted or transferred, instead of throwing errors that cause 502s on the cron job
- Automatically prune stale repos from the agent config's `selected_repository_ids` so they aren't retried on future syncs
- Introduce a discriminated union `FetchAlertsResult` to cleanly distinguish success, repo-not-found, and alerts-disabled responses

## Changes
- **`dependabot-api.ts`**: Changed `fetchAllDependabotAlerts` return type from `DependabotAlertRaw[]` to `FetchAlertsResult` discriminated union. HTTP 404 now returns `{ status: 'repo_not_found' }` instead of throwing.
- **`sync-service.ts`**: Added `pruneStaleReposFromConfig()` which removes deleted repo IDs from `selected_repository_ids` when in `'selected'` mode. Uses `getSecurityAgentConfigWithStatus` + `upsertAgentConfigForOwner` directly to preserve the current `isEnabled` state.
- **`types.ts`**: Added `staleRepos: string[]` to `SyncResult` to propagate not-found repos up the call chain.