### PR TITLE
fix: handle SIGUSR1 gateway restart without orphaned processes

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-23-v49-device-pairing
+# Build cache bust: 2026-02-24-v50-onboard-port-fix
 RUN echo "4"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js

--- a/kiloclaw/controller/src/supervisor.test.ts
+++ b/kiloclaw/controller/src/supervisor.test.ts
@@ -186,6 +186,55 @@ describe('createSupervisor', () => {
     expect(spawnImpl).toHaveBeenCalledTimes(1);
   });
 
+  it('respawns immediately without backoff or crash counter on clean exit (code 0)', async () => {
+    const { spawnImpl, children } = createSpawnHarness();
+    const supervisor = createSupervisor({
+      gatewayArgs: ['--port', '3001'],
+      spawnImpl: spawnImpl as never,
+      backoffInitialMs: 5_000,
+      backoffMaxMs: 60_000,
+      backoffMultiplier: 2,
+    });
+
+    await supervisor.start();
+    await flushMicrotasks();
+
+    // Gateway exits cleanly (e.g., SIGUSR1 supervised restart after update.run)
+    children[0].emit('exit', 0, null);
+    await flushMicrotasks();
+
+    // Should respawn immediately — no backoff delay needed
+    expect(spawnImpl).toHaveBeenCalledTimes(2);
+    expect(supervisor.getStats().restarts).toBe(1);
+    expect(supervisor.getState()).toBe('running');
+
+    // A subsequent crash should still use initial backoff (not escalated)
+    children[1].emit('exit', 1, null);
+    expect(supervisor.getStats().restarts).toBe(2);
+    vi.advanceTimersByTime(4_999);
+    expect(spawnImpl).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1);
+    await flushMicrotasks();
+    expect(spawnImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats signal-killed exit (code 0 + signal) as a crash', async () => {
+    const { spawnImpl, children } = createSpawnHarness();
+    const supervisor = createSupervisor({
+      gatewayArgs: ['--port', '3001'],
+      spawnImpl: spawnImpl as never,
+      backoffInitialMs: 1_000,
+    });
+
+    await supervisor.start();
+    await flushMicrotasks();
+
+    // Killed by signal — not a clean exit even though code may be 0
+    children[0].emit('exit', 0, 'SIGKILL');
+    expect(supervisor.getStats().restarts).toBe(1);
+    expect(supervisor.getState()).toBe('crashed');
+  });
+
   it('forwards SIGTERM on shutdown and suppresses restarts', async () => {
     const { spawnImpl, children } = createSpawnHarness();
     const supervisor = createSupervisor({

--- a/kiloclaw/controller/src/supervisor.ts
+++ b/kiloclaw/controller/src/supervisor.ts
@@ -155,8 +155,18 @@ export function createSupervisor(options: SupervisorOptions): Supervisor {
       return;
     }
 
-    state = 'crashed';
     restarts += 1;
+
+    // Clean exit (code 0, no signal) indicates an intentional restart
+    // (e.g., SIGUSR1 supervised restart after update.run). Respawn
+    // immediately without backoff.
+    if (code === 0 && signal === null) {
+      resetBackoff();
+      void spawnGateway();
+      return;
+    }
+
+    state = 'crashed';
     scheduleRestart();
   };
 

--- a/kiloclaw/openclaw-device-pairing-list.js
+++ b/kiloclaw/openclaw-device-pairing-list.js
@@ -11,7 +11,7 @@ const execFileAsync = promisify(execFile);
 process.env.HOME = '/root';
 
 (async () => {
-  const { stdout } = await execFileAsync('openclaw', ['devices', 'list', '--json'], {
+  const { stdout } = await execFileAsync('/usr/local/bin/openclaw', ['devices', 'list', '--json'], {
     encoding: 'utf8',
     timeout: 45000,
     env: { ...process.env, HOME: '/root' },
@@ -32,7 +32,9 @@ process.env.HOME = '/root';
 
   console.log(JSON.stringify({ requests }));
 })().catch(err => {
-  process.stderr.write(`[device-pairing-list] fatal: ${err}\n`);
+  const stderr = err && err.stderr ? err.stderr.toString().trim() : '';
+  const msg = stderr || String(err);
+  process.stderr.write(`[device-pairing-list] fatal: ${msg}\n`);
   console.log(JSON.stringify({ requests: [] }));
   process.exitCode = 1;
 });

--- a/kiloclaw/openclaw-pairing-list.js
+++ b/kiloclaw/openclaw-pairing-list.js
@@ -28,11 +28,15 @@ process.env.HOME = '/root';
 
   const results = await Promise.allSettled(
     channels.map(async channel => {
-      const { stdout } = await execFileAsync('openclaw', ['pairing', 'list', channel, '--json'], {
-        encoding: 'utf8',
-        timeout: 45000,
-        env: { ...process.env, HOME: '/root' },
-      });
+      const { stdout } = await execFileAsync(
+        '/usr/local/bin/openclaw',
+        ['pairing', 'list', channel, '--json'],
+        {
+          encoding: 'utf8',
+          timeout: 45000,
+          env: { ...process.env, HOME: '/root' },
+        }
+      );
       const data = JSON.parse(stdout.trim());
       return (data.requests || []).map(req => ({ ...req, channel }));
     })

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -1349,6 +1349,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         JSON.stringify({
           path,
           status: response.status,
+          body: rawBody.slice(0, 1024),
           issues: parsed.error.issues.map(issue => ({
             path: issue.path.join('.'),
             code: issue.code,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -863,8 +863,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }>,
     };
 
+    const logCtx = `sandboxId=${this.sandboxId} appId=${this.flyAppName}`;
     if (result.exit_code !== 0) {
-      console.error('[DO] device pairing list failed:', result.stderr);
+      console.error(`[DO] device pairing list failed: ${result.stderr} ${logCtx}`);
       return empty;
     }
 
@@ -875,7 +876,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         pairing = { requests: data.requests };
       }
     } catch {
-      console.error('[DO] device pairing list parse error:', result.stdout);
+      console.error(`[DO] device pairing list parse error: ${result.stdout} ${logCtx}`);
     }
 
     if (cacheKey) {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -306,7 +306,7 @@ platform.get('/gateway/status', async c => {
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     const status = statusCodeFromError(err);
-    console.error('[platform] gateway status failed:', message);
+    console.error(`[platform] gateway status failed: ${message} status=${status}`);
     return jsonError(message, status);
   }
 });

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -123,8 +123,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
 
     openclaw onboard --non-interactive --accept-risk \
         --mode local \
-        --gateway-port 18789 \
-        --gateway-bind lan \
+        --gateway-port 3001 \
+        --gateway-bind loopback \
         --skip-channels \
         --skip-skills \
         --skip-health

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -317,6 +317,12 @@ EOFPATCH
 # ============================================================
 # START CONTROLLER
 # ============================================================
+# Tell the gateway it's running under a supervisor. On SIGUSR1 restart,
+# the gateway will exit cleanly (code 0) instead of spawning a detached
+# child process. The controller's supervisor detects the clean exit and
+# respawns the gateway immediately without backoff.
+export INVOCATION_ID=1
+
 echo 'Starting KiloClaw controller...'
 
 # Build gateway args as a JSON array (safe quoting through node serialization).

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-02-24',
+    description:
+      'Improve OpenClaw restart handling when restarts are triggered via the OpenClaw Control UI.',
+    category: 'bugfix',
+    deployHint: 'redeploy_suggested',
+  },
+  {
     date: '2026-02-23',
     description:
       'Redesigned dashboard: live gateway process status, added ability to restart OpenClaw gateway.',


### PR DESCRIPTION
## Summary

- Fixes a bug where the openclaw gateway's SIGUSR1 restart (triggered by `update.run` in the Control UI) would spawn a detached child process, then the controller's supervisor would also respawn the gateway — resulting in unsupervised gateway processes.
- Sets `INVOCATION_ID=1` in `start-openclaw.sh` so the gateway recognizes it's running under a supervisor and exits cleanly (code 0) instead of spawning a detached child on SIGUSR1.
- Teaches the controller's supervisor to distinguish clean exits (code 0, no signal) from crashes — immediate respawn without backoff for intentional restarts, existing crash/backoff logic for failures.

## Details

When the gateway receives SIGUSR1 (e.g., from the Control UI's "Update & Restart" button), it drains active tasks, closes the server, and then decides how to restart based on environment hints. Without `INVOCATION_ID`, it doesn't detect a supervisor and spawns a detached child process before exiting. The controller then sees the exit as a crash and spawns *another* gateway — leaving an orphaned, unsupervised process.

`INVOCATION_ID` is a standard systemd convention that openclaw checks in `src/infra/process-respawn.ts` to detect supervised environments. Setting it causes the gateway to exit with code 0 and let the supervisor handle the respawn.

The supervisor change adds exit-code-aware restart logic: code 0 with no signal = intentional restart (immediate respawn, no backoff), anything else = crash (backoff + counter). The restart counter increments in both cases, with `lastExit` recording the cause.

## Other changes on this branch

The earlier commits (`tracking down error`, `Use full path and log additional info`) are from investigating the issue that led to this fix — debugging pairing list scripts and logging.