### PR TITLE
Cloud Agent Next - Propagate platform field through prepared session flow

### DIFF
--- a/cloud-agent-next/src/execution/orchestrator.ts
+++ b/cloud-agent-next/src/execution/orchestrator.ts
@@ -264,6 +264,9 @@ export class ExecutionOrchestrator {
           botId: initContext.botId,
           githubRepo: initContext.githubRepo,
           githubToken: initContext.githubToken,
+          gitUrl: initContext.gitUrl,
+          gitToken: initContext.gitToken,
+          platform: initContext.platform,
           envVars: initContext.envVars,
         };
 

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -642,6 +642,7 @@ export class CloudAgentSession extends DurableObject {
     githubAppType?: 'standard' | 'lite';
     gitUrl?: string;
     gitToken?: string;
+    platform?: 'github' | 'gitlab';
     envVars?: Record<string, string>;
     encryptedSecrets?: EncryptedSecrets;
     setupCommands?: string[];

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -217,6 +217,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
         githubToken: resolvedGithubToken, // Use resolved token (from input or generated from installation)
         gitUrl: input.gitUrl,
         gitToken: input.gitToken,
+        platform: input.platform,
         upstreamBranch: input.upstreamBranch,
         botId: ctx.botId,
       });
@@ -360,6 +361,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           githubAppType: resolvedGithubAppType,
           gitUrl: input.gitUrl,
           gitToken: input.gitToken,
+          platform: input.platform,
           envVars: input.envVars,
           encryptedSecrets: input.encryptedSecrets,
           setupCommands: input.setupCommands,

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -139,6 +139,10 @@ export const PrepareSessionInput = z
       .optional()
       .describe('Generic git repository HTTPS URL (mutually exclusive with githubRepo)'),
     gitToken: z.string().optional().describe('Git token for authentication with generic git repos'),
+    platform: z
+      .enum(['github', 'gitlab'])
+      .optional()
+      .describe('Git platform type for correct token/env var handling'),
 
     // Optional configuration
     envVars: envVarsSchema.optional().describe('Environment variables to inject into the session'),


### PR DESCRIPTION
## Summary

- Adds `platform` (`'github' | 'gitlab'`) to `PrepareSessionInput` zod schema so callers can explicitly specify the git platform instead of relying on the fragile `gitUrl.includes('gitlab')` heuristic.
- Passes `platform` through `session-prepare` handler into both `buildContext()` and `stub.prepare()`.
- Adds `gitUrl`, `gitToken`, and `platform` to the orchestrator's prepared session fast path so GitLab sessions get the correct `GITLAB_TOKEN` and `GITLAB_HOST` env vars on first execution.