### PR TITLE
nit: add trailing comma to VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "vitest.disableWorkspaceWarning": true
 }


### PR DESCRIPTION
This change keeps popping up locally for me, so I think it is something new in the latest VS Code?