### PR TITLE
feat(kiloclaw): controller, device pairing, and dashboard redesign

### DIFF
--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
-import { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useGatewayUrl } from '../hooks/useGatewayUrl';
@@ -27,6 +27,12 @@ export function ClawDashboard({ status }: { status: KiloClawDashboardStatus | un
   const mutations = useKiloClawMutations();
   const gatewayUrl = useGatewayUrl(status);
   const instanceStatus = hasPopulatedStatus(status) ? status : null;
+  const isRunning = instanceStatus?.status === 'running';
+  const {
+    data: gatewayStatus,
+    isLoading: gatewayLoading,
+    error: gatewayError,
+  } = useKiloClawGatewayStatus(isRunning);
 
   return (
     <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
@@ -54,7 +60,7 @@ export function ClawDashboard({ status }: { status: KiloClawDashboardStatus | un
                     value="instance"
                     className="text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   >
-                    Instance
+                    Gateway Process
                   </TabsTrigger>
                   <TabsTrigger
                     value="settings"
@@ -66,7 +72,12 @@ export function ClawDashboard({ status }: { status: KiloClawDashboardStatus | un
               </div>
               <CardContent className="p-5">
                 <TabsContent value="instance" className="mt-0">
-                  <InstanceTab status={instanceStatus} />
+                  <InstanceTab
+                    status={instanceStatus}
+                    gatewayStatus={gatewayStatus}
+                    gatewayLoading={gatewayLoading}
+                    gatewayError={gatewayError}
+                  />
                 </TabsContent>
                 <TabsContent value="settings" className="mt-0">
                   <SettingsTab status={instanceStatus} mutations={mutations} />

--- a/src/app/(app)/claw/components/ConfirmActionDialog.tsx
+++ b/src/app/(app)/claw/components/ConfirmActionDialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export function ConfirmActionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  confirmIcon,
+  isPending,
+  pendingLabel,
+  onConfirm,
+  className,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  confirmIcon?: ReactNode;
+  isPending: boolean;
+  pendingLabel: string;
+  onConfirm: () => void;
+  className?: string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={isPending ? undefined : onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button className={className} onClick={onConfirm} disabled={isPending}>
+            {isPending ? (
+              pendingLabel
+            ) : (
+              <>
+                {confirmIcon}
+                {confirmLabel}
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Play, RotateCw, Square, Stethoscope } from 'lucide-react';
+import { Play, RefreshCw, RotateCw, Stethoscope } from 'lucide-react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
@@ -42,23 +42,25 @@ export function InstanceControls({
           }}
         >
           <Play className="h-4 w-4" />
-          {mutations.start.isPending ? 'Starting...' : 'Start'}
+          {mutations.start.isPending ? 'Starting...' : 'Start Machine'}
         </Button>
         <Button
           size="sm"
           variant="outline"
-          className="border-red-500/30 text-red-400 hover:bg-red-500/10 hover:text-red-300"
-          disabled={!isRunning || mutations.stop.isPending || isDestroying}
+          className="border-violet-500/30 text-violet-400 hover:bg-violet-500/10 hover:text-violet-300"
+          disabled={!isRunning || mutations.restartOpenClaw.isPending || isDestroying}
           onClick={() => {
-            posthog?.capture('claw_stop_instance_clicked', { instance_status: status.status });
-            mutations.stop.mutate(undefined, {
-              onSuccess: () => toast.success('Instance stopped'),
+            posthog?.capture('claw_restart_openclaw_clicked', {
+              instance_status: status.status,
+            });
+            mutations.restartOpenClaw.mutate(undefined, {
+              onSuccess: () => toast.success('OpenClaw restarting'),
               onError: err => toast.error(err.message),
             });
           }}
         >
-          <Square className="h-4 w-4" />
-          {mutations.stop.isPending ? 'Stopping...' : 'Stop'}
+          <RefreshCw className="h-4 w-4" />
+          {mutations.restartOpenClaw.isPending ? 'Restarting...' : 'Restart OpenClaw'}
         </Button>
         <Button
           size="sm"

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useState } from 'react';
-import { Play, RefreshCw, RotateCw, Stethoscope } from 'lucide-react';
+import { Cpu, HardDrive, Play, RefreshCw, RotateCw, Stethoscope } from 'lucide-react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { DEFAULT_CLAW_INSTANCE_TYPE } from './claw.types';
+import { ConfirmActionDialog } from './ConfirmActionDialog';
 import { RunDoctorDialog } from './RunDoctorDialog';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
@@ -23,13 +26,27 @@ export function InstanceControls({
   const isStopped = status.status === 'stopped' || status.status === 'provisioned';
   const isDestroying = status.status === 'destroying';
   const [doctorOpen, setDoctorOpen] = useState(false);
+  const [confirmRestart, setConfirmRestart] = useState(false);
+  const [confirmRedeploy, setConfirmRedeploy] = useState(false);
 
   return (
     <div>
-      <h3 className="text-foreground mb-1 text-sm font-medium">Instance Controls</h3>
-      <p className="text-muted-foreground mb-4 text-xs">
-        Manage power state and gateway lifecycle.
-      </p>
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-foreground mb-1 text-sm font-medium">Instance Controls</h3>
+          <p className="text-muted-foreground text-xs">Manage power state and gateway lifecycle.</p>
+        </div>
+        <div className="flex flex-wrap justify-end gap-2">
+          <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
+            <Cpu className="h-3.5 w-3.5" />
+            {DEFAULT_CLAW_INSTANCE_TYPE.name} ({DEFAULT_CLAW_INSTANCE_TYPE.description})
+          </Badge>
+          <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
+            <HardDrive className="h-3.5 w-3.5" />
+            20 GB SSD
+          </Badge>
+        </div>
+      </div>
       <div className="flex flex-wrap items-center gap-2">
         <Button
           size="sm"
@@ -50,17 +67,14 @@ export function InstanceControls({
           className="border-violet-500/30 text-violet-400 hover:bg-violet-500/10 hover:text-violet-300"
           disabled={!isRunning || mutations.restartOpenClaw.isPending || isDestroying}
           onClick={() => {
-            posthog?.capture('claw_restart_openclaw_clicked', {
+            posthog?.capture('claw_restart_openclaw_prompted', {
               instance_status: status.status,
             });
-            mutations.restartOpenClaw.mutate(undefined, {
-              onSuccess: () => toast.success('OpenClaw restarting'),
-              onError: err => toast.error(err.message),
-            });
+            setConfirmRestart(true);
           }}
         >
           <RefreshCw className="h-4 w-4" />
-          {mutations.restartOpenClaw.isPending ? 'Restarting...' : 'Restart OpenClaw'}
+          Restart OpenClaw
         </Button>
         <Button
           size="sm"
@@ -68,15 +82,12 @@ export function InstanceControls({
           className="border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
           disabled={!isRunning || mutations.restartGateway.isPending || isDestroying}
           onClick={() => {
-            posthog?.capture('claw_redeploy_clicked', { instance_status: status.status });
-            mutations.restartGateway.mutate(undefined, {
-              onSuccess: () => toast.success('Gateway restarting'),
-              onError: err => toast.error(err.message),
-            });
+            posthog?.capture('claw_redeploy_prompted', { instance_status: status.status });
+            setConfirmRedeploy(true);
           }}
         >
           <RotateCw className="h-4 w-4" />
-          {mutations.restartGateway.isPending ? 'Redeploying...' : 'Redeploy'}
+          Redeploy
         </Button>
         <Button
           size="sm"
@@ -92,6 +103,56 @@ export function InstanceControls({
           OpenClaw Doctor
         </Button>
       </div>
+      <ConfirmActionDialog
+        open={confirmRestart}
+        onOpenChange={open => {
+          if (!open) posthog?.capture('claw_restart_openclaw_cancelled');
+          setConfirmRestart(open);
+        }}
+        title="Restart OpenClaw"
+        description="This will restart the gateway process inside the running machine. Active sessions will be briefly interrupted and reconnect automatically."
+        confirmLabel="Restart"
+        confirmIcon={<RefreshCw className="h-4 w-4" />}
+        isPending={mutations.restartOpenClaw.isPending}
+        pendingLabel="Restarting..."
+        className="border-violet-500/30 bg-violet-500/10 text-violet-400 hover:bg-violet-500/20 hover:text-violet-300"
+        onConfirm={() => {
+          posthog?.capture('claw_restart_openclaw_clicked', {
+            instance_status: status.status,
+          });
+          mutations.restartOpenClaw.mutate(undefined, {
+            onSuccess: () => {
+              toast.success('OpenClaw restarting');
+              setConfirmRestart(false);
+            },
+            onError: err => toast.error(err.message),
+          });
+        }}
+      />
+      <ConfirmActionDialog
+        open={confirmRedeploy}
+        onOpenChange={open => {
+          if (!open) posthog?.capture('claw_redeploy_cancelled');
+          setConfirmRedeploy(open);
+        }}
+        title="Redeploy Gateway"
+        description="This will stop the machine, rebuild environment variables and secrets, apply any pending image updates, and restart it. The machine will be briefly offline."
+        confirmLabel="Redeploy"
+        confirmIcon={<RotateCw className="h-4 w-4" />}
+        isPending={mutations.restartGateway.isPending}
+        pendingLabel="Redeploying..."
+        className="border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:text-amber-300"
+        onConfirm={() => {
+          posthog?.capture('claw_redeploy_clicked', { instance_status: status.status });
+          mutations.restartGateway.mutate(undefined, {
+            onSuccess: () => {
+              toast.success('Gateway restarting');
+              setConfirmRedeploy(false);
+            },
+            onError: err => toast.error(err.message),
+          });
+        }}
+      />
       <RunDoctorDialog
         open={doctorOpen}
         onOpenChange={setDoctorOpen}

--- a/src/app/(app)/claw/components/InstanceTab.tsx
+++ b/src/app/(app)/claw/components/InstanceTab.tsx
@@ -1,50 +1,125 @@
 'use client';
 
-import { Clock, Cpu, Globe, HardDrive, Hash } from 'lucide-react';
-import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
-import { Separator } from '@/components/ui/separator';
-import { DEFAULT_CLAW_INSTANCE_TYPE } from './claw.types';
-import { DetailTile } from './DetailTile';
+import { Activity, Loader2 } from 'lucide-react';
+import type { KiloClawDashboardStatus, GatewayProcessStatusResponse } from '@/lib/kiloclaw/types';
+import { Badge } from '@/components/ui/badge';
 import { formatTs } from './time';
 
-const PUBLIC_IP_DISPLAY = 'None';
-const DISK_SIZE_DISPLAY = '20 GB';
+const GATEWAY_STATE_STYLES: Record<
+  GatewayProcessStatusResponse['state'],
+  { label: string; className: string }
+> = {
+  running: {
+    label: 'Running',
+    className: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-400',
+  },
+  stopped: {
+    label: 'Stopped',
+    className: 'border-red-500/30 bg-red-500/15 text-red-400',
+  },
+  starting: {
+    label: 'Starting',
+    className: 'border-blue-500/30 bg-blue-500/15 text-blue-400',
+  },
+  stopping: {
+    label: 'Stopping',
+    className: 'border-amber-500/30 bg-amber-500/15 text-amber-400',
+  },
+  crashed: {
+    label: 'Crashed',
+    className: 'border-red-500/30 bg-red-500/15 text-red-400',
+  },
+  shutting_down: {
+    label: 'Shutting Down',
+    className: 'border-amber-500/30 bg-amber-500/15 text-amber-400 animate-pulse',
+  },
+};
 
-export function InstanceTab({ status }: { status: KiloClawDashboardStatus }) {
-  const details = [
-    { label: 'Instance ID', value: status.sandboxId || 'N/A', icon: Hash, mono: true },
-    {
-      label: 'Instance Type',
-      value: `${DEFAULT_CLAW_INSTANCE_TYPE.name} (${DEFAULT_CLAW_INSTANCE_TYPE.description})`,
-      icon: Cpu,
-      mono: false,
-    },
-    { label: 'Public IP', value: PUBLIC_IP_DISPLAY, icon: Globe, mono: true },
-    { label: 'Disk Size', value: DISK_SIZE_DISPLAY, icon: HardDrive, mono: false },
-    { label: 'Provisioned', value: formatTs(status.provisionedAt), icon: Clock, mono: false },
-    { label: 'Last Started', value: formatTs(status.lastStartedAt), icon: Clock, mono: false },
-  ];
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function formatLastExit(lastExit: NonNullable<GatewayProcessStatusResponse['lastExit']>): string {
+  const code = lastExit.code ?? 'null';
+  const signal = lastExit.signal ?? 'none';
+  const at = new Date(lastExit.at);
+  const timeStr = at.toLocaleString();
+  return `exit ${code} / ${signal} at ${timeStr}`;
+}
+
+export function InstanceTab({
+  status,
+  gatewayStatus,
+  gatewayLoading,
+  gatewayError,
+}: {
+  status: KiloClawDashboardStatus;
+  gatewayStatus: GatewayProcessStatusResponse | undefined;
+  gatewayLoading: boolean;
+  gatewayError: { message: string } | null;
+}) {
+  const isRunning = status.status === 'running';
+
+  if (!isRunning) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Gateway status is available when the machine is running.
+      </p>
+    );
+  }
+
+  if (gatewayLoading) {
+    return (
+      <div className="flex items-center gap-2">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="text-muted-foreground text-sm">Loading gateway status...</span>
+      </div>
+    );
+  }
+
+  if (gatewayError) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Failed to load gateway status: {gatewayError.message}
+      </p>
+    );
+  }
+
+  if (!gatewayStatus) return null;
+
+  const stateStyle = GATEWAY_STATE_STYLES[gatewayStatus.state];
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {details.map(detail => (
-          <DetailTile
-            key={detail.label}
-            label={detail.label}
-            value={detail.value}
-            icon={detail.icon}
-            mono={detail.mono}
-          />
-        ))}
+    <div className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-5">
+      <div>
+        <p className="text-muted-foreground mb-1.5 text-xs">State</p>
+        <Badge variant="outline" className={stateStyle.className}>
+          <Activity className="mr-1 h-3 w-3" />
+          {stateStyle.label}
+        </Badge>
       </div>
-
-      <Separator />
-
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <DetailTile label="Env Vars" value={String(status.envVarCount)} icon={Hash} />
-        <DetailTile label="Secrets" value={String(status.secretCount)} icon={Hash} />
-        <DetailTile label="Channels" value={String(status.channelCount)} icon={Hash} />
+      <div>
+        <p className="text-muted-foreground mb-1.5 text-xs">Uptime</p>
+        <p className="text-foreground text-sm font-medium">{formatUptime(gatewayStatus.uptime)}</p>
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-1.5 text-xs">Restarts</p>
+        <p className="text-foreground text-sm font-medium">{gatewayStatus.restarts}</p>
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-1.5 text-xs">Last Exit</p>
+        <p className="text-muted-foreground text-sm font-medium">
+          {gatewayStatus.lastExit ? formatLastExit(gatewayStatus.lastExit) : '—'}
+        </p>
+      </div>
+      <div>
+        <p className="text-muted-foreground mb-1.5 text-xs">Provisioned</p>
+        <p className="text-foreground text-sm font-medium">{formatTs(status.provisionedAt)}</p>
       </div>
     </div>
   );

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { AlertTriangle, Save, Square, X } from 'lucide-react';
+import { AlertTriangle, Hash, Save, Square, X } from 'lucide-react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
@@ -12,6 +12,7 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
+import { DetailTile } from './DetailTile';
 import { useDefaultModelSelection } from '../hooks/useDefaultModelSelection';
 import { ChannelTokenInput } from './ChannelTokenInput';
 import { CHANNELS, CHANNEL_TYPES, type ChannelDefinition } from './channel-config';
@@ -197,6 +198,14 @@ export function SettingsTab({
 
   return (
     <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <DetailTile label="Env Vars" value={String(status.envVarCount)} icon={Hash} />
+        <DetailTile label="Secrets" value={String(status.secretCount)} icon={Hash} />
+        <DetailTile label="Channels" value={String(status.channelCount)} icon={Hash} />
+      </div>
+
+      <Separator />
+
       <div>
         <h3 className="text-foreground mb-1 text-sm font-medium">KiloCode Configuration</h3>
         <p className="text-muted-foreground mb-4 text-xs">

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -12,6 +12,13 @@ export type ChangelogEntry = {
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-02-23',
+    description:
+      'Redesigned dashboard: live gateway process status, added ability to restart OpenClaw gateway.',
+    category: 'feature',
+    deployHint: null,
+  },
+  {
+    date: '2026-02-23',
     description: 'Deploy OpenClaw 2026.2.22. Added device pairing support to the dashboard.',
     category: 'feature',
     deployHint: 'redeploy_required',

--- a/src/app/(app)/claw/components/claw.types.ts
+++ b/src/app/(app)/claw/components/claw.types.ts
@@ -34,11 +34,11 @@ export const CLAW_STATUS_BADGE: Record<
   { label: string; className: string }
 > = {
   running: {
-    label: 'Running',
+    label: 'Machine Online',
     className: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-400',
   },
   stopped: {
-    label: 'Stopped',
+    label: 'Machine Stopped',
     className: 'border-red-500/30 bg-red-500/15 text-red-400',
   },
   provisioned: {

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -61,6 +61,16 @@ export function useRefreshDevicePairing() {
   };
 }
 
+export function useKiloClawGatewayStatus(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.kiloclaw.gatewayStatus.queryOptions(undefined, {
+      enabled,
+      refetchInterval: enabled ? 30_000 : false,
+    })
+  );
+}
+
 export function useKiloClawMutations() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -93,10 +103,24 @@ export function useKiloClawMutations() {
       })
     ),
     restartGateway: useMutation(
-      trpc.kiloclaw.restartGateway.mutationOptions({ onSuccess: invalidateStatus })
+      trpc.kiloclaw.restartGateway.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
+          });
+        },
+      })
     ),
     restartOpenClaw: useMutation(
-      trpc.kiloclaw.restartOpenClaw.mutationOptions({ onSuccess: invalidateStatus })
+      trpc.kiloclaw.restartOpenClaw.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
+          });
+        },
+      })
     ),
     approvePairingRequest: useMutation(
       trpc.kiloclaw.approvePairingRequest.mutationOptions({

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -95,6 +95,9 @@ export function useKiloClawMutations() {
     restartGateway: useMutation(
       trpc.kiloclaw.restartGateway.mutationOptions({ onSuccess: invalidateStatus })
     ),
+    restartOpenClaw: useMutation(
+      trpc.kiloclaw.restartOpenClaw.mutationOptions({ onSuccess: invalidateStatus })
+    ),
     approvePairingRequest: useMutation(
       trpc.kiloclaw.approvePairingRequest.mutationOptions({
         onSuccess: async () => {

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -287,6 +287,11 @@ export const kiloclawRouter = createTRPCRouter({
       return client.approveDevicePairingRequest(ctx.user.id, input.requestId);
     }),
 
+  gatewayStatus: kiloclawProcedure.query(async ({ ctx }) => {
+    const client = new KiloClawInternalClient();
+    return client.getGatewayStatus(ctx.user.id);
+  }),
+
   restartOpenClaw: kiloclawProcedure.mutation(async ({ ctx }) => {
     const client = new KiloClawInternalClient();
     return client.restartGatewayProcess(ctx.user.id);

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -287,6 +287,11 @@ export const kiloclawRouter = createTRPCRouter({
       return client.approveDevicePairingRequest(ctx.user.id, input.requestId);
     }),
 
+  restartOpenClaw: kiloclawProcedure.mutation(async ({ ctx }) => {
+    const client = new KiloClawInternalClient();
+    return client.restartGatewayProcess(ctx.user.id);
+  }),
+
   runDoctor: kiloclawProcedure.mutation(async ({ ctx }) => {
     const client = new KiloClawInternalClient();
     return client.runDoctor(ctx.user.id);


### PR DESCRIPTION
## Summary
- Redesign dashboard: live gateway process status polling, confirmation dialogs for restart/redeploy, reorganized tabs. Making room showing actually useful things.
- Differentiate machine vs gateway status labels (Machine Online/Stopped vs gateway Running/Stopped)
- Remove machine stop button (moving towards machines always being online to simplify things)
- Add "restart gateway" button that uses the controller to restart the gateway process. 