### PR TITLE
Add isChild filter to cli sessions v2 list endpoint

### DIFF
--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -74,7 +74,7 @@ const ListSessionsInputSchema = z.object({
   cursor: z.iso.datetime().optional(),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
-  isChild: z.boolean().optional(),
+  includeChildren: z.boolean().optional().default(false),
 });
 
 const GetSessionInputSchema = z.object({
@@ -97,7 +97,7 @@ export const cliSessionsV2Router = createTRPCRouter({
    * List sessions for the current user with cursor-based pagination.
    */
   list: baseProcedure.input(ListSessionsInputSchema).query(async ({ ctx, input }) => {
-    const { cursor, limit, orderBy, isChild } = input;
+    const { cursor, limit, orderBy, includeChildren } = input;
 
     const orderColumn =
       orderBy === 'updated_at' ? cli_sessions_v2.updated_at : cli_sessions_v2.created_at;
@@ -108,9 +108,7 @@ export const cliSessionsV2Router = createTRPCRouter({
       whereConditions.push(lt(orderColumn, cursor));
     }
 
-    if (isChild === true) {
-      whereConditions.push(isNotNull(cli_sessions_v2.parent_session_id));
-    } else if (isChild === false) {
+    if (!includeChildren) {
       whereConditions.push(isNull(cli_sessions_v2.parent_session_id));
     }
 

--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import * as z from 'zod';
 import { db } from '@/lib/drizzle';
-import { eq, and, desc, lt } from 'drizzle-orm';
+import { eq, and, desc, lt, isNull, isNotNull } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { TRPCClientError } from '@trpc/client';
 import { cli_sessions_v2 } from '@/db/schema';
@@ -74,6 +74,7 @@ const ListSessionsInputSchema = z.object({
   cursor: z.iso.datetime().optional(),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
+  isChild: z.boolean().optional(),
 });
 
 const GetSessionInputSchema = z.object({
@@ -96,7 +97,7 @@ export const cliSessionsV2Router = createTRPCRouter({
    * List sessions for the current user with cursor-based pagination.
    */
   list: baseProcedure.input(ListSessionsInputSchema).query(async ({ ctx, input }) => {
-    const { cursor, limit, orderBy } = input;
+    const { cursor, limit, orderBy, isChild } = input;
 
     const orderColumn =
       orderBy === 'updated_at' ? cli_sessions_v2.updated_at : cli_sessions_v2.created_at;
@@ -105,6 +106,12 @@ export const cliSessionsV2Router = createTRPCRouter({
 
     if (cursor) {
       whereConditions.push(lt(orderColumn, cursor));
+    }
+
+    if (isChild === true) {
+      whereConditions.push(isNotNull(cli_sessions_v2.parent_session_id));
+    } else if (isChild === false) {
+      whereConditions.push(isNull(cli_sessions_v2.parent_session_id));
     }
 
     const results = await db

--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import * as z from 'zod';
 import { db } from '@/lib/drizzle';
-import { eq, and, desc, lt, isNull, isNotNull } from 'drizzle-orm';
+import { eq, and, desc, lt, isNull } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { TRPCClientError } from '@trpc/client';
 import { cli_sessions_v2 } from '@/db/schema';


### PR DESCRIPTION
## Summary

- Adds optional `isChild` boolean parameter to the `list` endpoint of `cliSessionsV2Router`
- `isChild: true` returns only child sessions (those with a non-null `parent_session_id`)
- `isChild: false` returns only non-child (root) sessions
- Omitting `isChild` preserves existing behavior (returns all sessions)