### PR TITLE
add min/max constraints to MachineSizeSchema

### DIFF
--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -12,8 +12,8 @@ export type ModelEntry = { id: string; name: string };
 const ModelEntrySchema = z.object({ id: z.string(), name: z.string() });
 
 const MachineSizeSchema = z.object({
-  cpus: z.number(),
-  memory_mb: z.number(),
+  cpus: z.number().int().min(1).max(8),
+  memory_mb: z.number().int().min(256).max(16384),
   cpu_kind: z.enum(['shared', 'performance']).optional(),
 });
 


### PR DESCRIPTION
Constrain cpus to 1-8 and memory_mb to 256-16384 (16GB). Defense-in-depth against cost spikes from buggy or compromised callers — Fly API was the only validation layer.

Current deploy: shared-cpu-2x, 4GB. Limits provide 4x headroom.