### PR TITLE
AppBuilder - Cancel in-flight messages on session cancel

### DIFF
--- a/src/components/app-builder/project-manager/sessions/v1/messages.ts
+++ b/src/components/app-builder/project-manager/sessions/v1/messages.ts
@@ -62,6 +62,27 @@ export function updateMessage(store: V1SessionStore, message: CloudMessage): voi
 }
 
 /**
+ * Marks all partial (streaming) messages as complete.
+ * Called on session interrupt to prevent orphaned streaming messages.
+ */
+export function completePartialMessages(store: V1SessionStore): void {
+  const messages = store.getState().messages;
+  let hasChanges = false;
+
+  const updated = messages.map(m => {
+    if (m.partial) {
+      hasChanges = true;
+      return { ...m, partial: false };
+    }
+    return m;
+  });
+
+  if (hasChanges) {
+    store.setState({ messages: updated });
+  }
+}
+
+/**
  * Adds a user message to the store.
  */
 export function addUserMessage(store: V1SessionStore, content: string, images?: Images): void {

--- a/src/components/app-builder/project-manager/sessions/v1/streaming.ts
+++ b/src/components/app-builder/project-manager/sessions/v1/streaming.ts
@@ -19,7 +19,12 @@ import type { V1SessionStore } from './store';
 import type { AppTRPCClient } from '../../types';
 import type { Images } from '@/lib/images-schema';
 import type { WorkerVersion } from '@/lib/app-builder/types';
-import { addUserMessage, addErrorMessage, removeLastUserMessage } from './messages';
+import {
+  addUserMessage,
+  addErrorMessage,
+  removeLastUserMessage,
+  completePartialMessages,
+} from './messages';
 import { formatStreamError, createLogger } from '../../logging';
 
 type SendMessageResponse = { sessionId: string; workerVersion: WorkerVersion };
@@ -368,6 +373,7 @@ export function createV1StreamingCoordinator(config: V1StreamingConfig): V1Strea
 
     wsCoordinator?.interrupt();
 
+    completePartialMessages(store);
     store.setState({ isStreaming: false });
   }
 

--- a/src/components/app-builder/project-manager/sessions/v2/streaming.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/streaming.ts
@@ -471,6 +471,10 @@ export function createV2StreamingCoordinator(config: V2StreamingConfig): V2Strea
       wsManager = null;
     }
     currentCloudSessionId = null;
+
+    // Force-complete all in-flight messages so they don't appear stuck in streaming state
+    processor?.forceCompleteAll();
+
     store.setState({ isStreaming: false });
   }
 

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -860,6 +860,131 @@ describe('createEventProcessor', () => {
     });
   });
 
+  describe('forceCompleteAll', () => {
+    it('should force-complete in-flight assistant messages', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Create an in-flight assistant message (no completed time)
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      expect(callbacks.onMessageCompleted).not.toHaveBeenCalled();
+
+      processor.forceCompleteAll();
+
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledWith(
+        'session-123',
+        'msg-1',
+        expect.objectContaining({
+          info: expect.objectContaining({
+            id: 'msg-1',
+            time: expect.objectContaining({ completed: expect.any(Number) }),
+          }),
+        }),
+        null
+      );
+
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should complete pending user messages', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Create a user message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createUserInfo('user-msg-1') })
+      );
+
+      // Create an assistant message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('assist-msg-1') })
+      );
+
+      processor.forceCompleteAll();
+
+      // Both should be completed
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not fire onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Create an in-flight assistant message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      processor.forceCompleteAll();
+
+      // forceCompleteAll should NOT fire onError (unlike handleSessionTurnClose)
+      expect(callbacks.onError).not.toHaveBeenCalled();
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be a no-op when there are no in-flight messages', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.forceCompleteAll();
+
+      expect(callbacks.onMessageCompleted).not.toHaveBeenCalled();
+      expect(callbacks.onStreamingChanged).not.toHaveBeenCalled();
+    });
+
+    it('should ignore already-completed assistant messages', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Create and complete an assistant message normally
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+      processor.processEvent(
+        createKilocodeEvent('message.updated', {
+          info: createAssistantInfo('msg-1', 'session-123', Date.now()),
+        })
+      );
+
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+
+      // forceCompleteAll should not re-complete it
+      processor.forceCompleteAll();
+
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('invalid events', () => {
     it('should ignore events with unknown types', () => {
       const callbacks: EventProcessorCallbacks = {

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -93,6 +93,9 @@ export type EventProcessor = {
   /** Process a cloud agent event from WebSocket */
   processEvent: (event: CloudAgentEvent) => void;
 
+  /** Force-complete all in-flight messages. Called on session interrupt. */
+  forceCompleteAll: () => void;
+
   /** Clear all state */
   clear: () => void;
 };
@@ -387,20 +390,14 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   }
 
   /**
-   * Handle session.turn.close events.
-   * When reason is "error", force-complete all in-flight assistant messages
-   * that never received time.completed from the server.
+   * Force-complete all in-flight messages.
+   * Stamps synthetic time.completed on assistant messages and completes user messages.
+   * Sets streaming to false via callback.
    */
-  function handleSessionTurnClose(data: { sessionID?: string; reason?: string }): void {
-    if (data.reason !== 'error') {
-      return;
-    }
-
-    // Force-complete all in-flight assistant messages
+  function forceCompleteAllMessages(): void {
     const now = Date.now();
     for (const [key, message] of messagesMap) {
       if (isAssistantMessage(message.info) && !isAssistantMessageComplete(message)) {
-        // Set completed time so isMessageStreaming() returns false
         message.info = {
           ...message.info,
           time: { ...message.info.time, completed: now },
@@ -414,13 +411,25 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
       }
     }
 
-    // Complete any pending user messages too
     completeUserMessages();
 
     if (streaming) {
       streaming = false;
       callbacks.onStreamingChanged?.(false);
     }
+  }
+
+  /**
+   * Handle session.turn.close events.
+   * When reason is "error", force-complete all in-flight assistant messages
+   * that never received time.completed from the server.
+   */
+  function handleSessionTurnClose(data: { sessionID?: string; reason?: string }): void {
+    if (data.reason !== 'error') {
+      return;
+    }
+
+    forceCompleteAllMessages();
 
     callbacks.onError?.('The model failed to generate a response', data.sessionID);
   }
@@ -502,6 +511,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
   return {
     processEvent,
+    forceCompleteAll: forceCompleteAllMessages,
     clear,
   };
 }


### PR DESCRIPTION
## Summary

- Extract `forceCompleteAll` from the v2 event processor's `handleSessionTurnClose` so it can be called independently on session interrupt. This stamps a synthetic `time.completed` on in-flight assistant messages and completes pending user messages, preventing them from appearing stuck in a streaming state.
- Add `completePartialMessages` helper for the v1 session store that clears the `partial` flag on all streaming messages during interrupt.
- Both v1 and v2 streaming coordinators now call the respective cleanup on `cancelSession`, so the UI no longer shows orphaned "typing" indicators after cancellation.
- Add tests covering `forceCompleteAll` (in-flight messages, already-completed messages, no-op when empty, no spurious `onError` calls).