### PR TITLE
Do not disable reasoning by default for Kimi

### DIFF
--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -184,7 +184,6 @@ function applyToolChoiceSetting(
     isXaiModel(requestedModel) ||
     isOpenAiModel(requestedModel) ||
     isGeminiModel(requestedModel) ||
-    (isMoonshotModel(requestedModel) && !isReasoningEnabled) ||
     (isHaikuModel(requestedModel) && !isReasoningEnabled)
   ) {
     console.debug('[applyToolChoiceSetting] setting tool_choice required');

--- a/src/lib/providers/moonshotai.ts
+++ b/src/lib/providers/moonshotai.ts
@@ -7,12 +7,4 @@ export function isMoonshotModel(model: string) {
 export function applyMoonshotProviderSettings(requestToMutate: OpenRouterChatCompletionRequest) {
   // Moonshot models don't support the temperature parameter
   delete requestToMutate.temperature;
-
-  // normalize reasoning setting; extension only allows setting reasoning effort
-  const isReasoningEnabled =
-    (requestToMutate.reasoning?.enabled ?? false) === true ||
-    (requestToMutate.reasoning?.effort ?? 'none') !== 'none' ||
-    (requestToMutate.reasoning?.max_tokens ?? 0) > 0;
-
-  requestToMutate.reasoning = { enabled: isReasoningEnabled };
 }


### PR DESCRIPTION
This was a hack to support the old extension's reasoning effort, but it doesn't work with the CLI and break Kimi K2 Thinking.