### PR TITLE
fix(kiloclaw): cleaner startup with gateway readiness checks

### DIFF
--- a/kiloclaw/controller/src/index.ts
+++ b/kiloclaw/controller/src/index.ts
@@ -122,6 +122,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     createHttpProxy({
       expectedToken: config.expectedToken,
       requireProxyToken: config.requireProxyToken,
+      supervisor,
     })
   );
 
@@ -139,6 +140,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     handleWebSocketUpgrade(req, socket, head, {
       expectedToken: config.expectedToken,
       requireProxyToken: config.requireProxyToken,
+      supervisor,
       wsIdleTimeoutMs: config.wsIdleTimeoutMs,
       wsHandshakeTimeoutMs: config.wsHandshakeTimeoutMs,
       maxWsConnections: config.maxWsConnections,

--- a/kiloclaw/controller/src/proxy.test.ts
+++ b/kiloclaw/controller/src/proxy.test.ts
@@ -4,6 +4,16 @@ import type { Duplex } from 'node:stream';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import { createHttpProxy, handleWebSocketUpgrade } from './proxy';
+import type { Supervisor } from './supervisor';
+
+function createMockSupervisor(state: string): Supervisor {
+  return {
+    getState: () => state,
+    getStats: () => ({ state, uptime: 0, restarts: 0, lastExit: null }),
+    start: vi.fn(),
+    stop: vi.fn(),
+  } as unknown as Supervisor;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -64,6 +74,46 @@ describe('HTTP proxy', () => {
     expect(await resp.json()).toEqual({ error: 'Bad Gateway' });
   });
 
+  it('returns 503 when supervisor is not running (after auth)', async () => {
+    const app = new Hono();
+    app.all(
+      '*',
+      createHttpProxy({
+        expectedToken: 'token-1',
+        requireProxyToken: true,
+        supervisor: createMockSupervisor('starting'),
+      })
+    );
+
+    // Unauthenticated callers still get 401, not 503
+    const noToken = await app.request('/x');
+    expect(noToken.status).toBe(401);
+
+    // Authenticated callers get 503 when gateway is not ready
+    const resp = await app.request('/x', {
+      headers: { 'x-kiloclaw-proxy-token': 'token-1' },
+    });
+    expect(resp.status).toBe(503);
+    expect(await resp.json()).toEqual({ error: 'Gateway not ready' });
+  });
+
+  it('proxies normally when supervisor is running', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+    const app = new Hono();
+    app.all(
+      '*',
+      createHttpProxy({
+        expectedToken: 'token-1',
+        requireProxyToken: false,
+        supervisor: createMockSupervisor('running'),
+      })
+    );
+
+    const resp = await app.request('/x');
+    expect(resp.status).toBe(204);
+  });
+
   it('allows passthrough when proxy token is disabled', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
 
@@ -113,6 +163,20 @@ class FakeSocket extends EventEmitter {
 }
 
 describe('WebSocket proxy', () => {
+  it('rejects upgrade when supervisor is not running', () => {
+    const req = createIncomingMessage({ 'x-kiloclaw-proxy-token': 'token-1' });
+    const socket = new FakeSocket() as unknown as Duplex;
+
+    handleWebSocketUpgrade(req, socket, Buffer.alloc(0), {
+      expectedToken: 'token-1',
+      requireProxyToken: true,
+      supervisor: createMockSupervisor('crashed'),
+    });
+
+    expect((socket as unknown as FakeSocket).written.join('')).toContain('HTTP/1.1 503');
+    expect((socket as unknown as FakeSocket).destroyed).toBe(true);
+  });
+
   it('rejects upgrade without proxy token when enforcement is enabled', () => {
     const req = createIncomingMessage({});
     const socket = new FakeSocket() as unknown as Duplex;

--- a/kiloclaw/controller/src/proxy.ts
+++ b/kiloclaw/controller/src/proxy.ts
@@ -43,13 +43,13 @@ export function createHttpProxy(options: ProxyOptions) {
   const backendOrigin = `http://${backendHost}:${backendPort}`;
 
   return async (c: Context): Promise<Response> => {
-    if (options.supervisor && options.supervisor.getState() !== 'running') {
-      return c.json({ error: 'Gateway not ready' }, 503);
-    }
-
     const token = c.req.header('x-kiloclaw-proxy-token');
     if (!hasValidProxyToken(token, options.requireProxyToken, options.expectedToken)) {
       return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    if (options.supervisor && options.supervisor.getState() !== 'running') {
+      return c.json({ error: 'Gateway not ready' }, 503);
     }
 
     const incomingUrl = new URL(c.req.url);
@@ -112,11 +112,6 @@ export function handleWebSocketUpgrade(
   head: Buffer,
   options: ProxyOptions
 ): void {
-  if (options.supervisor && options.supervisor.getState() !== 'running') {
-    socketWriteServiceUnavailable(socket);
-    return;
-  }
-
   const backendHost = options.backendHost ?? '127.0.0.1';
   const backendPort = options.backendPort ?? 3001;
   const wsIdleTimeoutMs = options.wsIdleTimeoutMs ?? DEFAULT_WS_IDLE_TIMEOUT_MS;
@@ -128,6 +123,11 @@ export function handleWebSocketUpgrade(
 
   if (!hasValidProxyToken(token, options.requireProxyToken, options.expectedToken)) {
     socketWriteUnauthorized(socket);
+    return;
+  }
+
+  if (options.supervisor && options.supervisor.getState() !== 'running') {
+    socketWriteServiceUnavailable(socket);
     return;
   }
   if (wsState.activeConnections >= maxWsConnections) {

--- a/kiloclaw/controller/src/proxy.ts
+++ b/kiloclaw/controller/src/proxy.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { Context } from 'hono';
 import { timingSafeTokenEqual } from './auth';
+import type { Supervisor } from './supervisor';
 
 export const DEFAULT_WS_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 export const DEFAULT_WS_HANDSHAKE_TIMEOUT_MS = 5 * 1000;
@@ -11,6 +12,7 @@ export const DEFAULT_MAX_WS_CONNS = 100;
 export type ProxyOptions = {
   expectedToken: string;
   requireProxyToken: boolean;
+  supervisor?: Supervisor;
   backendHost?: string;
   backendPort?: number;
   wsIdleTimeoutMs?: number;
@@ -41,6 +43,10 @@ export function createHttpProxy(options: ProxyOptions) {
   const backendOrigin = `http://${backendHost}:${backendPort}`;
 
   return async (c: Context): Promise<Response> => {
+    if (options.supervisor && options.supervisor.getState() !== 'running') {
+      return c.json({ error: 'Gateway not ready' }, 503);
+    }
+
     const token = c.req.header('x-kiloclaw-proxy-token');
     if (!hasValidProxyToken(token, options.requireProxyToken, options.expectedToken)) {
       return c.json({ error: 'Unauthorized' }, 401);
@@ -106,12 +112,18 @@ export function handleWebSocketUpgrade(
   head: Buffer,
   options: ProxyOptions
 ): void {
+  if (options.supervisor && options.supervisor.getState() !== 'running') {
+    socketWriteServiceUnavailable(socket);
+    return;
+  }
+
   const backendHost = options.backendHost ?? '127.0.0.1';
   const backendPort = options.backendPort ?? 3001;
   const wsIdleTimeoutMs = options.wsIdleTimeoutMs ?? DEFAULT_WS_IDLE_TIMEOUT_MS;
   const wsHandshakeTimeoutMs = options.wsHandshakeTimeoutMs ?? DEFAULT_WS_HANDSHAKE_TIMEOUT_MS;
   const maxWsConnections = options.maxWsConnections ?? DEFAULT_MAX_WS_CONNS;
   const wsState = options.wsState ?? { activeConnections: 0 };
+
   const token = getHeaderToken(req.headers['x-kiloclaw-proxy-token']);
 
   if (!hasValidProxyToken(token, options.requireProxyToken, options.expectedToken)) {

--- a/kiloclaw/controller/src/routes/health.test.ts
+++ b/kiloclaw/controller/src/routes/health.test.ts
@@ -35,15 +35,26 @@ describe('GET /_kilo/health', () => {
     });
   });
 
-  it('returns 200 even when gateway is crashed', async () => {
+  it('returns 503 when gateway is not running', async () => {
     const app = new Hono();
     registerHealthRoute(app, createMockSupervisor('crashed'));
 
     const resp = await app.request('/_kilo/health');
-    expect(resp.status).toBe(200);
+    expect(resp.status).toBe(503);
     const body = (await resp.json()) as { status: string; gateway: string };
-    expect(body.status).toBe('ok');
+    expect(body.status).toBe('starting');
     expect(body.gateway).toBe('crashed');
+  });
+
+  it('returns 503 when gateway is starting', async () => {
+    const app = new Hono();
+    registerHealthRoute(app, createMockSupervisor('starting'));
+
+    const resp = await app.request('/_kilo/health');
+    expect(resp.status).toBe(503);
+    const body = (await resp.json()) as { status: string; gateway: string };
+    expect(body.status).toBe('starting');
+    expect(body.gateway).toBe('starting');
   });
 });
 

--- a/kiloclaw/controller/src/routes/health.ts
+++ b/kiloclaw/controller/src/routes/health.ts
@@ -4,12 +4,16 @@ import type { Supervisor } from '../supervisor';
 export function registerHealthRoute(app: Hono, supervisor: Supervisor): void {
   const handler = (c: Context) => {
     const stats = supervisor.getStats();
-    return c.json({
-      status: 'ok',
-      gateway: stats.state,
-      uptime: stats.uptime,
-      restarts: stats.restarts,
-    });
+    const ready = stats.state === 'running';
+    return c.json(
+      {
+        status: ready ? 'ok' : 'starting',
+        gateway: stats.state,
+        uptime: stats.uptime,
+        restarts: stats.restarts,
+      },
+      ready ? 200 : 503
+    );
   };
 
   app.get('/_kilo/health', handler);

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -669,7 +669,7 @@ describe('createNewMachine: persist ID before waitForState', () => {
             path: '/_kilo/health',
             interval: '30s',
             timeout: '5s',
-            grace_period: '60s',
+            grace_period: '120s',
           },
         },
       }),

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -200,7 +200,7 @@ function buildMachineConfig(
         path: '/_kilo/health',
         interval: '30s',
         timeout: '5s',
-        grace_period: '60s',
+        grace_period: '120s',
       },
     },
     mounts: flyVolumeId ? [{ volume: flyVolumeId, path: '/root' }] : [],


### PR DESCRIPTION
  - Health endpoint returns 503 until gateway is running, so Fly's health check and proxy don't route traffic to unready machines
  - HTTP/WS proxy short-circuits with 503 when gateway isn't running, eliminating ECONNREFUSED error spam during startup
  - Increase health check grace_period from 60s to 120s for margin