### PR TITLE
Add instanceId to pool metrics for per-instance deduplication

### DIFF
--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -108,7 +108,10 @@ if (usesSeparateReplica) {
 }
 
 // --- Pool observability ---
-// Periodic pool metrics (every 30s) — picked up by Vercel log drain → Axiom
+// Periodic pool metrics (every 30s) — picked up by Vercel log drain → Axiom.
+// instanceId lets us deduplicate readings per instance in Axiom queries.
+const instanceId = `${VERCEL_REGION ?? 'unknown'}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
 function logPoolMetrics() {
   const primary = { total: pool.totalCount, idle: pool.idleCount, waiting: pool.waitingCount };
   const replica = usesSeparateReplica
@@ -121,6 +124,7 @@ function logPoolMetrics() {
   console.log(
     JSON.stringify({
       type: 'pool_metrics',
+      instanceId,
       region: VERCEL_REGION ?? 'unknown',
       primary,
       replica,


### PR DESCRIPTION
## Summary

Adds a stable `instanceId` field to the pool metrics JSON logged every 30s (from #520). Without this, Axiom dashboard queries can't distinguish readings from different Vercel function instances, making it impossible to accurately compute global connection totals (sum across instances) vs per-instance stats.

The `instanceId` is generated once at module load as `{region}-{timestamp}-{random}`, e.g. `iad1-1771954564449-k3x9f2`. It's stable for the lifetime of the function instance.

### Updated Axiom dashboard queries

With `instanceId`, the dashboard charts should use this pattern to get accurate global totals:

```apl
| summarize latest_total=arg_max(_time, total) by instanceId, bin(_time, 1m)
| summarize sum(latest_total) by bin(_time, 1m)
```

## Changes

- `src/lib/drizzle.ts` — add `instanceId` field to pool metrics log output