### PR TITLE
Cloud Agent Next - Bump CLI version to 1.0.25

### DIFF
--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -118,7 +118,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "1.0.22",
+        "KILOCODE_CLI_VERSION": "1.0.25",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 120,


### PR DESCRIPTION
## Summary

- Bump `KILOCODE_CLI_VERSION` from `1.0.22` to `1.0.25` in `cloud-agent-next/wrangler.jsonc` production containers.