### PR TITLE
CloudAgentNext - Pass MCP server configs via KILO_CONFIG_CONTENT env var

### DIFF
--- a/cloud-agent-next/src/persistence/schemas.test.ts
+++ b/cloud-agent-next/src/persistence/schemas.test.ts
@@ -3,70 +3,69 @@ import { MCPServerConfigSchema, MetadataSchema } from './schemas.js';
 import type { MCPServerConfig } from './types.js';
 
 describe('MCPServerConfigSchema', () => {
-  describe('valid stdio configuration', () => {
-    it('should accept valid stdio config with command and args', () => {
+  describe('valid local configuration', () => {
+    it('should accept valid local config with command array', () => {
       const config = {
-        type: 'stdio' as const,
-        command: 'npx',
-        args: ['-y', '@modelcontextprotocol/server-puppeteer'],
+        type: 'local' as const,
+        command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'stdio',
-        command: 'npx',
-        args: ['-y', '@modelcontextprotocol/server-puppeteer'],
+      expect(result).toEqual({
+        type: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
       });
     });
 
-    it('should accept stdio config without explicit type', () => {
+    it('should accept local config with all optional fields', () => {
       const config = {
-        command: 'node',
-        args: ['server.js'],
+        type: 'local' as const,
+        command: ['node', 'server.js'],
+        environment: { NODE_ENV: 'production' },
+        enabled: true,
+        timeout: 30000,
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result.type).toBe('stdio');
-      expect(result.command).toBe('node');
+      expect(result).toEqual({
+        type: 'local',
+        command: ['node', 'server.js'],
+        environment: { NODE_ENV: 'production' },
+        enabled: true,
+        timeout: 30000,
+      });
     });
 
-    it('should accept stdio config with optional fields', () => {
+    it('should accept local config with enabled: false', () => {
       const config = {
-        command: 'node',
-        args: ['server.js'],
-        cwd: '/path/to/project',
-        env: { NODE_ENV: 'production' },
+        type: 'local' as const,
+        command: ['node', 'server.js'],
+        enabled: false,
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'stdio',
-        command: 'node',
-        args: ['server.js'],
-        cwd: '/path/to/project',
-        env: { NODE_ENV: 'production' },
-      });
+      expect(result.enabled).toBe(false);
     });
   });
 
-  describe('valid SSE configuration', () => {
-    it('should accept valid sse config with URL', () => {
+  describe('valid remote configuration', () => {
+    it('should accept valid remote config with URL', () => {
       const config = {
-        type: 'sse' as const,
+        type: 'remote' as const,
         url: 'https://mcp-server.example.com/sse',
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'sse',
+      expect(result).toEqual({
+        type: 'remote',
         url: 'https://mcp-server.example.com/sse',
       });
     });
 
-    it('should accept sse config with headers', () => {
+    it('should accept remote config with headers', () => {
       const config = {
-        type: 'sse' as const,
-        url: 'https://example.com/sse',
+        type: 'remote' as const,
+        url: 'https://example.com/mcp',
         headers: {
           Authorization: 'Bearer token123',
           'X-Custom-Header': 'value',
@@ -74,272 +73,154 @@ describe('MCPServerConfigSchema', () => {
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'sse',
-        url: 'https://example.com/sse',
+      expect(result).toEqual({
+        type: 'remote',
+        url: 'https://example.com/mcp',
         headers: {
           Authorization: 'Bearer token123',
           'X-Custom-Header': 'value',
         },
       });
     });
-  });
 
-  describe('valid streamable-http configuration', () => {
-    it('should accept valid streamable-http config with URL', () => {
+    it('should accept remote config with all optional fields', () => {
       const config = {
-        type: 'streamable-http' as const,
-        url: 'https://mcp-server.example.com/stream',
+        type: 'remote' as const,
+        url: 'https://example.com/mcp',
+        headers: { 'X-API-Key': 'key456' },
+        enabled: false,
+        timeout: 60000,
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'streamable-http',
-        url: 'https://mcp-server.example.com/stream',
-      });
-    });
-
-    it('should accept streamable-http config with headers', () => {
-      const config = {
-        type: 'streamable-http' as const,
-        url: 'https://example.com/stream',
-        headers: {
-          'X-API-Key': 'key456',
-        },
-      };
-
-      const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'streamable-http',
-        url: 'https://example.com/stream',
-        headers: {
-          'X-API-Key': 'key456',
-        },
+      expect(result).toEqual({
+        type: 'remote',
+        url: 'https://example.com/mcp',
+        headers: { 'X-API-Key': 'key456' },
+        enabled: false,
+        timeout: 60000,
       });
     });
   });
 
-  describe('stdio missing command', () => {
-    it('should reject stdio config without command field', () => {
-      const config = {
-        type: 'stdio' as const,
-        args: ['server.js'],
-      };
-
+  describe('local missing/invalid command', () => {
+    it('should reject local config without command field', () => {
+      const config = { type: 'local' };
       expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
 
-    it('should reject stdio config with empty command', () => {
+    it('should reject local config with empty command array', () => {
       const config = {
-        command: '',
-        args: ['server.js'],
+        type: 'local' as const,
+        command: [],
       };
-
-      expect(() => MCPServerConfigSchema.parse(config)).toThrow('Command cannot be empty');
+      expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
   });
 
-  describe('SSE invalid URL', () => {
-    it('should reject SSE config with malformed URL', () => {
+  describe('remote invalid URL', () => {
+    it('should reject remote config with malformed URL', () => {
       const config = {
-        type: 'sse' as const,
+        type: 'remote' as const,
         url: 'not-a-valid-url',
       };
 
       const result = MCPServerConfigSchema.safeParse(config);
       expect(result.success).toBe(false);
-      if (!result.success) {
-        // Zod returns "Invalid input" for discriminated union validation failures
-        expect(result.error.issues.length).toBeGreaterThan(0);
-      }
     });
 
-    it('should reject SSE config without protocol', () => {
+    it('should reject remote config without protocol', () => {
       const config = {
-        type: 'sse' as const,
-        url: 'example.com/sse',
+        type: 'remote' as const,
+        url: 'example.com/mcp',
       };
 
       const result = MCPServerConfigSchema.safeParse(config);
       expect(result.success).toBe(false);
-    });
-
-    it('should reject streamable-http config with malformed URL', () => {
-      const config = {
-        type: 'streamable-http' as const,
-        url: 'invalid url with spaces',
-      };
-
-      const result = MCPServerConfigSchema.safeParse(config);
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        // Zod returns "Invalid input" for discriminated union validation failures
-        expect(result.error.issues.length).toBeGreaterThan(0);
-      }
     });
   });
 
-  describe('field contamination', () => {
-    it('should reject stdio with URL field', () => {
+  describe('missing type discriminator', () => {
+    it('should reject config without type field', () => {
+      const config = { command: ['node', 'server.js'] };
+      const result = MCPServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject config with unknown type', () => {
+      const config = { type: 'stdio', command: 'node' };
+      const result = MCPServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('strict mode rejects unknown fields', () => {
+    it('should reject local config with url field', () => {
       const config = {
-        type: 'stdio' as const,
-        command: 'node',
-        args: ['server.js'],
+        type: 'local' as const,
+        command: ['node'],
         url: 'https://example.com',
       };
-
       expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
 
-    it('should reject stdio with headers field', () => {
+    it('should reject local config with headers field', () => {
       const config = {
-        command: 'node',
+        type: 'local' as const,
+        command: ['node'],
         headers: { Authorization: 'Bearer token' },
       };
-
       expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
 
-    it('should reject SSE with command field', () => {
+    it('should reject remote config with command field', () => {
       const config = {
-        type: 'sse' as const,
+        type: 'remote' as const,
         url: 'https://example.com',
-        command: 'node',
+        command: ['node'],
       };
-
       expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
 
-    it('should reject SSE with args field', () => {
+    it('should reject remote config with environment field', () => {
       const config = {
-        type: 'sse' as const,
+        type: 'remote' as const,
         url: 'https://example.com',
-        args: ['--flag'],
+        environment: { NODE_ENV: 'production' },
       };
-
       expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
 
-    it('should reject streamable-http with command field', () => {
+    it('should reject local config with legacy fields', () => {
       const config = {
-        type: 'streamable-http' as const,
-        url: 'https://example.com',
-        command: 'node',
+        type: 'local' as const,
+        command: ['node'],
+        alwaysAllow: ['tool1'],
       };
-
-      expect(() => MCPServerConfigSchema.parse(config)).toThrow();
-    });
-
-    it('should reject streamable-http with env field', () => {
-      const config = {
-        type: 'streamable-http' as const,
-        url: 'https://example.com',
-        env: { NODE_ENV: 'production' },
-      };
-
       expect(() => MCPServerConfigSchema.parse(config)).toThrow();
     });
   });
 
-  describe('BaseConfig fields', () => {
-    it('should accept timeout field within valid range', () => {
+  describe('optional fields', () => {
+    it('should accept timeout on local config', () => {
       const config = {
-        command: 'node',
-        timeout: 120,
+        type: 'local' as const,
+        command: ['node'],
+        timeout: 30000,
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result.timeout).toBe(120);
+      expect(result.timeout).toBe(30000);
     });
 
-    it('should reject timeout below minimum', () => {
+    it('should not add defaults for missing optional fields', () => {
       const config = {
-        command: 'node',
-        timeout: 0,
-      };
-
-      expect(() => MCPServerConfigSchema.parse(config)).toThrow();
-    });
-
-    it('should reject timeout above maximum', () => {
-      const config = {
-        command: 'node',
-        timeout: 3601,
-      };
-
-      expect(() => MCPServerConfigSchema.parse(config)).toThrow();
-    });
-
-    it('should accept alwaysAllow field', () => {
-      const config = {
-        command: 'node',
-        alwaysAllow: ['tool1', 'tool2', 'tool3'],
+        type: 'local' as const,
+        command: ['node'],
       };
 
       const result = MCPServerConfigSchema.parse(config);
-      expect(result.alwaysAllow).toEqual(['tool1', 'tool2', 'tool3']);
-    });
-
-    it('should accept watchPaths field', () => {
-      const config = {
-        command: 'node',
-        watchPaths: ['/src', '/config'],
-      };
-
-      const result = MCPServerConfigSchema.parse(config);
-      expect(result.watchPaths).toEqual(['/src', '/config']);
-    });
-
-    it('should accept disabledTools field', () => {
-      const config = {
-        command: 'node',
-        disabledTools: ['dangerous-tool', 'deprecated-tool'],
-      };
-
-      const result = MCPServerConfigSchema.parse(config);
-      expect(result.disabledTools).toEqual(['dangerous-tool', 'deprecated-tool']);
-    });
-
-    it('should accept all BaseConfig fields together', () => {
-      const config = {
-        type: 'stdio' as const,
-        command: 'node',
-        args: ['server.js'],
-        timeout: 90,
-        alwaysAllow: ['read_file'],
-        watchPaths: ['/src'],
-        disabledTools: ['delete_file'],
-      };
-
-      const result = MCPServerConfigSchema.parse(config);
-      expect(result).toMatchObject({
-        type: 'stdio',
-        command: 'node',
-        args: ['server.js'],
-        timeout: 90,
-        alwaysAllow: ['read_file'],
-        watchPaths: ['/src'],
-        disabledTools: ['delete_file'],
-      });
-    });
-
-    it('should apply default values for alwaysAllow and disabledTools', () => {
-      const config = {
-        command: 'node',
-      };
-
-      const result = MCPServerConfigSchema.parse(config);
-      expect(result.alwaysAllow).toEqual([]);
-      expect(result.disabledTools).toEqual([]);
-    });
-
-    it('should apply default timeout value', () => {
-      const config = {
-        command: 'node',
-      };
-
-      const result = MCPServerConfigSchema.parse(config);
-      expect(result.timeout).toBe(60);
+      expect(result).toEqual({ type: 'local', command: ['node'] });
     });
   });
 });
@@ -567,13 +448,12 @@ describe('MetadataSchema', () => {
     it('should accept valid record of MCP server configs', () => {
       const mcpServers: Record<string, MCPServerConfig> = {
         puppeteer: {
-          type: 'stdio',
-          command: 'npx',
-          args: ['-y', '@modelcontextprotocol/server-puppeteer'],
+          type: 'local',
+          command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
         },
         remote: {
-          type: 'sse',
-          url: 'https://example.com/sse',
+          type: 'remote',
+          url: 'https://example.com/mcp',
         },
       };
 
@@ -588,15 +468,16 @@ describe('MetadataSchema', () => {
 
       const result = MetadataSchema.parse(metadata);
       expect(result.mcpServers).toBeDefined();
-      expect(result.mcpServers!.puppeteer.type).toBe('stdio');
-      expect(result.mcpServers!.remote.type).toBe('sse');
+      expect(result.mcpServers!['puppeteer'].type).toBe('local');
+      expect(result.mcpServers!['remote'].type).toBe('remote');
     });
 
     it('should accept server names at maximum length', () => {
       const longServerName = 'A'.repeat(100);
       const mcpServers: Record<string, MCPServerConfig> = {
         [longServerName]: {
-          command: 'node',
+          type: 'local',
+          command: ['node'],
         },
       };
 
@@ -619,7 +500,8 @@ describe('MetadataSchema', () => {
       const longServerName = 'A'.repeat(101);
       const mcpServers: Record<string, MCPServerConfig> = {
         [longServerName]: {
-          command: 'node',
+          type: 'local',
+          command: ['node'],
         },
       };
 

--- a/cloud-agent-next/src/persistence/schemas.ts
+++ b/cloud-agent-next/src/persistence/schemas.ts
@@ -60,68 +60,37 @@ export const branchNameSchema = z
   );
 
 /**
- * Base configuration schema shared by all MCP server types
+ * Local MCP server configuration schema (runs a command).
  */
-const MCPServerBaseConfigSchema = z.object({
-  disabled: z.boolean().optional(),
-  timeout: z.number().min(1).max(3600).optional().default(60),
-  alwaysAllow: z.array(z.string()).default([]),
-  watchPaths: z.array(z.string()).optional(),
-  disabledTools: z.array(z.string()).default([]),
-});
-
-export const MCPStdioServerConfigSchema = MCPServerBaseConfigSchema.extend({
-  type: z.enum(['stdio']).optional(),
-  command: z.string().min(1, 'Command cannot be empty'),
-  args: z.array(z.string()).optional(),
-  cwd: z.string().optional(),
-  env: z.record(z.string(), z.string()).optional(),
-  // Field contamination prevention
-  url: z.undefined().optional(),
-  headers: z.undefined().optional(),
-}).transform(data => ({
-  ...data,
-  type: 'stdio' as const,
-}));
-
-export const MCPSseServerConfigSchema = MCPServerBaseConfigSchema.extend({
-  type: z.enum(['sse']),
-  url: z.string().url('URL must be a valid URL format'),
-  headers: z.record(z.string(), z.string()).optional(),
-  // Field contamination prevention
-  command: z.undefined().optional(),
-  args: z.undefined().optional(),
-  env: z.undefined().optional(),
-  cwd: z.undefined().optional(),
-}).transform(data => ({
-  ...data,
-  type: 'sse' as const,
-}));
-
-export const MCPStreamableHttpServerConfigSchema = MCPServerBaseConfigSchema.extend({
-  type: z.enum(['streamable-http']),
-  url: z.string().url('URL must be a valid URL format'),
-  headers: z.record(z.string(), z.string()).optional(),
-  // Field contamination prevention
-  command: z.undefined().optional(),
-  args: z.undefined().optional(),
-  env: z.undefined().optional(),
-  cwd: z.undefined().optional(),
-}).transform(data => ({
-  ...data,
-  type: 'streamable-http' as const,
-}));
+const MCPLocalServerConfigSchema = z
+  .object({
+    type: z.literal('local'),
+    command: z.string().array().min(1, 'Command array must have at least one element'),
+    environment: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
+    timeout: z.number().min(1).max(3_600_000).optional(),
+  })
+  .strict();
 
 /**
- * MCP Server configuration schema supporting three transport types:
- * - stdio: local process execution
- * - sse: Server-Sent Events
- * - streamable-http: HTTP streaming
+ * Remote MCP server configuration schema (connects to a URL).
  */
-export const MCPServerConfigSchema = z.union([
-  MCPStdioServerConfigSchema,
-  MCPSseServerConfigSchema,
-  MCPStreamableHttpServerConfigSchema,
+const MCPRemoteServerConfigSchema = z
+  .object({
+    type: z.literal('remote'),
+    url: z.string().url('URL must be a valid URL format'),
+    headers: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
+    timeout: z.number().min(1).max(3_600_000).optional(),
+  })
+  .strict();
+
+/**
+ * MCP Server configuration schema — CLI-native local/remote discriminated union.
+ */
+export const MCPServerConfigSchema = z.discriminatedUnion('type', [
+  MCPLocalServerConfigSchema,
+  MCPRemoteServerConfigSchema,
 ]);
 
 /**

--- a/cloud-agent-next/src/persistence/types.ts
+++ b/cloud-agent-next/src/persistence/types.ts
@@ -7,65 +7,39 @@ import type { Images } from './schemas.js';
 import type { SessionIngestBinding } from '../session-ingest-binding.js';
 
 /**
- * Base configuration shared by all MCP server types
+ * Local MCP server configuration (runs a command)
  */
-export type BaseConfig = {
-  /** Whether this server is disabled */
-  disabled?: boolean;
-  /** Timeout in seconds (1-3600), default 60 */
-  timeout?: number;
-  /** Tools that are always allowed without user confirmation */
-  alwaysAllow?: string[];
-  /** File paths to watch for changes */
-  watchPaths?: string[];
-  /** Tools that should be disabled */
-  disabledTools?: string[];
-};
-
-/**
- * Stdio-based MCP server configuration (local process)
- */
-export type StdioServerConfig = BaseConfig & {
-  /** Transport type - defaults to stdio */
-  type?: 'stdio';
-  /** Command to execute */
-  command: string;
-  /** Command arguments */
-  args?: string[];
-  /** Working directory for the command */
-  cwd?: string;
+export type MCPLocalServerConfig = {
+  type: 'local';
+  /** Command to execute — first element is the binary, rest are args */
+  command: string[];
   /** Environment variables for the command */
-  env?: Record<string, string>;
+  environment?: Record<string, string>;
+  /** Whether this server is enabled (default true) */
+  enabled?: boolean;
+  /** Timeout in milliseconds */
+  timeout?: number;
 };
 
 /**
- * SSE-based MCP server configuration (Server-Sent Events)
+ * Remote MCP server configuration (connects to a URL)
  */
-export type SseServerConfig = BaseConfig & {
-  /** Transport type */
-  type: 'sse';
+export type MCPRemoteServerConfig = {
+  type: 'remote';
   /** Server URL */
   url: string;
   /** HTTP headers */
   headers?: Record<string, string>;
+  /** Whether this server is enabled (default true) */
+  enabled?: boolean;
+  /** Timeout in milliseconds */
+  timeout?: number;
 };
 
 /**
- * Streamable HTTP-based MCP server configuration
+ * MCP Server configuration — CLI-native local/remote discriminated union
  */
-export type StreamableHttpServerConfig = BaseConfig & {
-  /** Transport type */
-  type: 'streamable-http';
-  /** Server URL */
-  url: string;
-  /** HTTP headers */
-  headers?: Record<string, string>;
-};
-
-/**
- * MCP Server configuration - discriminated union of three transport types
- */
-export type MCPServerConfig = StdioServerConfig | SseServerConfig | StreamableHttpServerConfig;
+export type MCPServerConfig = MCPLocalServerConfig | MCPRemoteServerConfig;
 
 export type CloudAgentSessionState = {
   /** Current version timestamp (for cache invalidation) */
@@ -108,7 +82,7 @@ export type CloudAgentSessionState = {
   encryptedSecrets?: EncryptedSecrets;
   /** Installation commands to run on init/resume */
   setupCommands?: string[];
-  /** MCP server configurations written to .kilocode/cli/global/setting/mcp_settings.json */
+  /** MCP server configurations injected via KILO_CONFIG_CONTENT env var */
   mcpServers?: Record<string, MCPServerConfig>;
   /** Upstream branch to checkout when cloning the repo */
   upstreamBranch?: string;

--- a/cloud-agent-next/src/router.test.ts
+++ b/cloud-agent-next/src/router.test.ts
@@ -650,7 +650,7 @@ describe('router sessionId validation', () => {
             envVars: { API_KEY: 'secret-value', DB_URL: 'postgres://localhost' },
             setupCommands: ['npm install', 'npm run build'],
             mcpServers: {
-              puppeteer: { command: 'npx', args: ['-y', '@mcp/puppeteer'] },
+              puppeteer: { type: 'local', command: ['npx', '-y', '@mcp/puppeteer'] },
             },
             preparedAt: 1700000000000,
             initiatedAt: 1700000001000,

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -7,7 +7,6 @@ import {
   determineBranchName,
   runSetupCommands,
   writeAuthFile,
-  writeMCPSettings,
 } from '../../session-service.js';
 import { InstallationLookupService } from '../../services/installation-lookup-service.js';
 import { GitHubTokenService } from '../../services/github-token-service.js';
@@ -232,7 +231,8 @@ const prepareSessionHandler = internalApiProtectedProcedure
         input.kilocodeOrganizationId,
         input.encryptedSecrets,
         input.createdOnPlatform,
-        input.appendSystemPrompt
+        input.appendSystemPrompt,
+        input.mcpServers
       );
 
       // 6. Clone repository
@@ -275,15 +275,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
         await runSetupCommands(session, context, input.setupCommands, true); // fail-fast
       }
 
-      // 9. Write MCP settings
-      if (input.mcpServers && Object.keys(input.mcpServers).length > 0) {
-        logger
-          .withFields({ count: Object.keys(input.mcpServers).length })
-          .info('Writing MCP settings');
-        await writeMCPSettings(sandbox, sessionHome, input.mcpServers);
-      }
-
-      // 9b. Write auth file for session ingest
+      // 9. Write auth file for session ingest
       await writeAuthFile(sandbox, sessionHome, ctx.authToken);
 
       // 10. Start kilo server

--- a/cloud-agent-next/src/session-prepare.test.ts
+++ b/cloud-agent-next/src/session-prepare.test.ts
@@ -72,7 +72,6 @@ vi.mock('./session-service.js', () => ({
   ),
   runSetupCommands: vi.fn().mockResolvedValue(undefined),
   writeAuthFile: vi.fn().mockResolvedValue(undefined),
-  writeMCPSettings: vi.fn().mockResolvedValue(undefined),
   InvalidSessionMetadataError: class InvalidSessionMetadataError extends Error {
     constructor(
       public readonly userId: string,

--- a/cloud-agent-next/src/session-prepare.test.ts
+++ b/cloud-agent-next/src/session-prepare.test.ts
@@ -349,14 +349,13 @@ describe('prepareSession endpoint', () => {
         githubToken: 'ghp_test_token',
         envVars: { API_KEY: 'secret' },
         setupCommands: ['npm install'],
-        mcpServers: { test: { command: 'npx', args: ['test-server'] } },
+        mcpServers: { test: { type: 'local', command: ['npx', 'test-server'] } },
         upstreamBranch: 'feature/test-branch',
         autoCommit: true,
         kilocodeOrganizationId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       });
 
       // Verify the DO was called with the expected configuration
-      // Note: mcpServers schema adds default values (type, timeout, alwaysAllow, disabledTools)
       expect(doStub.prepare).toHaveBeenCalledTimes(1);
       const callArg = doStub.prepare.mock.calls[0][0];
       expect(callArg.envVars).toEqual({ API_KEY: 'secret' });
@@ -364,8 +363,7 @@ describe('prepareSession endpoint', () => {
       expect(callArg.upstreamBranch).toBe('feature/test-branch');
       expect(callArg.autoCommit).toBe(true);
       expect(callArg.orgId).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
-      expect(callArg.mcpServers.test.command).toBe('npx');
-      expect(callArg.mcpServers.test.args).toEqual(['test-server']);
+      expect(callArg.mcpServers.test).toEqual({ type: 'local', command: ['npx', 'test-server'] });
     });
   });
 
@@ -992,9 +990,9 @@ describe('integration flow tests', () => {
 describe('MCP server count limits', () => {
   it('should reject more than MAX_MCP_SERVERS in PrepareSessionInput', () => {
     // Create an object with MAX_MCP_SERVERS + 1 servers
-    const tooManyServers: Record<string, { command: string }> = {};
+    const tooManyServers: Record<string, { type: 'local'; command: string[] }> = {};
     for (let i = 0; i <= schemaLimits.Limits.MAX_MCP_SERVERS; i++) {
-      tooManyServers[`server${i}`] = { command: 'npx' };
+      tooManyServers[`server${i}`] = { type: 'local', command: ['npx'] };
     }
 
     const result = schemas.PrepareSessionInput.safeParse({
@@ -1011,9 +1009,9 @@ describe('MCP server count limits', () => {
   });
 
   it('should accept exactly MAX_MCP_SERVERS in PrepareSessionInput', () => {
-    const maxServers: Record<string, { command: string }> = {};
+    const maxServers: Record<string, { type: 'local'; command: string[] }> = {};
     for (let i = 0; i < schemaLimits.Limits.MAX_MCP_SERVERS; i++) {
-      maxServers[`server${i}`] = { command: 'npx' };
+      maxServers[`server${i}`] = { type: 'local', command: ['npx'] };
     }
 
     const result = schemas.PrepareSessionInput.safeParse({
@@ -1027,9 +1025,9 @@ describe('MCP server count limits', () => {
   });
 
   it('should reject more than MAX_MCP_SERVERS in UpdateSessionInput', () => {
-    const tooManyServers: Record<string, { command: string }> = {};
+    const tooManyServers: Record<string, { type: 'local'; command: string[] }> = {};
     for (let i = 0; i <= schemaLimits.Limits.MAX_MCP_SERVERS; i++) {
-      tooManyServers[`server${i}`] = { command: 'npx' };
+      tooManyServers[`server${i}`] = { type: 'local', command: ['npx'] };
     }
 
     const result = schemas.UpdateSessionInput.safeParse({

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -39,7 +39,11 @@ import {
   manageBranch as mockManageBranch,
   restoreWorkspace as mockRestoreWorkspace,
 } from './workspace.js';
-import { InvalidSessionMetadataError, SessionService } from './session-service.js';
+import {
+  InvalidSessionMetadataError,
+  SessionService,
+  convertMcpServersForCli,
+} from './session-service.js';
 import type { SandboxInstance, SessionId, SessionContext, ExecutionSession } from './types.js';
 import type { PersistenceEnv, CloudAgentSessionState } from './persistence/types.js';
 
@@ -1540,27 +1544,25 @@ describe('SessionService', () => {
     });
   });
 
-  describe('MCP Settings File Writing', () => {
-    it('should create directory and write file to correct path', async () => {
+  describe('MCP Config in KILO_CONFIG_CONTENT', () => {
+    it('should include MCP servers in KILO_CONFIG_CONTENT env var', async () => {
       const fakeSession = {
         exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
       };
-      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
-      const sandboxWriteFile = vi.fn().mockResolvedValue(undefined);
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
       const sandbox = {
-        createSession: vi.fn().mockResolvedValue(fakeSession),
+        createSession: sandboxCreateSession,
         mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: sandboxExec,
-        writeFile: sandboxWriteFile,
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
       } as unknown as SandboxInstance;
       const sessionId: SessionId = 'agent_mcp_test';
-      const sessionHome = `/home/${sessionId}`;
       mockedSetupWorkspace.mockResolvedValue({
         workspacePath: `/workspace/org/user/sessions/${sessionId}`,
-        sessionHome,
+        sessionHome: `/home/${sessionId}`,
       });
 
       const service = new SessionService();
@@ -1584,32 +1586,28 @@ describe('SessionService', () => {
         mcpServers,
       });
 
-      // Verify directory creation
-      expect(sandboxExec).toHaveBeenCalledWith(
-        `mkdir -p ${sessionHome}/.kilocode/cli/global/settings`
-      );
-
-      // Verify file write
-      expect(sandboxWriteFile).toHaveBeenCalledWith(
-        `${sessionHome}/.kilocode/cli/global/settings/mcp_settings.json`,
-        expect.stringContaining('"mcpServers"')
-      );
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp).toBeDefined();
+      expect(configContent.mcp.puppeteer).toEqual({
+        type: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
+      });
     });
 
-    it('should handle empty mcpServers gracefully', async () => {
+    it('should not include mcp key when mcpServers is empty', async () => {
       const fakeSession = {
         exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
       };
-      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
-      const sandboxWriteFile = vi.fn().mockResolvedValue(undefined);
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
       const sandbox = {
-        createSession: vi.fn().mockResolvedValue(fakeSession),
+        createSession: sandboxCreateSession,
         mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: sandboxExec,
-        writeFile: sandboxWriteFile,
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
       } as unknown as SandboxInstance;
       const sessionId: SessionId = 'agent_empty_mcp';
       mockedSetupWorkspace.mockResolvedValue({
@@ -1631,27 +1629,24 @@ describe('SessionService', () => {
         mcpServers: {}, // Empty object
       });
 
-      // Should not attempt to write MCP settings
-      expect(sandboxWriteFile).not.toHaveBeenCalledWith(
-        expect.stringContaining('mcp_settings.json'),
-        expect.anything()
-      );
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp).toBeUndefined();
     });
 
-    it('should write valid JSON with correct structure', async () => {
+    it('should convert stdio, sse, and streamable-http to CLI format', async () => {
       const fakeSession = {
         exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
       };
-      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
-      const sandboxWriteFile = vi.fn().mockResolvedValue(undefined);
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
       const sandbox = {
-        createSession: vi.fn().mockResolvedValue(fakeSession),
+        createSession: sandboxCreateSession,
         mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: sandboxExec,
-        writeFile: sandboxWriteFile,
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
       } as unknown as SandboxInstance;
       const sessionId: SessionId = 'agent_mcp_json';
       mockedSetupWorkspace.mockResolvedValue({
@@ -1665,10 +1660,16 @@ describe('SessionService', () => {
           type: 'stdio' as const,
           command: 'node',
           args: ['server.js'],
+          env: { FOO: 'bar' },
         },
         'server-2': {
           type: 'sse' as const,
           url: 'https://example.com/mcp',
+          headers: { Authorization: 'Bearer tok' },
+        },
+        'server-3': {
+          type: 'streamable-http' as const,
+          url: 'https://example.com/stream',
         },
       };
 
@@ -1685,23 +1686,170 @@ describe('SessionService', () => {
         mcpServers,
       });
 
-      const writtenContent = sandboxWriteFile.mock.calls[0]?.[1] as string;
-      expect(writtenContent).toBeDefined();
-
-      // Should be valid JSON
-      const parsed = JSON.parse(writtenContent);
-      expect(parsed).toHaveProperty('mcpServers');
-      expect(parsed.mcpServers).toHaveProperty('server-1');
-      expect(parsed.mcpServers).toHaveProperty('server-2');
-      expect(parsed.mcpServers['server-1']).toMatchObject({
-        type: 'stdio',
-        command: 'node',
-        args: ['server.js'],
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp['server-1']).toEqual({
+        type: 'local',
+        command: ['node', 'server.js'],
+        environment: { FOO: 'bar' },
       });
-      expect(parsed.mcpServers['server-2']).toMatchObject({
-        type: 'sse',
+      expect(configContent.mcp['server-2']).toEqual({
+        type: 'remote',
         url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer tok' },
       });
+      expect(configContent.mcp['server-3']).toEqual({
+        type: 'remote',
+        url: 'https://example.com/stream',
+      });
+    });
+
+    it('should convert alwaysAllow to permission rules', async () => {
+      const fakeSession = {
+        exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
+      const sandbox = {
+        createSession: sandboxCreateSession,
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+      const sessionId: SessionId = 'agent_mcp_permissions';
+      mockedSetupWorkspace.mockResolvedValue({
+        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
+        sessionHome: `/home/${sessionId}`,
+      });
+
+      const service = new SessionService();
+      const mcpServers = {
+        'my-server': {
+          command: 'test',
+          alwaysAllow: ['tool_a', 'tool_b'],
+        },
+        'wildcard-server': {
+          command: 'test2',
+          alwaysAllow: ['*'],
+        },
+      };
+
+      await service.initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        githubRepo: 'acme/repo',
+        env: mockEnv,
+        mcpServers,
+      });
+
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      // alwaysAllow tools should become permission rules
+      expect(configContent.permission['my-server_tool_a']).toBe('allow');
+      expect(configContent.permission['my-server_tool_b']).toBe('allow');
+      // Wildcard alwaysAllow should map to server_* permission
+      expect(configContent.permission['wildcard-server_*']).toBe('allow');
+      // Existing external_directory permission should still be there
+      expect(configContent.permission.external_directory).toBeDefined();
+    });
+
+    it('should convert timeout from seconds to milliseconds', async () => {
+      const fakeSession = {
+        exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
+      const sandbox = {
+        createSession: sandboxCreateSession,
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+      const sessionId: SessionId = 'agent_mcp_timeout';
+      mockedSetupWorkspace.mockResolvedValue({
+        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
+        sessionHome: `/home/${sessionId}`,
+      });
+
+      const service = new SessionService();
+      const mcpServers = {
+        'timeout-server': {
+          command: 'test',
+          timeout: 120,
+        },
+      };
+
+      await service.initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        githubRepo: 'acme/repo',
+        env: mockEnv,
+        mcpServers,
+      });
+
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp['timeout-server'].timeout).toBe(120000);
+    });
+
+    it('should convert disabled to enabled: false', async () => {
+      const fakeSession = {
+        exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
+      const sandbox = {
+        createSession: sandboxCreateSession,
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+      const sessionId: SessionId = 'agent_mcp_disabled';
+      mockedSetupWorkspace.mockResolvedValue({
+        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
+        sessionHome: `/home/${sessionId}`,
+      });
+
+      const service = new SessionService();
+      const mcpServers = {
+        'disabled-server': {
+          command: 'test',
+          disabled: true,
+        },
+      };
+
+      await service.initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        githubRepo: 'acme/repo',
+        env: mockEnv,
+        mcpServers,
+      });
+
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp['disabled-server'].enabled).toBe(false);
     });
   });
 
@@ -1973,7 +2121,7 @@ describe('SessionService', () => {
       expect(fakeSession.exec).toHaveBeenCalledWith('npm run build', expect.any(Object));
     });
 
-    it('should re-write MCP settings from metadata on resume', async () => {
+    it('should include MCP config in KILO_CONFIG_CONTENT on resume', async () => {
       const metadata = {
         version: 123456789,
         sessionId: 'agent_resume_mcp',
@@ -2000,13 +2148,12 @@ describe('SessionService', () => {
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
       };
-      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
-      const sandboxWriteFile = vi.fn().mockResolvedValue(undefined);
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
       const sandbox = {
-        createSession: vi.fn().mockResolvedValue(fakeSession),
+        createSession: sandboxCreateSession,
         mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: sandboxExec,
-        writeFile: sandboxWriteFile,
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
       } as unknown as SandboxInstance;
 
       const service = new SessionService();
@@ -2021,11 +2168,14 @@ describe('SessionService', () => {
         env: testEnv,
       });
 
-      // Verify MCP settings were re-written (because repo didn't exist, triggering reclone)
-      expect(sandboxWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('mcp_settings.json'),
-        expect.stringContaining('puppeteer')
-      );
+      // Verify MCP config is in KILO_CONFIG_CONTENT env var
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp).toBeDefined();
+      expect(configContent.mcp.puppeteer).toMatchObject({
+        type: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
+      });
     });
 
     it('should restore envVars to context on resume', async () => {
@@ -2106,13 +2256,11 @@ describe('SessionService', () => {
         deleteFile: vi.fn().mockResolvedValue(undefined),
       };
       const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
-      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
-      const sandboxWriteFile = vi.fn().mockResolvedValue(undefined);
       const sandbox = {
         createSession: sandboxCreateSession,
         mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: sandboxExec,
-        writeFile: sandboxWriteFile,
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
       } as unknown as SandboxInstance;
 
       const service = new SessionService();
@@ -2137,11 +2285,14 @@ describe('SessionService', () => {
       // Verify setup commands re-run (because repo didn't exist, triggering reclone)
       expect(fakeSession.exec).toHaveBeenCalledWith('npm install', expect.any(Object));
 
-      // Verify MCP settings re-written (because repo didn't exist, triggering reclone)
-      expect(sandboxWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('mcp_settings.json'),
-        expect.any(String)
-      );
+      // Verify MCP config in KILO_CONFIG_CONTENT
+      const callArgs = sandboxCreateSession.mock.calls[0][0];
+      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      expect(configContent.mcp).toBeDefined();
+      expect(configContent.mcp.test).toMatchObject({
+        type: 'local',
+        command: ['test-server'],
+      });
     });
   });
 
@@ -3296,5 +3447,147 @@ describe('SessionService', () => {
       // git checkout -b should NOT be called (legacy CLI manages its own branch)
       expect(fakeSession.exec).not.toHaveBeenCalledWith(expect.stringContaining('git checkout -b'));
     });
+  });
+});
+
+describe('convertMcpServersForCli', () => {
+  it('converts stdio server to local format', () => {
+    const result = convertMcpServersForCli({
+      myServer: {
+        type: 'stdio',
+        command: 'node',
+        args: ['server.js', '--port', '3000'],
+        env: { NODE_ENV: 'production' },
+        cwd: '/app',
+      },
+    });
+
+    expect(result.mcp.myServer).toEqual({
+      type: 'local',
+      command: ['node', 'server.js', '--port', '3000'],
+      environment: { NODE_ENV: 'production' },
+      cwd: '/app',
+    });
+    expect(result.permission).toEqual({});
+  });
+
+  it('converts stdio server without explicit type', () => {
+    const result = convertMcpServersForCli({
+      myServer: {
+        command: 'npx',
+        args: ['-y', 'some-package'],
+      },
+    });
+
+    expect(result.mcp.myServer).toEqual({
+      type: 'local',
+      command: ['npx', '-y', 'some-package'],
+    });
+  });
+
+  it('converts sse server to remote format', () => {
+    const result = convertMcpServersForCli({
+      remote: {
+        type: 'sse',
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer tok123' },
+      },
+    });
+
+    expect(result.mcp.remote).toEqual({
+      type: 'remote',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer tok123' },
+    });
+  });
+
+  it('converts streamable-http server to remote format', () => {
+    const result = convertMcpServersForCli({
+      stream: {
+        type: 'streamable-http',
+        url: 'https://example.com/stream',
+      },
+    });
+
+    expect(result.mcp.stream).toEqual({
+      type: 'remote',
+      url: 'https://example.com/stream',
+    });
+  });
+
+  it('converts alwaysAllow to permission rules with name sanitization', () => {
+    const result = convertMcpServersForCli({
+      'my.server': {
+        command: 'test',
+        alwaysAllow: ['tool.a', 'tool-b'],
+      },
+    });
+
+    expect(result.permission).toEqual({
+      my_server_tool_a: 'allow',
+      'my_server_tool-b': 'allow',
+    });
+  });
+
+  it('converts wildcard alwaysAllow to server_* permission', () => {
+    const result = convertMcpServersForCli({
+      myServer: {
+        command: 'test',
+        alwaysAllow: ['*'],
+      },
+    });
+
+    expect(result.permission).toEqual({
+      'myServer_*': 'allow',
+    });
+  });
+
+  it('converts disabled to enabled: false', () => {
+    const result = convertMcpServersForCli({
+      myServer: {
+        command: 'test',
+        disabled: true,
+      },
+    });
+
+    expect(result.mcp.myServer).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  it('converts timeout from seconds to milliseconds', () => {
+    const result = convertMcpServersForCli({
+      myServer: {
+        command: 'test',
+        timeout: 120,
+      },
+    });
+
+    expect(result.mcp.myServer).toMatchObject({
+      timeout: 120000,
+    });
+  });
+
+  it('omits empty env/headers objects', () => {
+    const result = convertMcpServersForCli({
+      local: {
+        command: 'test',
+        env: {},
+      },
+      remote: {
+        type: 'sse',
+        url: 'https://example.com',
+        headers: {},
+      },
+    });
+
+    expect(result.mcp.local).not.toHaveProperty('environment');
+    expect(result.mcp.remote).not.toHaveProperty('headers');
+  });
+
+  it('returns empty objects for empty input', () => {
+    const result = convertMcpServersForCli({});
+    expect(result.mcp).toEqual({});
+    expect(result.permission).toEqual({});
   });
 });

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -39,11 +39,7 @@ import {
   manageBranch as mockManageBranch,
   restoreWorkspace as mockRestoreWorkspace,
 } from './workspace.js';
-import {
-  InvalidSessionMetadataError,
-  SessionService,
-  convertMcpServersForCli,
-} from './session-service.js';
+import { InvalidSessionMetadataError, SessionService } from './session-service.js';
 import type { SandboxInstance, SessionId, SessionContext, ExecutionSession } from './types.js';
 import type { PersistenceEnv, CloudAgentSessionState } from './persistence/types.js';
 
@@ -1568,8 +1564,8 @@ describe('SessionService', () => {
       const service = new SessionService();
       const mcpServers = {
         puppeteer: {
-          command: 'npx',
-          args: ['-y', '@modelcontextprotocol/server-puppeteer'],
+          type: 'local' as const,
+          command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
         },
       };
 
@@ -1634,7 +1630,7 @@ describe('SessionService', () => {
       expect(configContent.mcp).toBeUndefined();
     });
 
-    it('should convert stdio, sse, and streamable-http to CLI format', async () => {
+    it('should pass local and remote MCP configs directly to KILO_CONFIG_CONTENT', async () => {
       const fakeSession = {
         exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
@@ -1657,19 +1653,14 @@ describe('SessionService', () => {
       const service = new SessionService();
       const mcpServers = {
         'server-1': {
-          type: 'stdio' as const,
-          command: 'node',
-          args: ['server.js'],
-          env: { FOO: 'bar' },
+          type: 'local' as const,
+          command: ['node', 'server.js'],
+          environment: { FOO: 'bar' },
         },
         'server-2': {
-          type: 'sse' as const,
+          type: 'remote' as const,
           url: 'https://example.com/mcp',
           headers: { Authorization: 'Bearer tok' },
-        },
-        'server-3': {
-          type: 'streamable-http' as const,
-          url: 'https://example.com/stream',
         },
       };
 
@@ -1688,6 +1679,7 @@ describe('SessionService', () => {
 
       const callArgs = sandboxCreateSession.mock.calls[0][0];
       const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
+      // MCP configs are passed through directly — no conversion
       expect(configContent.mcp['server-1']).toEqual({
         type: 'local',
         command: ['node', 'server.js'],
@@ -1698,13 +1690,9 @@ describe('SessionService', () => {
         url: 'https://example.com/mcp',
         headers: { Authorization: 'Bearer tok' },
       });
-      expect(configContent.mcp['server-3']).toEqual({
-        type: 'remote',
-        url: 'https://example.com/stream',
-      });
     });
 
-    it('should convert alwaysAllow to permission rules', async () => {
+    it('should pass enabled and timeout fields directly', async () => {
       const fakeSession = {
         exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
@@ -1718,109 +1706,7 @@ describe('SessionService', () => {
         exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
       } as unknown as SandboxInstance;
-      const sessionId: SessionId = 'agent_mcp_permissions';
-      mockedSetupWorkspace.mockResolvedValue({
-        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
-        sessionHome: `/home/${sessionId}`,
-      });
-
-      const service = new SessionService();
-      const mcpServers = {
-        'my-server': {
-          command: 'test',
-          alwaysAllow: ['tool_a', 'tool_b'],
-        },
-        'wildcard-server': {
-          command: 'test2',
-          alwaysAllow: ['*'],
-        },
-      };
-
-      await service.initiate({
-        sandbox,
-        sandboxId: 'org__user',
-        orgId: 'org',
-        userId: 'user',
-        sessionId,
-        kilocodeToken: 'token',
-        kilocodeModel: 'test-model',
-        githubRepo: 'acme/repo',
-        env: mockEnv,
-        mcpServers,
-      });
-
-      const callArgs = sandboxCreateSession.mock.calls[0][0];
-      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
-      // alwaysAllow tools should become permission rules
-      expect(configContent.permission['my-server_tool_a']).toBe('allow');
-      expect(configContent.permission['my-server_tool_b']).toBe('allow');
-      // Wildcard alwaysAllow should map to server_* permission
-      expect(configContent.permission['wildcard-server_*']).toBe('allow');
-      // Existing external_directory permission should still be there
-      expect(configContent.permission.external_directory).toBeDefined();
-    });
-
-    it('should convert timeout from seconds to milliseconds', async () => {
-      const fakeSession = {
-        exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
-        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
-        writeFile: vi.fn().mockResolvedValue(undefined),
-        deleteFile: vi.fn().mockResolvedValue(undefined),
-      };
-      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
-      const sandbox = {
-        createSession: sandboxCreateSession,
-        mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
-        writeFile: vi.fn().mockResolvedValue(undefined),
-      } as unknown as SandboxInstance;
-      const sessionId: SessionId = 'agent_mcp_timeout';
-      mockedSetupWorkspace.mockResolvedValue({
-        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
-        sessionHome: `/home/${sessionId}`,
-      });
-
-      const service = new SessionService();
-      const mcpServers = {
-        'timeout-server': {
-          command: 'test',
-          timeout: 120,
-        },
-      };
-
-      await service.initiate({
-        sandbox,
-        sandboxId: 'org__user',
-        orgId: 'org',
-        userId: 'user',
-        sessionId,
-        kilocodeToken: 'token',
-        kilocodeModel: 'test-model',
-        githubRepo: 'acme/repo',
-        env: mockEnv,
-        mcpServers,
-      });
-
-      const callArgs = sandboxCreateSession.mock.calls[0][0];
-      const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
-      expect(configContent.mcp['timeout-server'].timeout).toBe(120000);
-    });
-
-    it('should convert disabled to enabled: false', async () => {
-      const fakeSession = {
-        exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
-        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
-        writeFile: vi.fn().mockResolvedValue(undefined),
-        deleteFile: vi.fn().mockResolvedValue(undefined),
-      };
-      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
-      const sandbox = {
-        createSession: sandboxCreateSession,
-        mkdir: vi.fn().mockResolvedValue(undefined),
-        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
-        writeFile: vi.fn().mockResolvedValue(undefined),
-      } as unknown as SandboxInstance;
-      const sessionId: SessionId = 'agent_mcp_disabled';
+      const sessionId: SessionId = 'agent_mcp_fields';
       mockedSetupWorkspace.mockResolvedValue({
         workspacePath: `/workspace/org/user/sessions/${sessionId}`,
         sessionHome: `/home/${sessionId}`,
@@ -1829,8 +1715,10 @@ describe('SessionService', () => {
       const service = new SessionService();
       const mcpServers = {
         'disabled-server': {
-          command: 'test',
-          disabled: true,
+          type: 'local' as const,
+          command: ['test'],
+          enabled: false,
+          timeout: 30000,
         },
       };
 
@@ -1849,7 +1737,12 @@ describe('SessionService', () => {
 
       const callArgs = sandboxCreateSession.mock.calls[0][0];
       const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
-      expect(configContent.mcp['disabled-server'].enabled).toBe(false);
+      expect(configContent.mcp['disabled-server']).toEqual({
+        type: 'local',
+        command: ['test'],
+        enabled: false,
+        timeout: 30000,
+      });
     });
   });
 
@@ -1882,7 +1775,7 @@ describe('SessionService', () => {
       const envVars = { API_KEY: 'test-123' };
       const setupCommands = ['npm install', 'npm build'];
       const mcpServers = {
-        test: { command: 'test-server' },
+        test: { type: 'local' as const, command: ['test-server'] },
       };
 
       await service.initiate({
@@ -1909,9 +1802,8 @@ describe('SessionService', () => {
           githubRepo: 'acme/repo',
           envVars: { API_KEY: 'test-123' },
           setupCommands: ['npm install', 'npm build'],
-          // MCPServerConfigSchema adds defaults for type, timeout, alwaysAllow, disabledTools
           mcpServers: {
-            test: expect.objectContaining({ command: 'test-server' }),
+            test: { type: 'local', command: ['test-server'] },
           },
         })
       );
@@ -1928,7 +1820,7 @@ describe('SessionService', () => {
         githubToken: 'test-token',
         envVars: { DATABASE_URL: 'postgres://localhost' },
         setupCommands: ['pnpm install'],
-        mcpServers: { github: { command: 'mcp-github' } },
+        mcpServers: { github: { type: 'local' as const, command: ['mcp-github'] } },
       };
 
       const { env: testEnv } = createMetadataEnv({
@@ -1997,7 +1889,7 @@ describe('SessionService', () => {
       const originalData = {
         envVars: { KEY1: 'value1', KEY2: 'value2' },
         setupCommands: ['command1', 'command2'],
-        mcpServers: { server1: { command: 'test' } },
+        mcpServers: { server1: { type: 'local' as const, command: ['test'] } },
       };
 
       const service = new SessionService();
@@ -2032,8 +1924,7 @@ describe('SessionService', () => {
       expect(result.context.envVars).toEqual(originalData.envVars);
       expect(savedMetadata).toBeDefined();
       expect(savedMetadata?.setupCommands).toEqual(originalData.setupCommands);
-      // MCPServerConfigSchema adds defaults for type, timeout, alwaysAllow, disabledTools
-      expect(savedMetadata?.mcpServers?.server1).toMatchObject({ command: 'test' });
+      expect(savedMetadata?.mcpServers?.server1).toEqual({ type: 'local', command: ['test'] });
     });
   });
 
@@ -2132,8 +2023,8 @@ describe('SessionService', () => {
         kiloSessionId: 'ses_test_kilo_session_id_0001',
         mcpServers: {
           puppeteer: {
-            command: 'npx',
-            args: ['-y', '@modelcontextprotocol/server-puppeteer'],
+            type: 'local' as const,
+            command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
           },
         },
       };
@@ -2168,11 +2059,11 @@ describe('SessionService', () => {
         env: testEnv,
       });
 
-      // Verify MCP config is in KILO_CONFIG_CONTENT env var
+      // Verify MCP config is passed through directly in KILO_CONFIG_CONTENT
       const callArgs = sandboxCreateSession.mock.calls[0][0];
       const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
       expect(configContent.mcp).toBeDefined();
-      expect(configContent.mcp.puppeteer).toMatchObject({
+      expect(configContent.mcp.puppeteer).toEqual({
         type: 'local',
         command: ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
       });
@@ -2241,7 +2132,7 @@ describe('SessionService', () => {
         githubRepo: 'acme/repo',
         envVars: { API_KEY: 'test' },
         setupCommands: ['npm install'],
-        mcpServers: { test: { command: 'test-server' } },
+        mcpServers: { test: { type: 'local' as const, command: ['test-server'] } },
         kiloSessionId: 'ses_test_kilo_session_id_0001',
       };
 
@@ -2285,11 +2176,11 @@ describe('SessionService', () => {
       // Verify setup commands re-run (because repo didn't exist, triggering reclone)
       expect(fakeSession.exec).toHaveBeenCalledWith('npm install', expect.any(Object));
 
-      // Verify MCP config in KILO_CONFIG_CONTENT
+      // Verify MCP config passed through directly in KILO_CONFIG_CONTENT
       const callArgs = sandboxCreateSession.mock.calls[0][0];
       const configContent = JSON.parse(callArgs.env.KILO_CONFIG_CONTENT);
       expect(configContent.mcp).toBeDefined();
-      expect(configContent.mcp.test).toMatchObject({
+      expect(configContent.mcp.test).toEqual({
         type: 'local',
         command: ['test-server'],
       });
@@ -3447,147 +3338,5 @@ describe('SessionService', () => {
       // git checkout -b should NOT be called (legacy CLI manages its own branch)
       expect(fakeSession.exec).not.toHaveBeenCalledWith(expect.stringContaining('git checkout -b'));
     });
-  });
-});
-
-describe('convertMcpServersForCli', () => {
-  it('converts stdio server to local format', () => {
-    const result = convertMcpServersForCli({
-      myServer: {
-        type: 'stdio',
-        command: 'node',
-        args: ['server.js', '--port', '3000'],
-        env: { NODE_ENV: 'production' },
-        cwd: '/app',
-      },
-    });
-
-    expect(result.mcp.myServer).toEqual({
-      type: 'local',
-      command: ['node', 'server.js', '--port', '3000'],
-      environment: { NODE_ENV: 'production' },
-      cwd: '/app',
-    });
-    expect(result.permission).toEqual({});
-  });
-
-  it('converts stdio server without explicit type', () => {
-    const result = convertMcpServersForCli({
-      myServer: {
-        command: 'npx',
-        args: ['-y', 'some-package'],
-      },
-    });
-
-    expect(result.mcp.myServer).toEqual({
-      type: 'local',
-      command: ['npx', '-y', 'some-package'],
-    });
-  });
-
-  it('converts sse server to remote format', () => {
-    const result = convertMcpServersForCli({
-      remote: {
-        type: 'sse',
-        url: 'https://example.com/mcp',
-        headers: { Authorization: 'Bearer tok123' },
-      },
-    });
-
-    expect(result.mcp.remote).toEqual({
-      type: 'remote',
-      url: 'https://example.com/mcp',
-      headers: { Authorization: 'Bearer tok123' },
-    });
-  });
-
-  it('converts streamable-http server to remote format', () => {
-    const result = convertMcpServersForCli({
-      stream: {
-        type: 'streamable-http',
-        url: 'https://example.com/stream',
-      },
-    });
-
-    expect(result.mcp.stream).toEqual({
-      type: 'remote',
-      url: 'https://example.com/stream',
-    });
-  });
-
-  it('converts alwaysAllow to permission rules with name sanitization', () => {
-    const result = convertMcpServersForCli({
-      'my.server': {
-        command: 'test',
-        alwaysAllow: ['tool.a', 'tool-b'],
-      },
-    });
-
-    expect(result.permission).toEqual({
-      my_server_tool_a: 'allow',
-      'my_server_tool-b': 'allow',
-    });
-  });
-
-  it('converts wildcard alwaysAllow to server_* permission', () => {
-    const result = convertMcpServersForCli({
-      myServer: {
-        command: 'test',
-        alwaysAllow: ['*'],
-      },
-    });
-
-    expect(result.permission).toEqual({
-      'myServer_*': 'allow',
-    });
-  });
-
-  it('converts disabled to enabled: false', () => {
-    const result = convertMcpServersForCli({
-      myServer: {
-        command: 'test',
-        disabled: true,
-      },
-    });
-
-    expect(result.mcp.myServer).toMatchObject({
-      enabled: false,
-    });
-  });
-
-  it('converts timeout from seconds to milliseconds', () => {
-    const result = convertMcpServersForCli({
-      myServer: {
-        command: 'test',
-        timeout: 120,
-      },
-    });
-
-    expect(result.mcp.myServer).toMatchObject({
-      timeout: 120000,
-    });
-  });
-
-  it('omits empty env/headers objects', () => {
-    const result = convertMcpServersForCli({
-      local: {
-        command: 'test',
-        env: {},
-      },
-      remote: {
-        type: 'sse',
-        url: 'https://example.com',
-        headers: {},
-      },
-    });
-
-    expect(result.mcp.local).not.toHaveProperty('environment');
-    expect(result.mcp.remote).not.toHaveProperty('headers');
-  });
-
-  it('returns empty objects for empty input', () => {
-    const result = convertMcpServersForCli({});
-    expect(result.mcp).toEqual({});
-    expect(result.permission).toEqual({});
   });
 });

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -257,35 +257,79 @@ export async function runSetupCommands(
   logger.info('Setup commands completed');
 }
 
-// Write MCP server config to global settings file in the session home.
-export async function writeMCPSettings(
-  sandbox: SandboxInstance,
-  sessionHome: string,
-  mcpServers: Record<string, MCPServerConfig>
-): Promise<void> {
-  if (!mcpServers || Object.keys(mcpServers).length === 0) {
-    return;
+/**
+ * Sanitize a name for use in MCP tool permission keys.
+ * Matches the CLI's sanitization: replace non-alphanumeric/underscore/hyphen chars with underscore.
+ */
+function sanitizeMcpName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/**
+ * Convert worker-format MCP server configs to CLI-native format for KILO_CONFIG_CONTENT.
+ *
+ * Worker format uses "stdio"/"sse"/"streamable-http" transport types.
+ * CLI format uses "local"/"remote" discriminated union.
+ *
+ * Returns { mcp, permission } where:
+ * - mcp: Record<string, CliMcpConfig> for the "mcp" key in config content
+ * - permission: Record<string, "allow"> for alwaysAllow → permission rule conversion
+ */
+export function convertMcpServersForCli(mcpServers: Record<string, MCPServerConfig>): {
+  mcp: Record<string, Record<string, unknown>>;
+  permission: Record<string, string>;
+} {
+  const mcp: Record<string, Record<string, unknown>> = {};
+  const permission: Record<string, string> = {};
+
+  for (const [serverName, config] of Object.entries(mcpServers)) {
+    let cliConfig: Record<string, unknown>;
+
+    if (config.type === 'sse' || config.type === 'streamable-http') {
+      // "sse" and "streamable-http" both map to "remote"
+      cliConfig = {
+        type: 'remote',
+        url: config.url,
+      };
+      if (config.headers && Object.keys(config.headers).length > 0) {
+        cliConfig.headers = config.headers;
+      }
+    } else {
+      // stdio (explicit or default when type is undefined)
+      cliConfig = {
+        type: 'local',
+        command: [config.command, ...(config.args ?? [])],
+      };
+      if (config.env && Object.keys(config.env).length > 0) {
+        cliConfig.environment = config.env;
+      }
+      if (config.cwd) {
+        cliConfig.cwd = config.cwd;
+      }
+    }
+    if (config.disabled) {
+      cliConfig.enabled = false;
+    }
+    if (config.timeout !== undefined) {
+      cliConfig.timeout = config.timeout * 1000;
+    }
+    mcp[serverName] = cliConfig;
+
+    // Convert alwaysAllow to permission rules
+    if (config.alwaysAllow && config.alwaysAllow.length > 0) {
+      const sanitizedServer = sanitizeMcpName(serverName);
+      if (config.alwaysAllow.includes('*')) {
+        permission[`${sanitizedServer}_*`] = 'allow';
+      } else {
+        for (const tool of config.alwaysAllow) {
+          const sanitizedTool = sanitizeMcpName(tool);
+          permission[`${sanitizedServer}_${sanitizedTool}`] = 'allow';
+        }
+      }
+    }
   }
 
-  const settingsDir = `${sessionHome}/.kilocode/cli/global/settings`;
-  const settingsPath = `${settingsDir}/mcp_settings.json`;
-
-  // Ensure directory exists
-  await sandbox.exec(`mkdir -p ${settingsDir}`);
-
-  // Generate settings JSON inline (no need for separate function)
-  const settingsJSON = JSON.stringify({ mcpServers }, null, 2);
-
-  // Write settings file
-  await sandbox.writeFile(settingsPath, settingsJSON);
-
-  const serverNames = Object.keys(mcpServers);
-  logger
-    .withTags({
-      serverCount: serverNames.length,
-      serverNames: serverNames.join(', '),
-    })
-    .info('Configured MCP servers');
+  return { mcp, permission };
 }
 
 // Write Kilo auth file so the CLI's KiloSessions can call session ingest.
@@ -459,7 +503,8 @@ export class SessionService {
     appendSystemPrompt?: string,
     gitUrl?: string,
     gitToken?: string,
-    platform?: 'github' | 'gitlab'
+    platform?: 'github' | 'gitlab',
+    mcpServers?: Record<string, MCPServerConfig>
   ): Record<string, string> {
     // Use override if available, otherwise use original values from API
     const kilocodeToken = env.KILOCODE_TOKEN_OVERRIDE ?? originalToken;
@@ -507,18 +552,30 @@ export class SessionService {
     if (env.KILO_OPENROUTER_BASE) {
       providerOptions.baseURL = env.KILO_OPENROUTER_BASE;
     }
-    const configContent: Record<string, unknown> = {
-      permission: {
-        external_directory: {
-          [`/tmp/attachments/${sessionId}/**`]: 'allow',
-        },
+    const permissionConfig: Record<string, unknown> = {
+      external_directory: {
+        [`/tmp/attachments/${sessionId}/**`]: 'allow',
       },
+    };
+    // Add MCP server configs converted to CLI-native format
+    let mcpConfig: Record<string, Record<string, unknown>> | undefined;
+    if (mcpServers && Object.keys(mcpServers).length > 0) {
+      const { mcp, permission: mcpPermissions } = convertMcpServersForCli(mcpServers);
+      mcpConfig = mcp;
+      // Merge alwaysAllow-derived permission rules with existing permissions
+      Object.assign(permissionConfig, mcpPermissions);
+    }
+    const configContent: Record<string, unknown> = {
+      permission: permissionConfig,
       provider: {
         kilo: {
           options: providerOptions,
         },
       },
     };
+    if (mcpConfig) {
+      configContent.mcp = mcpConfig;
+    }
     if (kilocodeModel && kilocodeModel.trim()) {
       const normalizedModel = kilocodeModel.startsWith('kilo/')
         ? kilocodeModel
@@ -601,7 +658,8 @@ export class SessionService {
     originalOrgId?: string,
     encryptedSecrets?: EncryptedSecrets,
     createdOnPlatform?: string,
-    appendSystemPrompt?: string
+    appendSystemPrompt?: string,
+    mcpServers?: Record<string, MCPServerConfig>
   ) {
     const { sessionId, sessionHome, workspacePath, envVars } = context;
 
@@ -621,7 +679,8 @@ export class SessionService {
       appendSystemPrompt,
       context.gitUrl,
       context.gitToken,
-      context.platform
+      context.platform,
+      mcpServers
     );
 
     const session = await sandbox.createSession({
@@ -721,7 +780,9 @@ export class SessionService {
       kilocodeModel,
       orgId,
       encryptedSecrets,
-      createdOnPlatform
+      createdOnPlatform,
+      undefined, // appendSystemPrompt
+      mcpServers
     );
 
     // Check disk space before clone for observability (logs warning if low)
@@ -764,11 +825,6 @@ export class SessionService {
     // Run setup commands after branch checkout
     if (setupCommands && setupCommands.length > 0) {
       await runSetupCommands(session, context, setupCommands, true); // fail-fast
-    }
-
-    // Write MCP server settings
-    if (mcpServers && Object.keys(mcpServers).length > 0) {
-      await writeMCPSettings(sandbox, context.sessionHome, mcpServers);
     }
 
     // Write auth file for session ingest
@@ -1006,7 +1062,8 @@ export class SessionService {
       orgId,
       encryptedSecrets,
       options.createdOnPlatform ?? existingMetadata?.createdOnPlatform,
-      existingMetadata?.appendSystemPrompt
+      existingMetadata?.appendSystemPrompt,
+      mcpServers
     );
 
     // Check disk space before clone for observability (logs warning if low)
@@ -1057,11 +1114,6 @@ export class SessionService {
     // Run setup commands (lenient mode since resuming)
     if (setupCommands && setupCommands.length > 0) {
       await runSetupCommands(session, context, setupCommands, false);
-    }
-
-    // Write MCP settings
-    if (mcpServers && Object.keys(mcpServers).length > 0) {
-      await writeMCPSettings(sandbox, context.sessionHome, mcpServers);
     }
 
     // Write auth file for session ingest
@@ -1208,7 +1260,8 @@ export class SessionService {
       orgId,
       metadata?.encryptedSecrets,
       metadata?.createdOnPlatform,
-      metadata?.appendSystemPrompt
+      metadata?.appendSystemPrompt,
+      metadata?.mcpServers
     );
 
     // Check if workspace repo exists - if not, we may need to reclone
@@ -1310,11 +1363,6 @@ export class SessionService {
     if (metadata.setupCommands && metadata.setupCommands.length > 0) {
       logger.info('Re-running setup commands after fresh clone');
       await runSetupCommands(session, context, metadata.setupCommands, false); // lenient
-    }
-
-    // Re-write MCP settings (fresh clone)
-    if (metadata.mcpServers && Object.keys(metadata.mcpServers).length > 0) {
-      await writeMCPSettings(sandbox, context.sessionHome, metadata.mcpServers);
     }
 
     // Re-write auth file (fresh clone)

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -257,81 +257,6 @@ export async function runSetupCommands(
   logger.info('Setup commands completed');
 }
 
-/**
- * Sanitize a name for use in MCP tool permission keys.
- * Matches the CLI's sanitization: replace non-alphanumeric/underscore/hyphen chars with underscore.
- */
-function sanitizeMcpName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_-]/g, '_');
-}
-
-/**
- * Convert worker-format MCP server configs to CLI-native format for KILO_CONFIG_CONTENT.
- *
- * Worker format uses "stdio"/"sse"/"streamable-http" transport types.
- * CLI format uses "local"/"remote" discriminated union.
- *
- * Returns { mcp, permission } where:
- * - mcp: Record<string, CliMcpConfig> for the "mcp" key in config content
- * - permission: Record<string, "allow"> for alwaysAllow → permission rule conversion
- */
-export function convertMcpServersForCli(mcpServers: Record<string, MCPServerConfig>): {
-  mcp: Record<string, Record<string, unknown>>;
-  permission: Record<string, string>;
-} {
-  const mcp: Record<string, Record<string, unknown>> = {};
-  const permission: Record<string, string> = {};
-
-  for (const [serverName, config] of Object.entries(mcpServers)) {
-    let cliConfig: Record<string, unknown>;
-
-    if (config.type === 'sse' || config.type === 'streamable-http') {
-      // "sse" and "streamable-http" both map to "remote"
-      cliConfig = {
-        type: 'remote',
-        url: config.url,
-      };
-      if (config.headers && Object.keys(config.headers).length > 0) {
-        cliConfig.headers = config.headers;
-      }
-    } else {
-      // stdio (explicit or default when type is undefined)
-      cliConfig = {
-        type: 'local',
-        command: [config.command, ...(config.args ?? [])],
-      };
-      if (config.env && Object.keys(config.env).length > 0) {
-        cliConfig.environment = config.env;
-      }
-      if (config.cwd) {
-        cliConfig.cwd = config.cwd;
-      }
-    }
-    if (config.disabled) {
-      cliConfig.enabled = false;
-    }
-    if (config.timeout !== undefined) {
-      cliConfig.timeout = config.timeout * 1000;
-    }
-    mcp[serverName] = cliConfig;
-
-    // Convert alwaysAllow to permission rules
-    if (config.alwaysAllow && config.alwaysAllow.length > 0) {
-      const sanitizedServer = sanitizeMcpName(serverName);
-      if (config.alwaysAllow.includes('*')) {
-        permission[`${sanitizedServer}_*`] = 'allow';
-      } else {
-        for (const tool of config.alwaysAllow) {
-          const sanitizedTool = sanitizeMcpName(tool);
-          permission[`${sanitizedServer}_${sanitizedTool}`] = 'allow';
-        }
-      }
-    }
-  }
-
-  return { mcp, permission };
-}
-
 // Write Kilo auth file so the CLI's KiloSessions can call session ingest.
 // The CLI reads ~/.local/share/kilo/auth.json via Auth.get("kilo") but we
 // never run `kilo auth login` — credentials are injected purely via env vars
@@ -552,29 +477,21 @@ export class SessionService {
     if (env.KILO_OPENROUTER_BASE) {
       providerOptions.baseURL = env.KILO_OPENROUTER_BASE;
     }
-    const permissionConfig: Record<string, unknown> = {
-      external_directory: {
-        [`/tmp/attachments/${sessionId}/**`]: 'allow',
-      },
-    };
-    // Add MCP server configs converted to CLI-native format
-    let mcpConfig: Record<string, Record<string, unknown>> | undefined;
-    if (mcpServers && Object.keys(mcpServers).length > 0) {
-      const { mcp, permission: mcpPermissions } = convertMcpServersForCli(mcpServers);
-      mcpConfig = mcp;
-      // Merge alwaysAllow-derived permission rules with existing permissions
-      Object.assign(permissionConfig, mcpPermissions);
-    }
     const configContent: Record<string, unknown> = {
-      permission: permissionConfig,
+      permission: {
+        external_directory: {
+          [`/tmp/attachments/${sessionId}/**`]: 'allow',
+        },
+      },
       provider: {
         kilo: {
           options: providerOptions,
         },
       },
     };
-    if (mcpConfig) {
-      configContent.mcp = mcpConfig;
+    // MCP configs are already in CLI-native format — pass through directly
+    if (mcpServers && Object.keys(mcpServers).length > 0) {
+      configContent.mcp = mcpServers;
     }
     if (kilocodeModel && kilocodeModel.trim()) {
       const normalizedModel = kilocodeModel.startsWith('kilo/')

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -19,37 +19,24 @@ import { INTERNAL_API_SECRET } from '@/lib/config.server';
 // TODO: Update this URL when the new cloud-agent-next worker is deployed
 const CLOUD_AGENT_NEXT_API_URL = getEnvVariable('CLOUD_AGENT_NEXT_API_URL') || '';
 
-// MCP server config types (local definition to avoid importing from cloud-agent)
-// Supports three transport types: stdio, sse, and streamable-http
-type MCPServerBaseConfig = {
-  disabled?: boolean;
+// MCP server config types — CLI-native local/remote format
+type MCPLocalServerConfig = {
+  type: 'local';
+  command: string[];
+  environment?: Record<string, string>;
+  enabled?: boolean;
   timeout?: number;
-  alwaysAllow?: string[];
-  watchPaths?: string[];
-  disabledTools?: string[];
 };
 
-type MCPStdioServerConfig = MCPServerBaseConfig & {
-  type?: 'stdio';
-  command: string;
-  args?: string[];
-  cwd?: string;
-  env?: Record<string, string>;
-};
-
-type MCPSseServerConfig = MCPServerBaseConfig & {
-  type: 'sse';
+type MCPRemoteServerConfig = {
+  type: 'remote';
   url: string;
   headers?: Record<string, string>;
+  enabled?: boolean;
+  timeout?: number;
 };
 
-type MCPStreamableHttpServerConfig = MCPServerBaseConfig & {
-  type: 'streamable-http';
-  url: string;
-  headers?: Record<string, string>;
-};
-
-type MCPServerConfig = MCPStdioServerConfig | MCPSseServerConfig | MCPStreamableHttpServerConfig;
+type MCPServerConfig = MCPLocalServerConfig | MCPRemoteServerConfig;
 
 /**
  * Type definitions for cloud-agent-next API procedures

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -23,43 +23,32 @@ export const agentModeNextSchema = z.enum([
   'custom',
 ]);
 
-// Base configuration shared by all MCP server types
-const mcpServerBaseConfigSchema = z.object({
-  disabled: z.boolean().optional(),
-  timeout: z.number().min(1).max(3600).optional(),
-  alwaysAllow: z.array(z.string()).optional(),
-  watchPaths: z.array(z.string()).optional(),
-  disabledTools: z.array(z.string()).optional(),
-});
+// Local MCP server configuration (runs a command)
+const mcpLocalServerConfigSchema = z
+  .object({
+    type: z.literal('local'),
+    command: z.string().array().min(1, 'Command array must have at least one element'),
+    environment: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
+    timeout: z.number().min(1).max(3_600_000).optional(),
+  })
+  .strict();
 
-// Stdio MCP server configuration (local process execution)
-const mcpStdioServerConfigSchema = mcpServerBaseConfigSchema.extend({
-  type: z.literal('stdio').optional(),
-  command: z.string().min(1, 'Command cannot be empty'),
-  args: z.array(z.string()).optional(),
-  cwd: z.string().optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+// Remote MCP server configuration (connects to a URL)
+const mcpRemoteServerConfigSchema = z
+  .object({
+    type: z.literal('remote'),
+    url: z.string().url('URL must be a valid URL format'),
+    headers: z.record(z.string(), z.string()).optional(),
+    enabled: z.boolean().optional(),
+    timeout: z.number().min(1).max(3_600_000).optional(),
+  })
+  .strict();
 
-// SSE MCP server configuration (Server-Sent Events)
-const mcpSseServerConfigSchema = mcpServerBaseConfigSchema.extend({
-  type: z.literal('sse'),
-  url: z.string().url('URL must be a valid URL format'),
-  headers: z.record(z.string(), z.string()).optional(),
-});
-
-// Streamable HTTP MCP server configuration
-const mcpStreamableHttpServerConfigSchema = mcpServerBaseConfigSchema.extend({
-  type: z.literal('streamable-http'),
-  url: z.string().url('URL must be a valid URL format'),
-  headers: z.record(z.string(), z.string()).optional(),
-});
-
-// Combined MCP server configuration schema supporting all transport types
-export const mcpServerConfigNextSchema = z.union([
-  mcpStdioServerConfigSchema,
-  mcpSseServerConfigSchema,
-  mcpStreamableHttpServerConfigSchema,
+// Combined MCP server configuration schema — CLI-native local/remote format
+export const mcpServerConfigNextSchema = z.discriminatedUnion('type', [
+  mcpLocalServerConfigSchema,
+  mcpRemoteServerConfigSchema,
 ]);
 
 // Schema for preparing a session


### PR DESCRIPTION
## Summary

- Replace file-based `writeMCPSettings` (which wrote `mcp_settings.json` to disk) with inline MCP config passed via the `KILO_CONFIG_CONTENT` environment variable
- Simplify MCP server config from a 3-type model (`stdio`/`sse`/`streamable-http`) to a CLI-native `local`/`remote` strict discriminated union, eliminating the `convertMcpServersForCli` conversion layer entirely
- MCP configs are now passed through directly to `KILO_CONFIG_CONTENT` without any translation — no more `alwaysAllow` → permission rules, `disabled` → `enabled`, `timeout` seconds → milliseconds, or `command`+`args` → `command[]` conversions
- Remove legacy fields (`alwaysAllow`, `watchPaths`, `disabledTools`, `disabled`, `cwd`, `env`, `args`) from schemas and types; replace with CLI-native fields (`enabled`, `environment`, `command: string[]`)
- Use `z.discriminatedUnion` with `.strict()` schemas for better validation and rejection of unknown fields
- Thread `mcpServers` through `getOrCreateSession` → `getSaferEnvVars` and remove all `writeMCPSettings` call sites (initiate, reinitiate, resume)
- Update `cloud-agent-client.ts` and `cloud-agent-next-schemas.ts` types to match the new `local`/`remote` format

## Test plan

All existing unit tests updated and passing. Removed `convertMcpServersForCli` tests (function deleted). Updated all test fixtures to use the new `{ type: 'local', command: ['...'] }` / `{ type: 'remote', url: '...' }` format. Schema tests cover strict mode rejection of unknown fields and missing type discriminator.