### PR TITLE
Revert: Reduce DB pool max from 100 to 15

### DIFF
--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -69,12 +69,9 @@ function getReplicaUrl(): string {
 }
 
 // Primary pool - always points to Frankfurt (writes go here)
-// max: 15 — keep low because Vercel can spawn 100+ concurrent serverless instances,
-// each with its own pool, all hitting the same pgbouncer. At max:100, a cold-start
-// cascade can open 100×N connections simultaneously and overwhelm pgbouncer.
 export const pool = new Pool({
   ...getDatabaseClientConfig(postgresUrl),
-  max: 15,
+  max: 100,
   connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
   idleTimeoutMillis: 3000,
   application_name: appName,
@@ -87,7 +84,7 @@ export const usesSeparateReplica = replicaUrl !== postgresUrl;
 const replicaPool = usesSeparateReplica
   ? new Pool({
       ...getDatabaseClientConfig(replicaUrl),
-      max: 15,
+      max: 100,
       connectionTimeoutMillis: Number.parseInt(POSTGRES_CONNECT_TIMEOUT || '30000'),
       idleTimeoutMillis: 3000,
       application_name: `${appName}-replica`,


### PR DESCRIPTION
## Summary

- Reverts the pool max reduction back to 100 (from #554)
- **Do not merge unless #554 causes issues** — this is a pre-prepared rollback PR

## When to use

Merge this if the pool max reduction in #554 causes connection timeout errors due to pools being too small under sustained high load.