### PR TITLE
AppBuilder - Improve logging tags and error handling in Durable Objects

### DIFF
--- a/cloudflare-app-builder/src/git-repository-do.ts
+++ b/cloudflare-app-builder/src/git-repository-do.ts
@@ -45,9 +45,14 @@ export class GitRepositoryDO extends DurableObject<Env> {
 
     logger.debug('Initializing SqliteFS', { id: this.ctx.id.toString() });
 
-    // Use our sql() tagged template helper for safe SQL parameterization
-    this.fs = new SqliteFS(this.sql.bind(this));
-    this.fs.init();
+    try {
+      // Use our sql() tagged template helper for safe SQL parameterization
+      this.fs = new SqliteFS(this.sql.bind(this));
+      this.fs.init();
+    } catch (error) {
+      logger.error('Failed to initialize SqliteFS', formatError(error));
+      throw error;
+    }
 
     // Check if .git directory exists
     try {
@@ -65,37 +70,43 @@ export class GitRepositoryDO extends DurableObject<Env> {
    * Check if the repository is initialized (RPC method)
    */
   async isInitialized(): Promise<boolean> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      await this.initializeFS();
-      return this._initialized;
-    });
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        await this.initializeFS();
+        return this._initialized;
+      }
+    );
   }
 
   /**
    * Initialize a new git repository (RPC method)
    */
   async initialize(): Promise<void> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      if (!this.fs) {
-        await this.initializeFS();
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        if (!this.fs) {
+          await this.initializeFS();
+        }
+
+        if (this._initialized) {
+          logger.debug('Repository already initialized');
+          return;
+        }
+
+        logger.debug('Initializing new git repository');
+
+        if (!this.fs) {
+          throw new Error('Filesystem not initialized');
+        }
+
+        await git.init({ fs: this.fs, dir: '/', defaultBranch: 'main' });
+        this._initialized = true;
+
+        logger.debug('Git repository initialized successfully');
       }
-
-      if (this._initialized) {
-        logger.debug('Repository already initialized');
-        return;
-      }
-
-      logger.debug('Initializing new git repository');
-
-      if (!this.fs) {
-        throw new Error('Filesystem not initialized');
-      }
-
-      await git.init({ fs: this.fs, dir: '/', defaultBranch: 'main' });
-      this._initialized = true;
-
-      logger.debug('Git repository initialized successfully');
-    });
+    );
   }
 
   /**
@@ -103,37 +114,40 @@ export class GitRepositoryDO extends DurableObject<Env> {
    * Files are expected to have base64-encoded content to safely handle binary data through RPC
    */
   async createInitialCommit(files: Record<string, string>): Promise<void> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      await this.initialize();
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        await this.initialize();
 
-      if (!this.fs) {
-        throw new Error('Filesystem not initialized');
+        if (!this.fs) {
+          throw new Error('Filesystem not initialized');
+        }
+
+        logger.debug('Creating initial commit', { fileCount: Object.keys(files).length });
+
+        // Write files (decode base64 to binary)
+        for (const [path, base64Content] of Object.entries(files)) {
+          // Decode base64 to binary
+          const bytes = Buffer.from(base64Content, 'base64');
+
+          await this.fs.writeFile(path, bytes);
+          await git.add({ fs: this.fs, dir: '/', filepath: path });
+        }
+
+        // Commit
+        await git.commit({
+          fs: this.fs,
+          dir: '/',
+          message: 'Initial commit',
+          author: {
+            name: 'Kilo Code Cloud',
+            email: 'agent@kilocode.ai',
+          },
+        });
+
+        logger.debug('Initial commit created');
       }
-
-      logger.debug('Creating initial commit', { fileCount: Object.keys(files).length });
-
-      // Write files (decode base64 to binary)
-      for (const [path, base64Content] of Object.entries(files)) {
-        // Decode base64 to binary
-        const bytes = Buffer.from(base64Content, 'base64');
-
-        await this.fs.writeFile(path, bytes);
-        await git.add({ fs: this.fs, dir: '/', filepath: path });
-      }
-
-      // Commit
-      await git.commit({
-        fs: this.fs,
-        dir: '/',
-        message: 'Initial commit',
-        author: {
-          name: 'Kilo Code Cloud',
-          email: 'agent@kilocode.ai',
-        },
-      });
-
-      logger.debug('Initial commit created');
-    });
+    );
   }
 
   /**
@@ -141,23 +155,26 @@ export class GitRepositoryDO extends DurableObject<Env> {
    * Returns objects with base64-encoded data for serialization
    */
   async exportGitObjects(): Promise<GitObject[]> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      if (!this.fs) {
-        await this.initializeFS();
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        if (!this.fs) {
+          await this.initializeFS();
+        }
+
+        if (!this._initialized || !this.fs) {
+          return [];
+        }
+
+        const objects = this.fs.exportGitObjects();
+
+        // Convert Uint8Array to base64 for JSON serialization
+        return objects.map(obj => ({
+          path: obj.path,
+          data: Buffer.from(obj.data).toString('base64'),
+        }));
       }
-
-      if (!this._initialized || !this.fs) {
-        return [];
-      }
-
-      const objects = this.fs.exportGitObjects();
-
-      // Convert Uint8Array to base64 for JSON serialization
-      return objects.map(obj => ({
-        path: obj.path,
-        data: Buffer.from(obj.data).toString('base64'),
-      }));
-    });
+    );
   }
 
   /**
@@ -165,88 +182,100 @@ export class GitRepositoryDO extends DurableObject<Env> {
    * Writes all objects to the filesystem, replacing existing ones
    */
   async importGitObjects(objects: GitObject[]): Promise<void> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      if (!this.fs) {
-        await this.initializeFS();
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        if (!this.fs) {
+          await this.initializeFS();
+        }
+
+        if (!this.fs) {
+          throw new Error('Filesystem not initialized');
+        }
+
+        // Ensure repo is initialized
+        if (!this._initialized) {
+          await this.initialize();
+        }
+
+        logger.debug('Importing git objects', { count: objects.length });
+
+        for (const obj of objects) {
+          // Convert base64 back to binary
+          const bytes = Buffer.from(obj.data, 'base64');
+
+          // Write to filesystem
+          await this.fs.writeFile(obj.path, bytes);
+        }
+
+        logger.debug('Git objects imported successfully');
       }
-
-      if (!this.fs) {
-        throw new Error('Filesystem not initialized');
-      }
-
-      // Ensure repo is initialized
-      if (!this._initialized) {
-        await this.initialize();
-      }
-
-      logger.debug('Importing git objects', { count: objects.length });
-
-      for (const obj of objects) {
-        // Convert base64 back to binary
-        const bytes = Buffer.from(obj.data, 'base64');
-
-        // Write to filesystem
-        await this.fs.writeFile(obj.path, bytes);
-      }
-
-      logger.debug('Git objects imported successfully');
-    });
+    );
   }
 
   /**
    * Get the latest commit hash on the main branch (RPC method)
    */
   async getLatestCommit(): Promise<string | null> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      if (!this.fs) {
-        await this.initializeFS();
-      }
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        if (!this.fs) {
+          await this.initializeFS();
+        }
 
-      if (!this._initialized || !this.fs) {
-        return null;
-      }
+        if (!this._initialized || !this.fs) {
+          return null;
+        }
 
-      try {
-        const commitHash = await git.resolveRef({ fs: this.fs, dir: '/', ref: 'HEAD' });
-        return commitHash;
-      } catch (err) {
-        logger.error('Failed to get latest commit', formatError(err));
-        return null;
+        try {
+          const commitHash = await git.resolveRef({ fs: this.fs, dir: '/', ref: 'HEAD' });
+          return commitHash;
+        } catch (err) {
+          logger.error('Failed to get latest commit', formatError(err));
+          return null;
+        }
       }
-    });
+    );
   }
 
   /**
    * Get storage statistics (RPC method)
    */
   async getStats(): Promise<RepositoryStats> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      if (!this.fs) {
-        await this.initializeFS();
-      }
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        if (!this.fs) {
+          await this.initializeFS();
+        }
 
-      if (!this.fs) {
-        return { totalObjects: 0, totalBytes: 0, largestObject: null, initialized: false };
-      }
+        if (!this.fs) {
+          return { totalObjects: 0, totalBytes: 0, largestObject: null, initialized: false };
+        }
 
-      const stats = this.fs.getStorageStats();
-      return { ...stats, initialized: this._initialized };
-    });
+        const stats = this.fs.getStorageStats();
+        return { ...stats, initialized: this._initialized };
+      }
+    );
   }
 
   // Legacy auth token verification (for transition period, read-only)
   // Only used to support existing repositories with stored tokens
   // New repositories should use JWT authentication instead
   async verifyAuthToken(token: string): Promise<boolean> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      const storedToken = await this.ctx.storage.get<string>('auth_token');
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        const storedToken = await this.ctx.storage.get<string>('auth_token');
 
-      if (!storedToken || storedToken.trim().length === 0) {
-        return false;
+        if (!storedToken || storedToken.trim().length === 0) {
+          return false;
+        }
+
+        return storedToken === token;
       }
-
-      return storedToken === token;
-    });
+    );
   }
 
   /**
@@ -254,17 +283,20 @@ export class GitRepositoryDO extends DurableObject<Env> {
    * Called when deleting a project to clean up storage
    */
   async deleteAll(): Promise<void> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      logger.info('Deleting all repository data');
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        logger.info('Deleting all repository data');
 
-      // deleteAll() clears all storage including SQLite tables
-      await this.ctx.storage.deleteAll();
+        // deleteAll() clears all storage including SQLite tables
+        await this.ctx.storage.deleteAll();
 
-      this._initialized = false;
-      this.fs = null;
+        this._initialized = false;
+        this.fs = null;
 
-      logger.info('Repository deleted successfully');
-    });
+        logger.info('Repository deleted successfully');
+      }
+    );
   }
 
   /**
@@ -273,26 +305,37 @@ export class GitRepositoryDO extends DurableObject<Env> {
    * while keeping a grace period for rollback.
    */
   async scheduleDelete(delayMs: number): Promise<void> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      const deleteAt = Date.now() + delayMs;
-      await this.ctx.storage.setAlarm(deleteAt);
-      logger.info('Scheduled self-deletion', {
-        deleteAt: new Date(deleteAt).toISOString(),
-      });
-    });
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        try {
+          const deleteAt = Date.now() + delayMs;
+          await this.ctx.storage.setAlarm(deleteAt);
+          logger.info('Scheduled self-deletion', {
+            deleteAt: new Date(deleteAt).toISOString(),
+          });
+        } catch (error) {
+          logger.error('Failed to schedule self-deletion', formatError(error));
+          throw error;
+        }
+      }
+    );
   }
 
   /**
    * Alarm handler: self-deletes all repository data.
    */
   async alarm(): Promise<void> {
-    return withLogTags({ source: 'GitRepositoryDO' }, async () => {
-      logger.info('Alarm fired: deleting repository data');
-      await this.ctx.storage.deleteAll();
-      this._initialized = false;
-      this.fs = null;
-      logger.info('Repository self-deleted');
-    });
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
+        logger.info('Alarm fired: deleting repository data');
+        await this.ctx.storage.deleteAll();
+        this._initialized = false;
+        this.fs = null;
+        logger.info('Repository self-deleted');
+      }
+    );
   }
 
   /**
@@ -307,95 +350,100 @@ export class GitRepositoryDO extends DurableObject<Env> {
     remoteUrl: string,
     authToken: string
   ): Promise<{ success: boolean; error?: string }> {
-    if (!this.fs) {
-      await this.initializeFS();
-    }
-
-    if (!this._initialized || !this.fs) {
-      return { success: false, error: 'Repository not initialized' };
-    }
-
-    logger.info('Pushing repository to remote', {
-      id: this.ctx.id.toString(),
-      remoteUrl: sanitizeGitUrl(remoteUrl),
-    });
-
-    try {
-      // Export git objects from SQLite storage
-      const gitObjects = this.fs.exportGitObjects();
-
-      if (gitObjects.length === 0) {
-        return { success: false, error: 'No git objects to push' };
-      }
-
-      // Build in-memory FS for isomorphic-git push operation
-      const memFs = new MemFS();
-      await git.init({ fs: memFs, dir: '/', defaultBranch: 'main' });
-
-      // Import all git objects into the in-memory FS
-      for (const obj of gitObjects) {
-        await memFs.writeFile(obj.path, obj.data);
-      }
-
-      // Get all branches to push (uses isomorphic-git to handle nested refs like feature/foo)
-      let branches: string[] = [];
-      try {
-        branches = await git.listBranches({ fs: memFs, dir: '/' });
-      } catch {
-        branches = ['main']; // Default to main if no branches found
-      }
-
-      logger.info('Pushing branches to remote', { branches });
-
-      // Track push results
-      let mainPushed = false;
-      const failedBranches: string[] = [];
-
-      // Push each branch to the remote
-      for (const branch of branches) {
+    return withLogTags(
+      { source: 'GitRepositoryDO', tags: { appId: this.ctx.id.name } },
+      async () => {
         try {
-          await git.push({
-            fs: memFs,
-            http,
-            dir: '/',
-            url: remoteUrl,
-            ref: branch,
-            remoteRef: branch,
-            onAuth: () => ({ username: 'x-access-token', password: authToken }),
-            force: false, // Don't force push
+          if (!this.fs) {
+            await this.initializeFS();
+          }
+
+          if (!this._initialized || !this.fs) {
+            return { success: false, error: 'Repository not initialized' };
+          }
+
+          logger.info('Pushing repository to remote', {
+            id: this.ctx.id.toString(),
+            remoteUrl: sanitizeGitUrl(remoteUrl),
           });
 
-          logger.info('Successfully pushed branch', { branch });
-          if (branch === 'main') {
-            mainPushed = true;
+          // Export git objects from SQLite storage
+          const gitObjects = this.fs.exportGitObjects();
+
+          if (gitObjects.length === 0) {
+            return { success: false, error: 'No git objects to push' };
           }
-        } catch (branchError) {
-          // Log but continue with other branches
-          logger.warn('Failed to push branch', {
-            branch,
-            error: branchError instanceof Error ? branchError.message : String(branchError),
+
+          // Build in-memory FS for isomorphic-git push operation
+          const memFs = new MemFS();
+          await git.init({ fs: memFs, dir: '/', defaultBranch: 'main' });
+
+          // Import all git objects into the in-memory FS
+          for (const obj of gitObjects) {
+            await memFs.writeFile(obj.path, obj.data);
+          }
+
+          // Get all branches to push (uses isomorphic-git to handle nested refs like feature/foo)
+          let branches: string[] = [];
+          try {
+            branches = await git.listBranches({ fs: memFs, dir: '/' });
+          } catch {
+            branches = ['main']; // Default to main if no branches found
+          }
+
+          logger.info('Pushing branches to remote', { branches });
+
+          // Track push results
+          let mainPushed = false;
+          const failedBranches: string[] = [];
+
+          // Push each branch to the remote
+          for (const branch of branches) {
+            try {
+              await git.push({
+                fs: memFs,
+                http,
+                dir: '/',
+                url: remoteUrl,
+                ref: branch,
+                remoteRef: branch,
+                onAuth: () => ({ username: 'x-access-token', password: authToken }),
+                force: false, // Don't force push
+              });
+
+              logger.info('Successfully pushed branch', { branch });
+              if (branch === 'main') {
+                mainPushed = true;
+              }
+            } catch (branchError) {
+              // Log but continue with other branches
+              logger.warn('Failed to push branch', {
+                branch,
+                ...formatError(branchError),
+              });
+              failedBranches.push(branch);
+            }
+          }
+
+          // Main branch must be pushed successfully
+          if (!mainPushed) {
+            const errorMessage = failedBranches.includes('main')
+              ? 'Failed to push main branch'
+              : 'Main branch not found in repository';
+            logger.error('Push failed: main branch not pushed', { failedBranches });
+            return { success: false, error: errorMessage };
+          }
+
+          logger.info('Repository push completed successfully', {
+            failedBranches: failedBranches.length > 0 ? failedBranches : undefined,
           });
-          failedBranches.push(branch);
+          return { success: true };
+        } catch (error) {
+          logger.error('Failed to push repository to remote', formatError(error));
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return { success: false, error: errorMessage };
         }
       }
-
-      // Main branch must be pushed successfully
-      if (!mainPushed) {
-        const errorMessage = failedBranches.includes('main')
-          ? 'Failed to push main branch'
-          : 'Main branch not found in repository';
-        logger.error('Push failed: main branch not pushed', { failedBranches });
-        return { success: false, error: errorMessage };
-      }
-
-      logger.info('Repository push completed successfully', {
-        failedBranches: failedBranches.length > 0 ? failedBranches : undefined,
-      });
-      return { success: true };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error('Failed to push repository to remote', { error: errorMessage });
-      return { success: false, error: errorMessage };
-    }
+    );
   }
 }

--- a/cloudflare-app-builder/src/git-repository-do.ts
+++ b/cloudflare-app-builder/src/git-repository-do.ts
@@ -50,6 +50,7 @@ export class GitRepositoryDO extends DurableObject<Env> {
       this.fs = new SqliteFS(this.sql.bind(this));
       this.fs.init();
     } catch (error) {
+      this.fs = null;
       logger.error('Failed to initialize SqliteFS', formatError(error));
       throw error;
     }

--- a/cloudflare-app-builder/src/handlers/migrate-to-github.ts
+++ b/cloudflare-app-builder/src/handlers/migrate-to-github.ts
@@ -6,7 +6,7 @@
  * to clone from GitHub and schedules deletion of the internal git repo.
  */
 
-import { logger } from '../utils/logger';
+import { logger, formatError } from '../utils/logger';
 import { verifyBearerToken } from '../utils/auth';
 import type { Env } from '../types';
 import { MigrateToGithubRequestSchema } from '../api-schemas';
@@ -135,7 +135,11 @@ export async function handleMigrateToGithub(
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
-    logger.error({ source: 'MigrateToGithubHandler' }, 'Migrate to GitHub handler error', error);
+    logger.error(
+      { source: 'MigrateToGithubHandler' },
+      'Migrate to GitHub handler error',
+      formatError(error)
+    );
     return new Response(
       JSON.stringify({
         success: false,

--- a/cloudflare-app-builder/src/preview-do.ts
+++ b/cloudflare-app-builder/src/preview-do.ts
@@ -305,17 +305,22 @@ export class PreviewDO extends DurableObject<Env> {
     return withLogTags(
       { source: 'PreviewDO', tags: { appId: this.persistedState.appId ?? undefined } },
       async () => {
-        logger.info('Setting GitHub source', {
-          githubRepo: config.githubRepo,
-          hasOrgId: !!config.orgId,
-        });
-        this.persistedState.githubSource = config;
-        await this.savePersistedState();
+        try {
+          logger.info('Setting GitHub source', {
+            githubRepo: config.githubRepo,
+            hasOrgId: !!config.orgId,
+          });
+          this.persistedState.githubSource = config;
+          await this.savePersistedState();
 
-        // Destroy the sandbox to ensure a clean state when switching sources.
-        // The next build will clone fresh from GitHub.
-        await this.destroy();
-        logger.info('Sandbox destroyed after setting GitHub source');
+          // Destroy the sandbox to ensure a clean state when switching sources.
+          // The next build will clone fresh from GitHub.
+          await this.destroy();
+          logger.info('Sandbox destroyed after setting GitHub source');
+        } catch (error) {
+          logger.error('Failed to set GitHub source', formatError(error));
+          throw error;
+        }
       }
     );
   }


### PR DESCRIPTION
## Summary

- Add `appId` tag to all `withLogTags` calls in `GitRepositoryDO` so logs can be correlated to specific apps.
- Wrap `pushToRemote` in `withLogTags` (was the only method missing it).
- Add try/catch error handling to `initializeFS`, `scheduleDelete`, and `setGitHubSource` in `PreviewDO`.
- Use `formatError()` consistently instead of passing raw error objects to the logger (fixes structured logging in `migrate-to-github` handler and `pushToRemote`).