### PR TITLE
CloudAgentNext - Bump CLI version to 7.0.29

### DIFF
--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -118,7 +118,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "1.0.25",
+        "KILOCODE_CLI_VERSION": "7.0.29",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 120,


### PR DESCRIPTION
## Summary

- Bump `KILOCODE_CLI_VERSION` in `cloud-agent-next/wrangler.jsonc` from `1.0.25` to `7.0.29`