### PR TITLE
fix: log user-interrupted security analysis at info level instead of error

### DIFF
--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -297,7 +297,8 @@ async function handleAnalysisFailed(
       ? `Analysis interrupted: ${payload.errorMessage ?? 'unknown reason'}`
       : (payload.errorMessage ?? 'Analysis failed');
 
-  logError('Analysis failed/interrupted', {
+  const logger = payload.status === 'interrupted' ? log : logError;
+  logger('Analysis failed/interrupted', {
     findingId,
     correlationId,
     status: payload.status,


### PR DESCRIPTION
## Summary

- Demotes user-initiated security analysis interruptions from `error` to `info` log level in the callback handler, eliminating unnecessary Sentry noise
- Actual `failed` callbacks remain at `error` level since those may indicate real system problems

Fixes KILOCODE-WEB-DM6