### PR TITLE
feat(gastown): Dashboard deep drill-down (#225)

### DIFF
--- a/src/app/(app)/components/AppSidebar.tsx
+++ b/src/app/(app)/components/AppSidebar.tsx
@@ -1,12 +1,27 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import type { Sidebar } from '@/components/ui/sidebar';
 import { useUrlOrganizationId } from '@/hooks/useUrlOrganizationId';
 import PersonalAppSidebar from './PersonalAppSidebar';
 import OrganizationAppSidebar from './OrganizationAppSidebar';
+import { GastownTownSidebar } from '@/components/gastown/GastownTownSidebar';
+
+/** Extract the townId from a /gastown/[townId] pathname, or null. */
+function extractGastownTownId(pathname: string): string | null {
+  const match = pathname.match(/^\/gastown\/([0-9a-f-]{36})/);
+  return match ? match[1] : null;
+}
 
 export default function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const currentOrgId = useUrlOrganizationId();
+  const pathname = usePathname();
+
+  // Inside a specific gastown town — show the town-specific sidebar
+  const gastownTownId = extractGastownTownId(pathname);
+  if (gastownTownId) {
+    return <GastownTownSidebar townId={gastownTownId} {...props} />;
+  }
 
   // Render organization sidebar if viewing an organization
   if (currentOrgId) {

--- a/src/app/(app)/gastown/[townId]/MayorTerminalBar.tsx
+++ b/src/app/(app)/gastown/[townId]/MayorTerminalBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { use } from 'react';
-import { MayorChat } from '@/components/gastown/MayorChat';
+import { TerminalBar } from '@/components/gastown/TerminalBar';
 
 export function MayorTerminalBar({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = use(params);
-  return <MayorChat townId={townId} />;
+  return <TerminalBar townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -160,9 +160,9 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
   );
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Top bar */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+    <div>
+      {/* Top bar — sticky */}
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-3">
           {townQuery.isLoading ? (
             <Skeleton className="h-6 w-40" />
@@ -187,273 +187,269 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
         </Button>
       </div>
 
-      {/* Main content area */}
-      <div className="flex-1 overflow-y-auto">
-        <div className="grid grid-cols-1 gap-0 lg:grid-cols-[1fr_380px]">
-          {/* Left column: activity feed (social-media-style) */}
-          <div className="border-r border-white/[0.06]">
-            {/* Stats strip */}
-            <div className="grid grid-cols-4 border-b border-white/[0.06]">
-              <StatCell
-                label="Open"
-                value={openBeadCount}
-                icon={<Hexagon className="size-3.5" />}
-                color="text-sky-400"
-              />
-              <StatCell
-                label="In Progress"
-                value={inProgressBeadCount}
-                icon={<Bot className="size-3.5" />}
-                color="text-violet-400"
-              />
-              <StatCell
-                label="Closed"
-                value={closedBeadCount}
-                icon={<Zap className="size-3.5" />}
-                color="text-emerald-400"
-              />
-              <StatCell
-                label="Escalations"
-                value={escalationsCount}
-                icon={<AlertTriangle className="size-3.5" />}
-                color="text-orange-400"
-              />
-            </div>
+      {/* Main content area — no scroll container; viewport scrolls */}
+      <div className="grid grid-cols-1 gap-0 lg:grid-cols-[1fr_380px]">
+        {/* Left column: activity feed */}
+        <div className="border-r border-white/[0.06]">
+          {/* Stats strip */}
+          <div className="grid grid-cols-4 border-b border-white/[0.06]">
+            <StatCell
+              label="Open"
+              value={openBeadCount}
+              icon={<Hexagon className="size-3.5" />}
+              color="text-sky-400"
+            />
+            <StatCell
+              label="In Progress"
+              value={inProgressBeadCount}
+              icon={<Bot className="size-3.5" />}
+              color="text-violet-400"
+            />
+            <StatCell
+              label="Closed"
+              value={closedBeadCount}
+              icon={<Zap className="size-3.5" />}
+              color="text-emerald-400"
+            />
+            <StatCell
+              label="Escalations"
+              value={escalationsCount}
+              icon={<AlertTriangle className="size-3.5" />}
+              color="text-orange-400"
+            />
+          </div>
 
-            {/* Activity chart */}
-            <div className="border-b border-white/[0.06] px-5 pt-4 pb-2">
-              <div className="mb-2 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Activity className="size-3.5 text-white/30" />
-                  <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
-                    Activity — 24h
-                  </span>
-                </div>
-                <span className="font-mono text-[11px] text-white/30">{events.length} events</span>
-              </div>
-              <div className="h-[100px]">
-                {activityData.length > 0 ? (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <AreaChart data={activityData}>
-                      <defs>
-                        <linearGradient id="activityGrad" x1="0" y1="0" x2="0" y2="1">
-                          <stop offset="0%" stopColor="oklch(95% 0.15 108)" stopOpacity={0.3} />
-                          <stop offset="100%" stopColor="oklch(95% 0.15 108)" stopOpacity={0} />
-                        </linearGradient>
-                      </defs>
-                      <XAxis dataKey="time" hide />
-                      <YAxis hide />
-                      <Tooltip
-                        contentStyle={{
-                          background: 'oklch(0.15 0 0)',
-                          border: '1px solid oklch(1 0 0 / 0.1)',
-                          borderRadius: '8px',
-                          fontSize: '11px',
-                          color: 'oklch(1 0 0 / 0.7)',
-                        }}
-                        labelFormatter={() => ''}
-                        formatter={(value: number) => [value, 'events']}
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="count"
-                        stroke="oklch(95% 0.15 108)"
-                        strokeWidth={1.5}
-                        fill="url(#activityGrad)"
-                      />
-                    </AreaChart>
-                  </ResponsiveContainer>
-                ) : (
-                  <div className="flex h-full items-center justify-center text-xs text-white/20">
-                    No activity data
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Activity feed — clickable items */}
-            <div className="px-2">
-              <div className="flex items-center gap-2 px-3 pt-4 pb-2">
+          {/* Activity chart */}
+          <div className="border-b border-white/[0.06] px-5 pt-4 pb-2">
+            <div className="mb-2 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Activity className="size-3.5 text-white/30" />
                 <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
-                  Feed
+                  Activity — 24h
                 </span>
               </div>
-              <ActivityFeedView
-                townId={townId}
-                events={events.slice(-80)}
-                isLoading={townEventsQuery.isLoading}
-                onEventClick={event => openDrawer({ type: 'event', event })}
-              />
+              <span className="font-mono text-[11px] text-white/30">{events.length} events</span>
+            </div>
+            <div className="h-[100px]">
+              {activityData.length > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={activityData}>
+                    <defs>
+                      <linearGradient id="activityGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="oklch(95% 0.15 108)" stopOpacity={0.3} />
+                        <stop offset="100%" stopColor="oklch(95% 0.15 108)" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <XAxis dataKey="time" hide />
+                    <YAxis hide />
+                    <Tooltip
+                      contentStyle={{
+                        background: 'oklch(0.15 0 0)',
+                        border: '1px solid oklch(1 0 0 / 0.1)',
+                        borderRadius: '8px',
+                        fontSize: '11px',
+                        color: 'oklch(1 0 0 / 0.7)',
+                      }}
+                      labelFormatter={() => ''}
+                      formatter={(value: number) => [value, 'events']}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="count"
+                      stroke="oklch(95% 0.15 108)"
+                      strokeWidth={1.5}
+                      fill="url(#activityGrad)"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex h-full items-center justify-center text-xs text-white/20">
+                  No activity data
+                </div>
+              )}
             </div>
           </div>
 
-          {/* Right column: rigs + recent agents + topology */}
-          <div className="flex flex-col">
-            <div className="flex-1 p-4">
-              {/* Rigs */}
-              <div className="mb-3 flex items-center justify-between">
-                <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
-                  Rigs ({rigs.length})
-                </span>
-              </div>
+          {/* Activity feed — clickable items */}
+          <div className="px-2">
+            <div className="flex items-center gap-2 px-3 pt-4 pb-2">
+              <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                Feed
+              </span>
+            </div>
+            <ActivityFeedView
+              townId={townId}
+              events={events.slice(-80)}
+              isLoading={townEventsQuery.isLoading}
+              onEventClick={event => openDrawer({ type: 'event', event })}
+            />
+          </div>
+        </div>
 
-              {rigsQuery.isLoading && (
-                <div className="space-y-2">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <Skeleton key={i} className="h-16 w-full rounded-lg" />
-                  ))}
-                </div>
-              )}
+        {/* Right column: rigs + recent agents + topology — sticky alongside the feed */}
+        <div className="lg:sticky lg:top-[53px] lg:self-start">
+          <div className="p-4">
+            {/* Rigs */}
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                Rigs ({rigs.length})
+              </span>
+            </div>
 
-              {rigs.length === 0 && !rigsQuery.isLoading && (
-                <div className="rounded-xl border border-dashed border-white/10 p-6 text-center">
-                  <GitBranch className="mx-auto mb-2 size-6 text-white/20" />
-                  <p className="text-xs text-white/40">
-                    No rigs yet. Connect a repo to get started.
-                  </p>
-                  <button
-                    onClick={() => setIsCreateRigOpen(true)}
-                    className="mt-3 inline-flex items-center gap-1 rounded-md bg-white/[0.06] px-3 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.1] hover:text-white/80"
-                  >
-                    <Plus className="size-3" />
-                    Create rig
-                  </button>
-                </div>
-              )}
-
-              <AnimatePresence mode="popLayout">
-                {rigs.map((rig, i) => (
-                  <motion.div
-                    key={rig.id}
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -8 }}
-                    transition={{ delay: i * 0.04, duration: 0.25 }}
-                    onClick={() => void router.push(`/gastown/${townId}/rigs/${rig.id}`)}
-                    className="group mb-2 cursor-pointer rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="min-w-0">
-                        <span className="text-sm font-medium text-white/85">{rig.name}</span>
-                        <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
-                          <GitBranch className="size-3" />
-                          <span>{rig.default_branch}</span>
-                          <span className="text-white/20">|</span>
-                          <Clock className="size-3" />
-                          <span>
-                            {formatDistanceToNow(new Date(rig.created_at), { addSuffix: true })}
-                          </span>
-                        </div>
-                      </div>
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          if (confirm(`Delete rig "${rig.name}"?`)) {
-                            deleteRig.mutate({ rigId: rig.id });
-                          }
-                        }}
-                        className="rounded p-1 text-white/20 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-400"
-                      >
-                        <Trash2 className="size-3" />
-                      </button>
-                    </div>
-                    <div className="mt-2 max-w-full truncate font-mono text-[10px] text-white/25">
-                      {rig.git_url}
-                    </div>
-                  </motion.div>
+            {rigsQuery.isLoading && (
+              <div className="space-y-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-16 w-full rounded-lg" />
                 ))}
-              </AnimatePresence>
+              </div>
+            )}
 
-              {/* Recent Agents */}
-              {recentAgents.length > 0 && (
-                <div className="mt-5">
-                  <div className="mb-2.5 flex items-center justify-between">
-                    <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
-                      Recent Agents
-                    </span>
+            {rigs.length === 0 && !rigsQuery.isLoading && (
+              <div className="rounded-xl border border-dashed border-white/10 p-6 text-center">
+                <GitBranch className="mx-auto mb-2 size-6 text-white/20" />
+                <p className="text-xs text-white/40">No rigs yet. Connect a repo to get started.</p>
+                <button
+                  onClick={() => setIsCreateRigOpen(true)}
+                  className="mt-3 inline-flex items-center gap-1 rounded-md bg-white/[0.06] px-3 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.1] hover:text-white/80"
+                >
+                  <Plus className="size-3" />
+                  Create rig
+                </button>
+              </div>
+            )}
+
+            <AnimatePresence mode="popLayout">
+              {rigs.map((rig, i) => (
+                <motion.div
+                  key={rig.id}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -8 }}
+                  transition={{ delay: i * 0.04, duration: 0.25 }}
+                  onClick={() => void router.push(`/gastown/${townId}/rigs/${rig.id}`)}
+                  className="group mb-2 cursor-pointer rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="min-w-0">
+                      <span className="text-sm font-medium text-white/85">{rig.name}</span>
+                      <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
+                        <GitBranch className="size-3" />
+                        <span>{rig.default_branch}</span>
+                        <span className="text-white/20">|</span>
+                        <Clock className="size-3" />
+                        <span>
+                          {formatDistanceToNow(new Date(rig.created_at), { addSuffix: true })}
+                        </span>
+                      </div>
+                    </div>
                     <button
-                      onClick={() => void router.push(`/gastown/${townId}/agents`)}
-                      className="text-[10px] text-white/25 transition-colors hover:text-white/50"
+                      onClick={e => {
+                        e.stopPropagation();
+                        if (confirm(`Delete rig "${rig.name}"?`)) {
+                          deleteRig.mutate({ rigId: rig.id });
+                        }
+                      }}
+                      className="rounded p-1 text-white/20 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-400"
                     >
-                      View all
+                      <Trash2 className="size-3" />
                     </button>
                   </div>
-                  <div className="space-y-1.5">
-                    <AnimatePresence mode="popLayout">
-                      {recentAgents.map((agent, i) => {
-                        const RoleIcon = ROLE_ICONS[agent.role] ?? Bot;
-                        return (
-                          <motion.div
-                            key={agent.id}
-                            initial={{ opacity: 0, x: 8 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            exit={{ opacity: 0, x: -8 }}
-                            transition={{ delay: i * 0.04, duration: 0.2 }}
-                            onClick={() => {
-                              const a = agent as Agent & { rigId: string };
-                              openDrawer({
-                                type: 'agent',
-                                agentId: agent.id,
-                                rigId: a.rigId,
-                                townId,
-                              });
-                            }}
-                            className="group/agent flex cursor-pointer items-center gap-2.5 rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2 transition-colors hover:border-white/[0.1] hover:bg-white/[0.03]"
-                          >
-                            <div className="relative flex size-7 shrink-0 items-center justify-center rounded-md bg-white/[0.05]">
-                              <RoleIcon className="size-3.5 text-white/40" />
-                              <span
-                                className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ring-[oklch(0.12_0_0)] ${AGENT_STATUS_DOT[agent.status] ?? 'bg-white/20'}`}
-                              />
-                            </div>
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-1.5">
-                                <span className="truncate text-xs font-medium text-white/75">
-                                  {agent.name}
-                                </span>
-                                <span className="shrink-0 text-[9px] text-white/25 capitalize">
-                                  {agent.role}
-                                </span>
-                              </div>
-                              <div className="flex items-center gap-1.5 text-[10px] text-white/25">
-                                <span>{(agent as Agent & { rigName: string }).rigName}</span>
-                                <span className="text-white/10">·</span>
-                                <span>
-                                  {agent.last_activity_at
-                                    ? formatDistanceToNow(new Date(agent.last_activity_at), {
-                                        addSuffix: true,
-                                      })
-                                    : 'no activity'}
-                                </span>
-                              </div>
-                            </div>
-                            <ChevronRight className="size-3 shrink-0 text-white/0 transition-colors group-hover/agent:text-white/20" />
-                          </motion.div>
-                        );
-                      })}
-                    </AnimatePresence>
+                  <div className="mt-2 max-w-full truncate font-mono text-[10px] text-white/25">
+                    {rig.git_url}
                   </div>
-                </div>
-              )}
+                </motion.div>
+              ))}
+            </AnimatePresence>
 
-              {/* System Topology (mini view) */}
-              {rigs.length > 0 && (
-                <div className="mt-5">
-                  <div className="mb-2 text-[11px] font-medium tracking-wide text-white/40 uppercase">
-                    System Topology
-                  </div>
-                  <div className="h-[280px] rounded-lg border border-white/[0.06] bg-white/[0.02]">
-                    <SystemTopology
-                      townName={townQuery.data?.name ?? 'Town'}
-                      rigs={rigs}
-                      agentsByRig={{}}
-                      recentEvents={events.slice(-10)}
-                      onSelectRig={rigId => void router.push(`/gastown/${townId}/rigs/${rigId}`)}
-                    />
-                  </div>
+            {/* Recent Agents */}
+            {recentAgents.length > 0 && (
+              <div className="mt-5">
+                <div className="mb-2.5 flex items-center justify-between">
+                  <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                    Recent Agents
+                  </span>
+                  <button
+                    onClick={() => void router.push(`/gastown/${townId}/agents`)}
+                    className="text-[10px] text-white/25 transition-colors hover:text-white/50"
+                  >
+                    View all
+                  </button>
                 </div>
-              )}
-            </div>
+                <div className="space-y-1.5">
+                  <AnimatePresence mode="popLayout">
+                    {recentAgents.map((agent, i) => {
+                      const RoleIcon = ROLE_ICONS[agent.role] ?? Bot;
+                      return (
+                        <motion.div
+                          key={agent.id}
+                          initial={{ opacity: 0, x: 8 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          exit={{ opacity: 0, x: -8 }}
+                          transition={{ delay: i * 0.04, duration: 0.2 }}
+                          onClick={() => {
+                            const a = agent as Agent & { rigId: string };
+                            openDrawer({
+                              type: 'agent',
+                              agentId: agent.id,
+                              rigId: a.rigId,
+                              townId,
+                            });
+                          }}
+                          className="group/agent flex cursor-pointer items-center gap-2.5 rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2 transition-colors hover:border-white/[0.1] hover:bg-white/[0.03]"
+                        >
+                          <div className="relative flex size-7 shrink-0 items-center justify-center rounded-md bg-white/[0.05]">
+                            <RoleIcon className="size-3.5 text-white/40" />
+                            <span
+                              className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ring-[oklch(0.12_0_0)] ${AGENT_STATUS_DOT[agent.status] ?? 'bg-white/20'}`}
+                            />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-1.5">
+                              <span className="truncate text-xs font-medium text-white/75">
+                                {agent.name}
+                              </span>
+                              <span className="shrink-0 text-[9px] text-white/25 capitalize">
+                                {agent.role}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-1.5 text-[10px] text-white/25">
+                              <span>{(agent as Agent & { rigName: string }).rigName}</span>
+                              <span className="text-white/10">·</span>
+                              <span>
+                                {agent.last_activity_at
+                                  ? formatDistanceToNow(new Date(agent.last_activity_at), {
+                                      addSuffix: true,
+                                    })
+                                  : 'no activity'}
+                              </span>
+                            </div>
+                          </div>
+                          <ChevronRight className="size-3 shrink-0 text-white/0 transition-colors group-hover/agent:text-white/20" />
+                        </motion.div>
+                      );
+                    })}
+                  </AnimatePresence>
+                </div>
+              </div>
+            )}
+
+            {/* System Topology (mini view) */}
+            {rigs.length > 0 && (
+              <div className="mt-5">
+                <div className="mb-2 text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                  System Topology
+                </div>
+                <div className="h-[280px] rounded-lg border border-white/[0.06] bg-white/[0.02]">
+                  <SystemTopology
+                    townName={townQuery.data?.name ?? 'Town'}
+                    rigs={rigs}
+                    agentsByRig={{}}
+                    recentEvents={events.slice(-10)}
+                    onSelectRig={rigId => void router.push(`/gastown/${townId}/rigs/${rigId}`)}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -128,16 +128,25 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
     })),
   });
 
-  const recentAgents = useMemo(() => {
-    const agents: Array<Agent & { rigName: string; rigId: string }> = [];
+  const agentsByRig = useMemo(() => {
+    const map: Record<string, Agent[]> = {};
     rigAgentQueries.forEach((q, i) => {
       const rig = rigs[i];
-      if (q.data && rig) {
-        for (const agent of q.data) {
+      if (q.data && rig) map[rig.id] = q.data;
+    });
+    return map;
+  }, [rigAgentQueries, rigs]);
+
+  const recentAgents = useMemo(() => {
+    const agents: Array<Agent & { rigName: string; rigId: string }> = [];
+    for (const [rigId, rigAgents] of Object.entries(agentsByRig)) {
+      const rig = rigs.find(r => r.id === rigId);
+      if (rig) {
+        for (const agent of rigAgents) {
           agents.push({ ...agent, rigName: rig.name, rigId: rig.id });
         }
       }
-    });
+    }
     // Sort by last_activity_at descending, then by created_at
     agents.sort((a, b) => {
       const aTime = a.last_activity_at ?? a.created_at;
@@ -145,7 +154,7 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
       return new Date(bTime).getTime() - new Date(aTime).getTime();
     });
     return agents.slice(0, 5);
-  }, [rigAgentQueries, rigs]);
+  }, [agentsByRig, rigs]);
 
   const deleteRig = useMutation(
     trpc.gastown.deleteRig.mutationOptions({
@@ -443,7 +452,7 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
                   <SystemTopology
                     townName={townQuery.data?.name ?? 'Town'}
                     rigs={rigs}
-                    agentsByRig={{}}
+                    agentsByRig={agentsByRig}
                     recentEvents={events.slice(-10)}
                     onSelectRig={rigId => void router.push(`/gastown/${townId}/rigs/${rigId}`)}
                   />

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -1,40 +1,151 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
-import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateRigDialog } from '@/components/gastown/CreateRigDialog';
 import { ActivityFeedView } from '@/components/gastown/ActivityFeed';
-import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
-import { ArrowLeft, Plus, GitBranch, Trash2, Activity, Users, Settings } from 'lucide-react';
+import { useDrawerStack } from '@/components/gastown/DrawerStack';
+import { SystemTopology } from '@/components/gastown/SystemTopology';
+import {
+  Plus,
+  GitBranch,
+  Trash2,
+  Hexagon,
+  Bot,
+  AlertTriangle,
+  Activity,
+  Zap,
+  Clock,
+  Crown,
+  Shield,
+  Eye,
+  ChevronRight,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
+import { AreaChart, Area, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { motion, AnimatePresence } from 'motion/react';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Agent = RouterOutputs['gastown']['listAgents'][number];
 
 type TownOverviewPageClientProps = {
   townId: string;
 };
 
+const ROLE_ICONS: Record<string, typeof Bot> = {
+  polecat: Bot,
+  mayor: Crown,
+  refinery: Shield,
+  witness: Eye,
+};
+
+const AGENT_STATUS_DOT: Record<string, string> = {
+  idle: 'bg-white/25',
+  working: 'bg-emerald-400',
+  active: 'bg-emerald-400',
+  stalled: 'bg-amber-400',
+  dead: 'bg-red-400',
+  starting: 'bg-sky-400',
+};
+
+/** Bucket events into 30-minute windows for the sparkline chart. */
+function bucketEventsOverTime(events: Array<{ created_at: string }>, windowMinutes = 30) {
+  if (events.length === 0) return [];
+
+  const now = Date.now();
+  const windowMs = windowMinutes * 60 * 1000;
+  const bucketCount = Math.ceil((24 * 60) / windowMinutes);
+  const buckets = Array.from({ length: bucketCount }, (_, i) => ({
+    time: new Date(now - (bucketCount - 1 - i) * windowMs).toISOString(),
+    count: 0,
+  }));
+
+  for (const event of events) {
+    const ts = new Date(event.created_at).getTime();
+    const idx = Math.floor((ts - (now - bucketCount * windowMs)) / windowMs);
+    if (idx >= 0 && idx < bucketCount) {
+      buckets[idx].count++;
+    }
+  }
+
+  return buckets;
+}
+
 export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) {
   const router = useRouter();
   const trpc = useTRPC();
   const [isCreateRigOpen, setIsCreateRigOpen] = useState(false);
+  const { open: openDrawer } = useDrawerStack();
 
   const queryClient = useQueryClient();
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
   const townEventsQuery = useQuery({
-    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 80 }),
+    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 200 }),
     refetchInterval: 5_000,
   });
 
-  const escalationsCount = (townEventsQuery.data ?? []).filter(
-    e => e.event_type === 'escalated'
-  ).length;
+  const rigs = rigsQuery.data ?? [];
+  const events = townEventsQuery.data ?? [];
+
+  const activityData = useMemo(() => bucketEventsOverTime(events), [events]);
+
+  // Fetch beads for each rig so stats reflect actual bead state, not event counts.
+  const rigBeadQueries = useQueries({
+    queries: rigs.map(rig => ({
+      ...trpc.gastown.listBeads.queryOptions({ rigId: rig.id }),
+      refetchInterval: 8_000,
+    })),
+  });
+
+  const allBeads = useMemo(() => {
+    return rigBeadQueries.flatMap((q, i) => {
+      const rig = rigs[i];
+      return q.data && rig ? q.data : [];
+    });
+  }, [rigBeadQueries, rigs]);
+
+  // Stats from actual bead state (excluding agent beads)
+  const userBeads = allBeads.filter(b => b.type !== 'agent');
+  const openBeadCount = userBeads.filter(b => b.status === 'open').length;
+  const inProgressBeadCount = userBeads.filter(b => b.status === 'in_progress').length;
+  const closedBeadCount = userBeads.filter(b => b.status === 'closed').length;
+  const escalationsCount = events.filter(e => e.event_type === 'escalated').length;
+
+  // Fetch agents for each rig to populate the recent agents section.
+  // useQueries accepts a dynamic-length array (unlike useQuery in a loop).
+  const rigAgentQueries = useQueries({
+    queries: rigs.map(rig => ({
+      ...trpc.gastown.listAgents.queryOptions({ rigId: rig.id }),
+      refetchInterval: 8_000,
+    })),
+  });
+
+  const recentAgents = useMemo(() => {
+    const agents: Array<Agent & { rigName: string; rigId: string }> = [];
+    rigAgentQueries.forEach((q, i) => {
+      const rig = rigs[i];
+      if (q.data && rig) {
+        for (const agent of q.data) {
+          agents.push({ ...agent, rigName: rig.name, rigId: rig.id });
+        }
+      }
+    });
+    // Sort by last_activity_at descending, then by created_at
+    agents.sort((a, b) => {
+      const aTime = a.last_activity_at ?? a.created_at;
+      const bTime = b.last_activity_at ?? b.created_at;
+      return new Date(bTime).getTime() - new Date(aTime).getTime();
+    });
+    return agents.slice(0, 5);
+  }, [rigAgentQueries, rigs]);
 
   const deleteRig = useMutation(
     trpc.gastown.deleteRig.mutationOptions({
@@ -49,195 +160,300 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
   );
 
   return (
-    <PageContainer>
-      <GastownBackdrop contentClassName="p-5 md:p-7">
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between gap-3">
-            <button
-              onClick={() => void router.push('/gastown')}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-white/60 transition-colors hover:bg-white/5 hover:text-white/85"
-            >
-              <ArrowLeft className="size-4" />
-              Back to towns
-            </button>
-
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => void router.push(`/gastown/${townId}/settings`)}
-                className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-white/60 transition-colors hover:bg-white/5 hover:text-white/85"
-              >
-                <Settings className="size-4" />
-                Settings
-              </button>
-              <Button
-                variant="primary"
-                size="md"
-                onClick={() => setIsCreateRigOpen(true)}
-                className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-              >
-                <Plus className="size-5" />
-                New Rig
-              </Button>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-3">
-            <div>
-              {townQuery.isLoading ? (
-                <>
-                  <Skeleton className="h-9 w-56" />
-                  <Skeleton className="mt-2 h-4 w-40" />
-                </>
-              ) : (
-                <>
-                  <h1 className="text-3xl font-semibold tracking-tight text-balance text-white/95">
-                    {townQuery.data?.name}
-                  </h1>
-                  <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
-                    Chat-first command center with radical transparency. Everything here is a live
-                    object: rigs, agents, beads, events.
-                  </p>
-                </>
-              )}
-            </div>
-
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-                <div className="text-[11px] tracking-wider text-white/40 uppercase">Rigs</div>
-                <div className="mt-0.5 text-lg font-semibold text-white/85">
-                  {(rigsQuery.data ?? []).length}
-                </div>
-              </div>
-              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-                <div className="text-[11px] tracking-wider text-white/40 uppercase">
-                  Escalations
-                </div>
-                <div className="mt-0.5 text-lg font-semibold text-white/85">{escalationsCount}</div>
-              </div>
-              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-                <div className="text-[11px] tracking-wider text-white/40 uppercase">
-                  Events (80)
-                </div>
-                <div className="mt-0.5 text-lg font-semibold text-white/85">
-                  {townEventsQuery.isLoading ? '…' : (townEventsQuery.data ?? []).length}
-                </div>
-              </div>
-              <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-                <div className="text-[11px] tracking-wider text-white/40 uppercase">System</div>
-                <div className="mt-1 inline-flex items-center gap-2 text-sm text-white/70">
-                  <span className="size-2 rounded-full bg-emerald-400" />
-                  Live
-                </div>
-              </div>
-            </div>
-          </div>
+    <div className="flex h-full flex-col">
+      {/* Top bar */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-3">
+          {townQuery.isLoading ? (
+            <Skeleton className="h-6 w-40" />
+          ) : (
+            <h1 className="text-lg font-semibold tracking-tight text-white/90">
+              {townQuery.data?.name}
+            </h1>
+          )}
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+            <span className="size-1.5 rounded-full bg-emerald-400" />
+            Live
+          </span>
         </div>
-      </GastownBackdrop>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setIsCreateRigOpen(true)}
+          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+        >
+          <Plus className="size-3.5" />
+          New Rig
+        </Button>
+      </div>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
-        <div className="space-y-4 lg:col-span-12">
-          {/* Rig Cards */}
-          <div>
-            <h2 className="mb-2 flex items-center gap-2 text-sm font-medium text-white/70">
-              <Users className="size-4" />
-              Rigs
-            </h2>
+      {/* Main content area */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="grid grid-cols-1 gap-0 lg:grid-cols-[1fr_380px]">
+          {/* Left column: activity feed (social-media-style) */}
+          <div className="border-r border-white/[0.06]">
+            {/* Stats strip */}
+            <div className="grid grid-cols-4 border-b border-white/[0.06]">
+              <StatCell
+                label="Open"
+                value={openBeadCount}
+                icon={<Hexagon className="size-3.5" />}
+                color="text-sky-400"
+              />
+              <StatCell
+                label="In Progress"
+                value={inProgressBeadCount}
+                icon={<Bot className="size-3.5" />}
+                color="text-violet-400"
+              />
+              <StatCell
+                label="Closed"
+                value={closedBeadCount}
+                icon={<Zap className="size-3.5" />}
+                color="text-emerald-400"
+              />
+              <StatCell
+                label="Escalations"
+                value={escalationsCount}
+                icon={<AlertTriangle className="size-3.5" />}
+                color="text-orange-400"
+              />
+            </div>
 
-            {rigsQuery.isLoading && (
-              <div className="space-y-3">
-                {Array.from({ length: 2 }).map((_, i) => (
-                  <Card key={i}>
-                    <CardContent className="p-3">
-                      <Skeleton className="h-5 w-40" />
-                      <Skeleton className="mt-1.5 h-3.5 w-56" />
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            )}
-
-            {rigsQuery.data && rigsQuery.data.length === 0 && (
-              <GastownBackdrop>
-                <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
-                  <GitBranch className="size-9 text-white/40" />
-                  <div>
-                    <div className="text-sm font-medium text-white/75">No rigs yet</div>
-                    <div className="mt-1 text-xs text-white/45">
-                      Connect a repo to create a rig; agents will spawn inside the town container.
-                    </div>
-                  </div>
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={() => setIsCreateRigOpen(true)}
-                    className="gap-1 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-                  >
-                    <Plus className="size-4" />
-                    Create rig
-                  </Button>
+            {/* Activity chart */}
+            <div className="border-b border-white/[0.06] px-5 pt-4 pb-2">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Activity className="size-3.5 text-white/30" />
+                  <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                    Activity — 24h
+                  </span>
                 </div>
-              </GastownBackdrop>
-            )}
+                <span className="font-mono text-[11px] text-white/30">{events.length} events</span>
+              </div>
+              <div className="h-[100px]">
+                {activityData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={activityData}>
+                      <defs>
+                        <linearGradient id="activityGrad" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor="oklch(95% 0.15 108)" stopOpacity={0.3} />
+                          <stop offset="100%" stopColor="oklch(95% 0.15 108)" stopOpacity={0} />
+                        </linearGradient>
+                      </defs>
+                      <XAxis dataKey="time" hide />
+                      <YAxis hide />
+                      <Tooltip
+                        contentStyle={{
+                          background: 'oklch(0.15 0 0)',
+                          border: '1px solid oklch(1 0 0 / 0.1)',
+                          borderRadius: '8px',
+                          fontSize: '11px',
+                          color: 'oklch(1 0 0 / 0.7)',
+                        }}
+                        labelFormatter={() => ''}
+                        formatter={(value: number) => [value, 'events']}
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="count"
+                        stroke="oklch(95% 0.15 108)"
+                        strokeWidth={1.5}
+                        fill="url(#activityGrad)"
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-xs text-white/20">
+                    No activity data
+                  </div>
+                )}
+              </div>
+            </div>
 
-            {rigsQuery.data && rigsQuery.data.length > 0 && (
-              <div className="space-y-2">
-                {rigsQuery.data.map(rig => (
-                  <Card
-                    key={rig.id}
-                    className="cursor-pointer border-white/10 bg-white/[0.03] transition-[border-color,background-color,transform] hover:bg-white/[0.05]"
-                    onClick={() => void router.push(`/gastown/${townId}/rigs/${rig.id}`)}
+            {/* Activity feed — clickable items */}
+            <div className="px-2">
+              <div className="flex items-center gap-2 px-3 pt-4 pb-2">
+                <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                  Feed
+                </span>
+              </div>
+              <ActivityFeedView
+                townId={townId}
+                events={events.slice(-80)}
+                isLoading={townEventsQuery.isLoading}
+                onEventClick={event => openDrawer({ type: 'event', event })}
+              />
+            </div>
+          </div>
+
+          {/* Right column: rigs + recent agents + topology */}
+          <div className="flex flex-col">
+            <div className="flex-1 p-4">
+              {/* Rigs */}
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                  Rigs ({rigs.length})
+                </span>
+              </div>
+
+              {rigsQuery.isLoading && (
+                <div className="space-y-2">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-16 w-full rounded-lg" />
+                  ))}
+                </div>
+              )}
+
+              {rigs.length === 0 && !rigsQuery.isLoading && (
+                <div className="rounded-xl border border-dashed border-white/10 p-6 text-center">
+                  <GitBranch className="mx-auto mb-2 size-6 text-white/20" />
+                  <p className="text-xs text-white/40">
+                    No rigs yet. Connect a repo to get started.
+                  </p>
+                  <button
+                    onClick={() => setIsCreateRigOpen(true)}
+                    className="mt-3 inline-flex items-center gap-1 rounded-md bg-white/[0.06] px-3 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.1] hover:text-white/80"
                   >
-                    <CardContent className="flex items-center justify-between p-3">
+                    <Plus className="size-3" />
+                    Create rig
+                  </button>
+                </div>
+              )}
+
+              <AnimatePresence mode="popLayout">
+                {rigs.map((rig, i) => (
+                  <motion.div
+                    key={rig.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -8 }}
+                    transition={{ delay: i * 0.04, duration: 0.25 }}
+                    onClick={() => void router.push(`/gastown/${townId}/rigs/${rig.id}`)}
+                    className="group mb-2 cursor-pointer rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
+                  >
+                    <div className="flex items-center justify-between">
                       <div className="min-w-0">
-                        <h3 className="font-medium text-white/85">{rig.name}</h3>
-                        <div className="mt-0.5 flex items-center gap-2 text-xs text-white/55">
-                          <span className="flex items-center gap-1">
-                            <GitBranch className="size-3" />
-                            {rig.default_branch}
-                          </span>
-                          <span className="max-w-[260px] truncate font-mono text-[11px] text-white/45">
-                            {rig.git_url}
+                        <span className="text-sm font-medium text-white/85">{rig.name}</span>
+                        <div className="mt-1 flex items-center gap-2 text-[11px] text-white/40">
+                          <GitBranch className="size-3" />
+                          <span>{rig.default_branch}</span>
+                          <span className="text-white/20">|</span>
+                          <Clock className="size-3" />
+                          <span>
+                            {formatDistanceToNow(new Date(rig.created_at), { addSuffix: true })}
                           </span>
                         </div>
                       </div>
-                      <div className="flex shrink-0 items-center gap-2">
-                        <span className="text-xs text-white/45">
-                          {formatDistanceToNow(new Date(rig.created_at), { addSuffix: true })}
-                        </span>
-                        <button
-                          onClick={e => {
-                            e.stopPropagation();
-                            if (confirm(`Delete rig "${rig.name}"?`)) {
-                              deleteRig.mutate({ rigId: rig.id });
-                            }
-                          }}
-                          className="rounded p-1 text-white/35 transition-colors hover:bg-red-500/10 hover:text-red-300"
-                        >
-                          <Trash2 className="size-3.5" />
-                        </button>
-                      </div>
-                    </CardContent>
-                  </Card>
+                      <button
+                        onClick={e => {
+                          e.stopPropagation();
+                          if (confirm(`Delete rig "${rig.name}"?`)) {
+                            deleteRig.mutate({ rigId: rig.id });
+                          }
+                        }}
+                        className="rounded p-1 text-white/20 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-400"
+                      >
+                        <Trash2 className="size-3" />
+                      </button>
+                    </div>
+                    <div className="mt-2 max-w-full truncate font-mono text-[10px] text-white/25">
+                      {rig.git_url}
+                    </div>
+                  </motion.div>
                 ))}
-              </div>
-            )}
-          </div>
+              </AnimatePresence>
 
-          {/* Activity Feed */}
-          <div>
-            <h2 className="mb-2 flex items-center gap-2 text-sm font-medium text-white/70">
-              <Activity className="size-4" />
-              Activity
-            </h2>
-            <GastownBackdrop>
-              <div className="p-0">
-                <ActivityFeedView
-                  townId={townId}
-                  events={(townEventsQuery.data ?? []).slice(-50)}
-                  isLoading={townEventsQuery.isLoading}
-                />
-              </div>
-            </GastownBackdrop>
+              {/* Recent Agents */}
+              {recentAgents.length > 0 && (
+                <div className="mt-5">
+                  <div className="mb-2.5 flex items-center justify-between">
+                    <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                      Recent Agents
+                    </span>
+                    <button
+                      onClick={() => void router.push(`/gastown/${townId}/agents`)}
+                      className="text-[10px] text-white/25 transition-colors hover:text-white/50"
+                    >
+                      View all
+                    </button>
+                  </div>
+                  <div className="space-y-1.5">
+                    <AnimatePresence mode="popLayout">
+                      {recentAgents.map((agent, i) => {
+                        const RoleIcon = ROLE_ICONS[agent.role] ?? Bot;
+                        return (
+                          <motion.div
+                            key={agent.id}
+                            initial={{ opacity: 0, x: 8 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            exit={{ opacity: 0, x: -8 }}
+                            transition={{ delay: i * 0.04, duration: 0.2 }}
+                            onClick={() => {
+                              const a = agent as Agent & { rigId: string };
+                              openDrawer({
+                                type: 'agent',
+                                agentId: agent.id,
+                                rigId: a.rigId,
+                                townId,
+                              });
+                            }}
+                            className="group/agent flex cursor-pointer items-center gap-2.5 rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2 transition-colors hover:border-white/[0.1] hover:bg-white/[0.03]"
+                          >
+                            <div className="relative flex size-7 shrink-0 items-center justify-center rounded-md bg-white/[0.05]">
+                              <RoleIcon className="size-3.5 text-white/40" />
+                              <span
+                                className={`absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ring-[oklch(0.12_0_0)] ${AGENT_STATUS_DOT[agent.status] ?? 'bg-white/20'}`}
+                              />
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-1.5">
+                                <span className="truncate text-xs font-medium text-white/75">
+                                  {agent.name}
+                                </span>
+                                <span className="shrink-0 text-[9px] text-white/25 capitalize">
+                                  {agent.role}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-1.5 text-[10px] text-white/25">
+                                <span>{(agent as Agent & { rigName: string }).rigName}</span>
+                                <span className="text-white/10">·</span>
+                                <span>
+                                  {agent.last_activity_at
+                                    ? formatDistanceToNow(new Date(agent.last_activity_at), {
+                                        addSuffix: true,
+                                      })
+                                    : 'no activity'}
+                                </span>
+                              </div>
+                            </div>
+                            <ChevronRight className="size-3 shrink-0 text-white/0 transition-colors group-hover/agent:text-white/20" />
+                          </motion.div>
+                        );
+                      })}
+                    </AnimatePresence>
+                  </div>
+                </div>
+              )}
+
+              {/* System Topology (mini view) */}
+              {rigs.length > 0 && (
+                <div className="mt-5">
+                  <div className="mb-2 text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                    System Topology
+                  </div>
+                  <div className="h-[280px] rounded-lg border border-white/[0.06] bg-white/[0.02]">
+                    <SystemTopology
+                      townName={townQuery.data?.name ?? 'Town'}
+                      rigs={rigs}
+                      agentsByRig={{}}
+                      recentEvents={events.slice(-10)}
+                      onSelectRig={rigId => void router.push(`/gastown/${townId}/rigs/${rigId}`)}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -247,6 +463,38 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
         isOpen={isCreateRigOpen}
         onClose={() => setIsCreateRigOpen(false)}
       />
-    </PageContainer>
+
+      {/* Drawers are rendered by the layout-level DrawerStackProvider */}
+    </div>
+  );
+}
+
+function StatCell({
+  label,
+  value,
+  icon,
+  color,
+}: {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+  color: string;
+}) {
+  return (
+    <div className="border-r border-white/[0.06] px-4 py-3 last:border-r-0">
+      <div className={`flex items-center gap-1.5 ${color}`}>
+        {icon}
+        <span className="text-[10px] font-medium tracking-wide uppercase opacity-70">{label}</span>
+      </div>
+      <motion.div
+        key={value}
+        initial={{ y: 6, opacity: 0.4 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+        className="mt-1 font-mono text-xl font-semibold text-white/85"
+      >
+        {value}
+      </motion.div>
+    </div>
   );
 }

--- a/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { useDrawerStack } from '@/components/gastown/DrawerStack';
+import { Bot, Crown, Shield, Eye, Clock, Hexagon } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { motion, AnimatePresence } from 'motion/react';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Agent = RouterOutputs['gastown']['listAgents'][number];
+
+const ROLE_ICONS: Record<string, typeof Bot> = {
+  polecat: Bot,
+  mayor: Crown,
+  refinery: Shield,
+  witness: Eye,
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  idle: 'bg-white/20',
+  working: 'bg-emerald-400',
+  stalled: 'bg-amber-400',
+  dead: 'bg-red-400',
+};
+
+export function AgentsPageClient({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+  const { open: openDrawer } = useDrawerStack();
+
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+  const rigs = rigsQuery.data ?? [];
+
+  const rigAgentQueries = useQueries({
+    queries: rigs.map(rig => ({
+      ...trpc.gastown.listAgents.queryOptions({ rigId: rig.id }),
+      refetchInterval: 5_000,
+    })),
+  });
+
+  const allAgents = useMemo(() => {
+    const agents: Array<Agent & { rigName: string; rigId: string }> = [];
+    rigAgentQueries.forEach((q, i) => {
+      const rig = rigs[i];
+      if (q.data && rig) {
+        for (const agent of q.data) {
+          agents.push({ ...agent, rigName: rig.name, rigId: rig.id });
+        }
+      }
+    });
+    return agents;
+  }, [rigAgentQueries, rigs]);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-2">
+          <Bot className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Agents</h1>
+          <span className="ml-1 font-mono text-xs text-white/30">{allAgents.length}</span>
+        </div>
+      </div>
+
+      {/* Agent grid */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {allAgents.length === 0 && !rigsQuery.isLoading && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Bot className="mb-3 size-8 text-white/10" />
+            <p className="text-sm text-white/30">No agents have been spawned yet.</p>
+            <p className="mt-1 text-xs text-white/20">Sling work on a rig to create agents.</p>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <AnimatePresence mode="popLayout">
+            {allAgents.map((agent, i) => {
+              const RoleIcon = ROLE_ICONS[agent.role] ?? Bot;
+              const rigId = (agent as Agent & { rigId: string }).rigId;
+              return (
+                <motion.div
+                  key={agent.id}
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  transition={{ delay: i * 0.03, duration: 0.2 }}
+                  onClick={() => openDrawer({ type: 'agent', agentId: agent.id, rigId, townId })}
+                  className="group cursor-pointer rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-2.5">
+                      <div className="flex size-8 items-center justify-center rounded-lg bg-white/[0.05]">
+                        <RoleIcon className="size-4 text-white/50" />
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-sm font-medium text-white/85">{agent.name}</span>
+                          <span
+                            className={`size-1.5 rounded-full ${STATUS_COLORS[agent.status] ?? 'bg-white/20'}`}
+                          />
+                        </div>
+                        <div className="text-[10px] text-white/35 capitalize">{agent.role}</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex items-center gap-3 text-[10px] text-white/30">
+                    <span className="inline-flex items-center gap-1">
+                      <Hexagon className="size-2.5" />
+                      {agent.current_hook_bead_id ? agent.current_hook_bead_id.slice(0, 8) : 'idle'}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Clock className="size-2.5" />
+                      {agent.last_activity_at
+                        ? formatDistanceToNow(new Date(agent.last_activity_at), {
+                            addSuffix: true,
+                          })
+                        : 'never'}
+                    </span>
+                  </div>
+
+                  <div className="mt-2 text-[10px] text-white/20">
+                    {(agent as Agent & { rigName: string }).rigName}
+                  </div>
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -1,0 +1,11 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { AgentsPageClient } from './AgentsPageClient';
+
+export default async function AgentsPage({ params }: { params: Promise<{ townId: string }> }) {
+  const { townId } = await params;
+  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/agents`);
+  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  return <AgentsPageClient townId={townId} />;
+}

--- a/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { useDrawerStack } from '@/components/gastown/DrawerStack';
+import { Hexagon, Search, Filter } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+import { motion, AnimatePresence } from 'motion/react';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Bead = RouterOutputs['gastown']['listBeads'][number];
+
+type BeadsPageClientProps = {
+  townId: string;
+};
+
+const STATUS_DOT: Record<string, string> = {
+  open: 'bg-sky-400',
+  in_progress: 'bg-amber-400',
+  closed: 'bg-emerald-400',
+  failed: 'bg-red-400',
+};
+
+export function BeadsPageClient({ townId }: BeadsPageClientProps) {
+  const trpc = useTRPC();
+  const { open: openDrawer } = useDrawerStack();
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+  const rigs = rigsQuery.data ?? [];
+
+  // Fetch beads for each rig — useQueries handles dynamic-length arrays safely
+  const rigBeadQueries = useQueries({
+    queries: rigs.map(rig => ({
+      ...trpc.gastown.listBeads.queryOptions({ rigId: rig.id }),
+      refetchInterval: 8_000,
+    })),
+  });
+
+  const allBeads = useMemo(() => {
+    const beads: Array<Bead & { rigName: string; rigId: string }> = [];
+    rigBeadQueries.forEach((q, i) => {
+      const rig = rigs[i];
+      if (q.data && rig) {
+        for (const bead of q.data) {
+          beads.push({ ...bead, rigName: rig.name, rigId: rig.id });
+        }
+      }
+    });
+    // Sort newest first
+    beads.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    return beads;
+  }, [rigBeadQueries, rigs]);
+
+  const filteredBeads = useMemo(() => {
+    let beads = allBeads;
+    if (statusFilter) {
+      beads = beads.filter(b => b.status === statusFilter);
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      beads = beads.filter(
+        b => b.title.toLowerCase().includes(q) || b.bead_id.toLowerCase().includes(q)
+      );
+    }
+    return beads;
+  }, [allBeads, statusFilter, search]);
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { open: 0, in_progress: 0, closed: 0, failed: 0 };
+    for (const bead of allBeads) {
+      counts[bead.status] = (counts[bead.status] ?? 0) + 1;
+    }
+    return counts;
+  }, [allBeads]);
+
+  const isLoading = rigsQuery.isLoading || rigBeadQueries.some(q => q.isLoading);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-2">
+          <Hexagon className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Beads</h1>
+          <span className="ml-1 font-mono text-xs text-white/30">{allBeads.length}</span>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-3 border-b border-white/[0.06] px-6 py-2">
+        {/* Search */}
+        <div className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5">
+          <Search className="size-3 text-white/30" />
+          <input
+            type="text"
+            placeholder="Search beads..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="w-48 bg-transparent text-xs text-white/80 outline-none placeholder:text-white/25"
+          />
+        </div>
+
+        {/* Status filter chips */}
+        <div className="flex items-center gap-1">
+          <FilterChip
+            label="All"
+            count={allBeads.length}
+            active={statusFilter === null}
+            onClick={() => setStatusFilter(null)}
+          />
+          {Object.entries(statusCounts).map(([status, count]) => (
+            <FilterChip
+              key={status}
+              label={status.replace('_', ' ')}
+              count={count}
+              active={statusFilter === status}
+              onClick={() => setStatusFilter(statusFilter === status ? null : status)}
+              dotColor={STATUS_DOT[status]}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Bead list */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading && (
+          <div className="space-y-0">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex animate-pulse items-center gap-3 border-b border-white/[0.04] px-6 py-3"
+              >
+                <div className="size-2 rounded-full bg-white/10" />
+                <div className="h-3 w-40 rounded bg-white/5" />
+                <div className="ml-auto h-3 w-20 rounded bg-white/5" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && filteredBeads.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Hexagon className="mb-3 size-8 text-white/10" />
+            <p className="text-sm text-white/30">
+              {search || statusFilter ? 'No beads match your filters.' : 'No beads yet.'}
+            </p>
+          </div>
+        )}
+
+        <AnimatePresence mode="popLayout">
+          {filteredBeads.map((bead, i) => (
+            <motion.div
+              key={bead.bead_id}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ delay: Math.min(i * 0.02, 0.3), duration: 0.15 }}
+              onClick={() => {
+                const rigId = (bead as Bead & { rigId: string }).rigId;
+                openDrawer({ type: 'bead', beadId: bead.bead_id, rigId });
+              }}
+              className="group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02]"
+            >
+              <span
+                className={`size-2 shrink-0 rounded-full ${STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm text-white/80">{bead.title}</span>
+                  <span className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[9px] font-medium text-white/30">
+                    {bead.type}
+                  </span>
+                </div>
+                <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
+                  <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
+                  <span className="text-white/15">|</span>
+                  <span>{(bead as Bead & { rigName: string }).rigName}</span>
+                  <span className="text-white/15">|</span>
+                  <span>{formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}</span>
+                </div>
+              </div>
+              <span className="shrink-0 text-[10px] text-white/25 capitalize">{bead.priority}</span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      {/* Drawers are rendered by the layout-level DrawerStackProvider */}
+    </div>
+  );
+}
+
+function FilterChip({
+  label,
+  count,
+  active,
+  onClick,
+  dotColor,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+  dotColor?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-medium capitalize transition-colors ${
+        active
+          ? 'bg-white/[0.08] text-white/70'
+          : 'text-white/30 hover:bg-white/[0.04] hover:text-white/50'
+      }`}
+    >
+      {dotColor && <span className={`size-1.5 rounded-full ${dotColor}`} />}
+      {label}
+      <span className="font-mono text-[9px] opacity-60">{count}</span>
+    </button>
+  );
+}

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -1,0 +1,11 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { BeadsPageClient } from './BeadsPageClient';
+
+export default async function BeadsPage({ params }: { params: Promise<{ townId: string }> }) {
+  const { townId } = await params;
+  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/beads`);
+  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  return <BeadsPageClient townId={townId} />;
+}

--- a/src/app/(app)/gastown/[townId]/layout.tsx
+++ b/src/app/(app)/gastown/[townId]/layout.tsx
@@ -1,3 +1,6 @@
+import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
+import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
+import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { MayorTerminalBar } from './MayorTerminalBar';
 
 export default function TownLayout({
@@ -8,10 +11,15 @@ export default function TownLayout({
   params: Promise<{ townId: string }>;
 }) {
   return (
-    <>
-      {/* Bottom padding clears the fixed terminal bar (40px title + 320px terminal) */}
-      <div className="pb-[360px]">{children}</div>
-      <MayorTerminalBar params={params} />
-    </>
+    <TerminalBarProvider>
+      <DrawerStackProvider renderContent={renderDrawerContent}>
+        {/* Fullscreen edge-to-edge layout for gastown town pages.
+            Bottom padding clears the fixed terminal bar. */}
+        <div className="flex min-h-screen flex-col pb-[340px]">
+          <div className="flex-1">{children}</div>
+        </div>
+        <MayorTerminalBar params={params} />
+      </DrawerStackProvider>
+    </TerminalBarProvider>
   );
 }

--- a/src/app/(app)/gastown/[townId]/mail/MailPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/MailPageClient.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Mail } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+
+export function MailPageClient({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+
+  const eventsQuery = useQuery({
+    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 200 }),
+    refetchInterval: 5_000,
+  });
+
+  const mailEvents = (eventsQuery.data ?? []).filter(e => e.event_type === 'mail_sent');
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-2">
+          <Mail className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Mail</h1>
+          <span className="ml-1 font-mono text-xs text-white/30">{mailEvents.length}</span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {mailEvents.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Mail className="mb-3 size-8 text-white/10" />
+            <p className="text-sm text-white/30">No mail events yet.</p>
+            <p className="mt-1 text-xs text-white/20">
+              Protocol mail flows between agents will appear here.
+            </p>
+          </div>
+        )}
+
+        {mailEvents
+          .slice()
+          .reverse()
+          .map(event => (
+            <div
+              key={event.bead_event_id}
+              className="flex items-start gap-3 border-b border-white/[0.04] px-6 py-3 transition-colors hover:bg-white/[0.02]"
+            >
+              <Mail className="mt-0.5 size-3.5 shrink-0 text-sky-400/60" />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm text-white/75">{event.new_value ?? 'Mail sent'}</div>
+                <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
+                  {event.rig_name && <span>{event.rig_name}</span>}
+                  <span>
+                    {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -1,0 +1,11 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { MailPageClient } from './MailPageClient';
+
+export default async function MailPage({ params }: { params: Promise<{ townId: string }> }) {
+  const { townId } = await params;
+  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/mail`);
+  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  return <MailPageClient townId={townId} />;
+}

--- a/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { GitMerge, CheckCircle } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+
+export function MergesPageClient({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+
+  const eventsQuery = useQuery({
+    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 200 }),
+    refetchInterval: 5_000,
+  });
+
+  const mergeEvents = (eventsQuery.data ?? []).filter(
+    e => e.event_type === 'review_submitted' || e.event_type === 'review_completed'
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-2">
+          <GitMerge className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Merge Queue</h1>
+          <span className="ml-1 font-mono text-xs text-white/30">{mergeEvents.length}</span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {mergeEvents.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <GitMerge className="mb-3 size-8 text-white/10" />
+            <p className="text-sm text-white/30">No merge activity yet.</p>
+            <p className="mt-1 text-xs text-white/20">
+              Review submissions and merge completions will appear here.
+            </p>
+          </div>
+        )}
+
+        {mergeEvents
+          .slice()
+          .reverse()
+          .map(event => {
+            const isCompleted = event.event_type === 'review_completed';
+            return (
+              <div
+                key={event.bead_event_id}
+                className="flex items-start gap-3 border-b border-white/[0.04] px-6 py-3 transition-colors hover:bg-white/[0.02]"
+              >
+                {isCompleted ? (
+                  <CheckCircle className="mt-0.5 size-3.5 shrink-0 text-emerald-400/60" />
+                ) : (
+                  <GitMerge className="mt-0.5 size-3.5 shrink-0 text-indigo-400/60" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-white/75">
+                    {isCompleted ? 'Review completed' : 'Submitted for review'}
+                    {event.new_value ? `: ${event.new_value}` : ''}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
+                    {event.rig_name && <span>{event.rig_name}</span>}
+                    <span>
+                      {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -1,0 +1,11 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { MergesPageClient } from './MergesPageClient';
+
+export default async function MergesPage({ params }: { params: Promise<{ townId: string }> }) {
+  const { townId } = await params;
+  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/merges`);
+  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  return <MergesPageClient townId={townId} />;
+}

--- a/src/app/(app)/gastown/[townId]/observability/ObservabilityPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/ObservabilityPageClient.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Activity, Clock, Hexagon, Bot, GitMerge, AlertTriangle, Mail } from 'lucide-react';
+import { formatDistanceToNow, format, subHours, differenceInMinutes } from 'date-fns';
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+
+type EventTypeCounts = Record<string, number>;
+
+export function ObservabilityPageClient({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+
+  const eventsQuery = useQuery({
+    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 500 }),
+    refetchInterval: 5_000,
+  });
+
+  const events = eventsQuery.data ?? [];
+
+  // Event type distribution
+  const typeCounts = useMemo(() => {
+    const counts: EventTypeCounts = {};
+    for (const event of events) {
+      counts[event.event_type] = (counts[event.event_type] ?? 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [events]);
+
+  // Events per hour (last 24h)
+  const hourlyData = useMemo(() => {
+    const now = new Date();
+    const buckets = Array.from({ length: 24 }, (_, i) => {
+      const hour = subHours(now, 23 - i);
+      return {
+        hour: format(hour, 'HH:mm'),
+        count: 0,
+      };
+    });
+
+    for (const event of events) {
+      const eventTime = new Date(event.created_at);
+      const hoursAgo = differenceInMinutes(now, eventTime) / 60;
+      const idx = Math.floor(23 - hoursAgo);
+      if (idx >= 0 && idx < 24) {
+        buckets[idx].count++;
+      }
+    }
+
+    return buckets;
+  }, [events]);
+
+  // Per-rig event counts
+  const rigEventCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const event of events) {
+      const rigName = event.rig_name ?? 'unknown';
+      counts[rigName] = (counts[rigName] ?? 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([rig, count]) => ({ rig, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [events]);
+
+  const tooltipStyles = {
+    contentStyle: {
+      background: 'oklch(0.12 0 0)',
+      border: '1px solid oklch(1 0 0 / 0.08)',
+      borderRadius: '8px',
+      fontSize: '11px',
+      color: 'oklch(1 0 0 / 0.7)',
+    },
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-2">
+          <Activity className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Observability</h1>
+          <span className="ml-1 font-mono text-xs text-white/30">{events.length} events</span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-5">
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+          {/* Event rate over time */}
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Clock className="size-3.5 text-white/25" />
+              <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                Events / Hour — 24h
+              </span>
+            </div>
+            <div className="h-[180px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={hourlyData}>
+                  <defs>
+                    <linearGradient id="obsGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="oklch(95% 0.15 108)" stopOpacity={0.25} />
+                      <stop offset="100%" stopColor="oklch(95% 0.15 108)" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid stroke="oklch(1 0 0 / 0.04)" strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="hour"
+                    tick={{ fontSize: 9, fill: 'oklch(1 0 0 / 0.25)' }}
+                    axisLine={{ stroke: 'oklch(1 0 0 / 0.06)' }}
+                    tickLine={false}
+                    interval={3}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 9, fill: 'oklch(1 0 0 / 0.25)' }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={30}
+                  />
+                  <Tooltip {...tooltipStyles} />
+                  <Area
+                    type="monotone"
+                    dataKey="count"
+                    stroke="oklch(95% 0.15 108)"
+                    strokeWidth={1.5}
+                    fill="url(#obsGrad)"
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Event type distribution */}
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Hexagon className="size-3.5 text-white/25" />
+              <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                Event Types
+              </span>
+            </div>
+            <div className="h-[180px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={typeCounts} layout="vertical">
+                  <CartesianGrid stroke="oklch(1 0 0 / 0.04)" strokeDasharray="3 3" />
+                  <XAxis
+                    type="number"
+                    tick={{ fontSize: 9, fill: 'oklch(1 0 0 / 0.25)' }}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    dataKey="type"
+                    type="category"
+                    tick={{ fontSize: 9, fill: 'oklch(1 0 0 / 0.35)' }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={90}
+                  />
+                  <Tooltip {...tooltipStyles} />
+                  <Bar dataKey="count" fill="oklch(95% 0.15 108 / 0.5)" radius={[0, 3, 3, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Per-rig breakdown */}
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Bot className="size-3.5 text-white/25" />
+              <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                Events by Rig
+              </span>
+            </div>
+            <div className="space-y-2">
+              {rigEventCounts.map(({ rig, count }) => (
+                <div key={rig} className="flex items-center justify-between">
+                  <span className="truncate text-xs text-white/60">{rig}</span>
+                  <div className="flex items-center gap-2">
+                    <div
+                      className="h-1.5 rounded-full bg-[color:oklch(95%_0.15_108_/_0.4)]"
+                      style={{
+                        width: `${Math.max(
+                          (count / Math.max(rigEventCounts[0]?.count ?? 1, 1)) * 100,
+                          8
+                        )}px`,
+                      }}
+                    />
+                    <span className="font-mono text-[10px] text-white/30">{count}</span>
+                  </div>
+                </div>
+              ))}
+              {rigEventCounts.length === 0 && <p className="text-xs text-white/20">No rig data</p>}
+            </div>
+          </div>
+
+          {/* Recent event stream */}
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Activity className="size-3.5 text-white/25" />
+              <span className="text-[11px] font-medium tracking-wide text-white/40 uppercase">
+                Latest Events
+              </span>
+            </div>
+            <div className="max-h-[180px] space-y-1 overflow-y-auto">
+              {events
+                .slice(-20)
+                .reverse()
+                .map(event => {
+                  const EventIcon = EVENT_ICON_MAP[event.event_type] ?? Activity;
+                  return (
+                    <div
+                      key={event.bead_event_id}
+                      className="flex items-center gap-2 rounded px-1.5 py-1 text-[10px] transition-colors hover:bg-white/[0.03]"
+                    >
+                      <EventIcon className="size-3 shrink-0 text-white/25" />
+                      <span className="flex-1 truncate text-white/55">{event.event_type}</span>
+                      <span className="shrink-0 text-white/20">
+                        {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                      </span>
+                    </div>
+                  );
+                })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const EVENT_ICON_MAP: Record<string, typeof Activity> = {
+  created: Hexagon,
+  hooked: Bot,
+  unhooked: Bot,
+  closed: Hexagon,
+  escalated: AlertTriangle,
+  review_submitted: GitMerge,
+  review_completed: GitMerge,
+  mail_sent: Mail,
+};

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -1,0 +1,15 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { ObservabilityPageClient } from './ObservabilityPageClient';
+
+export default async function ObservabilityPage({
+  params,
+}: {
+  params: Promise<{ townId: string }>;
+}) {
+  const { townId } = await params;
+  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/observability`);
+  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  return <ObservabilityPageClient townId={townId} />;
+}

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -1,21 +1,17 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { toast } from 'sonner';
-import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BeadBoard } from '@/components/gastown/BeadBoard';
 import { AgentCard } from '@/components/gastown/AgentCard';
-import { AgentStream } from '@/components/gastown/AgentStream';
-import { AgentTerminal } from '@/components/gastown/AgentTerminal';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
-import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
-import { GastownBeadDetailSheet } from '@/components/gastown/GastownBeadDetailSheet';
-import { ArrowLeft, Plus, GitBranch } from 'lucide-react';
+import { useDrawerStack } from '@/components/gastown/DrawerStack';
+import { Plus, GitBranch, Hexagon, Bot } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
 
 type RigDetailPageClientProps = {
   townId: string;
@@ -23,12 +19,9 @@ type RigDetailPageClientProps = {
 };
 
 export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps) {
-  const router = useRouter();
   const trpc = useTRPC();
   const [isSlingOpen, setIsSlingOpen] = useState(false);
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
-  const [selectedBeadId, setSelectedBeadId] = useState<string | null>(null);
-  const [agentView, setAgentView] = useState<'events' | 'terminal'>('events');
+  const { open: openDrawer } = useDrawerStack();
 
   const queryClient = useQueryClient();
   const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId }));
@@ -48,8 +41,6 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
     return acc;
   }, {});
 
-  const selectedBead = (beadsQuery.data ?? []).find(b => b.bead_id === selectedBeadId) ?? null;
-
   const deleteBead = useMutation(
     trpc.gastown.deleteBead.mutationOptions({
       onSuccess: () => {
@@ -64,238 +55,156 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
     trpc.gastown.deleteAgent.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({ queryKey: trpc.gastown.listAgents.queryKey() });
-        setSelectedAgentId(null);
         toast.success('Agent deleted');
       },
       onError: err => toast.error(err.message),
     })
   );
 
+  const beads = beadsQuery.data ?? [];
+  const agents = agentsQuery.data ?? [];
+
+  const openBeads = beads.filter(b => b.status === 'open' && b.type !== 'agent').length;
+  const inProgressBeads = beads.filter(
+    b => b.status === 'in_progress' && b.type !== 'agent'
+  ).length;
+  const closedBeads = beads.filter(b => b.status === 'closed' && b.type !== 'agent').length;
+
   return (
-    <PageContainer>
-      <GastownBackdrop contentClassName="p-5 md:p-7">
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between gap-3">
-            <button
-              onClick={() => void router.push(`/gastown/${townId}`)}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-white/60 transition-colors hover:bg-white/5 hover:text-white/85"
-            >
-              <ArrowLeft className="size-4" />
-              Back to town
-            </button>
-
-            <Button
-              variant="primary"
-              size="md"
-              onClick={() => setIsSlingOpen(true)}
-              className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-            >
-              <Plus className="size-5" />
-              Sling Work
-            </Button>
-          </div>
-
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              {rigQuery.isLoading ? (
-                <>
-                  <Skeleton className="h-9 w-56" />
-                  <Skeleton className="mt-2 h-4 w-80" />
-                </>
-              ) : (
-                <>
-                  <h1 className="text-3xl font-semibold tracking-tight text-balance text-white/95">
-                    {rig?.name}
-                  </h1>
-                  {rig && (
-                    <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-white/60">
-                      <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-1">
-                        <GitBranch className="size-3.5" />
-                        {rig.default_branch}
-                      </span>
-                      <span className="max-w-[560px] truncate rounded-full border border-white/10 bg-black/25 px-3 py-1 font-mono text-[12px] text-white/55">
-                        {rig.git_url}
-                      </span>
-                    </div>
-                  )}
-                </>
+    <div className="flex h-full flex-col">
+      {/* Top bar */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-3">
+          {rigQuery.isLoading ? (
+            <Skeleton className="h-6 w-40" />
+          ) : (
+            <>
+              <h1 className="text-lg font-semibold tracking-tight text-white/90">{rig?.name}</h1>
+              {rig && (
+                <span className="inline-flex items-center gap-1 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[11px] text-white/40">
+                  <GitBranch className="size-3" />
+                  {rig.default_branch}
+                </span>
               )}
-            </div>
+            </>
+          )}
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setIsSlingOpen(true)}
+          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+        >
+          <Plus className="size-3.5" />
+          Sling Work
+        </Button>
+      </div>
 
-            <div className="hidden shrink-0 items-center gap-3 lg:flex">
-              <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
-                <div className="text-[11px] tracking-wider text-white/40 uppercase">Beads</div>
-                <div className="mt-0.5 text-sm font-medium text-white/80">
-                  {(beadsQuery.data ?? []).length}
-                </div>
-              </div>
-              <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
-                <div className="text-[11px] tracking-wider text-white/40 uppercase">Agents</div>
-                <div className="mt-0.5 text-sm font-medium text-white/80">
-                  {(agentsQuery.data ?? []).length}
-                </div>
-              </div>
-            </div>
+      {/* Stats strip */}
+      <div className="grid grid-cols-3 border-b border-white/[0.06]">
+        <RigStatCell label="Open" value={openBeads} color="text-sky-400" />
+        <RigStatCell label="In Progress" value={inProgressBeads} color="text-amber-400" />
+        <RigStatCell label="Closed" value={closedBeads} color="text-emerald-400" />
+      </div>
+
+      {/* Main content: columns layout */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Column 1: Bead Board */}
+        <div className="flex flex-1 flex-col overflow-y-auto border-r border-white/[0.06]">
+          <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
+            <Hexagon className="size-3 text-white/25" />
+            <span className="text-[10px] font-medium tracking-wide text-white/35 uppercase">
+              Bead Board
+            </span>
+            <span className="ml-auto font-mono text-[10px] text-white/20">{beads.length}</span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-3">
+            <BeadBoard
+              beads={beads}
+              isLoading={beadsQuery.isLoading}
+              onDeleteBead={beadId => {
+                if (confirm('Delete this bead?')) {
+                  deleteBead.mutate({ rigId, beadId });
+                }
+              }}
+              onSelectBead={bead => openDrawer({ type: 'bead', beadId: bead.bead_id, rigId })}
+              agentNameById={agentNameById}
+            />
           </div>
         </div>
-      </GastownBackdrop>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
-        <div className="lg:col-span-8">
-          <div className="mb-3 flex items-end justify-between gap-3">
-            <div>
-              <h2 className="text-sm font-medium tracking-wide text-white/70">Bead Board</h2>
-              <p className="mt-0.5 text-xs text-white/45">
-                Read-only kanban view with click-through details.
-              </p>
-            </div>
-            <div className="hidden text-xs text-white/45 md:block">
-              Tip: click a bead to open the ledger.
-            </div>
+        {/* Column 2: Agent Roster */}
+        <div className="flex w-[320px] shrink-0 flex-col overflow-y-auto">
+          <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
+            <Bot className="size-3 text-white/25" />
+            <span className="text-[10px] font-medium tracking-wide text-white/35 uppercase">
+              Agents
+            </span>
+            <span className="ml-auto font-mono text-[10px] text-white/20">{agents.length}</span>
           </div>
 
-          <GastownBackdrop>
-            <div className="p-4">
-              <BeadBoard
-                beads={beadsQuery.data ?? []}
-                isLoading={beadsQuery.isLoading}
-                onDeleteBead={beadId => {
-                  if (confirm('Delete this bead?')) {
-                    deleteBead.mutate({ rigId, beadId });
-                  }
-                }}
-                onSelectBead={bead => {
-                  setSelectedBeadId(bead.bead_id);
-                }}
-                selectedBeadId={selectedBeadId}
-                agentNameById={agentNameById}
-              />
-            </div>
-          </GastownBackdrop>
-        </div>
+          <div className="flex-1 overflow-y-auto p-3">
+            {agentsQuery.isLoading && (
+              <div className="space-y-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-20 w-full rounded-lg" />
+                ))}
+              </div>
+            )}
 
-        <div className="lg:col-span-4">
-          <div className="mb-3">
-            <h2 className="text-sm font-medium tracking-wide text-white/70">Agent Roster</h2>
-            <p className="mt-0.5 text-xs text-white/45">
-              Live identities with hook + last activity.
-            </p>
-          </div>
+            {agents.length === 0 && !agentsQuery.isLoading && (
+              <div className="rounded-lg border border-dashed border-white/[0.08] p-4 text-center text-xs text-white/30">
+                No agents yet. Sling work to spawn a polecat.
+              </div>
+            )}
 
-          <GastownBackdrop>
-            <div className="p-4">
-              {agentsQuery.isLoading && (
-                <div className="space-y-3">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <Skeleton key={i} className="h-24 w-full rounded-lg" />
-                  ))}
-                </div>
-              )}
-
-              {agentsQuery.data && agentsQuery.data.length === 0 && (
-                <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4 text-sm text-white/55">
-                  No agents yet. Sling work to spawn a polecat.
-                </div>
-              )}
-
-              {agentsQuery.data && agentsQuery.data.length > 0 && (
-                <div className="space-y-3">
-                  {agentsQuery.data.map(agent => (
-                    <AgentCard
-                      key={agent.id}
-                      agent={agent}
-                      isSelected={selectedAgentId === agent.id}
-                      onSelect={() =>
-                        setSelectedAgentId(prev => (prev === agent.id ? null : agent.id))
+            <AnimatePresence mode="popLayout">
+              {agents.map((agent, i) => (
+                <motion.div
+                  key={agent.id}
+                  initial={{ opacity: 0, x: 12 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -12 }}
+                  transition={{ delay: i * 0.03, duration: 0.2 }}
+                  className="mb-2"
+                >
+                  <AgentCard
+                    agent={agent}
+                    isSelected={false}
+                    onSelect={() => openDrawer({ type: 'agent', agentId: agent.id, rigId, townId })}
+                    onDelete={() => {
+                      if (confirm(`Delete agent "${agent.name}"?`)) {
+                        deleteAgent.mutate({ rigId, agentId: agent.id });
                       }
-                      onDelete={() => {
-                        if (confirm(`Delete agent "${agent.name}"?`)) {
-                          deleteAgent.mutate({ rigId, agentId: agent.id });
-                        }
-                      }}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          </GastownBackdrop>
+                    }}
+                  />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
         </div>
       </div>
 
-      {/* Agent Stream / Terminal */}
-      {selectedAgentId && (
-        <div className="mt-6">
-          <div className="mb-3 flex items-end justify-between">
-            <div>
-              <h2 className="text-sm font-medium tracking-wide text-white/70">
-                {agentView === 'events' ? 'Agent Stream' : 'Agent Terminal'}
-              </h2>
-              <p className="mt-0.5 text-xs text-white/45">
-                {agentView === 'events'
-                  ? 'Real-time tool calls, diffs, and narrative output.'
-                  : 'Live terminal view of the agent session.'}
-              </p>
-            </div>
-            <div className="flex gap-1 rounded-lg border border-white/10 bg-white/[0.03] p-0.5">
-              <button
-                onClick={() => setAgentView('events')}
-                className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
-                  agentView === 'events'
-                    ? 'bg-white/10 text-white/90'
-                    : 'text-white/50 hover:text-white/70'
-                }`}
-              >
-                Events
-              </button>
-              <button
-                onClick={() => setAgentView('terminal')}
-                className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
-                  agentView === 'terminal'
-                    ? 'bg-white/10 text-white/90'
-                    : 'text-white/50 hover:text-white/70'
-                }`}
-              >
-                Terminal
-              </button>
-            </div>
-          </div>
-          {agentView === 'events' ? (
-            <AgentStream
-              townId={townId}
-              agentId={selectedAgentId}
-              onClose={() => setSelectedAgentId(null)}
-            />
-          ) : (
-            <AgentTerminal
-              townId={townId}
-              agentId={selectedAgentId}
-              onClose={() => setSelectedAgentId(null)}
-            />
-          )}
-        </div>
-      )}
-
-      <GastownBeadDetailSheet
-        open={Boolean(selectedBeadId)}
-        onOpenChange={open => {
-          if (!open) setSelectedBeadId(null);
-        }}
-        bead={selectedBead}
-        rigId={rigId}
-        agentNameById={agentNameById}
-        onDelete={
-          selectedBead
-            ? () => {
-                if (confirm('Delete this bead?')) {
-                  deleteBead.mutate({ rigId, beadId: selectedBead.bead_id });
-                  setSelectedBeadId(null);
-                }
-              }
-            : undefined
-        }
-      />
-
       <SlingDialog rigId={rigId} isOpen={isSlingOpen} onClose={() => setIsSlingOpen(false)} />
-    </PageContainer>
+    </div>
+  );
+}
+
+function RigStatCell({ label, value, color }: { label: string; value: number; color: string }) {
+  return (
+    <div className="border-r border-white/[0.06] px-4 py-2.5 last:border-r-0">
+      <div className={`text-[10px] font-medium tracking-wide uppercase ${color} opacity-60`}>
+        {label}
+      </div>
+      <motion.div
+        key={value}
+        initial={{ y: 4, opacity: 0.4 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+        className="mt-0.5 font-mono text-lg font-semibold text-white/80"
+      >
+        {value}
+      </motion.div>
+    </div>
   );
 }

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -1,23 +1,76 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
-import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
 import { toast } from 'sonner';
-import { ArrowLeft, Plus, Trash2, Eye, EyeOff, Save, Settings } from 'lucide-react';
+import {
+  Plus,
+  Trash2,
+  Eye,
+  EyeOff,
+  Save,
+  Settings,
+  GitBranch,
+  KeyRound,
+  Bot,
+  Shield,
+  Variable,
+} from 'lucide-react';
+import { motion } from 'motion/react';
 
 type Props = { townId: string };
 
 type EnvVarEntry = { key: string; value: string; isNew?: boolean };
+
+// Section definitions for the scrollspy nav
+const SECTIONS = [
+  { id: 'git-auth', label: 'Git Authentication', icon: GitBranch },
+  { id: 'env-vars', label: 'Environment Variables', icon: Variable },
+  { id: 'agent-defaults', label: 'Agent Defaults', icon: Bot },
+  { id: 'refinery', label: 'Refinery', icon: Shield },
+] as const;
+
+function useScrollSpy(sectionIds: readonly string[]) {
+  const [activeId, setActiveId] = useState<string>(sectionIds[0]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        // Find the topmost visible section
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '-80px 0px -60% 0px', threshold: 0 }
+    );
+
+    for (const id of sectionIds) {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [sectionIds]);
+
+  return activeId;
+}
+
+function scrollToSection(id: string) {
+  const el = document.getElementById(id);
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+}
 
 export function TownSettingsPageClient({ townId }: Props) {
   const router = useRouter();
@@ -65,6 +118,8 @@ export function TownSettingsPageClient({ townId }: Props) {
     setInitialized(true);
   }
 
+  const activeSection = useScrollSpy(SECTIONS.map(s => s.id));
+
   function handleSave() {
     const envVarObj: Record<string, string> = {};
     for (const entry of envVars) {
@@ -78,7 +133,6 @@ export function TownSettingsPageClient({ townId }: Props) {
       config: {
         env_vars: envVarObj,
         git_auth: {
-          // Only send non-masked values (masked values contain ****)
           ...(githubToken && !githubToken.startsWith('****') ? { github_token: githubToken } : {}),
           ...(gitlabToken && !gitlabToken.startsWith('****') ? { gitlab_token: gitlabToken } : {}),
           ...(gitlabInstanceUrl ? { gitlab_instance_url: gitlabInstanceUrl } : {}),
@@ -120,237 +174,363 @@ export function TownSettingsPageClient({ townId }: Props) {
 
   if (townQuery.isLoading || configQuery.isLoading) {
     return (
-      <PageContainer>
-        <GastownBackdrop contentClassName="p-5 md:p-7">
-          <Skeleton className="h-8 w-64" />
-        </GastownBackdrop>
-        <div className="space-y-4 px-1">
-          <Skeleton className="h-48 w-full" />
-          <Skeleton className="h-48 w-full" />
+      <div className="flex h-full flex-col">
+        <div className="border-b border-white/[0.06] px-6 py-3">
+          <Skeleton className="h-6 w-48" />
         </div>
-      </PageContainer>
+        <div className="flex-1 p-6">
+          <div className="space-y-6">
+            <Skeleton className="h-48 w-full rounded-xl" />
+            <Skeleton className="h-48 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
     );
   }
 
   return (
-    <PageContainer>
-      {/* Header */}
-      <GastownBackdrop contentClassName="p-5 md:p-7">
-        <div className="flex items-center gap-3">
-          <button
-            onClick={() => router.push(`/gastown/${townId}`)}
-            className="flex items-center gap-1 text-sm text-white/60 transition-colors hover:text-white/90"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back
-          </button>
+    <div className="flex h-full flex-col">
+      {/* Top bar */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+        <div className="flex items-center gap-2.5">
+          <Settings className="size-4 text-white/40" />
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Settings</h1>
+          <span className="text-sm text-white/30">{townQuery.data?.name}</span>
         </div>
-        <div className="mt-3 flex items-center gap-3">
-          <Settings className="h-6 w-6 text-white/70" />
-          <h1 className="text-xl font-semibold text-white/95">
-            {townQuery.data?.name ?? 'Town'} — Settings
-          </h1>
-        </div>
-        <p className="mt-1 text-sm text-white/55">
-          Configure environment variables, git authentication, and agent defaults.
-        </p>
-      </GastownBackdrop>
+        <Button
+          onClick={handleSave}
+          disabled={updateConfig.isPending}
+          variant="primary"
+          size="sm"
+          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+        >
+          <Save className="size-3.5" />
+          {updateConfig.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
 
-      <div className="space-y-6 px-1">
-        {/* Git Authentication */}
-        <Card className="border-white/10 bg-white/[0.03]">
-          <CardHeader>
-            <CardTitle className="text-base text-white/90">Git Authentication</CardTitle>
-            <p className="text-sm text-white/55">
-              Tokens used for cloning and pushing to private repositories.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setShowTokens(!showTokens)}
-                className="flex items-center gap-1 text-xs text-white/50 hover:text-white/80"
+      {/* Two-column body — single scroll container so sticky works */}
+      <div className="flex-1 overflow-y-auto scroll-smooth">
+        <div className="flex">
+          {/* Main content */}
+          <div className="min-w-0 flex-1">
+            <div className="mx-auto max-w-2xl space-y-8 px-6 pt-6 pb-24">
+              {/* ── Git Authentication ──────────────────────────────── */}
+              <SettingsSection
+                id="git-auth"
+                title="Git Authentication"
+                description="Tokens used for cloning and pushing to private repositories."
+                icon={GitBranch}
+                index={0}
               >
-                {showTokens ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-                {showTokens ? 'Hide' : 'Show'} tokens
-              </button>
-            </div>
+                <div className="mb-4 flex items-center gap-2">
+                  <button
+                    onClick={() => setShowTokens(!showTokens)}
+                    className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-white/40 transition-colors hover:bg-white/[0.04] hover:text-white/65"
+                  >
+                    {showTokens ? <EyeOff className="size-3" /> : <Eye className="size-3" />}
+                    {showTokens ? 'Hide tokens' : 'Reveal tokens'}
+                  </button>
+                </div>
 
-            <div className="space-y-1">
-              <Label className="text-white/70">GitHub Token (PAT or Installation Token)</Label>
-              <Input
-                type={showTokens ? 'text' : 'password'}
-                value={githubToken}
-                onChange={e => setGithubToken(e.target.value)}
-                placeholder="ghp_xxxxxxxxxxxx"
-                className="border-white/10 bg-white/[0.05] text-white/90 placeholder:text-white/30"
-              />
-              <p className="text-xs text-white/40">
-                Used to authenticate <code>git clone</code> and <code>git push</code> for GitHub
-                repos.
-              </p>
-            </div>
-
-            <div className="space-y-1">
-              <Label className="text-white/70">GitLab Token</Label>
-              <Input
-                type={showTokens ? 'text' : 'password'}
-                value={gitlabToken}
-                onChange={e => setGitlabToken(e.target.value)}
-                placeholder="glpat-xxxxxxxxxxxx"
-                className="border-white/10 bg-white/[0.05] text-white/90 placeholder:text-white/30"
-              />
-            </div>
-
-            <div className="space-y-1">
-              <Label className="text-white/70">GitLab Instance URL (self-hosted)</Label>
-              <Input
-                value={gitlabInstanceUrl}
-                onChange={e => setGitlabInstanceUrl(e.target.value)}
-                placeholder="https://gitlab.example.com"
-                className="border-white/10 bg-white/[0.05] text-white/90 placeholder:text-white/30"
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Environment Variables */}
-        <Card className="border-white/10 bg-white/[0.03]">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div>
-                <CardTitle className="text-base text-white/90">Environment Variables</CardTitle>
-                <p className="text-sm text-white/55">
-                  Injected into all agent processes. Agent-level overrides take precedence.
-                </p>
-              </div>
-              <Button variant="outline" size="sm" onClick={addEnvVar}>
-                <Plus className="mr-1 h-3 w-3" />
-                Add
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {envVars.length === 0 ? (
-              <p className="text-sm text-white/40">No environment variables configured.</p>
-            ) : (
-              <div className="space-y-2">
-                {envVars.map((entry, i) => (
-                  <div key={i} className="flex items-center gap-2">
+                <div className="space-y-4">
+                  <FieldGroup
+                    label="GitHub Token (PAT or Installation Token)"
+                    hint="Used to authenticate git clone and git push for GitHub repos."
+                  >
                     <Input
-                      value={entry.key}
-                      onChange={e => updateEnvVar(i, 'key', e.target.value)}
-                      placeholder="KEY"
-                      className="w-40 border-white/10 bg-white/[0.05] font-mono text-sm text-white/90 placeholder:text-white/30"
+                      type={showTokens ? 'text' : 'password'}
+                      value={githubToken}
+                      onChange={e => setGithubToken(e.target.value)}
+                      placeholder="ghp_xxxxxxxxxxxx"
+                      className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
                     />
-                    <span className="text-white/40">=</span>
+                  </FieldGroup>
+
+                  <FieldGroup label="GitLab Token">
                     <Input
-                      value={entry.value}
-                      onChange={e => updateEnvVar(i, 'value', e.target.value)}
-                      placeholder="value"
-                      className="flex-1 border-white/10 bg-white/[0.05] font-mono text-sm text-white/90 placeholder:text-white/30"
+                      type={showTokens ? 'text' : 'password'}
+                      value={gitlabToken}
+                      onChange={e => setGitlabToken(e.target.value)}
+                      placeholder="glpat-xxxxxxxxxxxx"
+                      className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
                     />
-                    <button
-                      onClick={() => removeEnvVar(i)}
-                      className="text-white/40 transition-colors hover:text-red-400"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                  </FieldGroup>
 
-        {/* Agent Defaults */}
-        <Card className="border-white/10 bg-white/[0.03]">
-          <CardHeader>
-            <CardTitle className="text-base text-white/90">Agent Defaults</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-1">
-              <Label className="text-white/70">Default Model</Label>
-              <Input
-                value={defaultModel}
-                onChange={e => setDefaultModel(e.target.value)}
-                placeholder="anthropic/claude-sonnet-4.6"
-                className="border-white/10 bg-white/[0.05] text-white/90 placeholder:text-white/30"
-              />
-            </div>
+                  <FieldGroup label="GitLab Instance URL" hint="For self-hosted GitLab.">
+                    <Input
+                      value={gitlabInstanceUrl}
+                      onChange={e => setGitlabInstanceUrl(e.target.value)}
+                      placeholder="https://gitlab.example.com"
+                      className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                    />
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
 
-            <div className="space-y-1">
-              <Label className="text-white/70">Max Polecats per Rig</Label>
-              <Input
-                type="number"
-                min={1}
-                max={20}
-                value={maxPolecats ?? ''}
-                onChange={e =>
-                  setMaxPolecats(e.target.value ? parseInt(e.target.value, 10) : undefined)
+              {/* ── Environment Variables ────────────────────────────── */}
+              <SettingsSection
+                id="env-vars"
+                title="Environment Variables"
+                description="Injected into all agent processes. Agent-level overrides take precedence."
+                icon={Variable}
+                index={1}
+                action={
+                  <button
+                    onClick={addEnvVar}
+                    className="inline-flex items-center gap-1 rounded-md bg-white/[0.05] px-2.5 py-1 text-[11px] text-white/50 transition-colors hover:bg-white/[0.08] hover:text-white/70"
+                  >
+                    <Plus className="size-3" />
+                    Add
+                  </button>
                 }
-                placeholder="5"
-                className="w-24 border-white/10 bg-white/[0.05] text-white/90 placeholder:text-white/30"
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Refinery Configuration */}
-        <Card className="border-white/10 bg-white/[0.03]">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div>
-                <CardTitle className="text-base text-white/90">Refinery (Quality Gates)</CardTitle>
-                <p className="text-sm text-white/55">
-                  Commands run before merging polecat branches into the default branch.
-                </p>
-              </div>
-              <Button variant="outline" size="sm" onClick={addRefineryGate}>
-                <Plus className="mr-1 h-3 w-3" />
-                Add Gate
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {refineryGates.length === 0 ? (
-              <p className="text-sm text-white/40">No quality gates configured.</p>
-            ) : (
-              <div className="space-y-2">
-                {refineryGates.map((gate, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <Input
-                      value={gate}
-                      onChange={e => updateRefineryGate(i, e.target.value)}
-                      placeholder="npm test"
-                      className="flex-1 border-white/10 bg-white/[0.05] font-mono text-sm text-white/90 placeholder:text-white/30"
-                    />
-                    <button
-                      onClick={() => removeRefineryGate(i)}
-                      className="text-white/40 transition-colors hover:text-red-400"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+              >
+                {envVars.length === 0 ? (
+                  <p className="text-xs text-white/25">No environment variables configured.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {envVars.map((entry, i) => (
+                      <motion.div
+                        key={i}
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        className="flex items-center gap-2"
+                      >
+                        <Input
+                          value={entry.key}
+                          onChange={e => updateEnvVar(i, 'key', e.target.value)}
+                          placeholder="KEY"
+                          className="w-40 border-white/[0.08] bg-white/[0.03] font-mono text-xs text-white/85 placeholder:text-white/20"
+                        />
+                        <span className="text-[10px] text-white/20">=</span>
+                        <Input
+                          value={entry.value}
+                          onChange={e => updateEnvVar(i, 'value', e.target.value)}
+                          placeholder="value"
+                          className="flex-1 border-white/[0.08] bg-white/[0.03] font-mono text-xs text-white/85 placeholder:text-white/20"
+                        />
+                        <button
+                          onClick={() => removeEnvVar(i)}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                        >
+                          <Trash2 className="size-3" />
+                        </button>
+                      </motion.div>
+                    ))}
                   </div>
-                ))}
-              </div>
-            )}
+                )}
+              </SettingsSection>
 
-            <div className="flex items-center gap-3">
-              <Switch checked={autoMerge} onCheckedChange={setAutoMerge} />
-              <Label className="text-white/70">Auto-merge when all gates pass</Label>
+              {/* ── Agent Defaults ───────────────────────────────────── */}
+              <SettingsSection
+                id="agent-defaults"
+                title="Agent Defaults"
+                description="Default configuration applied to newly spawned agents."
+                icon={Bot}
+                index={2}
+              >
+                <div className="space-y-4">
+                  <FieldGroup label="Default Model">
+                    <Input
+                      value={defaultModel}
+                      onChange={e => setDefaultModel(e.target.value)}
+                      placeholder="anthropic/claude-sonnet-4.6"
+                      className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                    />
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Max Polecats per Rig"
+                    hint="Upper bound on concurrent worker agents per rig."
+                  >
+                    <Input
+                      type="number"
+                      min={1}
+                      max={20}
+                      value={maxPolecats ?? ''}
+                      onChange={e =>
+                        setMaxPolecats(e.target.value ? parseInt(e.target.value, 10) : undefined)
+                      }
+                      placeholder="5"
+                      className="w-28 border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                    />
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+
+              {/* ── Refinery (Quality Gates) ─────────────────────────── */}
+              <SettingsSection
+                id="refinery"
+                title="Refinery"
+                description="Quality gates run before merging polecat branches into the default branch."
+                icon={Shield}
+                index={3}
+                action={
+                  <button
+                    onClick={addRefineryGate}
+                    className="inline-flex items-center gap-1 rounded-md bg-white/[0.05] px-2.5 py-1 text-[11px] text-white/50 transition-colors hover:bg-white/[0.08] hover:text-white/70"
+                  >
+                    <Plus className="size-3" />
+                    Add Gate
+                  </button>
+                }
+              >
+                {refineryGates.length === 0 ? (
+                  <p className="text-xs text-white/25">No quality gates configured.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {refineryGates.map((gate, i) => (
+                      <motion.div
+                        key={i}
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        className="flex items-center gap-2"
+                      >
+                        <Input
+                          value={gate}
+                          onChange={e => updateRefineryGate(i, e.target.value)}
+                          placeholder="npm test"
+                          className="flex-1 border-white/[0.08] bg-white/[0.03] font-mono text-xs text-white/85 placeholder:text-white/20"
+                        />
+                        <button
+                          onClick={() => removeRefineryGate(i)}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                        >
+                          <Trash2 className="size-3" />
+                        </button>
+                      </motion.div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="mt-4 flex items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                  <Switch checked={autoMerge} onCheckedChange={setAutoMerge} />
+                  <div>
+                    <Label className="text-sm text-white/70">Auto-merge</Label>
+                    <p className="text-[11px] text-white/30">
+                      Automatically merge when all gates pass.
+                    </p>
+                  </div>
+                </div>
+              </SettingsSection>
             </div>
-          </CardContent>
-        </Card>
+          </div>
 
-        {/* Save Button */}
-        <div className="flex justify-end pb-8">
-          <Button onClick={handleSave} disabled={updateConfig.isPending}>
-            <Save className="mr-2 h-4 w-4" />
-            {updateConfig.isPending ? 'Saving...' : 'Save Configuration'}
-          </Button>
+          {/* Right sidebar — sticky scrollspy nav */}
+          <div className="hidden w-52 shrink-0 lg:block">
+            <nav className="sticky top-6 px-4 pt-6">
+              <div className="mb-3 text-[10px] font-medium tracking-wide text-white/25 uppercase">
+                On this page
+              </div>
+              <ul className="space-y-0.5">
+                {SECTIONS.map(section => {
+                  const isActive = activeSection === section.id;
+                  const SectionIcon = section.icon;
+
+                  return (
+                    <li key={section.id}>
+                      <button
+                        onClick={() => scrollToSection(section.id)}
+                        className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs transition-colors ${
+                          isActive
+                            ? 'bg-white/[0.06] text-white/80'
+                            : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
+                        }`}
+                      >
+                        <SectionIcon className="size-3 shrink-0" />
+                        <span>{section.label}</span>
+                        {isActive && (
+                          <motion.div
+                            layoutId="settings-nav-indicator"
+                            className="ml-auto size-1 rounded-full bg-[color:oklch(95%_0.15_108)]"
+                            transition={{ type: 'spring', stiffness: 350, damping: 30 }}
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {/* Save button mirrored in sidebar */}
+              <div className="mt-6 border-t border-white/[0.06] pt-4">
+                <Button
+                  onClick={handleSave}
+                  disabled={updateConfig.isPending}
+                  variant="primary"
+                  size="sm"
+                  className="w-full gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+                >
+                  <Save className="size-3" />
+                  {updateConfig.isPending ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </nav>
+          </div>
         </div>
       </div>
-    </PageContainer>
+    </div>
+  );
+}
+
+// ── Shared sub-components ────────────────────────────────────────────────
+
+function SettingsSection({
+  id,
+  title,
+  description,
+  icon: Icon,
+  index,
+  action,
+  children,
+}: {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof Settings;
+  index: number;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.section
+      id={id}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.06, duration: 0.35 }}
+      className="scroll-mt-6"
+    >
+      <div className="mb-4 flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex size-8 items-center justify-center rounded-lg bg-white/[0.04] ring-1 ring-white/[0.06]">
+            <Icon className="size-4 text-white/40" />
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-white/85">{title}</h2>
+            <p className="mt-0.5 text-xs text-white/35">{description}</p>
+          </div>
+        </div>
+        {action}
+      </div>
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">{children}</div>
+    </motion.section>
+  );
+}
+
+function FieldGroup({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-white/55">{label}</Label>
+      {children}
+      {hint && <p className="text-[11px] text-white/25">{hint}</p>}
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,21 @@
 @import '@xterm/xterm/css/xterm.css';
 @plugin '@tailwindcss/typography';
 
+/* xterm's helper textarea is used for IME/clipboard but Tailwind v4's reset
+   overrides its off-screen positioning, making it visible as a garbled box.
+   Re-assert the off-screen placement with enough specificity to survive the reset. */
+.xterm .xterm-helper-textarea {
+  position: absolute !important;
+  opacity: 0 !important;
+  left: -9999em !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
+  border: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/components/gastown/ActivityFeed.tsx
+++ b/src/components/gastown/ActivityFeed.tsx
@@ -13,7 +13,9 @@ import {
   PlayCircle,
   PauseCircle,
   Mail,
+  ChevronRight,
 } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
 
 const EVENT_ICONS: Record<string, typeof Activity> = {
   created: PlayCircle,
@@ -91,9 +93,15 @@ type ActivityFeedViewProps = {
   townId: string;
   events?: TownEvent[];
   isLoading?: boolean;
+  onEventClick?: (event: TownEvent) => void;
 };
 
-export function ActivityFeedView({ townId, events, isLoading }: ActivityFeedViewProps) {
+export function ActivityFeedView({
+  townId,
+  events,
+  isLoading,
+  onEventClick,
+}: ActivityFeedViewProps) {
   const trpc = useTRPC();
   const query = useQuery({
     ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 50 }),
@@ -108,10 +116,16 @@ export function ActivityFeedView({ townId, events, isLoading }: ActivityFeedView
     return (
       <div className="space-y-2 p-3">
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="flex animate-pulse items-center gap-2">
-            <div className="bg-muted h-4 w-4 rounded-full" />
-            <div className="bg-muted h-3 flex-1 rounded" />
-          </div>
+          <motion.div
+            key={i}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: i * 0.05 }}
+            className="flex items-center gap-2"
+          >
+            <div className="size-4 rounded-full bg-white/[0.06]" />
+            <div className="h-3 flex-1 rounded bg-white/[0.04]" />
+          </motion.div>
         ))}
       </div>
     );
@@ -119,42 +133,70 @@ export function ActivityFeedView({ townId, events, isLoading }: ActivityFeedView
 
   if (!effectiveEvents?.length) {
     return (
-      <div className="text-muted-foreground flex flex-col items-center justify-center p-6 text-sm">
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="text-muted-foreground flex flex-col items-center justify-center p-6 text-sm"
+      >
         <Activity className="mb-2 h-8 w-8 opacity-40" />
         <p>No activity yet</p>
-      </div>
+      </motion.div>
     );
   }
 
-  // Show newest first
-  const sorted = [...effectiveEvents].reverse();
+  // Newest first — events from the API come oldest-first, so reverse.
+  const sorted = [...effectiveEvents].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+
+  const clickable = Boolean(onEventClick);
 
   return (
-    <div className="max-h-[420px] space-y-1 overflow-y-auto p-2">
-      {sorted.map(event => {
-        const Icon = EVENT_ICONS[event.event_type] ?? Activity;
-        const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
+    <div className="max-h-[420px] space-y-0.5 overflow-y-auto p-2">
+      <AnimatePresence initial={false}>
+        {sorted.map(event => {
+          const Icon = EVENT_ICONS[event.event_type] ?? Activity;
+          const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
 
-        return (
-          <div
-            key={event.bead_event_id}
-            className="flex items-start gap-2 rounded-xl px-2 py-1.5 text-sm transition-colors hover:bg-white/[0.05]"
-          >
-            <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${color}`} />
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-white/85">
-                {eventDescription(toEventDescriptionInput(event))}
-              </p>
-              <p className="text-xs text-white/40">
-                {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
-              </p>
-            </div>
-          </div>
-        );
-      })}
+          return (
+            <motion.div
+              key={event.bead_event_id}
+              layout
+              initial={{ opacity: 0, height: 0, y: -8 }}
+              animate={{ opacity: 1, height: 'auto', y: 0 }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+              role={clickable ? 'button' : undefined}
+              tabIndex={clickable ? 0 : undefined}
+              onClick={clickable ? () => onEventClick?.(event) : undefined}
+              onKeyDown={
+                clickable
+                  ? e => {
+                      if (e.key === 'Enter' || e.key === ' ') onEventClick?.(event);
+                    }
+                  : undefined
+              }
+              className={`flex items-start gap-2 rounded-xl px-2 py-1.5 text-sm transition-colors hover:bg-white/[0.05] ${clickable ? 'cursor-pointer' : ''}`}
+            >
+              <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${color}`} />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-white/85">
+                  {eventDescription(toEventDescriptionInput(event))}
+                </p>
+                <p className="text-xs text-white/40">
+                  {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                </p>
+              </div>
+              {clickable && <ChevronRight className="mt-1 size-3 shrink-0 text-white/15" />}
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
     </div>
   );
 }
+
+export type { TownEvent };
 
 export function ActivityFeed({ townId }: { townId: string }) {
   return <ActivityFeedView townId={townId} />;
@@ -171,10 +213,16 @@ export function BeadEventTimeline({ rigId, beadId }: { rigId: string; beadId: st
     return (
       <div className="space-y-2 p-2">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex animate-pulse items-center gap-2">
-            <div className="bg-muted h-3 w-3 rounded-full" />
-            <div className="bg-muted h-2.5 flex-1 rounded" />
-          </div>
+          <motion.div
+            key={i}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: i * 0.06 }}
+            className="flex items-center gap-2"
+          >
+            <div className="size-3 rounded-full bg-white/[0.06]" />
+            <div className="h-2.5 flex-1 rounded bg-white/[0.04]" />
+          </motion.div>
         ))}
       </div>
     );
@@ -186,24 +234,32 @@ export function BeadEventTimeline({ rigId, beadId }: { rigId: string; beadId: st
 
   return (
     <div className="space-y-1 p-2">
-      {events.map(event => {
-        const Icon = EVENT_ICONS[event.event_type] ?? Activity;
-        const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
+      <AnimatePresence initial={false}>
+        {events.map((event, i) => {
+          const Icon = EVENT_ICONS[event.event_type] ?? Activity;
+          const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
 
-        return (
-          <div key={event.bead_event_id} className="flex items-start gap-2 py-1 text-xs">
-            <Icon className={`mt-0.5 h-3 w-3 shrink-0 ${color}`} />
-            <div className="min-w-0 flex-1">
-              <span className="text-foreground">
-                {eventDescription(toEventDescriptionInput(event))}
-              </span>
-              <span className="text-muted-foreground ml-1">
-                {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
-              </span>
-            </div>
-          </div>
-        );
-      })}
+          return (
+            <motion.div
+              key={event.bead_event_id}
+              initial={{ opacity: 0, x: -6 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: i * 0.03, duration: 0.2 }}
+              className="flex items-start gap-2 py-1 text-xs"
+            >
+              <Icon className={`mt-0.5 h-3 w-3 shrink-0 ${color}`} />
+              <div className="min-w-0 flex-1">
+                <span className="text-foreground">
+                  {eventDescription(toEventDescriptionInput(event))}
+                </span>
+                <span className="text-muted-foreground ml-1">
+                  {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                </span>
+              </div>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/gastown/ActivityFeed.tsx
+++ b/src/components/gastown/ActivityFeed.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import type { inferRouterOutputs } from '@trpc/server';
@@ -112,6 +113,9 @@ export function ActivityFeedView({
   const effectiveEvents = events ?? query.data;
   const effectiveLoading = isLoading ?? query.isLoading;
 
+  const PAGE_SIZE = 10;
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
   if (effectiveLoading) {
     return (
       <div className="space-y-2 p-3">
@@ -149,12 +153,15 @@ export function ActivityFeedView({
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
 
+  const visible = sorted.slice(0, visibleCount);
+  const hasMore = visibleCount < sorted.length;
+
   const clickable = Boolean(onEventClick);
 
   return (
-    <div className="max-h-[420px] space-y-0.5 overflow-y-auto p-2">
+    <div className="space-y-0.5 p-2">
       <AnimatePresence initial={false}>
-        {sorted.map(event => {
+        {visible.map(event => {
           const Icon = EVENT_ICONS[event.event_type] ?? Activity;
           const color = EVENT_COLORS[event.event_type] ?? 'text-muted-foreground';
 
@@ -192,6 +199,17 @@ export function ActivityFeedView({
           );
         })}
       </AnimatePresence>
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount(c => c + PAGE_SIZE)}
+          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs text-white/35 transition-colors hover:bg-white/[0.04] hover:text-white/55"
+        >
+          Show more
+          <span className="font-mono text-[10px] text-white/20">
+            {sorted.length - visibleCount} remaining
+          </span>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/gastown/AgentDetailDrawer.tsx
+++ b/src/components/gastown/AgentDetailDrawer.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { Drawer } from 'vaul';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Badge } from '@/components/ui/badge';
+import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+import { format, formatDistanceToNow } from 'date-fns';
+import {
+  X,
+  Bot,
+  Crown,
+  Shield,
+  Eye,
+  Hash,
+  Clock,
+  Hexagon,
+  Terminal,
+  Zap,
+  Activity,
+} from 'lucide-react';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Agent = RouterOutputs['gastown']['listAgents'][number];
+type Bead = RouterOutputs['gastown']['listBeads'][number];
+
+type AgentDetailDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agent: Agent | null;
+  rigId: string;
+  townId: string;
+  onConnect?: (agentId: string, agentName: string) => void;
+  onDelete?: () => void;
+};
+
+const ROLE_ICONS: Record<string, typeof Bot> = {
+  polecat: Bot,
+  mayor: Crown,
+  refinery: Shield,
+  witness: Eye,
+};
+
+const STATUS_DOT: Record<string, string> = {
+  idle: 'bg-white/25',
+  working: 'bg-emerald-400',
+  stalled: 'bg-amber-400',
+  dead: 'bg-red-400',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  idle: 'Idle',
+  working: 'Working',
+  stalled: 'Stalled',
+  dead: 'Dead',
+};
+
+export function AgentDetailDrawer({
+  open,
+  onOpenChange,
+  agent,
+  rigId,
+  townId,
+  onConnect,
+  onDelete,
+}: AgentDetailDrawerProps) {
+  const trpc = useTRPC();
+
+  // Fetch related beads for this agent
+  const beadsQuery = useQuery({
+    ...trpc.gastown.listBeads.queryOptions({ rigId }),
+    enabled: open && Boolean(agent),
+    refetchInterval: 8_000,
+  });
+
+  const relatedBeads = (beadsQuery.data ?? []).filter(b => b.assignee_agent_bead_id === agent?.id);
+
+  const RoleIcon = agent ? (ROLE_ICONS[agent.role] ?? Bot) : Bot;
+
+  return (
+    <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
+        <Drawer.Content
+          className="fixed top-0 right-0 bottom-0 z-50 flex w-[480px] max-w-[94vw] flex-col outline-none"
+          style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
+        >
+          <div className="flex h-full flex-col overflow-hidden rounded-l-2xl border-l border-white/[0.08] bg-[oklch(0.12_0_0)]">
+            {/* Header */}
+            <div className="flex items-start justify-between border-b border-white/[0.06] px-5 pt-5 pb-4">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-3">
+                  <div className="flex size-10 items-center justify-center rounded-xl bg-white/[0.05] ring-1 ring-white/[0.08]">
+                    <RoleIcon className="size-5 text-white/50" />
+                  </div>
+                  <div>
+                    <Drawer.Title className="text-base font-semibold text-white/90">
+                      {agent?.name ?? 'Agent'}
+                    </Drawer.Title>
+                    <Drawer.Description className="mt-0.5 flex items-center gap-2 text-xs text-white/35">
+                      <span className="capitalize">{agent?.role}</span>
+                      {agent && (
+                        <>
+                          <span className="text-white/15">·</span>
+                          <span className="flex items-center gap-1">
+                            <span
+                              className={`size-1.5 rounded-full ${STATUS_DOT[agent.status] ?? 'bg-white/20'}`}
+                            />
+                            {STATUS_LABEL[agent.status] ?? agent.status}
+                          </span>
+                        </>
+                      )}
+                    </Drawer.Description>
+                  </div>
+                </div>
+              </div>
+
+              <button
+                onClick={() => onOpenChange(false)}
+                className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            {/* Actions bar */}
+            {agent && (
+              <div className="flex items-center gap-2 border-b border-white/[0.06] px-5 py-3">
+                {onConnect && (
+                  <button
+                    onClick={() => {
+                      onConnect(agent.id, agent.name);
+                      onOpenChange(false);
+                    }}
+                    className="inline-flex items-center gap-1.5 rounded-lg bg-[color:oklch(95%_0.15_108_/_0.12)] px-3 py-1.5 text-xs font-medium text-[color:oklch(95%_0.15_108)] ring-1 ring-[color:oklch(95%_0.15_108_/_0.2)] transition-colors hover:bg-[color:oklch(95%_0.15_108_/_0.2)]"
+                  >
+                    <Terminal className="size-3.5" />
+                    Connect
+                  </button>
+                )}
+                {onDelete && (
+                  <button
+                    onClick={onDelete}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/8 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/15"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto">
+              {!agent ? (
+                <div className="p-6 text-center text-sm text-white/30">
+                  Select an agent to inspect.
+                </div>
+              ) : (
+                <>
+                  {/* Metadata grid */}
+                  <div className="grid grid-cols-2 border-b border-white/[0.06]">
+                    <MetaCell icon={Hash} label="ID" value={agent.id.slice(0, 12)} mono />
+                    <MetaCell
+                      icon={Clock}
+                      label="Created"
+                      value={format(new Date(agent.created_at), 'MMM d, HH:mm')}
+                    />
+                    <MetaCell
+                      icon={Zap}
+                      label="Dispatch Attempts"
+                      value={String(agent.dispatch_attempts)}
+                    />
+                    <MetaCell
+                      icon={Activity}
+                      label="Last Active"
+                      value={
+                        agent.last_activity_at
+                          ? formatDistanceToNow(new Date(agent.last_activity_at), {
+                              addSuffix: true,
+                            })
+                          : 'Never'
+                      }
+                    />
+                    <MetaCell
+                      icon={Hexagon}
+                      label="Hooked Bead"
+                      value={
+                        agent.current_hook_bead_id
+                          ? agent.current_hook_bead_id.slice(0, 12)
+                          : 'None'
+                      }
+                      mono={Boolean(agent.current_hook_bead_id)}
+                    />
+                    <MetaCell icon={Bot} label="Identity" value={agent.identity || 'Default'} />
+                  </div>
+
+                  {/* Related Beads */}
+                  <div className="border-b border-white/[0.06] px-5 py-4">
+                    <div className="mb-3 flex items-center justify-between">
+                      <div className="flex items-center gap-1.5">
+                        <Hexagon className="size-3 text-white/25" />
+                        <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                          Assigned Beads
+                        </span>
+                      </div>
+                      <span className="font-mono text-[10px] text-white/20">
+                        {relatedBeads.length}
+                      </span>
+                    </div>
+
+                    {relatedBeads.length === 0 ? (
+                      <p className="text-xs text-white/20">No beads assigned to this agent.</p>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {relatedBeads.map(bead => (
+                          <BeadRow key={bead.bead_id} bead={bead} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Activity Timeline */}
+                  {agent.current_hook_bead_id && (
+                    <div className="px-5 pt-4">
+                      <div className="mb-2 flex items-center gap-1.5">
+                        <Clock className="size-3 text-white/25" />
+                        <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                          Hooked Bead Events
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                  {agent.current_hook_bead_id && (
+                    <div className="px-3 pb-6">
+                      <BeadEventTimeline rigId={rigId} beadId={agent.current_hook_bead_id} />
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}
+
+function MetaCell({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className={`mt-0.5 truncate text-sm text-white/75 ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+const BEAD_STATUS_DOT: Record<string, string> = {
+  open: 'bg-sky-400',
+  in_progress: 'bg-amber-400',
+  closed: 'bg-emerald-400',
+  failed: 'bg-red-400',
+};
+
+function BeadRow({ bead }: { bead: Bead }) {
+  return (
+    <div className="flex items-center gap-2.5 rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2">
+      <span
+        className={`size-2 shrink-0 rounded-full ${BEAD_STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs text-white/70">{bead.title}</div>
+        <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-white/30">
+          <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
+          <span className="text-white/10">·</span>
+          <span className="capitalize">{bead.status.replace('_', ' ')}</span>
+        </div>
+      </div>
+      <Badge variant="outline" className="shrink-0 text-[9px]">
+        {bead.type}
+      </Badge>
+    </div>
+  );
+}

--- a/src/components/gastown/AgentTerminalTabs.tsx
+++ b/src/components/gastown/AgentTerminalTabs.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { AgentTerminal } from './AgentTerminal';
+import { useSidebar } from '@/components/ui/sidebar';
+import { ChevronDown, ChevronUp, X, Terminal as TerminalIcon, Plus } from 'lucide-react';
+
+type TerminalTab = {
+  agentId: string;
+  agentName: string;
+};
+
+type AgentTerminalTabsProps = {
+  townId: string;
+  tabs: TerminalTab[];
+  onCloseTab: (agentId: string) => void;
+  onCloseAll: () => void;
+};
+
+const COLLAPSED_HEIGHT = 36;
+const EXPANDED_HEIGHT = 300;
+
+export function AgentTerminalTabs({
+  townId,
+  tabs,
+  onCloseTab,
+  onCloseAll,
+}: AgentTerminalTabsProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [activeTabId, setActiveTabId] = useState<string | null>(tabs[0]?.agentId ?? null);
+  const { state: sidebarState, isMobile } = useSidebar();
+
+  // If the active tab gets closed, select the last remaining tab
+  const activeTab = tabs.find(t => t.agentId === activeTabId);
+  if (!activeTab && tabs.length > 0 && activeTabId !== tabs[tabs.length - 1].agentId) {
+    setActiveTabId(tabs[tabs.length - 1].agentId);
+  }
+
+  if (tabs.length === 0) return null;
+
+  const sidebarLeft = isMobile ? '0px' : sidebarState === 'expanded' ? '16rem' : '3rem';
+
+  return (
+    <div
+      className="fixed right-0 bottom-0 z-40 border-t border-white/[0.08] bg-[oklch(0.08_0_0)]"
+      style={{
+        left: sidebarLeft,
+        height: collapsed ? COLLAPSED_HEIGHT : COLLAPSED_HEIGHT + EXPANDED_HEIGHT,
+        transition: 'left 200ms linear, height 150ms ease',
+      }}
+    >
+      {/* Tab bar */}
+      <div
+        className="flex items-center border-b border-white/[0.06]"
+        style={{ height: COLLAPSED_HEIGHT }}
+      >
+        {/* Collapse toggle */}
+        <button
+          onClick={() => setCollapsed(c => !c)}
+          className="flex h-full items-center gap-1.5 px-3 text-white/40 transition-colors hover:text-white/60"
+        >
+          <TerminalIcon className="size-3" />
+          {collapsed ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+        </button>
+
+        {/* Tabs */}
+        <div className="flex flex-1 items-center gap-0.5 overflow-x-auto px-1">
+          {tabs.map(tab => (
+            <div
+              key={tab.agentId}
+              onClick={() => {
+                setActiveTabId(tab.agentId);
+                if (collapsed) setCollapsed(false);
+              }}
+              className={`group flex cursor-pointer items-center gap-1.5 rounded-t-md px-3 py-1 text-[11px] transition-colors ${
+                tab.agentId === activeTabId
+                  ? 'bg-white/[0.06] text-white/80'
+                  : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
+              }`}
+            >
+              <span className="max-w-[100px] truncate">{tab.agentName}</span>
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  onCloseTab(tab.agentId);
+                }}
+                className="rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-white/10"
+              >
+                <X className="size-2.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {/* Close all */}
+        <button
+          onClick={onCloseAll}
+          className="flex h-full items-center px-3 text-[10px] text-white/25 transition-colors hover:text-white/50"
+        >
+          Close all
+        </button>
+      </div>
+
+      {/* Terminal content */}
+      {!collapsed && activeTab && (
+        <div style={{ height: EXPANDED_HEIGHT }} className="overflow-hidden">
+          <AgentTerminalInline
+            key={activeTab.agentId}
+            townId={townId}
+            agentId={activeTab.agentId}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Inline terminal variant that fills its container (no Card wrapper).
+ * Re-uses the AgentTerminal logic but just renders the terminal div.
+ */
+function AgentTerminalInline({ townId, agentId }: { townId: string; agentId: string }) {
+  return (
+    <div className="h-full">
+      <AgentTerminal
+        townId={townId}
+        agentId={agentId}
+        onClose={() => {
+          // no-op: closing is handled by the tab bar
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/gastown/BeadBoard.tsx
+++ b/src/components/gastown/BeadBoard.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { Trash2 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
+import { motion, AnimatePresence } from 'motion/react';
 
 type Bead = {
   bead_id: string;
@@ -67,8 +68,6 @@ function BeadCard({
     ? agentNameById?.[bead.assignee_agent_bead_id]
     : null;
 
-  // Use a non-interactive wrapper (div) + interactive elements inside.
-  // Avoid nesting <button> inside <button> (invalid HTML, a11y issues).
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!onSelect) return;
     if (e.key === 'Enter' || e.key === ' ') {
@@ -177,10 +176,15 @@ export function BeadBoard({
 
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-      {statusColumns.map(status => {
-        const columnBeads = beads.filter(b => b.status === status);
+      {statusColumns.map((status, colIdx) => {
+        const columnBeads = beads.filter(b => b.status === status && b.type !== 'agent');
         return (
-          <div key={status}>
+          <motion.div
+            key={status}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: colIdx * 0.08, duration: 0.3 }}
+          >
             <div className="mb-3 flex items-center gap-2">
               <span
                 className={cn(
@@ -190,24 +194,53 @@ export function BeadBoard({
               >
                 {statusLabels[status]}
               </span>
-              <span className="text-xs text-white/45">{columnBeads.length}</span>
+              <motion.span
+                key={columnBeads.length}
+                initial={{ scale: 1.3, opacity: 0.5 }}
+                animate={{ scale: 1, opacity: 1 }}
+                className="text-xs text-white/45"
+              >
+                {columnBeads.length}
+              </motion.span>
             </div>
             <div className="space-y-2">
-              {columnBeads.length === 0 && (
-                <p className="py-4 text-center text-xs text-white/35">No beads</p>
-              )}
-              {columnBeads.map(bead => (
-                <BeadCard
-                  key={bead.bead_id}
-                  bead={bead}
-                  onDelete={onDeleteBead ? () => onDeleteBead(bead.bead_id) : undefined}
-                  onSelect={onSelectBead ? () => onSelectBead(bead) : undefined}
-                  isSelected={selectedBeadId === bead.bead_id}
-                  agentNameById={agentNameById}
-                />
-              ))}
+              <AnimatePresence mode="popLayout" initial={false}>
+                {columnBeads.length === 0 && (
+                  <motion.p
+                    key="empty"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    className="py-4 text-center text-xs text-white/35"
+                  >
+                    No beads
+                  </motion.p>
+                )}
+                {columnBeads.map(bead => (
+                  <motion.div
+                    key={bead.bead_id}
+                    layout
+                    initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                    animate={{ opacity: 1, scale: 1, y: 0 }}
+                    exit={{ opacity: 0, scale: 0.95, y: -10 }}
+                    transition={{
+                      layout: { duration: 0.3, ease: [0.25, 0.1, 0.25, 1] },
+                      opacity: { duration: 0.2 },
+                      scale: { duration: 0.2 },
+                    }}
+                  >
+                    <BeadCard
+                      bead={bead}
+                      onDelete={onDeleteBead ? () => onDeleteBead(bead.bead_id) : undefined}
+                      onSelect={onSelectBead ? () => onSelectBead(bead) : undefined}
+                      isSelected={selectedBeadId === bead.bead_id}
+                      agentNameById={agentNameById}
+                    />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
-          </div>
+          </motion.div>
         );
       })}
     </div>

--- a/src/components/gastown/BeadDetailDrawer.tsx
+++ b/src/components/gastown/BeadDetailDrawer.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { Drawer } from 'vaul';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/Button';
+import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+import { formatDistanceToNow, format } from 'date-fns';
+import { Clock, Flag, Hash, Tags, User, X, Hexagon, FileText, GitBranch } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Bead = RouterOutputs['gastown']['listBeads'][number];
+
+type BeadDetailDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bead: Bead | null;
+  rigId: string;
+  agentNameById?: Record<string, string>;
+  onDelete?: () => void;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  open: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
+  in_progress: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  closed: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  failed: 'border-red-500/30 bg-red-500/10 text-red-300',
+};
+
+const PRIORITY_STYLES: Record<string, string> = {
+  critical: 'text-red-400',
+  high: 'text-orange-400',
+  medium: 'text-amber-400',
+  low: 'text-white/50',
+};
+
+export function BeadDetailDrawer({
+  open,
+  onOpenChange,
+  bead,
+  rigId,
+  agentNameById,
+  onDelete,
+}: BeadDetailDrawerProps) {
+  const assigneeName = bead?.assignee_agent_bead_id
+    ? agentNameById?.[bead.assignee_agent_bead_id]
+    : null;
+
+  return (
+    <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
+        <Drawer.Content
+          className="fixed top-0 right-0 bottom-0 z-50 flex w-[520px] max-w-[94vw] flex-col outline-none"
+          style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
+        >
+          <div className="flex h-full flex-col overflow-hidden rounded-l-2xl border-l border-white/[0.08] bg-[oklch(0.12_0_0)]">
+            {/* Header */}
+            <div className="flex items-start justify-between border-b border-white/[0.06] px-5 pt-5 pb-4">
+              <div className="min-w-0 flex-1">
+                <Drawer.Title className="flex items-center gap-2 text-base font-semibold text-white/90">
+                  <Hexagon className="size-4 shrink-0 text-[color:oklch(95%_0.15_108_/_0.7)]" />
+                  <span className="truncate">{bead?.title ?? 'Bead'}</span>
+                </Drawer.Title>
+                <Drawer.Description className="mt-1.5 text-xs text-white/35">
+                  Full inspection view — metadata, body, and event timeline.
+                </Drawer.Description>
+
+                {bead && (
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] font-medium ${STATUS_STYLES[bead.status] ?? 'border-white/10 text-white/50'}`}
+                    >
+                      {bead.status.replace('_', ' ')}
+                    </span>
+                    <Badge variant="outline" className="text-[10px]">
+                      {bead.type}
+                    </Badge>
+                    <span
+                      className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${PRIORITY_STYLES[bead.priority] ?? 'text-white/50'}`}
+                    >
+                      <Flag className="size-2.5" />
+                      {bead.priority}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex shrink-0 items-center gap-1.5">
+                {onDelete && bead && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={onDelete}
+                    className="border border-red-500/20 bg-red-500/10 text-xs text-red-300 hover:bg-red-500/15"
+                  >
+                    Delete
+                  </Button>
+                )}
+                <button
+                  onClick={() => onOpenChange(false)}
+                  className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+                >
+                  <X className="size-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto">
+              {!bead ? (
+                <div className="p-6 text-center text-sm text-white/30">
+                  Select a bead to inspect.
+                </div>
+              ) : (
+                <div className="flex flex-col gap-0">
+                  {/* Metadata grid */}
+                  <div className="grid grid-cols-2 border-b border-white/[0.06]">
+                    <MetaCell icon={Hash} label="Bead ID" value={bead.bead_id.slice(0, 8)} mono />
+                    <MetaCell
+                      icon={Clock}
+                      label="Created"
+                      value={format(new Date(bead.created_at), 'MMM d, HH:mm')}
+                    />
+                    <MetaCell
+                      icon={User}
+                      label="Assignee"
+                      value={
+                        assigneeName ??
+                        (bead.assignee_agent_bead_id
+                          ? bead.assignee_agent_bead_id.slice(0, 8)
+                          : 'Unassigned')
+                      }
+                    />
+                    <MetaCell
+                      icon={Tags}
+                      label="Labels"
+                      value={bead.labels.length ? bead.labels.join(', ') : 'None'}
+                    />
+                    {bead.parent_bead_id && (
+                      <MetaCell
+                        icon={GitBranch}
+                        label="Parent"
+                        value={bead.parent_bead_id.slice(0, 8)}
+                        mono
+                      />
+                    )}
+                  </div>
+
+                  {/* Body */}
+                  {bead.body && bead.body.trim().length > 0 && (
+                    <div className="border-b border-white/[0.06] px-5 py-4">
+                      <div className="mb-2 flex items-center gap-1.5">
+                        <FileText className="size-3 text-white/25" />
+                        <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                          Description
+                        </span>
+                      </div>
+                      <div className="prose prose-sm prose-invert prose-headings:text-white/80 prose-p:text-white/65 prose-a:text-[color:oklch(95%_0.15_108)] prose-strong:text-white/80 prose-code:rounded prose-code:bg-white/[0.06] prose-code:px-1 prose-code:py-0.5 prose-code:text-[11px] prose-code:text-white/70 prose-pre:bg-white/[0.04] prose-pre:border prose-pre:border-white/[0.06] prose-li:text-white/65 max-w-none">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{bead.body}</ReactMarkdown>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Event Timeline */}
+                  <div className="px-5 pt-4 pb-2">
+                    <div className="mb-2 flex items-center gap-1.5">
+                      <Clock className="size-3 text-white/25" />
+                      <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                        Event Timeline
+                      </span>
+                    </div>
+                  </div>
+                  <div className="px-3 pb-6">
+                    <BeadEventTimeline rigId={rigId} beadId={bead.bead_id} />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}
+
+function MetaCell({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="border-r border-b border-white/[0.04] px-4 py-3 last:border-r-0 [&:nth-child(2n)]:border-r-0">
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className={`mt-0.5 truncate text-sm text-white/75 ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/components/gastown/ConvoyTimeline.tsx
+++ b/src/components/gastown/ConvoyTimeline.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+import { formatDistanceToNow, differenceInMinutes } from 'date-fns';
+import { Hexagon, Clock, AlertTriangle, CheckCircle, Loader2 } from 'lucide-react';
+import { motion } from 'motion/react';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Bead = RouterOutputs['gastown']['listBeads'][number];
+
+type ConvoyTimelineProps = {
+  /** All beads from a rig (or across rigs) */
+  beads: Bead[];
+  agentNameById: Record<string, string>;
+  onSelectBead?: (beadId: string) => void;
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  open: 'border-sky-500/40 bg-sky-500/15',
+  in_progress: 'border-amber-500/40 bg-amber-500/15',
+  closed: 'border-emerald-500/40 bg-emerald-500/15',
+  failed: 'border-red-500/40 bg-red-500/15',
+};
+
+const STATUS_DOT_COLORS: Record<string, string> = {
+  open: 'bg-sky-400',
+  in_progress: 'bg-amber-400',
+  closed: 'bg-emerald-400',
+  failed: 'bg-red-400',
+};
+
+/**
+ * Horizontal timeline showing bead completion events over time.
+ * Groups beads by parent_bead_id to form "convoys".
+ */
+export function ConvoyTimeline({ beads, agentNameById, onSelectBead }: ConvoyTimelineProps) {
+  // Group into convoys by parent_bead_id
+  const convoys = useMemo(() => {
+    const groups: Record<string, Bead[]> = {};
+    const standalone: Bead[] = [];
+
+    for (const bead of beads) {
+      if (bead.parent_bead_id) {
+        const key = bead.parent_bead_id;
+        groups[key] ??= [];
+        groups[key].push(bead);
+      } else {
+        standalone.push(bead);
+      }
+    }
+
+    const result: Array<{ id: string; label: string; beads: Bead[]; isConvoy: boolean }> = [];
+
+    // Add actual convoys
+    for (const [parentId, children] of Object.entries(groups)) {
+      const parent = beads.find(b => b.bead_id === parentId);
+      result.push({
+        id: parentId,
+        label: parent?.title ?? `Convoy ${parentId.slice(0, 8)}`,
+        beads: children.sort(
+          (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        ),
+        isConvoy: true,
+      });
+    }
+
+    // Add standalone beads as single-bead "convoys"
+    for (const bead of standalone) {
+      if (!groups[bead.bead_id]) {
+        result.push({
+          id: bead.bead_id,
+          label: bead.title,
+          beads: [bead],
+          isConvoy: false,
+        });
+      }
+    }
+
+    return result;
+  }, [beads]);
+
+  if (beads.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Hexagon className="mb-2 size-6 text-white/10" />
+        <p className="text-xs text-white/25">No beads to visualize.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {convoys.map(convoy => {
+        const completedCount = convoy.beads.filter(b => b.status === 'closed').length;
+        const total = convoy.beads.length;
+        const allDone = completedCount === total;
+        const hasStalled = convoy.beads.some(b => b.status === 'open' && !b.assignee_agent_bead_id);
+
+        return (
+          <div
+            key={convoy.id}
+            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3"
+          >
+            {/* Convoy header */}
+            <div className="mb-2.5 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {convoy.isConvoy && (
+                  <span className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[9px] font-medium text-white/40">
+                    CONVOY
+                  </span>
+                )}
+                <span className="max-w-[300px] truncate text-xs font-medium text-white/70">
+                  {convoy.label}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                {hasStalled && (
+                  <span className="flex items-center gap-1 text-[9px] text-orange-400">
+                    <AlertTriangle className="size-2.5" />
+                    Stranded
+                  </span>
+                )}
+                <span className="font-mono text-[10px] text-white/30">
+                  {completedCount}/{total}
+                </span>
+              </div>
+            </div>
+
+            {/* Timeline track */}
+            <div className="relative flex items-center gap-1 overflow-x-auto py-1">
+              {/* Track line */}
+              <div className="absolute top-1/2 right-0 left-0 h-px -translate-y-1/2 bg-white/[0.06]" />
+
+              {convoy.beads.map((bead, i) => {
+                const assigneeName = bead.assignee_agent_bead_id
+                  ? agentNameById[bead.assignee_agent_bead_id]
+                  : null;
+
+                return (
+                  <motion.button
+                    key={bead.bead_id}
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ delay: i * 0.06, duration: 0.25 }}
+                    onClick={() => onSelectBead?.(bead.bead_id)}
+                    className={`relative z-10 flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[10px] transition-all hover:scale-105 ${STATUS_COLORS[bead.status] ?? 'border-white/10 bg-white/[0.03]'}`}
+                    title={`${bead.title} (${bead.status})`}
+                  >
+                    {bead.status === 'closed' ? (
+                      <CheckCircle className="size-3 text-emerald-400" />
+                    ) : bead.status === 'in_progress' ? (
+                      <Loader2 className="size-3 animate-spin text-amber-400" />
+                    ) : (
+                      <span
+                        className={`size-2 rounded-full ${STATUS_DOT_COLORS[bead.status] ?? 'bg-white/20'}`}
+                      />
+                    )}
+                    <span className="max-w-[80px] truncate text-white/70">
+                      {bead.title.slice(0, 20)}
+                    </span>
+                    {assigneeName && <span className="ml-0.5 text-white/30">{assigneeName}</span>}
+                  </motion.button>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Detects convoys where beads are open but no agents are assigned.
+ */
+export function StrandedConvoyAlert({ beads, onSling }: { beads: Bead[]; onSling?: () => void }) {
+  const strandedBeads = beads.filter(b => b.status === 'open' && !b.assignee_agent_bead_id);
+
+  if (strandedBeads.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-orange-500/20 bg-orange-500/5 px-4 py-2.5">
+      <AlertTriangle className="size-4 shrink-0 text-orange-400" />
+      <div className="flex-1">
+        <span className="text-xs font-medium text-orange-300">
+          {strandedBeads.length} stranded bead{strandedBeads.length > 1 ? 's' : ''}
+        </span>
+        <span className="ml-1 text-[10px] text-orange-400/60">— open but no agent assigned</span>
+      </div>
+      {onSling && (
+        <button
+          onClick={onSling}
+          className="rounded-md bg-orange-500/15 px-3 py-1 text-[10px] font-medium text-orange-300 transition-colors hover:bg-orange-500/25"
+        >
+          Sling
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/gastown/DrawerStack.tsx
+++ b/src/components/gastown/DrawerStack.tsx
@@ -8,7 +8,7 @@ import { X, ChevronLeft } from 'lucide-react';
 
 export type ResourceRef =
   | { type: 'bead'; beadId: string; rigId: string }
-  | { type: 'agent'; agentId: string; rigId: string; townId: string }
+  | { type: 'agent'; agentId: string; rigId: string; townId?: string }
   | { type: 'event'; event: import('./ActivityFeed').TownEvent };
 
 type DrawerStackEntry = {

--- a/src/components/gastown/DrawerStack.tsx
+++ b/src/components/gastown/DrawerStack.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, useRef, type ReactNode } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { X, ChevronLeft } from 'lucide-react';
+
+// ── Resource types ───────────────────────────────────────────────────────
+
+export type ResourceRef =
+  | { type: 'bead'; beadId: string; rigId: string }
+  | { type: 'agent'; agentId: string; rigId: string; townId: string }
+  | { type: 'event'; event: import('./ActivityFeed').TownEvent };
+
+type DrawerStackEntry = {
+  key: string;
+  resource: ResourceRef;
+};
+
+// ── Context ──────────────────────────────────────────────────────────────
+
+type DrawerStackContextValue = {
+  stack: DrawerStackEntry[];
+  push: (resource: ResourceRef) => void;
+  pop: () => void;
+  closeAll: () => void;
+  /** Replace the entire stack with a single entry (for opening from a page) */
+  open: (resource: ResourceRef) => void;
+};
+
+const DrawerStackContext = createContext<DrawerStackContextValue | null>(null);
+
+export function useDrawerStack() {
+  const ctx = useContext(DrawerStackContext);
+  if (!ctx) throw new Error('useDrawerStack must be used within DrawerStackProvider');
+  return ctx;
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────
+
+let globalKeyCounter = 0;
+
+function makeKey() {
+  return `drawer-${++globalKeyCounter}`;
+}
+
+export function DrawerStackProvider({
+  children,
+  renderContent,
+}: {
+  children: ReactNode;
+  /** Render the drawer body for a given resource. Receives onNavigate to push sub-resources. */
+  renderContent: (
+    resource: ResourceRef,
+    helpers: {
+      push: (resource: ResourceRef) => void;
+      close: () => void;
+    }
+  ) => ReactNode;
+}) {
+  const [stack, setStack] = useState<DrawerStackEntry[]>([]);
+
+  const push = useCallback((resource: ResourceRef) => {
+    setStack(prev => [...prev, { key: makeKey(), resource }]);
+  }, []);
+
+  const pop = useCallback(() => {
+    setStack(prev => (prev.length > 0 ? prev.slice(0, -1) : prev));
+  }, []);
+
+  const closeAll = useCallback(() => {
+    setStack([]);
+  }, []);
+
+  const open = useCallback((resource: ResourceRef) => {
+    setStack([{ key: makeKey(), resource }]);
+  }, []);
+
+  return (
+    <DrawerStackContext.Provider value={{ stack, push, pop, closeAll, open }}>
+      {children}
+      <DrawerStackRenderer
+        stack={stack}
+        pop={pop}
+        closeAll={closeAll}
+        push={push}
+        renderContent={renderContent}
+      />
+    </DrawerStackContext.Provider>
+  );
+}
+
+// ── Renderer ─────────────────────────────────────────────────────────────
+
+const DRAWER_WIDTH = 500;
+/** How many px each background layer shifts left per depth level */
+const DEPTH_OFFSET = 40;
+/** Extra shift on hover */
+const HOVER_EXTRA = 24;
+
+function DrawerStackRenderer({
+  stack,
+  pop,
+  closeAll,
+  push,
+  renderContent,
+}: {
+  stack: DrawerStackEntry[];
+  pop: () => void;
+  closeAll: () => void;
+  push: (resource: ResourceRef) => void;
+  renderContent: (
+    resource: ResourceRef,
+    helpers: { push: (resource: ResourceRef) => void; close: () => void }
+  ) => ReactNode;
+}) {
+  const isOpen = stack.length > 0;
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop — click to close all */}
+          <motion.div
+            key="drawer-stack-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={closeAll}
+            className="fixed inset-0 z-[60] bg-black/50"
+          />
+
+          {/* Drawer layers */}
+          {stack.map((entry, index) => {
+            const depth = stack.length - 1 - index; // 0 = top
+            const isTop = depth === 0;
+
+            return (
+              <DrawerLayer
+                key={entry.key}
+                depth={depth}
+                totalLayers={stack.length}
+                isTop={isTop}
+                onClose={isTop ? pop : undefined}
+                onBack={index > 0 && isTop ? pop : undefined}
+              >
+                {renderContent(entry.resource, {
+                  push,
+                  close: isTop ? pop : closeAll,
+                })}
+              </DrawerLayer>
+            );
+          })}
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+// ── Individual drawer layer ──────────────────────────────────────────────
+
+function DrawerLayer({
+  depth,
+  totalLayers,
+  isTop,
+  onClose,
+  onBack,
+  children,
+}: {
+  depth: number;
+  totalLayers: number;
+  isTop: boolean;
+  onClose?: () => void;
+  onBack?: (() => void) | false;
+  children: ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  // Top layer: right: 0. Background layers: shift left by depth * offset.
+  // On hover, background layers shift further left.
+  const rightOffset = isTop ? 0 : -(depth * DEPTH_OFFSET + (hovered ? HOVER_EXTRA : 0));
+  const scale = isTop ? 1 : 1 - depth * 0.015;
+  const opacity = isTop ? 1 : 0.6 + (hovered ? 0.25 : 0);
+
+  return (
+    <motion.div
+      initial={{ x: DRAWER_WIDTH + 20 }}
+      animate={{
+        x: rightOffset,
+        scale,
+        opacity,
+      }}
+      exit={{ x: DRAWER_WIDTH + 20, opacity: 0 }}
+      transition={{
+        type: 'spring',
+        stiffness: 400,
+        damping: 35,
+        opacity: { duration: 0.2 },
+      }}
+      onMouseEnter={() => {
+        if (!isTop) setHovered(true);
+      }}
+      onMouseLeave={() => setHovered(false)}
+      className="fixed top-0 right-0 bottom-0 z-[61] flex flex-col outline-none"
+      style={{
+        width: DRAWER_WIDTH,
+        maxWidth: '94vw',
+        zIndex: 61 + (totalLayers - depth),
+        pointerEvents: isTop ? 'auto' : hovered ? 'auto' : 'none',
+      }}
+    >
+      <div className="flex h-full flex-col overflow-hidden rounded-l-2xl border-l border-white/[0.08] bg-[oklch(0.12_0_0)] shadow-2xl">
+        {/* Header bar with back / close */}
+        <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2">
+          <div className="flex items-center gap-1">
+            {onBack && (
+              <button
+                onClick={onBack}
+                className="rounded-md p-1 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+              >
+                <ChevronLeft className="size-4" />
+              </button>
+            )}
+          </div>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="rounded-md p-1 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto">{children}</div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/gastown/DrawerStackContent.tsx
+++ b/src/components/gastown/DrawerStackContent.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { ResourceRef } from './DrawerStack';
+import { BeadPanel } from './drawer-panels/BeadPanel';
+import { AgentPanel } from './drawer-panels/AgentPanel';
+import { EventPanel } from './drawer-panels/EventPanel';
+
+/**
+ * Dispatch function that maps a ResourceRef to the right panel component.
+ * Passed as `renderContent` to DrawerStackProvider.
+ */
+export function renderDrawerContent(
+  resource: ResourceRef,
+  helpers: { push: (ref: ResourceRef) => void; close: () => void }
+): ReactNode {
+  switch (resource.type) {
+    case 'bead':
+      return <BeadPanel beadId={resource.beadId} rigId={resource.rigId} push={helpers.push} />;
+    case 'agent':
+      return (
+        <AgentPanel
+          agentId={resource.agentId}
+          rigId={resource.rigId}
+          townId={resource.townId}
+          push={helpers.push}
+          close={helpers.close}
+        />
+      );
+    case 'event':
+      return <EventPanel event={resource.event} push={helpers.push} />;
+  }
+}

--- a/src/components/gastown/EventDetailDrawer.tsx
+++ b/src/components/gastown/EventDetailDrawer.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { Drawer } from 'vaul';
+import type { TownEvent } from './ActivityFeed';
+import { format, formatDistanceToNow } from 'date-fns';
+import {
+  X,
+  Activity,
+  GitMerge,
+  AlertTriangle,
+  CheckCircle,
+  PlayCircle,
+  PauseCircle,
+  Mail,
+  Hash,
+  Clock,
+  Bot,
+  Hexagon,
+  FileText,
+  ArrowRight,
+} from 'lucide-react';
+
+type EventDetailDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  event: TownEvent | null;
+};
+
+const EVENT_ICONS: Record<string, typeof Activity> = {
+  created: PlayCircle,
+  hooked: PlayCircle,
+  unhooked: PauseCircle,
+  status_changed: Activity,
+  closed: CheckCircle,
+  escalated: AlertTriangle,
+  review_submitted: GitMerge,
+  review_completed: GitMerge,
+  mail_sent: Mail,
+};
+
+const EVENT_ACCENT: Record<string, string> = {
+  created: 'border-sky-500/20 bg-sky-500/8',
+  hooked: 'border-emerald-500/20 bg-emerald-500/8',
+  unhooked: 'border-amber-500/20 bg-amber-500/8',
+  status_changed: 'border-violet-500/20 bg-violet-500/8',
+  closed: 'border-emerald-500/20 bg-emerald-500/8',
+  escalated: 'border-red-500/20 bg-red-500/8',
+  review_submitted: 'border-indigo-500/20 bg-indigo-500/8',
+  review_completed: 'border-emerald-500/20 bg-emerald-500/8',
+  mail_sent: 'border-sky-500/20 bg-sky-500/8',
+};
+
+const EVENT_ICON_COLOR: Record<string, string> = {
+  created: 'text-sky-400',
+  hooked: 'text-emerald-400',
+  unhooked: 'text-amber-400',
+  status_changed: 'text-violet-400',
+  closed: 'text-emerald-400',
+  escalated: 'text-red-400',
+  review_submitted: 'text-indigo-400',
+  review_completed: 'text-emerald-400',
+  mail_sent: 'text-sky-400',
+};
+
+const EVENT_LABEL: Record<string, string> = {
+  created: 'Bead Created',
+  hooked: 'Agent Hooked',
+  unhooked: 'Agent Unhooked',
+  status_changed: 'Status Changed',
+  closed: 'Bead Closed',
+  escalated: 'Escalation Created',
+  review_submitted: 'Submitted for Review',
+  review_completed: 'Review Completed',
+  mail_sent: 'Mail Sent',
+};
+
+export function EventDetailDrawer({ open, onOpenChange, event }: EventDetailDrawerProps) {
+  if (!event) return null;
+
+  const Icon = EVENT_ICONS[event.event_type] ?? Activity;
+  const accent = EVENT_ACCENT[event.event_type] ?? 'border-white/10 bg-white/5';
+  const iconColor = EVENT_ICON_COLOR[event.event_type] ?? 'text-white/50';
+  const label = EVENT_LABEL[event.event_type] ?? event.event_type;
+
+  const metadataEntries = Object.entries(event.metadata).filter(
+    ([, v]) => v !== null && v !== undefined && v !== ''
+  );
+
+  return (
+    <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Drawer.Content
+          className="fixed top-0 right-0 bottom-0 z-50 flex w-[440px] max-w-[92vw] flex-col outline-none"
+          style={{ '--initial-transform': 'calc(100% + 8px)' } as React.CSSProperties}
+        >
+          <div className="flex h-full flex-col overflow-hidden rounded-l-2xl border-l border-white/[0.08] bg-[oklch(0.12_0_0)]">
+            {/* Header */}
+            <div className="flex items-start justify-between border-b border-white/[0.06] px-5 pt-5 pb-4">
+              <div className="min-w-0 flex-1">
+                <Drawer.Title className="text-base font-semibold text-white/90">
+                  Event Detail
+                </Drawer.Title>
+                <Drawer.Description className="mt-1 text-xs text-white/30">
+                  Full context for this activity event.
+                </Drawer.Description>
+              </div>
+              <button
+                onClick={() => onOpenChange(false)}
+                className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto">
+              {/* Event type banner */}
+              <div className={`mx-5 mt-4 rounded-xl border p-4 ${accent}`}>
+                <div className="flex items-center gap-3">
+                  <div
+                    className={`flex size-10 items-center justify-center rounded-lg bg-black/20 ${iconColor}`}
+                  >
+                    <Icon className="size-5" />
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-white/85">{label}</div>
+                    <div className="mt-0.5 text-[10px] text-white/40 capitalize">
+                      {event.event_type.replace(/_/g, ' ')}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Metadata grid */}
+              <div className="mt-4 border-t border-white/[0.06]">
+                <div className="grid grid-cols-2">
+                  <MetaCell
+                    icon={Hash}
+                    label="Event ID"
+                    value={event.bead_event_id.slice(0, 12)}
+                    mono
+                  />
+                  <MetaCell
+                    icon={Clock}
+                    label="Time"
+                    value={format(new Date(event.created_at), 'MMM d, HH:mm:ss')}
+                  />
+                  <MetaCell icon={Hexagon} label="Bead" value={event.bead_id.slice(0, 12)} mono />
+                  <MetaCell
+                    icon={Bot}
+                    label="Agent"
+                    value={event.agent_id ? event.agent_id.slice(0, 12) : 'System'}
+                    mono={Boolean(event.agent_id)}
+                  />
+                  {'rig_name' in event && event.rig_name && (
+                    <MetaCell icon={FileText} label="Rig" value={event.rig_name} />
+                  )}
+                  <MetaCell
+                    icon={Clock}
+                    label="Relative"
+                    value={formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                  />
+                </div>
+              </div>
+
+              {/* Value transition */}
+              {(event.old_value || event.new_value) && (
+                <div className="mx-5 mt-4">
+                  <div className="mb-2 text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                    Value Change
+                  </div>
+                  <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                    <span className="max-w-[140px] truncate rounded bg-white/[0.04] px-2 py-1 font-mono text-xs text-white/50">
+                      {event.old_value ?? '—'}
+                    </span>
+                    <ArrowRight className="size-3.5 shrink-0 text-white/20" />
+                    <span className="max-w-[140px] truncate rounded bg-white/[0.04] px-2 py-1 font-mono text-xs text-white/70">
+                      {event.new_value ?? '—'}
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              {/* Metadata */}
+              {metadataEntries.length > 0 && (
+                <div className="mx-5 mt-4 pb-6">
+                  <div className="mb-2 text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                    Metadata
+                  </div>
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02]">
+                    {metadataEntries.map(([key, value], i) => (
+                      <div
+                        key={key}
+                        className={`flex items-start justify-between gap-4 px-3 py-2 ${
+                          i < metadataEntries.length - 1 ? 'border-b border-white/[0.04]' : ''
+                        }`}
+                      >
+                        <span className="shrink-0 text-[11px] text-white/40">{key}</span>
+                        <span className="min-w-0 truncate text-right font-mono text-[11px] text-white/65">
+                          {typeof value === 'string' ? value : JSON.stringify(value)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}
+
+function MetaCell({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className={`mt-0.5 truncate text-sm text-white/75 ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/components/gastown/GastownTownSidebar.tsx
+++ b/src/components/gastown/GastownTownSidebar.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarFooter,
+  SidebarSeparator,
+} from '@/components/ui/sidebar';
+import {
+  ArrowLeft,
+  LayoutDashboard,
+  Hexagon,
+  Bot,
+  GitMerge,
+  Mail,
+  Activity,
+  Settings,
+  Crown,
+} from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+
+type GastownTownSidebarProps = {
+  townId: string;
+} & React.ComponentProps<typeof Sidebar>;
+
+export function GastownTownSidebar({ townId, ...sidebarProps }: GastownTownSidebarProps) {
+  const pathname = usePathname();
+  const trpc = useTRPC();
+
+  const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+
+  const townName = townQuery.data?.name ?? 'Town';
+  const rigs = rigsQuery.data ?? [];
+
+  const basePath = `/gastown/${townId}`;
+
+  const isActive = (path: string) => {
+    if (path === basePath) return pathname === basePath;
+    return pathname.startsWith(path);
+  };
+
+  const navItems = [
+    { title: 'Overview', icon: LayoutDashboard, url: basePath },
+    { title: 'Beads', icon: Hexagon, url: `${basePath}/beads` },
+    { title: 'Agents', icon: Bot, url: `${basePath}/agents` },
+    { title: 'Merge Queue', icon: GitMerge, url: `${basePath}/merges` },
+    { title: 'Mail', icon: Mail, url: `${basePath}/mail` },
+    { title: 'Observability', icon: Activity, url: `${basePath}/observability` },
+  ];
+
+  return (
+    <Sidebar {...sidebarProps}>
+      <SidebarHeader className="p-3">
+        <div className="flex flex-col gap-3">
+          {/* Back link */}
+          <Link
+            href="/gastown"
+            prefetch={false}
+            className="group/back inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs text-white/45 transition-colors hover:bg-white/5 hover:text-white/75"
+          >
+            <ArrowLeft className="size-3 transition-transform group-hover/back:-translate-x-0.5" />
+            All towns
+          </Link>
+
+          {/* Town identity */}
+          <div className="flex items-center gap-2.5 px-1">
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-[color:oklch(95%_0.15_108_/_0.15)] ring-1 ring-[color:oklch(95%_0.15_108_/_0.25)]">
+              <Crown className="size-4 text-[color:oklch(95%_0.15_108)]" />
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-white/90">{townName}</div>
+              <div className="flex items-center gap-1.5 text-[10px] text-white/40">
+                <span className="size-1.5 rounded-full bg-emerald-400" />
+                Live
+              </div>
+            </div>
+          </div>
+        </div>
+      </SidebarHeader>
+
+      <SidebarSeparator />
+
+      <SidebarContent>
+        {/* Primary navigation */}
+        <SidebarGroup>
+          <SidebarGroupLabel className="text-[10px] font-semibold tracking-[0.08em] text-white/30 uppercase">
+            Navigation
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {navItems.map((item, i) => (
+                <motion.div
+                  key={item.title}
+                  initial={{ opacity: 0, x: -8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: i * 0.04, duration: 0.2 }}
+                >
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={isActive(item.url)}>
+                      <Link href={item.url} prefetch={false}>
+                        <item.icon className="size-4" />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </motion.div>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {/* Rigs section */}
+        {rigs.length > 0 && (
+          <SidebarGroup>
+            <SidebarGroupLabel className="text-[10px] font-semibold tracking-[0.08em] text-white/30 uppercase">
+              Rigs
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <AnimatePresence initial={false}>
+                  {rigs.map((rig, i) => {
+                    const rigPath = `${basePath}/rigs/${rig.id}`;
+                    return (
+                      <motion.div
+                        key={rig.id}
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                        transition={{ delay: i * 0.03, duration: 0.2 }}
+                      >
+                        <SidebarMenuItem>
+                          <SidebarMenuButton asChild isActive={isActive(rigPath)}>
+                            <Link href={rigPath} prefetch={false}>
+                              <div className="flex size-4 items-center justify-center rounded bg-white/[0.06] text-[9px] font-bold text-white/50">
+                                {rig.name.charAt(0).toUpperCase()}
+                              </div>
+                              <span className="truncate">{rig.name}</span>
+                            </Link>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      </motion.div>
+                    );
+                  })}
+                </AnimatePresence>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
+      </SidebarContent>
+
+      <SidebarFooter className="p-2">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild isActive={isActive(`${basePath}/settings`)}>
+              <Link href={`${basePath}/settings`} prefetch={false}>
+                <Settings className="size-4" />
+                <span>Settings</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/src/components/gastown/GastownTownSidebar.tsx
+++ b/src/components/gastown/GastownTownSidebar.tsx
@@ -15,7 +15,6 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   SidebarFooter,
-  SidebarSeparator,
 } from '@/components/ui/sidebar';
 import {
   ArrowLeft,
@@ -90,7 +89,7 @@ export function GastownTownSidebar({ townId, ...sidebarProps }: GastownTownSideb
         </div>
       </SidebarHeader>
 
-      <SidebarSeparator />
+      <div className="mx-3 border-b border-white/[0.08]" />
 
       <SidebarContent>
         {/* Primary navigation */}

--- a/src/components/gastown/MoleculeStepper.tsx
+++ b/src/components/gastown/MoleculeStepper.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { CheckCircle, Circle, Loader2 } from 'lucide-react';
+import { motion } from 'motion/react';
+
+type MoleculeStep = {
+  name: string;
+  description?: string;
+  status: 'completed' | 'current' | 'pending';
+  summary?: string;
+};
+
+type MoleculeStepperProps = {
+  steps: MoleculeStep[];
+  moleculeName?: string;
+};
+
+/**
+ * Checkout-flow-style progress stepper for molecule/formula execution.
+ * Shows completed steps with summaries, current step pulsing, future steps dimmed.
+ */
+export function MoleculeStepper({ steps, moleculeName }: MoleculeStepperProps) {
+  if (steps.length === 0) {
+    return <div className="text-center text-xs text-white/25">No molecule steps attached.</div>;
+  }
+
+  return (
+    <div>
+      {moleculeName && (
+        <div className="mb-3 flex items-center gap-2">
+          <span className="rounded bg-violet-500/15 px-2 py-0.5 text-[9px] font-medium tracking-wide text-violet-300 uppercase">
+            Molecule
+          </span>
+          <span className="text-xs font-medium text-white/60">{moleculeName}</span>
+        </div>
+      )}
+
+      <div className="relative space-y-0">
+        {steps.map((step, i) => {
+          const isLast = i === steps.length - 1;
+
+          return (
+            <div key={i} className="relative flex gap-3">
+              {/* Vertical connector line */}
+              {!isLast && (
+                <div
+                  className={`absolute top-6 left-[11px] h-[calc(100%-8px)] w-px ${
+                    step.status === 'completed' ? 'bg-emerald-500/30' : 'bg-white/[0.06]'
+                  }`}
+                />
+              )}
+
+              {/* Step indicator */}
+              <div className="relative z-10 flex shrink-0 pt-0.5">
+                {step.status === 'completed' ? (
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ delay: i * 0.1, type: 'spring', stiffness: 300 }}
+                  >
+                    <CheckCircle className="size-[22px] text-emerald-400" />
+                  </motion.div>
+                ) : step.status === 'current' ? (
+                  <div className="relative">
+                    <Loader2 className="size-[22px] animate-spin text-[color:oklch(95%_0.15_108)]" />
+                    <span className="absolute -inset-1 animate-ping rounded-full bg-[color:oklch(95%_0.15_108_/_0.2)]" />
+                  </div>
+                ) : (
+                  <Circle className="size-[22px] text-white/15" />
+                )}
+              </div>
+
+              {/* Step content */}
+              <div className="flex-1 pb-5">
+                <div
+                  className={`text-sm font-medium ${
+                    step.status === 'completed'
+                      ? 'text-white/60'
+                      : step.status === 'current'
+                        ? 'text-white/90'
+                        : 'text-white/25'
+                  }`}
+                >
+                  {step.name}
+                </div>
+                {step.description && (
+                  <div
+                    className={`mt-0.5 text-[11px] ${
+                      step.status === 'pending' ? 'text-white/15' : 'text-white/35'
+                    }`}
+                  >
+                    {step.description}
+                  </div>
+                )}
+                {step.status === 'completed' && step.summary && (
+                  <div className="mt-1.5 rounded-md border border-emerald-500/10 bg-emerald-500/5 px-2.5 py-1.5 text-[10px] text-emerald-300/70">
+                    {step.summary}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+type Formula = {
+  name: string;
+  description: string;
+  stepCount: number;
+  steps: Array<{ name: string; description?: string }>;
+};
+
+type FormulaLibraryProps = {
+  formulas: Formula[];
+  onSelect?: (formula: Formula) => void;
+};
+
+/**
+ * Browse available formulas with descriptions and step previews.
+ */
+export function FormulaLibrary({ formulas, onSelect }: FormulaLibraryProps) {
+  if (formulas.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Circle className="mb-2 size-6 text-white/10" />
+        <p className="text-xs text-white/25">No formulas available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {formulas.map((formula, i) => (
+        <motion.button
+          key={i}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.05 }}
+          onClick={() => onSelect?.(formula)}
+          className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-white/75">{formula.name}</span>
+            <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[9px] text-white/30">
+              {formula.stepCount} steps
+            </span>
+          </div>
+          <div className="mt-1 text-[11px] text-white/35">{formula.description}</div>
+          <div className="mt-2 flex items-center gap-1">
+            {formula.steps.slice(0, 5).map((step, j) => (
+              <span
+                key={j}
+                className="rounded bg-white/[0.04] px-1.5 py-0.5 text-[8px] text-white/25"
+              >
+                {step.name}
+              </span>
+            ))}
+            {formula.steps.length > 5 && (
+              <span className="text-[8px] text-white/15">+{formula.steps.length - 5}</span>
+            )}
+          </div>
+        </motion.button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/gastown/SystemTopology.tsx
+++ b/src/components/gastown/SystemTopology.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useMemo, useRef, useEffect, useState } from 'react';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+import { Crown, Bot, Hexagon, Shield, Eye, GitBranch } from 'lucide-react';
+import { motion } from 'motion/react';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Rig = RouterOutputs['gastown']['listRigs'][number];
+type Agent = RouterOutputs['gastown']['listAgents'][number];
+type TownEvent = RouterOutputs['gastown']['getTownEvents'][number];
+
+type SystemTopologyProps = {
+  townName: string;
+  rigs: Rig[];
+  /** Map of rigId -> agents for that rig */
+  agentsByRig: Record<string, Agent[]>;
+  /** Recent events to show animated mail flow arrows */
+  recentEvents?: TownEvent[];
+  onSelectRig?: (rigId: string) => void;
+  onSelectAgent?: (agentId: string) => void;
+};
+
+const ROLE_ICONS: Record<string, typeof Bot> = {
+  polecat: Bot,
+  mayor: Crown,
+  refinery: Shield,
+  witness: Eye,
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  idle: 'stroke-white/20',
+  working: 'stroke-emerald-400',
+  active: 'stroke-emerald-400',
+  stalled: 'stroke-amber-400',
+  dead: 'stroke-red-400',
+  starting: 'stroke-sky-400',
+};
+
+const STATUS_FILL: Record<string, string> = {
+  idle: 'fill-white/10',
+  working: 'fill-emerald-400/20',
+  active: 'fill-emerald-400/20',
+  stalled: 'fill-amber-400/20',
+  dead: 'fill-red-400/20',
+  starting: 'fill-sky-400/20',
+};
+
+/**
+ * SVG-based system topology view showing the town structure.
+ * Mayor at center, rigs radiating outward, agents within each rig.
+ */
+export function SystemTopology({
+  townName,
+  rigs,
+  agentsByRig,
+  recentEvents = [],
+  onSelectRig,
+  onSelectAgent,
+}: SystemTopologyProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dims, setDims] = useState({ width: 800, height: 500 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setDims({
+          width: entry.contentRect.width,
+          height: Math.max(entry.contentRect.height, 400),
+        });
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const { width, height } = dims;
+  const cx = width / 2;
+  const cy = height / 2;
+  const rigRadius = Math.min(width, height) * 0.32;
+
+  // Compute rig positions in a circle around center
+  const rigPositions = useMemo(() => {
+    return rigs.map((rig, i) => {
+      const angle = (2 * Math.PI * i) / Math.max(rigs.length, 1) - Math.PI / 2;
+      return {
+        rig,
+        x: cx + rigRadius * Math.cos(angle),
+        y: cy + rigRadius * Math.sin(angle),
+        angle,
+      };
+    });
+  }, [rigs, cx, cy, rigRadius]);
+
+  // Compute agent positions around each rig
+  const agentPositions = useMemo(() => {
+    const positions: Array<{
+      agent: Agent;
+      x: number;
+      y: number;
+      rigX: number;
+      rigY: number;
+    }> = [];
+
+    for (const rp of rigPositions) {
+      const agents = agentsByRig[rp.rig.id] ?? [];
+      const agentOrbitRadius = 45;
+
+      agents.forEach((agent, j) => {
+        const agentAngle = rp.angle + (j - (agents.length - 1) / 2) * 0.5;
+        positions.push({
+          agent,
+          x: rp.x + agentOrbitRadius * Math.cos(agentAngle),
+          y: rp.y + agentOrbitRadius * Math.sin(agentAngle),
+          rigX: rp.x,
+          rigY: rp.y,
+        });
+      });
+    }
+    return positions;
+  }, [rigPositions, agentsByRig]);
+
+  // Recent mail events for animated arrows
+  const mailFlows = useMemo(() => {
+    return recentEvents.filter(e => e.event_type === 'mail_sent').slice(-8);
+  }, [recentEvents]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        className="overflow-visible"
+      >
+        {/* Background grid */}
+        <defs>
+          <pattern id="topoGrid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path
+              d="M 40 0 L 0 0 0 40"
+              fill="none"
+              stroke="oklch(1 0 0 / 0.03)"
+              strokeWidth="0.5"
+            />
+          </pattern>
+          {/* Glow filter */}
+          <filter id="glow">
+            <feGaussianBlur stdDeviation="3" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+          <radialGradient id="centerGlow">
+            <stop offset="0%" stopColor="oklch(95% 0.15 108)" stopOpacity="0.15" />
+            <stop offset="100%" stopColor="oklch(95% 0.15 108)" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        <rect width={width} height={height} fill="url(#topoGrid)" />
+
+        {/* Center glow */}
+        <circle cx={cx} cy={cy} r={rigRadius * 0.6} fill="url(#centerGlow)" />
+
+        {/* Connections from center to rigs */}
+        {rigPositions.map(rp => (
+          <line
+            key={rp.rig.id}
+            x1={cx}
+            y1={cy}
+            x2={rp.x}
+            y2={rp.y}
+            stroke="oklch(1 0 0 / 0.06)"
+            strokeWidth="1"
+            strokeDasharray="4 4"
+          />
+        ))}
+
+        {/* Connections from rigs to agents */}
+        {agentPositions.map(ap => (
+          <line
+            key={ap.agent.id}
+            x1={ap.rigX}
+            y1={ap.rigY}
+            x2={ap.x}
+            y2={ap.y}
+            stroke="oklch(1 0 0 / 0.04)"
+            strokeWidth="0.5"
+          />
+        ))}
+
+        {/* Animated mail flow arrows */}
+        {mailFlows.map((event, i) => {
+          // Animate from center outward for now (could be agent-to-agent with proper data)
+          const targetRig = rigPositions.find(rp => rp.rig.name === event.rig_name);
+          if (!targetRig) return null;
+
+          return (
+            <motion.circle
+              key={`mail-${event.bead_event_id}`}
+              cx={cx}
+              cy={cy}
+              r={2.5}
+              fill="oklch(0.7 0.15 200)"
+              filter="url(#glow)"
+              animate={{
+                cx: [cx, targetRig.x],
+                cy: [cy, targetRig.y],
+                opacity: [1, 0],
+              }}
+              transition={{
+                duration: 1.5,
+                delay: i * 0.2,
+                repeat: Infinity,
+                repeatDelay: 3,
+              }}
+            />
+          );
+        })}
+
+        {/* Agent nodes */}
+        {agentPositions.map(ap => {
+          const RoleIcon = ROLE_ICONS[ap.agent.role] ?? Bot;
+          return (
+            <g
+              key={ap.agent.id}
+              className="cursor-pointer"
+              onClick={() => onSelectAgent?.(ap.agent.id)}
+            >
+              <circle
+                cx={ap.x}
+                cy={ap.y}
+                r={10}
+                className={`${STATUS_FILL[ap.agent.status] ?? 'fill-white/5'} ${STATUS_COLORS[ap.agent.status] ?? 'stroke-white/10'}`}
+                strokeWidth="1"
+              />
+              <text x={ap.x} y={ap.y + 20} textAnchor="middle" className="fill-white/25 text-[8px]">
+                {ap.agent.name}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Rig nodes */}
+        {rigPositions.map(rp => (
+          <g key={rp.rig.id} className="cursor-pointer" onClick={() => onSelectRig?.(rp.rig.id)}>
+            <circle
+              cx={rp.x}
+              cy={rp.y}
+              r={22}
+              fill="oklch(0.15 0 0)"
+              stroke="oklch(1 0 0 / 0.12)"
+              strokeWidth="1.5"
+            />
+            <text
+              x={rp.x}
+              y={rp.y + 3}
+              textAnchor="middle"
+              className="fill-white/60 text-[9px] font-medium"
+            >
+              {rp.rig.name.slice(0, 5)}
+            </text>
+            <text x={rp.x} y={rp.y + 38} textAnchor="middle" className="fill-white/30 text-[8px]">
+              {rp.rig.name}
+            </text>
+          </g>
+        ))}
+
+        {/* Center (Mayor) node */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={28}
+          fill="oklch(0.12 0 0)"
+          stroke="oklch(95% 0.15 108 / 0.4)"
+          strokeWidth="2"
+          filter="url(#glow)"
+        />
+        <text
+          x={cx}
+          y={cy - 4}
+          textAnchor="middle"
+          className="fill-[color:oklch(95%_0.15_108)] text-[10px] font-bold"
+        >
+          MAYOR
+        </text>
+        <text x={cx} y={cy + 8} textAnchor="middle" className="fill-white/40 text-[7px]">
+          {townName}
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -1,0 +1,513 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { useSidebar } from '@/components/ui/sidebar';
+import { useTerminalBar } from './TerminalBarContext';
+import { ChevronDown, ChevronUp, Crown, Terminal as TerminalIcon, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+
+const COLLAPSED_HEIGHT = 38;
+const EXPANDED_HEIGHT = 300;
+
+type TerminalBarProps = {
+  townId: string;
+};
+
+/**
+ * Unified bottom terminal bar. Always shows a Mayor tab (non-closeable).
+ * Agent terminal tabs are opened/closed via TerminalBarContext.
+ */
+export function TerminalBar({ townId }: TerminalBarProps) {
+  const { state: sidebarState, isMobile } = useSidebar();
+  const {
+    tabs: agentTabs,
+    activeTabId,
+    collapsed,
+    closeTab,
+    setActiveTabId,
+    setCollapsed,
+  } = useTerminalBar();
+
+  const sidebarLeft = isMobile ? '0px' : sidebarState === 'expanded' ? '16rem' : '3rem';
+
+  const allTabs = [
+    { id: 'mayor', label: 'Mayor', kind: 'mayor' as const, agentId: '' },
+    ...agentTabs,
+  ];
+
+  // Default to mayor tab if nothing selected
+  const effectiveActiveId = activeTabId ?? 'mayor';
+  const activeTab = allTabs.find(t => t.id === effectiveActiveId) ?? allTabs[0];
+
+  return (
+    <div
+      className="fixed right-0 bottom-0 z-50 border-t border-white/[0.08] bg-[#0a0a0a] transition-[left] duration-200 ease-linear"
+      style={{
+        left: sidebarLeft,
+        height: collapsed ? COLLAPSED_HEIGHT : COLLAPSED_HEIGHT + EXPANDED_HEIGHT,
+      }}
+    >
+      {/* Tab bar */}
+      <div
+        className="flex items-center border-b border-white/[0.06]"
+        style={{ height: COLLAPSED_HEIGHT }}
+      >
+        {/* Collapse toggle */}
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="flex h-full items-center gap-1.5 px-3 text-white/40 transition-colors hover:text-white/60"
+        >
+          <TerminalIcon className="size-3" />
+          {collapsed ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+        </button>
+
+        {/* Tabs */}
+        <div className="flex flex-1 items-center gap-0.5 overflow-x-auto px-1">
+          <AnimatePresence initial={false}>
+            {allTabs.map(tab => {
+              const isActive = tab.id === effectiveActiveId;
+              const isMayor = tab.kind === 'mayor';
+
+              return (
+                <motion.div
+                  key={tab.id}
+                  layout
+                  initial={{ opacity: 0, scale: 0.85, width: 0 }}
+                  animate={{ opacity: 1, scale: 1, width: 'auto' }}
+                  exit={{ opacity: 0, scale: 0.85, width: 0 }}
+                  transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+                  onClick={() => {
+                    setActiveTabId(tab.id);
+                    if (collapsed) setCollapsed(false);
+                  }}
+                  className={`group flex cursor-pointer items-center gap-1.5 overflow-hidden rounded-t-md px-3 py-1 text-[11px] whitespace-nowrap transition-colors ${
+                    isActive
+                      ? 'bg-white/[0.06] text-white/80'
+                      : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
+                  }`}
+                >
+                  {isMayor && (
+                    <Crown className="size-3 shrink-0 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+                  )}
+                  <span className="max-w-[120px] truncate">{tab.label}</span>
+                  {!isMayor && (
+                    <button
+                      onClick={e => {
+                        e.stopPropagation();
+                        closeTab(tab.id);
+                      }}
+                      className="shrink-0 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-white/10"
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  )}
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {/* Terminal content area */}
+      <AnimatePresence mode="wait">
+        {!collapsed && activeTab && (
+          <motion.div
+            key={activeTab.id}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            style={{ height: EXPANDED_HEIGHT }}
+            className="overflow-hidden"
+          >
+            {activeTab.kind === 'mayor' ? (
+              <MayorTerminalPane townId={townId} collapsed={collapsed} />
+            ) : (
+              <AgentTerminalPane townId={townId} agentId={activeTab.agentId} />
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Mayor Terminal Pane ──────────────────────────────────────────────────
+
+function MayorTerminalPane({ townId, collapsed }: { townId: string; collapsed: boolean }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [connected, setConnected] = useState(false);
+  const [status, setStatus] = useState('Initializing...');
+
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const xtermRef = useRef<import('@xterm/xterm').Terminal | null>(null);
+  const fitAddonRef = useRef<import('@xterm/addon-fit').FitAddon | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const ptyRef = useRef<{ id: string } | null>(null);
+
+  const ensureMayor = useMutation(
+    trpc.gastown.ensureMayor.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getMayorStatus.queryKey(),
+        });
+      },
+    })
+  );
+
+  const ensuredTownRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (ensuredTownRef.current === townId) return;
+    ensuredTownRef.current = townId;
+    ensureMayor.mutate({ townId });
+  }, [townId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const statusQuery = useQuery({
+    ...trpc.gastown.getMayorStatus.queryOptions({ townId }),
+    refetchInterval: query => {
+      const session = query.state.data?.session;
+      if (!session) return 3_000;
+      if (session.status === 'active' || session.status === 'starting') return 3_000;
+      return 10_000;
+    },
+  });
+
+  const mayorAgentId = statusQuery.data?.session?.agentId ?? null;
+
+  const createPty = useMutation(
+    trpc.gastown.createPtySession.mutationOptions({
+      onError: err => setStatus(`Error: ${err.message}`),
+    })
+  );
+
+  const resizePty = useMutation(trpc.gastown.resizePtySession.mutationOptions({}));
+  const resizeMutateRef = useRef(resizePty.mutate);
+  resizeMutateRef.current = resizePty.mutate;
+
+  const connectedAgentRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!mayorAgentId || mayorAgentId === connectedAgentRef.current) return;
+    const agentId = mayorAgentId;
+    connectedAgentRef.current = agentId;
+
+    let disposed = false;
+
+    async function init() {
+      const container = terminalRef.current;
+      if (!container) return;
+
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
+        import('@xterm/xterm'),
+        import('@xterm/addon-fit'),
+        import('@xterm/addon-web-links'),
+      ]);
+
+      if (disposed) return;
+
+      xtermRef.current?.dispose();
+
+      const fitAddon = new FitAddon();
+      const webLinksAddon = new WebLinksAddon();
+
+      const term = new Terminal({
+        cursorBlink: true,
+        fontSize: 13,
+        fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+        theme: {
+          background: '#0a0a0a',
+          foreground: '#e0e0e0',
+          cursor: '#e0e0e0',
+          selectionBackground: '#3a3a5a',
+        },
+        allowProposedApi: true,
+      });
+
+      term.loadAddon(fitAddon);
+      term.loadAddon(webLinksAddon);
+      term.open(container);
+      fitAddon.fit();
+
+      xtermRef.current = term;
+      fitAddonRef.current = fitAddon;
+
+      setStatus('Connecting to mayor...');
+
+      function doResize(cols: number, rows: number) {
+        if (!ptyRef.current) return;
+        resizeMutateRef.current({
+          townId,
+          agentId,
+          ptyId: ptyRef.current.id,
+          cols,
+          rows,
+        });
+      }
+
+      let result: { pty: { id: string }; wsUrl: string } | null = null;
+      for (let attempt = 0; attempt < 10 && !disposed; attempt++) {
+        try {
+          result = await new Promise<{ pty: { id: string }; wsUrl: string }>((resolve, reject) => {
+            createPty.mutate({ townId, agentId }, { onSuccess: resolve, onError: reject });
+          });
+          break;
+        } catch {
+          if (disposed) return;
+          setStatus(`Waiting for mayor... (${attempt + 1})`);
+          await new Promise(r => setTimeout(r, 3_000));
+        }
+      }
+
+      if (disposed || !result) {
+        if (!disposed && !result) setStatus('Failed to connect to mayor');
+        return;
+      }
+
+      ptyRef.current = result.pty;
+      setStatus('Connecting...');
+
+      const ws = new WebSocket(result.wsUrl);
+      ws.binaryType = 'arraybuffer';
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (disposed) return;
+        setConnected(true);
+        setStatus('Connected');
+        const dims = fitAddon.proposeDimensions();
+        if (dims) doResize(dims.cols, dims.rows);
+      };
+
+      ws.onmessage = (e: MessageEvent) => {
+        if (e.data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(e.data));
+        } else if (typeof e.data === 'string') {
+          if (e.data.startsWith('{')) {
+            try {
+              JSON.parse(e.data);
+              return;
+            } catch {
+              // not JSON control message
+            }
+          }
+          term.write(e.data);
+        }
+      };
+
+      ws.onclose = () => {
+        if (disposed) return;
+        setConnected(false);
+        setStatus('Disconnected');
+      };
+
+      ws.onerror = () => {
+        if (disposed) return;
+        setStatus('Connection error');
+      };
+
+      term.onData(data => {
+        if (ws.readyState === WebSocket.OPEN) ws.send(data);
+      });
+
+      term.onResize(({ cols, rows }) => doResize(cols, rows));
+
+      const observer = new ResizeObserver(() => fitAddon.fit());
+      observer.observe(container);
+      resizeObserverRef.current = observer;
+    }
+
+    void init();
+
+    return () => {
+      disposed = true;
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+      wsRef.current?.close(1000, 'Mayor terminal unmount');
+      wsRef.current = null;
+      xtermRef.current?.dispose();
+      xtermRef.current = null;
+      fitAddonRef.current = null;
+      ptyRef.current = null;
+      connectedAgentRef.current = null;
+    };
+  }, [mayorAgentId, townId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { state: sidebarState } = useSidebar();
+
+  // Re-fit terminal when expanding or sidebar changes
+  useEffect(() => {
+    if (collapsed || !fitAddonRef.current) return;
+    const t = setTimeout(() => fitAddonRef.current?.fit(), 50);
+    return () => clearTimeout(t);
+  }, [collapsed, sidebarState]);
+
+  return (
+    <div className="relative h-full">
+      {/* Status indicator overlaid top-right */}
+      <div className="absolute top-1.5 right-3 z-10 flex items-center gap-1.5">
+        <span className={`size-1.5 rounded-full ${connected ? 'bg-emerald-400' : 'bg-white/20'}`} />
+        <span className="text-[10px] text-white/35">{status}</span>
+      </div>
+      <div ref={terminalRef} className="h-full overflow-hidden px-1" />
+    </div>
+  );
+}
+
+// ── Agent Terminal Pane ──────────────────────────────────────────────────
+
+function AgentTerminalPane({ townId, agentId }: { townId: string; agentId: string }) {
+  const trpc = useTRPC();
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const xtermRef = useRef<import('@xterm/xterm').Terminal | null>(null);
+  const fitAddonRef = useRef<import('@xterm/addon-fit').FitAddon | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const ptyRef = useRef<{ id: string } | null>(null);
+  const [status, setStatus] = useState<string>('Initializing...');
+  const [connected, setConnected] = useState(false);
+
+  const createPty = useMutation(
+    trpc.gastown.createPtySession.mutationOptions({
+      onError: err => setStatus(`Error: ${err.message}`),
+    })
+  );
+
+  const resizePty = useMutation(trpc.gastown.resizePtySession.mutationOptions({}));
+  const resizeMutateRef = useRef(resizePty.mutate);
+  resizeMutateRef.current = resizePty.mutate;
+
+  useEffect(() => {
+    let disposed = false;
+
+    async function init() {
+      const container = terminalRef.current;
+      if (!container) return;
+
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
+        import('@xterm/xterm'),
+        import('@xterm/addon-fit'),
+        import('@xterm/addon-web-links'),
+      ]);
+
+      if (disposed) return;
+
+      const fitAddon = new FitAddon();
+      const webLinksAddon = new WebLinksAddon();
+
+      const term = new Terminal({
+        cursorBlink: true,
+        fontSize: 13,
+        fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+        theme: {
+          background: '#0a0a0a',
+          foreground: '#e0e0e0',
+          cursor: '#e0e0e0',
+          selectionBackground: '#3a3a5a',
+        },
+        allowProposedApi: true,
+      });
+
+      term.loadAddon(fitAddon);
+      term.loadAddon(webLinksAddon);
+      term.open(container);
+      fitAddon.fit();
+
+      xtermRef.current = term;
+      fitAddonRef.current = fitAddon;
+
+      setStatus('Creating PTY session...');
+
+      function doResize(cols: number, rows: number) {
+        if (!ptyRef.current) return;
+        resizeMutateRef.current({ townId, agentId, ptyId: ptyRef.current.id, cols, rows });
+      }
+
+      const result = await new Promise<{ pty: { id: string }; wsUrl: string }>(
+        (resolve, reject) => {
+          createPty.mutate({ townId, agentId }, { onSuccess: resolve, onError: reject });
+        }
+      );
+
+      if (disposed) return;
+
+      ptyRef.current = result.pty;
+      setStatus('Connecting...');
+
+      const ws = new WebSocket(result.wsUrl);
+      ws.binaryType = 'arraybuffer';
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (disposed) return;
+        setConnected(true);
+        setStatus('Connected');
+        const dims = fitAddon.proposeDimensions();
+        if (dims) doResize(dims.cols, dims.rows);
+      };
+
+      ws.onmessage = (e: MessageEvent) => {
+        if (e.data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(e.data));
+        } else if (typeof e.data === 'string') {
+          if (e.data.startsWith('{')) {
+            try {
+              JSON.parse(e.data);
+              return;
+            } catch {
+              // not JSON
+            }
+          }
+          term.write(e.data);
+        }
+      };
+
+      ws.onclose = () => {
+        if (disposed) return;
+        setConnected(false);
+        setStatus('Disconnected');
+      };
+
+      ws.onerror = () => {
+        if (disposed) return;
+        setStatus('Connection error');
+      };
+
+      term.onData(data => {
+        if (ws.readyState === WebSocket.OPEN) ws.send(data);
+      });
+
+      term.onResize(({ cols, rows }) => doResize(cols, rows));
+
+      const observer = new ResizeObserver(() => fitAddon.fit());
+      observer.observe(container);
+      resizeObserverRef.current = observer;
+    }
+
+    void init();
+
+    return () => {
+      disposed = true;
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+      wsRef.current?.close(1000, 'Agent terminal unmount');
+      wsRef.current = null;
+      xtermRef.current?.dispose();
+      xtermRef.current = null;
+      fitAddonRef.current = null;
+      ptyRef.current = null;
+    };
+  }, [townId, agentId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="relative h-full">
+      <div className="absolute top-1.5 right-3 z-10 flex items-center gap-1.5">
+        <span className={`size-1.5 rounded-full ${connected ? 'bg-emerald-400' : 'bg-white/20'}`} />
+        <span className="text-[10px] text-white/35">{status}</span>
+      </div>
+      <div ref={terminalRef} className="h-full overflow-hidden px-1" />
+    </div>
+  );
+}

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -425,11 +425,19 @@ function AgentTerminalPane({ townId, agentId }: { townId: string; agentId: strin
         resizeMutateRef.current({ townId, agentId, ptyId: ptyRef.current.id, cols, rows });
       }
 
-      const result = await new Promise<{ pty: { id: string }; wsUrl: string }>(
-        (resolve, reject) => {
+      let result: { pty: { id: string }; wsUrl: string };
+      try {
+        result = await new Promise<{ pty: { id: string }; wsUrl: string }>((resolve, reject) => {
           createPty.mutate({ townId, agentId }, { onSuccess: resolve, onError: reject });
+        });
+      } catch (err) {
+        if (!disposed) {
+          setStatus(
+            `Error: ${err instanceof Error ? err.message : 'Failed to create PTY session'}`
+          );
         }
-      );
+        return;
+      }
 
       if (disposed) return;
 

--- a/src/components/gastown/TerminalBarContext.tsx
+++ b/src/components/gastown/TerminalBarContext.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+type TerminalTab = {
+  id: string;
+  label: string;
+  kind: 'mayor' | 'agent';
+  agentId: string;
+};
+
+type TerminalBarContextValue = {
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+  collapsed: boolean;
+  openAgentTab: (agentId: string, agentName: string) => void;
+  closeTab: (tabId: string) => void;
+  setActiveTabId: (id: string) => void;
+  setCollapsed: (collapsed: boolean) => void;
+};
+
+const TerminalBarContext = createContext<TerminalBarContextValue | null>(null);
+
+export function useTerminalBar() {
+  const ctx = useContext(TerminalBarContext);
+  if (!ctx) throw new Error('useTerminalBar must be used within TerminalBarProvider');
+  return ctx;
+}
+
+export function TerminalBarProvider({ children }: { children: ReactNode }) {
+  const [tabs, setTabs] = useState<TerminalTab[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  const openAgentTab = useCallback((agentId: string, agentName: string) => {
+    const tabId = `agent:${agentId}`;
+    setTabs(prev => {
+      if (prev.some(t => t.id === tabId)) return prev;
+      return [...prev, { id: tabId, label: agentName, kind: 'agent', agentId }];
+    });
+    setActiveTabId(tabId);
+    setCollapsed(false);
+  }, []);
+
+  const closeTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const next = prev.filter(t => t.id !== tabId);
+      return next;
+    });
+    setActiveTabId(prev => {
+      if (prev !== tabId) return prev;
+      // Fall back to mayor tab
+      return 'mayor';
+    });
+  }, []);
+
+  return (
+    <TerminalBarContext.Provider
+      value={{ tabs, activeTabId, collapsed, openAgentTab, closeTab, setActiveTabId, setCollapsed }}
+    >
+      {children}
+    </TerminalBarContext.Provider>
+  );
+}

--- a/src/components/gastown/drawer-panels/AgentPanel.tsx
+++ b/src/components/gastown/drawer-panels/AgentPanel.tsx
@@ -52,24 +52,28 @@ const BEAD_STATUS_DOT: Record<string, string> = {
 export function AgentPanel({
   agentId,
   rigId,
-  townId,
+  townId: townIdProp,
   push,
   close,
 }: {
   agentId: string;
   rigId: string;
-  townId: string;
+  townId?: string;
   push: (ref: ResourceRef) => void;
   close: () => void;
 }) {
   const trpc = useTRPC();
   const { openAgentTab } = useTerminalBar();
 
+  const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId }));
   const agentsQuery = useQuery(trpc.gastown.listAgents.queryOptions({ rigId }));
   const beadsQuery = useQuery({
     ...trpc.gastown.listBeads.queryOptions({ rigId }),
     refetchInterval: 8_000,
   });
+
+  // Derive townId from the rig if not provided directly
+  const townId = townIdProp || rigQuery.data?.town_id || '';
 
   const agent = (agentsQuery.data ?? []).find(a => a.id === agentId);
   const relatedBeads = (beadsQuery.data ?? []).filter(b => b.assignee_agent_bead_id === agentId);
@@ -140,7 +144,7 @@ export function AgentPanel({
         {/* Hooked bead — clickable */}
         {agent.current_hook_bead_id ? (
           <button
-            onClick={() => push({ type: 'bead', beadId: agent.current_hook_bead_id!, rigId })}
+            onClick={() => push({ type: 'bead', beadId: agent.current_hook_bead_id ?? '', rigId })}
             className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
           >
             <div className="flex items-center gap-1 text-[10px] text-white/30">

--- a/src/components/gastown/drawer-panels/AgentPanel.tsx
+++ b/src/components/gastown/drawer-panels/AgentPanel.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Badge } from '@/components/ui/badge';
+import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
+import { useTerminalBar } from '@/components/gastown/TerminalBarContext';
+import type { ResourceRef } from '@/components/gastown/DrawerStack';
+import { format, formatDistanceToNow } from 'date-fns';
+import {
+  Bot,
+  Crown,
+  Shield,
+  Eye,
+  Hash,
+  Clock,
+  Hexagon,
+  Terminal,
+  Zap,
+  Activity,
+  ChevronRight,
+} from 'lucide-react';
+
+const ROLE_ICONS: Record<string, typeof Bot> = {
+  polecat: Bot,
+  mayor: Crown,
+  refinery: Shield,
+  witness: Eye,
+};
+
+const STATUS_DOT: Record<string, string> = {
+  idle: 'bg-white/25',
+  working: 'bg-emerald-400',
+  stalled: 'bg-amber-400',
+  dead: 'bg-red-400',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  idle: 'Idle',
+  working: 'Working',
+  stalled: 'Stalled',
+  dead: 'Dead',
+};
+
+const BEAD_STATUS_DOT: Record<string, string> = {
+  open: 'bg-sky-400',
+  in_progress: 'bg-amber-400',
+  closed: 'bg-emerald-400',
+  failed: 'bg-red-400',
+};
+
+export function AgentPanel({
+  agentId,
+  rigId,
+  townId,
+  push,
+  close,
+}: {
+  agentId: string;
+  rigId: string;
+  townId: string;
+  push: (ref: ResourceRef) => void;
+  close: () => void;
+}) {
+  const trpc = useTRPC();
+  const { openAgentTab } = useTerminalBar();
+
+  const agentsQuery = useQuery(trpc.gastown.listAgents.queryOptions({ rigId }));
+  const beadsQuery = useQuery({
+    ...trpc.gastown.listBeads.queryOptions({ rigId }),
+    refetchInterval: 8_000,
+  });
+
+  const agent = (agentsQuery.data ?? []).find(a => a.id === agentId);
+  const relatedBeads = (beadsQuery.data ?? []).filter(b => b.assignee_agent_bead_id === agentId);
+
+  if (!agent) {
+    return <div className="p-6 text-center text-sm text-white/30">Loading agent…</div>;
+  }
+
+  const RoleIcon = ROLE_ICONS[agent.role] ?? Bot;
+
+  return (
+    <div className="flex flex-col gap-0">
+      {/* Header */}
+      <div className="border-b border-white/[0.06] px-5 pt-4 pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-white/[0.05] ring-1 ring-white/[0.08]">
+            <RoleIcon className="size-5 text-white/50" />
+          </div>
+          <div>
+            <div className="text-base font-semibold text-white/90">{agent.name}</div>
+            <div className="mt-0.5 flex items-center gap-2 text-xs text-white/35">
+              <span className="capitalize">{agent.role}</span>
+              <span className="text-white/15">·</span>
+              <span className="flex items-center gap-1">
+                <span
+                  className={`size-1.5 rounded-full ${STATUS_DOT[agent.status] ?? 'bg-white/20'}`}
+                />
+                {STATUS_LABEL[agent.status] ?? agent.status}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            onClick={() => {
+              openAgentTab(agent.id, agent.name);
+              close();
+            }}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-[color:oklch(95%_0.15_108_/_0.12)] px-3 py-1.5 text-xs font-medium text-[color:oklch(95%_0.15_108)] ring-1 ring-[color:oklch(95%_0.15_108_/_0.2)] transition-colors hover:bg-[color:oklch(95%_0.15_108_/_0.2)]"
+          >
+            <Terminal className="size-3.5" />
+            Connect
+          </button>
+        </div>
+      </div>
+
+      {/* Metadata grid */}
+      <div className="grid grid-cols-2 border-b border-white/[0.06]">
+        <MetaCell icon={Hash} label="ID" value={agent.id.slice(0, 12)} mono />
+        <MetaCell
+          icon={Clock}
+          label="Created"
+          value={format(new Date(agent.created_at), 'MMM d, HH:mm')}
+        />
+        <MetaCell icon={Zap} label="Dispatch Attempts" value={String(agent.dispatch_attempts)} />
+        <MetaCell
+          icon={Activity}
+          label="Last Active"
+          value={
+            agent.last_activity_at
+              ? formatDistanceToNow(new Date(agent.last_activity_at), { addSuffix: true })
+              : 'Never'
+          }
+        />
+
+        {/* Hooked bead — clickable */}
+        {agent.current_hook_bead_id ? (
+          <button
+            onClick={() => push({ type: 'bead', beadId: agent.current_hook_bead_id!, rigId })}
+            className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+          >
+            <div className="flex items-center gap-1 text-[10px] text-white/30">
+              <Hexagon className="size-3" />
+              Hooked Bead
+            </div>
+            <div className="mt-0.5 flex items-center gap-1 font-mono text-xs text-[color:oklch(95%_0.15_108)]">
+              <span>{agent.current_hook_bead_id.slice(0, 12)}</span>
+              <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
+            </div>
+          </button>
+        ) : (
+          <MetaCell icon={Hexagon} label="Hooked Bead" value="None" />
+        )}
+
+        <MetaCell icon={Bot} label="Identity" value={agent.identity || 'Default'} />
+      </div>
+
+      {/* Related Beads — clickable rows */}
+      <div className="border-b border-white/[0.06] px-5 py-4">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Hexagon className="size-3 text-white/25" />
+            <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+              Assigned Beads
+            </span>
+          </div>
+          <span className="font-mono text-[10px] text-white/20">{relatedBeads.length}</span>
+        </div>
+
+        {relatedBeads.length === 0 ? (
+          <p className="text-xs text-white/20">No beads assigned to this agent.</p>
+        ) : (
+          <div className="space-y-1.5">
+            {relatedBeads.map(bead => (
+              <button
+                key={bead.bead_id}
+                onClick={() => push({ type: 'bead', beadId: bead.bead_id, rigId })}
+                className="group/bead flex w-full items-center gap-2.5 rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2 text-left transition-colors hover:border-white/[0.1] hover:bg-white/[0.03]"
+              >
+                <span
+                  className={`size-2 shrink-0 rounded-full ${BEAD_STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-xs text-white/70">{bead.title}</div>
+                  <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-white/30">
+                    <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
+                    <span className="text-white/10">·</span>
+                    <span className="capitalize">{bead.status.replace('_', ' ')}</span>
+                  </div>
+                </div>
+                <ChevronRight className="size-3 shrink-0 text-white/10 transition-colors group-hover/bead:text-white/25" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Hooked Bead Event Timeline */}
+      {agent.current_hook_bead_id && (
+        <>
+          <div className="px-5 pt-4">
+            <div className="mb-2 flex items-center gap-1.5">
+              <Clock className="size-3 text-white/25" />
+              <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+                Hooked Bead Events
+              </span>
+            </div>
+          </div>
+          <div className="px-3 pb-6">
+            <BeadEventTimeline rigId={rigId} beadId={agent.current_hook_bead_id} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function MetaCell({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className={`mt-0.5 truncate text-sm text-white/75 ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -112,7 +112,7 @@ export function BeadPanel({
               if (townId) {
                 push({
                   type: 'agent',
-                  agentId: bead.assignee_agent_bead_id!,
+                  agentId: bead.assignee_agent_bead_id ?? '',
                   rigId,
                   townId,
                 });
@@ -145,7 +145,7 @@ export function BeadPanel({
         {/* Parent bead — clickable */}
         {bead.parent_bead_id && (
           <button
-            onClick={() => push({ type: 'bead', beadId: bead.parent_bead_id!, rigId })}
+            onClick={() => push({ type: 'bead', beadId: bead.parent_bead_id ?? '', rigId })}
             className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
           >
             <div className="flex items-center gap-1 text-[10px] text-white/30">

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Badge } from '@/components/ui/badge';
+import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
+import type { ResourceRef } from '@/components/gastown/DrawerStack';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { RootRouter } from '@/routers/root-router';
+import { format } from 'date-fns';
+import {
+  Clock,
+  Flag,
+  Hash,
+  Tags,
+  User,
+  Hexagon,
+  FileText,
+  GitBranch,
+  ChevronRight,
+  Bot,
+} from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+type RouterOutputs = inferRouterOutputs<RootRouter>;
+type Bead = RouterOutputs['gastown']['listBeads'][number];
+
+const STATUS_STYLES: Record<string, string> = {
+  open: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
+  in_progress: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  closed: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  failed: 'border-red-500/30 bg-red-500/10 text-red-300',
+};
+
+const PRIORITY_STYLES: Record<string, string> = {
+  critical: 'text-red-400',
+  high: 'text-orange-400',
+  medium: 'text-amber-400',
+  low: 'text-white/50',
+};
+
+export function BeadPanel({
+  beadId,
+  rigId,
+  push,
+}: {
+  beadId: string;
+  rigId: string;
+  push: (ref: ResourceRef) => void;
+}) {
+  const trpc = useTRPC();
+  const beadsQuery = useQuery(trpc.gastown.listBeads.queryOptions({ rigId }));
+  const agentsQuery = useQuery(trpc.gastown.listAgents.queryOptions({ rigId }));
+  const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId }));
+
+  const bead = (beadsQuery.data ?? []).find(b => b.bead_id === beadId);
+  const agentNameById = (agentsQuery.data ?? []).reduce<Record<string, string>>((acc, a) => {
+    acc[a.id] = a.name;
+    return acc;
+  }, {});
+
+  if (!bead) {
+    return <div className="p-6 text-center text-sm text-white/30">Loading bead…</div>;
+  }
+
+  const assigneeName = bead.assignee_agent_bead_id
+    ? agentNameById[bead.assignee_agent_bead_id]
+    : null;
+
+  const townId = rigQuery.data?.town_id;
+
+  return (
+    <div className="flex flex-col gap-0">
+      {/* Title area */}
+      <div className="border-b border-white/[0.06] px-5 pt-4 pb-4">
+        <div className="flex items-center gap-2 text-base font-semibold text-white/90">
+          <Hexagon className="size-4 shrink-0 text-[color:oklch(95%_0.15_108_/_0.7)]" />
+          <span className="truncate">{bead.title}</span>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <span
+            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] font-medium ${STATUS_STYLES[bead.status] ?? 'border-white/10 text-white/50'}`}
+          >
+            {bead.status.replace('_', ' ')}
+          </span>
+          <Badge variant="outline" className="text-[10px]">
+            {bead.type}
+          </Badge>
+          <span
+            className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${PRIORITY_STYLES[bead.priority] ?? 'text-white/50'}`}
+          >
+            <Flag className="size-2.5" />
+            {bead.priority}
+          </span>
+        </div>
+      </div>
+
+      {/* Metadata grid */}
+      <div className="grid grid-cols-2 border-b border-white/[0.06]">
+        <MetaCell icon={Hash} label="Bead ID" value={bead.bead_id.slice(0, 8)} mono />
+        <MetaCell
+          icon={Clock}
+          label="Created"
+          value={format(new Date(bead.created_at), 'MMM d, HH:mm')}
+        />
+
+        {/* Assignee — clickable to open agent drawer */}
+        {bead.assignee_agent_bead_id ? (
+          <button
+            onClick={() => {
+              if (townId) {
+                push({
+                  type: 'agent',
+                  agentId: bead.assignee_agent_bead_id!,
+                  rigId,
+                  townId,
+                });
+              }
+            }}
+            className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+          >
+            <div className="flex items-center gap-1 text-[10px] text-white/30">
+              <User className="size-3" />
+              Assignee
+            </div>
+            <div className="mt-0.5 flex items-center gap-1 text-sm text-[color:oklch(95%_0.15_108)]">
+              <Bot className="size-3" />
+              <span className="truncate">
+                {assigneeName ?? bead.assignee_agent_bead_id.slice(0, 8)}
+              </span>
+              <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
+            </div>
+          </button>
+        ) : (
+          <MetaCell icon={User} label="Assignee" value="Unassigned" />
+        )}
+
+        <MetaCell
+          icon={Tags}
+          label="Labels"
+          value={bead.labels.length ? bead.labels.join(', ') : 'None'}
+        />
+
+        {/* Parent bead — clickable */}
+        {bead.parent_bead_id && (
+          <button
+            onClick={() => push({ type: 'bead', beadId: bead.parent_bead_id!, rigId })}
+            className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+          >
+            <div className="flex items-center gap-1 text-[10px] text-white/30">
+              <GitBranch className="size-3" />
+              Parent Bead
+            </div>
+            <div className="mt-0.5 flex items-center gap-1 font-mono text-xs text-[color:oklch(95%_0.15_108)]">
+              <span>{bead.parent_bead_id.slice(0, 8)}</span>
+              <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
+            </div>
+          </button>
+        )}
+      </div>
+
+      {/* Body (markdown) */}
+      {bead.body && bead.body.trim().length > 0 && (
+        <div className="border-b border-white/[0.06] px-5 py-4">
+          <div className="mb-2 flex items-center gap-1.5">
+            <FileText className="size-3 text-white/25" />
+            <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+              Description
+            </span>
+          </div>
+          <div className="prose prose-sm prose-invert prose-headings:text-white/80 prose-p:text-white/65 prose-a:text-[color:oklch(95%_0.15_108)] prose-strong:text-white/80 prose-code:rounded prose-code:bg-white/[0.06] prose-code:px-1 prose-code:py-0.5 prose-code:text-[11px] prose-code:text-white/70 prose-pre:bg-white/[0.04] prose-pre:border prose-pre:border-white/[0.06] prose-li:text-white/65 max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{bead.body}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+
+      {/* Event Timeline */}
+      <div className="px-5 pt-4 pb-2">
+        <div className="mb-2 flex items-center gap-1.5">
+          <Clock className="size-3 text-white/25" />
+          <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+            Event Timeline
+          </span>
+        </div>
+      </div>
+      <div className="px-3 pb-6">
+        <BeadEventTimeline rigId={rigId} beadId={bead.bead_id} />
+      </div>
+    </div>
+  );
+}
+
+function MetaCell({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className={`mt-0.5 truncate text-sm text-white/75 ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/components/gastown/drawer-panels/EventPanel.tsx
+++ b/src/components/gastown/drawer-panels/EventPanel.tsx
@@ -131,7 +131,7 @@ export function EventPanel({
   const summary = eventSummary(event);
 
   const meta = event.metadata;
-  const rigId = 'rig_id' in event ? (event.rig_id as string | undefined) : undefined;
+  const rigId = 'rig_id' in event && typeof event.rig_id === 'string' ? event.rig_id : undefined;
   const rigName = 'rig_name' in event ? event.rig_name : undefined;
 
   // Extract well-known metadata fields to show in context sections
@@ -237,7 +237,9 @@ export function EventPanel({
               icon={Bot}
               label={event.agent_id.slice(0, 12)}
               mono
-              onClick={() => push({ type: 'agent', agentId: event.agent_id!, rigId, townId: '' })}
+              onClick={() =>
+                push({ type: 'agent', agentId: event.agent_id ?? '', rigId, townId: undefined })
+              }
             />
           ) : (
             <span className="font-mono text-xs text-white/50">{event.agent_id.slice(0, 12)}</span>
@@ -306,7 +308,7 @@ export function EventPanel({
                   icon={Bot}
                   label={mailTo.slice(0, 12)}
                   mono
-                  onClick={() => push({ type: 'agent', agentId: mailTo, rigId, townId: '' })}
+                  onClick={() => push({ type: 'agent', agentId: mailTo, rigId, townId: undefined })}
                 />
               </div>
             )}
@@ -318,7 +320,7 @@ export function EventPanel({
                   label={event.agent_id.slice(0, 12)}
                   mono
                   onClick={() =>
-                    push({ type: 'agent', agentId: event.agent_id!, rigId, townId: '' })
+                    push({ type: 'agent', agentId: event.agent_id ?? '', rigId, townId: undefined })
                   }
                 />
               </div>
@@ -355,7 +357,9 @@ export function EventPanel({
               icon={Bot}
               label="Agent"
               value={event.agent_id.slice(0, 12)}
-              onClick={() => push({ type: 'agent', agentId: event.agent_id!, rigId, townId: '' })}
+              onClick={() =>
+                push({ type: 'agent', agentId: event.agent_id ?? '', rigId, townId: undefined })
+              }
             />
           ) : (
             <MetaCell

--- a/src/components/gastown/drawer-panels/EventPanel.tsx
+++ b/src/components/gastown/drawer-panels/EventPanel.tsx
@@ -1,0 +1,522 @@
+'use client';
+
+import type { TownEvent } from '@/components/gastown/ActivityFeed';
+import type { ResourceRef } from '@/components/gastown/DrawerStack';
+import { format, formatDistanceToNow } from 'date-fns';
+import {
+  Activity,
+  GitMerge,
+  AlertTriangle,
+  CheckCircle,
+  PlayCircle,
+  PauseCircle,
+  Mail,
+  Hash,
+  Clock,
+  Bot,
+  Hexagon,
+  FileText,
+  ArrowRight,
+  ChevronRight,
+  GitBranch,
+  Tag,
+  MessageSquare,
+  Send,
+} from 'lucide-react';
+
+const EVENT_ICONS: Record<string, typeof Activity> = {
+  created: PlayCircle,
+  hooked: PlayCircle,
+  unhooked: PauseCircle,
+  status_changed: Activity,
+  closed: CheckCircle,
+  escalated: AlertTriangle,
+  review_submitted: GitMerge,
+  review_completed: GitMerge,
+  mail_sent: Mail,
+};
+
+const EVENT_ACCENT: Record<string, string> = {
+  created: 'border-sky-500/20 bg-sky-500/8',
+  hooked: 'border-emerald-500/20 bg-emerald-500/8',
+  unhooked: 'border-amber-500/20 bg-amber-500/8',
+  status_changed: 'border-violet-500/20 bg-violet-500/8',
+  closed: 'border-emerald-500/20 bg-emerald-500/8',
+  escalated: 'border-red-500/20 bg-red-500/8',
+  review_submitted: 'border-indigo-500/20 bg-indigo-500/8',
+  review_completed: 'border-emerald-500/20 bg-emerald-500/8',
+  mail_sent: 'border-sky-500/20 bg-sky-500/8',
+};
+
+const EVENT_ICON_COLOR: Record<string, string> = {
+  created: 'text-sky-400',
+  hooked: 'text-emerald-400',
+  unhooked: 'text-amber-400',
+  status_changed: 'text-violet-400',
+  closed: 'text-emerald-400',
+  escalated: 'text-red-400',
+  review_submitted: 'text-indigo-400',
+  review_completed: 'text-emerald-400',
+  mail_sent: 'text-sky-400',
+};
+
+const EVENT_LABEL: Record<string, string> = {
+  created: 'Bead Created',
+  hooked: 'Agent Hooked',
+  unhooked: 'Agent Unhooked',
+  status_changed: 'Status Changed',
+  closed: 'Bead Closed',
+  escalated: 'Escalation Created',
+  review_submitted: 'Submitted for Review',
+  review_completed: 'Review Completed',
+  mail_sent: 'Mail Sent',
+};
+
+const STATUS_PILL: Record<string, string> = {
+  open: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
+  in_progress: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  closed: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  failed: 'border-red-500/30 bg-red-500/10 text-red-300',
+};
+
+/** Build a human-readable one-line summary. */
+function eventSummary(event: TownEvent): string | null {
+  const meta = event.metadata;
+  switch (event.event_type) {
+    case 'created': {
+      const title = typeof meta.title === 'string' ? meta.title : null;
+      const type = typeof meta.type === 'string' ? meta.type : null;
+      return title ? `A new ${type ?? 'bead'} "${title}" was created.` : null;
+    }
+    case 'hooked':
+      return 'An agent picked up this bead and started working on it.';
+    case 'unhooked':
+      return 'The agent released this bead and is no longer working on it.';
+    case 'status_changed':
+      return `Status changed from ${event.old_value ?? '?'} to ${event.new_value ?? '?'}.`;
+    case 'closed':
+      return 'This bead has been completed and closed.';
+    case 'escalated':
+      return 'An escalation was raised — this may need human attention.';
+    case 'review_submitted': {
+      const branch = typeof meta.branch === 'string' ? meta.branch : event.new_value;
+      return branch ? `Branch "${branch}" was submitted for review.` : 'Submitted for code review.';
+    }
+    case 'review_completed': {
+      const msg = typeof meta.message === 'string' ? meta.message : null;
+      const by = typeof meta.completedBy === 'string' ? meta.completedBy : null;
+      if (event.new_value === 'merged') return `Branch merged${by ? ` by ${by}` : ''}.`;
+      return msg ? `Review completed: ${msg}` : `Review ${event.new_value ?? 'completed'}.`;
+    }
+    case 'mail_sent': {
+      const subject = typeof meta.subject === 'string' ? meta.subject : null;
+      return subject ? `Mail sent: "${subject}"` : 'Inter-agent mail was sent.';
+    }
+    default:
+      return null;
+  }
+}
+
+export function EventPanel({
+  event,
+  push,
+}: {
+  event: TownEvent;
+  push: (ref: ResourceRef) => void;
+}) {
+  const Icon = EVENT_ICONS[event.event_type] ?? Activity;
+  const accent = EVENT_ACCENT[event.event_type] ?? 'border-white/10 bg-white/5';
+  const iconColor = EVENT_ICON_COLOR[event.event_type] ?? 'text-white/50';
+  const label = EVENT_LABEL[event.event_type] ?? event.event_type;
+  const summary = eventSummary(event);
+
+  const meta = event.metadata;
+  const rigId = 'rig_id' in event ? (event.rig_id as string | undefined) : undefined;
+  const rigName = 'rig_name' in event ? event.rig_name : undefined;
+
+  // Extract well-known metadata fields to show in context sections
+  const beadTitle = typeof meta.title === 'string' ? meta.title : null;
+  const beadType = typeof meta.type === 'string' ? meta.type : null;
+  const branch = typeof meta.branch === 'string' ? meta.branch : null;
+  const commitSha = typeof meta.commit_sha === 'string' ? meta.commit_sha : null;
+  const reviewMessage = typeof meta.message === 'string' ? meta.message : null;
+  const completedBy = typeof meta.completedBy === 'string' ? meta.completedBy : null;
+  const mailSubject = typeof meta.subject === 'string' ? meta.subject : null;
+  const mailTo = typeof meta.to === 'string' ? meta.to : null;
+
+  // Metadata entries excluding the ones we render in context sections
+  const contextKeys = new Set([
+    'title',
+    'type',
+    'branch',
+    'commit_sha',
+    'message',
+    'completedBy',
+    'subject',
+    'to',
+  ]);
+  const extraMetadata = Object.entries(meta).filter(
+    ([k, v]) => !contextKeys.has(k) && v !== null && v !== undefined && v !== ''
+  );
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="px-5 pt-4 pb-2">
+        <div className="text-base font-semibold text-white/90">Event Detail</div>
+        <div className="mt-0.5 text-xs text-white/30">
+          {format(new Date(event.created_at), 'EEEE, MMM d yyyy · HH:mm:ss')}
+        </div>
+      </div>
+
+      {/* Event type banner */}
+      <div className={`mx-5 mt-2 rounded-xl border p-4 ${accent}`}>
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex size-10 items-center justify-center rounded-lg bg-black/20 ${iconColor}`}
+          >
+            <Icon className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold text-white/85">{label}</div>
+            {summary && <div className="mt-1 text-xs leading-relaxed text-white/50">{summary}</div>}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Event-type-specific context ──────────────────────────── */}
+
+      {/* created: bead title + type */}
+      {event.event_type === 'created' && beadTitle && (
+        <ContextSection icon={Hexagon} title="Created Bead">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-white/75">{beadTitle}</span>
+            {beadType && (
+              <span className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[9px] font-medium text-white/40">
+                {beadType}
+              </span>
+            )}
+          </div>
+          {rigId && (
+            <ResourceLink
+              icon={Hexagon}
+              label="Open bead"
+              onClick={() => push({ type: 'bead', beadId: event.bead_id, rigId })}
+            />
+          )}
+        </ContextSection>
+      )}
+
+      {/* status_changed: status transition */}
+      {event.event_type === 'status_changed' && (event.old_value || event.new_value) && (
+        <ContextSection icon={Activity} title="Status Transition">
+          <div className="flex items-center gap-2">
+            <span
+              className={`inline-flex rounded-md border px-2 py-0.5 text-[10px] font-medium ${STATUS_PILL[event.old_value ?? ''] ?? 'border-white/10 text-white/40'}`}
+            >
+              {event.old_value ?? '—'}
+            </span>
+            <ArrowRight className="size-3.5 text-white/20" />
+            <span
+              className={`inline-flex rounded-md border px-2 py-0.5 text-[10px] font-medium ${STATUS_PILL[event.new_value ?? ''] ?? 'border-white/10 text-white/40'}`}
+            >
+              {event.new_value ?? '—'}
+            </span>
+          </div>
+        </ContextSection>
+      )}
+
+      {/* hooked / unhooked: agent involved */}
+      {(event.event_type === 'hooked' || event.event_type === 'unhooked') && event.agent_id && (
+        <ContextSection
+          icon={Bot}
+          title={event.event_type === 'hooked' ? 'Agent Assigned' : 'Agent Released'}
+        >
+          {rigId ? (
+            <ResourceLink
+              icon={Bot}
+              label={event.agent_id.slice(0, 12)}
+              mono
+              onClick={() => push({ type: 'agent', agentId: event.agent_id!, rigId, townId: '' })}
+            />
+          ) : (
+            <span className="font-mono text-xs text-white/50">{event.agent_id.slice(0, 12)}</span>
+          )}
+        </ContextSection>
+      )}
+
+      {/* review_submitted: branch info */}
+      {event.event_type === 'review_submitted' && branch && (
+        <ContextSection icon={GitBranch} title="Branch">
+          <div className="flex items-center gap-2 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+            <GitBranch className="size-3 text-indigo-400/60" />
+            <span className="font-mono text-xs text-white/70">{branch}</span>
+          </div>
+        </ContextSection>
+      )}
+
+      {/* review_completed: result details */}
+      {event.event_type === 'review_completed' && (
+        <ContextSection icon={GitMerge} title="Review Result">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <span
+                className={`inline-flex rounded-md border px-2 py-0.5 text-[10px] font-medium ${
+                  event.new_value === 'merged'
+                    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+                    : 'border-white/10 text-white/50'
+                }`}
+              >
+                {event.new_value ?? 'completed'}
+              </span>
+              {completedBy && <span className="text-[10px] text-white/30">by {completedBy}</span>}
+            </div>
+            {reviewMessage && (
+              <div className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+                <MessageSquare className="mb-1 size-3 text-white/20" />
+                <p className="text-xs leading-relaxed text-white/55">{reviewMessage}</p>
+              </div>
+            )}
+            {commitSha && (
+              <div className="flex items-center gap-1.5 text-[10px] text-white/30">
+                <Hash className="size-3" />
+                <span className="font-mono">{commitSha.slice(0, 12)}</span>
+              </div>
+            )}
+          </div>
+        </ContextSection>
+      )}
+
+      {/* mail_sent: subject + recipient */}
+      {event.event_type === 'mail_sent' && (
+        <ContextSection icon={Send} title="Mail">
+          <div className="space-y-2">
+            {mailSubject && (
+              <div className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+                <div className="mb-0.5 text-[9px] font-medium tracking-wide text-white/25 uppercase">
+                  Subject
+                </div>
+                <p className="text-xs text-white/65">{mailSubject}</p>
+              </div>
+            )}
+            {mailTo && rigId && (
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] text-white/30">To:</span>
+                <ResourceLink
+                  icon={Bot}
+                  label={mailTo.slice(0, 12)}
+                  mono
+                  onClick={() => push({ type: 'agent', agentId: mailTo, rigId, townId: '' })}
+                />
+              </div>
+            )}
+            {event.agent_id && rigId && (
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] text-white/30">From:</span>
+                <ResourceLink
+                  icon={Bot}
+                  label={event.agent_id.slice(0, 12)}
+                  mono
+                  onClick={() =>
+                    push({ type: 'agent', agentId: event.agent_id!, rigId, townId: '' })
+                  }
+                />
+              </div>
+            )}
+          </div>
+        </ContextSection>
+      )}
+
+      {/* ── Core metadata grid ────────────────────────────────────── */}
+      <div className="mt-2 border-t border-white/[0.06]">
+        <div className="grid grid-cols-2">
+          <MetaCell icon={Hash} label="Event ID" value={event.bead_event_id.slice(0, 12)} mono />
+          <MetaCell
+            icon={Clock}
+            label="Time"
+            value={format(new Date(event.created_at), 'MMM d, HH:mm:ss')}
+          />
+
+          {/* Bead — clickable */}
+          {rigId ? (
+            <LinkCell
+              icon={Hexagon}
+              label="Bead"
+              value={event.bead_id.slice(0, 12)}
+              onClick={() => push({ type: 'bead', beadId: event.bead_id, rigId })}
+            />
+          ) : (
+            <MetaCell icon={Hexagon} label="Bead" value={event.bead_id.slice(0, 12)} mono />
+          )}
+
+          {/* Agent — clickable */}
+          {event.agent_id && rigId ? (
+            <LinkCell
+              icon={Bot}
+              label="Agent"
+              value={event.agent_id.slice(0, 12)}
+              onClick={() => push({ type: 'agent', agentId: event.agent_id!, rigId, townId: '' })}
+            />
+          ) : (
+            <MetaCell
+              icon={Bot}
+              label="Agent"
+              value={event.agent_id ? event.agent_id.slice(0, 12) : 'System'}
+              mono={Boolean(event.agent_id)}
+            />
+          )}
+
+          {rigName && <MetaCell icon={FileText} label="Rig" value={rigName} />}
+          <MetaCell
+            icon={Clock}
+            label="Relative"
+            value={formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+          />
+        </div>
+      </div>
+
+      {/* Value transition (for types not already shown in context sections) */}
+      {event.event_type !== 'status_changed' && (event.old_value || event.new_value) && (
+        <div className="mx-5 mt-4">
+          <div className="mb-2 text-[10px] font-medium tracking-wide text-white/30 uppercase">
+            Value Change
+          </div>
+          <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+            <span className="max-w-[160px] truncate rounded bg-white/[0.04] px-2 py-1 font-mono text-xs text-white/50">
+              {event.old_value ?? '—'}
+            </span>
+            <ArrowRight className="size-3.5 shrink-0 text-white/20" />
+            <span className="max-w-[160px] truncate rounded bg-white/[0.04] px-2 py-1 font-mono text-xs text-white/70">
+              {event.new_value ?? '—'}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Extra metadata (fields not already shown in context sections) */}
+      {extraMetadata.length > 0 && (
+        <div className="mx-5 mt-4 pb-6">
+          <div className="mb-2 text-[10px] font-medium tracking-wide text-white/30 uppercase">
+            Metadata
+          </div>
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02]">
+            {extraMetadata.map(([key, value], i) => (
+              <div
+                key={key}
+                className={`flex items-start justify-between gap-4 px-3 py-2 ${
+                  i < extraMetadata.length - 1 ? 'border-b border-white/[0.04]' : ''
+                }`}
+              >
+                <span className="shrink-0 text-[11px] text-white/40">{key}</span>
+                <span className="min-w-0 truncate text-right font-mono text-[11px] text-white/65">
+                  {typeof value === 'string' ? value : JSON.stringify(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────
+
+function ContextSection({
+  icon: SectionIcon,
+  title,
+  children,
+}: {
+  icon: typeof Activity;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mx-5 mt-4">
+      <div className="mb-2 flex items-center gap-1.5">
+        <SectionIcon className="size-3 text-white/25" />
+        <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+          {title}
+        </span>
+      </div>
+      <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">{children}</div>
+    </div>
+  );
+}
+
+function ResourceLink({
+  icon: LinkIcon,
+  label,
+  mono,
+  onClick,
+}: {
+  icon: typeof Bot;
+  label: string;
+  mono?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="group/rlink mt-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors hover:bg-white/[0.04]"
+    >
+      <LinkIcon className="size-3 text-[color:oklch(95%_0.15_108_/_0.6)]" />
+      <span className={`text-[color:oklch(95%_0.15_108)] ${mono ? 'font-mono text-[11px]' : ''}`}>
+        {label}
+      </span>
+      <ChevronRight className="size-3 text-white/15 transition-colors group-hover/rlink:text-white/30" />
+    </button>
+  );
+}
+
+function LinkCell({
+  icon: CellIcon,
+  label,
+  value,
+  onClick,
+}: {
+  icon: typeof Hexagon;
+  label: string;
+  value: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+    >
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <CellIcon className="size-3" />
+        {label}
+      </div>
+      <div className="mt-0.5 flex items-center gap-1 font-mono text-xs text-[color:oklch(95%_0.15_108)]">
+        <span>{value}</span>
+        <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
+      </div>
+    </button>
+  );
+}
+
+function MetaCell({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+      <div className="flex items-center gap-1 text-[10px] text-white/30">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className={`mt-0.5 truncate text-sm text-white/75 ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the Dashboard Deep Drill-Down sub-issue (#225) of the Gastown Properties epic (#204).

- **Layered drawer stack** — arbitrarily-deep resource inspector with offset positioning and hover-peek. Clicking a bead's assignee opens an agent drawer on top; clicking that agent's hooked bead opens another bead drawer, etc. All cross-references between beads, agents, and events are clickable.
- **Unified terminal bar** — replaces separate MayorChat and AgentTerminalTabs with a single tabbed bar at the layout level. Mayor tab is always present and non-closeable; agent tabs are opened from the drawer's Connect button and closeable.
- **Town-specific sidebar** — animated nav (Overview, Beads, Agents, Merge Queue, Mail, Observability, Settings) with live rig list that updates when rigs are created/deleted.
- **New full-page views** — Beads (filterable/searchable list), Agents (grid with drawer), Mail, Merges, Observability (recharts time-series + event type distribution), Settings (two-column with scrollspy right-nav).
- **Kanban board animations** — framer-motion layout transitions for bead cards entering/exiting/moving between columns; agent beads filtered out.
- **Activity feed** — sorted newest-first, animated entry/exit, clickable items opening event detail drawer.
- **Event detail drawer** — event-type-specific context sections (status transition pills, branch info, mail subject/recipient, review result), human-readable summaries, clickable bead/agent cross-links.
- **Overview stats from real bead state** — counts derived from actual bead status across rigs instead of event window.
- **Stat cell number animations** — spring-animated value transitions on polling updates.
- **xterm helper textarea fix** — CSS override for Tailwind v4 reset stomping xterm internal positioning.
- **Sidebar separator overflow fix** — replaced SidebarSeparator with inset border.

## New files

| Path | Purpose |
|---|---|
| `DrawerStack.tsx` | Stack context, provider, and animated layer renderer |
| `drawer-panels/{Bead,Agent,Event}Panel.tsx` | Content panels with cross-resource links |
| `TerminalBar.tsx` / `TerminalBarContext.tsx` | Unified terminal bar + shared context |
| `GastownTownSidebar.tsx` | Town-specific sidebar component |
| `BeadDetailDrawer.tsx` / `AgentDetailDrawer.tsx` / `EventDetailDrawer.tsx` | Standalone drawer shells (legacy, superseded by DrawerStack) |
| `agents/`, `beads/`, `mail/`, `merges/`, `observability/` pages | New route pages |
| `ConvoyTimeline.tsx`, `SystemTopology.tsx`, `MoleculeStepper.tsx` | Visualization components |