### PR TITLE
CloudAgentNext - Sync sandbox capacity and enable auto-deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -175,6 +175,30 @@ jobs:
     uses: ./.github/workflows/deploy-cloud-agent.yml
     secrets: inherit
 
+  check-cloud-agent-next-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs['cloud-agent-next'] }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for cloud-agent-next changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            cloud-agent-next:
+              - 'cloud-agent-next/**'
+
+  deploy-cloud-agent-next:
+    needs: [check-cloud-agent-next-changes]
+    if: needs.check-cloud-agent-next-changes.outputs.changed == 'true'
+    uses: ./.github/workflows/deploy-cloud-agent-next.yml
+    secrets: inherit
+
   check-session-ingest-changes:
     runs-on: ubuntu-latest
     outputs:

--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -120,7 +120,7 @@
       "image_vars": {
         "KILOCODE_CLI_VERSION": "1.0.22",
       },
-      "max_instances": 20,
+      "max_instances": 200,
       "rollout_active_grace_period": 120,
     },
   ],


### PR DESCRIPTION
## Summary
- Increase cloud-agent-next production `max_instances` from 20 to 200, matching cloud-agent's capacity.
- Add cloud-agent-next to the `deploy-production.yml` workflow so it auto-deploys on merge to main when `cloud-agent-next/**` files change, following the same pattern as all other workers.