### PR TITLE
feat(kiloclaw): expand default Fly regions and shuffle before selecting

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -31,8 +31,9 @@ export const DEFAULT_MACHINE_GUEST = {
 /** Default Fly Volume size in GB */
 export const DEFAULT_VOLUME_SIZE_GB = 10;
 
-/** Default Fly region priority list when FLY_REGION env var is not set */
-export const DEFAULT_FLY_REGION = 'dfw,yyz,cdg';
+/** Default Fly region priority list when FLY_REGION env var is not set.
+ *  Callers shuffle before selecting so order here doesn't matter. */
+export const DEFAULT_FLY_REGION = 'cdg,arn,yyz,ord,dfw,lax';
 
 // Alarm cadence by instance status
 /** Running machines: fast health checks */

--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -33,7 +33,7 @@ export const DEFAULT_VOLUME_SIZE_GB = 10;
 
 /** Default Fly region priority list when FLY_REGION env var is not set.
  *  Callers shuffle before selecting so order here doesn't matter. */
-export const DEFAULT_FLY_REGION = 'cdg,arn,yyz,ord,dfw,lax';
+export const DEFAULT_FLY_REGION = 'cdg,arn,yyz,ord,iad,lax';
 
 // Alarm cadence by instance status
 /** Running machines: fast health checks */

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -833,7 +833,12 @@ describe('gateway process control via controller', () => {
 // selectRecoveryCandidate (pure function, no mocks needed)
 // ============================================================================
 
-import { selectRecoveryCandidate, parseRegions, deprioritizeRegion } from './kiloclaw-instance';
+import {
+  selectRecoveryCandidate,
+  parseRegions,
+  deprioritizeRegion,
+  shuffleRegions,
+} from './kiloclaw-instance';
 import type { FlyMachine } from '../fly/types';
 
 function fakeMachine(overrides: Partial<FlyMachine>): FlyMachine {
@@ -1082,6 +1087,38 @@ describe('deprioritizeRegion', () => {
   });
 });
 
+describe('shuffleRegions', () => {
+  it('returns the same elements', () => {
+    const input = ['cdg', 'arn', 'yyz', 'ord', 'dfw', 'lax'];
+    const result = shuffleRegions([...input]);
+    expect(result.sort()).toEqual(input.sort());
+  });
+
+  it('returns a single-element array unchanged', () => {
+    expect(shuffleRegions(['dfw'])).toEqual(['dfw']);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(shuffleRegions([])).toEqual([]);
+  });
+
+  it('mutates in place and returns the same reference', () => {
+    const arr = ['a', 'b', 'c'];
+    const result = shuffleRegions(arr);
+    expect(result).toBe(arr);
+  });
+
+  it('produces different orderings over many runs', () => {
+    const input = ['cdg', 'arn', 'yyz', 'ord', 'dfw', 'lax'];
+    const orderings = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      orderings.add(shuffleRegions([...input]).join(','));
+    }
+    // With 6 elements (720 permutations), 50 shuffles should produce at least 2 distinct orderings
+    expect(orderings.size).toBeGreaterThan(1);
+  });
+});
+
 // ============================================================================
 // Live check in getStatus()
 // ============================================================================
@@ -1307,14 +1344,15 @@ describe('start: 412 insufficient resources recovery', () => {
     // Old volume was deleted
     expect(flyClient.deleteVolume).toHaveBeenCalledWith(expect.anything(), 'vol-1');
     // New volume created via fallback with deprioritized regions and compute hint
-    expect(flyClient.createVolumeWithFallback).toHaveBeenCalledWith(
-      expect.anything(),
+    const regions412Call = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
+    expect(regions412Call[1]).toEqual(
       expect.objectContaining({
         compute: expect.objectContaining({ cpus: 2, memory_mb: 4096 }),
-      }),
-      // 'iad' not in FLY_REGION='us,eu', so deprioritizeRegion returns unchanged
-      ['us', 'eu']
+      })
     );
+    // Regions are shuffled, so just check the set (deprioritize is a no-op here
+    // because 'iad' is not in FLY_REGION='us,eu')
+    expect(regions412Call[2].sort()).toEqual(['eu', 'us']);
     // source_volume_id should NOT be set for fresh provision
     const createVolumeCall = (flyClient.createVolumeWithFallback as Mock).mock.calls[0][1];
     expect(createVolumeCall.source_volume_id).toBeUndefined();
@@ -1352,14 +1390,15 @@ describe('start: 412 insufficient resources recovery', () => {
     await instance.start('user-1');
 
     // Volume was forked (source_volume_id set) with compute hint and deprioritized regions
-    expect(flyClient.createVolumeWithFallback).toHaveBeenCalledWith(
-      expect.anything(),
+    const regionsForkCall = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
+    expect(regionsForkCall[1]).toEqual(
       expect.objectContaining({
         source_volume_id: 'vol-1',
         compute: expect.objectContaining({ cpus: 2, memory_mb: 4096 }),
-      }),
-      ['us', 'eu']
+      })
     );
+    // Regions are shuffled — check the set
+    expect(regionsForkCall[2].sort()).toEqual(['eu', 'us']);
     // Old volume was deleted
     expect(flyClient.deleteVolume).toHaveBeenCalledWith(expect.anything(), 'vol-1');
     // Machine was retried
@@ -1416,14 +1455,15 @@ describe('start: 412 insufficient resources recovery', () => {
     // Old machine was destroyed
     expect(flyClient.destroyMachine).toHaveBeenCalledWith(expect.anything(), 'machine-1');
     // Volume was forked (has user data) with compute hint
-    expect(flyClient.createVolumeWithFallback).toHaveBeenCalledWith(
-      expect.anything(),
+    const regionsUpdateCall = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
+    expect(regionsUpdateCall[1]).toEqual(
       expect.objectContaining({
         source_volume_id: 'vol-1',
         compute: expect.objectContaining({ cpus: 2, memory_mb: 4096 }),
-      }),
-      ['us', 'eu']
+      })
     );
+    // Regions are shuffled then deprioritized — check the set
+    expect(regionsUpdateCall[2].sort()).toEqual(['eu', 'us']);
     // New machine was created
     expect(storage._store.get('flyMachineId')).toBe('machine-new');
     expect(storage._store.get('flyVolumeId')).toBe('vol-new');

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -245,6 +245,17 @@ export function parseRegions(regionList: string): string[] {
     .filter(Boolean);
 }
 
+/** Fisher-Yates shuffle (in-place). Returns the same array for chaining. */
+export function shuffleRegions(regions: string[]): string[] {
+  for (let i = regions.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = regions[i];
+    regions[i] = regions[j];
+    regions[j] = tmp;
+  }
+  return regions;
+}
+
 /**
  * Move a failed region to the end of the list so we try other regions first.
  * E.g. deprioritizeRegion(['dfw', 'yyz', 'cdg'], 'dfw') → ['yyz', 'cdg', 'dfw']
@@ -439,7 +450,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     // with capacity for both the volume and the expected machine spec.
     if (isNew && !this.flyVolumeId) {
       const flyConfig = this.getFlyConfig();
-      const regions = parseRegions(config.region ?? this.env.FLY_REGION ?? DEFAULT_FLY_REGION);
+      const regions = shuffleRegions(
+        parseRegions(config.region ?? this.env.FLY_REGION ?? DEFAULT_FLY_REGION)
+      );
       const guest = guestFromSize(config.machineSize ?? null);
       const volume = await fly.createVolumeWithFallback(
         flyConfig,
@@ -1917,7 +1930,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     if (this.flyVolumeId) return;
     if (!this.sandboxId) return;
 
-    const regions = parseRegions(this.flyRegion ?? this.env.FLY_REGION ?? DEFAULT_FLY_REGION);
+    // When flyRegion is set this is a single region — shuffle is a no-op.
+    const regions = shuffleRegions(
+      parseRegions(this.flyRegion ?? this.env.FLY_REGION ?? DEFAULT_FLY_REGION)
+    );
     const volume = await fly.createVolumeWithFallback(
       flyConfig,
       {
@@ -1955,7 +1971,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const oldVolumeId = this.flyVolumeId;
     const oldRegion = this.flyRegion;
     const hasUserData = this.lastStartedAt !== null;
-    const allRegions = parseRegions(this.env.FLY_REGION ?? DEFAULT_FLY_REGION);
+    const allRegions = shuffleRegions(parseRegions(this.env.FLY_REGION ?? DEFAULT_FLY_REGION));
     const regions = deprioritizeRegion(allRegions, oldRegion);
     const compute = guestFromSize(this.machineSize);
 


### PR DESCRIPTION
## Summary

- Expand the default Fly region list from 3 (`dfw,yyz,cdg`) to 6 (`cdg,arn,yyz,ord,iad,lax`), adding Stockholm, Chicago, Los Angeles, and IAD. Removing DFW.
- Shuffle regions before volume creation so new users are distributed across regions rather than always hitting the first one
