### PR TITLE
kiloclaw: reduce default memory to 3 GB and surface machineSize in status API

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -21,10 +21,10 @@ export const KILOCLAW_AUTH_COOKIE_MAX_AGE = 60 * 60 * 24;
 /** Expected JWT token version -- must match cloud's JWT_TOKEN_VERSION */
 export const KILO_TOKEN_VERSION = 3;
 
-/** Default Fly Machine guest spec (shared-cpu-2x, 4GB) */
+/** Default Fly Machine guest spec (shared-cpu-2x, 3GB) */
 export const DEFAULT_MACHINE_GUEST = {
   cpus: 2,
-  memory_mb: 4096,
+  memory_mb: 3072,
   cpu_kind: 'shared' as const,
 };
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1364,7 +1364,7 @@ describe('start: 412 insufficient resources recovery', () => {
     const regions412Call = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
     expect(regions412Call[1]).toEqual(
       expect.objectContaining({
-        compute: expect.objectContaining({ cpus: 2, memory_mb: 4096 }),
+        compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }),
       })
     );
     // Regions are shuffled, so just check the set (deprioritize is a no-op here
@@ -1411,7 +1411,7 @@ describe('start: 412 insufficient resources recovery', () => {
     expect(regionsForkCall[1]).toEqual(
       expect.objectContaining({
         source_volume_id: 'vol-1',
-        compute: expect.objectContaining({ cpus: 2, memory_mb: 4096 }),
+        compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }),
       })
     );
     // Regions are shuffled — check the set
@@ -1476,7 +1476,7 @@ describe('start: 412 insufficient resources recovery', () => {
     expect(regionsUpdateCall[1]).toEqual(
       expect.objectContaining({
         source_volume_id: 'vol-1',
-        compute: expect.objectContaining({ cpus: 2, memory_mb: 4096 }),
+        compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }),
       })
     );
     // Regions are shuffled then deprioritized — check the set

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -1215,6 +1215,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     flyMachineId: string | null;
     flyVolumeId: string | null;
     flyRegion: string | null;
+    machineSize: MachineSize | null;
     openclawVersion: string | null;
     imageVariant: string | null;
     trackedImageTag: string | null;
@@ -1248,6 +1249,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       flyMachineId: this.flyMachineId,
       flyVolumeId: this.flyVolumeId,
       flyRegion: this.flyRegion,
+      machineSize: this.machineSize,
       openclawVersion: this.openclawVersion,
       imageVariant: this.imageVariant,
       trackedImageTag: this.trackedImageTag,
@@ -1411,6 +1413,19 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     try {
       const flyConfig = this.getFlyConfig();
+
+      // Backfill machineSize from live Fly machine config for legacy instances
+      // before stopping, so the guest sent to updateMachine matches the actual
+      // deployed size instead of the new default.
+      if (this.machineSize === null && this.flyMachineId) {
+        const machine = await fly.getMachine(flyConfig, this.flyMachineId);
+        if (machine.config?.guest) {
+          const { cpus, memory_mb, cpu_kind } = machine.config.guest;
+          this.machineSize = { cpus, memory_mb, cpu_kind };
+          await this.ctx.storage.put(storageUpdate({ machineSize: this.machineSize }));
+        }
+      }
+
       await fly.stopMachineAndWait(flyConfig, this.flyMachineId);
 
       const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
@@ -1685,6 +1700,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     try {
       const flyConfig = this.getFlyConfig();
       const machine = await fly.getMachine(flyConfig, this.flyMachineId);
+
+      // Backfill machineSize from live Fly machine config for legacy instances
+      if (this.machineSize === null && machine.config?.guest) {
+        const { cpus, memory_mb, cpu_kind } = machine.config.guest;
+        this.machineSize = { cpus, memory_mb, cpu_kind };
+        await this.ctx.storage.put(storageUpdate({ machineSize: this.machineSize }));
+      }
 
       if (machine.state === 'started') {
         // Confirmed running — reset in-memory fail count
@@ -2151,13 +2173,25 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    */
   private async startExistingMachine(
     flyConfig: FlyClientConfig,
-    machineConfig: FlyMachineConfig,
+    initialMachineConfig: FlyMachineConfig,
     minSecretsVersion?: number
   ): Promise<void> {
     if (!this.flyMachineId) return;
 
     try {
       const machine = await fly.getMachine(flyConfig, this.flyMachineId);
+
+      // Backfill machineSize from live Fly machine config for legacy instances,
+      // then re-derive guest so updateMachine sends the actual deployed size
+      // instead of the new default.
+      let machineConfig = initialMachineConfig;
+      if (this.machineSize === null && machine.config?.guest) {
+        const { cpus, memory_mb, cpu_kind } = machine.config.guest;
+        this.machineSize = { cpus, memory_mb, cpu_kind };
+        await this.ctx.storage.put(storageUpdate({ machineSize: this.machineSize }));
+        machineConfig = { ...machineConfig, guest: guestFromSize(this.machineSize) };
+      }
+
       if (machine.state === 'stopped' || machine.state === 'created') {
         await fly.updateMachine(flyConfig, this.flyMachineId, machineConfig, { minSecretsVersion });
         await fly.waitForState(flyConfig, this.flyMachineId, 'started', STARTUP_TIMEOUT_SECONDS);
@@ -2169,11 +2203,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
     } catch (err) {
       if (fly.isFlyNotFound(err)) {
-        // Machine confirmed gone — safe to recreate
+        // Machine confirmed gone — safe to recreate (new default is correct here)
         console.log('[DO] Machine gone (404), creating new one');
         this.flyMachineId = null;
         await this.ctx.storage.put(storageUpdate({ flyMachineId: null }));
-        await this.createNewMachine(flyConfig, machineConfig, minSecretsVersion);
+        await this.createNewMachine(flyConfig, initialMachineConfig, minSecretsVersion);
       } else {
         // Transient error (timeout, 500, network) — don't create a duplicate.
         // Let the caller surface the error; reconciliation will repair later.

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -8,9 +8,17 @@ import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { DEFAULT_CLAW_INSTANCE_TYPE } from './claw.types';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
 import { RunDoctorDialog } from './RunDoctorDialog';
+
+const VOLUME_SIZE_GB = 10;
+// Default machine spec fallback (matches kiloclaw DEFAULT_MACHINE_GUEST)
+const DEFAULT_CPUS = 2;
+const DEFAULT_MEMORY_MB = 3072;
+
+function formatMemory(mb: number): string {
+  return mb >= 1024 ? `${mb / 1024} GB` : `${mb} MB`;
+}
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
@@ -56,11 +64,12 @@ export function InstanceControls({
         <div className="flex flex-wrap justify-end gap-2">
           <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
             <Cpu className="h-3.5 w-3.5" />
-            {DEFAULT_CLAW_INSTANCE_TYPE.name} ({DEFAULT_CLAW_INSTANCE_TYPE.description})
+            {status.machineSize?.cpus ?? DEFAULT_CPUS} vCPU,{' '}
+            {formatMemory(status.machineSize?.memory_mb ?? DEFAULT_MEMORY_MB)} RAM
           </Badge>
           <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
             <HardDrive className="h-3.5 w-3.5" />
-            20 GB SSD
+            {VOLUME_SIZE_GB} GB SSD
           </Badge>
         </div>
       </div>

--- a/src/app/(app)/claw/components/claw.types.ts
+++ b/src/app/(app)/claw/components/claw.types.ts
@@ -1,33 +1,6 @@
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 
 export type ClawState = KiloClawDashboardStatus['status'];
-export type ClawInstanceTypeName = 'shared-cpu-2x2' | 'shared-cpu-2x4' | 'performance-cpu-2x4';
-export type ClawInstanceType = {
-  name: ClawInstanceTypeName;
-  description: string;
-  isDefault: boolean;
-};
-
-export const CLAW_INSTANCE_TYPES = [
-  {
-    name: 'shared-cpu-2x2',
-    description: '2 vCPU, 2 GB RAM',
-    isDefault: false,
-  },
-  {
-    name: 'shared-cpu-2x4',
-    description: '2 vCPU, 4 GB RAM',
-    isDefault: true,
-  },
-  {
-    name: 'performance-cpu-2x4',
-    description: '2 vCPU, 4 GB RAM (Performance CPU)',
-    isDefault: false,
-  },
-] satisfies readonly [ClawInstanceType, ...ClawInstanceType[]];
-
-export const DEFAULT_CLAW_INSTANCE_TYPE =
-  CLAW_INSTANCE_TYPES.find(instanceType => instanceType.isDefault) ?? CLAW_INSTANCE_TYPES[0];
 
 export const CLAW_STATUS_BADGE: Record<
   Exclude<ClawState, null>,

--- a/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
+++ b/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
@@ -18,6 +18,7 @@ const baseStatus: KiloClawDashboardStatus = {
   flyMachineId: null,
   flyVolumeId: null,
   flyRegion: null,
+  machineSize: null,
   gatewayToken: 'token',
   workerUrl: 'https://claw.kilo.ai',
 };

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -94,6 +94,13 @@ export type DevicePairingApproveResponse = {
   message: string;
 };
 
+/** Fly Machine guest spec (CPU/memory configuration) */
+export type MachineSize = {
+  cpus: number;
+  memory_mb: number;
+  cpu_kind?: 'shared' | 'performance';
+};
+
 /** Response from GET /api/platform/status and GET /api/kiloclaw/status */
 export type PlatformStatusResponse = {
   userId: string | null;
@@ -109,6 +116,7 @@ export type PlatformStatusResponse = {
   flyMachineId: string | null;
   flyVolumeId: string | null;
   flyRegion: string | null;
+  machineSize: MachineSize | null;
 };
 
 /** A Fly volume snapshot. */


### PR DESCRIPTION
## Summary

- Reduces the default Fly Machine memory from 4 GB to 3 GB (`DEFAULT_MACHINE_GUEST.memory_mb: 4096 → 3072`)
- Surfaces `machineSize` (cpus, memory_mb, cpu_kind) from the Durable Object through the status API to the frontend, replacing hardcoded CPU/memory/disk badges with live values
- Fixes the disk badge from incorrectly showing `20 GB SSD` to the actual `10 GB SSD`
- Removes dead `CLAW_INSTANCE_TYPES` / `DEFAULT_CLAW_INSTANCE_TYPE` code

## Legacy instance safety

Legacy instances that were provisioned before `machineSize` was tracked (i.e. `machineSize === null` in DO state) are backfilled from the live Fly machine's `config.guest` in three paths:

- **`syncStatusFromLiveCheck()`** — fire-and-forget background check during `getStatus()` polling
- **`startExistingMachine()`** — reads the machine before `updateMachine()`, re-derives guest from the backfilled size so the update preserves the deployed config
- **`restartGateway()`** — reads the machine before stopping, so the subsequent `updateMachine()` uses the actual deployed size

This prevents legacy 4 GB instances from being silently downsized to 3 GB on their next start or restart.

## Files changed

| File | Change |
|------|--------|
| `kiloclaw/src/config.ts` | `memory_mb: 4096 → 3072` |
| `src/lib/kiloclaw/types.ts` | Add `MachineSize` type + field on `PlatformStatusResponse` |
| `kiloclaw/src/durable-objects/kiloclaw-instance.ts` | Return `machineSize` in `getStatus()`; backfill in 3 paths |
| `src/app/(app)/claw/components/InstanceControls.tsx` | Live CPU/memory/disk badges from status |
| `src/app/(app)/claw/components/claw.types.ts` | Remove dead instance type code |
| `src/app/(app)/claw/components/withStatusQueryBoundary.test.ts` | Add `machineSize` to test fixture |
| `kiloclaw/src/durable-objects/kiloclaw-instance.test.ts` | Update assertions for new 3072 default |