### PR TITLE
Add admin Cancel & Refund button to Kilo Pass section

### DIFF
--- a/src/app/admin/components/UserAdmin/UserAdminKiloPass.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminKiloPass.tsx
@@ -2,10 +2,23 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { useQuery } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Coins } from 'lucide-react';
+import { useState } from 'react';
 import { formatMicrodollars, formatDate } from '@/lib/admin-utils';
 import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import CheckKiloPassButton from './CheckKiloPassButton';
 import { KiloPassIssuanceItemKind } from '@/lib/kilo-pass/enums';
 
@@ -19,6 +32,38 @@ export function UserAdminKiloPass({ userId }: { userId: string }) {
   const trpc = useTRPC();
   const { data, isLoading, error } = useQuery(
     trpc.admin.users.getKiloPassState.queryOptions({ userId })
+  );
+
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [cancelReason, setCancelReason] = useState('');
+  const queryClient = useQueryClient();
+
+  const cancelMutation = useMutation(
+    trpc.admin.users.cancelAndRefundKiloPass.mutationOptions({
+      onSuccess: result => {
+        setCancelDialogOpen(false);
+        setCancelReason('');
+        void queryClient.invalidateQueries(
+          trpc.admin.users.getKiloPassState.queryOptions({ userId })
+        );
+        const parts = ['Kilo Pass cancelled.'];
+        if (result.refundedAmountCents != null) {
+          parts.push(`Refunded $${(result.refundedAmountCents / 100).toFixed(2)}.`);
+        } else {
+          parts.push('No invoice to refund.');
+        }
+        if (result.balanceResetAmountUsd != null) {
+          parts.push(`Balance reset ($${result.balanceResetAmountUsd.toFixed(2)} zeroed).`);
+        }
+        if (!result.alreadyBlocked) {
+          parts.push('Account blocked.');
+        }
+        toast.success(parts.join(' '));
+      },
+      onError: error => {
+        toast.error(error.message || 'Failed to cancel Kilo Pass');
+      },
+    })
   );
 
   if (isLoading) {
@@ -65,6 +110,8 @@ export function UserAdminKiloPass({ userId }: { userId: string }) {
   }
 
   const { subscription, issuances, currentPeriodUsageUsd, thresholds } = data;
+
+  const canCancel = subscription.status !== 'canceled';
 
   const statusColor =
     subscription.status === 'active'
@@ -124,6 +171,13 @@ export function UserAdminKiloPass({ userId }: { userId: string }) {
             <p className="font-mono text-sm">{subscription.currentStreakMonths} months</p>
           </div>
         </div>
+        {canCancel && (
+          <div>
+            <Button size="sm" variant="destructive" onClick={() => setCancelDialogOpen(true)}>
+              Cancel & Refund
+            </Button>
+          </div>
+        )}
 
         {/* Current Period Usage */}
         {currentPeriodUsageUsd != null && (
@@ -248,6 +302,48 @@ export function UserAdminKiloPass({ userId }: { userId: string }) {
           </div>
         </div>
       </CardContent>
+
+      <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cancel & Refund Kilo Pass</DialogTitle>
+            <DialogDescription>
+              This will perform all of the following actions:
+              <ul className="mt-2 list-disc pl-4 text-sm">
+                <li>Cancel the Stripe subscription immediately</li>
+                <li>Refund the latest paid invoice</li>
+                <li>Block this account</li>
+                <li>Reset the user&apos;s balance to $0</li>
+              </ul>
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="cancel-reason">Reason (required)</Label>
+            <Textarea
+              id="cancel-reason"
+              value={cancelReason}
+              onChange={e => setCancelReason(e.target.value)}
+              placeholder="Enter the reason for this action..."
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCancelDialogOpen(false)}
+              disabled={cancelMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={cancelMutation.isPending || cancelReason.trim().length === 0}
+              onClick={() => cancelMutation.mutate({ userId, reason: cancelReason.trim() })}
+            >
+              {cancelMutation.isPending ? 'Processing...' : 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/app/admin/components/UserAdmin/UserAdminKiloPass.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminKiloPass.tsx
@@ -174,7 +174,7 @@ export function UserAdminKiloPass({ userId }: { userId: string }) {
         {canCancel && (
           <div>
             <Button size="sm" variant="destructive" onClick={() => setCancelDialogOpen(true)}>
-              Cancel & Refund
+              Nuke Pass
             </Button>
           </div>
         )}
@@ -306,7 +306,7 @@ export function UserAdminKiloPass({ userId }: { userId: string }) {
       <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Cancel & Refund Kilo Pass</DialogTitle>
+            <DialogTitle>Nuke Pass</DialogTitle>
             <DialogDescription>
               This will perform all of the following actions:
               <ul className="mt-2 list-disc pl-4 text-sm">

--- a/src/app/users/after-sign-in/route.tsx
+++ b/src/app/users/after-sign-in/route.tsx
@@ -6,12 +6,14 @@ import { APP_URL } from '@/lib/constants';
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
-  const { user } = await getUserFromAuth({ adminOnly: false });
+  const { user } = await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true });
 
   let responsePath: string;
 
   if (!user) {
     responsePath = '/users/sign_in';
+  } else if (user.blocked_reason) {
+    responsePath = '/account-blocked';
   } else {
     const callbackPath = url.searchParams.get('callbackPath');
     if (callbackPath && isValidCallbackPath(callbackPath)) {

--- a/src/lib/promoCreditCategories.ts
+++ b/src/lib/promoCreditCategories.ts
@@ -308,6 +308,12 @@ const nonSelfServicePromos: readonly NonSelfServicePromoCreditCategoryConfig[] =
     expect_negative_amount: true,
   },
   {
+    credit_category: 'admin-cancel-refund-kilo-pass',
+    description: 'Balance zeroed by admin during Kilo Pass cancellation and refund',
+    is_idempotent: false,
+    expect_negative_amount: true,
+  },
+  {
     credit_category: 'organization_custom',
     description: 'Custom credit grant for organization',
     is_idempotent: false,

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -544,8 +544,10 @@ export const adminRouter = createTRPCRouter({
             status: 'paid',
             limit: 1,
           });
-          const paymentIntentId = payments.data[0]?.payment.payment_intent;
-          if (paymentIntentId && typeof paymentIntentId === 'string') {
+          const rawPaymentIntent = payments.data[0]?.payment.payment_intent;
+          const paymentIntentId =
+            typeof rawPaymentIntent === 'string' ? rawPaymentIntent : rawPaymentIntent?.id;
+          if (paymentIntentId) {
             try {
               const refund = await stripeClient.refunds.create({
                 payment_intent: paymentIntentId,

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/drizzle';
 import {
   user_admin_notes,
   kilocode_users,
+  kilo_pass_subscriptions,
   stytch_fingerprints,
   enrichment_data,
   user_auth_provider,
@@ -38,6 +39,10 @@ import { APP_URL } from '@/lib/constants';
 import { revalidatePath } from 'next/cache';
 import { recomputeUserBalances } from '@/lib/recomputeUserBalances';
 import { getStripeInvoices } from '@/lib/stripe';
+import { client as stripeClient } from '@/lib/stripe-client';
+import type Stripe from 'stripe';
+import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
+import { kilo_pass_scheduled_changes } from '@/db/schema';
 import {
   getKilocodeRepoOpenPullRequestCounts,
   getKilocodeRepoOpenPullRequestsSummary,
@@ -128,6 +133,11 @@ const UpdateModelSchema = z.object({
 
 const GetUserInvoicesSchema = z.object({
   stripe_customer_id: z.string(),
+});
+
+const CancelAndRefundKiloPassSchema = z.object({
+  userId: z.string(),
+  reason: z.string().min(1, 'Reason is required').trim(),
 });
 
 export const adminRouter = createTRPCRouter({
@@ -463,6 +473,150 @@ export const adminRouter = createTRPCRouter({
           );
 
         return { success: true };
+      }),
+
+    cancelAndRefundKiloPass: adminProcedure
+      .input(CancelAndRefundKiloPassSchema)
+      .mutation(async ({ input, ctx }) => {
+        const user = await db.query.kilocode_users.findFirst({
+          columns: {
+            id: true,
+            stripe_customer_id: true,
+            microdollars_used: true,
+            total_microdollars_acquired: true,
+            blocked_reason: true,
+          },
+          where: eq(kilocode_users.id, input.userId),
+        });
+
+        if (!user) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+        }
+
+        const subscription = await getKiloPassStateForUser(db, input.userId);
+        if (!subscription) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'No Kilo Pass subscription found for this user',
+          });
+        }
+
+        if (subscription.status === 'canceled') {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Kilo Pass subscription is already canceled',
+          });
+        }
+
+        const scheduledChange = await db.query.kilo_pass_scheduled_changes.findFirst({
+          columns: { stripe_schedule_id: true },
+          where: and(
+            eq(
+              kilo_pass_scheduled_changes.stripe_subscription_id,
+              subscription.stripeSubscriptionId
+            ),
+            isNull(kilo_pass_scheduled_changes.deleted_at)
+          ),
+        });
+
+        if (scheduledChange) {
+          await releaseScheduledChangeForSubscription({
+            dbOrTx: db,
+            stripe: stripeClient,
+            stripeSubscriptionId: subscription.stripeSubscriptionId,
+            stripeScheduleIdIfMissingRow: scheduledChange.stripe_schedule_id,
+            kiloUserIdIfMissingRow: input.userId,
+            reason: 'cancel_subscription',
+          });
+        }
+
+        await stripeClient.subscriptions.cancel(subscription.stripeSubscriptionId);
+
+        await db
+          .update(kilo_pass_subscriptions)
+          .set({
+            status: 'canceled',
+            cancel_at_period_end: false,
+            ended_at: new Date().toISOString(),
+          })
+          .where(
+            eq(kilo_pass_subscriptions.stripe_subscription_id, subscription.stripeSubscriptionId)
+          );
+
+        let refundedAmountCents: number | null = null;
+        const latestInvoices = await stripeClient.invoices.list({
+          subscription: subscription.stripeSubscriptionId,
+          limit: 1,
+          status: 'paid',
+          expand: ['data.payment_intent'],
+        });
+        type InvoiceWithPaymentIntent = (typeof latestInvoices.data)[number] & {
+          payment_intent?: Stripe.PaymentIntent | string | null;
+        };
+        const latestInvoice = latestInvoices.data[0] as InvoiceWithPaymentIntent | undefined;
+        if (latestInvoice?.payment_intent) {
+          const paymentIntentId =
+            typeof latestInvoice.payment_intent === 'string'
+              ? latestInvoice.payment_intent
+              : latestInvoice.payment_intent.id;
+          const refund = await stripeClient.refunds.create({
+            payment_intent: paymentIntentId,
+          });
+          refundedAmountCents = refund.amount;
+        }
+
+        if (!user.blocked_reason) {
+          await db
+            .update(kilocode_users)
+            .set({ blocked_reason: input.reason })
+            .where(eq(kilocode_users.id, input.userId));
+        }
+
+        const currentBalanceMicrodollars =
+          user.total_microdollars_acquired - user.microdollars_used;
+        let balanceResetAmount: number | null = null;
+        if (currentBalanceMicrodollars > 0) {
+          await db.insert(credit_transactions).values({
+            kilo_user_id: input.userId,
+            organization_id: null,
+            is_free: true,
+            amount_microdollars: -currentBalanceMicrodollars,
+            credit_category: 'admin-cancel-refund-kilo-pass',
+            description: `Balance zeroed by admin: ${input.reason}`,
+            original_baseline_microdollars_used: user.microdollars_used,
+          });
+          await db
+            .update(kilocode_users)
+            .set({
+              total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${currentBalanceMicrodollars}`,
+            })
+            .where(eq(kilocode_users.id, input.userId));
+          balanceResetAmount = fromMicrodollars(currentBalanceMicrodollars);
+        }
+
+        const noteParts = [
+          `Kilo Pass cancelled and refunded by admin.`,
+          `Reason: ${input.reason}`,
+          refundedAmountCents != null
+            ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
+            : 'No invoice to refund.',
+          balanceResetAmount != null
+            ? `Balance reset: $${balanceResetAmount.toFixed(2)} zeroed.`
+            : 'Balance was already $0.',
+          !user.blocked_reason ? 'Account blocked.' : 'Account was already blocked.',
+        ];
+        await db.insert(user_admin_notes).values({
+          kilo_user_id: input.userId,
+          note_content: noteParts.join(' '),
+          admin_kilo_user_id: ctx.user.id,
+        });
+
+        return {
+          success: true,
+          refundedAmountCents,
+          balanceResetAmountUsd: balanceResetAmount,
+          alreadyBlocked: !!user.blocked_reason,
+        };
       }),
   }),
 

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -481,8 +481,6 @@ export const adminRouter = createTRPCRouter({
           columns: {
             id: true,
             stripe_customer_id: true,
-            microdollars_used: true,
-            total_microdollars_acquired: true,
             blocked_reason: true,
           },
           where: eq(kilocode_users.id, input.userId),
@@ -564,9 +562,6 @@ export const adminRouter = createTRPCRouter({
           }
         }
 
-        const currentBalanceMicrodollars =
-          user.total_microdollars_acquired - user.microdollars_used;
-
         const balanceResetAmountUsd = await db.transaction(async tx => {
           await tx
             .update(kilo_pass_subscriptions)
@@ -587,8 +582,22 @@ export const adminRouter = createTRPCRouter({
               .where(eq(kilocode_users.id, input.userId));
           }
 
+          const freshUserRows = await tx
+            .select({
+              microdollars_used: kilocode_users.microdollars_used,
+              total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+            })
+            .from(kilocode_users)
+            .where(eq(kilocode_users.id, input.userId))
+            .for('update')
+            .limit(1);
+          const freshUser = freshUserRows[0];
+          const currentBalanceMicrodollars = freshUser
+            ? freshUser.total_microdollars_acquired - freshUser.microdollars_used
+            : 0;
+
           let balanceReset: number | null = null;
-          if (currentBalanceMicrodollars > 0) {
+          if (currentBalanceMicrodollars > 0 && freshUser) {
             await tx.insert(credit_transactions).values({
               kilo_user_id: input.userId,
               organization_id: null,
@@ -596,7 +605,7 @@ export const adminRouter = createTRPCRouter({
               amount_microdollars: -currentBalanceMicrodollars,
               credit_category: 'admin-cancel-refund-kilo-pass',
               description: `Balance zeroed by admin: ${input.reason}`,
-              original_baseline_microdollars_used: user.microdollars_used,
+              original_baseline_microdollars_used: freshUser.microdollars_used,
             });
             await tx
               .update(kilocode_users)

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -40,7 +40,6 @@ import { revalidatePath } from 'next/cache';
 import { recomputeUserBalances } from '@/lib/recomputeUserBalances';
 import { getStripeInvoices } from '@/lib/stripe';
 import { client as stripeClient } from '@/lib/stripe-client';
-import type Stripe from 'stripe';
 import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
 import { kilo_pass_scheduled_changes } from '@/db/schema';
 import {
@@ -532,89 +531,104 @@ export const adminRouter = createTRPCRouter({
 
         await stripeClient.subscriptions.cancel(subscription.stripeSubscriptionId);
 
-        await db
-          .update(kilo_pass_subscriptions)
-          .set({
-            status: 'canceled',
-            cancel_at_period_end: false,
-            ended_at: new Date().toISOString(),
-          })
-          .where(
-            eq(kilo_pass_subscriptions.stripe_subscription_id, subscription.stripeSubscriptionId)
-          );
-
         let refundedAmountCents: number | null = null;
-        const latestInvoices = await stripeClient.invoices.list({
+        const paidInvoices = await stripeClient.invoices.list({
           subscription: subscription.stripeSubscriptionId,
-          limit: 1,
           status: 'paid',
-          expand: ['data.payment_intent'],
+          limit: 1,
         });
-        type InvoiceWithPaymentIntent = (typeof latestInvoices.data)[number] & {
-          payment_intent?: Stripe.PaymentIntent | string | null;
-        };
-        const latestInvoice = latestInvoices.data[0] as InvoiceWithPaymentIntent | undefined;
-        if (latestInvoice?.payment_intent) {
-          const paymentIntentId =
-            typeof latestInvoice.payment_intent === 'string'
-              ? latestInvoice.payment_intent
-              : latestInvoice.payment_intent.id;
-          const refund = await stripeClient.refunds.create({
-            payment_intent: paymentIntentId,
+        const paidInvoice = paidInvoices.data[0];
+        if (paidInvoice) {
+          const payments = await stripeClient.invoicePayments.list({
+            invoice: paidInvoice.id,
+            status: 'paid',
+            limit: 1,
           });
-          refundedAmountCents = refund.amount;
-        }
-
-        if (!user.blocked_reason) {
-          await db
-            .update(kilocode_users)
-            .set({ blocked_reason: input.reason })
-            .where(eq(kilocode_users.id, input.userId));
+          const paymentIntentId = payments.data[0]?.payment.payment_intent;
+          if (paymentIntentId && typeof paymentIntentId === 'string') {
+            try {
+              const refund = await stripeClient.refunds.create({
+                payment_intent: paymentIntentId,
+              });
+              refundedAmountCents = refund.amount;
+            } catch (err) {
+              if (
+                !(err instanceof stripeClient.errors.StripeInvalidRequestError) ||
+                err.code !== 'charge_already_refunded'
+              ) {
+                throw err;
+              }
+            }
+          }
         }
 
         const currentBalanceMicrodollars =
           user.total_microdollars_acquired - user.microdollars_used;
-        let balanceResetAmount: number | null = null;
-        if (currentBalanceMicrodollars > 0) {
-          await db.insert(credit_transactions).values({
-            kilo_user_id: input.userId,
-            organization_id: null,
-            is_free: true,
-            amount_microdollars: -currentBalanceMicrodollars,
-            credit_category: 'admin-cancel-refund-kilo-pass',
-            description: `Balance zeroed by admin: ${input.reason}`,
-            original_baseline_microdollars_used: user.microdollars_used,
-          });
-          await db
-            .update(kilocode_users)
-            .set({
-              total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${currentBalanceMicrodollars}`,
-            })
-            .where(eq(kilocode_users.id, input.userId));
-          balanceResetAmount = fromMicrodollars(currentBalanceMicrodollars);
-        }
 
-        const noteParts = [
-          `Kilo Pass cancelled and refunded by admin.`,
-          `Reason: ${input.reason}`,
-          refundedAmountCents != null
-            ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
-            : 'No invoice to refund.',
-          balanceResetAmount != null
-            ? `Balance reset: $${balanceResetAmount.toFixed(2)} zeroed.`
-            : 'Balance was already $0.',
-          !user.blocked_reason ? 'Account blocked.' : 'Account was already blocked.',
-        ];
-        await db.insert(user_admin_notes).values({
-          kilo_user_id: input.userId,
-          note_content: noteParts.join(' '),
-          admin_kilo_user_id: ctx.user.id,
+        const balanceResetAmountUsd = await db.transaction(async tx => {
+          await tx
+            .update(kilo_pass_subscriptions)
+            .set({
+              status: 'canceled',
+              cancel_at_period_end: false,
+              ended_at: new Date().toISOString(),
+              current_streak_months: 0,
+            })
+            .where(
+              eq(kilo_pass_subscriptions.stripe_subscription_id, subscription.stripeSubscriptionId)
+            );
+
+          if (!user.blocked_reason) {
+            await tx
+              .update(kilocode_users)
+              .set({ blocked_reason: input.reason })
+              .where(eq(kilocode_users.id, input.userId));
+          }
+
+          let balanceReset: number | null = null;
+          if (currentBalanceMicrodollars > 0) {
+            await tx.insert(credit_transactions).values({
+              kilo_user_id: input.userId,
+              organization_id: null,
+              is_free: true,
+              amount_microdollars: -currentBalanceMicrodollars,
+              credit_category: 'admin-cancel-refund-kilo-pass',
+              description: `Balance zeroed by admin: ${input.reason}`,
+              original_baseline_microdollars_used: user.microdollars_used,
+            });
+            await tx
+              .update(kilocode_users)
+              .set({
+                total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${currentBalanceMicrodollars}`,
+              })
+              .where(eq(kilocode_users.id, input.userId));
+            balanceReset = fromMicrodollars(currentBalanceMicrodollars);
+          }
+
+          const noteParts = [
+            `Kilo Pass cancelled and refunded by admin.`,
+            `Reason: ${input.reason}`,
+            refundedAmountCents != null
+              ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
+              : 'No invoice to refund.',
+            balanceReset != null
+              ? `Balance reset: $${balanceReset.toFixed(2)} zeroed.`
+              : 'Balance was already $0.',
+            !user.blocked_reason ? 'Account blocked.' : 'Account was already blocked.',
+          ];
+          await tx.insert(user_admin_notes).values({
+            kilo_user_id: input.userId,
+            note_content: noteParts.join(' '),
+            admin_kilo_user_id: ctx.user.id,
+          });
+
+          return balanceReset;
         });
 
         return {
           success: true,
           refundedAmountCents,
-          balanceResetAmountUsd: balanceResetAmount,
+          balanceResetAmountUsd,
           alreadyBlocked: !!user.blocked_reason,
         };
       }),


### PR DESCRIPTION
## Summary

- Adds a **Nuke Pass** destructive action button to the Kilo Pass card in the per-user admin panel
- Clicking opens a confirmation dialog requiring a reason before proceeding
- A single server-side mutation performs all four actions, with all DB writes in a single transaction:
  1. Cancels the Stripe subscription immediately (not at period end)
  2. Refunds the latest paid invoice for that subscription (via `invoices.list` + `invoicePayments.list`, no expansion required)
  3. Blocks the user account (sets `blocked_reason`)
  4. Resets the user's balance to $0 via a negative `credit_transactions` ledger entry
- Also fixes an infinite redirect loop for already-logged-in users who get banned: `after-sign-in` was treating blocked users as unauthenticated, bouncing them to `sign_in`, which then redirected them back — now they go directly to `/account-blocked`

## Implementation details

- New tRPC mutation: `admin.users.cancelAndRefundKiloPass`
- New credit category: `admin-cancel-refund-kilo-pass` for the balance-zeroing ledger entry
- Releases any active scheduled plan changes before cancelling (same pattern as existing cancel flow)
- `current_streak_months` reset to 0 in the same DB update (pre-empts the webhook handler which would otherwise miss the transition)
- Refund is idempotent: `charge_already_refunded` Stripe errors are caught and treated as a no-op
- Payment intent ID handles both string and expanded object forms
- Skips blocking/balance reset if already blocked or balance is already $0
- Records a full summary as an admin note
- On success, invalidates the Kilo Pass query and shows a toast with outcome details