### PR TITLE
AppBuilder - Add question tool support

### DIFF
--- a/src/components/app-builder/AppBuilderChat.tsx
+++ b/src/components/app-builder/AppBuilderChat.tsx
@@ -31,6 +31,7 @@ import type { CloudMessage } from '@/components/cloud-agent/types';
 import type { StoredMessage } from '@/components/cloud-agent-next/types';
 import { isMessageStreaming } from '@/components/cloud-agent-next/types';
 import { MessageBubble as V2MessageBubble } from '@/components/cloud-agent-next/MessageBubble';
+import { QuestionContextProvider } from '@/components/cloud-agent-next/QuestionContext';
 import type { AppBuilderSession, V1Session, V2Session } from './project-manager/types';
 import {
   filterAppBuilderMessages,
@@ -372,11 +373,15 @@ function V2SessionMessages({ session }: { session: V2Session }) {
   }
 
   return (
-    <>
+    <QuestionContextProvider
+      questionRequestIds={sessionState.questionRequestIds}
+      cloudAgentSessionId={session.cloudAgentSessionId}
+      organizationId={session.organizationId}
+    >
       <V2StaticMessages messages={v2Static} />
       <V2DynamicMessages messages={v2Dynamic} />
       {sessionState.isStreaming && v2Dynamic.length === 0 && <TypingIndicator />}
-    </>
+    </QuestionContextProvider>
   );
 }
 

--- a/src/components/app-builder/AppBuilderChat.tsx
+++ b/src/components/app-builder/AppBuilderChat.tsx
@@ -203,10 +203,12 @@ function ExpandableSessionBlock({
   session,
   visibleSessionCount,
   onLoadMore,
+  organizationId,
 }: {
   session: AppBuilderSession;
   visibleSessionCount: number;
   onLoadMore: () => void;
+  organizationId?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
   const { ended_at, title } = session.info;
@@ -243,7 +245,7 @@ function ExpandableSessionBlock({
       </button>
       {expanded &&
         (session.type === 'v2' ? (
-          <V2SessionMessages session={session} />
+          <V2SessionMessages session={session} organizationId={organizationId} />
         ) : (
           <V1SessionMessages
             session={session}
@@ -352,7 +354,13 @@ function V1SessionMessages({
 /**
  * Renders a V2 session's messages.
  */
-function V2SessionMessages({ session }: { session: V2Session }) {
+function V2SessionMessages({
+  session,
+  organizationId,
+}: {
+  session: V2Session;
+  organizationId?: string;
+}) {
   const sessionState = useSyncExternalStore(session.subscribe, session.getState);
 
   const { v2Static, v2Dynamic } = useMemo(() => {
@@ -375,8 +383,8 @@ function V2SessionMessages({ session }: { session: V2Session }) {
   return (
     <QuestionContextProvider
       questionRequestIds={sessionState.questionRequestIds}
-      cloudAgentSessionId={session.cloudAgentSessionId}
-      organizationId={session.organizationId}
+      cloudAgentSessionId={session.info.cloud_agent_session_id}
+      organizationId={organizationId ?? null}
     >
       <V2StaticMessages messages={v2Static} />
       <V2DynamicMessages messages={v2Dynamic} />
@@ -393,11 +401,13 @@ function SessionMessages({
   isLast,
   visibleSessionCount,
   onLoadMore,
+  organizationId,
 }: {
   session: AppBuilderSession;
   isLast: boolean;
   visibleSessionCount: number;
   onLoadMore: () => void;
+  organizationId?: string;
 }) {
   if (!isLast) {
     return (
@@ -405,12 +415,13 @@ function SessionMessages({
         session={session}
         visibleSessionCount={visibleSessionCount}
         onLoadMore={onLoadMore}
+        organizationId={organizationId}
       />
     );
   }
 
   if (session.type === 'v2') {
-    return <V2SessionMessages session={session} />;
+    return <V2SessionMessages session={session} organizationId={organizationId} />;
   }
 
   return (
@@ -657,6 +668,7 @@ export function AppBuilderChat({ organizationId }: AppBuilderChatProps) {
                 isLast={index === sessions.length - 1}
                 visibleSessionCount={visibleSessionCount}
                 onLoadMore={handleLoadMore}
+                organizationId={organizationId}
               />
             ))
           )}

--- a/src/components/app-builder/ProjectManager.ts
+++ b/src/components/app-builder/ProjectManager.ts
@@ -74,7 +74,12 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
   // --- Session building ---
 
   function toDisplayInfo(info: ProjectSessionInfo): SessionDisplayInfo {
-    return { id: info.id, ended_at: info.ended_at, title: info.title };
+    return {
+      id: info.id,
+      cloud_agent_session_id: info.cloud_agent_session_id,
+      ended_at: info.ended_at,
+      title: info.title,
+    };
   }
 
   function createStaticSession(info: ProjectSessionInfo): AppBuilderSession {
@@ -85,7 +90,6 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
       projectId,
       organizationId,
       trpcClient,
-      cloudAgentSessionId: info.cloud_agent_session_id,
     };
     if (info.worker_version === 'v2') {
       return createV2Session(streamingConfig);
@@ -134,7 +138,6 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
             projectId,
             organizationId,
             trpcClient,
-            cloudAgentSessionId: proj.session_id ?? null,
             onStreamComplete: () => startPreviewPollingIfNeeded(),
             onSessionChanged: handleSessionChanged,
           })
@@ -147,7 +150,6 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
             projectId,
             organizationId,
             trpcClient,
-            cloudAgentSessionId: proj.session_id ?? null,
             sessionPrepared: info.prepared,
             onStreamComplete: () => startPreviewPollingIfNeeded(),
             onSessionChanged: handleSessionChanged,
@@ -173,6 +175,7 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
 
     const newInfo: SessionDisplayInfo = {
       id: newSessionId,
+      cloud_agent_session_id: newSessionId,
       ended_at: null,
       title: null,
     };
@@ -185,7 +188,6 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
             projectId,
             organizationId,
             trpcClient,
-            cloudAgentSessionId: newSessionId,
             onStreamComplete: () => startPreviewPollingIfNeeded(),
             onSessionChanged: handleSessionChanged,
           })
@@ -195,7 +197,6 @@ export function createProjectManager(config: ProjectManagerConfig): ProjectManag
             projectId,
             organizationId,
             trpcClient,
-            cloudAgentSessionId: newSessionId,
             sessionPrepared: true,
             onStreamComplete: () => startPreviewPollingIfNeeded(),
             onSessionChanged: handleSessionChanged,

--- a/src/components/app-builder/project-manager/__tests__/messages.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/messages.test.ts
@@ -22,6 +22,7 @@ function createMockStore(initialMessages: CloudMessage[] = []): V1SessionStore {
     getState: () => ({
       messages,
       isStreaming: false,
+      questionRequestIds: new Map<string, string>(),
     }),
     setState: jest.fn(partial => {
       if ('messages' in partial && partial.messages) {
@@ -37,6 +38,7 @@ function createMockStore(initialMessages: CloudMessage[] = []): V1SessionStore {
       messages = updater(messages);
       listeners.forEach(l => l());
     }),
+    setQuestionRequestId: jest.fn(),
   };
 }
 

--- a/src/components/app-builder/project-manager/__tests__/streaming.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/streaming.test.ts
@@ -30,6 +30,7 @@ function createMockStore(): {
   setState: jest.Mock;
   subscribe: jest.Mock;
   updateMessages: jest.Mock;
+  setQuestionRequestId: jest.Mock;
   stateUpdates: Array<Record<string, unknown>>;
 } {
   const stateUpdates: Array<Record<string, unknown>> = [];
@@ -38,7 +39,7 @@ function createMockStore(): {
 
   return {
     stateUpdates,
-    getState: () => ({ messages, isStreaming }),
+    getState: () => ({ messages, isStreaming, questionRequestIds: new Map<string, string>() }),
     setState: jest.fn((partial: Partial<V1SessionState>) => {
       stateUpdates.push(partial);
       if ('messages' in partial && partial.messages) {
@@ -52,6 +53,7 @@ function createMockStore(): {
     updateMessages: jest.fn((updater: (msgs: CloudMessage[]) => CloudMessage[]) => {
       messages = updater(messages);
     }),
+    setQuestionRequestId: jest.fn(),
   };
 }
 

--- a/src/components/app-builder/project-manager/sessions/session-store.ts
+++ b/src/components/app-builder/project-manager/sessions/session-store.ts
@@ -10,6 +10,7 @@
 export type SessionState<TMessage> = {
   messages: TMessage[];
   isStreaming: boolean;
+  questionRequestIds: Map<string, string>;
 };
 
 export type SessionStore<TMessage> = {
@@ -17,12 +18,14 @@ export type SessionStore<TMessage> = {
   setState: (partial: Partial<SessionState<TMessage>>) => void;
   subscribe: (listener: () => void) => () => void;
   updateMessages: (updater: (messages: TMessage[]) => TMessage[]) => void;
+  setQuestionRequestId: (callId: string, requestId: string) => void;
 };
 
 export function createSessionStore<TMessage>(initialMessages: TMessage[]): SessionStore<TMessage> {
   let state: SessionState<TMessage> = {
     messages: initialMessages,
     isStreaming: false,
+    questionRequestIds: new Map(),
   };
 
   const listeners = new Set<() => void>();
@@ -66,5 +69,11 @@ export function createSessionStore<TMessage>(initialMessages: TMessage[]): Sessi
     setState({ messages: updater(state.messages) });
   }
 
-  return { getState, setState, subscribe, updateMessages };
+  function setQuestionRequestId(callId: string, requestId: string): void {
+    const updated = new Map(state.questionRequestIds);
+    updated.set(callId, requestId);
+    setState({ questionRequestIds: updated });
+  }
+
+  return { getState, setState, subscribe, updateMessages, setQuestionRequestId };
 }

--- a/src/components/app-builder/project-manager/sessions/types.ts
+++ b/src/components/app-builder/project-manager/sessions/types.ts
@@ -36,6 +36,8 @@ export type V1Session = SessionBase & {
 export type V2Session = SessionBase & {
   type: 'v2';
   getState: () => V2SessionState;
+  cloudAgentSessionId: string | null;
+  organizationId: string | null;
 };
 
 export type AppBuilderSession = V1Session | V2Session;

--- a/src/components/app-builder/project-manager/sessions/types.ts
+++ b/src/components/app-builder/project-manager/sessions/types.ts
@@ -36,8 +36,6 @@ export type V1Session = SessionBase & {
 export type V2Session = SessionBase & {
   type: 'v2';
   getState: () => V2SessionState;
-  cloudAgentSessionId: string | null;
-  organizationId: string | null;
 };
 
 export type AppBuilderSession = V1Session | V2Session;

--- a/src/components/app-builder/project-manager/sessions/v1/v1-session.ts
+++ b/src/components/app-builder/project-manager/sessions/v1/v1-session.ts
@@ -22,7 +22,6 @@ export type CreateV1SessionConfig = {
   projectId?: string;
   organizationId?: string | null;
   trpcClient?: AppTRPCClient;
-  cloudAgentSessionId?: string | null;
   sessionPrepared?: boolean | null;
   onStreamComplete?: () => void;
   onSessionChanged?: (
@@ -43,11 +42,11 @@ export function createV1Session(config: CreateV1SessionConfig): V1Session {
     projectId,
     organizationId,
     trpcClient,
-    cloudAgentSessionId,
     sessionPrepared,
     onStreamComplete,
     onSessionChanged,
   } = config;
+  const cloudAgentSessionId = info.cloud_agent_session_id;
 
   const store = createV1SessionStore(initialMessages);
 

--- a/src/components/app-builder/project-manager/sessions/v2/streaming.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/streaming.ts
@@ -180,6 +180,10 @@ export function createV2StreamingCoordinator(config: V2StreamingConfig): V2Strea
         // onStreamComplete is called from onSessionStatusChanged (idle) — not here,
         // to avoid triggering preview polling twice per stream completion.
       },
+
+      onQuestionAsked: (requestId, callId) => {
+        store.setQuestionRequestId(callId, requestId);
+      },
     };
   }
 

--- a/src/components/app-builder/project-manager/sessions/v2/v2-session.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/v2-session.ts
@@ -108,5 +108,7 @@ export function createV2Session(config: CreateV2SessionConfig): V2Session {
     connectToExistingSession,
     loadMessages,
     destroy,
+    cloudAgentSessionId: cloudAgentSessionId ?? null,
+    organizationId: organizationId ?? null,
   };
 }

--- a/src/components/app-builder/project-manager/sessions/v2/v2-session.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/v2-session.ts
@@ -22,7 +22,6 @@ export type CreateV2SessionConfig = {
   projectId?: string;
   organizationId?: string | null;
   trpcClient?: AppTRPCClient;
-  cloudAgentSessionId?: string | null;
   onStreamComplete?: () => void;
   onSessionChanged?: (
     newSessionId: string,
@@ -42,10 +41,11 @@ export function createV2Session(config: CreateV2SessionConfig): V2Session {
     projectId,
     organizationId,
     trpcClient,
-    cloudAgentSessionId,
     onStreamComplete,
     onSessionChanged,
   } = config;
+
+  const cloudAgentSessionId = info.cloud_agent_session_id;
 
   const store = createV2SessionStore(initialMessages);
 
@@ -108,7 +108,5 @@ export function createV2Session(config: CreateV2SessionConfig): V2Session {
     connectToExistingSession,
     loadMessages,
     destroy,
-    cloudAgentSessionId: cloudAgentSessionId ?? null,
-    organizationId: organizationId ?? null,
   };
 }

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -22,6 +22,8 @@ import {
   sessionConfigAtom,
   totalCostAtom,
   getChildSessionMessagesAtom,
+  questionRequestIdsAtom,
+  sessionOrganizationIdAtom,
 } from './store/atoms';
 import { buildSessionConfig, needsResumeConfiguration } from './session-config';
 import {
@@ -52,6 +54,7 @@ import { usePreparedSession } from './hooks/usePreparedSession';
 import { buildPrepareSessionRepoParams, extractRepoFromGitUrl } from './utils/git-utils';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
 import { CloudChatPresentation } from './CloudChatPresentation';
+import { QuestionContextProvider } from './QuestionContext';
 import type { ResumeConfig } from './ResumeConfigModal';
 import type { AgentMode, SessionStartConfig } from './types';
 
@@ -80,6 +83,8 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   const currentSessionId = useAtomValue(currentSessionIdAtom);
   const sessionConfig = useAtomValue(sessionConfigAtom);
   const totalCost = useAtomValue(totalCostAtom);
+  const questionRequestIds = useAtomValue(questionRequestIdsAtom);
+  const questionOrganizationId = useAtomValue(sessionOrganizationIdAtom);
 
   // Write to atoms
   const setError = useSetAtom(errorAtom);
@@ -906,63 +911,69 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
     : false;
 
   return (
-    <CloudChatPresentation
-      organizationId={organizationId}
-      staticMessages={staticMessages}
-      dynamicMessages={dynamicMessages}
-      sessions={sessions}
-      currentSessionId={currentSessionId}
-      currentDbSessionId={currentDbSessionId}
-      cloudAgentSessionId={cloudAgentSessionId}
-      sessionConfig={sessionConfig}
-      totalCost={totalCost}
-      error={error}
-      isStreaming={isStreaming}
-      isLoadingFromDb={isLoadingFromDb}
-      isStale={isStale}
-      isSessionInitiated={isSessionInitiated}
-      showScrollButton={showScrollButton}
-      mobileSheetOpen={mobileSheetOpen}
-      soundEnabled={soundEnabled}
-      showOrgContextModal={showOrgContextModal}
-      showResumeModal={showResumeModal}
-      pendingSessionForOrgContext={pendingSessionForOrgContext}
-      pendingResumeSession={pendingResumeSession}
-      isNonResumableSession={isNonResumableSession}
-      needsResumeConfig={needsResumeConfig}
-      resumeConfigPersisting={resumeConfigPersisting}
-      resumeConfigFailed={resumeConfigError !== null}
-      resumeConfigError={resumeConfigError}
-      modelOptions={modelOptions}
-      isLoadingModels={isLoadingModels}
-      defaultModel={defaultModel}
-      availableCommands={availableCommands}
-      scrollContainerRef={scrollContainerRef}
-      messagesEndRef={messagesEndRef}
-      persistedResumeConfig={persistedResumeConfig}
-      onSendMessage={handleSendMessage}
-      onStopExecution={handleStopExecution}
-      onRefresh={handleRefreshSession}
-      onNewSession={handleNewSession}
-      onSelectSession={handleSelectSession}
-      onDeleteSession={handleDeleteSession}
-      onDismissError={handleDismissError}
-      onOrgContextConfirm={handleOrgContextConfirm}
-      onOrgContextClose={handleOrgContextClose}
-      onResumeConfirm={handleResumeConfirm}
-      onResumeClose={handleResumeClose}
-      onReopenResumeModal={reopenResumeModal}
-      onScroll={handleScroll}
-      onScrollToBottom={scrollToBottom}
-      onToggleSound={handleToggleSound}
-      onMenuClick={() => setMobileSheetOpen(true)}
-      onMobileSheetOpenChange={setMobileSheetOpen}
-      inputMode={inputMode}
-      inputModel={inputModel}
-      onInputModeChange={handleInputModeChange}
-      onInputModelChange={handleInputModelChange}
-      isOldSession={isOldSession}
-      getChildMessages={getChildSessionMessages}
-    />
+    <QuestionContextProvider
+      questionRequestIds={questionRequestIds}
+      cloudAgentSessionId={currentSessionId}
+      organizationId={questionOrganizationId}
+    >
+      <CloudChatPresentation
+        organizationId={organizationId}
+        staticMessages={staticMessages}
+        dynamicMessages={dynamicMessages}
+        sessions={sessions}
+        currentSessionId={currentSessionId}
+        currentDbSessionId={currentDbSessionId}
+        cloudAgentSessionId={cloudAgentSessionId}
+        sessionConfig={sessionConfig}
+        totalCost={totalCost}
+        error={error}
+        isStreaming={isStreaming}
+        isLoadingFromDb={isLoadingFromDb}
+        isStale={isStale}
+        isSessionInitiated={isSessionInitiated}
+        showScrollButton={showScrollButton}
+        mobileSheetOpen={mobileSheetOpen}
+        soundEnabled={soundEnabled}
+        showOrgContextModal={showOrgContextModal}
+        showResumeModal={showResumeModal}
+        pendingSessionForOrgContext={pendingSessionForOrgContext}
+        pendingResumeSession={pendingResumeSession}
+        isNonResumableSession={isNonResumableSession}
+        needsResumeConfig={needsResumeConfig}
+        resumeConfigPersisting={resumeConfigPersisting}
+        resumeConfigFailed={resumeConfigError !== null}
+        resumeConfigError={resumeConfigError}
+        modelOptions={modelOptions}
+        isLoadingModels={isLoadingModels}
+        defaultModel={defaultModel}
+        availableCommands={availableCommands}
+        scrollContainerRef={scrollContainerRef}
+        messagesEndRef={messagesEndRef}
+        persistedResumeConfig={persistedResumeConfig}
+        onSendMessage={handleSendMessage}
+        onStopExecution={handleStopExecution}
+        onRefresh={handleRefreshSession}
+        onNewSession={handleNewSession}
+        onSelectSession={handleSelectSession}
+        onDeleteSession={handleDeleteSession}
+        onDismissError={handleDismissError}
+        onOrgContextConfirm={handleOrgContextConfirm}
+        onOrgContextClose={handleOrgContextClose}
+        onResumeConfirm={handleResumeConfirm}
+        onResumeClose={handleResumeClose}
+        onReopenResumeModal={reopenResumeModal}
+        onScroll={handleScroll}
+        onScrollToBottom={scrollToBottom}
+        onToggleSound={handleToggleSound}
+        onMenuClick={() => setMobileSheetOpen(true)}
+        onMobileSheetOpenChange={setMobileSheetOpen}
+        inputMode={inputMode}
+        inputModel={inputModel}
+        onInputModeChange={handleInputModeChange}
+        onInputModelChange={handleInputModelChange}
+        isOldSession={isOldSession}
+        getChildMessages={getChildSessionMessages}
+      />
+    </QuestionContextProvider>
   );
 }

--- a/src/components/cloud-agent-next/QuestionContext.tsx
+++ b/src/components/cloud-agent-next/QuestionContext.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+type QuestionContextValue = {
+  questionRequestIds: Map<string, string>;
+  cloudAgentSessionId: string | null;
+  organizationId: string | null;
+};
+
+const QuestionContext = createContext<QuestionContextValue>({
+  questionRequestIds: new Map(),
+  cloudAgentSessionId: null,
+  organizationId: null,
+});
+
+export function useQuestionContext(): QuestionContextValue {
+  return useContext(QuestionContext);
+}
+
+type QuestionContextProviderProps = QuestionContextValue & {
+  children: ReactNode;
+};
+
+export function QuestionContextProvider({
+  questionRequestIds,
+  cloudAgentSessionId,
+  organizationId,
+  children,
+}: QuestionContextProviderProps) {
+  const value = useMemo(
+    () => ({ questionRequestIds, cloudAgentSessionId, organizationId }),
+    [questionRequestIds, cloudAgentSessionId, organizationId]
+  );
+  return <QuestionContext.Provider value={value}>{children}</QuestionContext.Provider>;
+}

--- a/src/components/cloud-agent-next/QuestionToolCard.tsx
+++ b/src/components/cloud-agent-next/QuestionToolCard.tsx
@@ -1,15 +1,11 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { useAtomValue } from 'jotai';
+
 import { ChevronDown, Loader2, XCircle, Check, Send, X, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRawTRPCClient } from '@/lib/trpc/utils';
-import {
-  questionRequestIdsAtom,
-  currentSessionIdAtom,
-  sessionOrganizationIdAtom,
-} from './store/atoms';
+import { useQuestionContext } from './QuestionContext';
 import type { ToolPart } from './types';
 import type { QuestionInfo } from '@/types/opencode.gen';
 
@@ -278,9 +274,11 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const trpcClient = useRawTRPCClient();
-  const questionRequestIds = useAtomValue(questionRequestIdsAtom);
-  const sessionId = useAtomValue(currentSessionIdAtom);
-  const organizationId = useAtomValue(sessionOrganizationIdAtom);
+  const {
+    questionRequestIds,
+    cloudAgentSessionId: sessionId,
+    organizationId,
+  } = useQuestionContext();
 
   const requestId = toolPart.callID ? questionRequestIds.get(toolPart.callID) : undefined;
 

--- a/src/lib/app-builder/types.ts
+++ b/src/lib/app-builder/types.ts
@@ -96,11 +96,12 @@ export type ProjectSessionInfo = {
 
 /**
  * Subset of session info exposed on SessionBase for UI display and identity.
- * Routing-only fields (worker_version, initiated, prepared, cloud_agent_session_id)
- * are consumed in buildSessions() and not stored on the session object.
+ * Routing-only fields (worker_version, initiated, prepared) are consumed in
+ * buildSessions() and not stored on the session object.
  */
 export type SessionDisplayInfo = {
   id: string;
+  cloud_agent_session_id: string | null;
   ended_at: string | null;
   title: string | null;
 };


### PR DESCRIPTION
## Summary

- Extracts `QuestionToolCard`'s Jotai atom dependencies (`questionRequestIdsAtom`, `currentSessionIdAtom`, `sessionOrganizationIdAtom`) into a new `QuestionContext` React Context, so the component can be used outside the Cloud Agent Next Jotai store (i.e. in App Builder).
- Extends the generic `SessionState` / `SessionStore` with `questionRequestIds` (a `Map<string, string>`) and a `setQuestionRequestId` helper.
- Wires the V2 streaming coordinator's `onQuestionAsked` callback to populate request IDs in the store.
- Exposes `cloudAgentSessionId` and `organizationId` on `V2Session` so `AppBuilderChat` can pass them to `QuestionContextProvider`.
- Wraps both `CloudChatContainer` and `V2SessionMessages` (App Builder) with `QuestionContextProvider`.