### PR TITLE
Cloud Agent - Fix infinite streaming state on LLM error

### DIFF
--- a/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/src/components/cloud-agent-next/MessageBubble.tsx
@@ -2,6 +2,7 @@
 
 import { User, Bot, Scissors, Image, FileText, AlertCircle } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
+import type { AssistantMessage } from '@/types/opencode.gen';
 import type { StoredMessage, Part, CompactionPart } from './types';
 import {
   isUserMessage,
@@ -86,9 +87,7 @@ function getUserTextContent(parts: Part[]): string {
 /**
  * Extract a human-readable error message from an AssistantMessage error field.
  */
-function getAssistantErrorMessage(
-  error: NonNullable<import('@/types/opencode.gen').AssistantMessage['error']>
-): string {
+function getAssistantErrorMessage(error: NonNullable<AssistantMessage['error']>): string {
   if ('data' in error && 'message' in error.data && typeof error.data.message === 'string') {
     return error.data.message;
   }

--- a/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/src/components/cloud-agent-next/MessageBubble.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { User, Bot, Scissors, Image, FileText } from 'lucide-react';
+import { User, Bot, Scissors, Image, FileText, AlertCircle } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import type { StoredMessage, Part, CompactionPart } from './types';
 import {
@@ -81,6 +81,18 @@ function InlineFileAttachment({ part }: { part: FilePart }) {
 function getUserTextContent(parts: Part[]): string {
   const textParts = parts.filter(isTextPart);
   return textParts.map(p => p.text).join('');
+}
+
+/**
+ * Extract a human-readable error message from an AssistantMessage error field.
+ */
+function getAssistantErrorMessage(
+  error: NonNullable<import('@/types/opencode.gen').AssistantMessage['error']>
+): string {
+  if ('data' in error && 'message' in error.data && typeof error.data.message === 'string') {
+    return error.data.message;
+  }
+  return 'An error occurred while generating a response';
 }
 
 type MessageBubbleProps = {
@@ -192,7 +204,10 @@ export function MessageBubble({
 
   // Assistant message
   if (isAssistantMessage(message.info)) {
-    const { cost, tokens } = message.info;
+    const { cost, tokens, error } = message.info;
+    // Show error when message failed with no output
+    const showError = !isStreaming && error !== undefined;
+    const errorMessage = error ? getAssistantErrorMessage(error) : undefined;
 
     return (
       <div className="flex items-start gap-2 py-4 md:gap-3">
@@ -214,8 +229,14 @@ export function MessageBubble({
                 Streaming...
               </span>
             )}
+            {showError && (
+              <span className="text-destructive flex items-center gap-1 text-xs">
+                <AlertCircle className="h-3 w-3" />
+                Failed
+              </span>
+            )}
             {/* Cost/token display */}
-            {!isStreaming && (cost !== undefined || tokens !== undefined) && (
+            {!isStreaming && !showError && (cost !== undefined || tokens !== undefined) && (
               <span className="text-muted-foreground text-xs">
                 {tokens !== undefined &&
                   `${(tokens.input + tokens.output).toLocaleString()} tokens`}
@@ -235,6 +256,8 @@ export function MessageBubble({
               />
             ))}
           </div>
+          {/* Inline error message for failed responses */}
+          {showError && errorMessage && <p className="text-destructive text-sm">{errorMessage}</p>}
         </div>
       </div>
     );

--- a/src/components/cloud-agent-next/types.ts
+++ b/src/components/cloud-agent-next/types.ts
@@ -227,8 +227,9 @@ export function isPartStreaming(part: Part): boolean {
  * Check if any parts in a message are still streaming.
  */
 export function isMessageStreaming(message: StoredMessage): boolean {
-  // Check if the assistant message has a completed timestamp
-  if (isAssistantMessage(message.info) && !message.info.time.completed) {
+  // Assistant messages without completed time are still streaming,
+  // unless they have an error (failed before producing output)
+  if (isAssistantMessage(message.info) && !message.info.time.completed && !message.info.error) {
     return true;
   }
   // Check if any parts are still streaming

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -748,6 +748,118 @@ describe('createEventProcessor', () => {
     });
   });
 
+  describe('session.turn.close events', () => {
+    it('should force-complete in-flight assistant messages on error reason', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Create an in-flight assistant message (no completed time)
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      expect(callbacks.onMessageCompleted).not.toHaveBeenCalled();
+
+      // Turn closes with error
+      processor.processEvent(
+        createKilocodeEvent('session.turn.close', {
+          sessionID: 'session-123',
+          reason: 'error',
+        })
+      );
+
+      // Should force-complete the assistant message
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledWith(
+        'session-123',
+        'msg-1',
+        expect.objectContaining({
+          info: expect.objectContaining({
+            id: 'msg-1',
+            time: expect.objectContaining({ completed: expect.any(Number) }),
+          }),
+        }),
+        null
+      );
+
+      // Should stop streaming and fire error
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'The model failed to generate a response',
+        'session-123'
+      );
+    });
+
+    it('should not force-complete messages when reason is not error', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Create an in-flight assistant message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      // Turn closes without error reason
+      processor.processEvent(
+        createKilocodeEvent('session.turn.close', {
+          sessionID: 'session-123',
+          reason: 'complete',
+        })
+      );
+
+      // Should not force-complete
+      expect(callbacks.onMessageCompleted).not.toHaveBeenCalled();
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it('should also complete pending user messages on error turn close', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Create a user message (won't have completed time)
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createUserInfo('user-msg-1') })
+      );
+
+      // Create an assistant message (no completed time)
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('assist-msg-1') })
+      );
+
+      // Turn closes with error
+      processor.processEvent(
+        createKilocodeEvent('session.turn.close', {
+          sessionID: 'session-123',
+          reason: 'error',
+        })
+      );
+
+      // Both messages should be completed
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('invalid events', () => {
     it('should ignore events with unknown types', () => {
       const callbacks: EventProcessorCallbacks = {

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -44,6 +44,7 @@ const HANDLED_EVENT_TYPES = new Set([
   'session.updated',
   'session.error',
   'session.idle',
+  'session.turn.close',
   'question.asked',
 ]);
 
@@ -386,6 +387,45 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   }
 
   /**
+   * Handle session.turn.close events.
+   * When reason is "error", force-complete all in-flight assistant messages
+   * that never received time.completed from the server.
+   */
+  function handleSessionTurnClose(data: { sessionID?: string; reason?: string }): void {
+    if (data.reason !== 'error') {
+      return;
+    }
+
+    // Force-complete all in-flight assistant messages
+    const now = Date.now();
+    for (const [key, message] of messagesMap) {
+      if (isAssistantMessage(message.info) && !isAssistantMessageComplete(message)) {
+        // Set completed time so isMessageStreaming() returns false
+        message.info = {
+          ...message.info,
+          time: { ...message.info.time, completed: now },
+        };
+
+        const [sessionId, messageId] = key.split(':');
+        const parentSessionId = getParentSessionId(sessionId);
+        callbacks.onMessageCompleted?.(sessionId, messageId, message, parentSessionId);
+        completedMessages.add(key);
+        messagesMap.delete(key);
+      }
+    }
+
+    // Complete any pending user messages too
+    completeUserMessages();
+
+    if (streaming) {
+      streaming = false;
+      callbacks.onStreamingChanged?.(false);
+    }
+
+    callbacks.onError?.('The model failed to generate a response', data.sessionID);
+  }
+
+  /**
    * Process a cloud agent event, dispatching to the appropriate handler.
    */
   function processEvent(event: CloudAgentEvent): void {
@@ -437,6 +477,10 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
       case 'session.idle':
         handleSessionIdle();
+        break;
+
+      case 'session.turn.close':
+        handleSessionTurnClose(data as { sessionID?: string; reason?: string });
         break;
 
       case 'question.asked':


### PR DESCRIPTION
## Summary

- Handle `session.turn.close` events with `reason: "error"` in the event processor to force-complete in-flight assistant messages that never received a final `message.updated` from the server
- Update `isMessageStreaming()` to treat messages with an `error` field as complete, preventing the "Streaming..." indicator from persisting indefinitely
- Display a "Failed" badge and inline error message in `MessageBubble` for errored assistant messages

## Problem

When the LLM fails before producing any output, the server sends `session.turn.close` with `reason: "error"` but no final `message.updated` with `time.completed`. The client ignored this event, leaving the UI stuck showing "Streaming..." forever.

## Changes

- **`event-processor.ts`**: Added `session.turn.close` to handled event types and implemented `handleSessionTurnClose()` which sets `time.completed` on in-flight assistant messages, completes pending user messages, stops streaming, and fires the error callback
- **`types.ts`**: `isMessageStreaming()` now returns `false` for messages with an `error` field
- **`MessageBubble.tsx`**: Added error UI — "Failed" badge next to the bot icon and an inline error message extracted from the `AssistantMessage.error` discriminated union
- **`event-processor.test.ts`**: Added 3 tests covering error turn close, non-error turn close, and user message completion on error