### PR TITLE
Filter PAYMENT_REQUIRED from Sentry error reporting

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -24,6 +24,7 @@ function isDrizzleQueryError(error: unknown): error is DrizzleQueryError {
 const TRPC_4XX_CODES = new Set([
   'BAD_REQUEST',
   'UNAUTHORIZED',
+  'PAYMENT_REQUIRED',
   'FORBIDDEN',
   'NOT_FOUND',
   'METHOD_NOT_SUPPORTED',


### PR DESCRIPTION
## Summary
- Add `PAYMENT_REQUIRED` to the `TRPC_4XX_CODES` set in `sentry.server.config.ts` so that expected insufficient-credits errors (402) are filtered out by `beforeSend` and no longer reported to Sentry.

Fixes KILOCODE-WEB-B5Y