### PR TITLE
Fix: Populate git credentials from platform integrations on rig creation

### DIFF
--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -42,6 +42,10 @@ export async function updateTownConfig(
         ? (current.git_auth[key] ?? incoming)
         : incoming;
     }
+    // platform_integration_id is not masked — always take the update value
+    if (update.git_auth.platform_integration_id !== undefined) {
+      resolvedGitAuth.platform_integration_id = update.git_auth.platform_integration_id;
+    }
   }
 
   const merged: TownConfig = {

--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -30,11 +30,25 @@ export async function updateTownConfig(
     }
   }
 
+  // git_auth: preserve masked token values (starting with "****") to avoid
+  // overwriting real secrets when the UI round-trips masked config.
+  let resolvedGitAuth = current.git_auth;
+  if (update.git_auth) {
+    resolvedGitAuth = { ...current.git_auth };
+    for (const key of ['github_token', 'gitlab_token', 'gitlab_instance_url'] as const) {
+      const incoming = update.git_auth[key];
+      if (incoming === undefined) continue;
+      resolvedGitAuth[key] = incoming.startsWith('****')
+        ? (current.git_auth[key] ?? incoming)
+        : incoming;
+    }
+  }
+
   const merged: TownConfig = {
     ...current,
     ...update,
     env_vars: resolvedEnvVars,
-    git_auth: { ...current.git_auth, ...(update.git_auth ?? {}) },
+    git_auth: resolvedGitAuth,
     refinery:
       update.refinery !== undefined
         ? { ...current.refinery, ...update.refinery }

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -250,6 +250,9 @@ export async function startMergeInContainer(
     if (params.townConfig.git_auth?.gitlab_token) {
       envVars.GITLAB_TOKEN = params.townConfig.git_auth.gitlab_token;
     }
+    if (params.townConfig.git_auth?.gitlab_instance_url) {
+      envVars.GITLAB_INSTANCE_URL = params.townConfig.git_auth.gitlab_instance_url;
+    }
     if (token) envVars.GASTOWN_SESSION_TOKEN = token;
     if (env.GASTOWN_API_URL) envVars.GASTOWN_API_URL = env.GASTOWN_API_URL;
     const mergeKilocodeToken = params.kilocodeToken ?? params.townConfig.kilocode_token;

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -187,6 +187,8 @@ export const TownConfigSchema = z.object({
       github_token: z.string().optional(),
       gitlab_token: z.string().optional(),
       gitlab_instance_url: z.string().optional(),
+      /** Platform integration ID used to refresh tokens (stored for token refresh) */
+      platform_integration_id: z.string().optional(),
     })
     .default({}),
 

--- a/cloudflare-gastown/test/unit/config.test.ts
+++ b/cloudflare-gastown/test/unit/config.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TownConfigSchema } from '../../src/types';
+
+// We can't import the actual config functions because they depend on
+// DurableObjectStorage. Instead, test the merge logic directly.
+
+/**
+ * Reproduces the merge logic from config.ts updateTownConfig.
+ */
+function mergeTownConfig(
+  current: ReturnType<typeof TownConfigSchema.parse>,
+  update: Partial<ReturnType<typeof TownConfigSchema.parse>>
+) {
+  // env_vars masked-value preservation
+  let resolvedEnvVars = current.env_vars;
+  if (update.env_vars) {
+    resolvedEnvVars = {};
+    for (const [key, value] of Object.entries(update.env_vars)) {
+      resolvedEnvVars[key] = value.startsWith('****') ? (current.env_vars[key] ?? value) : value;
+    }
+  }
+
+  // git_auth masked-value preservation
+  let resolvedGitAuth = current.git_auth;
+  if (update.git_auth) {
+    resolvedGitAuth = { ...current.git_auth };
+    for (const key of ['github_token', 'gitlab_token', 'gitlab_instance_url'] as const) {
+      const incoming = update.git_auth[key];
+      if (incoming === undefined) continue;
+      resolvedGitAuth[key] = incoming.startsWith('****')
+        ? (current.git_auth[key] ?? incoming)
+        : incoming;
+    }
+    // platform_integration_id is not masked
+    if (update.git_auth.platform_integration_id !== undefined) {
+      resolvedGitAuth.platform_integration_id = update.git_auth.platform_integration_id;
+    }
+  }
+
+  return TownConfigSchema.parse({
+    ...current,
+    ...update,
+    env_vars: resolvedEnvVars,
+    git_auth: resolvedGitAuth,
+  });
+}
+
+describe('town config merge logic', () => {
+  const defaultConfig = () =>
+    TownConfigSchema.parse({
+      env_vars: {},
+      git_auth: {},
+    });
+
+  describe('git_auth masked-value preservation', () => {
+    it('preserves real github_token when masked value is sent', () => {
+      const current = TownConfigSchema.parse({
+        git_auth: { github_token: 'ghs_realtoken123456' },
+      });
+      const update = { git_auth: { github_token: '****3456' } };
+      const result = mergeTownConfig(current, update);
+      expect(result.git_auth.github_token).toBe('ghs_realtoken123456');
+    });
+
+    it('preserves real gitlab_token when masked value is sent', () => {
+      const current = TownConfigSchema.parse({
+        git_auth: { gitlab_token: 'glpat-realtoken789' },
+      });
+      const update = { git_auth: { gitlab_token: '****t789' } };
+      const result = mergeTownConfig(current, update);
+      expect(result.git_auth.gitlab_token).toBe('glpat-realtoken789');
+    });
+
+    it('updates github_token when real value is sent', () => {
+      const current = TownConfigSchema.parse({
+        git_auth: { github_token: 'ghs_old_token' },
+      });
+      const update = { git_auth: { github_token: 'ghs_new_token' } };
+      const result = mergeTownConfig(current, update);
+      expect(result.git_auth.github_token).toBe('ghs_new_token');
+    });
+
+    it('preserves existing tokens when only gitlab_instance_url is updated', () => {
+      const current = TownConfigSchema.parse({
+        git_auth: {
+          gitlab_token: 'glpat-mytoken',
+          gitlab_instance_url: 'https://gitlab.example.com',
+        },
+      });
+      const update = { git_auth: { gitlab_instance_url: 'https://gitlab.newhost.com' } };
+      const result = mergeTownConfig(current, update);
+      expect(result.git_auth.gitlab_token).toBe('glpat-mytoken');
+      expect(result.git_auth.gitlab_instance_url).toBe('https://gitlab.newhost.com');
+    });
+
+    it('preserves platform_integration_id across updates', () => {
+      const current = TownConfigSchema.parse({
+        git_auth: {
+          github_token: 'ghs_token',
+          platform_integration_id: 'int-123',
+        },
+      });
+      const update = {
+        git_auth: { github_token: 'ghs_fresh_token', platform_integration_id: 'int-123' },
+      };
+      const result = mergeTownConfig(current, update);
+      expect(result.git_auth.github_token).toBe('ghs_fresh_token');
+      expect(result.git_auth.platform_integration_id).toBe('int-123');
+    });
+  });
+
+  describe('env_vars masked-value preservation', () => {
+    it('preserves real value when masked value is sent', () => {
+      const current = TownConfigSchema.parse({
+        env_vars: { SECRET_KEY: 'real_secret_value' },
+      });
+      const update = { env_vars: { SECRET_KEY: '****alue' } };
+      const result = mergeTownConfig(current, update);
+      expect(result.env_vars.SECRET_KEY).toBe('real_secret_value');
+    });
+
+    it('updates value when real value is sent', () => {
+      const current = TownConfigSchema.parse({
+        env_vars: { API_KEY: 'old_key' },
+      });
+      const update = { env_vars: { API_KEY: 'new_key' } };
+      const result = mergeTownConfig(current, update);
+      expect(result.env_vars.API_KEY).toBe('new_key');
+    });
+  });
+});

--- a/src/lib/gastown/gastown-client.ts
+++ b/src/lib/gastown/gastown-client.ts
@@ -422,6 +422,7 @@ export const TownConfigSchema = z.object({
     github_token: z.string().optional(),
     gitlab_token: z.string().optional(),
     gitlab_instance_url: z.string().optional(),
+    platform_integration_id: z.string().optional(),
   }),
   kilocode_token: z.string().optional(),
   owner_user_id: z.string().optional(),

--- a/src/lib/gastown/git-credentials.ts
+++ b/src/lib/gastown/git-credentials.ts
@@ -1,0 +1,120 @@
+import 'server-only';
+import { db } from '@/lib/drizzle';
+import { platform_integrations } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
+import { getValidGitLabToken } from '@/lib/integrations/gitlab-service';
+import { INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
+
+const LOG_PREFIX = '[gastown-git-credentials]';
+
+type GitLabMetadata = {
+  access_token?: string;
+  refresh_token?: string;
+  token_expires_at?: string;
+  gitlab_instance_url?: string;
+  auth_type?: string;
+  client_id?: string;
+  client_secret?: string;
+};
+
+/**
+ * Resolved git credentials from a platform integration.
+ * Suitable for writing into TownConfig.git_auth.
+ */
+export type ResolvedGitCredentials = {
+  github_token?: string;
+  gitlab_token?: string;
+  gitlab_instance_url?: string;
+};
+
+/**
+ * Resolve git credentials from a platform integration ID.
+ *
+ * For GitHub: generates an installation token (expires in ~1 hour).
+ * For GitLab: returns a valid OAuth/PAT token (auto-refreshed if expired).
+ *
+ * Returns null if the integration is missing, inactive, or has no usable credentials.
+ */
+export async function resolveGitCredentialsFromIntegration(
+  platformIntegrationId: string
+): Promise<ResolvedGitCredentials | null> {
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.id, platformIntegrationId),
+        eq(platform_integrations.integration_status, INTEGRATION_STATUS.ACTIVE)
+      )
+    )
+    .limit(1);
+
+  if (!integration) {
+    console.warn(`${LOG_PREFIX} integration not found or inactive: id=${platformIntegrationId}`);
+    return null;
+  }
+
+  if (integration.platform === 'github' && integration.platform_installation_id) {
+    try {
+      const tokenData = await generateGitHubInstallationToken(
+        integration.platform_installation_id,
+        integration.github_app_type ?? 'standard'
+      );
+      console.log(
+        `${LOG_PREFIX} resolved GitHub token for integration=${platformIntegrationId} expires_at=${tokenData.expires_at}`
+      );
+      return { github_token: tokenData.token };
+    } catch (err) {
+      console.error(
+        `${LOG_PREFIX} failed to generate GitHub installation token for integration=${platformIntegrationId}:`,
+        err
+      );
+      return null;
+    }
+  }
+
+  if (integration.platform === 'gitlab') {
+    try {
+      const token = await getValidGitLabToken(integration);
+      const metadata = integration.metadata as GitLabMetadata | null;
+      const instanceUrl = metadata?.gitlab_instance_url;
+
+      console.log(
+        `${LOG_PREFIX} resolved GitLab token for integration=${platformIntegrationId} instanceUrl=${instanceUrl ?? 'gitlab.com'}`
+      );
+
+      return {
+        gitlab_token: token,
+        // Only set gitlab_instance_url for self-hosted instances
+        ...(instanceUrl &&
+          instanceUrl !== 'https://gitlab.com' && { gitlab_instance_url: instanceUrl }),
+      };
+    } catch (err) {
+      console.error(
+        `${LOG_PREFIX} failed to get GitLab token for integration=${platformIntegrationId}:`,
+        err
+      );
+      return null;
+    }
+  }
+
+  console.warn(
+    `${LOG_PREFIX} unsupported platform="${integration.platform}" for integration=${platformIntegrationId}`
+  );
+  return null;
+}
+
+/**
+ * Refresh git credentials for a town's git_auth config.
+ *
+ * If a platformIntegrationId is provided, fetches a fresh token from the
+ * integration and returns the updated git_auth fields. Otherwise returns null,
+ * meaning the existing town config credentials should be used as-is.
+ */
+export async function refreshGitCredentials(
+  platformIntegrationId: string | undefined | null
+): Promise<ResolvedGitCredentials | null> {
+  if (!platformIntegrationId) return null;
+  return resolveGitCredentialsFromIntegration(platformIntegrationId);
+}

--- a/src/routers/gastown-router.ts
+++ b/src/routers/gastown-router.ts
@@ -6,6 +6,10 @@ import * as gastown from '@/lib/gastown/gastown-client';
 import { GastownApiError } from '@/lib/gastown/gastown-client';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { GASTOWN_SERVICE_URL } from '@/lib/config.server';
+import {
+  resolveGitCredentialsFromIntegration,
+  refreshGitCredentials,
+} from '@/lib/gastown/git-credentials';
 
 const LOG_PREFIX = '[gastown-router]';
 
@@ -104,7 +108,7 @@ export const gastownRouter = createTRPCRouter({
         `[gastown-router] createRig: generating kilocodeToken for user=${ctx.user.id} tokenLength=${kilocodeToken?.length ?? 0}`
       );
 
-      return withGastownError(() =>
+      const rig = await withGastownError(() =>
         gastown.createRig(ctx.user.id, {
           town_id: input.townId,
           name: input.name,
@@ -114,6 +118,34 @@ export const gastownRouter = createTRPCRouter({
           platform_integration_id: input.platformIntegrationId,
         })
       );
+
+      // Resolve git credentials from the platform integration and store
+      // them in the town config so agents can clone and push.
+      if (input.platformIntegrationId) {
+        const gitCredentials = await resolveGitCredentialsFromIntegration(
+          input.platformIntegrationId
+        );
+        if (gitCredentials) {
+          console.log(
+            `${LOG_PREFIX} createRig: resolved git credentials for integration=${input.platformIntegrationId} hasGithub=${!!gitCredentials.github_token} hasGitlab=${!!gitCredentials.gitlab_token}`
+          );
+          await withGastownError(() =>
+            gastown.updateTownConfig(input.townId, {
+              git_auth: {
+                ...gitCredentials,
+                // Store the integration ID so we can refresh tokens later
+                platform_integration_id: input.platformIntegrationId,
+              },
+            })
+          );
+        } else {
+          console.warn(
+            `${LOG_PREFIX} createRig: could not resolve git credentials for integration=${input.platformIntegrationId}`
+          );
+        }
+      }
+
+      return rig;
     }),
 
   listRigs: baseProcedure
@@ -183,6 +215,28 @@ export const gastownRouter = createTRPCRouter({
       const rig = await withGastownError(() => gastown.getRig(ctx.user.id, input.rigId));
       console.log(`${LOG_PREFIX} sling: rig verified, name=${rig.name}`);
 
+      // Refresh git credentials before dispatch. GitHub installation tokens
+      // expire after ~1 hour, so we refresh them each time a bead is slung
+      // to ensure the agent gets a fresh token.
+      const townConfig = await withGastownError(() => gastown.getTownConfig(rig.town_id));
+      const integrationId = townConfig.git_auth.platform_integration_id;
+      if (integrationId) {
+        const freshCredentials = await refreshGitCredentials(integrationId);
+        if (freshCredentials) {
+          await withGastownError(() =>
+            gastown.updateTownConfig(rig.town_id, {
+              git_auth: {
+                ...freshCredentials,
+                platform_integration_id: integrationId,
+              },
+            })
+          );
+          console.log(
+            `${LOG_PREFIX} sling: refreshed git credentials for integration=${integrationId}`
+          );
+        }
+      }
+
       // Atomic sling: creates bead, assigns/creates polecat, hooks them,
       // and arms the alarm — all in a single Rig DO call to avoid TOCTOU races.
       const result = await withGastownError(() =>
@@ -225,6 +279,27 @@ export const gastownRouter = createTRPCRouter({
       if (town.owner_user_id !== ctx.user.id) {
         console.error(`${LOG_PREFIX} sendMessage: FORBIDDEN - town owner mismatch`);
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Not your town' });
+      }
+
+      // Refresh git credentials before mayor interaction. The mayor may
+      // delegate work that requires fresh git tokens.
+      const townConfig = await withGastownError(() => gastown.getTownConfig(input.townId));
+      const integrationId = townConfig.git_auth.platform_integration_id;
+      if (integrationId) {
+        const freshCredentials = await refreshGitCredentials(integrationId);
+        if (freshCredentials) {
+          await withGastownError(() =>
+            gastown.updateTownConfig(input.townId, {
+              git_auth: {
+                ...freshCredentials,
+                platform_integration_id: integrationId,
+              },
+            })
+          );
+          console.log(
+            `${LOG_PREFIX} sendMessage: refreshed git credentials for integration=${integrationId}`
+          );
+        }
       }
 
       // Send message directly to MayorDO — single DO call, no beads


### PR DESCRIPTION
## Summary

Closes #443

Polecat agents fail to `git push` because git credentials are never populated in the town config. This PR fixes the credential flow end-to-end:

- **Resolve tokens on rig creation**: When a rig is created with a `platform_integration_id`, the tRPC `createRig` mutation now resolves a GitHub installation token or GitLab OAuth/PAT token from the integration and writes it to `town_config.git_auth`.
- **Refresh tokens before dispatch**: The `sling` and `sendMessage` mutations now refresh git credentials before triggering work, since GitHub installation tokens expire after ~1 hour.
- **Fix GITLAB_INSTANCE_URL in merge dispatch**: `startMergeInContainer` was missing the `GITLAB_INSTANCE_URL` env var mapping (already present in `startAgentInContainer`).
- **Fix masked-value preservation for git_auth**: The config update logic now preserves masked token values (starting with `****`) for git_auth fields, preventing the UI from overwriting real secrets when round-tripping config.
- **Store platform_integration_id in git_auth**: Enables future token refresh lookups without needing the rig record.

### Files changed

| File | Change |
|---|---|
| `src/lib/gastown/git-credentials.ts` | New module: resolves GitHub/GitLab tokens from platform integrations |
| `src/routers/gastown-router.ts` | Credential resolution on createRig, token refresh on sling/sendMessage |
| `cloudflare-gastown/src/dos/town/container-dispatch.ts` | Add GITLAB_INSTANCE_URL to merge dispatch |
| `cloudflare-gastown/src/dos/town/config.ts` | Masked-value preservation for git_auth tokens |
| `cloudflare-gastown/src/types.ts` | Add platform_integration_id to TownConfigSchema git_auth |
| `src/lib/gastown/gastown-client.ts` | Mirror platform_integration_id in client schema |
| `cloudflare-gastown/test/unit/config.test.ts` | Unit tests for config merge logic |

### Limitations / Follow-up

- Token refresh happens at sling/sendMessage time (Next.js server), not inside the Cloudflare Worker alarm. For agents running longer than ~1 hour, a service binding from the gastown worker to the git-token-service would be needed for mid-session refresh.
- E2E test (create town → create rig → sling → push) requires a live GitHub integration and is not included in unit tests.