### PR TITLE
Admin Session Traces - Resolve Cloud Agent Session IDs

### DIFF
--- a/src/app/admin/api/session-traces/hooks.ts
+++ b/src/app/admin/api/session-traces/hooks.ts
@@ -28,3 +28,13 @@ export function useAdminApiConversationHistory(sessionId: string | null) {
     enabled: !!sessionId,
   });
 }
+
+export function useAdminResolveCloudAgentSession(cloudAgentSessionId: string | null) {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.admin.sessionTraces.resolveCloudAgentSession.queryOptions({
+      cloud_agent_session_id: cloudAgentSessionId ?? '',
+    }),
+    enabled: !!cloudAgentSessionId,
+  });
+}

--- a/src/app/admin/components/SessionTraceViewer.tsx
+++ b/src/app/admin/components/SessionTraceViewer.tsx
@@ -18,6 +18,7 @@ import {
   useAdminSessionTrace,
   useAdminSessionMessages,
   useAdminApiConversationHistory,
+  useAdminResolveCloudAgentSession,
 } from '@/app/admin/api/session-traces/hooks';
 import { Search, User, Calendar, Globe, GitBranch, Loader2, Download } from 'lucide-react';
 import type { CloudMessage, Message } from '@/components/cloud-agent/types';
@@ -25,6 +26,7 @@ import type { StoredMessage } from '@/components/cloud-agent-next/types';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SES_PREFIX = 'ses_';
+const AGENT_PREFIX = 'agent_';
 
 function convertToMessage(cloudMessage: CloudMessage): Message & {
   say?: string;
@@ -57,13 +59,29 @@ export function SessionTraceViewer() {
   const [inputValue, setInputValue] = useState('');
   const [searchedSessionId, setSearchedSessionId] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
+  const [resolvedFromAgent, setResolvedFromAgent] = useState<string | null>(null);
+
+  const resolveQuery = useAdminResolveCloudAgentSession(pendingAgentId);
+
+  // When the agent ID resolves, transition to the CLI session ID
+  useEffect(() => {
+    if (resolveQuery.data?.session_id && pendingAgentId) {
+      const resolved = resolveQuery.data.session_id;
+      setResolvedFromAgent(pendingAgentId);
+      setPendingAgentId(null);
+      setSearchedSessionId(resolved);
+      router.replace(`/admin/session-traces?sessionId=${resolved}`);
+    }
+  }, [resolveQuery.data, pendingAgentId, router]);
 
   // Initialize from URL parameter on mount
   useEffect(() => {
-    if (
-      sessionIdFromUrl &&
-      (UUID_REGEX.test(sessionIdFromUrl) || sessionIdFromUrl.startsWith(SES_PREFIX))
-    ) {
+    if (!sessionIdFromUrl) return;
+    if (sessionIdFromUrl.startsWith(AGENT_PREFIX)) {
+      setInputValue(sessionIdFromUrl);
+      setPendingAgentId(sessionIdFromUrl);
+    } else if (UUID_REGEX.test(sessionIdFromUrl) || sessionIdFromUrl.startsWith(SES_PREFIX)) {
       setInputValue(sessionIdFromUrl);
       setSearchedSessionId(sessionIdFromUrl);
     }
@@ -79,16 +97,26 @@ export function SessionTraceViewer() {
       setValidationError('Please enter a session ID');
       return;
     }
-    if (!UUID_REGEX.test(trimmed) && !trimmed.startsWith(SES_PREFIX)) {
+
+    const isAgent = trimmed.startsWith(AGENT_PREFIX);
+    if (!UUID_REGEX.test(trimmed) && !trimmed.startsWith(SES_PREFIX) && !isAgent) {
       setValidationError(
-        'Invalid session ID. Expected a UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) or a v2 ID (ses_...)'
+        'Invalid session ID. Expected a UUID, a v2 ID (ses_...), or a cloud agent session ID (agent_...)'
       );
       return;
     }
+
     setValidationError(null);
-    setSearchedSessionId(trimmed);
-    // Update URL to make the link shareable (replace to avoid growing history stack)
-    router.replace(`/admin/session-traces?sessionId=${trimmed}`);
+    setResolvedFromAgent(null);
+
+    if (isAgent) {
+      setPendingAgentId(trimmed);
+      setSearchedSessionId(null);
+    } else {
+      setPendingAgentId(null);
+      setSearchedSessionId(trimmed);
+      router.replace(`/admin/session-traces?sessionId=${trimmed}`);
+    }
   };
 
   const downloadJson = (data: unknown, filename: string) => {
@@ -157,30 +185,57 @@ export function SessionTraceViewer() {
           <CardHeader>
             <CardTitle>Session Trace Viewer</CardTitle>
             <CardDescription>
-              Enter a CLI session ID (UUID or ses_...) to view the full session trace
+              Enter a CLI session ID (UUID or ses_...) or a cloud agent session ID (agent_...) to
+              view the full session trace
             </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="flex gap-2">
               <Input
-                placeholder="e.g., 550e8400-e29b-41d4-a716-446655440000 or ses_abc123..."
+                placeholder="e.g., 550e8400-e29b-41d4-a716-446655440000, ses_abc123..., or agent_..."
                 value={inputValue}
                 onChange={e => setInputValue(e.target.value)}
                 onKeyDown={e => e.key === 'Enter' && handleSearch()}
                 className="font-mono"
               />
-              <Button onClick={handleSearch} disabled={sessionQuery.isLoading}>
-                {sessionQuery.isLoading ? (
+              <Button
+                onClick={handleSearch}
+                disabled={sessionQuery.isLoading || resolveQuery.isLoading}
+              >
+                {sessionQuery.isLoading || resolveQuery.isLoading ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 ) : (
                   <Search className="mr-2 h-4 w-4" />
                 )}
-                {sessionQuery.isLoading ? 'Loading...' : 'Search'}
+                {resolveQuery.isLoading
+                  ? 'Resolving...'
+                  : sessionQuery.isLoading
+                    ? 'Loading...'
+                    : 'Search'}
               </Button>
             </div>
             {validationError && <p className="mt-2 text-sm text-red-500">{validationError}</p>}
           </CardContent>
         </Card>
+
+        {resolveQuery.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              {resolveQuery.error?.message || 'Could not resolve cloud agent session ID'}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {resolvedFromAgent && (
+          <Alert>
+            <AlertDescription>
+              Resolved from cloud agent session{' '}
+              <code className="bg-muted rounded px-1 py-0.5 font-mono text-sm">
+                {resolvedFromAgent}
+              </code>
+            </AlertDescription>
+          </Alert>
+        )}
 
         {sessionQuery.isError && (
           <Alert variant="destructive">

--- a/src/app/admin/components/SessionTraceViewer.tsx
+++ b/src/app/admin/components/SessionTraceViewer.tsx
@@ -81,6 +81,7 @@ export function SessionTraceViewer() {
     if (sessionIdFromUrl.startsWith(AGENT_PREFIX)) {
       setInputValue(sessionIdFromUrl);
       setPendingAgentId(sessionIdFromUrl);
+      setSearchedSessionId(null);
     } else if (UUID_REGEX.test(sessionIdFromUrl) || sessionIdFromUrl.startsWith(SES_PREFIX)) {
       setInputValue(sessionIdFromUrl);
       setSearchedSessionId(sessionIdFromUrl);
@@ -218,7 +219,7 @@ export function SessionTraceViewer() {
           </CardContent>
         </Card>
 
-        {resolveQuery.isError && (
+        {pendingAgentId && resolveQuery.isError && (
           <Alert variant="destructive">
             <AlertDescription>
               {resolveQuery.error?.message || 'Could not resolve cloud agent session ID'}

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -883,6 +883,37 @@ export const adminRouter = createTRPCRouter({
   codeReviews: adminCodeReviewsRouter,
 
   sessionTraces: createTRPCRouter({
+    resolveCloudAgentSession: adminProcedure
+      .input(z.object({ cloud_agent_session_id: z.string().startsWith('agent_') }))
+      .query(async ({ input }) => {
+        // Check v1 first
+        const [v1] = await db
+          .select({ session_id: cliSessions.session_id })
+          .from(cliSessions)
+          .where(eq(cliSessions.cloud_agent_session_id, input.cloud_agent_session_id))
+          .limit(1);
+
+        if (v1) {
+          return { session_id: v1.session_id };
+        }
+
+        // Then check v2
+        const [v2] = await db
+          .select({ session_id: cli_sessions_v2.session_id })
+          .from(cli_sessions_v2)
+          .where(eq(cli_sessions_v2.cloud_agent_session_id, input.cloud_agent_session_id))
+          .limit(1);
+
+        if (v2) {
+          return { session_id: v2.session_id };
+        }
+
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No CLI session found for this cloud agent session ID',
+        });
+      }),
+
     get: adminProcedure
       .input(z.object({ session_id: sessionIdSchema }))
       .query(async ({ input }) => {


### PR DESCRIPTION
## Summary

- Adds a `resolveCloudAgentSession` admin endpoint that looks up `agent_*` cloud agent session IDs across both `cli_sessions` (v1) and `cli_sessions_v2` tables, returning the corresponding CLI session ID.
- Adds a `useAdminResolveCloudAgentSession` React Query hook.
- Updates the Session Trace Viewer to accept `agent_*` IDs in the search box and URL params. When an agent ID is entered, it resolves to the CLI session ID, updates the URL for shareability, and shows a banner indicating the resolution source.

Existing endpoints and queries are untouched — resolution happens as a separate one-time query before the standard session trace flow.