### PR TITLE
Removing login page terms checkbox

### DIFF
--- a/src/app/users/layout.tsx
+++ b/src/app/users/layout.tsx
@@ -4,7 +4,7 @@ import { PageContainer } from '@/components/layouts/PageContainer';
 export default function SignInUpLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="bg-background h-full w-full">
-      <PageContainer>
+      <PageContainer fullBleed>
         <div className="flex min-h-screen flex-col justify-between">
           <AnimatedLogo />
           <div>{children}</div>

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -13,9 +13,6 @@ import Link from 'next/link';
 import { Mail, SquareUserRound } from 'lucide-react';
 import type { SignInFormInitialState } from '@/hooks/useSignInFlow';
 import { OAuthProviderIds, ProdNonSSOAuthProviders } from '@/lib/auth/provider-metadata';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 type SignInFormProps = {
   searchParams: Record<string, string>;
@@ -47,7 +44,6 @@ export function SignInForm({
     isSignUp,
     storybookInitialState,
   });
-  const showTermsTooltip = !flow.termsAccepted;
 
   // Show minimal loading state while checking localStorage for returning user hint
   // This prevents flash of "new user" UI before switching to "returning user" UI
@@ -297,59 +293,29 @@ export function SignInForm({
               ) : (
                 // Provider buttons view (initial state)
                 <>
-                  <div className="mb-4 flex items-center space-x-2">
-                    <Checkbox
-                      id="termsAccepted"
-                      checked={flow.termsAccepted}
-                      onCheckedChange={flow.handleTermsAcceptedChange}
-                    />
-                    <Label htmlFor="termsAccepted" className="text-muted-foreground text-sm">
-                      By checking this box, I am agreeing to the{' '}
-                      <a
-                        href="https://kilo.ai/terms"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:underline"
-                      >
-                        Terms & Conditions
-                      </a>
-                    </Label>
-                  </div>
                   <div className="mx-auto max-w-md space-y-4">
                     {/* OAuth provider buttons - Google first */}
-                    {showTermsTooltip ? (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="inline-flex w-full flex-col gap-4">
-                              <AuthProviderButtons
-                                providers={OAuthProviderIds}
-                                onProviderClick={flow.handleOAuthClick}
-                                disabled={true}
-                              />
-                              <SignInButton onClick={flow.handleShowEmailInput} disabled={true}>
-                                <Mail />
-                                Continue with Email
-                              </SignInButton>
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>Agree to ToS to continue</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    ) : (
-                      <>
-                        <AuthProviderButtons
-                          providers={OAuthProviderIds}
-                          onProviderClick={flow.handleOAuthClick}
-                          disabled={false}
-                        />
-                        <SignInButton onClick={flow.handleShowEmailInput} disabled={false}>
-                          <Mail />
-                          Continue with Email
-                        </SignInButton>
-                      </>
-                    )}
+                    <AuthProviderButtons
+                      providers={OAuthProviderIds}
+                      onProviderClick={flow.handleOAuthClick}
+                    />
+                    <SignInButton onClick={flow.handleShowEmailInput}>
+                      <Mail />
+                      Continue with Email
+                    </SignInButton>
                   </div>
+
+                  <p className="text-muted-foreground mx-auto mt-4 max-w-md text-sm">
+                    By continuing, you are agreeing to the{' '}
+                    <a
+                      href="https://kilo.ai/terms"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      Terms &amp; Conditions
+                    </a>
+                  </p>
 
                   {/* Divider */}
                   <div className="mx-auto my-6 max-w-md">

--- a/src/hooks/useSignInFlow.ts
+++ b/src/hooks/useSignInFlow.ts
@@ -60,7 +60,6 @@ export type SignInFlowReturn = {
   error: string;
   pendingSignIn: AuthProviderId | null;
   turnstileError: boolean;
-  termsAccepted: boolean;
 
   // Handlers
   handleEmailChange: (value: string) => void;
@@ -77,7 +76,6 @@ export type SignInFlowReturn = {
   handleSendMagicLink: () => Promise<void>;
   handleShowEmailInput: () => void;
   handleToggleOtherMethods: () => void;
-  handleTermsAcceptedChange: (accepted: boolean) => void;
 };
 
 export function useSignInFlow({
@@ -172,8 +170,6 @@ export function useSignInFlow({
   const [showOtherMethods, setShowOtherMethods] = useState(
     storybookInitialState?.showOtherMethods ?? false
   );
-
-  const [termsAccepted, setTermsAccepted] = useState(false);
 
   // Store pending SSO orgId in ref instead of window object
   const pendingSSOOrgIdRef = useRef<string | null>(null);
@@ -580,10 +576,6 @@ export function useSignInFlow({
     setShowOtherMethods(prev => !prev);
   }, []);
 
-  const handleTermsAcceptedChange = useCallback((accepted: boolean) => {
-    setTermsAccepted(accepted);
-  }, []);
-
   const handleClearHint = useCallback(() => {
     clearHint();
     setEmailState('');
@@ -622,7 +614,6 @@ export function useSignInFlow({
     error,
     pendingSignIn,
     turnstileError,
-    termsAccepted,
     handleEmailChange,
     handleEmailSubmit,
     handleOAuthClick,
@@ -637,6 +628,5 @@ export function useSignInFlow({
     handleSendMagicLink,
     handleShowEmailInput,
     handleToggleOtherMethods,
-    handleTermsAcceptedChange,
   };
 }


### PR DESCRIPTION
We are removing the Login/Signup Terms & Conditions checkbox logic. 

Changes in this PR:
- Removed checkbox gating of Login/Signup buttons
- Keeping the Terms text notice below the buttons.
- Fix Login page overflow vertical scroll

Current | Changes
-|-
<img width="1512" height="861" alt="Screenshot 2026-02-23 at 09 24 55" src="https://github.com/user-attachments/assets/d9ffbf23-08cd-458c-9e68-a2dc48cdadfa" /> | <img width="1512" height="861" alt="Screenshot 2026-02-23 at 09 24 47" src="https://github.com/user-attachments/assets/5f4d0187-f70c-40ee-a99f-2c0a7c479fe0" />
