### PR TITLE
feat(kiloclaw): add OpenClaw image version tracking

### DIFF
--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -51,12 +51,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Extract the OpenClaw version from the Dockerfile so the worker can
+      # self-register the version → image tag mapping in KV on first request.
+      - name: Extract OpenClaw version
+        id: openclaw-version
+        run: |
+          VERSION=$(sed -n 's/.*openclaw@\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' kiloclaw/Dockerfile | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to extract OpenClaw version from Dockerfile"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       # Deploy CF Worker with the commit SHA as the image tag.
       # --var overrides the default FLY_IMAGE_TAG in wrangler.jsonc,
       # so new machine creates/restarts use the exact image from this build.
+      # OPENCLAW_VERSION enables worker self-registration of the version in KV.
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: kiloclaw
-          command: deploy --var FLY_IMAGE_TAG:${{ github.sha }}
+          command: deploy --var FLY_IMAGE_TAG:${{ github.sha }} --var OPENCLAW_VERSION:${{ steps.openclaw-version.outputs.version }}

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -28,6 +28,11 @@ FLY_REGION=us,eu
 # In dev, use "latest" or run scripts/push-dev.sh which sets a timestamped tag.
 # In production, pin to a version (e.g., v40, sha-abc1234).
 FLY_IMAGE_TAG=latest
+# OpenClaw version (must match the openclaw@x.x.x version in the Dockerfile).
+# Used by the worker to self-register the version → image tag mapping in KV,
+# enabling per-user version tracking. Without this, version tracking fields
+# will be null and instances fall back to FLY_IMAGE_TAG directly.
+OPENCLAW_VERSION=2026.2.9
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/kiloclaw/src/lib/image-version.test.ts
+++ b/kiloclaw/src/lib/image-version.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { suppressConsole } from '../test-utils';
+import { resolveLatestVersion, registerVersionIfNeeded } from './image-version';
+import { imageVersionKey, imageVersionLatestKey } from '../schemas/image-version';
+import type { ImageVersionEntry } from '../schemas/image-version';
+
+/** KV mock that handles the 'json' type parameter like the real KV API. */
+function createJsonKV(): KVNamespace & { _store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    get: (key: string, type?: string) => {
+      const val = store.get(key) ?? null;
+      if (val === null) return Promise.resolve(null);
+      if (type === 'json') return Promise.resolve(JSON.parse(val));
+      return Promise.resolve(val);
+    },
+    put: (key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+    delete: (key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    },
+    list: () => Promise.resolve({ keys: [], list_complete: true, cacheStatus: null }),
+    getWithMetadata: () => Promise.resolve({ value: null, metadata: null, cacheStatus: null }),
+    _store: store,
+  } as unknown as KVNamespace & { _store: Map<string, string> };
+}
+
+function makeEntry(overrides: Partial<ImageVersionEntry> = {}): ImageVersionEntry {
+  return {
+    openclawVersion: '2026.2.9',
+    variant: 'default',
+    imageTag: 'dev-123456',
+    imageDigest: null,
+    publishedAt: '2026-02-22T18:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('resolveLatestVersion', () => {
+  beforeEach(() => suppressConsole());
+
+  it('returns the full entry when latest is populated', async () => {
+    const kv = createJsonKV();
+    const entry = makeEntry();
+    await kv.put(imageVersionLatestKey('default'), JSON.stringify(entry));
+
+    const result = await resolveLatestVersion(kv, 'default');
+    expect(result).toEqual(entry);
+  });
+
+  it('returns null when KV is empty', async () => {
+    const kv = createJsonKV();
+    const result = await resolveLatestVersion(kv, 'default');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for invalid KV data', async () => {
+    const kv = createJsonKV();
+    await kv.put(imageVersionLatestKey('default'), JSON.stringify({ bad: 'data' }));
+
+    const result = await resolveLatestVersion(kv, 'default');
+    expect(result).toBeNull();
+  });
+});
+
+describe('registerVersionIfNeeded', () => {
+  beforeEach(() => suppressConsole());
+
+  it('writes both versioned and latest keys on first registration', async () => {
+    const kv = createJsonKV();
+
+    const result = await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-123');
+    expect(result).toBe(true);
+
+    // Check both KV keys were written
+    const versioned = kv._store.get(imageVersionKey('2026.2.9', 'default'));
+    const latest = kv._store.get(imageVersionLatestKey('default'));
+    expect(versioned).toBeDefined();
+    expect(latest).toBeDefined();
+
+    const parsedVersioned = JSON.parse(versioned!);
+    expect(parsedVersioned.openclawVersion).toBe('2026.2.9');
+    expect(parsedVersioned.variant).toBe('default');
+    expect(parsedVersioned.imageTag).toBe('dev-123');
+    expect(parsedVersioned.imageDigest).toBeNull();
+
+    // Both keys should have identical content
+    expect(versioned).toBe(latest);
+  });
+
+  it('no-ops when version and tag already match', async () => {
+    const kv = createJsonKV();
+
+    // First registration
+    await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-123');
+
+    // Second registration with same values
+    const result = await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-123');
+    expect(result).toBe(false);
+  });
+
+  it('overwrites when version changes', async () => {
+    const kv = createJsonKV();
+
+    await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-123');
+    const result = await registerVersionIfNeeded(kv, '2026.2.10', 'default', 'dev-456');
+    expect(result).toBe(true);
+
+    const latest = JSON.parse(kv._store.get(imageVersionLatestKey('default'))!);
+    expect(latest.openclawVersion).toBe('2026.2.10');
+    expect(latest.imageTag).toBe('dev-456');
+  });
+
+  it('overwrites when same version but different tag (rebuild)', async () => {
+    const kv = createJsonKV();
+
+    await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-123');
+    const result = await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-456');
+    expect(result).toBe(true);
+
+    const latest = JSON.parse(kv._store.get(imageVersionLatestKey('default'))!);
+    expect(latest.imageTag).toBe('dev-456');
+  });
+
+  it('stores imageDigest when provided', async () => {
+    const kv = createJsonKV();
+
+    await registerVersionIfNeeded(kv, '2026.2.9', 'default', 'dev-123', 'sha256:abc');
+
+    const latest = JSON.parse(kv._store.get(imageVersionLatestKey('default'))!);
+    expect(latest.imageDigest).toBe('sha256:abc');
+  });
+});

--- a/kiloclaw/src/lib/image-version.ts
+++ b/kiloclaw/src/lib/image-version.ts
@@ -1,0 +1,98 @@
+import {
+  ImageVersionEntrySchema,
+  imageVersionKey,
+  imageVersionLatestKey,
+} from '../schemas/image-version';
+import type { ImageVersionEntry } from '../schemas/image-version';
+
+/**
+ * Read `image-version:latest:<variant>` from KV.
+ * Returns the full parsed ImageVersionEntry or null (single KV read).
+ * Callers destructure what they need.
+ */
+export async function resolveLatestVersion(
+  kv: KVNamespace,
+  variant: string
+): Promise<ImageVersionEntry | null> {
+  const raw = await kv.get(imageVersionLatestKey(variant), 'json');
+  if (!raw) return null;
+
+  const parsed = ImageVersionEntrySchema.safeParse(raw);
+  if (!parsed.success) {
+    console.warn('[image-version] Invalid latest entry in KV:', parsed.error.flatten());
+    return null;
+  }
+
+  return parsed.data;
+}
+
+/**
+ * Look up the image tag for a specific OpenClaw version + variant from KV.
+ * Returns the image tag, or null if the version is not registered.
+ */
+export async function lookupImageTag(
+  kv: KVNamespace,
+  version: string,
+  variant: string
+): Promise<string | null> {
+  const raw = await kv.get(imageVersionKey(version, variant), 'json');
+  if (!raw) return null;
+
+  const parsed = ImageVersionEntrySchema.safeParse(raw);
+  if (!parsed.success) {
+    console.warn(
+      '[image-version] Invalid version entry in KV for',
+      version,
+      variant,
+      parsed.error.flatten()
+    );
+    return null;
+  }
+
+  return parsed.data.imageTag;
+}
+
+/**
+ * Register a version in KV if the latest entry doesn't already match.
+ * Writes both the versioned key and the latest pointer. Idempotent —
+ * safe to call on every request (no-ops if already current).
+ *
+ * imageDigest is optional — the worker knows its tag but not its digest.
+ */
+export async function registerVersionIfNeeded(
+  kv: KVNamespace,
+  openclawVersion: string,
+  variant: string,
+  imageTag: string,
+  imageDigest: string | null = null
+): Promise<boolean> {
+  // Check if latest already matches — avoid unnecessary writes
+  const existing = await kv.get(imageVersionLatestKey(variant), 'json');
+  if (existing) {
+    const parsed = ImageVersionEntrySchema.safeParse(existing);
+    if (
+      parsed.success &&
+      parsed.data.openclawVersion === openclawVersion &&
+      parsed.data.imageTag === imageTag
+    ) {
+      return false; // already current
+    }
+  }
+
+  const entry: ImageVersionEntry = {
+    openclawVersion,
+    variant,
+    imageTag,
+    imageDigest,
+    publishedAt: new Date().toISOString(),
+  };
+
+  const serialized = JSON.stringify(entry);
+  await Promise.all([
+    kv.put(imageVersionKey(openclawVersion, variant), serialized),
+    kv.put(imageVersionLatestKey(variant), serialized),
+  ]);
+
+  console.log('[image-version] Registered version:', openclawVersion, variant, '→', imageTag);
+  return true;
+}

--- a/kiloclaw/src/lib/image-version.ts
+++ b/kiloclaw/src/lib/image-version.ts
@@ -3,7 +3,7 @@ import {
   imageVersionKey,
   imageVersionLatestKey,
 } from '../schemas/image-version';
-import type { ImageVersionEntry } from '../schemas/image-version';
+import type { ImageVersionEntry, ImageVariant } from '../schemas/image-version';
 
 /**
  * Read `image-version:latest:<variant>` from KV.
@@ -62,7 +62,7 @@ export async function lookupImageTag(
 export async function registerVersionIfNeeded(
   kv: KVNamespace,
   openclawVersion: string,
-  variant: string,
+  variant: ImageVariant,
   imageTag: string,
   imageDigest: string | null = null
 ): Promise<boolean> {

--- a/kiloclaw/src/lib/image-version.ts
+++ b/kiloclaw/src/lib/image-version.ts
@@ -12,7 +12,7 @@ import type { ImageVersionEntry, ImageVariant } from '../schemas/image-version';
  */
 export async function resolveLatestVersion(
   kv: KVNamespace,
-  variant: string
+  variant: ImageVariant
 ): Promise<ImageVersionEntry | null> {
   const raw = await kv.get(imageVersionLatestKey(variant), 'json');
   if (!raw) return null;
@@ -24,32 +24,6 @@ export async function resolveLatestVersion(
   }
 
   return parsed.data;
-}
-
-/**
- * Look up the image tag for a specific OpenClaw version + variant from KV.
- * Returns the image tag, or null if the version is not registered.
- */
-export async function lookupImageTag(
-  kv: KVNamespace,
-  version: string,
-  variant: string
-): Promise<string | null> {
-  const raw = await kv.get(imageVersionKey(version, variant), 'json');
-  if (!raw) return null;
-
-  const parsed = ImageVersionEntrySchema.safeParse(raw);
-  if (!parsed.success) {
-    console.warn(
-      '[image-version] Invalid version entry in KV for',
-      version,
-      variant,
-      parsed.error.flatten()
-    );
-    return null;
-  }
-
-  return parsed.data.imageTag;
 }
 
 /**

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -15,6 +15,11 @@ import {
   ChannelsPatchSchema,
 } from '../schemas/instance-config';
 import type { ModelEntry } from '../schemas/instance-config';
+import {
+  ImageVersionEntrySchema,
+  imageVersionKey,
+  imageVersionLatestKey,
+} from '../schemas/image-version';
 import { z } from 'zod';
 import { withDORetry } from '../util/do-retry';
 import { deriveGatewayToken } from '../auth/gateway-token';
@@ -363,6 +368,47 @@ platform.get('/volume-snapshots', async c => {
     console.error('[platform] volume-snapshots failed:', message);
     return c.json({ error: message }, 500);
   }
+});
+
+// POST /api/platform/publish-image-version
+// Manual fallback for publishing/correcting version entries.
+// Primary registration path is worker self-registration on deploy.
+const PublishImageVersionSchema = z.object({
+  openclawVersion: z.string().min(1),
+  variant: z.string().min(1).default('default'),
+  imageTag: z.string().min(1),
+  imageDigest: z.string().nullable().optional(),
+});
+
+platform.post('/publish-image-version', async c => {
+  const result = await parseBody(c, PublishImageVersionSchema);
+  if ('error' in result) return result.error;
+
+  const { openclawVersion, variant, imageTag, imageDigest } = result.data;
+
+  const entry = {
+    openclawVersion,
+    variant,
+    imageTag,
+    imageDigest: imageDigest ?? null,
+    publishedAt: new Date().toISOString(),
+  };
+
+  // Validate against schema
+  const parsed = ImageVersionEntrySchema.safeParse(entry);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid version entry', details: parsed.error.flatten() }, 400);
+  }
+
+  // Write both the versioned key and the latest key (both store the full entry)
+  const serialized = JSON.stringify(parsed.data);
+  await Promise.all([
+    c.env.KV_CLAW_CACHE.put(imageVersionKey(openclawVersion, variant), serialized),
+    c.env.KV_CLAW_CACHE.put(imageVersionLatestKey(variant), serialized),
+  ]);
+
+  console.log('[platform] Published image version:', openclawVersion, variant, '→', imageTag);
+  return c.json({ ok: true, ...parsed.data }, 201);
 });
 
 export { platform };

--- a/kiloclaw/src/schemas/image-version.test.ts
+++ b/kiloclaw/src/schemas/image-version.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ImageVersionEntrySchema,
+  ImageVariantSchema,
+  imageVersionKey,
+  imageVersionLatestKey,
+} from './image-version';
+
+describe('imageVersionKey', () => {
+  it('produces the expected key format', () => {
+    expect(imageVersionKey('2026.2.9', 'default')).toBe('image-version:2026.2.9:default');
+  });
+
+  it('throws when version is "latest"', () => {
+    expect(() => imageVersionKey('latest', 'default')).toThrow('Cannot use "latest" as a version');
+  });
+});
+
+describe('imageVersionLatestKey', () => {
+  it('produces the expected key format', () => {
+    expect(imageVersionLatestKey('default')).toBe('image-version:latest:default');
+  });
+});
+
+describe('ImageVariantSchema', () => {
+  it('accepts "default"', () => {
+    expect(ImageVariantSchema.parse('default')).toBe('default');
+  });
+
+  it('rejects unknown variants', () => {
+    const result = ImageVariantSchema.safeParse('secure');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ImageVersionEntrySchema', () => {
+  it('parses a valid entry', () => {
+    const entry = {
+      openclawVersion: '2026.2.9',
+      variant: 'default',
+      imageTag: 'dev-123',
+      imageDigest: null,
+      publishedAt: '2026-02-22T18:00:00Z',
+    };
+    expect(ImageVersionEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it('accepts imageDigest as a string', () => {
+    const entry = {
+      openclawVersion: '2026.2.9',
+      variant: 'default',
+      imageTag: 'dev-123',
+      imageDigest: 'sha256:abc123',
+      publishedAt: '2026-02-22T18:00:00Z',
+    };
+    expect(ImageVersionEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it('rejects invalid variant', () => {
+    const entry = {
+      openclawVersion: '2026.2.9',
+      variant: 'unknown',
+      imageTag: 'dev-123',
+      imageDigest: null,
+      publishedAt: '2026-02-22T18:00:00Z',
+    };
+    const result = ImageVersionEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = ImageVersionEntrySchema.safeParse({ openclawVersion: '2026.2.9' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/kiloclaw/src/schemas/image-version.ts
+++ b/kiloclaw/src/schemas/image-version.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * Supported image variants. Day 1 ships with "default" only.
+ * Adding a new variant requires a code change + deploy (extend the enum).
+ */
+export const ImageVariantSchema = z.enum(['default']);
+export type ImageVariant = z.infer<typeof ImageVariantSchema>;
+
+/**
+ * KV value for `image-version:<openclawVersion>:<variant>` keys
+ * and `image-version:latest:<variant>` keys (both store the full entry).
+ */
+export const ImageVersionEntrySchema = z.object({
+  openclawVersion: z.string(),
+  variant: z.string(),
+  imageTag: z.string(),
+  imageDigest: z.string().nullable(),
+  publishedAt: z.string(),
+});
+
+export type ImageVersionEntry = z.infer<typeof ImageVersionEntrySchema>;
+
+// KV key helpers — variant is encoded in the key so each lookup is a single read.
+
+export function imageVersionKey(version: string, variant: string): string {
+  return `image-version:${version}:${variant}`;
+}
+
+export function imageVersionLatestKey(variant: string): string {
+  return `image-version:latest:${variant}`;
+}

--- a/kiloclaw/src/schemas/image-version.ts
+++ b/kiloclaw/src/schemas/image-version.ts
@@ -13,7 +13,7 @@ export type ImageVariant = z.infer<typeof ImageVariantSchema>;
  */
 export const ImageVersionEntrySchema = z.object({
   openclawVersion: z.string(),
-  variant: z.string(),
+  variant: ImageVariantSchema,
   imageTag: z.string(),
   imageDigest: z.string().nullable(),
   publishedAt: z.string(),
@@ -22,8 +22,12 @@ export const ImageVersionEntrySchema = z.object({
 export type ImageVersionEntry = z.infer<typeof ImageVersionEntrySchema>;
 
 // KV key helpers — variant is encoded in the key so each lookup is a single read.
+// "latest" is reserved for the latest pointer key and cannot be used as a version.
 
 export function imageVersionKey(version: string, variant: string): string {
+  if (version === 'latest') {
+    throw new Error('Cannot use "latest" as a version — it is reserved for the latest pointer key');
+  }
   return `image-version:${version}:${variant}`;
 }
 

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -127,6 +127,10 @@ export const PersistedStateSchema = z.object({
   // Cooldown: last time we attempted metadata-based machine recovery from Fly.
   // Prevents hammering listMachines on every alarm when there's genuinely nothing.
   lastMetadataRecoveryAt: z.number().nullable().default(null),
+  // Image version tracking: records what version/variant/tag a user was provisioned with
+  openclawVersion: z.string().nullable().default(null),
+  imageVariant: z.string().nullable().default(null),
+  trackedImageTag: z.string().nullable().default(null),
 });
 
 export type PersistedState = z.infer<typeof PersistedStateSchema>;

--- a/kiloclaw/src/types.ts
+++ b/kiloclaw/src/types.ts
@@ -35,6 +35,7 @@ export type KiloClawEnv = {
   FLY_REGISTRY_APP?: string; // Shared app for Docker image registry
   FLY_REGION?: string;
   FLY_IMAGE_TAG?: string;
+  OPENCLAW_VERSION?: string;
 
   // OpenClaw gateway configuration
   OPENCLAW_ALLOWED_ORIGINS?: string;

--- a/kiloclaw/test/docker-image-testing.md
+++ b/kiloclaw/test/docker-image-testing.md
@@ -187,6 +187,13 @@ The `push-dev.sh` script builds for linux/amd64 and pushes to a Fly app's regist
 It reads `FLY_APP_NAME` from `.dev.vars` (defaults to `kiloclaw-dev`) and updates
 `FLY_IMAGE_TAG` in `.dev.vars` so the worker uses the new tag on next machine create.
 
+> **Version tracking:** Make sure `OPENCLAW_VERSION` is set in `.dev.vars` to match
+> the `openclaw@x.x.x` version in the Dockerfile (see `.dev.vars.example`). This
+> enables the worker to self-register the version → image tag mapping in KV, so
+> provisioned instances track which OpenClaw version they're running. Without it,
+> version tracking fields will be null (instances still work via `FLY_IMAGE_TAG` fallback).
+> Update this value whenever you bump the OpenClaw version in the Dockerfile.
+
 ```bash
 # Authenticate Docker with Fly registry (also in prerequisites, but tokens expire per session)
 fly auth docker


### PR DESCRIPTION
Track which OpenClaw version, variant, and image tag each user is provisioned with. 
Foundation for future version pinning, staged rollouts and support for image variants.

  - Version registry in KV (variant-aware keys, single-read resolution)
  - Per-user tracking in DO state (openclawVersion, imageVariant, trackedImageTag)
  - Synchronous image tag resolution from DO state (no KV on hot path)
  - Fly machine metadata stamping for external queryability
  - Worker self-registration on deploy via ctx.waitUntil()
  - Admin publish-image-version endpoint as manual fallback
  - CI workflow extracts version from Dockerfile for production deploys


## Summary

Adds tracking and observability for which OpenClaw version + variant + image tag each user was provisioned with. 

## What Changed

### New Files
- `kiloclaw/src/schemas/image-version.ts` — `ImageVersionEntrySchema` (with variant + imageDigest), `ImageVariantSchema` enum (`"default"` only for day 1), variant-aware KV key helpers
- `kiloclaw/src/lib/image-version.ts` — `resolveLatestVersion(kv, variant)` returns full entry, `lookupImageTag()`, `registerVersionIfNeeded()` for worker self-registration (idempotent)

### Modified Files
- `kiloclaw/src/schemas/instance-config.ts` — Added `trackedImageTag` to `PersistedStateSchema` (alongside existing `openclawVersion`, `imageVariant`)
- `kiloclaw/src/types.ts` — Added `OPENCLAW_VERSION` to `KiloClawEnv`
- `kiloclaw/src/durable-objects/kiloclaw-instance.ts`:
  - `trackedImageTag` field added to DO state (load, persist, reset in all paths)
  - Provision resolves latest on ALL provisions (not just new — re-provision also re-resolves)
  - `resolveImageTag()` is now **synchronous** — reads `trackedImageTag` from DO state, no KV on the hot path
  - Extended `MachineIdentity` type with `openclawVersion` and `imageVariant`
  - Added `METADATA_KEY_OPENCLAW_VERSION` / `METADATA_KEY_IMAGE_VARIANT` — stamped on Fly machines at create/update
  - `getStatus()` returns `trackedImageTag`
  - Removed `upgradeVersion()` DO method (deferred to pinning phase)
- `kiloclaw/src/routes/platform.ts`:
  - `publish-image-version` endpoint updated: accepts `variant` (defaults to `"default"`), optional `imageDigest`, writes variant-aware KV keys
  - Removed `upgrade-version` endpoint (deferred to pinning phase)
- `kiloclaw/src/index.ts` — Worker self-registration via `ctx.waitUntil(registerVersionIfNeeded(...))` on every request (idempotent, no-ops after first write per deploy)

### CI / Release Process
- `.github/workflows/deploy-kiloclaw.yml` — New "Extract OpenClaw version" step parses `openclaw@x.x.x` from Dockerfile, passes `--var OPENCLAW_VERSION:$VERSION` to wrangler deploy. Fails the build if version extraction fails.

### Dev Setup / Docs
- `kiloclaw/.dev.vars.example` — Added `OPENCLAW_VERSION=2026.2.9` with explanation
- `kiloclaw/test/docker-image-testing.md` — Added callout in Step 3 about setting `OPENCLAW_VERSION` in `.dev.vars`

## Variant Support

Day 1 ships with a single variant: `"default"`. The variant is hardcoded at provision time:
```typescript
const variant = 'default'; // hardcoded day 1
```

The plumbing is fully variant-aware:
- KV keys include variant: `image-version:2026.2.9:default`, `image-version:latest:default`
- DO state stores `imageVariant`
- Fly machine metadata stamps `kiloclaw_image_variant`
- `ImageVariantSchema` is `z.enum(["default"])` — adding a new variant requires extending the enum (deliberate, not ad-hoc)

Future variants slot in naturally with no data model changes.

## Release Process Changes

### Production (CI)
The deploy workflow now:
1. Extracts `OPENCLAW_VERSION` from Dockerfile (`sed` pattern matching `openclaw@x.x.x`)
2. Passes it as `--var OPENCLAW_VERSION:$VERSION` alongside `--var FLY_IMAGE_TAG:$GITHUB_SHA`
3. On first request after deploy, the worker self-registers `version + variant → imageTag` in KV

No manual publish step needed. The `publish-image-version` admin endpoint exists as a fallback for corrections/hotfixes.

### Local Dev
Developers must add `OPENCLAW_VERSION=x.x.x` to `.dev.vars` (matching the version in `Dockerfile`). Without it, self-registration silently no-ops and version tracking fields will be null (instances still work via `FLY_IMAGE_TAG` fallback).

Update `OPENCLAW_VERSION` in `.dev.vars` whenever you bump the OpenClaw version in the Dockerfile.

## Testing Performed

### Unit Tests
- All 267 existing tests pass (13 test files, vitest, 394ms)
- TypeScript compiles cleanly (`tsc --noEmit`)

### End-to-End Testing (Fly.io)

**Setup:**
- Pushed dev image via `push-dev.sh` → tag `dev-1771781624`
- Set `OPENCLAW_VERSION=2026.2.9` in `.dev.vars`
- Restarted wrangler dev

**Test 1: Worker self-registration**
- Hit any endpoint to trigger `ctx.waitUntil(registerVersionIfNeeded(...))`
- Wrangler logs confirmed: `[image-version] Registered version: 2026.2.9 default → dev-1771781624`
- Result: PASS

**Test 2: Provision resolves version from KV**
- Provisioned instance for real user
- Status API returned:
  ```json
  {
    "openclawVersion": "2026.2.9",
    "imageVariant": "default",
    "trackedImageTag": "dev-1771781624"
  }
  ```
- Result: PASS

**Test 3: Fly machine metadata**
- Started instance, checked machine metadata via `fly machines list --json`
- Metadata included:
  ```json
  {
    "kiloclaw_openclaw_version": "2026.2.9",
    "kiloclaw_image_variant": "default",
    "kiloclaw_sandbox_id": "...",
    "kiloclaw_user_id": "..."
  }
  ```
- Verified in Fly dashboard
- Result: PASS

**Test 4: Stop/start preserves tracked tag**
- Stopped instance → status showed fields persisted (not null)
- Started instance → same `trackedImageTag` used, fields unchanged
- Confirms `resolveImageTag()` reads from DO state (no KV on hot path)
- Result: PASS

**Test 5: Backward compatibility**
- Instances provisioned before tracking (no version fields) fall back to `FLY_IMAGE_TAG` via:
  ```typescript
  private resolveImageTag(): string {
    if (this.trackedImageTag) return this.trackedImageTag;
    return this.env.FLY_IMAGE_TAG ?? 'latest';
  }
  ```
- Zod schema defaults all three fields to `null` — existing DO state parses cleanly

**Test 5: Three-way consistency check (KV ↔ DO ↔ Fly)**
- Queried all three data stores independently and compared:

| Field | KV Registry | DO State (Status API) | Fly Machine |
|-------|------------|----------------------|-------------|
| version | `2026.2.9` | `2026.2.9` | `kiloclaw_openclaw_version: 2026.2.9` |
| variant | `default` | `default` | `kiloclaw_image_variant: default` |
| image tag | `dev-1771781624` | `dev-1771781624` | `config.image: ...:dev-1771781624` |
| digest | `null` (expected — worker doesn't know its digest) | n/a (not stored in DO) | n/a (deferred) |

- KV checked via `wrangler kv key get` for both `image-version:latest:default` and `image-version:2026.2.9:default`
- DO state checked via `GET /api/platform/status`
- Fly machine checked via `fly machines list --json` (metadata + config.image)
- Result: PASS — all three layers agree

**Test 6: Version upgrade — full end-to-end with new image**
- Pushed a new dev image (`dev-1771783173`) and set `OPENCLAW_VERSION=2026.2.99` (fake version to simulate a bump)
- Restarted wrangler, hit an endpoint to trigger self-registration
- KV updated: `image-version:latest:default` now points to `2026.2.99 → dev-1771783173`
- Destroyed existing instance, re-provisioned, started
- Three-way consistency check:

| Layer | version | variant | image tag |
|-------|---------|---------|-----------|
| **KV** | `2026.2.99` | `default` | `dev-1771783173` |
| **DO** | `2026.2.99` | `default` | `dev-1771783173` |
| **Fly** | `2026.2.99` | `default` | `...:dev-1771783173` |

- Confirms: new deploy → self-registration overwrites KV → destroy + re-provision picks up new version → start stamps new metadata on Fly machine
- Result: PASS

### Not Tested (Deferred)
- Non-default variants (only `"default"` exists; plumbing is there but nothing to exercise)
- `imageDigest` backfill via admin endpoint
- Production CI workflow (tested locally; CI change is straightforward)