### PR TITLE
fix: handle archived repos in Dependabot alert sync

### DIFF
--- a/src/lib/security-agent/github/dependabot-api.ts
+++ b/src/lib/security-agent/github/dependabot-api.ts
@@ -165,9 +165,13 @@ export async function fetchAllDependabotAlerts(
     const httpStatus = (error as { status?: number }).status;
     const message = (error as { message?: string }).message;
 
-    // Handle case where Dependabot alerts are disabled for the repository
-    if (httpStatus === 403 && message?.includes('Dependabot alerts are disabled')) {
-      log(`Dependabot alerts are disabled for ${owner}/${repo}, skipping`);
+    // Handle case where Dependabot alerts are disabled or unavailable for the repository
+    if (
+      httpStatus === 403 &&
+      (message?.includes('Dependabot alerts are disabled') ||
+        message?.includes('Dependabot alerts are not available'))
+    ) {
+      log(`Dependabot alerts are not available for ${owner}/${repo}, skipping`);
       return { status: 'alerts_disabled' };
     }
 


### PR DESCRIPTION
## Summary

- GitHub returns a `403` with `"Dependabot alerts are not available"` for archived repositories, distinct from the existing `"Dependabot alerts are disabled"` message
- The sync was throwing an unhandled exception instead of gracefully skipping these repos
- Broadens the existing `403` check in `fetchAllDependabotAlerts` to match both messages

Fixes KILOCODE-WEB-BZ5