### PR TITLE
fix: return 400 instead of 500 for oversized userId in sandboxId

### DIFF
--- a/kiloclaw/src/index.ts
+++ b/kiloclaw/src/index.ts
@@ -117,7 +117,11 @@ async function authGuard(c: Context<AppEnv>, next: Next) {
 async function deriveSandboxId(c: Context<AppEnv>, next: Next) {
   const userId = c.get('userId');
   if (userId) {
-    c.set('sandboxId', sandboxIdFromUserId(userId));
+    try {
+      c.set('sandboxId', sandboxIdFromUserId(userId));
+    } catch {
+      return c.text('Invalid user identifier', 400);
+    }
   }
   return next();
 }

--- a/kiloclaw/src/index.ts
+++ b/kiloclaw/src/index.ts
@@ -119,8 +119,11 @@ async function deriveSandboxId(c: Context<AppEnv>, next: Next) {
   if (userId) {
     try {
       c.set('sandboxId', sandboxIdFromUserId(userId));
-    } catch {
-      return c.text('Invalid user identifier', 400);
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('userId too long')) {
+        return c.text('Invalid user identifier', 400);
+      }
+      throw err;
     }
   }
   return next();


### PR DESCRIPTION
fix: return 400 instead of 500 for oversized userId in sandboxId derivation