### PR TITLE
Gate Gastown UI to admin-only users (#537)

### DIFF
--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -131,7 +131,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
-    ...(ENABLE_GASTOWN_FEATURE
+    ...(ENABLE_GASTOWN_FEATURE && isAdmin
       ? [
           {
             title: 'Gastown',

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -5,7 +5,9 @@ import { AgentsPageClient } from './AgentsPageClient';
 
 export default async function AgentsPage({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/agents`);
-  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/agents`
+  );
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
   return <AgentsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -5,7 +5,9 @@ import { BeadsPageClient } from './BeadsPageClient';
 
 export default async function BeadsPage({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/beads`);
-  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/beads`
+  );
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
   return <BeadsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -5,7 +5,9 @@ import { MailPageClient } from './MailPageClient';
 
 export default async function MailPage({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/mail`);
-  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/mail`
+  );
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
   return <MailPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -5,7 +5,9 @@ import { MergesPageClient } from './MergesPageClient';
 
 export default async function MergesPage({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/merges`);
-  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/merges`
+  );
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
   return <MergesPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -9,7 +9,9 @@ export default async function ObservabilityPage({
   params: Promise<{ townId: string }>;
 }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/observability`);
-  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/observability`
+  );
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
   return <ObservabilityPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/page.tsx
@@ -9,9 +9,9 @@ export default async function TownOverviewPage({
   params: Promise<{ townId: string }>;
 }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
+  const user = await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
 
-  if (!ENABLE_GASTOWN_FEATURE) {
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -9,9 +9,11 @@ export default async function RigDetailPage({
   params: Promise<{ townId: string; rigId: string }>;
 }) {
   const { townId, rigId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`);
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`
+  );
 
-  if (!ENABLE_GASTOWN_FEATURE) {
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/settings/page.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/page.tsx
@@ -9,7 +9,9 @@ export default async function TownSettingsPage({
   params: Promise<{ townId: string }>;
 }) {
   const { townId } = await params;
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}/settings`);
-  if (!ENABLE_GASTOWN_FEATURE) return notFound();
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/settings`
+  );
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
   return <TownSettingsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/page.tsx
+++ b/src/app/(app)/gastown/page.tsx
@@ -4,9 +4,9 @@ import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
 import { TownListPageClient } from './TownListPageClient';
 
 export default async function GastownPage() {
-  await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
+  const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
 
-  if (!ENABLE_GASTOWN_FEATURE) {
+  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) {
     return notFound();
   }
 

--- a/src/routers/gastown-router.ts
+++ b/src/routers/gastown-router.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import * as gastown from '@/lib/gastown/gastown-client';
@@ -102,7 +102,7 @@ async function withGastownError<T>(fn: () => Promise<T>): Promise<T> {
 export const gastownRouter = createTRPCRouter({
   // ── Towns ───────────────────────────────────────────────────────────────
 
-  createTown: baseProcedure
+  createTown: adminProcedure
     .input(
       z.object({
         name: z.string().min(1).max(64),
@@ -126,11 +126,11 @@ export const gastownRouter = createTRPCRouter({
       return town;
     }),
 
-  listTowns: baseProcedure.query(async ({ ctx }) => {
+  listTowns: adminProcedure.query(async ({ ctx }) => {
     return withGastownError(() => gastown.listTowns(ctx.user.id));
   }),
 
-  getTown: baseProcedure
+  getTown: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const town = await withGastownError(() => gastown.getTown(ctx.user.id, input.townId));
@@ -142,7 +142,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Rigs ────────────────────────────────────────────────────────────────
 
-  createRig: baseProcedure
+  createRig: adminProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -220,7 +220,7 @@ export const gastownRouter = createTRPCRouter({
       return rig;
     }),
 
-  listRigs: baseProcedure
+  listRigs: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       // Verify ownership
@@ -231,7 +231,7 @@ export const gastownRouter = createTRPCRouter({
       return withGastownError(() => gastown.listRigs(ctx.user.id, input.townId));
     }),
 
-  getRig: baseProcedure
+  getRig: adminProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const rig = await withGastownError(() => gastown.getRig(ctx.user.id, input.rigId));
@@ -244,7 +244,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Beads ───────────────────────────────────────────────────────────────
 
-  listBeads: baseProcedure
+  listBeads: adminProcedure
     .input(
       z.object({
         rigId: z.string().uuid(),
@@ -261,7 +261,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Agents ──────────────────────────────────────────────────────────────
 
-  listAgents: baseProcedure
+  listAgents: adminProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const rig = await withGastownError(() => gastown.getRig(ctx.user.id, input.rigId));
@@ -270,7 +270,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Work Assignment ─────────────────────────────────────────────────────
 
-  sling: baseProcedure
+  sling: adminProcedure
     .input(
       z.object({
         rigId: z.string().uuid(),
@@ -309,7 +309,7 @@ export const gastownRouter = createTRPCRouter({
   // Routes messages to MayorDO (town-level persistent conversational agent).
   // No beads are created — the mayor decides when to delegate work via tools.
 
-  sendMessage: baseProcedure
+  sendMessage: adminProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -351,7 +351,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Mayor Status ──────────────────────────────────────────────────────
 
-  getMayorStatus: baseProcedure
+  getMayorStatus: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       // Verify ownership
@@ -362,7 +362,7 @@ export const gastownRouter = createTRPCRouter({
       return withGastownError(() => gastown.getMayorStatus(input.townId));
     }),
 
-  ensureMayor: baseProcedure
+  ensureMayor: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       const town = await withGastownError(() => gastown.getTown(ctx.user.id, input.townId));
@@ -386,7 +386,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Agent Streams ───────────────────────────────────────────────────────
 
-  getAgentStreamUrl: baseProcedure
+  getAgentStreamUrl: adminProcedure
     .input(
       z.object({
         agentId: z.string().uuid(),
@@ -416,7 +416,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Agent Terminal (PTY) ──────────────────────────────────────────────────
 
-  createPtySession: baseProcedure
+  createPtySession: adminProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -443,7 +443,7 @@ export const gastownRouter = createTRPCRouter({
       return { pty, wsUrl };
     }),
 
-  resizePtySession: baseProcedure
+  resizePtySession: adminProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -465,7 +465,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Town Configuration ──────────────────────────────────────────────────
 
-  getTownConfig: baseProcedure
+  getTownConfig: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const town = await withGastownError(() => gastown.getTown(ctx.user.id, input.townId));
@@ -475,7 +475,7 @@ export const gastownRouter = createTRPCRouter({
       return withGastownError(() => gastown.getTownConfig(input.townId));
     }),
 
-  updateTownConfig: baseProcedure
+  updateTownConfig: adminProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -492,7 +492,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Events ─────────────────────────────────────────────────────────────
 
-  getBeadEvents: baseProcedure
+  getBeadEvents: adminProcedure
     .input(
       z.object({
         rigId: z.string().uuid(),
@@ -512,7 +512,7 @@ export const gastownRouter = createTRPCRouter({
       );
     }),
 
-  getTownEvents: baseProcedure
+  getTownEvents: adminProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -535,7 +535,7 @@ export const gastownRouter = createTRPCRouter({
 
   // ── Deletes ────────────────────────────────────────────────────────────
 
-  deleteTown: baseProcedure
+  deleteTown: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       const town = await withGastownError(() => gastown.getTown(ctx.user.id, input.townId));
@@ -545,13 +545,13 @@ export const gastownRouter = createTRPCRouter({
       await withGastownError(() => gastown.deleteTown(ctx.user.id, input.townId));
     }),
 
-  deleteRig: baseProcedure
+  deleteRig: adminProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await withGastownError(() => gastown.deleteRig(ctx.user.id, input.rigId));
     }),
 
-  deleteBead: baseProcedure
+  deleteBead: adminProcedure
     .input(z.object({ rigId: z.string().uuid(), beadId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       // Verify the caller owns this rig before deleting
@@ -559,7 +559,7 @@ export const gastownRouter = createTRPCRouter({
       await withGastownError(() => gastown.deleteBead(rig.town_id, rig.id, input.beadId));
     }),
 
-  deleteAgent: baseProcedure
+  deleteAgent: adminProcedure
     .input(z.object({ rigId: z.string().uuid(), agentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       // Verify the caller owns this rig before deleting


### PR DESCRIPTION
## Summary

- Restrict all Gastown UI, tRPC procedures, and navigation to `is_admin` users only — temporary gate until Gastown is ready for beta/GA
- Non-admin users see a 404 on any `/gastown/*` page and get `FORBIDDEN` on any Gastown tRPC call
- The Gastown sidebar link is hidden for non-admin users

## Changes

**tRPC layer** (`src/routers/gastown-router.ts`):
- Replaced all 22 `baseProcedure` references with `adminProcedure` (the existing admin middleware from `src/lib/trpc/init.ts` that throws `FORBIDDEN` for non-admin users)

**Server pages** (9 files under `src/app/(app)/gastown/`):
- Each page now captures the user from `getUserFromAuthOrRedirect` and checks `user.is_admin`, returning `notFound()` for non-admins

**Navigation** (`src/app/(app)/components/PersonalAppSidebar.tsx`):
- Gastown sidebar link now requires both `ENABLE_GASTOWN_FEATURE` and `isAdmin` to render

**Worker-level gate not added**: The Gastown CF worker is behind Cloudflare Access and only called server-to-server via `gastown-client.ts`. The tRPC admin gate is the proper enforcement point — no changes needed in the worker.

## Validation

- `pnpm typecheck` passes
- Pre-commit hooks (prettier + typecheck) pass

Closes #537