### PR TITLE
AppBuilder - Fix subagent messages displaying inline in main chat

### DIFF
--- a/src/components/app-builder/AppBuilderChat.tsx
+++ b/src/components/app-builder/AppBuilderChat.tsx
@@ -262,13 +262,15 @@ function ExpandableSessionBlock({
  */
 const V2StaticMessages = memo(function V2StaticMessages({
   messages,
+  getChildMessages,
 }: {
   messages: StoredMessage[];
+  getChildMessages?: (sessionId: string) => StoredMessage[];
 }) {
   return (
     <>
       {messages.map(msg => (
-        <V2MessageBubble key={msg.info.id} message={msg} />
+        <V2MessageBubble key={msg.info.id} message={msg} getChildMessages={getChildMessages} />
       ))}
     </>
   );
@@ -277,7 +279,13 @@ const V2StaticMessages = memo(function V2StaticMessages({
 /**
  * V2 dynamic messages (streaming)
  */
-function V2DynamicMessages({ messages }: { messages: StoredMessage[] }) {
+function V2DynamicMessages({
+  messages,
+  getChildMessages,
+}: {
+  messages: StoredMessage[];
+  getChildMessages?: (sessionId: string) => StoredMessage[];
+}) {
   return (
     <>
       {messages.map(msg => {
@@ -287,6 +295,7 @@ function V2DynamicMessages({ messages }: { messages: StoredMessage[] }) {
             key={`${msg.info.id}-${streaming ? 'streaming' : 'complete'}`}
             message={msg}
             isStreaming={streaming}
+            getChildMessages={getChildMessages}
           />
         );
       })}
@@ -376,6 +385,15 @@ function V2SessionMessages({
     return { v2Static: staticMsgs, v2Dynamic: dynamicMsgs };
   }, [sessionState.messages]);
 
+  // Identity changes when childSessionMessages changes, which forces memo'd
+  // V2StaticMessages to re-render with updated child session data.
+  // This is intentional: static parent messages may contain task tool parts
+  // whose child sessions are still streaming.
+  const getChildMessages = useCallback(
+    (childSessionId: string) => session.getChildSessionMessages(childSessionId),
+    [session, sessionState.childSessionMessages] // eslint-disable-line react-hooks/exhaustive-deps -- childSessionMessages triggers re-render
+  );
+
   if (sessionState.messages.length === 0 && !sessionState.isStreaming) {
     return null;
   }
@@ -386,8 +404,8 @@ function V2SessionMessages({
       cloudAgentSessionId={session.info.cloud_agent_session_id}
       organizationId={organizationId ?? null}
     >
-      <V2StaticMessages messages={v2Static} />
-      <V2DynamicMessages messages={v2Dynamic} />
+      <V2StaticMessages messages={v2Static} getChildMessages={getChildMessages} />
+      <V2DynamicMessages messages={v2Dynamic} getChildMessages={getChildMessages} />
       {sessionState.isStreaming && v2Dynamic.length === 0 && <TypingIndicator />}
     </QuestionContextProvider>
   );

--- a/src/components/app-builder/project-manager/__tests__/messages.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/messages.test.ts
@@ -16,6 +16,7 @@ import type { CloudMessage, StreamEvent } from '@/components/cloud-agent/types';
 // Helper to create a mock V1 session store for testing
 function createMockStore(initialMessages: CloudMessage[] = []): V1SessionStore {
   let messages = [...initialMessages];
+  const childSessionMessages = new Map<string, CloudMessage[]>();
   const listeners = new Set<() => void>();
 
   return {
@@ -23,6 +24,7 @@ function createMockStore(initialMessages: CloudMessage[] = []): V1SessionStore {
       messages,
       isStreaming: false,
       questionRequestIds: new Map<string, string>(),
+      childSessionMessages,
     }),
     setState: jest.fn(partial => {
       if ('messages' in partial && partial.messages) {
@@ -39,6 +41,15 @@ function createMockStore(initialMessages: CloudMessage[] = []): V1SessionStore {
       listeners.forEach(l => l());
     }),
     setQuestionRequestId: jest.fn(),
+    updateChildSessionMessages: jest.fn(
+      (childSessionId: string, updater: (msgs: CloudMessage[]) => CloudMessage[]) => {
+        const existing = childSessionMessages.get(childSessionId) ?? [];
+        childSessionMessages.set(childSessionId, updater(existing));
+      }
+    ),
+    getChildSessionMessages: jest.fn((childSessionId: string) => {
+      return childSessionMessages.get(childSessionId) ?? [];
+    }),
   };
 }
 

--- a/src/components/app-builder/project-manager/__tests__/store.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/store.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { createProjectStore, createInitialState } from '../store';
+import { createSessionStore } from '../sessions/session-store';
 import type { ProjectState } from '../types';
 
 /**
@@ -180,6 +181,72 @@ describe('createProjectStore', () => {
       await flushNotifications();
       expect(listener1).not.toHaveBeenCalled();
       expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('createSessionStore', () => {
+  describe('child session messages', () => {
+    it('returns empty array for unknown child session', () => {
+      const store = createSessionStore<{ id: string }>([]);
+
+      expect(store.getChildSessionMessages('unknown-session')).toEqual([]);
+    });
+
+    it('stores messages for a child session', () => {
+      const store = createSessionStore<{ id: string }>([]);
+      const msg = { id: 'msg-1' };
+
+      store.updateChildSessionMessages('child-1', () => [msg]);
+
+      expect(store.getChildSessionMessages('child-1')).toEqual([msg]);
+    });
+
+    it('updates existing child session messages via updater', () => {
+      const store = createSessionStore<{ id: string }>([]);
+
+      store.updateChildSessionMessages('child-1', () => [{ id: 'msg-1' }]);
+      store.updateChildSessionMessages('child-1', msgs => [...msgs, { id: 'msg-2' }]);
+
+      expect(store.getChildSessionMessages('child-1')).toEqual([{ id: 'msg-1' }, { id: 'msg-2' }]);
+    });
+
+    it('keeps child sessions isolated from each other', () => {
+      const store = createSessionStore<{ id: string }>([]);
+
+      store.updateChildSessionMessages('child-1', () => [{ id: 'msg-a' }]);
+      store.updateChildSessionMessages('child-2', () => [{ id: 'msg-b' }]);
+
+      expect(store.getChildSessionMessages('child-1')).toEqual([{ id: 'msg-a' }]);
+      expect(store.getChildSessionMessages('child-2')).toEqual([{ id: 'msg-b' }]);
+    });
+
+    it('does not affect parent messages', () => {
+      const store = createSessionStore<{ id: string }>([{ id: 'parent-msg' }]);
+
+      store.updateChildSessionMessages('child-1', () => [{ id: 'child-msg' }]);
+
+      expect(store.getState().messages).toEqual([{ id: 'parent-msg' }]);
+    });
+
+    it('notifies subscribers when child session messages change', async () => {
+      const store = createSessionStore<{ id: string }>([]);
+      const listener = jest.fn();
+
+      store.subscribe(listener);
+      store.updateChildSessionMessages('child-1', () => [{ id: 'msg-1' }]);
+
+      await flushNotifications();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes childSessionMessages in state', () => {
+      const store = createSessionStore<{ id: string }>([]);
+
+      store.updateChildSessionMessages('child-1', () => [{ id: 'msg-1' }]);
+
+      const state = store.getState();
+      expect(state.childSessionMessages.get('child-1')).toEqual([{ id: 'msg-1' }]);
     });
   });
 });

--- a/src/components/app-builder/project-manager/__tests__/streaming.test.ts
+++ b/src/components/app-builder/project-manager/__tests__/streaming.test.ts
@@ -31,15 +31,23 @@ function createMockStore(): {
   subscribe: jest.Mock;
   updateMessages: jest.Mock;
   setQuestionRequestId: jest.Mock;
+  updateChildSessionMessages: jest.Mock;
+  getChildSessionMessages: jest.Mock;
   stateUpdates: Array<Record<string, unknown>>;
 } {
   const stateUpdates: Array<Record<string, unknown>> = [];
   let messages: CloudMessage[] = [];
   let isStreaming = false;
+  const childSessionMessages = new Map<string, CloudMessage[]>();
 
   return {
     stateUpdates,
-    getState: () => ({ messages, isStreaming, questionRequestIds: new Map<string, string>() }),
+    getState: () => ({
+      messages,
+      isStreaming,
+      questionRequestIds: new Map<string, string>(),
+      childSessionMessages,
+    }),
     setState: jest.fn((partial: Partial<V1SessionState>) => {
       stateUpdates.push(partial);
       if ('messages' in partial && partial.messages) {
@@ -54,6 +62,15 @@ function createMockStore(): {
       messages = updater(messages);
     }),
     setQuestionRequestId: jest.fn(),
+    updateChildSessionMessages: jest.fn(
+      (childSessionId: string, updater: (msgs: CloudMessage[]) => CloudMessage[]) => {
+        const existing = childSessionMessages.get(childSessionId) ?? [];
+        childSessionMessages.set(childSessionId, updater(existing));
+      }
+    ),
+    getChildSessionMessages: jest.fn((childSessionId: string) => {
+      return childSessionMessages.get(childSessionId) ?? [];
+    }),
   };
 }
 

--- a/src/components/app-builder/project-manager/sessions/session-store.ts
+++ b/src/components/app-builder/project-manager/sessions/session-store.ts
@@ -11,6 +11,8 @@ export type SessionState<TMessage> = {
   messages: TMessage[];
   isStreaming: boolean;
   questionRequestIds: Map<string, string>;
+  /** Messages from child/subagent sessions, keyed by child session ID */
+  childSessionMessages: Map<string, TMessage[]>;
 };
 
 export type SessionStore<TMessage> = {
@@ -19,6 +21,11 @@ export type SessionStore<TMessage> = {
   subscribe: (listener: () => void) => () => void;
   updateMessages: (updater: (messages: TMessage[]) => TMessage[]) => void;
   setQuestionRequestId: (callId: string, requestId: string) => void;
+  updateChildSessionMessages: (
+    childSessionId: string,
+    updater: (messages: TMessage[]) => TMessage[]
+  ) => void;
+  getChildSessionMessages: (childSessionId: string) => TMessage[];
 };
 
 export function createSessionStore<TMessage>(initialMessages: TMessage[]): SessionStore<TMessage> {
@@ -26,6 +33,7 @@ export function createSessionStore<TMessage>(initialMessages: TMessage[]): Sessi
     messages: initialMessages,
     isStreaming: false,
     questionRequestIds: new Map(),
+    childSessionMessages: new Map(),
   };
 
   const listeners = new Set<() => void>();
@@ -75,5 +83,27 @@ export function createSessionStore<TMessage>(initialMessages: TMessage[]): Sessi
     setState({ questionRequestIds: updated });
   }
 
-  return { getState, setState, subscribe, updateMessages, setQuestionRequestId };
+  function updateChildSessionMessages(
+    childSessionId: string,
+    updater: (messages: TMessage[]) => TMessage[]
+  ): void {
+    const newMap = new Map(state.childSessionMessages);
+    const existing = newMap.get(childSessionId) ?? [];
+    newMap.set(childSessionId, updater(existing));
+    setState({ childSessionMessages: newMap });
+  }
+
+  function getChildSessionMessages(childSessionId: string): TMessage[] {
+    return state.childSessionMessages.get(childSessionId) ?? [];
+  }
+
+  return {
+    getState,
+    setState,
+    subscribe,
+    updateMessages,
+    setQuestionRequestId,
+    updateChildSessionMessages,
+    getChildSessionMessages,
+  };
 }

--- a/src/components/app-builder/project-manager/sessions/types.ts
+++ b/src/components/app-builder/project-manager/sessions/types.ts
@@ -36,6 +36,7 @@ export type V1Session = SessionBase & {
 export type V2Session = SessionBase & {
   type: 'v2';
   getState: () => V2SessionState;
+  getChildSessionMessages: (childSessionId: string) => StoredMessage[];
 };
 
 export type AppBuilderSession = V1Session | V2Session;

--- a/src/components/app-builder/project-manager/sessions/v2/streaming.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/streaming.ts
@@ -84,19 +84,31 @@ export function createV2StreamingCoordinator(config: V2StreamingConfig): V2Strea
   // WebSocket + EventProcessor
   // ---------------------------------------------------------------------------
 
+  /** Returns the appropriate message updater for parent vs child session messages. */
+  function messageUpdater(
+    sessionId: string,
+    parentSessionId: string | null
+  ): (updater: (msgs: StoredMessage[]) => StoredMessage[]) => void {
+    return parentSessionId !== null
+      ? updater => store.updateChildSessionMessages(sessionId, updater)
+      : store.updateMessages;
+  }
+
   function createProcessorCallbacks(): EventProcessorCallbacks {
     return {
-      onMessageUpdated: (_sessionId, messageId, message, _parentSessionId) => {
-        store.updateMessages(messages => {
+      onMessageUpdated: (sessionId, messageId, message, parentSessionId) => {
+        const update = messageUpdater(sessionId, parentSessionId);
+        const storedMsg: StoredMessage = { info: message.info, parts: message.parts };
+        update(messages => {
           const idx = messages.findIndex(m => m.info.id === messageId);
-          const storedMsg: StoredMessage = { info: message.info, parts: message.parts };
           if (idx >= 0) {
             const updated = [...messages];
             updated[idx] = storedMsg;
             return updated;
           }
           // Replace optimistic user message when the real one arrives from server
-          if (message.info.role === 'user') {
+          // (only applies to parent session messages)
+          if (parentSessionId === null && message.info.role === 'user') {
             const optimisticIdx = messages.findIndex(
               m => m.info.role === 'user' && m.info.id.startsWith('optimistic-')
             );
@@ -106,25 +118,37 @@ export function createV2StreamingCoordinator(config: V2StreamingConfig): V2Strea
               return updated;
             }
           }
-          return [...messages, storedMsg];
+          const updated = [...messages, storedMsg];
+          if (parentSessionId !== null) {
+            updated.sort((a, b) => a.info.time.created - b.info.time.created);
+          }
+          return updated;
         });
       },
 
-      onMessageCompleted: (_sessionId, messageId, message, _parentSessionId) => {
-        store.updateMessages(messages => {
+      onMessageCompleted: (sessionId, messageId, message, parentSessionId) => {
+        const update = messageUpdater(sessionId, parentSessionId);
+        const storedMsg: StoredMessage = { info: message.info, parts: message.parts };
+        update(messages => {
           const idx = messages.findIndex(m => m.info.id === messageId);
-          const storedMsg: StoredMessage = { info: message.info, parts: message.parts };
           if (idx >= 0) {
             const updated = [...messages];
             updated[idx] = storedMsg;
             return updated;
           }
-          return [...messages, storedMsg];
+          const updated = [...messages, storedMsg];
+          if (parentSessionId !== null) {
+            updated.sort((a, b) => a.info.time.created - b.info.time.created);
+          }
+          return updated;
         });
       },
 
-      onPartUpdated: (_sessionId, messageId, _partId, part, _parentSessionId) => {
-        store.updateMessages(messages => {
+      onPartUpdated: (sessionId, messageId, _partId, part, parentSessionId) => {
+        messageUpdater(
+          sessionId,
+          parentSessionId
+        )(messages => {
           const idx = messages.findIndex(m => m.info.id === messageId);
           if (idx < 0) return messages;
           const msg = messages[idx];
@@ -141,8 +165,11 @@ export function createV2StreamingCoordinator(config: V2StreamingConfig): V2Strea
         });
       },
 
-      onPartRemoved: (_sessionId, messageId, partId, _parentSessionId) => {
-        store.updateMessages(messages => {
+      onPartRemoved: (sessionId, messageId, partId, parentSessionId) => {
+        messageUpdater(
+          sessionId,
+          parentSessionId
+        )(messages => {
           const idx = messages.findIndex(m => m.info.id === messageId);
           if (idx < 0) return messages;
           const msg = messages[idx];

--- a/src/components/app-builder/project-manager/sessions/v2/v2-session.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/v2-session.ts
@@ -102,6 +102,7 @@ export function createV2Session(config: CreateV2SessionConfig): V2Session {
     info,
     getState: store.getState,
     subscribe: store.subscribe,
+    getChildSessionMessages: store.getChildSessionMessages,
     sendMessage,
     interrupt,
     startInitialStreaming,


### PR DESCRIPTION
## Summary

- Subagent (child session) messages were incorrectly mixed into the parent session's message list, causing them to render inline in the main chat view.
- Adds `childSessionMessages` storage to the session store (`Map<string, TMessage[]>`) with `updateChildSessionMessages` / `getChildSessionMessages` accessors.
- Routes streaming callbacks (`onMessageUpdated`, `onMessageCompleted`, `onPartUpdated`, `onPartRemoved`) to child-specific storage when `parentSessionId` is non-null.
- Threads a `getChildMessages` callback through `V2StaticMessages` and `V2DynamicMessages` so rendering components can access child session data without polluting the parent message list.
- Child messages are sorted by creation time on insert.
- Adds unit tests for child session message isolation, subscriber notification, and state exposure. Updates existing streaming and messages test mocks.