### PR TITLE
Normalize gitUrl in cli-sessions-v2 list query to match write-time sanitization

### DIFF
--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -10,6 +10,7 @@ import { createCloudAgentNextClient } from '@/lib/cloud-agent-next/cloud-agent-c
 import { generateApiToken } from '@/lib/tokens';
 import { fetchSessionMessages } from '@/lib/session-ingest-client';
 import { baseGetSessionNextOutputSchema } from './cloud-agent-next-schemas';
+import { sanitizeGitUrl } from '@/routers/cli-sessions-router';
 
 /**
  * Check if an error indicates the session was not found in the cloud-agent DO.
@@ -114,7 +115,7 @@ export const cliSessionsV2Router = createTRPCRouter({
     }
 
     if (gitUrl) {
-      whereConditions.push(eq(cli_sessions_v2.git_url, gitUrl));
+      whereConditions.push(eq(cli_sessions_v2.git_url, sanitizeGitUrl(gitUrl)));
     }
 
     const results = await db


### PR DESCRIPTION
## Summary

- The `list` endpoint in `cli-sessions-v2-router` now applies `sanitizeGitUrl` to the `gitUrl` filter input before querying, matching the normalization applied when sessions are written (stripping credentials, query params, and hash from HTTP(S) URLs; stripping query params from SSH URLs).
- Reuses the existing exported `sanitizeGitUrl` from `cli-sessions-router.ts`.