### PR TITLE
Cloud Agent Next - Add createdOnPlatform

### DIFF
--- a/cloud-agent-next/src/execution/orchestrator.ts
+++ b/cloud-agent-next/src/execution/orchestrator.ts
@@ -275,7 +275,7 @@ export class ExecutionOrchestrator {
           initContext.kilocodeModel ?? 'default',
           orgId,
           initContext.encryptedSecrets,
-          undefined,
+          initContext.createdOnPlatform,
           existingMetadata.appendSystemPrompt
         );
 
@@ -323,6 +323,7 @@ export class ExecutionOrchestrator {
           mcpServers: initContext.mcpServers,
           botId: initContext.botId,
           githubAppType: initContext.githubAppType,
+          createdOnPlatform: initContext.createdOnPlatform,
           // Note: existingMetadata requires CloudAgentSessionState, not our simplified type
           ...gitSource,
         });
@@ -351,6 +352,7 @@ export class ExecutionOrchestrator {
         botId: initContext.botId,
         githubAppType: initContext.githubAppType,
         platform: initContext.platform,
+        createdOnPlatform: initContext.createdOnPlatform,
       });
     } catch (error) {
       if (error instanceof ExecutionError) throw error;

--- a/cloud-agent-next/src/execution/types.ts
+++ b/cloud-agent-next/src/execution/types.ts
@@ -90,6 +90,7 @@ export type InitializeContext = {
   githubAppType?: 'standard' | 'lite';
   /** Git platform type for correct token/env var handling */
   platform?: 'github' | 'gitlab';
+  createdOnPlatform?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -127,6 +128,7 @@ type InitiateExecutionRequest = BaseExecutionRequest & {
   orgId?: string;
   /** Git platform type for correct token/env var handling */
   platform?: 'github' | 'gitlab';
+  createdOnPlatform?: string;
 };
 
 /**
@@ -247,6 +249,7 @@ export type InitContext = {
   githubAppType?: 'lite' | 'standard';
   /** Git platform type for correct token/env var handling */
   platform?: 'github' | 'gitlab';
+  createdOnPlatform?: string;
 };
 
 /**

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -652,6 +652,7 @@ export class CloudAgentSession extends DurableObject {
     upstreamBranch?: string;
     callbackTarget?: CallbackTarget;
     images?: Images;
+    createdOnPlatform?: string;
     // Workspace metadata (set during prepareSession)
     workspacePath?: string;
     sessionHome?: string;
@@ -1445,6 +1446,7 @@ export class CloudAgentSession extends DurableObject {
           upstreamBranch: request.upstreamBranch,
           botId: request.botId,
           platform: request.platform,
+          createdOnPlatform: request.createdOnPlatform,
         };
 
         const plan = this.buildExecutionPlan({
@@ -1529,6 +1531,7 @@ export class CloudAgentSession extends DurableObject {
           isPreparedSession: true,
           githubAppType: metadata.githubAppType,
           platform: metadata.platform,
+          createdOnPlatform: metadata.createdOnPlatform,
         };
 
         const plan = this.buildExecutionPlan({

--- a/cloud-agent-next/src/persistence/schemas.ts
+++ b/cloud-agent-next/src/persistence/schemas.ts
@@ -162,6 +162,7 @@ export const MetadataSchema = z.object({
     .optional(),
   upstreamBranch: branchNameSchema.optional(),
   kiloSessionId: z.string().optional(),
+  createdOnPlatform: z.string().max(100).optional(),
 
   // Execution params
   prompt: z.string().max(Limits.MAX_PROMPT_LENGTH).optional(),

--- a/cloud-agent-next/src/persistence/types.ts
+++ b/cloud-agent-next/src/persistence/types.ts
@@ -78,6 +78,8 @@ export type CloudAgentSessionState = {
   userId: string;
   /** Bot/service identifier (if token is for a bot) */
   botId?: string;
+  /** Platform that created this session (e.g. slack, app-builder) */
+  createdOnPlatform?: string;
   /** Kilocode authentication token for CLI (stored securely, never exposed in getSession) */
   kilocodeToken?: string;
   /** Last save timestamp */

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -230,7 +230,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
         input.model,
         input.kilocodeOrganizationId,
         input.encryptedSecrets,
-        undefined, // createdOnPlatform
+        input.createdOnPlatform,
         input.appendSystemPrompt
       );
 
@@ -311,7 +311,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           ctx.userId,
           ctx.env,
           input.kilocodeOrganizationId,
-          'cloud-agent'
+          input.createdOnPlatform ?? 'cloud-agent'
         );
       } catch (error) {
         logger
@@ -370,6 +370,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           appendSystemPrompt: input.appendSystemPrompt,
           callbackTarget: input.callbackTarget,
           images: input.images,
+          createdOnPlatform: input.createdOnPlatform,
           // Workspace metadata
           workspacePath,
           sessionHome,

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -190,6 +190,11 @@ export const PrepareSessionInput = z
     images: ImagesSchema.optional().describe(
       'Optional image attachments to download from R2 to the sandbox'
     ),
+    createdOnPlatform: z
+      .string()
+      .max(100)
+      .optional()
+      .describe('Platform that created this session (e.g. slack, app-builder)'),
   })
   .refine(validateGitSource, {
     message: 'Must provide either githubRepo or gitUrl, but not both',

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1005,7 +1005,7 @@ export class SessionService {
       kilocodeModel,
       orgId,
       encryptedSecrets,
-      undefined, // createdOnPlatform - not used for initiateFromKiloSession
+      options.createdOnPlatform ?? existingMetadata?.createdOnPlatform,
       existingMetadata?.appendSystemPrompt
     );
 
@@ -1207,7 +1207,7 @@ export class SessionService {
       kilocodeModel,
       orgId,
       metadata?.encryptedSecrets,
-      undefined, // createdOnPlatform - not used for resume
+      metadata?.createdOnPlatform,
       metadata?.appendSystemPrompt
     );
 
@@ -1825,6 +1825,7 @@ type InitiateFromKiloSessionBaseOptions = {
   botId?: string;
   /** GitHub App type for selecting correct slug/bot identity */
   githubAppType?: 'standard' | 'lite';
+  createdOnPlatform?: string;
   /**
    * Existing metadata from prepared session flow.
    * When provided, saveSessionMetadata will merge with it to preserve

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -28,6 +28,11 @@ FLY_REGION=us,eu
 # In dev, use "latest" or run scripts/push-dev.sh which sets a timestamped tag.
 # In production, pin to a version (e.g., v40, sha-abc1234).
 FLY_IMAGE_TAG=latest
+# OpenClaw version (must match the openclaw@x.x.x version in the Dockerfile).
+# Used by the worker to self-register the version → image tag mapping in KV,
+# enabling per-user version tracking. Without this, version tracking fields
+# will be null and instances fall back to FLY_IMAGE_TAG directly.
+OPENCLAW_VERSION=2026.2.9
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -28,11 +28,6 @@ FLY_REGION=us,eu
 # In dev, use "latest" or run scripts/push-dev.sh which sets a timestamped tag.
 # In production, pin to a version (e.g., v40, sha-abc1234).
 FLY_IMAGE_TAG=latest
-# OpenClaw version (must match the openclaw@x.x.x version in the Dockerfile).
-# Used by the worker to self-register the version → image tag mapping in KV,
-# enabling per-user version tracking. Without this, version tracking fields
-# will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.2.9
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.


### PR DESCRIPTION
## Summary

- Wires the optional `createdOnPlatform` field from the `PrepareSession` API input through execution types, persistence layer, orchestrator, and session service so callers can attribute sessions to their originating platform (e.g. `slack`, `app-builder`).
- Previously hardcoded to `undefined` or `'cloud-agent'`, the value now propagates into the `KILO_PLATFORM` and `KILOCODE_FEATURE` env vars and is persisted in session metadata so it survives resumes.
- Removes the unused `OPENCLAW_VERSION` entry from `kiloclaw/.dev.vars.example`.

## Changes

| File | What changed |
|------|-------------|
| `cloud-agent-next/src/router/schemas.ts` | Added `createdOnPlatform` to `PrepareSessionInput` schema (`z.string().max(100).optional()`) |
| `cloud-agent-next/src/router/handlers/session-prepare.ts` | Pass `input.createdOnPlatform` to `getOrCreateSession`, `createCliSessionViaSessionIngest`, and DO metadata |
| `cloud-agent-next/src/execution/types.ts` | Added `createdOnPlatform` to `InitializeContext`, `InitiateExecutionRequest`, and `InitContext` |
| `cloud-agent-next/src/execution/orchestrator.ts` | Thread `createdOnPlatform` from `initContext` to all three session paths (fast, legacy prepared, new) |
| `cloud-agent-next/src/persistence/types.ts` | Added `createdOnPlatform` to `CloudAgentSessionState` |
| `cloud-agent-next/src/persistence/schemas.ts` | Added `createdOnPlatform` to `MetadataSchema` |
| `cloud-agent-next/src/persistence/CloudAgentSession.ts` | Thread field through `prepareSession` metadata and execution initiation |
| `cloud-agent-next/src/session-service.ts` | Use `createdOnPlatform` from options/metadata instead of hardcoded `undefined` in `initiateFromKiloSession` and `resume` paths; added to `InitiateFromKiloSessionBaseOptions` type |
| `kiloclaw/.dev.vars.example` | Removed unused `OPENCLAW_VERSION` variable and its comment block |