### PR TITLE
fix(kiloclaw): treat Fly 403 org quota exceeded as capacity error

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -1060,11 +1060,15 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     } catch (err) {
       if (!fly.isFlyInsufficientResources(err)) throw err;
 
-      // 412: host where the volume lives has no capacity.
+      // Capacity error (403/409/412): host or region has no room.
       // Replace the volume (fork if user data exists, fresh otherwise)
       // and retry machine creation once.
-      console.warn('[DO] Insufficient resources (412), replacing stranded volume');
-      await this.replaceStrandedVolume(flyConfig, 'start_412_recovery');
+      // isFlyInsufficientResources guarantees err is FlyApiError
+      const code = err instanceof fly.FlyApiError ? err.status : 0;
+      console.error(
+        `[DO] Insufficient resources (${code}) in ${this.flyRegion ?? 'unknown'}, replacing stranded volume`
+      );
+      await this.replaceStrandedVolume(flyConfig, `start_${code}_recovery`);
 
       // Rebuild machine config with new volume ID
       const retryConfig = buildMachineConfig(

--- a/kiloclaw/src/fly/client.test.ts
+++ b/kiloclaw/src/fly/client.test.ts
@@ -63,6 +63,27 @@ describe('isFlyInsufficientResources', () => {
     expect(isFlyInsufficientResources(err)).toBe(true);
   });
 
+  // -- Confirmed production 403 payload: org quota exceeded --
+
+  it('matches production 403 payload: org memory quota exceeded in region', () => {
+    const body =
+      '{"error":"organization \\"Kilo\\" is using 1970176 MB of memory in dfw which is over the allowed quota. please consider other regions"}';
+    const err = new FlyApiError(`Fly API createMachine failed (403): ${body}`, 403, body);
+    expect(isFlyInsufficientResources(err)).toBe(true);
+  });
+
+  // -- Non-capacity 403s: must NOT trigger recovery --
+
+  it('returns false for auth 403 errors', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const body = '{"error":"forbidden: insufficient permissions"}';
+    const err = new FlyApiError(`Fly API failed (403): ${body}`, 403, body);
+    expect(isFlyInsufficientResources(err)).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
   // -- Non-capacity 409s: must NOT trigger recovery --
 
   it('returns false for non-capacity 409 conflicts', () => {
@@ -105,6 +126,19 @@ describe('isFlyInsufficientResources', () => {
     expect(isFlyInsufficientResources(err)).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith(
       '[fly] Unclassified 412 error (not treated as capacity):',
+      body
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('returns false and logs warning for unclassified 403', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const body = '{"error":"some unknown 403 reason"}';
+    const err = new FlyApiError(`Fly API failed (403): ${body}`, 403, body);
+
+    expect(isFlyInsufficientResources(err)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[fly] Unclassified 403 error (not treated as capacity):',
       body
     );
     warnSpy.mockRestore();

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -259,8 +259,9 @@ export function isFlyNotFound(err: unknown): boolean {
  * Status codes that Fly uses for capacity/resource exhaustion errors.
  * - 412: "insufficient resources" when creating a machine with an existing volume
  * - 409: "insufficient memory" when updating/starting a machine on a full host
+ * - 403: org memory quota exceeded in a region ("over the allowed quota")
  */
-const CAPACITY_STATUS_CODES = [409, 412];
+const CAPACITY_STATUS_CODES = [403, 409, 412];
 
 /**
  * Capacity-related markers in Fly error bodies. Matched case-insensitively
@@ -269,22 +270,28 @@ const CAPACITY_STATUS_CODES = [409, 412];
  * Confirmed from production:
  * - 412: "insufficient resources to create new machine with existing volume 'vol_xxx'"
  * - 409: "could not reserve resource for machine: insufficient memory available to fulfill request"
+ * - 403: 'organization "Kilo" is using N MB of memory in {region} which is over the allowed quota'
  *
  * Add new markers here when the unclassified warning log reveals new
  * capacity error formats from Fly.
  */
-const CAPACITY_MARKERS = ['insufficient resources', 'insufficient memory'];
+const CAPACITY_MARKERS = [
+  'insufficient resources',
+  'insufficient memory',
+  'over the allowed quota',
+];
 
 /**
  * Check if a Fly API error is a capacity/resource exhaustion issue
- * (host where a volume/machine lives has no room).
+ * (host where a volume/machine lives has no room, or org quota exceeded).
  *
- * Fly uses 412 for volume-pinned capacity issues and 409 for memory
- * exhaustion on updateMachine. Both codes are also used for unrelated
- * errors (precondition/version mismatches, conflicts), so we only
+ * Fly uses 412 for volume-pinned capacity issues, 409 for memory
+ * exhaustion on updateMachine, and 403 for org memory quota exceeded
+ * in a region. These codes are also used for unrelated errors
+ * (precondition/version mismatches, conflicts, auth), so we only
  * trigger recovery when the body contains explicit capacity markers.
  *
- * Logs a warning for unclassified 409/412s so we can tune matching.
+ * Logs a warning for unclassified 403/409/412s so we can tune matching.
  */
 export function isFlyInsufficientResources(err: unknown): boolean {
   if (!(err instanceof FlyApiError) || !CAPACITY_STATUS_CODES.includes(err.status)) return false;


### PR DESCRIPTION
## Summary

- Fly returns 403 with `"over the allowed quota"` when an org exceeds its memory quota in a specific region. Previously this surfaced as an opaque non-retryable error. Now it triggers the existing capacity recovery flow: replace the stranded volume (deprioritizing the exhausted region), and retry machine creation in another region.

## Changes

- Add `403` to `CAPACITY_STATUS_CODES` and `"over the allowed quota"` to `CAPACITY_MARKERS` in `kiloclaw/src/fly/client.ts`
- Make the DO recovery log dynamic — includes actual status code and region instead of hardcoded `412`
- Upgrade recovery log from `console.warn` to `console.error`
- Add tests: 403 quota match, auth 403 rejection, unclassified 403 warning

## Production error this fixes

```
[do-retry] Non-retryable error start attempt=1 FlyApiError: Fly API createMachine failed (403):
{"error":"organization \"Kilo\" is using 1970176 MB of memory in dfw which is over the allowed quota. please consider other regions"}
```