### PR TITLE
CloudAgent - Fetch session messages from ingest worker

### DIFF
--- a/src/lib/session-ingest-client.ts
+++ b/src/lib/session-ingest-client.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+import { z } from 'zod';
+import { SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
+import { generateApiToken } from '@/lib/tokens';
+import type { User } from '@/db/schema';
+
+// Mirrors SharedSessionSnapshotSchema from cloudflare-session-ingest/src/util/share-output.ts.
+// Kept in sync manually (same pattern as cloud-agent-client.ts).
+const SessionExportResponseSchema = z.object({
+  info: z.unknown(),
+  messages: z.array(
+    z.looseObject({
+      info: z.looseObject({
+        id: z.string(),
+      }),
+      parts: z.array(
+        z.looseObject({
+          id: z.string(),
+        })
+      ),
+    })
+  ),
+});
+
+type SessionExportMessage = z.infer<typeof SessionExportResponseSchema>['messages'][number];
+
+export async function fetchSessionMessages(
+  sessionId: string,
+  user: User
+): Promise<SessionExportMessage[] | null> {
+  if (!SESSION_INGEST_WORKER_URL) {
+    throw new Error('SESSION_INGEST_WORKER_URL is not configured');
+  }
+
+  const token = generateApiToken(user);
+  const url = `${SESSION_INGEST_WORKER_URL}/api/session/${encodeURIComponent(sessionId)}/export`;
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => 'Unknown error');
+    throw new Error(`Session ingest export failed: ${response.status} ${text}`);
+  }
+
+  const data = SessionExportResponseSchema.parse(await response.json());
+  return data.messages;
+}


### PR DESCRIPTION
## Summary

- Replace the stub `getSessionMessages` endpoint (which returned `{ messages: [] }`) with a real implementation that fetches messages from the session-ingest Cloudflare worker via its `/api/session/:id/export` endpoint.
- Add `src/lib/session-ingest-client.ts` — a focused module that handles the HTTP call, auth token generation, Zod schema validation, and 404-as-null semantics.
- Update `src/routers/cli-sessions-v2-router.ts` to call `fetchSessionMessages` with proper error handling (matching the `getWithRuntimeState` pattern), converting `null` to `[]` and wrapping failures in `TRPCError`.

No client-side or ingest worker changes needed — the export endpoint already exists, and the frontend already runs messages through `parseStoredMessages()`.