### PR TITLE
Removing auto triage feature guard

### DIFF
--- a/src/app/(app)/auto-triage/AutoTriagePageClient.tsx
+++ b/src/app/(app)/auto-triage/AutoTriagePageClient.tsx
@@ -29,7 +29,9 @@ export function AutoTriagePageClient({
   const trpc = useTRPC();
 
   // Fetch GitHub App installation status
-  const { data: statusData } = useQuery(trpc.personalAutoTriage.getGitHubStatus.queryOptions());
+  const { data: statusData, isLoading: isStatusLoading } = useQuery(
+    trpc.personalAutoTriage.getGitHubStatus.queryOptions()
+  );
 
   const isGitHubAppInstalled = statusData?.connected && statusData?.integration?.isValid;
 
@@ -51,7 +53,7 @@ export function AutoTriagePageClient({
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <h1 className="text-3xl font-bold">Auto Triage</h1>
-          <Badge variant="new">new</Badge>
+          <Badge variant="beta">beta</Badge>
         </div>
         <p className="text-muted-foreground">
           Automatically triage GitHub issues with Al-powered analysis
@@ -68,7 +70,7 @@ export function AutoTriagePageClient({
       </div>
 
       {/* GitHub App Required Alert */}
-      {!isGitHubAppInstalled && (
+      {!isStatusLoading && !isGitHubAppInstalled && (
         <Alert>
           <Rocket className="h-4 w-4" />
           <AlertTitle>GitHub App Required</AlertTitle>
@@ -97,7 +99,7 @@ export function AutoTriagePageClient({
           <TabsTrigger
             value="tickets"
             className="flex items-center gap-2"
-            disabled={!isGitHubAppInstalled}
+            disabled={!isStatusLoading && !isGitHubAppInstalled}
           >
             <ListChecks className="h-4 w-4" />
             Tickets
@@ -111,7 +113,7 @@ export function AutoTriagePageClient({
 
         {/* Tickets Tab */}
         <TabsContent value="tickets" className="mt-6 space-y-4">
-          {isGitHubAppInstalled ? (
+          {isStatusLoading || isGitHubAppInstalled ? (
             <AutoTriageTicketsCard />
           ) : (
             <Alert>

--- a/src/app/(app)/auto-triage/page.tsx
+++ b/src/app/(app)/auto-triage/page.tsx
@@ -1,7 +1,5 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { AutoTriagePageClient } from './AutoTriagePageClient';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { notFound } from 'next/navigation';
 
 type AutoTriagePageProps = {
   searchParams: Promise<{ success?: string; error?: string }>;
@@ -10,14 +8,6 @@ type AutoTriagePageProps = {
 export default async function PersonalAutoTriagePage({ searchParams }: AutoTriagePageProps) {
   const search = await searchParams;
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/auto-triage');
-
-  // Feature flags - use server-side check with user ID as distinct ID
-  const isAutoTriageFeatureEnabled = await isFeatureFlagEnabled('auto-triage-feature', user.id);
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
-  if (!isAutoTriageFeatureEnabled && !isDevelopment) {
-    return notFound();
-  }
 
   return (
     <AutoTriagePageClient

--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -162,19 +162,13 @@ export default function OrganizationAppSidebar({
           },
         ]
       : []),
+    {
+      title: 'Auto Triage',
+      icon: ListChecks,
+      url: `/organizations/${organizationId}/auto-triage`,
+    },
     ...(isAutoTriageFeatureEnabled || isDevelopment
-      ? [
-          {
-            title: 'Auto Triage',
-            icon: ListChecks,
-            url: `/organizations/${organizationId}/auto-triage`,
-          },
-          {
-            title: 'Auto Fix',
-            icon: Wrench,
-            url: `/organizations/${organizationId}/auto-fix`,
-          },
-        ]
+      ? [{ title: 'Auto Fix', icon: Wrench, url: `/organizations/${organizationId}/auto-fix` }]
       : []),
     ...(ENABLE_DEPLOY_FEATURE
       ? [

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -107,19 +107,13 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
+    {
+      title: 'Auto Triage',
+      icon: ListChecks,
+      url: '/auto-triage',
+    },
     ...(isAutoTriageFeatureEnabled || isDevelopment
-      ? [
-          {
-            title: 'Auto Triage',
-            icon: ListChecks,
-            url: '/auto-triage',
-          },
-          {
-            title: 'Auto Fix',
-            icon: Wrench,
-            url: '/auto-fix',
-          },
-        ]
+      ? [{ title: 'Auto Fix', icon: Wrench, url: '/auto-fix' }]
       : []),
     ...(ENABLE_DEPLOY_FEATURE
       ? [

--- a/src/app/(app)/organizations/[id]/auto-triage/AutoTriagePageClient.tsx
+++ b/src/app/(app)/organizations/[id]/auto-triage/AutoTriagePageClient.tsx
@@ -29,7 +29,7 @@ export function AutoTriagePageClient({
   const trpc = useTRPC();
 
   // Fetch GitHub App installation status
-  const { data: statusData } = useQuery(
+  const { data: statusData, isLoading: isStatusLoading } = useQuery(
     trpc.organizations.autoTriage.getGitHubStatus.queryOptions({
       organizationId,
     })
@@ -72,7 +72,7 @@ export function AutoTriagePageClient({
       </div>
 
       {/* GitHub App Required Alert */}
-      {!isGitHubAppInstalled && (
+      {!isStatusLoading && !isGitHubAppInstalled && (
         <Alert>
           <Rocket className="h-4 w-4" />
           <AlertTitle>GitHub App Required</AlertTitle>
@@ -101,7 +101,7 @@ export function AutoTriagePageClient({
           <TabsTrigger
             value="tickets"
             className="flex items-center gap-2"
-            disabled={!isGitHubAppInstalled}
+            disabled={!isStatusLoading && !isGitHubAppInstalled}
           >
             <ListChecks className="h-4 w-4" />
             Tickets
@@ -115,7 +115,7 @@ export function AutoTriagePageClient({
 
         {/* Tickets Tab */}
         <TabsContent value="tickets" className="mt-6 space-y-4">
-          {isGitHubAppInstalled ? (
+          {isStatusLoading || isGitHubAppInstalled ? (
             <AutoTriageTicketsCard organizationId={organizationId} />
           ) : (
             <Alert>

--- a/src/app/(app)/organizations/[id]/auto-triage/page.tsx
+++ b/src/app/(app)/organizations/[id]/auto-triage/page.tsx
@@ -1,7 +1,5 @@
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
-import { notFound } from 'next/navigation';
 import { AutoTriagePageClient } from './AutoTriagePageClient';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 
 type AutoTriagePageProps = {
   params: Promise<{ id: string }>;
@@ -9,19 +7,7 @@ type AutoTriagePageProps = {
 };
 
 export default async function AutoTriagePage({ params, searchParams }: AutoTriagePageProps) {
-  const { id: organizationId } = await params;
   const search = await searchParams;
-
-  // Feature flags - use server-side check with organization ID as distinct ID
-  const isAutoTriageFeatureEnabled = await isFeatureFlagEnabled(
-    'auto-triage-feature',
-    organizationId
-  );
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
-  if (!isAutoTriageFeatureEnabled && !isDevelopment) {
-    return notFound();
-  }
 
   return (
     <OrganizationByPageLayout


### PR DESCRIPTION
We are releasing the Auto Triage feature to all users so let's remove the feature flag check. 
Since the Auto Fix is still under development we keep it under the current feature flag.