### PR TITLE
refactor(security-agent): redesign analysis jobs & findings UI with smart retry

### DIFF
--- a/cloud-agent-next/src/auth.ts
+++ b/cloud-agent-next/src/auth.ts
@@ -17,6 +17,10 @@ export function validateKiloToken(
 ):
   | { success: true; userId: string; token: string; botId?: string }
   | { success: false; error: string } {
+  if (!secret) {
+    return { success: false, error: 'NEXTAUTH_SECRET is not configured on the worker' };
+  }
+
   // Check header exists and has Bearer format
   if (!authHeader) {
     return { success: false, error: 'Missing Authorization header' };

--- a/src/components/security-agent/AnalysisJobsCard.tsx
+++ b/src/components/security-agent/AnalysisJobsCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -10,20 +9,21 @@ import {
   CheckCircle2,
   XCircle,
   Clock,
-  AlertCircle,
   ChevronLeft,
   ChevronRight,
   RotateCcw,
   Package,
-  ExternalLink,
+  RefreshCw,
 } from 'lucide-react';
-import Link from 'next/link';
 import { useTRPC } from '@/lib/trpc/utils';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { differenceInDays, differenceInHours, differenceInMinutes } from 'date-fns';
 import { toast } from 'sonner';
 import { SeverityBadge } from './SeverityBadge';
-import type { SecurityFindingAnalysis } from '@/lib/security-agent/core/types';
+import { FindingDetailDialog } from './FindingDetailDialog';
+import { DismissFindingDialog, type DismissReason } from './DismissFindingDialog';
+import { cn } from '@/lib/utils';
+import type { SecurityFinding } from '@/db/schema';
 
 type AnalysisJobsCardProps = {
   organizationId?: string;
@@ -31,39 +31,50 @@ type AnalysisJobsCardProps = {
 };
 
 type AnalysisStatus = 'pending' | 'running' | 'completed' | 'failed';
+type Severity = 'critical' | 'high' | 'medium' | 'low';
 
 const statusConfig: Record<
   AnalysisStatus,
   {
     icon: React.ComponentType<{ className?: string }>;
-    variant: 'default' | 'secondary' | 'destructive' | 'outline';
     label: string;
+    badgeClass: string;
   }
 > = {
-  pending: { icon: Clock, variant: 'secondary', label: 'Queued' },
-  running: { icon: Loader2, variant: 'default', label: 'Analyzing' },
-  completed: { icon: CheckCircle2, variant: 'default', label: 'Completed' },
-  failed: { icon: XCircle, variant: 'destructive', label: 'Failed' },
+  pending: {
+    icon: Clock,
+    label: 'Queued',
+    badgeClass: 'border-gray-500/30 bg-gray-500/20 text-gray-400',
+  },
+  running: {
+    icon: Loader2,
+    label: 'Analyzing',
+    badgeClass: 'border-yellow-500/30 bg-yellow-500/20 text-yellow-400',
+  },
+  completed: {
+    icon: CheckCircle2,
+    label: 'Completed',
+    badgeClass: 'border-green-500/30 bg-green-500/20 text-green-400',
+  },
+  failed: {
+    icon: XCircle,
+    label: 'Failed',
+    badgeClass: 'border-red-500/30 bg-red-500/20 text-red-400',
+  },
 };
 
 const PAGE_SIZE = 10;
 
-type AnalysisJob = {
-  id: string;
-  package_name: string;
-  severity: string;
-  repo_full_name: string;
-  title: string;
-  analysis_status: string | null;
-  analysis_started_at: Date | null;
-  analysis_completed_at: Date | null;
-  analysis_error: string | null;
-  analysis: SecurityFindingAnalysis | null;
-  session_id: string | null;
-  cli_session_id: string | null;
-};
+function formatCompactTimeAgo(date: Date) {
+  const now = new Date();
+  const days = Math.abs(differenceInDays(now, date));
+  if (days >= 1) return `${days}d ago`;
+  const hours = Math.abs(differenceInHours(now, date));
+  if (hours >= 1) return `${hours}h ago`;
+  const minutes = Math.abs(differenceInMinutes(now, date));
+  return `${minutes}m ago`;
+}
 
-// Helper to detect GitHub integration errors from error messages
 function isGitHubIntegrationError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
@@ -71,19 +82,121 @@ function isGitHubIntegrationError(error: unknown): boolean {
     message.includes('GitHub installation') ||
     message.includes('installation_id') ||
     message.includes('Bad credentials') ||
-    message.includes('Not Found') // GitHub API returns 404 for uninstalled apps
+    message.includes('Not Found')
   );
 }
+
+// ─── Row sub-components ──────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: AnalysisStatus | null }) {
+  if (!status) return null;
+  const info = statusConfig[status];
+  const Icon = info.icon;
+  return (
+    <Badge variant="outline" className={info.badgeClass}>
+      <Icon className={cn('mr-1 h-3 w-3', status === 'running' && 'animate-spin')} />
+      {info.label}
+    </Badge>
+  );
+}
+
+function AnalysisJobRow({
+  finding,
+  onRetry,
+  isRetrying,
+  retryDisabled,
+  onClick,
+}: {
+  finding: SecurityFinding;
+  onRetry: (id: string) => void;
+  isRetrying: boolean;
+  retryDisabled: boolean;
+  onClick: () => void;
+}) {
+  const status = finding.analysis_status as AnalysisStatus | null;
+  const canRetry = status === 'failed' || (status === 'completed' && finding.analysis);
+
+  const time =
+    finding.analysis_completed_at && (status === 'completed' || status === 'failed')
+      ? formatCompactTimeAgo(new Date(finding.analysis_completed_at))
+      : finding.analysis_started_at
+        ? formatCompactTimeAgo(new Date(finding.analysis_started_at))
+        : null;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className={cn(
+        'hover:bg-muted/50 grid w-full cursor-pointer grid-cols-[96px_1fr_80px_100px_16px] items-center gap-x-1.5 px-4 py-3 text-left transition-colors',
+        status === 'failed' && 'bg-red-500/5'
+      )}
+    >
+      {/* Severity */}
+      <div>
+        <SeverityBadge severity={finding.severity as Severity} size="sm" />
+      </div>
+
+      {/* Title + package */}
+      <div className="min-w-0">
+        <h4 className="truncate text-sm font-medium">{finding.title}</h4>
+        <span className="text-muted-foreground mt-0.5 flex items-center gap-1 text-xs">
+          <Package className="h-3 w-3" />
+          {finding.package_name}
+        </span>
+      </div>
+
+      {/* Status + time */}
+      <div className="text-xs">
+        <StatusBadge status={status} />
+        {time && <div className="text-muted-foreground mt-1 text-xs">{time}</div>}
+      </div>
+
+      {/* Action */}
+      <div className="flex items-center justify-end">
+        {canRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={e => {
+              e.stopPropagation();
+              onRetry(finding.id);
+            }}
+            disabled={isRetrying || retryDisabled}
+            className="gap-1"
+          >
+            <RotateCcw className={cn('h-3 w-3', isRetrying && 'animate-spin')} />
+            {isRetrying ? 'Starting...' : 'Retry'}
+          </Button>
+        )}
+      </div>
+
+      {/* Detail chevron */}
+      <ChevronRight className="text-muted-foreground h-4 w-4" />
+    </div>
+  );
+}
+
+// ─── Main Component ─────────────────────────────────────────────────────────
 
 export function AnalysisJobsCard({ organizationId, onGitHubError }: AnalysisJobsCardProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [startingAnalysisId, setStartingAnalysisId] = useState<string | null>(null);
+  const [selectedFinding, setSelectedFinding] = useState<SecurityFinding | null>(null);
+  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  const [dismissDialogOpen, setDismissDialogOpen] = useState(false);
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const isOrg = !!organizationId;
   const offset = (currentPage - 1) * PAGE_SIZE;
 
-  // Fetch findings with analysis status (pending, running, completed, failed)
   const { data, isLoading, isFetching } = useQuery({
     ...(isOrg
       ? trpc.organizations.securityAgent.listAnalysisJobs.queryOptions({
@@ -98,326 +211,236 @@ export function AnalysisJobsCard({ organizationId, onGitHubError }: AnalysisJobs
     refetchInterval: query => {
       const result = query.state.data;
       if (!result) return false;
-      const jobs = (result.jobs || []) as AnalysisJob[];
-      const hasActiveJobs = jobs.some(j =>
-        ['pending', 'running'].includes(j.analysis_status || '')
+      const findings = (result.jobs || []) as SecurityFinding[];
+      const hasActiveJobs = findings.some(f =>
+        ['pending', 'running'].includes(f.analysis_status || '')
       );
-      return hasActiveJobs ? 5000 : false; // Poll every 5s if active jobs
+      return hasActiveJobs ? 5000 : false;
     },
   });
 
-  // Retry mutation for failed analyses (organization)
+  const handleMutationSuccess = async () => {
+    onGitHubError?.(null);
+    await queryClient.invalidateQueries();
+    setStartingAnalysisId(null);
+  };
+
+  const handleMutationError = (error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    if (isGitHubIntegrationError(error)) {
+      onGitHubError?.(message);
+      toast.error('GitHub Integration Error', {
+        description: 'The GitHub App may have been uninstalled. Please check your integrations.',
+      });
+    } else {
+      toast.error('Analysis Failed', { description: message, duration: 8000 });
+    }
+    setStartingAnalysisId(null);
+  };
+
   const retryOrgMutation = useMutation(
     trpc.organizations.securityAgent.startAnalysis.mutationOptions({
-      onSuccess: async () => {
-        onGitHubError?.(null); // Clear any previous error on success
-        await queryClient.invalidateQueries();
-        setStartingAnalysisId(null);
+      onSuccess: handleMutationSuccess,
+      onError: handleMutationError,
+    })
+  );
+
+  const retryUserMutation = useMutation(
+    trpc.securityAgent.startAnalysis.mutationOptions({
+      onSuccess: handleMutationSuccess,
+      onError: handleMutationError,
+    })
+  );
+
+  const handleRetry = (findingId: string) => {
+    setStartingAnalysisId(findingId);
+    // If the finding has triage data, retry only sandbox analysis to avoid redundant triage
+    const jobs = (data?.jobs || []) as SecurityFinding[];
+    const finding = jobs.find(f => f.id === findingId);
+    const retrySandboxOnly = !!finding?.analysis?.triage && finding.analysis_status === 'failed';
+    if (isOrg) {
+      retryOrgMutation.mutate({ organizationId: organizationId, findingId, retrySandboxOnly });
+    } else {
+      retryUserMutation.mutate({ findingId, retrySandboxOnly });
+    }
+  };
+
+  // Dismiss mutation (organization)
+  const dismissOrgMutation = useMutation(
+    trpc.organizations.securityAgent.dismissFinding.mutationOptions({
+      onSuccess: () => {
+        toast.success('Finding dismissed');
+        void queryClient.invalidateQueries();
+        setDismissDialogOpen(false);
+        setDetailDialogOpen(false);
+        setSelectedFinding(null);
       },
       onError: error => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (isGitHubIntegrationError(error)) {
-          onGitHubError?.(message); // Set error at page level
-          toast.error('GitHub Integration Error', {
-            description:
-              'The GitHub App may have been uninstalled. Please check your integrations.',
-          });
-        } else {
-          toast.error('Analysis Failed', {
-            description: message,
-            duration: 8000, // 8 seconds for errors
-          });
-        }
-        setStartingAnalysisId(null);
+        toast.error('Failed to dismiss finding', { description: error.message });
       },
     })
   );
 
-  // Retry mutation for failed analyses (user)
-  const retryUserMutation = useMutation(
-    trpc.securityAgent.startAnalysis.mutationOptions({
-      onSuccess: async () => {
-        onGitHubError?.(null); // Clear any previous error on success
-        await queryClient.invalidateQueries();
-        setStartingAnalysisId(null);
+  // Dismiss mutation (user)
+  const dismissUserMutation = useMutation(
+    trpc.securityAgent.dismissFinding.mutationOptions({
+      onSuccess: () => {
+        toast.success('Finding dismissed');
+        void queryClient.invalidateQueries();
+        setDismissDialogOpen(false);
+        setDetailDialogOpen(false);
+        setSelectedFinding(null);
       },
       onError: error => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (isGitHubIntegrationError(error)) {
-          onGitHubError?.(message); // Set error at page level
-          toast.error('GitHub Integration Error', {
-            description:
-              'The GitHub App may have been uninstalled. Please check your integrations.',
-          });
-        } else {
-          toast.error('Analysis Failed', {
-            description: message,
-            duration: 8000, // 8 seconds for errors
-          });
-        }
-        setStartingAnalysisId(null);
+        toast.error('Failed to dismiss finding', { description: error.message });
       },
     })
   );
+
+  const handleDismiss = (reason: DismissReason, comment?: string) => {
+    if (!selectedFinding) return;
+    if (isOrg && organizationId) {
+      dismissOrgMutation.mutate({
+        organizationId,
+        findingId: selectedFinding.id,
+        reason,
+        comment,
+      });
+    } else {
+      dismissUserMutation.mutate({
+        findingId: selectedFinding.id,
+        reason,
+        comment,
+      });
+    }
+  };
+
+  const handleRowClick = (finding: SecurityFinding) => {
+    setSelectedFinding(finding);
+    setDetailDialogOpen(true);
+  };
+
+  const handleOpenDismissDialog = () => {
+    setDetailDialogOpen(false);
+    setDismissDialogOpen(true);
+  };
 
   if (isLoading) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Analysis Jobs</CardTitle>
-          <CardDescription>Loading...</CardDescription>
-        </CardHeader>
-      </Card>
+      <div className="flex items-center justify-center py-12">
+        <RefreshCw className="text-muted-foreground h-6 w-6 animate-spin" />
+      </div>
     );
   }
 
-  const jobs = (data?.jobs || []) as AnalysisJob[];
+  const findings = (data?.jobs || []) as SecurityFinding[];
   const total = data?.total || 0;
   const runningCount = data?.runningCount || 0;
   const concurrencyLimit = data?.concurrencyLimit || 3;
   const totalPages = Math.ceil(total / PAGE_SIZE);
-  const hasPrevious = currentPage > 1;
-  const hasNext = currentPage < totalPages;
-
-  if (jobs.length === 0 && currentPage === 1) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Brain className="h-5 w-5" />
-            Analysis Jobs
-          </CardTitle>
-          <CardDescription>No analysis jobs yet</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm">
-            Analysis jobs will appear here when you analyze security findings. Click &quot;Start
-            Analysis&quot; on any finding to begin.
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
+  const startItem = offset + 1;
+  const endItem = Math.min(offset + findings.length, total);
+  const isDismissing = isOrg ? dismissOrgMutation.isPending : dismissUserMutation.isPending;
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle className="flex items-center gap-2">
-              <Brain className="h-5 w-5" />
-              Analysis Jobs
-            </CardTitle>
-            <CardDescription>
-              {total > 0 ? (
-                <>
-                  Showing {offset + 1}-{Math.min(offset + jobs.length, total)} of {total} jobs
-                </>
-              ) : (
-                'No analysis jobs'
-              )}
-            </CardDescription>
+    <div className="space-y-4">
+      {/* Summary bar */}
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-800 bg-gray-900/50 px-4 py-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-5">
+          <span className="text-muted-foreground flex items-center gap-2 text-sm">
+            <Loader2 className="h-4 w-4" />
+            {runningCount} Running
+          </span>
+          <span className="text-muted-foreground flex items-center gap-2 text-sm">
+            <CheckCircle2 className="h-4 w-4" />
+            {findings.filter(f => f.analysis_status === 'completed').length} Completed
+          </span>
+          <span className="text-muted-foreground flex items-center gap-2 text-sm">
+            <XCircle className="h-4 w-4" />
+            {findings.filter(f => f.analysis_status === 'failed').length} Failed
+          </span>
+        </div>
+        <Badge variant={runningCount >= concurrencyLimit ? 'destructive' : 'secondary'}>
+          {runningCount}/{concurrencyLimit} capacity
+        </Badge>
+      </div>
+
+      {/* Rows */}
+      <div className="rounded-lg border border-gray-800">
+        {findings.length === 0 ? (
+          <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
+            <Brain className="mb-2 h-8 w-8 opacity-50" />
+            <p>No analysis jobs yet</p>
+            <p className="mt-1 text-xs">
+              Click &quot;Start Analysis&quot; on any finding to begin.
+            </p>
           </div>
-          {/* Concurrency indicator */}
-          <Badge variant={runningCount >= concurrencyLimit ? 'destructive' : 'secondary'}>
-            {runningCount}/{concurrencyLimit} running
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-3">
-          {jobs.map(job => {
-            const status = job.analysis_status as AnalysisStatus | null;
-            const statusInfo = status ? statusConfig[status] : null;
-            const StatusIcon = statusInfo?.icon || AlertCircle;
-
-            return (
-              <div
-                key={job.id}
-                className="hover:bg-muted/50 flex items-start gap-3 rounded-lg border p-3 transition-colors"
-              >
-                {/* Status Icon */}
-                <div className="mt-1">
-                  <StatusIcon
-                    className={`h-5 w-5 ${status === 'running' ? 'animate-spin' : ''} ${
-                      status === 'completed'
-                        ? 'text-green-500'
-                        : status === 'failed'
-                          ? 'text-red-500'
-                          : 'text-muted-foreground'
-                    }`}
-                  />
-                </div>
-
-                {/* Job Info */}
-                <div className="min-w-0 flex-1 space-y-1">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <Package className="text-muted-foreground h-4 w-4" />
-                        <span className="font-medium">{job.package_name}</span>
-                        <SeverityBadge
-                          severity={job.severity as 'critical' | 'high' | 'medium' | 'low'}
-                        />
-                      </div>
-                      <div className="text-muted-foreground mt-0.5 text-xs">
-                        {job.repo_full_name} • {job.title}
-                      </div>
-                    </div>
-
-                    {/* Status Badge */}
-                    {statusInfo && (
-                      <Badge variant={statusInfo.variant} className="gap-1 whitespace-nowrap">
-                        <StatusIcon
-                          className={`h-3 w-3 ${status === 'running' ? 'animate-spin' : ''}`}
-                        />
-                        {statusInfo.label}
-                      </Badge>
-                    )}
-                  </div>
-
-                  {/* Timestamps */}
-                  <div className="text-muted-foreground flex items-center gap-3 text-xs">
-                    {job.analysis_started_at && (
-                      <span>
-                        Started{' '}
-                        {formatDistanceToNow(new Date(job.analysis_started_at), {
-                          addSuffix: true,
-                        })}
-                      </span>
-                    )}
-                    {/* Only show completed_at when status is completed or failed */}
-                    {job.analysis_completed_at &&
-                      (status === 'completed' || status === 'failed') && (
-                        <span>
-                          Completed{' '}
-                          {formatDistanceToNow(new Date(job.analysis_completed_at), {
-                            addSuffix: true,
-                          })}
-                        </span>
-                      )}
-                  </div>
-
-                  {/* Cloud Agent Session Link */}
-                  {job.cli_session_id && (
-                    <div className="mt-1">
-                      <Link
-                        href={
-                          organizationId
-                            ? `/organizations/${organizationId}/cloud/chat?sessionId=${job.cli_session_id}`
-                            : `/cloud/chat?sessionId=${job.cli_session_id}`
-                        }
-                        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                        View agent session
-                      </Link>
-                    </div>
-                  )}
-
-                  {/* Error Message */}
-                  {job.analysis_error && (
-                    <div className="text-destructive mt-1 text-xs">Error: {job.analysis_error}</div>
-                  )}
-
-                  {/* Analysis Result Summary with Re-run button */}
-                  {status === 'completed' && job.analysis && (
-                    <div className="mt-2 flex items-center gap-2 text-xs">
-                      <Badge variant="outline" className="bg-green-500/20 text-green-400">
-                        Analysis Complete
-                      </Badge>
-                      <span className="text-muted-foreground">
-                        View finding details for full analysis
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setStartingAnalysisId(job.id);
-                          if (isOrg) {
-                            retryOrgMutation.mutate({
-                              organizationId: organizationId,
-                              findingId: job.id,
-                            });
-                          } else {
-                            retryUserMutation.mutate({ findingId: job.id });
-                          }
-                        }}
-                        disabled={startingAnalysisId === job.id || runningCount >= concurrencyLimit}
-                        className="ml-auto gap-1"
-                      >
-                        <RotateCcw
-                          className={`h-3 w-3 ${startingAnalysisId === job.id ? 'animate-spin' : ''}`}
-                        />
-                        {startingAnalysisId === job.id ? 'Starting...' : 'Re-run Analysis'}
-                      </Button>
-                    </div>
-                  )}
-
-                  {/* Retry Button for Failed */}
-                  {status === 'failed' && (
-                    <div className="mt-2 flex items-center gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setStartingAnalysisId(job.id);
-                          if (isOrg) {
-                            retryOrgMutation.mutate({
-                              organizationId: organizationId,
-                              findingId: job.id,
-                            });
-                          } else {
-                            retryUserMutation.mutate({ findingId: job.id });
-                          }
-                        }}
-                        disabled={startingAnalysisId === job.id || runningCount >= concurrencyLimit}
-                        className="gap-2"
-                      >
-                        <RotateCcw
-                          className={`h-3 w-3 ${startingAnalysisId === job.id ? 'animate-spin' : ''}`}
-                        />
-                        {startingAnalysisId === job.id ? 'Starting...' : 'Retry'}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Pagination Controls */}
-        {total > PAGE_SIZE && (
-          <div className="mt-4 flex items-center justify-between border-t pt-4">
-            <div className="text-muted-foreground text-sm">
-              Page {currentPage} of {totalPages}
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
-                disabled={!hasPrevious || isFetching}
-                className="flex items-center gap-1"
-              >
-                <ChevronLeft className="h-4 w-4" />
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setCurrentPage(p => p + 1)}
-                disabled={!hasNext || isFetching}
-                className="flex items-center gap-1"
-              >
-                Next
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
+        ) : (
+          <div className="divide-y divide-gray-800">
+            {findings.map(finding => (
+              <AnalysisJobRow
+                key={finding.id}
+                finding={finding}
+                onRetry={handleRetry}
+                isRetrying={startingAnalysisId === finding.id}
+                retryDisabled={runningCount >= concurrencyLimit}
+                onClick={() => handleRowClick(finding)}
+              />
+            ))}
           </div>
         )}
-      </CardContent>
-    </Card>
+      </div>
+
+      {/* Pagination */}
+      {total > 0 && (
+        <div className="flex flex-wrap items-center justify-between gap-3 pt-2">
+          <p className="text-muted-foreground text-sm">
+            Showing {startItem}–{endItem} of {total}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+              disabled={currentPage <= 1 || isFetching}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Previous
+            </Button>
+            <span className="text-muted-foreground text-sm">
+              Page {currentPage} of {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage(p => p + 1)}
+              disabled={currentPage >= totalPages || isFetching}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Finding Detail Dialog */}
+      <FindingDetailDialog
+        finding={selectedFinding}
+        open={detailDialogOpen}
+        onOpenChange={setDetailDialogOpen}
+        onDismiss={handleOpenDismissDialog}
+        canDismiss={selectedFinding?.status === 'open'}
+        organizationId={organizationId}
+      />
+
+      {/* Dismiss Finding Dialog */}
+      <DismissFindingDialog
+        finding={selectedFinding}
+        open={dismissDialogOpen}
+        onOpenChange={setDismissDialogOpen}
+        onDismiss={handleDismiss}
+        isLoading={isDismissing}
+      />
+    </div>
   );
 }

--- a/src/components/security-agent/AnalysisJobsCard.tsx
+++ b/src/components/security-agent/AnalysisJobsCard.tsx
@@ -211,7 +211,7 @@ export function AnalysisJobsCard({ organizationId, onGitHubError }: AnalysisJobs
     refetchInterval: query => {
       const result = query.state.data;
       if (!result) return false;
-      const findings = (result.jobs || []) as SecurityFinding[];
+      const findings = result.jobs || [];
       const hasActiveJobs = findings.some(f =>
         ['pending', 'running'].includes(f.analysis_status || '')
       );
@@ -255,7 +255,7 @@ export function AnalysisJobsCard({ organizationId, onGitHubError }: AnalysisJobs
   const handleRetry = (findingId: string) => {
     setStartingAnalysisId(findingId);
     // If the finding has triage data, retry only sandbox analysis to avoid redundant triage
-    const jobs = (data?.jobs || []) as SecurityFinding[];
+    const jobs = data?.jobs || [];
     const finding = jobs.find(f => f.id === findingId);
     const retrySandboxOnly = !!finding?.analysis?.triage && finding.analysis_status === 'failed';
     if (isOrg) {
@@ -333,7 +333,7 @@ export function AnalysisJobsCard({ organizationId, onGitHubError }: AnalysisJobs
     );
   }
 
-  const findings = (data?.jobs || []) as SecurityFinding[];
+  const findings = data?.jobs || [];
   const total = data?.total || 0;
   const runningCount = data?.runningCount || 0;
   const concurrencyLimit = data?.concurrencyLimit || 3;

--- a/src/components/security-agent/FindingDetailDialog.tsx
+++ b/src/components/security-agent/FindingDetailDialog.tsx
@@ -116,14 +116,15 @@ export function FindingDetailDialog({
   const isAnalyzing =
     startAnalysisMutation.isPending || analysisStatus === 'pending' || analysisStatus === 'running';
 
-  const handleStartAnalysis = () => {
+  const handleStartAnalysis = ({ retrySandboxOnly }: { retrySandboxOnly?: boolean } = {}) => {
     if (isOrg) {
       startOrgAnalysisMutation.mutate({
         organizationId: organizationId,
         findingId: finding.id,
+        retrySandboxOnly,
       });
     } else {
-      startUserAnalysisMutation.mutate({ findingId: finding.id });
+      startUserAnalysisMutation.mutate({ findingId: finding.id, retrySandboxOnly });
     }
   };
 
@@ -261,6 +262,23 @@ export function FindingDetailDialog({
                   analysis={analysis}
                   showSandboxReasoning={analysisStatus === 'running'}
                 />
+                {/* Show error + retry when triage succeeded but sandbox analysis failed */}
+                {analysisStatus === 'failed' && (
+                  <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3">
+                    <p className="text-sm text-red-400">
+                      Codebase analysis failed: {analysisError || 'Unknown error'}
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleStartAnalysis({ retrySandboxOnly: true })}
+                      disabled={isAnalyzing}
+                      className="mt-2"
+                    >
+                      Retry Analysis
+                    </Button>
+                  </div>
+                )}
                 {cliSessionId && (
                   <div className="mt-2">
                     <Link
@@ -287,7 +305,7 @@ export function FindingDetailDialog({
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={handleStartAnalysis}
+                  onClick={() => handleStartAnalysis()}
                   disabled={isAnalyzing}
                   className="mt-2"
                 >
@@ -332,7 +350,7 @@ export function FindingDetailDialog({
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={handleStartAnalysis}
+                  onClick={() => handleStartAnalysis()}
                   disabled={isAnalyzing}
                 >
                   <Brain className="mr-2 h-4 w-4" />

--- a/src/components/security-agent/SecurityAgentPageClient.tsx
+++ b/src/components/security-agent/SecurityAgentPageClient.tsx
@@ -550,12 +550,12 @@ export function SecurityAgentPageClient({ organizationId, isAdmin }: SecurityAge
   }, []);
 
   const handleStartAnalysis = useCallback(
-    (findingId: string) => {
+    (findingId: string, { retrySandboxOnly }: { retrySandboxOnly?: boolean } = {}) => {
       setStartingAnalysisId(findingId);
       if (isOrg && organizationId) {
-        orgStartAnalysisMutate({ organizationId, findingId });
+        orgStartAnalysisMutate({ organizationId, findingId, retrySandboxOnly });
       } else {
-        personalStartAnalysisMutate({ findingId });
+        personalStartAnalysisMutate({ findingId, retrySandboxOnly });
       }
     },
     [isOrg, organizationId, orgStartAnalysisMutate, personalStartAnalysisMutate]

--- a/src/components/security-agent/SecurityFindingRow.tsx
+++ b/src/components/security-agent/SecurityFindingRow.tsx
@@ -1,14 +1,14 @@
 'use client';
 
+import { differenceInDays, differenceInHours, isPast } from 'date-fns';
+import { Brain, CheckCircle2, ChevronRight, Clock, Package } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { SeverityBadge } from './SeverityBadge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import type { SecurityFinding } from '@/db/schema';
+import { cn } from '@/lib/utils';
 import { AnalysisStatusBadge } from './AnalysisStatusBadge';
 import { FindingStatusBadge } from './FindingStatusBadge';
-import { ExploitabilityBadge } from './ExploitabilityBadge';
-import { cn } from '@/lib/utils';
-import { formatDistanceToNow, isPast } from 'date-fns';
-import { ExternalLink, Package, Clock, CheckCircle2, Brain, Loader2 } from 'lucide-react';
-import type { SecurityFinding } from '@/db/schema';
+import { SeverityBadge } from './SeverityBadge';
 
 type Severity = 'critical' | 'high' | 'medium' | 'low';
 
@@ -19,21 +19,29 @@ function isSeverity(value: string): value is Severity {
 type SecurityFindingRowProps = {
   finding: SecurityFinding;
   onClick: () => void;
-  onStartAnalysis?: (findingId: string) => void;
+  onStartAnalysis?: (findingId: string, options?: { retrySandboxOnly?: boolean }) => void;
   isStartingAnalysis?: boolean;
 };
+
+function formatCompactDistance(date: Date) {
+  const now = new Date();
+  const days = Math.abs(differenceInDays(now, date));
+  if (days >= 1) return `${days}d`;
+  const hours = Math.abs(differenceInHours(now, date));
+  return `${hours}h`;
+}
 
 function getSlaStatus(slaDueAt: string | null, status: string) {
   if (status !== 'open' || !slaDueAt) return null;
 
   const dueDate = new Date(slaDueAt);
-  const isOverdue = isPast(dueDate);
+  const compact = formatCompactDistance(dueDate);
 
-  if (isOverdue) {
+  if (isPast(dueDate)) {
     return (
       <span className="flex items-center gap-1 text-xs text-red-400">
         <Clock className="h-3 w-3" />
-        {formatDistanceToNow(dueDate)} overdue
+        {compact} overdue
       </span>
     );
   }
@@ -41,7 +49,7 @@ function getSlaStatus(slaDueAt: string | null, status: string) {
   return (
     <span className="text-muted-foreground flex items-center gap-1 text-xs">
       <Clock className="h-3 w-3" />
-      Due in {formatDistanceToNow(dueDate)}
+      Due {compact}
     </span>
   );
 }
@@ -53,73 +61,90 @@ export function SecurityFindingRow({
   isStartingAnalysis,
 }: SecurityFindingRowProps) {
   const severity: Severity = isSeverity(finding.severity) ? finding.severity : 'medium';
-  const hasAnalysis = !!finding.analysis_status;
   const canStartAnalysis =
-    finding.status === 'open' && !hasAnalysis && onStartAnalysis && !isStartingAnalysis;
+    finding.status === 'open' &&
+    (!finding.analysis_status || finding.analysis_status === 'failed') &&
+    onStartAnalysis &&
+    !isStartingAnalysis;
 
   const handleStartAnalysis = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (onStartAnalysis) {
-      onStartAnalysis(finding.id);
+      const retrySandboxOnly = !!finding.analysis?.triage && finding.analysis_status === 'failed';
+      onStartAnalysis(finding.id, { retrySandboxOnly });
     }
   };
 
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       className={cn(
-        'hover:bg-muted/50 cursor-pointer rounded-lg border p-4 transition-colors',
+        'hover:bg-muted/50 grid w-full cursor-pointer grid-cols-[96px_1fr_80px_100px_16px] items-center gap-x-1.5 px-4 py-3 text-left transition-colors',
         finding.status === 'open' && finding.sla_due_at && isPast(new Date(finding.sla_due_at))
-          ? 'border-red-500/30'
+          ? 'bg-red-500/5'
           : ''
       )}
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1 space-y-2">
-          <div className="flex items-center gap-2">
-            <h4 className="truncate font-medium">{finding.title}</h4>
-            <SeverityBadge severity={severity} size="sm" />
-          </div>
+      {/* Severity */}
+      <div>
+        <SeverityBadge severity={severity} size="sm" />
+      </div>
 
-          <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-sm">
-            <span className="flex items-center gap-1">
-              <Package className="h-3 w-3" />
-              {finding.package_name}
+      {/* Title + package */}
+      <div className="min-w-0">
+        <h4 className="truncate text-sm font-medium">{finding.title}</h4>
+        <span className="text-muted-foreground mt-0.5 flex items-center gap-1 text-xs">
+          <Package className="h-3 w-3" />
+          {finding.package_name}
+        </span>
+      </div>
+
+      {/* Status + SLA/Fixed */}
+      <div className="text-xs">
+        <FindingStatusBadge status={finding.status} />
+        <div className="mt-1">
+          {getSlaStatus(finding.sla_due_at, finding.status)}
+          {finding.status === 'fixed' && finding.fixed_at && (
+            <span className="flex items-center gap-1 text-xs text-green-400">
+              <CheckCircle2 className="h-3 w-3" />
+              {formatCompactDistance(new Date(finding.fixed_at))} ago
             </span>
-            <span>•</span>
-            <span>{finding.package_ecosystem}</span>
-            <span>•</span>
-            <span>{finding.repo_full_name}</span>
-            {finding.cve_id && (
-              <>
-                <span>•</span>
-                <span className="font-mono text-xs">{finding.cve_id}</span>
-              </>
-            )}
-            {!finding.cve_id && finding.ghsa_id && (
-              <>
-                <span>•</span>
-                <span className="font-mono text-xs">{finding.ghsa_id}</span>
-              </>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            {getSlaStatus(finding.sla_due_at, finding.status)}
-            {finding.status === 'fixed' && finding.fixed_at && (
-              <span className="flex items-center gap-1 text-xs text-green-400">
-                <CheckCircle2 className="h-3 w-3" />
-                Fixed {formatDistanceToNow(new Date(finding.fixed_at), { addSuffix: true })}
-              </span>
-            )}
-            <AnalysisStatusBadge status={finding.analysis_status} isStarting={isStartingAnalysis} />
-            <ExploitabilityBadge analysis={finding.analysis} size="sm" />
-          </div>
+          )}
         </div>
+      </div>
 
-        <div className="flex flex-col items-end gap-2">
-          <FindingStatusBadge status={finding.status} />
-          {canStartAnalysis && (
+      {/* Analysis */}
+      <div className="flex items-center justify-end">
+        {canStartAnalysis ? (
+          finding.analysis_status === 'failed' ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleStartAnalysis}
+                  disabled={isStartingAnalysis}
+                  className="gap-1 border-yellow-500/30 text-yellow-400 hover:bg-yellow-500/10"
+                >
+                  <Brain className="h-3 w-3" />
+                  Retry
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {finding.analysis_error ||
+                  finding.analysis?.triage?.needsSandboxReasoning ||
+                  'Analysis failed'}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
             <Button
               variant="outline"
               size="sm"
@@ -127,28 +152,17 @@ export function SecurityFindingRow({
               disabled={isStartingAnalysis}
               className="gap-1"
             >
-              {isStartingAnalysis ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <Brain className="h-3 w-3" />
-              )}
+              <Brain className="h-3 w-3" />
               Analyze
             </Button>
-          )}
-          {finding.dependabot_html_url && (
-            <a
-              href={finding.dependabot_html_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={e => e.stopPropagation()}
-              className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
-            >
-              <ExternalLink className="h-3 w-3" />
-              View on GitHub
-            </a>
-          )}
-        </div>
+          )
+        ) : (
+          <AnalysisStatusBadge status={finding.analysis_status} isStarting={isStartingAnalysis} />
+        )}
       </div>
+
+      {/* Detail chevron */}
+      <ChevronRight className="text-muted-foreground h-4 w-4" />
     </div>
   );
 }

--- a/src/components/security-agent/SecurityFindingRow.tsx
+++ b/src/components/security-agent/SecurityFindingRow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { differenceInDays, differenceInHours, isPast } from 'date-fns';
+import { differenceInDays, differenceInHours, differenceInMinutes, isPast } from 'date-fns';
 import { Brain, CheckCircle2, ChevronRight, Clock, Package } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -28,7 +28,9 @@ function formatCompactDistance(date: Date) {
   const days = Math.abs(differenceInDays(now, date));
   if (days >= 1) return `${days}d`;
   const hours = Math.abs(differenceInHours(now, date));
-  return `${hours}h`;
+  if (hours >= 1) return `${hours}h`;
+  const minutes = Math.abs(differenceInMinutes(now, date));
+  return `${minutes}m`;
 }
 
 function getSlaStatus(slaDueAt: string | null, status: string) {

--- a/src/components/security-agent/SecurityFindingsCard.tsx
+++ b/src/components/security-agent/SecurityFindingsCard.tsx
@@ -1,5 +1,17 @@
 'use client';
 
+import { formatDistanceToNow } from 'date-fns';
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Loader2,
+  RefreshCw,
+  Settings2,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -8,21 +20,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { SecurityFindingRow } from './SecurityFindingRow';
-import { RepositoryFilter } from './RepositoryFilter';
-import {
-  RefreshCw,
-  ChevronLeft,
-  ChevronRight,
-  AlertTriangle,
-  CheckCircle2,
-  Loader2,
-  AlertCircle,
-  Settings2,
-  Clock,
-} from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
 import type { SecurityFinding } from '@/db/schema';
+import { RepositoryFilter } from './RepositoryFilter';
+import { SecurityFindingRow } from './SecurityFindingRow';
 
 type Repository = {
   id: number;
@@ -74,7 +74,7 @@ type SecurityFindingsCardProps = {
   hasIntegration: boolean;
   onEnableClick: () => void;
   lastSyncTime?: string | null;
-  onStartAnalysis?: (findingId: string) => void;
+  onStartAnalysis?: (findingId: string, options?: { retrySandboxOnly?: boolean }) => void;
   startingAnalysisId?: string | null;
   isAdmin: boolean;
 };
@@ -188,7 +188,10 @@ export function SecurityFindingsCard({
             {lastSyncTime && (
               <span className="text-muted-foreground flex items-center gap-1 text-xs">
                 <Clock className="h-3 w-3" />
-                Last synced {formatDistanceToNow(new Date(lastSyncTime), { addSuffix: true })}
+                Last synced{' '}
+                {formatDistanceToNow(new Date(lastSyncTime), {
+                  addSuffix: true,
+                })}
               </span>
             )}
             {isAdmin && (

--- a/src/lib/security-agent/core/schemas.ts
+++ b/src/lib/security-agent/core/schemas.ts
@@ -234,7 +234,6 @@ export const AnalysisResponseLegacySchema = z.object({
 export const StartAnalysisInputSchema = z.object({
   findingId: z.string().uuid(),
   model: z.string().optional(),
-  forceSandbox: z.boolean().optional(), // Skip triage decision, always run sandbox
   retrySandboxOnly: z.boolean().optional(), // Skip triage, reuse existing triage data, retry only sandbox
 });
 

--- a/src/lib/security-agent/core/schemas.ts
+++ b/src/lib/security-agent/core/schemas.ts
@@ -234,6 +234,8 @@ export const AnalysisResponseLegacySchema = z.object({
 export const StartAnalysisInputSchema = z.object({
   findingId: z.string().uuid(),
   model: z.string().optional(),
+  forceSandbox: z.boolean().optional(), // Skip triage decision, always run sandbox
+  retrySandboxOnly: z.boolean().optional(), // Skip triage, reuse existing triage data, retry only sandbox
 });
 
 /**

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -19,7 +19,12 @@ import {
 import { generateApiToken } from '@/lib/tokens';
 import { getSecurityFindingById } from '../db/security-findings';
 import { updateAnalysisStatus } from '../db/security-analysis';
-import type { AnalysisMode, SecurityFindingAnalysis, SecurityReviewOwner } from '../core/types';
+import type {
+  AnalysisMode,
+  SecurityFindingAnalysis,
+  SecurityFindingTriage,
+  SecurityReviewOwner,
+} from '../core/types';
 import type { User, SecurityFinding } from '@/db/schema';
 import {
   trackSecurityAgentAnalysisStarted,
@@ -243,6 +248,8 @@ export async function startSecurityAnalysis(params: {
   githubToken?: string;
   model?: string;
   analysisMode?: AnalysisMode;
+  forceSandbox?: boolean;
+  retrySandboxOnly?: boolean;
   organizationId?: string;
 }): Promise<{ started: boolean; error?: string; triageOnly?: boolean }> {
   const {
@@ -252,6 +259,8 @@ export async function startSecurityAnalysis(params: {
     githubToken,
     model = 'anthropic/claude-sonnet-4',
     analysisMode = 'auto',
+    forceSandbox = false,
+    retrySandboxOnly = false,
     organizationId,
   } = params;
 
@@ -268,8 +277,25 @@ export async function startSecurityAnalysis(params: {
     return { started: false, error: 'Analysis already in progress' };
   }
 
-  // Mark as pending
-  await updateAnalysisStatus(findingId, 'pending');
+  // When retrying sandbox only, preserve existing triage data
+  const existingTriage = retrySandboxOnly ? finding.analysis?.triage : undefined;
+  if (retrySandboxOnly && !existingTriage) {
+    log('retrySandboxOnly requested but no existing triage found, falling back to full analysis', {
+      correlationId,
+      findingId,
+    });
+  }
+  const skipTriage = retrySandboxOnly && !!existingTriage;
+
+  // Mark as pending, preserving existing analysis (with triage) when retrying sandbox only.
+  // Coerce null → undefined so updateAnalysisStatus treats it as "not provided" and
+  // does not overwrite the analysis column with null (its `status === 'pending'` branch
+  // only clears `analysis` when `updates.analysis === undefined`).
+  if (skipTriage) {
+    await updateAnalysisStatus(findingId, 'pending', { analysis: finding.analysis ?? undefined });
+  } else {
+    await updateAnalysisStatus(findingId, 'pending');
+  }
 
   const analysisStartTime = Date.now();
 
@@ -277,57 +303,84 @@ export async function startSecurityAnalysis(params: {
     // Generate auth token for LLM calls
     const authToken = generateApiToken(user);
 
-    // =========================================================================
-    // Tier 1: Quick Triage (always runs)
-    // =========================================================================
-    log('Starting Tier 1 triage', { correlationId, findingId, model });
+    let triage: SecurityFindingTriage;
 
-    trackSecurityAgentAnalysisStarted({
-      distinctId: user.id,
-      userId: user.id,
-      organizationId,
-      findingId,
-      model,
-      analysisMode,
-    });
-
-    const tier1Start = performance.now();
-    const triage = await triageSecurityFinding({
-      finding,
-      authToken,
-      model,
-      correlationId,
-      userId: user.id,
-      organizationId,
-    });
-    const tier1DurationMs = Math.round(performance.now() - tier1Start);
-
-    log('Triage complete', {
-      correlationId,
-      findingId,
-      durationMs: tier1DurationMs,
-      suggestedAction: triage.suggestedAction,
-      confidence: triage.confidence,
-      needsSandboxAnalysis: triage.needsSandboxAnalysis,
-    });
-
-    addBreadcrumb({
-      category: 'security-agent.triage',
-      message: `Triage outcome: ${triage.suggestedAction}`,
-      level: 'info',
-      data: {
+    if (skipTriage) {
+      // =========================================================================
+      // Reuse existing triage (sandbox-only retry)
+      // =========================================================================
+      triage = existingTriage;
+      log('Skipping Tier 1 triage, reusing existing triage for sandbox retry', {
         correlationId,
         findingId,
         suggestedAction: triage.suggestedAction,
         confidence: triage.confidence,
-        needsSandbox: triage.needsSandboxAnalysis,
-        durationMs: tier1DurationMs,
-      },
-    });
+      });
 
-    // Decide whether to run sandbox analysis based on analysis mode
+      trackSecurityAgentAnalysisStarted({
+        distinctId: user.id,
+        userId: user.id,
+        organizationId,
+        findingId,
+        model,
+        analysisMode,
+      });
+    } else {
+      // =========================================================================
+      // Tier 1: Quick Triage (always runs)
+      // =========================================================================
+      log('Starting Tier 1 triage', { correlationId, findingId, model });
+
+      trackSecurityAgentAnalysisStarted({
+        distinctId: user.id,
+        userId: user.id,
+        organizationId,
+        findingId,
+        model,
+        analysisMode,
+      });
+
+      const tier1Start = performance.now();
+      triage = await triageSecurityFinding({
+        finding,
+        authToken,
+        model,
+        correlationId,
+        userId: user.id,
+        organizationId,
+      });
+      const tier1DurationMs = Math.round(performance.now() - tier1Start);
+
+      log('Triage complete', {
+        correlationId,
+        findingId,
+        durationMs: tier1DurationMs,
+        suggestedAction: triage.suggestedAction,
+        confidence: triage.confidence,
+        needsSandboxAnalysis: triage.needsSandboxAnalysis,
+      });
+
+      addBreadcrumb({
+        category: 'security-agent.triage',
+        message: `Triage outcome: ${triage.suggestedAction}`,
+        level: 'info',
+        data: {
+          correlationId,
+          findingId,
+          suggestedAction: triage.suggestedAction,
+          confidence: triage.confidence,
+          needsSandbox: triage.needsSandboxAnalysis,
+          durationMs: tier1DurationMs,
+        },
+      });
+    }
+
+    // Decide whether to run sandbox analysis based on analysis mode and per-request overrides
     const runSandbox =
-      analysisMode === 'deep' || (analysisMode === 'auto' && triage.needsSandboxAnalysis);
+      forceSandbox ||
+      skipTriage ||
+      analysisMode === 'deep' ||
+      (analysisMode === 'auto' && triage.needsSandboxAnalysis);
 
     if (!runSandbox) {
       // =========================================================================

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -709,6 +709,8 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           githubToken,
           model,
           analysisMode,
+          forceSandbox: input.forceSandbox,
+          retrySandboxOnly: input.retrySandboxOnly,
           organizationId: input.organizationId,
         });
       } catch (error) {

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -709,7 +709,6 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           githubToken,
           model,
           analysisMode,
-          forceSandbox: input.forceSandbox,
           retrySandboxOnly: input.retrySandboxOnly,
           organizationId: input.organizationId,
         });

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -683,6 +683,8 @@ export const securityAgentRouter = createTRPCRouter({
         githubToken,
         model,
         analysisMode,
+        forceSandbox: input.forceSandbox,
+        retrySandboxOnly: input.retrySandboxOnly,
         // Personal user - no organizationId
       });
     } catch (error) {

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -683,7 +683,6 @@ export const securityAgentRouter = createTRPCRouter({
         githubToken,
         model,
         analysisMode,
-        forceSandbox: input.forceSandbox,
         retrySandboxOnly: input.retrySandboxOnly,
         // Personal user - no organizationId
       });


### PR DESCRIPTION
## Summary

- Redesign AnalysisJobsCard and SecurityFindingRow from card-based layouts to compact grid/table layouts with summary bar, compact timestamps, and keyboard accessibility
- Integrate FindingDetailDialog and DismissFindingDialog directly into AnalysisJobsCard, removing the need for the parent to wire them up
- When triage succeeds but sandbox analysis fails, show the error message and a "Retry Analysis" button in the finding detail dialog
- Add `retrySandboxOnly` API parameter so retries skip redundant triage and go straight to sandbox analysis, reusing existing triage data (falls back to full analysis if no prior triage exists)

## Details

The AnalysisJobsCard was previously a Card component rendering each job as a bordered item with multiple sections. It is now a flat list of grid rows with a summary bar showing running/completed/failed counts. Each row is clickable and opens the FindingDetailDialog directly.

SecurityFindingRow was similarly refactored to a 5-column grid layout matching the new AnalysisJobsCard rows, with failed findings showing a "Retry" button (with tooltip showing the error) instead of "Analyze".

The retry optimization (`retrySandboxOnly`) applies across all surfaces: finding detail dialog, findings list row, and analysis jobs card.

Also includes an unrelated fix in cloud-agent-next to return an actionable error when `NEXTAUTH_SECRET` is not configured.

## Screenshots

| Before | After |
|--------|--------|
| <img width="2026" height="2098" alt="20260224-135136@2x" src="https://github.com/user-attachments/assets/c0d7db00-ea4e-4d88-8332-0f586f383369" /> | <img width="2210" height="2148" alt="20260224-124559@2x" src="https://github.com/user-attachments/assets/f5088874-3b81-4623-8d72-42b53a9e6459" /> |
| <img width="2196" height="2248" alt="20260223-235706@2x" src="https://github.com/user-attachments/assets/a018642f-a1e3-40b2-bb1f-70c0bc06b05d" /> | <img width="2232" height="1022" alt="20260224-124609@2x" src="https://github.com/user-attachments/assets/6d9dcb3d-e234-4033-8db5-a035172c7f4d" /> |