### PR TITLE
AppBuilder - Preview fetch fix and git integration test refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       cloud_agent_next: ${{ steps.filter.outputs.cloud_agent_next }}
       webhook_agent: ${{ steps.filter.outputs.webhook_agent }}
       kiloclaw: ${{ steps.filter.outputs.kiloclaw }}
+      app_builder: ${{ steps.filter.outputs.app_builder }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,6 +37,8 @@ jobs:
               - 'cloudflare-webhook-agent-ingest/**'
             kiloclaw:
               - 'kiloclaw/**'
+            app_builder:
+              - 'cloudflare-app-builder/**'
 
   test:
     runs-on: ubuntu-24.04-8core
@@ -295,6 +298,36 @@ jobs:
       - name: Run kiloclaw tests
         run: pnpm --filter kiloclaw test
 
+  app-builder:
+    needs: changes
+    if: needs.changes.outputs.app_builder == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck (app-builder)
+        run: pnpm --filter app-builder typecheck
+
+      - name: Run app-builder tests
+        run: pnpm --filter app-builder test
+
   cloudflare:
     strategy:
       fail-fast: false
@@ -304,8 +337,6 @@ jobs:
             filter: kilo-deploy-builder
           - name: deploy-dispatcher
             filter: deploy-dispatcher
-          - name: app-builder
-            filter: app-builder
           - name: code-review
             filter: kilo-code-review-worker
     name: cloudflare-${{ matrix.name }}

--- a/cloudflare-app-builder/package.json
+++ b/cloudflare-app-builder/package.json
@@ -9,7 +9,9 @@
     "cf-typegen": "wrangler types --env-interface CloudflareEnv worker-configuration.d.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:git": "tsx src/_integration_tests/test-git-integration.ts"
+    "test:git": "tsx src/_integration_tests/test-git-integration.ts",
+    "test:git-head": "tsx src/_integration_tests/test-git-head-and-history.ts",
+    "test:git-all": "tsx src/_integration_tests/test-git-integration.ts && tsx src/_integration_tests/test-git-head-and-history.ts"
   },
   "dependencies": {
     "@ashishkumar472/cf-git": "1.0.5",

--- a/cloudflare-app-builder/src/_integration_tests/git-test-helpers.ts
+++ b/cloudflare-app-builder/src/_integration_tests/git-test-helpers.ts
@@ -1,0 +1,352 @@
+/**
+ * Shared helpers for git integration tests.
+ *
+ * These run real `git` CLI commands against a locally running
+ * cloudflare-app-builder worker (default http://localhost:8790).
+ */
+
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// --- Configuration ---
+
+export const APP_BUILDER_URL = process.env.APP_BUILDER_URL || 'http://localhost:8790';
+export const AUTH_TOKEN = process.env.AUTH_TOKEN || 'dev-token-change-this-in-production';
+
+// --- Types ---
+
+export type TokenPermission = 'full' | 'ro';
+
+export type InitSuccessResponse = {
+  success: true;
+  app_id: string;
+  git_url: string;
+};
+
+export type TokenResponse = {
+  success: true;
+  token: string;
+  expires_at: string;
+  permission: TokenPermission;
+};
+
+// --- Logging ---
+
+export function log(message: string, data?: unknown) {
+  console.log(`[TEST] ${message}`, data ? JSON.stringify(data, null, 2) : '');
+}
+
+export function logError(message: string, error?: unknown) {
+  console.error(`[ERROR] ${message}`, error);
+}
+
+export function logSuccess(message: string) {
+  console.log(`[✓] ${message}`);
+}
+
+export function logFailure(message: string) {
+  console.error(`[✗] ${message}`);
+}
+
+// --- API helpers ---
+
+export async function initProject(projectId: string): Promise<InitSuccessResponse> {
+  const endpoint = `${APP_BUILDER_URL}/apps/${encodeURIComponent(projectId)}/init`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to init project: ${response.status} - ${errorText}`);
+  }
+
+  return response.json();
+}
+
+export async function generateGitToken(
+  appId: string,
+  permission: TokenPermission
+): Promise<TokenResponse> {
+  const endpoint = `${APP_BUILDER_URL}/apps/${encodeURIComponent(appId)}/token`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+    },
+    body: JSON.stringify({ permission }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to generate token: ${response.status} - ${errorText}`);
+  }
+
+  return response.json();
+}
+
+// --- Git CLI helpers ---
+
+export function buildGitUrlWithToken(gitUrl: string, token: string): string {
+  const url = new URL(gitUrl);
+  url.username = 'x-access-token';
+  url.password = token;
+  return url.toString();
+}
+
+export function runGitCommand(dir: string, command: string, expectFailure = false): string {
+  const fullCommand = `cd "${dir}" && ${command}`;
+  log(`Running: ${command}`);
+
+  try {
+    const output = execSync(fullCommand, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (expectFailure) {
+      throw new Error(`Expected command to fail but it succeeded: ${command}`);
+    }
+    return output;
+  } catch (error: unknown) {
+    if (expectFailure) {
+      const execError = error as { stderr?: string; stdout?: string; message?: string };
+      log('Command failed as expected', {
+        stderr: execError.stderr?.slice(0, 500),
+        stdout: execError.stdout?.slice(0, 500),
+      });
+      return execError.stderr || execError.message || 'Command failed';
+    }
+    throw error;
+  }
+}
+
+/**
+ * Run a git command and return stdout, ignoring non-zero exit codes.
+ * Useful for commands like `git symbolic-ref HEAD` that fail in detached state.
+ */
+export function runGitCommandSafe(
+  dir: string,
+  command: string
+): { stdout: string; stderr: string; exitCode: number } {
+  const fullCommand = `cd "${dir}" && ${command}`;
+
+  try {
+    const stdout = execSync(fullCommand, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout: stdout.trim(), stderr: '', exitCode: 0 };
+  } catch (error: unknown) {
+    const execError = error as {
+      stderr?: string;
+      stdout?: string;
+      status?: number;
+    };
+    return {
+      stdout: (execError.stdout || '').trim(),
+      stderr: (execError.stderr || '').trim(),
+      exitCode: execError.status ?? 1,
+    };
+  }
+}
+
+// --- High-level helpers ---
+
+/**
+ * Clone a repository into a subdirectory of `parentDir`.
+ * Returns the absolute path to the cloned directory.
+ */
+export async function cloneRepo(
+  appId: string,
+  gitUrl: string,
+  parentDir: string,
+  dirName: string
+): Promise<string> {
+  const tokenResult = await generateGitToken(appId, 'full');
+  const authedUrl = buildGitUrlWithToken(gitUrl, tokenResult.token);
+  const cloneDir = join(parentDir, dirName);
+  mkdirSync(cloneDir, { recursive: true });
+  runGitCommand(parentDir, `git clone "${authedUrl}" ${dirName}`);
+  return cloneDir;
+}
+
+/**
+ * Configure git user in the given directory.
+ */
+export function configureGitUser(dir: string) {
+  runGitCommand(dir, 'git config user.email "test@example.com"');
+  runGitCommand(dir, 'git config user.name "Test User"');
+}
+
+/**
+ * Stage everything, commit, and optionally push.
+ */
+export function commitAll(dir: string, message: string) {
+  runGitCommand(dir, 'git add -A');
+  runGitCommand(dir, `git commit -m "${message}"`);
+}
+
+export function push(dir: string, branch = 'main') {
+  runGitCommand(dir, `git push origin ${branch}`);
+}
+
+// --- Temp dir management ---
+
+export function createTempDir(prefix = 'app-builder-test-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export function removeTempDir(dir: string) {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch (e) {
+    logError('Failed to cleanup temp directory', e);
+  }
+}
+
+// --- Assertions ---
+
+export class AssertionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AssertionError';
+  }
+}
+
+export function assertEqual<T>(actual: T, expected: T, label: string) {
+  if (actual !== expected) {
+    throw new AssertionError(
+      `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+}
+
+export function assertIncludes(haystack: string, needle: string, label: string) {
+  if (!haystack.includes(needle)) {
+    throw new AssertionError(
+      `${label}: expected string to include ${JSON.stringify(needle)}, got ${JSON.stringify(haystack.slice(0, 200))}`
+    );
+  }
+}
+
+export function assertFileContent(
+  dir: string,
+  relativePath: string,
+  expected: string,
+  label: string
+) {
+  const content = readFileSync(join(dir, relativePath), 'utf-8');
+  assertEqual(content, expected, label);
+}
+
+export function assertFileExists(dir: string, relativePath: string, label: string) {
+  const files = readdirSync(dir, { recursive: true }) as string[];
+  // readdirSync with recursive returns relative paths; just check the file exists by reading it
+  try {
+    readFileSync(join(dir, relativePath));
+  } catch {
+    throw new AssertionError(`${label}: file "${relativePath}" does not exist in ${dir}`);
+  }
+}
+
+/**
+ * Assert that the working directory is on a named branch (NOT detached HEAD).
+ * Runs multiple independent checks.
+ */
+export function assertNotDetachedHead(dir: string, expectedBranch = 'main') {
+  // Check 1: git branch --show-current (empty in detached HEAD)
+  const branchShowCurrent = runGitCommandSafe(dir, 'git branch --show-current');
+  assertEqual(branchShowCurrent.stdout, expectedBranch, 'git branch --show-current');
+
+  // Check 2: git symbolic-ref HEAD (errors in detached HEAD)
+  const symbolicRef = runGitCommandSafe(dir, 'git symbolic-ref HEAD');
+  assertEqual(symbolicRef.exitCode, 0, 'git symbolic-ref HEAD exit code');
+  assertEqual(symbolicRef.stdout, `refs/heads/${expectedBranch}`, 'git symbolic-ref HEAD');
+
+  // Check 3: git rev-parse --abbrev-ref HEAD (returns "HEAD" if detached)
+  const abbrevRef = runGitCommandSafe(dir, 'git rev-parse --abbrev-ref HEAD');
+  assertEqual(abbrevRef.stdout, expectedBranch, 'git rev-parse --abbrev-ref HEAD');
+
+  // Check 4: git status should say "On branch main", not "HEAD detached"
+  const status = runGitCommandSafe(dir, 'git status');
+  assertIncludes(status.stdout, `On branch ${expectedBranch}`, 'git status branch line');
+}
+
+/**
+ * Count commits in the current branch's history.
+ */
+export function countCommits(dir: string): number {
+  const output = runGitCommand(dir, 'git rev-list --count HEAD');
+  return parseInt(output.trim(), 10);
+}
+
+/**
+ * Get the list of commit messages (most recent first).
+ */
+export function getCommitMessages(dir: string): string[] {
+  const output = runGitCommand(dir, 'git log --format=%s');
+  return output
+    .trim()
+    .split('\n')
+    .filter(line => line.length > 0);
+}
+
+// --- Test runner ---
+
+export type TestFn = () => Promise<void>;
+
+/**
+ * Run a set of named test functions, collecting pass/fail results.
+ * Returns `true` if all tests passed.
+ */
+export async function runTestSuite(
+  suiteName: string,
+  tests: Array<{ name: string; fn: TestFn }>
+): Promise<boolean> {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`  ${suiteName}`);
+  console.log('='.repeat(60));
+
+  const results: Array<{ name: string; passed: boolean; error?: string }> = [];
+
+  for (const test of tests) {
+    console.log(`\n--- ${test.name} ---`);
+    try {
+      await test.fn();
+      logSuccess(test.name);
+      results.push({ name: test.name, passed: true });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logFailure(`${test.name}: ${msg}`);
+      results.push({ name: test.name, passed: false, error: msg });
+    }
+  }
+
+  // Summary
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`  Results: ${suiteName}`);
+  console.log('='.repeat(60));
+
+  const passed = results.filter(r => r.passed).length;
+  const failed = results.filter(r => !r.passed).length;
+
+  for (const r of results) {
+    console.log(`  ${r.passed ? '✓' : '✗'} ${r.name}${r.error ? ` — ${r.error}` : ''}`);
+  }
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`);
+
+  return failed === 0;
+}
+
+// Re-export fs utilities for convenience
+export { writeFileSync, readFileSync, readdirSync, mkdirSync, join };

--- a/cloudflare-app-builder/src/_integration_tests/git-test-helpers.ts
+++ b/cloudflare-app-builder/src/_integration_tests/git-test-helpers.ts
@@ -103,6 +103,22 @@ export function buildGitUrlWithToken(gitUrl: string, token: string): string {
   return url.toString();
 }
 
+function stringProp(obj: unknown, key: string): string | undefined {
+  if (obj != null && typeof obj === 'object' && key in obj) {
+    const val = (obj as Record<string, unknown>)[key];
+    return typeof val === 'string' ? val : undefined;
+  }
+  return undefined;
+}
+
+function numberProp(obj: unknown, key: string): number | undefined {
+  if (obj != null && typeof obj === 'object' && key in obj) {
+    const val = (obj as Record<string, unknown>)[key];
+    return typeof val === 'number' ? val : undefined;
+  }
+  return undefined;
+}
+
 export function runGitCommand(dir: string, command: string, expectFailure = false): string {
   const fullCommand = `cd "${dir}" && ${command}`;
   log(`Running: ${command}`);
@@ -118,12 +134,14 @@ export function runGitCommand(dir: string, command: string, expectFailure = fals
     return output;
   } catch (error: unknown) {
     if (expectFailure) {
-      const execError = error as { stderr?: string; stdout?: string; message?: string };
+      const stderr = stringProp(error, 'stderr');
+      const stdout = stringProp(error, 'stdout');
+      const message = stringProp(error, 'message');
       log('Command failed as expected', {
-        stderr: execError.stderr?.slice(0, 500),
-        stdout: execError.stdout?.slice(0, 500),
+        stderr: stderr?.slice(0, 500),
+        stdout: stdout?.slice(0, 500),
       });
-      return execError.stderr || execError.message || 'Command failed';
+      return stderr || message || 'Command failed';
     }
     throw error;
   }
@@ -146,15 +164,10 @@ export function runGitCommandSafe(
     });
     return { stdout: stdout.trim(), stderr: '', exitCode: 0 };
   } catch (error: unknown) {
-    const execError = error as {
-      stderr?: string;
-      stdout?: string;
-      status?: number;
-    };
     return {
-      stdout: (execError.stdout || '').trim(),
-      stderr: (execError.stderr || '').trim(),
-      exitCode: execError.status ?? 1,
+      stdout: (stringProp(error, 'stdout') || '').trim(),
+      stderr: (stringProp(error, 'stderr') || '').trim(),
+      exitCode: numberProp(error, 'status') ?? 1,
     };
   }
 }
@@ -249,8 +262,6 @@ export function assertFileContent(
 }
 
 export function assertFileExists(dir: string, relativePath: string, label: string) {
-  const files = readdirSync(dir, { recursive: true }) as string[];
-  // readdirSync with recursive returns relative paths; just check the file exists by reading it
   try {
     readFileSync(join(dir, relativePath));
   } catch {

--- a/cloudflare-app-builder/src/_integration_tests/test-git-head-and-history.ts
+++ b/cloudflare-app-builder/src/_integration_tests/test-git-head-and-history.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Integration tests for Git HEAD state and commit history.
+ *
+ * Specifically targets:
+ * - Detached HEAD regressions after clone
+ * - Commit history preservation across push/clone cycles
+ * - Incremental push correctness
+ * - Bidirectional clone→push→clone round-trips
+ *
+ * Prerequisites:
+ * - App builder running at http://localhost:8790
+ * - Set AUTH_TOKEN environment variable (or use default dev token)
+ *
+ * Usage:
+ *   cd cloudflare-app-builder
+ *   AUTH_TOKEN=dev-token-change-this-in-production pnpm test:git-head
+ */
+
+import {
+  APP_BUILDER_URL,
+  initProject,
+  cloneRepo,
+  configureGitUser,
+  commitAll,
+  push,
+  createTempDir,
+  removeTempDir,
+  runGitCommand,
+  log,
+  logSuccess,
+  assertEqual,
+  assertFileContent,
+  assertFileExists,
+  assertNotDetachedHead,
+  countCommits,
+  getCommitMessages,
+  runTestSuite,
+  writeFileSync,
+  join,
+} from './git-test-helpers';
+
+function uniqueId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// =========================================================================
+// Test 1: Multiple local commits then push, clone verifies all history
+// =========================================================================
+async function testMultipleCommitsThenPush() {
+  const testId = uniqueId('multi-commit');
+  const tempDir = createTempDir();
+
+  try {
+    log(`Project: ${testId}`);
+    const { git_url: gitUrl } = await initProject(testId);
+
+    // Clone
+    const dir1 = await cloneRepo(testId, gitUrl, tempDir, 'work');
+    configureGitUser(dir1);
+
+    // First local commit: create file A
+    const fileAContent = 'File A — first commit';
+    writeFileSync(join(dir1, 'fileA.txt'), fileAContent);
+    commitAll(dir1, 'Add file A');
+
+    // Second local commit: modify A + create B
+    const fileAUpdated = 'File A — updated in second commit';
+    const fileBContent = 'File B — second commit';
+    writeFileSync(join(dir1, 'fileA.txt'), fileAUpdated);
+    writeFileSync(join(dir1, 'fileB.txt'), fileBContent);
+    commitAll(dir1, 'Update A, add B');
+
+    // Push both commits at once
+    push(dir1);
+
+    // Clone into a fresh folder
+    const dir2 = await cloneRepo(testId, gitUrl, tempDir, 'verify');
+
+    // Assertions
+    assertNotDetachedHead(dir2, 'main');
+
+    // 3 commits: initial template + "Add file A" + "Update A, add B"
+    const commitCount = countCommits(dir2);
+    assertEqual(commitCount, 3, 'commit count');
+
+    const messages = getCommitMessages(dir2);
+    assertEqual(messages[0], 'Update A, add B', 'most recent commit message');
+    assertEqual(messages[1], 'Add file A', 'second commit message');
+    assertEqual(messages[2], 'Initial commit', 'initial commit message');
+
+    assertFileContent(dir2, 'fileA.txt', fileAUpdated, 'fileA.txt content');
+    assertFileContent(dir2, 'fileB.txt', fileBContent, 'fileB.txt content');
+
+    // git status should be clean
+    const status = runGitCommand(dir2, 'git status --porcelain');
+    assertEqual(status.trim(), '', 'git status clean');
+
+    logSuccess('All history and files verified in fresh clone');
+  } finally {
+    removeTempDir(tempDir);
+  }
+}
+
+// =========================================================================
+// Test 2: Incremental pushes — push, then push again, then clone
+// =========================================================================
+async function testIncrementalPushes() {
+  const testId = uniqueId('incr-push');
+  const tempDir = createTempDir();
+
+  try {
+    log(`Project: ${testId}`);
+    const { git_url: gitUrl } = await initProject(testId);
+
+    // Clone
+    const dir1 = await cloneRepo(testId, gitUrl, tempDir, 'work');
+    configureGitUser(dir1);
+
+    // First commit + push
+    writeFileSync(join(dir1, 'first.txt'), 'first push content');
+    commitAll(dir1, 'First push');
+    push(dir1);
+
+    // Second commit + push (incremental)
+    writeFileSync(join(dir1, 'second.txt'), 'second push content');
+    commitAll(dir1, 'Second push');
+    push(dir1);
+
+    // Clone into fresh folder
+    const dir2 = await cloneRepo(testId, gitUrl, tempDir, 'verify');
+
+    // Assertions
+    assertNotDetachedHead(dir2, 'main');
+
+    const commitCount = countCommits(dir2);
+    assertEqual(commitCount, 3, 'commit count after 2 incremental pushes');
+
+    assertFileContent(dir2, 'first.txt', 'first push content', 'first.txt content');
+    assertFileContent(dir2, 'second.txt', 'second push content', 'second.txt content');
+
+    const messages = getCommitMessages(dir2);
+    assertEqual(messages[0], 'Second push', 'latest commit');
+    assertEqual(messages[1], 'First push', 'second commit');
+
+    logSuccess('Incremental pushes preserved correctly');
+  } finally {
+    removeTempDir(tempDir);
+  }
+}
+
+// =========================================================================
+// Test 3: Bidirectional — clone in dir1 push, clone in dir2 push, verify
+// =========================================================================
+async function testBidirectionalPushes() {
+  const testId = uniqueId('bidir');
+  const tempDir = createTempDir();
+
+  try {
+    log(`Project: ${testId}`);
+    const { git_url: gitUrl } = await initProject(testId);
+
+    // Clone into dir1, make changes, push
+    const dir1 = await cloneRepo(testId, gitUrl, tempDir, 'dir1');
+    configureGitUser(dir1);
+    writeFileSync(join(dir1, 'from-dir1.txt'), 'created in dir1');
+    commitAll(dir1, 'Commit from dir1');
+    push(dir1);
+
+    // Clone into dir2 (simulates cloud-agent picking up the repo)
+    const dir2 = await cloneRepo(testId, gitUrl, tempDir, 'dir2');
+    assertNotDetachedHead(dir2, 'main');
+    configureGitUser(dir2);
+
+    // Verify dir2 has dir1's file
+    assertFileContent(dir2, 'from-dir1.txt', 'created in dir1', 'dir1 file in dir2');
+
+    // Make changes in dir2, push
+    writeFileSync(join(dir2, 'from-dir2.txt'), 'created in dir2');
+    commitAll(dir2, 'Commit from dir2');
+    push(dir2);
+
+    // Clone into dir3 (final verification)
+    const dir3 = await cloneRepo(testId, gitUrl, tempDir, 'dir3');
+
+    assertNotDetachedHead(dir3, 'main');
+
+    assertFileContent(dir3, 'from-dir1.txt', 'created in dir1', 'dir1 file in dir3');
+    assertFileContent(dir3, 'from-dir2.txt', 'created in dir2', 'dir2 file in dir3');
+
+    const commitCount = countCommits(dir3);
+    assertEqual(commitCount, 3, 'total commit count (initial + dir1 + dir2)');
+
+    const messages = getCommitMessages(dir3);
+    assertEqual(messages[0], 'Commit from dir2', 'latest commit from dir2');
+    assertEqual(messages[1], 'Commit from dir1', 'commit from dir1');
+
+    logSuccess('Bidirectional push round-trip verified');
+  } finally {
+    removeTempDir(tempDir);
+  }
+}
+
+// =========================================================================
+// Test 4: Detached HEAD regression — thorough checks after every clone
+// =========================================================================
+async function testDetachedHeadRegression() {
+  const testId = uniqueId('detached');
+  const tempDir = createTempDir();
+
+  try {
+    log(`Project: ${testId}`);
+    const { git_url: gitUrl } = await initProject(testId);
+
+    // Clone immediately after init (only initial commit exists)
+    log('Cloning immediately after init...');
+    const dir1 = await cloneRepo(testId, gitUrl, tempDir, 'clone-after-init');
+    assertNotDetachedHead(dir1, 'main');
+    logSuccess('Clone after init: NOT detached HEAD');
+
+    // Push a commit
+    configureGitUser(dir1);
+    writeFileSync(join(dir1, 'change.txt'), 'some change');
+    commitAll(dir1, 'Add change');
+    push(dir1);
+
+    // Clone after first push
+    log('Cloning after first push...');
+    const dir2 = await cloneRepo(testId, gitUrl, tempDir, 'clone-after-push1');
+    assertNotDetachedHead(dir2, 'main');
+    logSuccess('Clone after 1st push: NOT detached HEAD');
+
+    // Push another commit
+    configureGitUser(dir2);
+    writeFileSync(join(dir2, 'change2.txt'), 'another change');
+    commitAll(dir2, 'Add change2');
+    push(dir2);
+
+    // Clone after second push
+    log('Cloning after second push...');
+    const dir3 = await cloneRepo(testId, gitUrl, tempDir, 'clone-after-push2');
+    assertNotDetachedHead(dir3, 'main');
+    logSuccess('Clone after 2nd push: NOT detached HEAD');
+
+    // Verify the full chain is intact
+    assertEqual(countCommits(dir3), 3, 'final commit count');
+
+    logSuccess('No detached HEAD detected at any stage');
+  } finally {
+    removeTempDir(tempDir);
+  }
+}
+
+// =========================================================================
+// Test 5: Clone of fresh repo (only template initial commit)
+// =========================================================================
+async function testCloneFreshRepo() {
+  const testId = uniqueId('fresh');
+  const tempDir = createTempDir();
+
+  try {
+    log(`Project: ${testId}`);
+    const { git_url: gitUrl } = await initProject(testId);
+
+    // Clone immediately — no pushes have occurred yet
+    const dir1 = await cloneRepo(testId, gitUrl, tempDir, 'fresh-clone');
+
+    // Should be on main, not detached
+    assertNotDetachedHead(dir1, 'main');
+
+    // Should have exactly 1 commit (the initial template commit)
+    assertEqual(countCommits(dir1), 1, 'commit count');
+    assertEqual(getCommitMessages(dir1)[0], 'Initial commit', 'initial commit message');
+
+    // Template files should exist (at minimum package.json for nextjs-starter)
+    assertFileExists(dir1, 'package.json', 'template package.json');
+
+    // Should be able to make changes and push
+    configureGitUser(dir1);
+    writeFileSync(join(dir1, 'new-file.txt'), 'new content');
+    commitAll(dir1, 'First user commit');
+    push(dir1);
+
+    // Verify the push took
+    const dir2 = await cloneRepo(testId, gitUrl, tempDir, 'verify');
+    assertNotDetachedHead(dir2, 'main');
+    assertEqual(countCommits(dir2), 2, 'commit count after push');
+    assertFileContent(dir2, 'new-file.txt', 'new content', 'new-file.txt content');
+
+    logSuccess('Fresh repo clone + first push verified');
+  } finally {
+    removeTempDir(tempDir);
+  }
+}
+
+// =========================================================================
+// Main
+// =========================================================================
+
+async function main() {
+  log('Git HEAD & History Integration Tests', { appBuilderUrl: APP_BUILDER_URL });
+
+  const allPassed = await runTestSuite('Git HEAD & History', [
+    { name: 'Multiple commits then push', fn: testMultipleCommitsThenPush },
+    { name: 'Incremental pushes', fn: testIncrementalPushes },
+    { name: 'Bidirectional push round-trip', fn: testBidirectionalPushes },
+    { name: 'Detached HEAD regression', fn: testDetachedHeadRegression },
+    { name: 'Clone fresh repo (template only)', fn: testCloneFreshRepo },
+  ]);
+
+  process.exit(allPassed ? 0 : 1);
+}
+
+main().catch(error => {
+  console.error('Unhandled error', error);
+  process.exit(1);
+});

--- a/cloudflare-app-builder/src/_integration_tests/test-git-integration.ts
+++ b/cloudflare-app-builder/src/_integration_tests/test-git-integration.ts
@@ -11,7 +11,7 @@
  *
  * Usage:
  *   cd cloudflare-app-builder
- *   AUTH_TOKEN=dev-token-change-this-in-production npx ts-node src/test-git-integration.ts
+ *   AUTH_TOKEN=dev-token-change-this-in-production pnpm test:git
  *
  * What this tests:
  * 1. Initialize a new project
@@ -22,131 +22,28 @@
  * 6. Verify read-only token cannot push
  */
 
-import { execSync } from 'child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-
-// --- Configuration ---
-const APP_BUILDER_URL = process.env.APP_BUILDER_URL || 'http://localhost:8790';
-const AUTH_TOKEN = process.env.AUTH_TOKEN || 'dev-token-change-this-in-production';
-
-// --- Types ---
-type TokenPermission = 'full' | 'ro';
-
-type InitSuccessResponse = {
-  success: true;
-  app_id: string;
-  git_url: string;
-};
-
-type TokenResponse = {
-  success: true;
-  token: string;
-  expires_at: string;
-  permission: TokenPermission;
-};
-
-// --- Helper Functions ---
-
-function log(message: string, data?: unknown) {
-  console.log(`[TEST] ${message}`, data ? JSON.stringify(data, null, 2) : '');
-}
-
-function logError(message: string, error?: unknown) {
-  console.error(`[ERROR] ${message}`, error);
-}
-
-function logSuccess(message: string) {
-  console.log(`[✓] ${message}`);
-}
-
-function logFailure(message: string) {
-  console.error(`[✗] ${message}`);
-}
-
-async function initProject(projectId: string): Promise<InitSuccessResponse> {
-  const endpoint = `${APP_BUILDER_URL}/apps/${encodeURIComponent(projectId)}/init`;
-
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${AUTH_TOKEN}`,
-    },
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => 'Unknown error');
-    throw new Error(`Failed to init project: ${response.status} - ${errorText}`);
-  }
-
-  return response.json();
-}
-
-async function generateGitToken(
-  appId: string,
-  permission: TokenPermission
-): Promise<TokenResponse> {
-  const endpoint = `${APP_BUILDER_URL}/apps/${encodeURIComponent(appId)}/token`;
-
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${AUTH_TOKEN}`,
-    },
-    body: JSON.stringify({ permission }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => 'Unknown error');
-    throw new Error(`Failed to generate token: ${response.status} - ${errorText}`);
-  }
-
-  return response.json();
-}
-
-function buildGitUrlWithToken(gitUrl: string, token: string): string {
-  // Replace https://hostname/path with https://x-access-token:token@hostname/path
-  const url = new URL(gitUrl);
-  url.username = 'x-access-token';
-  url.password = token;
-  return url.toString();
-}
-
-function runGitCommand(dir: string, command: string, expectFailure = false): string {
-  const fullCommand = `cd "${dir}" && ${command}`;
-  log(`Running: ${command}`);
-
-  try {
-    const output = execSync(fullCommand, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    if (expectFailure) {
-      throw new Error(`Expected command to fail but it succeeded: ${command}`);
-    }
-    return output;
-  } catch (error: unknown) {
-    // execSync throws on non-zero exit
-    if (expectFailure) {
-      const execError = error as { stderr?: string; stdout?: string; message?: string };
-      log('Command failed as expected', {
-        stderr: execError.stderr?.slice(0, 500),
-        stdout: execError.stdout?.slice(0, 500),
-      });
-      return execError.stderr || execError.message || 'Command failed';
-    }
-    throw error;
-  }
-}
-
-// --- Main Test ---
+import {
+  APP_BUILDER_URL,
+  initProject,
+  generateGitToken,
+  buildGitUrlWithToken,
+  runGitCommand,
+  createTempDir,
+  removeTempDir,
+  log,
+  logError,
+  logSuccess,
+  logFailure,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  mkdirSync,
+  join,
+} from './git-test-helpers';
 
 async function runTests() {
   const testId = `test-git-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const tempDir = mkdtempSync(join(tmpdir(), 'app-builder-test-'));
+  const tempDir = createTempDir();
 
   log('Starting git integration test', {
     testId,
@@ -319,31 +216,26 @@ async function runTests() {
     // All Tests Passed
     // ===========================================
     console.log('\n' + '='.repeat(50));
-    console.log('🎉 ALL TESTS PASSED!');
+    console.log('ALL TESTS PASSED');
     console.log('='.repeat(50));
     console.log(`\nTest Summary:`);
     console.log(`  - Project ID: ${testId}`);
     console.log(`  - Git URL: ${gitUrl}`);
-    console.log(`  - Full token clone: ✓`);
-    console.log(`  - Full token push: ✓`);
-    console.log(`  - Push persistence verified: ✓`);
-    console.log(`  - Read-only token clone: ✓`);
-    console.log(`  - Read-only token push blocked: ✓`);
+    console.log(`  - Full token clone: PASS`);
+    console.log(`  - Full token push: PASS`);
+    console.log(`  - Push persistence verified: PASS`);
+    console.log(`  - Read-only token clone: PASS`);
+    console.log(`  - Read-only token push blocked: PASS`);
   } catch (error) {
     logError('Test failed', error);
     console.log('\n' + '='.repeat(50));
-    console.log('❌ TESTS FAILED');
+    console.log('TESTS FAILED');
     console.log('='.repeat(50));
     process.exit(1);
   } finally {
-    // Cleanup
     log('\nCleaning up temp directory...');
-    try {
-      rmSync(tempDir, { recursive: true, force: true });
-      log('Cleanup complete');
-    } catch (e) {
-      logError('Failed to cleanup temp directory', e);
-    }
+    removeTempDir(tempDir);
+    log('Cleanup complete');
   }
 }
 

--- a/cloudflare-app-builder/src/preview-do.ts
+++ b/cloudflare-app-builder/src/preview-do.ts
@@ -403,7 +403,9 @@ export class PreviewDO extends DurableObject<Env> {
             if (!checkoutResult.success) {
               throw new Error('Failed to clone repo');
             }
-            const pullResult = await sandbox.exec('cd /workspace && git reset --hard origin/main');
+            const pullResult = await sandbox.exec(
+              'cd /workspace && git fetch origin && git reset --hard origin/main'
+            );
             if (!pullResult.success) {
               throw new Error('Failed to pull new changes');
             }


### PR DESCRIPTION
Fixes builder preview staleness by adding `git fetch origin` before `git reset --hard origin/main` in `preview-do.ts`, ensuring previews always pick up the latest pushed changes. Also refactors the git integration tests by extracting shared helpers (API calls, git CLI wrappers, assertions, temp dir management, test runner) into a reusable `git-test-helpers.ts` module, adds a new `test-git-head-and-history.ts` suite with 5 tests specifically targeting detached HEAD regressions, commit history preservation, incremental pushes, and bidirectional clone/push round-trips, and replaces unsafe `as` casts with safe property accessor helpers.