### PR TITLE
Reduce Vercel DB pool sizes and enforce statement_timeout

### DIFF
--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -66,9 +66,10 @@ function getReplicaUrl(): string {
 // Primary pool - always points to Frankfurt (writes go here)
 export const pool = new Pool({
   ...getDatabaseClientConfig(postgresUrl),
-  max: 100,
+  max: 10,
   connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
   idleTimeoutMillis: 3000,
+  statement_timeout: Number.parseInt(POSTGRES_MAX_QUERY_TIME || '20000'),
   application_name: appName,
 });
 
@@ -79,9 +80,10 @@ export const usesSeparateReplica = replicaUrl !== postgresUrl;
 const replicaPool = usesSeparateReplica
   ? new Pool({
       ...getDatabaseClientConfig(replicaUrl),
-      max: 100,
+      max: 10,
       connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
       idleTimeoutMillis: 3000,
+      statement_timeout: Number.parseInt(POSTGRES_MAX_QUERY_TIME || '20000'),
       application_name: `${appName}-replica`,
     })
   : pool; // Reuse primary pool if no separate replica


### PR DESCRIPTION
## Summary

- Reduce pool `max` from 100 to 10 per pool (primary + replica) — at peak, dozens of warm Vercel instances across 20+ regions each holding `max:100` connections contributes significantly to hitting the Supabase PgBouncer `max_client_conn` limit (3000).
- Apply `POSTGRES_MAX_QUERY_TIME` as `statement_timeout` on the pool — the env var was validated to exist on startup but was never actually passed to the pool config.

Part of the fix for `max_client_conn` connection exhaustion (see also #497 for the Cloudflare worker changes).