### PR TITLE
Reload FFs on identify

### DIFF
--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -102,6 +102,11 @@ function IdentifyUser() {
       if (currentAnonymousId && currentAnonymousId !== session.user.email) {
         posthog.alias(session.user.email, currentAnonymousId);
       }
+      // Re-fetch feature flags now that the user is identified.
+      // Without this, flags evaluated for the anonymous ID remain cached,
+      // so user-targeted flags (e.g. kiloclaw) would stay false until
+      // the next natural reload.
+      posthog.reloadFeatureFlags();
     } else if (status === 'unauthenticated' && previousStatus === 'authenticated') {
       // Reset PostHog identification only when transitioning from authenticated to unauthenticated (logout)
       posthog.reset();


### PR DESCRIPTION
This PR reloads featureflags from posthog on "IndentifyUser" so that on login the FFs will be reloaded. I'm hoping this solves an often reported issue of being able to navigate to `app.kilo.ai/claw` but not seeing `Claw` in the left sidebar (because the actual server side route calculates the FF for the user, but if it was already "false" when they loaded client side it never updates)