### PR TITLE
Add max pool size to pool_metrics for accurate utilization

### DIFF
--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -162,12 +162,18 @@ if (IS_PROD) {
 }
 
 function logPoolMetrics() {
-  const primary = { total: pool.totalCount, idle: pool.idleCount, waiting: pool.waitingCount };
+  const primary = {
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
+    max: pool.options.max,
+  };
   const replica = usesSeparateReplica
     ? {
         total: replicaPool.totalCount,
         idle: replicaPool.idleCount,
         waiting: replicaPool.waitingCount,
+        max: replicaPool.options.max,
       }
     : null;
   console.log(


### PR DESCRIPTION
## Summary
- Adds `max` (configured pool size) to the `pool_metrics` JSON log for both primary and replica pools
- Fixes misleading 100% utilization spikes on the dashboard — these were caused by `(total - idle) / total` being 100% when a fresh instance has 1 connection in use out of a max of 100

## Dashboard update after deploy
Update the "Pool Utilization % (primary)" chart APL to:
```
['vercel']
| where message startswith '{"type":"pool_metrics"'
| extend parsed = parse_json(message)
| extend iid = tostring(parsed.instanceId)
| extend total = todouble(parsed.primary.total), idle = todouble(parsed.primary.idle), max = todouble(parsed.primary.max)
| extend utilization_pct = iff(max > 0, ((total - idle) / max) * 100.0, 0.0)
| extend bucket = bin(_time, 1m)
| summarize arg_max(_time, utilization_pct) by iid, bucket
| project-away _time
| project-rename _time = bucket
| summarize avg(utilization_pct), max(utilization_pct) by bin(_time, 1m)
```