### PR TITLE
feat: change exec security from deny to allowlist for skills install

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm-slim
 ENV NODE_VERSION=22.13.1
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       ca-certificates curl git xz-utils unzip \
+       ca-certificates curl git xz-utils unzip jq \
     && ARCH="$(dpkg --print-architecture)" \
     && case "${ARCH}" in \
          amd64) NODE_ARCH="x64" ;; \
@@ -46,7 +46,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-24-v50-onboard-port-fix
+# Build cache bust: 2026-02-24-v51-exec-allowlist
 RUN echo "4"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-24-v51-exec-allowlist
+# Build cache bust: 2026-02-25-v52-exec-host-gateway
 RUN echo "4"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -246,11 +246,12 @@ config.agents.defaults = config.agents.defaults || {};
 config.agents.defaults.model = { primary: defaultModel };
 console.log('KiloCode provider configured with base URL ' + baseUrl);
 
-// Exec security: allowlist mode lets skills install and agent exec work
-// while still gating unknown commands via the Control UI approval dialog.
-// The ask=on-miss default prompts for commands not in the allowlist.
+// Exec: KiloClaw machines have no Docker sandbox, so exec must target the
+// gateway host directly. Allowlist mode gates unknown commands via the
+// Control UI approval dialog; safe bins (jq, head, tail, etc.) auto-allow.
 config.tools = config.tools || {};
 config.tools.exec = config.tools.exec || {};
+config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
 

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -246,12 +246,12 @@ config.agents.defaults = config.agents.defaults || {};
 config.agents.defaults.model = { primary: defaultModel };
 console.log('KiloCode provider configured with base URL ' + baseUrl);
 
-// Explicitly lock down exec tool security (defense-in-depth).
-// OpenClaw defaults to these values, but pinning them here prevents
-// silent regression if upstream defaults change in a future version.
+// Exec security: allowlist mode lets skills install and agent exec work
+// while still gating unknown commands via the Control UI approval dialog.
+// The ask=on-miss default prompts for commands not in the allowlist.
 config.tools = config.tools || {};
 config.tools.exec = config.tools.exec || {};
-config.tools.exec.security = 'deny';
+config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
 
 // Telegram configuration

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -13,7 +13,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-02-25',
     description:
-      'Adjust tools.exec.security from deny to allowlist. Skills install and agent exec now work with approval prompts in the Control UI.',
+      'Adjust tools.exec.security from deny to allowlist. Asking the agent to exec commands will trigger approval prompts in the Control UI.',
     category: 'feature',
     deployHint: 'redeploy_suggested',
   },

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-02-25',
+    description:
+      'Adjust tools.exec.security from deny to allowlist. Skills install and agent exec now work with approval prompts in the Control UI.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
     date: '2026-02-24',
     description:
       'Improve OpenClaw restart handling when restarts are triggered via the OpenClaw Control UI.',


### PR DESCRIPTION
## Summary

- Change `tools.exec.security` from `deny` to `allowlist` in the KiloClaw startup config, fixing the `exec denied: host=gateway security=deny` error users hit when running `openclaw skills install`
- Add `jq` to the Docker image
- Add changelog entry for the claw dashboard

## How it works

With `security=allowlist` and `ask=on-miss`:
- Commands matching the allowlist run without prompting
- All other commands show an approval dialog in the Control UI
- Users click "Allow once" or "Always allow"
- No pre-populated allowlist — users build it organically through the approval UX

## Files changed

| File | Change |
|---|---|
| `kiloclaw/Dockerfile` | Add `jq` to apt-get, bump cache bust |
| `kiloclaw/start-openclaw.sh` | `tools.exec.security`: `deny` → `allowlist` |
| `src/app/(app)/claw/components/changelog-data.ts` | Add changelog entry |