### PR TITLE
set WORKER_ENV=production by default in wrangler config

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -5,6 +5,9 @@
 NEXTAUTH_SECRET=dev-secret-change-me
 INTERNAL_API_SECRET=dev-internal-secret
 GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
+# Override WORKER_ENV to "development" for local dev.
+# Production default is set in wrangler.jsonc. This override disables JWT env
+# claim enforcement and uses "dev-" prefixed Fly app names.
 WORKER_ENV=development
 
 # Optional: Override KiloCode base URL (dev)

--- a/kiloclaw/DEVELOPMENT.md
+++ b/kiloclaw/DEVELOPMENT.md
@@ -127,10 +127,10 @@ user-provided encrypted secrets and channel tokens are silently skipped.
 
 ### Development Flags
 
-| Variable     | Description                                                                                         |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| `DEV_MODE`   | Set to `true` to skip JWT auth and enable `allowInsecureAuth` in the container. **Local dev only.** |
-| `WORKER_ENV` | Set to `production` to enforce JWT `env` claim matching. When unset, env validation is skipped.     |
+| Variable     | Description                                                                                                                                                                               |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEV_MODE`   | Set to `true` to skip JWT auth and enable `allowInsecureAuth` in the container. **Local dev only.**                                                                                       |
+| `WORKER_ENV` | Defaults to `"production"` in `wrangler.jsonc`. **Set to `"development"` in `.dev.vars` for local dev.** Controls JWT `env` claim matching and Fly app name prefixes (`dev-` vs `acct-`). |
 
 ### Optional
 
@@ -170,8 +170,7 @@ npx wrangler secret put CF_ACCOUNT_ID
 # Set encryption key (get from the Next.js deployment's AGENT_ENV_VARS_PRIVATE_KEY)
 npx wrangler secret put AGENT_ENV_VARS_PRIVATE_KEY
 
-# Optional: enforce JWT env matching
-echo "production" | npx wrangler secret put WORKER_ENV
+# WORKER_ENV defaults to "production" in wrangler.jsonc -- no secret needed.
 
 # Deploy
 pnpm deploy
@@ -184,7 +183,7 @@ pnpm deploy
 | `NEXTAUTH_SECRET`            | `NEXTAUTH_SECRET`              | Same HS256 signing key for JWT verification           |
 | `INTERNAL_API_SECRET`        | `KILOCLAW_INTERNAL_API_SECRET` | Platform API authentication                           |
 | `AGENT_ENV_VARS_PRIVATE_KEY` | `AGENT_ENV_VARS_PUBLIC_KEY`    | RSA key pair (worker has private, Next.js has public) |
-| `WORKER_ENV`                 | `NODE_ENV`                     | Should both be `production` in prod                   |
+| `WORKER_ENV`                 | `NODE_ENV`                     | Defaults to `production` in `wrangler.jsonc`          |
 
 ## Architecture
 

--- a/kiloclaw/wrangler.jsonc
+++ b/kiloclaw/wrangler.jsonc
@@ -72,6 +72,8 @@
     "FLY_IMAGE_TAG": "latest",
     "FLY_REGION": "dfw,yyz,cdg",
     "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",
+    // Defaults to "production". For local dev, override to "development" in .dev.vars.
+    "WORKER_ENV": "production",
   },
   // Secrets (set via wrangler secret put):
   // FLY_API_TOKEN,


### PR DESCRIPTION
defense in depth
Now defaults to 'production' in wrangler.jsonc so JWT env claim validation is enforced automatically.

Local dev overrides to 'development' via .dev.vars