### PR TITLE
fix(kiloclaw): preserve image metadata on reprovision KV failure

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -408,7 +408,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.openclawVersion = latest.openclawVersion;
       this.imageVariant = latest.variant;
       this.trackedImageTag = latest.imageTag;
-    } else {
+    } else if (isNew) {
       this.openclawVersion = null;
       this.imageVariant = null;
       this.trackedImageTag = null;


### PR DESCRIPTION
Change else to else if (isNew) so that a transient KV lookup failure during reprovision does not clear existing tracked image metadata. 
Previously the else branch would null out openclawVersion, imageVariant, and trackedImageTag, causing resolveImageTag() to fall back to FLY_IMAGE_TAG instead of the previously resolved tag