### PR TITLE
refactor: extract shared bot run loop

### DIFF
--- a/src/lib/bots/core/run-bot.ts
+++ b/src/lib/bots/core/run-bot.ts
@@ -1,0 +1,190 @@
+import type OpenAI from 'openai';
+import type { FeatureValue } from '@/lib/feature-detection';
+import { sendProxiedChatCompletion } from '@/lib/llm-proxy-helpers';
+import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter/types';
+
+type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+type ChatCompletionResponse = OpenAI.Chat.Completions.ChatCompletion;
+type ToolCall = OpenAI.Chat.Completions.ChatCompletionMessageToolCall;
+
+export type BotToolResult = {
+  content: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type BotRunInput = {
+  authToken: string;
+  model: string;
+  systemPrompt: string;
+  userMessage: string;
+  tools?: OpenAI.Chat.Completions.ChatCompletionTool[];
+  toolExecutor?: (toolCall: ToolCall) => Promise<BotToolResult>;
+  onToolResult?: (toolCall: ToolCall, result: BotToolResult) => void | Promise<void>;
+  maxIterations?: number;
+  logPrefix?: string;
+  requestOptions: {
+    version: string;
+    userAgent: string;
+    organizationId?: string;
+    feature?: FeatureValue;
+  };
+};
+
+export type BotRunResult = {
+  response: string;
+  toolCallsMade: string[];
+  error?: string;
+};
+
+export async function runBot(input: BotRunInput): Promise<BotRunResult> {
+  const logPrefix = input.logPrefix ?? '[BotEngine]';
+  const toolCallsMade: string[] = [];
+  const messages: ChatMessage[] = [
+    {
+      role: 'system',
+      content: input.systemPrompt,
+    },
+    {
+      role: 'user',
+      content: input.userMessage,
+    },
+  ];
+
+  let finalResponse: string | null = null;
+  let errorMessage: string | undefined;
+  const maxIterations = input.maxIterations ?? 5;
+  let iteration = 0;
+
+  while (finalResponse === null && iteration < maxIterations) {
+    iteration++;
+    console.log(`${logPrefix} Tool loop iteration ${iteration}/${maxIterations}`);
+    console.log(`${logPrefix} Sending request to chat completions endpoint...`);
+
+    const body: OpenRouterChatCompletionRequest = {
+      model: input.model,
+      messages,
+    };
+
+    if (input.tools && input.tools.length > 0) {
+      body.tools = input.tools;
+      body.tool_choice = 'auto';
+    }
+
+    const result = await sendProxiedChatCompletion<ChatCompletionResponse>({
+      authToken: input.authToken,
+      version: input.requestOptions.version,
+      userAgent: input.requestOptions.userAgent,
+      body,
+      organizationId: input.requestOptions.organizationId,
+      feature: input.requestOptions.feature,
+    });
+
+    if (!result.ok) {
+      console.error(`${logPrefix} API error response:`, result.error);
+      finalResponse = `Sorry, there was an error calling the AI service (${result.status}): ${result.error.slice(0, 200)}`;
+      break;
+    }
+
+    const responseBody = result.data;
+    console.log(`${logPrefix} Response body parsed, choices count:`, responseBody.choices?.length);
+    const choice = responseBody.choices?.[0];
+
+    if (!choice) {
+      console.log(
+        `${logPrefix} No choice in response, response body:`,
+        JSON.stringify(responseBody)
+      );
+      finalResponse = 'Sorry, I could not generate a response.';
+      errorMessage = 'No choice in OpenRouter response';
+      break;
+    }
+
+    const message = choice.message;
+    console.log(
+      `${logPrefix} Message received - content length:`,
+      message.content?.length,
+      'tool_calls:',
+      message.tool_calls?.length || 0
+    );
+    console.log(`${logPrefix} Message content preview:`, message.content?.slice(0, 200));
+
+    if (message.tool_calls && message.tool_calls.length > 0) {
+      console.log(`${logPrefix} Tool calls detected:`, message.tool_calls.length);
+
+      messages.push({
+        role: 'assistant',
+        content: message.content,
+        tool_calls: message.tool_calls,
+      });
+      console.log(
+        `${logPrefix} Added assistant message to history, total messages:`,
+        messages.length
+      );
+
+      if (!input.toolExecutor) {
+        errorMessage = 'Tool call received without an executor';
+        finalResponse = 'Sorry, I could not process that request.';
+        break;
+      }
+
+      for (const toolCall of message.tool_calls) {
+        console.log(
+          `${logPrefix} Processing tool call:`,
+          toolCall.type,
+          toolCall.type === 'function' ? toolCall.function.name : 'N/A'
+        );
+
+        if (toolCall.type !== 'function') {
+          console.log(`${logPrefix} Skipping non-function tool call`);
+          continue;
+        }
+
+        toolCallsMade.push(toolCall.function.name);
+
+        try {
+          const toolResult = await input.toolExecutor(toolCall);
+          if (input.onToolResult) {
+            await input.onToolResult(toolCall, toolResult);
+          }
+
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolCall.id,
+            content: toolResult.content,
+          });
+          console.log(
+            `${logPrefix} Added tool result to history, total messages:`,
+            messages.length
+          );
+        } catch (error) {
+          const errMsg = error instanceof Error ? error.message : String(error);
+          console.error(`${logPrefix} Error executing tool:`, errMsg, error);
+          errorMessage = errMsg;
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolCall.id,
+            content: `Error executing tool: ${errMsg}`,
+          });
+        }
+      }
+    } else {
+      console.log(`${logPrefix} No tool calls, setting final response`);
+      finalResponse = message.content ?? 'Sorry, I could not generate a response.';
+    }
+  }
+
+  if (finalResponse === null) {
+    console.log(`${logPrefix} Max iterations reached, setting timeout message`);
+    finalResponse = 'Sorry, the request took too long to process.';
+    errorMessage = 'Max iterations reached';
+  }
+
+  console.log(`${logPrefix} Final response length:`, finalResponse.length);
+  console.log(`${logPrefix} Final response preview:`, finalResponse.slice(0, 500));
+
+  return {
+    response: finalResponse,
+    toolCallsMade,
+    error: errorMessage,
+  };
+}

--- a/src/lib/bots/core/run-bot.ts
+++ b/src/lib/bots/core/run-bot.ts
@@ -9,7 +9,6 @@ type ToolCall = OpenAI.Chat.Completions.ChatCompletionMessageToolCall;
 
 export type BotToolResult = {
   content: string;
-  metadata?: Record<string, unknown>;
 };
 
 export type BotRunInput = {

--- a/src/lib/bots/core/run-bot.ts
+++ b/src/lib/bots/core/run-bot.ts
@@ -19,7 +19,6 @@ export type BotRunInput = {
   userMessage: string;
   tools?: OpenAI.Chat.Completions.ChatCompletionTool[];
   toolExecutor: (toolCall: ToolCall) => Promise<BotToolResult>;
-  onToolResult?: (toolCall: ToolCall, result: BotToolResult) => void | Promise<void>;
   maxIterations?: number;
   logPrefix?: string;
   requestOptions: {
@@ -128,19 +127,12 @@ export async function runBot(input: BotRunInput): Promise<BotRunResult> {
           toolCall.type === 'function' ? toolCall.function.name : 'N/A'
         );
 
-        if (toolCall.type !== 'function') {
-          console.log(`${logPrefix} Skipping non-function tool call`);
-          continue;
-        }
-
-        toolCallsMade.push(toolCall.function.name);
+        toolCallsMade.push(
+          toolCall.type === 'custom' ? toolCall.custom.name : toolCall.function.name
+        );
 
         try {
           const toolResult = await input.toolExecutor(toolCall);
-          if (input.onToolResult) {
-            await input.onToolResult(toolCall, toolResult);
-          }
-
           messages.push({
             role: 'tool',
             tool_call_id: toolCall.id,

--- a/src/lib/bots/core/run-bot.ts
+++ b/src/lib/bots/core/run-bot.ts
@@ -126,9 +126,7 @@ export async function runBot(input: BotRunInput): Promise<BotRunResult> {
           toolCall.type === 'function' ? toolCall.function.name : 'N/A'
         );
 
-        toolCallsMade.push(
-          toolCall.type === 'custom' ? toolCall.custom.name : toolCall.function.name
-        );
+        toolCallsMade.push(toolCall.type === 'function' ? toolCall.function.name : 'N/A');
 
         try {
           const toolResult = await input.toolExecutor(toolCall);

--- a/src/lib/bots/core/run-bot.ts
+++ b/src/lib/bots/core/run-bot.ts
@@ -18,7 +18,7 @@ export type BotRunInput = {
   systemPrompt: string;
   userMessage: string;
   tools?: OpenAI.Chat.Completions.ChatCompletionTool[];
-  toolExecutor?: (toolCall: ToolCall) => Promise<BotToolResult>;
+  toolExecutor: (toolCall: ToolCall) => Promise<BotToolResult>;
   onToolResult?: (toolCall: ToolCall, result: BotToolResult) => void | Promise<void>;
   maxIterations?: number;
   logPrefix?: string;
@@ -120,12 +120,6 @@ export async function runBot(input: BotRunInput): Promise<BotRunResult> {
         `${logPrefix} Added assistant message to history, total messages:`,
         messages.length
       );
-
-      if (!input.toolExecutor) {
-        errorMessage = 'Tool call received without an executor';
-        finalResponse = 'Sorry, I could not process that request.';
-        break;
-      }
 
       for (const toolCall of message.tool_calls) {
         console.log(

--- a/src/lib/slack-bot.ts
+++ b/src/lib/slack-bot.ts
@@ -477,17 +477,12 @@ export async function processKiloBotMessage(
       );
       console.log('[SlackBot] Tool result received, length:', toolResult.response.length);
       console.log('[SlackBot] Tool result preview:', toolResult.response.slice(0, 100));
+      cloudAgentSessionId = toolResult.sessionId;
 
       return {
         content: toolResult.response,
         metadata: toolResult.sessionId ? { cloudAgentSessionId: toolResult.sessionId } : undefined,
       };
-    },
-    onToolResult: (_toolCall, result) => {
-      const sessionId = result.metadata?.cloudAgentSessionId;
-      if (typeof sessionId === 'string') {
-        cloudAgentSessionId = sessionId;
-      }
     },
   });
 

--- a/src/lib/slack-bot.ts
+++ b/src/lib/slack-bot.ts
@@ -15,7 +15,7 @@ import {
   getAccessTokenFromInstallation,
 } from '@/lib/integrations/slack-service';
 import type { PlatformIntegration } from '@/db/schema';
-import { sendProxiedChatCompletion } from '@/lib/llm-proxy-helpers';
+import { runBot } from '@/lib/bots/core/run-bot';
 import {
   formatGitHubRepositoriesForPrompt,
   getGitHubRepositoryContext,
@@ -329,9 +329,6 @@ async function spawnCloudAgentSession(
   return { response: fallbackResult, sessionId };
 }
 
-type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
-type ChatCompletionResponse = OpenAI.Chat.Completions.ChatCompletion;
-
 /**
  * Process a Kilo Bot message and return the response with metadata.
  * This is the main entry point for generating AI responses with tool support.
@@ -347,7 +344,6 @@ export async function processKiloBotMessage(
   console.log('[SlackBot] Looking up Slack integration for team:', teamId);
 
   // Track metadata for logging
-  const toolCallsMade: string[] = [];
   let cloudAgentSessionId: string | undefined;
 
   // Look up the Slack integration to find the owner
@@ -440,172 +436,67 @@ export async function processKiloBotMessage(
   const systemPrompt =
     KILO_BOT_SYSTEM_PROMPT + slackContextForPrompt + formatGitHubRepositoriesForPrompt(repoContext);
 
-  // Build initial messages array
-  const messages: ChatMessage[] = [
-    {
-      role: 'system',
-      content: systemPrompt,
-    },
-    {
-      role: 'user',
-      content: userMessage,
-    },
-  ];
-
-  // Tool calling loop - keep calling until we get a final response
-  let finalResponse: string | null = null;
-  let errorMessage: string | undefined;
-  const maxIterations = 5; // Prevent infinite loops
-  let iteration = 0;
-
-  while (finalResponse === null && iteration < maxIterations) {
-    iteration++;
-    console.log(`[SlackBot] Tool loop iteration ${iteration}/${maxIterations}`);
-
-    console.log('[SlackBot] Sending request to chat completions endpoint...');
-    const result = await sendProxiedChatCompletion<ChatCompletionResponse>({
-      authToken,
+  const runResult = await runBot({
+    authToken,
+    model: selectedModel,
+    systemPrompt,
+    userMessage,
+    tools: [SPAWN_CLOUD_AGENT_TOOL],
+    logPrefix: '[SlackBot]',
+    requestOptions: {
       version: SLACK_BOT_VERSION,
       userAgent: SLACK_BOT_USER_AGENT,
-      body: {
-        model: selectedModel,
-        messages,
-        tools: [SPAWN_CLOUD_AGENT_TOOL],
-        tool_choice: 'auto',
-      },
       organizationId: owner.type === 'org' ? owner.id : undefined,
       feature: 'slack',
-    });
-
-    if (!result.ok) {
-      console.error('[SlackBot] API error response:', result.error);
-      finalResponse = `Sorry, there was an error calling the AI service (${result.status}): ${result.error.slice(0, 200)}`;
-      break;
-    }
-
-    const responseBody = result.data;
-    console.log('[SlackBot] Response body parsed, choices count:', responseBody.choices?.length);
-    const choice = responseBody.choices?.[0];
-
-    if (!choice) {
-      console.log('[SlackBot] No choice in response, response body:', JSON.stringify(responseBody));
-      finalResponse = 'Sorry, I could not generate a response.';
-      errorMessage = 'No choice in OpenRouter response';
-      break;
-    }
-
-    const message = choice.message;
-    console.log(
-      '[SlackBot] Message received - content length:',
-      message.content?.length,
-      'tool_calls:',
-      message.tool_calls?.length || 0
-    );
-    console.log('[SlackBot] Message content preview:', message.content?.slice(0, 200));
-
-    // Check if the assistant wants to call a tool
-    if (message.tool_calls && message.tool_calls.length > 0) {
-      console.log('[SlackBot] Tool calls detected:', message.tool_calls.length);
-
-      // Add assistant message to conversation history
-      messages.push({
-        role: 'assistant',
-        content: message.content,
-        tool_calls: message.tool_calls,
-      });
-      console.log(
-        '[SlackBot] Added assistant message to history, total messages:',
-        messages.length
-      );
-
-      // Process each tool call
-      for (const toolCall of message.tool_calls) {
-        console.log(
-          '[SlackBot] Processing tool call:',
-          toolCall.type,
-          toolCall.type === 'function' ? toolCall.function.name : 'N/A'
-        );
-
-        // Skip non-function tool calls
-        if (toolCall.type !== 'function') {
-          console.log('[SlackBot] Skipping non-function tool call');
-          continue;
-        }
-
-        // Track the tool call
-        toolCallsMade.push(toolCall.function.name);
-
-        if (toolCall.function.name === 'spawn_cloud_agent') {
-          console.log(
-            '[SlackBot] spawn_cloud_agent tool call - arguments:',
-            toolCall.function.arguments
-          );
-          try {
-            const args = JSON.parse(toolCall.function.arguments);
-            console.log('[SlackBot] Parsed tool arguments:', JSON.stringify(args, null, 2));
-
-            console.log('[SlackBot] Calling spawnCloudAgentSession...');
-            const toolResult = await spawnCloudAgentSession(
-              args,
-              owner,
-              selectedModel,
-              authToken,
-              slackRequesterInfo
-            );
-            console.log('[SlackBot] Tool result received, length:', toolResult.response.length);
-            console.log('[SlackBot] Tool result preview:', toolResult.response.slice(0, 100));
-
-            // Track the cloud agent session ID
-            if (toolResult.sessionId) {
-              cloudAgentSessionId = toolResult.sessionId;
-            }
-
-            // Add tool result to conversation history
-            messages.push({
-              role: 'tool',
-              tool_call_id: toolCall.id,
-              content: toolResult.response,
-            });
-            console.log(
-              '[SlackBot] Added tool result to history, total messages:',
-              messages.length
-            );
-          } catch (error) {
-            const errMsg = error instanceof Error ? error.message : String(error);
-            console.error('[SlackBot] Error executing tool:', errMsg, error);
-            errorMessage = errMsg;
-            messages.push({
-              role: 'tool',
-              tool_call_id: toolCall.id,
-              content: `Error executing tool: ${errMsg}`,
-            });
-          }
-        } else {
-          console.log('[SlackBot] Unknown tool:', toolCall.function.name);
-        }
+    },
+    toolExecutor: async toolCall => {
+      if (toolCall.type !== 'function') {
+        console.log('[SlackBot] Skipping non-function tool call');
+        return { content: 'Skipped non-function tool call.' };
       }
-    } else {
-      // No tool calls - we have the final response
-      console.log('[SlackBot] No tool calls, setting final response');
-      finalResponse = message.content ?? 'Sorry, I could not generate a response.';
-    }
-  }
 
-  if (finalResponse === null) {
-    console.log('[SlackBot] Max iterations reached, setting timeout message');
-    finalResponse = 'Sorry, the request took too long to process.';
-    errorMessage = 'Max iterations reached';
-  }
+      if (toolCall.function.name !== 'spawn_cloud_agent') {
+        console.log('[SlackBot] Unknown tool:', toolCall.function.name);
+        return { content: `Error executing tool: Unknown tool ${toolCall.function.name}` };
+      }
 
-  console.log('[SlackBot] Final response length:', finalResponse.length);
-  console.log('[SlackBot] Final response preview:', finalResponse.slice(0, 500));
+      console.log(
+        '[SlackBot] spawn_cloud_agent tool call - arguments:',
+        toolCall.function.arguments
+      );
+      const args = JSON.parse(toolCall.function.arguments);
+      console.log('[SlackBot] Parsed tool arguments:', JSON.stringify(args, null, 2));
+
+      console.log('[SlackBot] Calling spawnCloudAgentSession...');
+      const toolResult = await spawnCloudAgentSession(
+        args,
+        owner,
+        selectedModel,
+        authToken,
+        slackRequesterInfo
+      );
+      console.log('[SlackBot] Tool result received, length:', toolResult.response.length);
+      console.log('[SlackBot] Tool result preview:', toolResult.response.slice(0, 100));
+
+      return {
+        content: toolResult.response,
+        metadata: toolResult.sessionId ? { cloudAgentSessionId: toolResult.sessionId } : undefined,
+      };
+    },
+    onToolResult: (_toolCall, result) => {
+      const sessionId = result.metadata?.cloudAgentSessionId;
+      if (typeof sessionId === 'string') {
+        cloudAgentSessionId = sessionId;
+      }
+    },
+  });
 
   return {
-    response: finalResponse,
+    response: runResult.response,
     modelUsed: selectedModel,
-    toolCallsMade,
+    toolCallsMade: runResult.toolCallsMade,
     cloudAgentSessionId,
-    error: errorMessage,
+    error: runResult.error,
     installation,
   };
 }

--- a/src/lib/slack-bot.ts
+++ b/src/lib/slack-bot.ts
@@ -477,7 +477,9 @@ export async function processKiloBotMessage(
       );
       console.log('[SlackBot] Tool result received, length:', toolResult.response.length);
       console.log('[SlackBot] Tool result preview:', toolResult.response.slice(0, 100));
-      cloudAgentSessionId = toolResult.sessionId;
+      if (toolResult.sessionId) {
+        cloudAgentSessionId = toolResult.sessionId;
+      }
 
       return {
         content: toolResult.response,


### PR DESCRIPTION
## Summary
- move the tool-loop/chat completion handling into a reusable bot runner
- keep Slack bot behavior by delegating to the core runner with the same tool execution
- capture tool metadata for the existing session id tracking

## Testing
- pnpm typecheck
- I've got the Slack bot running locally and verified that it still responds as expected to messages