### PR TITLE
chore(config): remove reactCompiler option from next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,7 +23,6 @@ validateGitLfs();
 const nextConfig = {
   reactStrictMode: true,
 
-  reactCompiler: true,
   devIndicators: { position: 'bottom-right' },
 
   async rewrites() {


### PR DESCRIPTION
Turns out it's not as production-ready as they claim.