### PR TITLE
AppBuilder - Add CORS headers for preview subdomain cross-origin requests

### DIFF
--- a/cloudflare-app-builder/src/index.ts
+++ b/cloudflare-app-builder/src/index.ts
@@ -80,7 +80,7 @@ function withCorsHeaders(response: Response, origin: string): Response {
   newResponse.headers.set('Access-Control-Allow-Origin', origin);
   newResponse.headers.set('Access-Control-Allow-Methods', 'GET, HEAD, POST, PUT, DELETE, OPTIONS');
   newResponse.headers.set('Access-Control-Allow-Headers', 'Content-Type');
-  newResponse.headers.set('Vary', 'Origin');
+  newResponse.headers.append('Vary', 'Origin');
   return newResponse;
 }
 

--- a/cloudflare-app-builder/src/index.ts
+++ b/cloudflare-app-builder/src/index.ts
@@ -63,6 +63,28 @@ function extractAppIdFromPath(pathname: string): string | null {
 }
 
 /**
+ * Return the origin if it's in the allow-list, otherwise null.
+ */
+function getAllowedOrigin(request: Request, env: Env): string | null {
+  const origin = request.headers.get('Origin');
+  if (!origin || !env.ALLOWED_ORIGINS) return null;
+  const allowed = env.ALLOWED_ORIGINS.split(',').map(s => s.trim());
+  return allowed.includes(origin) ? origin : null;
+}
+
+/**
+ * Append CORS headers to an existing response for an allowed origin.
+ */
+function withCorsHeaders(response: Response, origin: string): Response {
+  const newResponse = new Response(response.body, response);
+  newResponse.headers.set('Access-Control-Allow-Origin', origin);
+  newResponse.headers.set('Access-Control-Allow-Methods', 'GET, HEAD, POST, PUT, DELETE, OPTIONS');
+  newResponse.headers.set('Access-Control-Allow-Headers', 'Content-Type');
+  newResponse.headers.set('Vary', 'Origin');
+  return newResponse;
+}
+
+/**
  * Main worker fetch handler
  */
 export default {
@@ -86,8 +108,18 @@ export default {
       });
 
       if (subdomainAppId) {
+        const allowedOrigin = getAllowedOrigin(request, env);
+
+        // Handle CORS preflight for cross-origin requests (e.g. keep-alive pings from app.kilo.ai)
+        if (allowedOrigin && request.method === 'OPTIONS') {
+          const preflight = withCorsHeaders(new Response(null, { status: 204 }), allowedOrigin);
+          preflight.headers.set('Access-Control-Max-Age', '86400');
+          return preflight;
+        }
+
         // All requests to app-id.* subdomain are proxied to the preview sandbox
-        return handlePreviewProxy(request, env, subdomainAppId);
+        const response = await handlePreviewProxy(request, env, subdomainAppId);
+        return allowedOrigin ? withCorsHeaders(response, allowedOrigin) : response;
       }
 
       // Handle init requests

--- a/cloudflare-app-builder/worker-configuration.d.ts
+++ b/cloudflare-app-builder/worker-configuration.d.ts
@@ -9,6 +9,7 @@ declare namespace Cloudflare {
   interface Env {
     BACKEND_PUSH_NOTIFICATION_URL: 'https://app.kilo.ai/api/app-builder/push-notification';
     GIT_TOKEN_EXPIRY_SECONDS: '21600';
+    ALLOWED_ORIGINS: string;
     AUTH_TOKEN: string;
     BUILDER_HOSTNAME: string;
     GIT_JWT_SECRET: string;
@@ -32,6 +33,7 @@ declare namespace NodeJS {
         Cloudflare.Env,
         | 'BACKEND_PUSH_NOTIFICATION_URL'
         | 'GIT_TOKEN_EXPIRY_SECONDS'
+        | 'ALLOWED_ORIGINS'
         | 'AUTH_TOKEN'
         | 'BUILDER_HOSTNAME'
         | 'GIT_JWT_SECRET'

--- a/cloudflare-app-builder/wrangler.jsonc
+++ b/cloudflare-app-builder/wrangler.jsonc
@@ -16,6 +16,7 @@
     "BACKEND_PUSH_NOTIFICATION_URL": "https://app.kilo.ai/api/app-builder/push-notification",
     "GIT_TOKEN_EXPIRY_SECONDS": "21600",
     "DB_PROXY_URL": "https://db-proxy.engineering-e11.workers.dev",
+    "ALLOWED_ORIGINS": "https://app.kilo.ai",
   },
   "routes": [
     {


### PR DESCRIPTION
## Summary

- Add CORS support for cross-origin requests from `app.kilo.ai` to `*.builder.kiloapps.io` preview subdomains, fixing browser-blocked keep-alive pings from the main app to preview iframes.
- Origin allow-list is configured via the `ALLOWED_ORIGINS` env var (comma-separated, defaults to `https://app.kilo.ai`).
- CORS is scoped to subdomain preview proxy routes only, not API routes.
- Preflight `OPTIONS` responses include `Access-Control-Max-Age: 86400` to reduce repeated preflight requests.
- Whitespace in `ALLOWED_ORIGINS` entries is trimmed to prevent misconfiguration.