### PR TITLE
add created_at (epoch ms) to both o11y pipeline streams

### DIFF
--- a/cloudflare-o11y/pipelines/api-metrics-schema.json
+++ b/cloudflare-o11y/pipelines/api-metrics-schema.json
@@ -8,6 +8,7 @@
 		{ "name": "user_byok", "type": "bool", "required": true },
 		{ "name": "ttfb_ms", "type": "int64", "required": true },
 		{ "name": "complete_request_ms", "type": "int64", "required": true },
-		{ "name": "status_code", "type": "int32", "required": true }
+		{ "name": "status_code", "type": "int32", "required": true },
+		{ "name": "created_at", "type": "int64", "required": true }
 	]
 }

--- a/cloudflare-o11y/pipelines/session-metrics-schema.json
+++ b/cloudflare-o11y/pipelines/session-metrics-schema.json
@@ -15,6 +15,7 @@
 		{ "name": "compaction_count", "type": "int32", "required": true },
 		{ "name": "stuck_tool_call_count", "type": "int32", "required": true },
 		{ "name": "auto_compaction_count", "type": "int32", "required": true },
-		{ "name": "ingest_version", "type": "int32", "required": true }
+		{ "name": "ingest_version", "type": "int32", "required": true },
+		{ "name": "created_at", "type": "int64", "required": true }
 	]
 }

--- a/cloudflare-o11y/src/o11y-analytics.ts
+++ b/cloudflare-o11y/src/o11y-analytics.ts
@@ -48,6 +48,7 @@ export function writeApiMetricsDataPoint(
 				ttfb_ms: params.ttfbMs,
 				complete_request_ms: params.completeRequestMs,
 				status_code: params.statusCode,
+				created_at: Date.now(),
 			},
 		]),
 	);

--- a/cloudflare-o11y/src/session-metrics-analytics.ts
+++ b/cloudflare-o11y/src/session-metrics-analytics.ts
@@ -70,6 +70,7 @@ export async function writeSessionMetricsDataPoint(params: SessionMetricsParams,
 			stuck_tool_call_count: params.stuckToolCallCount,
 			auto_compaction_count: params.autoCompactionCount,
 			ingest_version: params.ingestVersion,
+			created_at: Date.now(),
 		},
 	]);
 }


### PR DESCRIPTION
## Summary

- Adds `created_at` (epoch milliseconds via `Date.now()`) to the `API_METRICS_STREAM` and `SESSION_METRICS_STREAM` pipeline send payloads
- Updates both pipeline schema JSON files accordingly

## Note

Stream schemas are immutable — both streams need to be recreated after merging:
```bash
# From cloudflare-o11y/
./pipelines/recreate-stream.sh o11y_api_metrics_stream pipelines/api-metrics-schema.json o11y_api_metrics_pipeline o11y_api_metrics_sink
./pipelines/recreate-stream.sh o11y_session_metrics_stream pipelines/session-metrics-schema.json o11y_session_metrics_pipeline o11y_session_metrics_sink
```