### PR TITLE
feat(kiloclaw): add volume snapshots listing to admin UI

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -48,7 +48,12 @@ import {
   LIVE_CHECK_THROTTLE_MS,
 } from '../config';
 import type { FlyClientConfig } from '../fly/client';
-import type { FlyMachineConfig, FlyMachine, FlyMachineState } from '../fly/types';
+import type {
+  FlyMachineConfig,
+  FlyMachine,
+  FlyMachineState,
+  FlyVolumeSnapshot,
+} from '../fly/types';
 import * as fly from '../fly/client';
 import { appNameFromUserId } from '../fly/apps';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../utils/env-encryption';
@@ -967,6 +972,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       channels: this.channels ?? undefined,
       machineSize: this.machineSize ?? undefined,
     };
+  }
+
+  async listVolumeSnapshots(): Promise<FlyVolumeSnapshot[]> {
+    await this.loadState();
+    if (!this.flyVolumeId) return [];
+    const flyConfig = this.getFlyConfig();
+    return fly.listVolumeSnapshots(flyConfig, this.flyVolumeId);
   }
 
   // ========================================================================

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -12,6 +12,7 @@ import type {
   FlyMachine,
   FlyMachineConfig,
   FlyVolume,
+  FlyVolumeSnapshot,
   CreateVolumeRequest,
   CreateMachineRequest,
   FlyWaitableState,
@@ -235,6 +236,15 @@ export async function deleteVolume(config: FlyClientConfig, volumeId: string): P
     method: 'DELETE',
   });
   await assertOk(resp, 'deleteVolume');
+}
+
+export async function listVolumeSnapshots(
+  config: FlyClientConfig,
+  volumeId: string
+): Promise<FlyVolumeSnapshot[]> {
+  const resp = await flyFetch(config, `/volumes/${volumeId}/snapshots`);
+  await assertOk(resp, 'listVolumeSnapshots');
+  return resp.json();
 }
 
 /**

--- a/kiloclaw/src/fly/types.ts
+++ b/kiloclaw/src/fly/types.ts
@@ -109,6 +109,18 @@ export type CreateVolumeRequest = {
   compute?: VolumeComputeHint;
 };
 
+// -- Volume snapshot types --
+
+export type FlyVolumeSnapshot = {
+  id: string;
+  created_at: string;
+  digest: string;
+  retention_days: number;
+  size: number;
+  status: string;
+  volume_size: number;
+};
+
 // -- Exec types --
 
 export type MachineExecRequest = {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -324,4 +324,26 @@ platform.get('/gateway-token', async c => {
   }
 });
 
+// GET /api/platform/volume-snapshots?userId=...
+// Returns the list of Fly volume snapshots for the user's instance.
+platform.get('/volume-snapshots', async c => {
+  const userId = c.req.query('userId');
+  if (!userId) {
+    return c.json({ error: 'userId query parameter is required' }, 400);
+  }
+
+  try {
+    const snapshots = await withDORetry(
+      instanceStubFactory(c.env, userId),
+      stub => stub.listVolumeSnapshots(),
+      'listVolumeSnapshots'
+    );
+    return c.json({ snapshots });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[platform] volume-snapshots failed:', message);
+    return c.json({ error: message }, 500);
+  }
+});
+
 export { platform };

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -10,6 +10,7 @@ import type {
   ChannelsPatchResponse,
   PairingListResponse,
   PairingApproveResponse,
+  VolumeSnapshotsResponse,
 } from './types';
 
 /**
@@ -100,6 +101,10 @@ export class KiloClawInternalClient {
       method: 'PATCH',
       body: JSON.stringify({ userId, ...input }),
     });
+  }
+
+  async listVolumeSnapshots(userId: string): Promise<VolumeSnapshotsResponse> {
+    return this.request(`/api/platform/volume-snapshots?userId=${encodeURIComponent(userId)}`);
   }
 
   async listPairingRequests(userId: string, refresh = false): Promise<PairingListResponse> {

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -90,6 +90,22 @@ export type PlatformStatusResponse = {
   flyRegion: string | null;
 };
 
+/** A Fly volume snapshot. */
+export type VolumeSnapshot = {
+  id: string;
+  created_at: string;
+  digest: string;
+  retention_days: number;
+  size: number;
+  status: string;
+  volume_size: number;
+};
+
+/** Response from GET /api/platform/volume-snapshots */
+export type VolumeSnapshotsResponse = {
+  snapshots: VolumeSnapshot[];
+};
+
 /** Response from GET /api/kiloclaw/config */
 export type UserConfigResponse = {
   envVarKeys: string[];


### PR DESCRIPTION
## Summary

- Wire up Fly volume snapshot listing (Machines API `GET /volumes/{id}/snapshots`) through the full stack to the admin instance detail page (includes new listVolumeSnapshots rpc)
- New "Volume Snapshots" card shows each snapshot's created time, status, size, retention days, and ID
- Volume ID in the card header links out to the Fly console
