### PR TITLE
Fix DB connection exhaustion (max_client_conn) by reducing pool sizes

### DIFF
--- a/cloud-agent-next/src/db/node-postgres.ts
+++ b/cloud-agent-next/src/db/node-postgres.ts
@@ -15,7 +15,7 @@ types.setTypeParser(types.builtins.INT8, val => parseInt(val, 10));
 
 export const createNodePostgresConnection: CreateDatabaseConnection = connectionString => {
   const createConnectedClient = async (): Promise<Client> => {
-    const client = new Client({ connectionString });
+    const client = new Client({ connectionString, statement_timeout: 10_000 });
     await client.connect();
     return client;
   };

--- a/cloud-agent-next/src/db/node-postgres.ts
+++ b/cloud-agent-next/src/db/node-postgres.ts
@@ -1,4 +1,11 @@
-import { Pool, types } from 'pg';
+/**
+ * pg Client implementation of the Database facade.
+ *
+ * Creates a new connection per query/transaction -- the expected pattern
+ * for Cloudflare Hyperdrive, which pools connections at the infrastructure level.
+ */
+
+import { Client, types } from 'pg';
 
 import type { CreateDatabaseConnection, Database } from './database.js';
 
@@ -6,30 +13,31 @@ import type { CreateDatabaseConnection, Database } from './database.js';
 // as regular numbers
 types.setTypeParser(types.builtins.INT8, val => parseInt(val, 10));
 
-// Ensure timestamptz values are properly handled as Date objects
-// types.setTypeParser(types.builtins.TIMESTAMPTZ, (val) => new Date(val))
-// types.setTypeParser(types.builtins.TIMESTAMP, (val) => new Date(val))
-
 export const createNodePostgresConnection: CreateDatabaseConnection = connectionString => {
-  const pool = new Pool({
-    connectionString,
-    max: 100,
-    statement_timeout: 10 * 1000,
-  });
-
-  pool.on('error', error => console.error('Pool:error - Unexpected error on idle client', error));
+  const createConnectedClient = async (): Promise<Client> => {
+    const client = new Client({ connectionString });
+    await client.connect();
+    return client;
+  };
 
   return {
     __kind: 'Database',
-    begin: async transactionFn => {
-      // Pull an available client from pg-pool
-      const client = await pool.connect();
 
+    query: async (text, values = {}) => {
+      const client = await createConnectedClient();
       try {
-        // Start the transaction
-        await client.query('begin');
+        const result = await client.query(text, Object.values(values));
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return result.rows ?? [];
+      } finally {
+        await client.end();
+      }
+    },
 
-        // Call user provided transaction function
+    begin: async transactionFn => {
+      const client = await createConnectedClient();
+      try {
+        await client.query('BEGIN');
         const result = await transactionFn({
           __kind: 'Transaction',
           query: async (text, values = {}) => {
@@ -38,31 +46,21 @@ export const createNodePostgresConnection: CreateDatabaseConnection = connection
             return rows ?? [];
           },
           rollback: async () => {
-            await client.query('rollback');
+            await client.query('ROLLBACK');
           },
         });
-
-        // Commit the results
-        await client.query('commit');
-
+        await client.query('COMMIT');
         return result;
       } catch (e) {
-        // Rollback if there were any errors
-        await client.query('rollback');
+        await client.query('ROLLBACK');
         throw e;
       } finally {
-        // Always release the client back to the pool!
-        client.release();
+        await client.end();
       }
     },
+
     end: async () => {
-      // no-op with node-postgres since we just query from the pool
+      // no-op -- each operation manages its own client
     },
-    query: async (text, values = {}) => {
-      const result = await pool.query(text, Object.values(values));
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return result.rows ?? [];
-    },
-    // casting as Database here so we don't have to manually fill in function args
   } satisfies Database;
 };

--- a/cloud-agent/src/db/node-postgres.ts
+++ b/cloud-agent/src/db/node-postgres.ts
@@ -15,7 +15,7 @@ types.setTypeParser(types.builtins.INT8, val => parseInt(val, 10));
 
 export const createNodePostgresConnection: CreateDatabaseConnection = connectionString => {
   const createConnectedClient = async (): Promise<Client> => {
-    const client = new Client({ connectionString });
+    const client = new Client({ connectionString, statement_timeout: 10_000 });
     await client.connect();
     return client;
   };

--- a/cloud-agent/src/db/node-postgres.ts
+++ b/cloud-agent/src/db/node-postgres.ts
@@ -1,4 +1,11 @@
-import { Pool, types } from 'pg';
+/**
+ * pg Client implementation of the Database facade.
+ *
+ * Creates a new connection per query/transaction -- the expected pattern
+ * for Cloudflare Hyperdrive, which pools connections at the infrastructure level.
+ */
+
+import { Client, types } from 'pg';
 
 import type { CreateDatabaseConnection, Database } from './database.js';
 
@@ -6,30 +13,31 @@ import type { CreateDatabaseConnection, Database } from './database.js';
 // as regular numbers
 types.setTypeParser(types.builtins.INT8, val => parseInt(val, 10));
 
-// Ensure timestamptz values are properly handled as Date objects
-// types.setTypeParser(types.builtins.TIMESTAMPTZ, (val) => new Date(val))
-// types.setTypeParser(types.builtins.TIMESTAMP, (val) => new Date(val))
-
 export const createNodePostgresConnection: CreateDatabaseConnection = connectionString => {
-  const pool = new Pool({
-    connectionString,
-    max: 100,
-    statement_timeout: 10 * 1000,
-  });
-
-  pool.on('error', error => console.error('Pool:error - Unexpected error on idle client', error));
+  const createConnectedClient = async (): Promise<Client> => {
+    const client = new Client({ connectionString });
+    await client.connect();
+    return client;
+  };
 
   return {
     __kind: 'Database',
-    begin: async transactionFn => {
-      // Pull an available client from pg-pool
-      const client = await pool.connect();
 
+    query: async (text, values = {}) => {
+      const client = await createConnectedClient();
       try {
-        // Start the transaction
-        await client.query('begin');
+        const result = await client.query(text, Object.values(values));
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return result.rows ?? [];
+      } finally {
+        await client.end();
+      }
+    },
 
-        // Call user provided transaction function
+    begin: async transactionFn => {
+      const client = await createConnectedClient();
+      try {
+        await client.query('BEGIN');
         const result = await transactionFn({
           __kind: 'Transaction',
           query: async (text, values = {}) => {
@@ -38,31 +46,21 @@ export const createNodePostgresConnection: CreateDatabaseConnection = connection
             return rows ?? [];
           },
           rollback: async () => {
-            await client.query('rollback');
+            await client.query('ROLLBACK');
           },
         });
-
-        // Commit the results
-        await client.query('commit');
-
+        await client.query('COMMIT');
         return result;
       } catch (e) {
-        // Rollback if there were any errors
-        await client.query('rollback');
+        await client.query('ROLLBACK');
         throw e;
       } finally {
-        // Always release the client back to the pool!
-        client.release();
+        await client.end();
       }
     },
+
     end: async () => {
-      // no-op with node-postgres since we just query from the pool
+      // no-op -- each operation manages its own client
     },
-    query: async (text, values = {}) => {
-      const result = await pool.query(text, Object.values(values));
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return result.rows ?? [];
-    },
-    // casting as Database here so we don't have to manually fill in function args
   } satisfies Database;
 };

--- a/cloudflare-git-token-service/src/db/database.ts
+++ b/cloudflare-git-token-service/src/db/database.ts
@@ -14,7 +14,7 @@ export type Database = {
 export function createDatabaseConnection(connectionString: string): Database {
   return {
     query: async <T = unknown>(text: string, values: unknown[] = []): Promise<T[]> => {
-      const client = new Client({ connectionString });
+      const client = new Client({ connectionString, statement_timeout: 10_000 });
       await client.connect();
       try {
         const result = await client.query(text, values);

--- a/cloudflare-git-token-service/src/db/database.ts
+++ b/cloudflare-git-token-service/src/db/database.ts
@@ -1,4 +1,4 @@
-import { Pool, types } from 'pg';
+import { Client, types } from 'pg';
 
 // Default postgres behavior is to use strings for big ints. This parses them as regular numbers
 types.setTypeParser(types.builtins.INT8, val => parseInt(val, 10));
@@ -7,19 +7,21 @@ export type Database = {
   query: <T = unknown>(text: string, values?: unknown[]) => Promise<T[]>;
 };
 
+/**
+ * Creates a new connection per query -- the expected pattern
+ * for Cloudflare Hyperdrive, which pools connections at the infrastructure level.
+ */
 export function createDatabaseConnection(connectionString: string): Database {
-  const pool = new Pool({
-    connectionString,
-    max: 100,
-    statement_timeout: 10 * 1000,
-  });
-
-  pool.on('error', error => console.error('Pool:error - Unexpected error on idle client', error));
-
   return {
     query: async <T = unknown>(text: string, values: unknown[] = []): Promise<T[]> => {
-      const result = await pool.query(text, values);
-      return (result.rows ?? []) as T[];
+      const client = new Client({ connectionString });
+      await client.connect();
+      try {
+        const result = await client.query(text, values);
+        return (result.rows ?? []) as T[];
+      } finally {
+        await client.end();
+      }
     },
   };
 }

--- a/cloudflare-session-ingest/src/db/kysely.ts
+++ b/cloudflare-session-ingest/src/db/kysely.ts
@@ -31,10 +31,14 @@ export type Database = {
   cli_sessions_v2: CliSessionsV2Table;
 };
 
+/**
+ * Hyperdrive pools connections at the infrastructure level,
+ * so we use max:1 to avoid holding extra connections open.
+ */
 export function getDb(hyperdrive: HyperdriveBinding): Kysely<Database> {
   const pool = new Pool({
     connectionString: hyperdrive.connectionString,
-    max: 5,
+    max: 1,
   });
 
   pool.on('error', error => {

--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -66,10 +66,9 @@ function getReplicaUrl(): string {
 // Primary pool - always points to Frankfurt (writes go here)
 export const pool = new Pool({
   ...getDatabaseClientConfig(postgresUrl),
-  max: 10,
+  max: 100,
   connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
   idleTimeoutMillis: 3000,
-  statement_timeout: Number.parseInt(POSTGRES_MAX_QUERY_TIME || '20000'),
   application_name: appName,
 });
 
@@ -80,10 +79,9 @@ export const usesSeparateReplica = replicaUrl !== postgresUrl;
 const replicaPool = usesSeparateReplica
   ? new Pool({
       ...getDatabaseClientConfig(replicaUrl),
-      max: 10,
+      max: 100,
       connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
       idleTimeoutMillis: 3000,
-      statement_timeout: Number.parseInt(POSTGRES_MAX_QUERY_TIME || '20000'),
       application_name: `${appName}-replica`,
     })
   : pool; // Reuse primary pool if no separate replica

--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -66,9 +66,10 @@ function getReplicaUrl(): string {
 // Primary pool - always points to Frankfurt (writes go here)
 export const pool = new Pool({
   ...getDatabaseClientConfig(postgresUrl),
-  max: 100,
+  max: 10,
   connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
   idleTimeoutMillis: 3000,
+  statement_timeout: Number.parseInt(POSTGRES_MAX_QUERY_TIME || '20000'),
   application_name: appName,
 });
 
@@ -79,9 +80,10 @@ export const usesSeparateReplica = replicaUrl !== postgresUrl;
 const replicaPool = usesSeparateReplica
   ? new Pool({
       ...getDatabaseClientConfig(replicaUrl),
-      max: 100,
+      max: 10,
       connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
       idleTimeoutMillis: 3000,
+      statement_timeout: Number.parseInt(POSTGRES_MAX_QUERY_TIME || '20000'),
       application_name: `${appName}-replica`,
     })
   : pool; // Reuse primary pool if no separate replica


### PR DESCRIPTION
## Summary

Fixes `no more connections allowed (max_client_conn)` errors caused by aggregate connection counts across all services exceeding the Supabase PgBouncer limit (3000).

- **CF workers** (`cloud-agent`, `cloud-agent-next`, `git-token-service`): Replace `pg.Pool(max:100)` with fresh `pg.Client` per operation, matching the Hyperdrive-recommended pattern already used by `kiloclaw` and `webhook-agent-ingest`. Hyperdrive handles connection pooling at the infrastructure level — using a driver-level pool on top is an anti-pattern that holds unnecessary connections open.
- **`session-ingest`**: Reduce pool `max` from 5 to 1 (Hyperdrive pools for us).
- **Vercel Next.js app** (`src/lib/drizzle.ts`): Reduce pool `max` from 100 to 10 per pool, and apply `POSTGRES_MAX_QUERY_TIME` as `statement_timeout` (was validated to exist but never actually enforced on the pool).

## Root Cause

At peak, the Supabase PgBouncer dashboard showed **2715/3000** pooler connections. The aggregate `max` across services was:

| Source | Old pool `max` | New |
|--------|---------------|-----|
| Vercel primary pool | 100 × N instances | 10 × N |
| Vercel replica pool | 100 × N instances | 10 × N |
| `cloud-agent` | 100 × M isolates (via Hyperdrive) | 1 per query (Client) |
| `cloud-agent-next` | 100 × M isolates (via Hyperdrive) | 1 per query (Client) |
| `git-token-service` | 100 × M isolates (via Hyperdrive) | 1 per query (Client) |
| `session-ingest` | 5 per request (via Hyperdrive) | 1 per request |

## Evidence from Axiom

Axiom logs from the incident window (2026-02-24 10:00–11:30 UTC) confirm the diagnosis:

**Traffic volume:** ~110,000 requests/minute (~1,800/sec) steady-state across 20+ Vercel regions (fra1, bom1, cdg1, arn1, sin1, cpt1, iad1, dxb1, lhr1, hkg1, sfo1, gru1, syd1, pdx1, cle1, etc.).

**Error burst at 10:15–10:25 UTC:** ~20,000 5xx errors in 10 minutes, across *all* routes — consistent with a database-level connection exhaustion (not an endpoint-specific bug):

| Route | 5xx errors (10:15–10:25) |
|-------|------------------------|
| `/api/openrouter/[...path]` | 5,716 |
| `/api/upload-cli-session-blob-v2` | 4,608 |
| `/api/profile/balance` | 4,048 |
| `/api/fim/completions` | 1,473 |
| `/api/trpc/[trpc]` | 512 |
| All other routes | ~3,600 |

**Long-running requests pin connections:** `/api/openrouter/[...path]` had 80,313 requests >5s in the 30-minute window around the incident, with avg duration **24.5s** and max **800s** (Vercel function timeout). These LLM streaming requests keep function instances warm, each holding a `max:100` pool open to PgBouncer.

**Connection math:** Dozens of warm Vercel instances across 20+ regions × 200 connections per instance (100 primary + 100 replica) easily exceeds the 3000 PgBouncer `max_client_conn`. Adding CF workers with their own `max:100` pools via Hyperdrive pushes it further.

## Verification

After deploy, monitor:
1. **Supabase dashboard** — pooler connections should drop significantly from the ~2715 baseline
2. **Sentry** — no more `max_client_conn` errors
3. **Vercel/Axiom logs** — watch for `statement_timeout` errors (would indicate previously-slow queries that now hit the 20s guard)

Fixes KILOCODE-WEB-B5R