### PR TITLE
Reduce DB pool max from 100 to 15 to prevent pgbouncer overload

### DIFF
--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -69,9 +69,12 @@ function getReplicaUrl(): string {
 }
 
 // Primary pool - always points to Frankfurt (writes go here)
+// max: 15 — keep low because Vercel can spawn 100+ concurrent serverless instances,
+// each with its own pool, all hitting the same pgbouncer. At max:100, a cold-start
+// cascade can open 100×N connections simultaneously and overwhelm pgbouncer.
 export const pool = new Pool({
   ...getDatabaseClientConfig(postgresUrl),
-  max: 100,
+  max: 15,
   connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
   idleTimeoutMillis: 3000,
   application_name: appName,
@@ -84,7 +87,7 @@ export const usesSeparateReplica = replicaUrl !== postgresUrl;
 const replicaPool = usesSeparateReplica
   ? new Pool({
       ...getDatabaseClientConfig(replicaUrl),
-      max: 100,
+      max: 15,
       connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
       idleTimeoutMillis: 3000,
       application_name: `${appName}-replica`,


### PR DESCRIPTION
## Summary

- Reduces `pg.Pool` `max` from 100 to 15 for both primary and replica pools
- Prevents pgbouncer overload during Vercel cold-start cascades

## Context

On Feb 25 at ~04:53 UTC, we observed a burst of DB connections that overwhelmed pgbouncer. Investigation showed:

- **255 unique Vercel instances** were simultaneously creating connections in a 3-minute window (vs baseline ~35-40)
- **8 instances hit the max of 100 connections each**, with 18 instances having 50+ connections
- No traffic spike, no deployment, no cron — this was a **Vercel cold-start scaling event**
- With `max: 100` per pool × 100+ instances, the theoretical ceiling is **10,000+ simultaneous connections** to pgbouncer

At `max: 15`, even with 255 instances the ceiling drops to ~3,825 — and in practice most instances only need 1-5 concurrent connections.

## Rollback

A revert branch (`revert/reduce-db-pool-max`) with a ready-to-merge PR is available at: (see linked PR)