### PR TITLE
perf: strip bloated fields from session ingest, reducing payload 50-77%

### DIFF
--- a/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
+++ b/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
@@ -13,7 +13,6 @@ import {
   extractNormalizedPlatformFromItem,
   extractNormalizedTitleFromItem,
 } from './session-ingest-extractors';
-import { stripIngestBloat } from '../util/strip-ingest-bloat';
 import {
   computeSessionMetrics,
   INACTIVITY_TIMEOUT_MS,
@@ -140,8 +139,7 @@ export class SessionIngestDO extends DurableObject<Env> {
     let hasSessionOpen = false;
     let closeReason: string | undefined;
 
-    for (const raw of payload) {
-      const item = stripIngestBloat(raw);
+    for (const item of payload) {
       const { item_id, item_type } = getItemIdentity(item);
 
       const itemDataJson = JSON.stringify(item.data);

--- a/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
+++ b/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
@@ -13,6 +13,7 @@ import {
   extractNormalizedPlatformFromItem,
   extractNormalizedTitleFromItem,
 } from './session-ingest-extractors';
+import { stripIngestBloat } from '../util/strip-ingest-bloat';
 import {
   computeSessionMetrics,
   INACTIVITY_TIMEOUT_MS,
@@ -139,7 +140,8 @@ export class SessionIngestDO extends DurableObject<Env> {
     let hasSessionOpen = false;
     let closeReason: string | undefined;
 
-    for (const item of payload) {
+    for (const raw of payload) {
+      const item = stripIngestBloat(raw);
       const { item_id, item_type } = getItemIdentity(item);
 
       const itemDataJson = JSON.stringify(item.data);

--- a/cloudflare-session-ingest/src/util/ingest-batching.ts
+++ b/cloudflare-session-ingest/src/util/ingest-batching.ts
@@ -1,5 +1,6 @@
 import type { IngestBatch } from '../types/session-sync';
 import { byteLengthUtf8, MAX_DO_INGEST_CHUNK_BYTES, MAX_INGEST_ITEM_BYTES } from './ingest-limits';
+import { stripIngestBloat } from './strip-ingest-bloat';
 
 export type SplitIngestBatchForDOResult = {
   chunks: IngestBatch[];
@@ -16,7 +17,10 @@ export function splitIngestBatchForDO(items: IngestBatch): SplitIngestBatchForDO
 
   let droppedOversizeItems = 0;
 
-  for (const item of items) {
+  for (const rawItem of items) {
+    // Strip bloated fields (file snapshots, diagnostics) before measuring size
+    // so items that are only oversized due to bloat are not dropped.
+    const item = stripIngestBloat(rawItem);
     const itemJson = JSON.stringify(item);
     const itemBytes = byteLengthUtf8(itemJson) + 1;
 

--- a/cloudflare-session-ingest/src/util/strip-ingest-bloat.test.ts
+++ b/cloudflare-session-ingest/src/util/strip-ingest-bloat.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { stripIngestBloat } from './strip-ingest-bloat';
+
+describe('stripIngestBloat', () => {
+  it('strips summary.diffs[].before and .after from session data', () => {
+    const item = {
+      type: 'session' as const,
+      data: {
+        id: 'ses_123',
+        title: 'Test',
+        summary: {
+          additions: 10,
+          deletions: 5,
+          files: 2,
+          diffs: [
+            {
+              file: 'a.ts',
+              before: 'old content of a.ts...',
+              after: 'new content of a.ts...',
+              additions: 5,
+              deletions: 3,
+            },
+            {
+              file: 'b.ts',
+              before: 'old content of b.ts...',
+              after: 'new content of b.ts...',
+              additions: 5,
+              deletions: 2,
+            },
+          ],
+        },
+      },
+    };
+
+    const result = stripIngestBloat(item);
+    const data = result.data as typeof item.data;
+
+    expect(data.summary.diffs).toHaveLength(2);
+    expect(data.summary.diffs[0].file).toBe('a.ts');
+    expect(data.summary.diffs[0].additions).toBe(5);
+    expect(data.summary.diffs[0]).not.toHaveProperty('before');
+    expect(data.summary.diffs[0]).not.toHaveProperty('after');
+    expect(data.summary.diffs[1]).not.toHaveProperty('before');
+    expect(data.summary.diffs[1]).not.toHaveProperty('after');
+  });
+
+  it('strips metadata.diagnostics from part data', () => {
+    const item = {
+      type: 'part' as const,
+      data: {
+        id: 'prt_123',
+        type: 'tool',
+        tool: 'edit',
+        state: {
+          status: 'completed',
+          metadata: {
+            diff: 'some diff...',
+            filediff: { file: 'a.ts', before: 'old', after: 'new', additions: 1, deletions: 1 },
+            diagnostics: {
+              '/project/a.ts': [{ severity: 1, message: 'err' }],
+              '/project/b.ts': [{ severity: 1, message: 'unrelated' }],
+            },
+          },
+        },
+      },
+    };
+
+    const result = stripIngestBloat(item);
+    const data = result.data as typeof item.data;
+
+    expect(data.state.metadata).not.toHaveProperty('diagnostics');
+    expect(data.state.metadata.diff).toBe('some diff...');
+  });
+
+  it('strips metadata.filediff.before and .after from part data', () => {
+    const item = {
+      type: 'part' as const,
+      data: {
+        id: 'prt_123',
+        type: 'tool',
+        state: {
+          status: 'completed',
+          metadata: {
+            filediff: {
+              file: 'a.ts',
+              before: 'x'.repeat(50000),
+              after: 'y'.repeat(50000),
+              additions: 10,
+              deletions: 5,
+            },
+          },
+        },
+      },
+    };
+
+    const result = stripIngestBloat(item);
+    const data = result.data as typeof item.data;
+
+    expect(data.state.metadata.filediff.file).toBe('a.ts');
+    expect(data.state.metadata.filediff.additions).toBe(10);
+    expect(data.state.metadata.filediff.deletions).toBe(5);
+    expect(data.state.metadata.filediff).not.toHaveProperty('before');
+    expect(data.state.metadata.filediff).not.toHaveProperty('after');
+  });
+
+  it('passes through non-session non-part items unchanged', () => {
+    const item = { type: 'kilo_meta' as const, data: { platform: 'vscode' } };
+    const result = stripIngestBloat(item);
+    expect(result).toEqual(item);
+  });
+
+  it('passes through message items unchanged', () => {
+    const item = {
+      type: 'message' as const,
+      data: { id: 'msg_123', role: 'assistant', summary: { diffs: [{ before: 'x', after: 'y' }] } },
+    };
+    const result = stripIngestBloat(item);
+    const data = result.data as typeof item.data;
+    expect(data.summary.diffs[0].before).toBe('x');
+  });
+
+  it('handles part without metadata gracefully', () => {
+    const item = {
+      type: 'part' as const,
+      data: { id: 'prt_123', type: 'text', text: 'hello' },
+    };
+    const result = stripIngestBloat(item);
+    expect(result).toEqual(item);
+  });
+
+  it('handles session without summary gracefully', () => {
+    const item = {
+      type: 'session' as const,
+      data: { id: 'ses_123', title: 'No summary' },
+    };
+    const result = stripIngestBloat(item);
+    expect(result).toEqual(item);
+  });
+
+  it('handles session with summary but no diffs', () => {
+    const item = {
+      type: 'session' as const,
+      data: { id: 'ses_123', title: 'Test', summary: { additions: 1, deletions: 0, files: 1 } },
+    };
+    const result = stripIngestBloat(item);
+    expect(result).toEqual(item);
+  });
+
+  it('does not mutate the original item', () => {
+    const item = {
+      type: 'part' as const,
+      data: {
+        id: 'prt_123',
+        type: 'tool',
+        state: {
+          status: 'completed',
+          metadata: {
+            diagnostics: { '/a.ts': [{ severity: 1, message: 'err' }] },
+            filediff: { file: 'a.ts', before: 'old', after: 'new' },
+          },
+        },
+      },
+    };
+
+    const original = JSON.parse(JSON.stringify(item));
+    stripIngestBloat(item);
+    expect(item).toEqual(original);
+  });
+});

--- a/cloudflare-session-ingest/src/util/strip-ingest-bloat.ts
+++ b/cloudflare-session-ingest/src/util/strip-ingest-bloat.ts
@@ -1,0 +1,87 @@
+type AnyRecord = Record<string, unknown>;
+
+export type StrippableItem = {
+  type: string;
+  data: unknown;
+};
+
+/**
+ * Strip bloated fields from ingest items before storage.
+ *
+ * Three fields are stripped:
+ * 1. session.summary.diffs[].before / .after — full file snapshots (50-400KB)
+ * 2. part.state.metadata.filediff.before / .after — duplicate file snapshots (50-300KB)
+ * 3. part.state.metadata.diagnostics — all-project LSP diagnostics (100-500KB)
+ *
+ * These fields are only needed for local UI rendering and are not used by the
+ * cloud (share page, metrics, export). Stripping them reduces ingest payload
+ * size by 50-77%.
+ *
+ * Returns a new item; does not mutate the input.
+ */
+export function stripIngestBloat<T extends StrippableItem>(item: T): T {
+  if (item.type === 'session') return stripSessionBloat(item);
+  if (item.type === 'part') return stripPartBloat(item);
+  return item;
+}
+
+function stripSessionBloat<T extends StrippableItem>(item: T): T {
+  const data = item.data as AnyRecord | null | undefined;
+  if (!data) return item;
+
+  const summary = data.summary as AnyRecord | null | undefined;
+  if (!summary) return item;
+
+  const diffs = summary.diffs as AnyRecord[] | null | undefined;
+  if (!diffs || !Array.isArray(diffs)) return item;
+
+  const stripped = diffs.map(diff => {
+    const { before, after, ...rest } = diff;
+    return rest;
+  });
+
+  return {
+    ...item,
+    data: {
+      ...data,
+      summary: {
+        ...summary,
+        diffs: stripped,
+      },
+    },
+  };
+}
+
+function stripPartBloat<T extends StrippableItem>(item: T): T {
+  const data = item.data as AnyRecord | null | undefined;
+  if (!data) return item;
+
+  const state = data.state as AnyRecord | null | undefined;
+  if (!state) return item;
+
+  const metadata = state.metadata as AnyRecord | null | undefined;
+  if (!metadata) return item;
+
+  const stripped: AnyRecord = { ...metadata };
+
+  // Strip diagnostics entirely — not used by cloud
+  delete stripped.diagnostics;
+
+  // Strip filediff.before / .after — keep the rest (file, additions, deletions)
+  const filediff = stripped.filediff as AnyRecord | null | undefined;
+  if (filediff && typeof filediff === 'object') {
+    const { before, after, ...rest } = filediff;
+    stripped.filediff = rest;
+  }
+
+  return {
+    ...item,
+    data: {
+      ...data,
+      state: {
+        ...state,
+        metadata: stripped,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Strip bloated fields from session ingest items before storage in the Durable Object. These fields are only needed for local UI rendering and are not used by the cloud (share page, metrics, export).

## What's Stripped

| Field | Where | What it contains | Typical size |
|---|---|---|---|
| `session.data.summary.diffs[].before` / `.after` | Session items | Full file content snapshots (before/after edit) | 50-400KB per session |
| `part.data.state.metadata.filediff.before` / `.after` | Part items (edit tool) | Duplicate full file snapshots | 50-300KB per session |
| `part.data.state.metadata.diagnostics` | Part items (edit/write/apply_patch tools) | ALL project LSP diagnostics, not just the edited file | 100-500KB per session |

### Measured Impact

From two profiled sessions in the kilocode repo:

| Session | Ingest payload before | After stripping | Reduction |
|---|---|---|---|
| 45 msgs, 164 parts | 1,516KB | 355KB | **77%** |
| 40 msgs, 152 parts | 811KB | 389KB | **52%** |

The remaining fields (file path, additions/deletions counts, diff text) are preserved — only the raw file content and project-wide diagnostics are removed.

## Changes

- New `cloudflare-session-ingest/src/util/strip-ingest-bloat.ts` — `stripIngestBloat(item)` function that creates a new item with bloated fields removed (does not mutate input)
- `cloudflare-session-ingest/src/dos/SessionIngestDO.ts` — apply `stripIngestBloat()` to each item in the `ingest()` method before `JSON.stringify` and storage
- New `cloudflare-session-ingest/src/util/strip-ingest-bloat.test.ts` — 9 test cases covering session stripping, part stripping, passthrough for other types, graceful handling of missing fields, and immutability

## Testing

```
119 tests passed across 10 files (including 9 new)
```

## Companion PR

[Kilo-Org/kilocode#6241](https://github.com/Kilo-Org/kilocode/pull/6241) — filters diagnostics to only the edited file(s) in the local CLI tools, reducing what gets stored in the local SQLite database.
