### PR TITLE
fix(kilocnlaw) Handle Fly 409 insufficient memory alongside 412 insufficient resources

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -146,7 +146,7 @@ function guestFromSize(machineSize: MachineSize | null): FlyMachineConfig['guest
   return {
     cpus: machineSize.cpus,
     memory_mb: machineSize.memory_mb,
-    cpu_kind: machineSize.cpu_kind,
+    cpu_kind: machineSize.cpu_kind ?? 'shared',
   };
 }
 

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -246,30 +246,38 @@ export function isFlyNotFound(err: unknown): boolean {
 }
 
 /**
- * Capacity-related markers in Fly 412 error bodies. Matched case-insensitively
- * against the JSON body fields (error, status) and raw body text.
- *
- * Confirmed from production: "insufficient resources to create new machine
- * with existing volume 'vol_xxx'"
- *
- * Add new markers here when the unclassified-412 warning log reveals new
- * capacity error formats from Fly.
+ * Status codes that Fly uses for capacity/resource exhaustion errors.
+ * - 412: "insufficient resources" when creating a machine with an existing volume
+ * - 409: "insufficient memory" when updating/starting a machine on a full host
  */
-const CAPACITY_MARKERS = ['insufficient resources'];
+const CAPACITY_STATUS_CODES = [409, 412];
 
 /**
- * Check if a Fly API 412 error is specifically a capacity/resource exhaustion
- * issue (host where a volume is pinned has no room for a machine).
+ * Capacity-related markers in Fly error bodies. Matched case-insensitively
+ * against the JSON body fields (error, status) and raw body text.
  *
- * Fly overloads 412 for both capacity issues AND precondition/version mismatches
- * (e.g. min_secrets_version, machine_version). We only trigger volume
- * replacement recovery for genuine capacity problems — version/precondition
- * 412s should surface to the caller as-is.
+ * Confirmed from production:
+ * - 412: "insufficient resources to create new machine with existing volume 'vol_xxx'"
+ * - 409: "could not reserve resource for machine: insufficient memory available to fulfill request"
  *
- * Logs a warning for unclassified 412s so we can tune matching.
+ * Add new markers here when the unclassified warning log reveals new
+ * capacity error formats from Fly.
+ */
+const CAPACITY_MARKERS = ['insufficient resources', 'insufficient memory'];
+
+/**
+ * Check if a Fly API error is a capacity/resource exhaustion issue
+ * (host where a volume/machine lives has no room).
+ *
+ * Fly uses 412 for volume-pinned capacity issues and 409 for memory
+ * exhaustion on updateMachine. Both codes are also used for unrelated
+ * errors (precondition/version mismatches, conflicts), so we only
+ * trigger recovery when the body contains explicit capacity markers.
+ *
+ * Logs a warning for unclassified 409/412s so we can tune matching.
  */
 export function isFlyInsufficientResources(err: unknown): boolean {
-  if (!(err instanceof FlyApiError) || err.status !== 412) return false;
+  if (!(err instanceof FlyApiError) || !CAPACITY_STATUS_CODES.includes(err.status)) return false;
 
   // Build a single lowercase string from all available signal sources
   const searchText = `${err.message}\n${err.body}`.toLowerCase();
@@ -292,9 +300,9 @@ export function isFlyInsufficientResources(err: unknown): boolean {
   // Fall back to raw text matching across message + body
   if (CAPACITY_MARKERS.some(m => searchText.includes(m))) return true;
 
-  // 412 but no capacity signal — likely a version/precondition issue.
+  // 409/412 but no capacity signal — likely a version/precondition/conflict issue.
   // Log so we can tune matching if Fly introduces new capacity error formats.
-  console.warn('[fly] Unclassified 412 error (not treated as capacity):', err.body);
+  console.warn(`[fly] Unclassified ${err.status} error (not treated as capacity):`, err.body);
   return false;
 }
 


### PR DESCRIPTION
## Summary

- Broaden `isFlyInsufficientResources` to detect Fly **409** "insufficient memory" errors alongside the existing **412** "insufficient resources" detection
- Both trigger the same volume replacement + region walking recovery in `start()`
- Default `cpu_kind` to `'shared'` in `guestFromSize` when the caller's `machineSize` omits it

## Context

Production logs showed 409 errors on `updateMachine`:
```
"aborted: could not reserve resource for machine: insufficient memory available to fulfill request"
```

This is the same class of problem as 412 — the host can't fit the machine — but Fly uses a different status code for memory exhaustion on existing machines vs. volume-pinned capacity on new machines. Previously the 409 was treated as a transient error and re-thrown without recovery.

## Changes

| File | What |
|------|------|
| `src/fly/client.ts` | `CAPACITY_STATUS_CODES = [409, 412]`, added `'insufficient memory'` to `CAPACITY_MARKERS`, dynamic status code in unclassified warning |
| `src/fly/client.test.ts` | Tests for production 409 payload, non-capacity 409 conflict, unclassified 409 warning |
| `src/durable-objects/kiloclaw-instance.ts` | Default `cpu_kind` to `'shared'` in `guestFromSize` so compute hints always include it |
