### PR TITLE
chore(kiloclaw): increase pairing exec timeouts and run channels concurrently

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -595,7 +595,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       flyConfig,
       flyMachineId,
       ['/usr/bin/env', 'HOME=/root', 'node', '/usr/local/bin/openclaw-pairing-list.js'],
-      20
+      60
     );
 
     const empty = {
@@ -663,7 +663,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       flyConfig,
       flyMachineId,
       ['/usr/bin/env', 'HOME=/root', 'openclaw', 'pairing', 'approve', channel, code, '--notify'],
-      15
+      60
     );
 
     const success = result.exit_code === 0;

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -347,7 +347,7 @@ export async function execCommand(
   config: FlyClientConfig,
   machineId: string,
   command: string[],
-  timeout = 10
+  timeout = 60
 ): Promise<MachineExecResponse> {
   const body: MachineExecRequest = { command, timeout };
   const resp = await flyFetch(config, `/machines/${machineId}/exec`, {


### PR DESCRIPTION
## Summary

- Increase Fly exec timeouts across the board: default `execCommand` timeout from 10s → 60s, pairing list from 20s → 60s, and pairing approve from 15s → 60s to avoid premature timeouts on slow Fly machines.
- Refactor `openclaw-pairing-list.js` from sequential synchronous `execFileSync` calls to concurrent async execution via `Promise.allSettled`, with a per-channel timeout of 45s. This makes the script faster when multiple channels are configured and more resilient to individual channel failures.