### PR TITLE
kiloclaw: update Fly region list to current fleet

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -33,7 +33,7 @@ export const DEFAULT_VOLUME_SIZE_GB = 10;
 
 /** Default Fly region priority list when FLY_REGION env var is not set.
  *  Callers shuffle before selecting so order here doesn't matter. */
-export const DEFAULT_FLY_REGION = 'cdg,arn,yyz,ord,iad,lax';
+export const DEFAULT_FLY_REGION = 'ams,fra,lhr,arn,iad,ord,lax,sjc,ewr';
 
 // Alarm cadence by instance status
 /** Running machines: fast health checks */

--- a/kiloclaw/wrangler.jsonc
+++ b/kiloclaw/wrangler.jsonc
@@ -70,7 +70,7 @@
     "FLY_REGISTRY_APP": "kiloclaw-machines", // Shared Docker image registry
     "FLY_ORG_SLUG": "kilo-679", // Org for creating per-user Fly apps
     "FLY_IMAGE_TAG": "latest",
-    "FLY_REGION": "dfw,yyz,cdg",
+    "FLY_REGION": "ams,fra,lhr,arn,iad,ord,lax,sjc,ewr",
     "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",
     // Defaults to "production". For local dev, override to "development" in .dev.vars.
     "WORKER_ENV": "production",


### PR DESCRIPTION
Replace outdated region list (yyz,cdg) with the full set of active Fly regions minus excluded ones (cdg, yyz, dfw): EU: ams, fra, lhr, arn | NA: iad, ord, lax, sjc, ewr

Updates both the wrangler.jsonc production config and the DEFAULT_FLY_REGION fallback in config.ts.