### PR TITLE
fix(kiloclaw): persist and display actual volume size, bump default to 20GB

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -29,7 +29,7 @@ export const DEFAULT_MACHINE_GUEST = {
 };
 
 /** Default Fly Volume size in GB */
-export const DEFAULT_VOLUME_SIZE_GB = 20;
+export const DEFAULT_VOLUME_SIZE_GB = 10;
 
 /** Default Fly region priority list when FLY_REGION env var is not set */
 export const DEFAULT_FLY_REGION = 'dfw,yyz,cdg';

--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -29,7 +29,7 @@ export const DEFAULT_MACHINE_GUEST = {
 };
 
 /** Default Fly Volume size in GB */
-export const DEFAULT_VOLUME_SIZE_GB = 10;
+export const DEFAULT_VOLUME_SIZE_GB = 20;
 
 /** Default Fly region priority list when FLY_REGION env var is not set */
 export const DEFAULT_FLY_REGION = 'dfw,yyz,cdg';

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -504,7 +504,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           flyMachineId: this.flyMachineId,
           flyVolumeId: this.flyVolumeId,
           flyRegion: this.flyRegion,
-          volumeSizeGb: this.volumeSizeGb,
+          volumeSizeGb: this.flyVolumeId ? this.volumeSizeGb : null,
           healthCheckFailCount: 0,
           pendingDestroyMachineId: null,
           pendingDestroyVolumeId: null,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -343,6 +343,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private flyMachineId: string | null = null;
   private flyVolumeId: string | null = null;
   private flyRegion: string | null = null;
+  private volumeSizeGb: number | null = null;
   private machineSize: MachineSize | null = null;
   private healthCheckFailCount = 0;
   private pendingDestroyMachineId: string | null = null;
@@ -383,6 +384,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.flyMachineId = s.flyMachineId;
       this.flyVolumeId = s.flyVolumeId;
       this.flyRegion = s.flyRegion;
+      this.volumeSizeGb = s.volumeSizeGb;
       this.machineSize = s.machineSize;
       this.healthCheckFailCount = s.healthCheckFailCount;
       this.pendingDestroyMachineId = s.pendingDestroyMachineId;
@@ -452,6 +454,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
       this.flyVolumeId = volume.id;
       this.flyRegion = volume.region;
+      this.volumeSizeGb = volume.size_gb;
       console.log('[DO] Created Fly Volume:', volume.id, 'region:', volume.region);
     }
 
@@ -500,6 +503,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           flyMachineId: this.flyMachineId,
           flyVolumeId: this.flyVolumeId,
           flyRegion: this.flyRegion,
+          volumeSizeGb: this.volumeSizeGb,
           healthCheckFailCount: 0,
           pendingDestroyMachineId: null,
           pendingDestroyVolumeId: null,
@@ -1190,6 +1194,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     flyMachineId: string | null;
     flyVolumeId: string | null;
     flyRegion: string | null;
+    volumeSizeGb: number | null;
     openclawVersion: string | null;
     imageVariant: string | null;
     trackedImageTag: string | null;
@@ -1209,6 +1214,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.ctx.waitUntil(this.syncStatusFromLiveCheck());
     }
 
+    // Fire-and-forget backfill: if we have a volume but no cached size,
+    // fetch it from the Fly API so the next poll returns the real value.
+    if (this.volumeSizeGb === null && this.flyVolumeId) {
+      this.ctx.waitUntil(this.backfillVolumeSizeGb());
+    }
+
     return {
       userId: this.userId,
       sandboxId: this.sandboxId,
@@ -1223,6 +1234,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       flyMachineId: this.flyMachineId,
       flyVolumeId: this.flyVolumeId,
       flyRegion: this.flyRegion,
+      volumeSizeGb: this.volumeSizeGb,
       openclawVersion: this.openclawVersion,
       imageVariant: this.imageVariant,
       trackedImageTag: this.trackedImageTag,
@@ -1468,9 +1480,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       return;
     }
 
-    // Verify volume still exists on Fly
+    // Verify volume still exists on Fly (and backfill size if missing)
     try {
-      await fly.getVolume(flyConfig, this.flyVolumeId);
+      const volume = await fly.getVolume(flyConfig, this.flyVolumeId);
+      if (this.volumeSizeGb === null) {
+        this.volumeSizeGb = volume.size_gb;
+        await this.ctx.storage.put(storageUpdate({ volumeSizeGb: volume.size_gb }));
+      }
     } catch (err) {
       if (fly.isFlyNotFound(err)) {
         reconcileLog(reason, 'replace_lost_volume', {
@@ -1681,6 +1697,25 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
       // Transient error — silently fall back to cached state
       console.warn('[DO] Live check failed, using cached status:', err);
+    }
+  }
+
+  /**
+   * Fire-and-forget backfill for volumeSizeGb. Called from getStatus() and
+   * reconcileVolume() when the field is null but a volume exists.
+   */
+  private async backfillVolumeSizeGb(): Promise<void> {
+    if (!this.flyVolumeId) return;
+
+    try {
+      const flyConfig = this.getFlyConfig();
+      const volume = await fly.getVolume(flyConfig, this.flyVolumeId);
+      this.volumeSizeGb = volume.size_gb;
+      await this.ctx.storage.put(storageUpdate({ volumeSizeGb: volume.size_gb }));
+      console.log('[DO] Backfilled volumeSizeGb:', volume.size_gb);
+    } catch (err) {
+      // Non-fatal — will retry on next getStatus() or reconciliation cycle
+      console.warn('[DO] Failed to backfill volumeSizeGb:', err);
     }
   }
 
@@ -1930,7 +1965,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     this.flyVolumeId = volume.id;
     this.flyRegion = volume.region;
-    await this.ctx.storage.put(storageUpdate({ flyVolumeId: volume.id, flyRegion: volume.region }));
+    this.volumeSizeGb = volume.size_gb;
+    await this.ctx.storage.put(
+      storageUpdate({
+        flyVolumeId: volume.id,
+        flyRegion: volume.region,
+        volumeSizeGb: volume.size_gb,
+      })
+    );
 
     reconcileLog(reason, 'create_volume', {
       volume_id: volume.id,
@@ -1996,6 +2038,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
       this.flyVolumeId = forkedVolume.id;
       this.flyRegion = forkedVolume.region;
+      this.volumeSizeGb = forkedVolume.size_gb;
       reconcileLog(reason, 'fork_stranded_volume', {
         old_volume_id: oldVolumeId,
         old_region: oldRegion,
@@ -2019,6 +2062,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
       this.flyVolumeId = freshVolume.id;
       this.flyRegion = freshVolume.region;
+      this.volumeSizeGb = freshVolume.size_gb;
       reconcileLog(reason, 'create_replacement_volume', {
         old_volume_id: oldVolumeId,
         old_region: oldRegion,
@@ -2029,7 +2073,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // Persist new volume state
     await this.ctx.storage.put(
-      storageUpdate({ flyVolumeId: this.flyVolumeId, flyRegion: this.flyRegion })
+      storageUpdate({
+        flyVolumeId: this.flyVolumeId,
+        flyRegion: this.flyRegion,
+        volumeSizeGb: this.volumeSizeGb,
+      })
     );
 
     // Delete old volume (best-effort cleanup)

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -355,6 +355,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
   // In-memory only (not persisted to SQLite) — throttles live Fly checks in getStatus()
   private lastLiveCheckAt: number | null = null;
+  private backfillingVolumeSize = false;
 
   // ---- State loading ----
 
@@ -999,7 +1000,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           console.warn('[DO] Volume not found during region check, clearing');
           this.flyVolumeId = null;
           this.flyRegion = null;
-          await this.ctx.storage.put(storageUpdate({ flyVolumeId: null, flyRegion: null }));
+          this.volumeSizeGb = null;
+          await this.ctx.storage.put(
+            storageUpdate({ flyVolumeId: null, flyRegion: null, volumeSizeGb: null })
+          );
           await this.ensureVolume(flyConfig, 'start');
         }
         // Other errors: proceed with cached region, createMachine will fail
@@ -1216,8 +1220,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // Fire-and-forget backfill: if we have a volume but no cached size,
     // fetch it from the Fly API so the next poll returns the real value.
-    if (this.volumeSizeGb === null && this.flyVolumeId) {
-      this.ctx.waitUntil(this.backfillVolumeSizeGb());
+    if (this.volumeSizeGb === null && this.flyVolumeId && !this.backfillingVolumeSize) {
+      this.backfillingVolumeSize = true;
+      this.ctx.waitUntil(
+        this.backfillVolumeSizeGb().finally(() => {
+          this.backfillingVolumeSize = false;
+        })
+      );
     }
 
     return {
@@ -1494,7 +1503,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           old_volume_id: this.flyVolumeId,
         });
         this.flyVolumeId = null;
-        await this.ctx.storage.put(storageUpdate({ flyVolumeId: null }));
+        this.volumeSizeGb = null;
+        await this.ctx.storage.put(storageUpdate({ flyVolumeId: null, volumeSizeGb: null }));
         await this.ensureVolume(flyConfig, reason);
       }
       // Other errors: leave as-is, retry next alarm
@@ -1847,7 +1857,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     // Success or 404: clear
     this.pendingDestroyVolumeId = null;
     this.flyVolumeId = null;
-    await this.ctx.storage.put(storageUpdate({ pendingDestroyVolumeId: null, flyVolumeId: null }));
+    this.volumeSizeGb = null;
+    await this.ctx.storage.put(
+      storageUpdate({ pendingDestroyVolumeId: null, flyVolumeId: null, volumeSizeGb: null })
+    );
   }
 
   /**
@@ -1885,6 +1898,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.flyMachineId = null;
     this.flyVolumeId = null;
     this.flyRegion = null;
+    this.volumeSizeGb = null;
     this.machineSize = null;
     this.healthCheckFailCount = 0;
     this.pendingDestroyMachineId = null;
@@ -2049,7 +2063,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       // Fresh provision (never started) — no user data to preserve
       this.flyVolumeId = null;
       this.flyRegion = null;
-      await this.ctx.storage.put(storageUpdate({ flyVolumeId: null, flyRegion: null }));
+      this.volumeSizeGb = null;
+      await this.ctx.storage.put(
+        storageUpdate({ flyVolumeId: null, flyRegion: null, volumeSizeGb: null })
+      );
 
       const freshVolume = await fly.createVolumeWithFallback(
         flyConfig,
@@ -2204,6 +2221,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           flyMachineId: null,
           flyVolumeId: null,
           flyRegion: null,
+          volumeSizeGb: null,
           machineSize: null,
           healthCheckFailCount: 0,
           pendingDestroyMachineId: null,
@@ -2227,6 +2245,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.flyMachineId = null;
       this.flyVolumeId = null;
       this.flyRegion = null;
+      this.volumeSizeGb = null;
       this.machineSize = null;
       this.healthCheckFailCount = 0;
       this.pendingDestroyMachineId = null;

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -118,6 +118,8 @@ export const PersistedStateSchema = z.object({
   flyMachineId: z.string().nullable().default(null),
   flyVolumeId: z.string().nullable().default(null),
   flyRegion: z.string().nullable().default(null),
+  // Actual provisioned volume size in GB (backfilled from Fly API for existing instances)
+  volumeSizeGb: z.number().nullable().default(null),
   machineSize: MachineSizeSchema.nullable().default(null),
   // Health check tracking
   healthCheckFailCount: z.number().default(0),

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -43,7 +43,7 @@ export function InstanceControls({
           </Badge>
           <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
             <HardDrive className="h-3.5 w-3.5" />
-            20 GB SSD
+            {status.volumeSizeGb ?? 10} GB SSD
           </Badge>
         </div>
       </div>

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,12 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-02-24',
+    description: 'Fix instance type and size badges.',
+    category: 'bugfix',
+    deployHint: null,
+  },
+  {
     date: '2026-02-23',
     description:
       'Redesigned dashboard: live gateway process status, added ability to restart OpenClaw gateway.',

--- a/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
+++ b/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
@@ -18,6 +18,7 @@ const baseStatus: KiloClawDashboardStatus = {
   flyMachineId: null,
   flyVolumeId: null,
   flyRegion: null,
+  volumeSizeGb: null,
   gatewayToken: 'token',
   workerUrl: 'https://claw.kilo.ai',
 };

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -109,6 +109,7 @@ export type PlatformStatusResponse = {
   flyMachineId: string | null;
   flyVolumeId: string | null;
   flyRegion: string | null;
+  volumeSizeGb: number | null;
 };
 
 /** A Fly volume snapshot. */


### PR DESCRIPTION
## Summary

- Persist `volumeSizeGb` in the DO state so the dashboard displays the real provisioned disk size instead of a hardcoded value
- Backfill existing instances via fire-and-forget Fly API calls in `getStatus()` (fast — within one poll cycle) and `reconcileVolume()` (catches idle instances)
- Bump `DEFAULT_VOLUME_SIZE_GB` from 10 to 20 for new provisions
- Dashboard badge now shows `{volumeSizeGb} GB SSD` dynamically, with a 10 GB fallback before backfill completes

## Changes

- **`kiloclaw/src/schemas/instance-config.ts`** — Add `volumeSizeGb` to `PersistedStateSchema`
- **`kiloclaw/src/durable-objects/kiloclaw-instance.ts`** — Field, loadState, getStatus, backfill method, 4 volume creation sites, reconcileVolume backfill
- **`src/lib/kiloclaw/types.ts`** — Add `volumeSizeGb` to `PlatformStatusResponse`
- **`src/app/(app)/claw/components/InstanceControls.tsx`** — Dynamic disk size badge
- **`src/app/(app)/claw/components/changelog-data.ts`** — Bugfix entry