### PR TITLE
Add capacity warning banner to KiloClaw dashboard

### DIFF
--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { TriangleAlert } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useGatewayUrl } from '../hooks/useGatewayUrl';
@@ -42,6 +44,14 @@ export function ClawDashboard({ status }: { status: KiloClawDashboardStatus | un
         region={status?.flyRegion || null}
         gatewayUrl={gatewayUrl}
       />
+
+      <Alert variant="warning">
+        <TriangleAlert className="size-4" />
+        <AlertDescription>
+          KiloClaw ended up being really popular! We&apos;re working on getting additional capacity.
+          If you have trouble starting a machine, please try again in a few minutes.
+        </AlertDescription>
+      </Alert>
 
       <Card className="mt-6">
         {!instanceStatus ? (


### PR DESCRIPTION
## Summary

- Adds a warning banner to the `/claw` dashboard informing users that KiloClaw is experiencing high demand
- Uses the existing `Alert` component with the `warning` variant
- Advises users to retry in a few minutes if they have trouble starting a machine