### PR TITLE
fix: truncate Dependabot dismissed_comment to 280 char limit

### DIFF
--- a/src/lib/security-agent/github/dependabot-api.ts
+++ b/src/lib/security-agent/github/dependabot-api.ts
@@ -266,13 +266,20 @@ export async function dismissDependabotAlert(
   const tokenData = await generateGitHubInstallationToken(installationId);
   const octokit = new Octokit({ auth: tokenData.token });
 
+  // GitHub API limits dismissed_comment to 280 characters
+  const MAX_COMMENT_LENGTH = 280;
+  const truncatedComment =
+    dismissedComment && dismissedComment.length > MAX_COMMENT_LENGTH
+      ? dismissedComment.slice(0, MAX_COMMENT_LENGTH - 1) + '\u2026'
+      : dismissedComment;
+
   await octokit.rest.dependabot.updateAlert({
     owner,
     repo,
     alert_number: alertNumber,
     state: 'dismissed',
     dismissed_reason: dismissedReason,
-    dismissed_comment: dismissedComment,
+    dismissed_comment: truncatedComment,
   });
 }
 


### PR DESCRIPTION
## Summary

- GitHub's Dependabot API rejects `dismissed_comment` values over 280 characters
- Auto-dismiss passes LLM-generated reasoning text (`exploitabilityReasoning`, `needsSandboxReasoning`) that can easily exceed this limit
- Truncate with ellipsis at the API boundary in `dismissDependabotAlert` so all callers are protected