### PR TITLE
chore(kiloclaw): auto-destroy stale provisioned instances after 8 hours

### DIFF
--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -57,3 +57,6 @@ export const HEALTH_PROBE_TIMEOUT_SECONDS = 60;
 
 /** Interval between health probe retries during startup */
 export const HEALTH_PROBE_INTERVAL_MS = 3_000;
+
+/** Auto-destroy provisioned instances that never started after this duration */
+export const STALE_PROVISION_THRESHOLD_MS = 8 * 60 * 60 * 1000; // 8 hours

--- a/kiloclaw/src/db/stores/InstanceStore.ts
+++ b/kiloclaw/src/db/stores/InstanceStore.ts
@@ -9,8 +9,9 @@ const ActiveInstanceRow = z.object({
 });
 
 /**
- * Read-only Postgres access for the KiloClaw worker.
- * The Next.js backend is the sole writer to kiloclaw_instances.
+ * Postgres access for the KiloClaw worker.
+ * Reads via Hyperdrive. Writes are limited to lifecycle bookkeeping
+ * (e.g. marking an instance destroyed) that Next.js cannot observe.
  */
 export class InstanceStore extends SqlStore {
   constructor(db: Database | Transaction) {
@@ -40,5 +41,23 @@ export class InstanceStore extends SqlStore {
     if (rows.length === 0) return null;
     const row = ActiveInstanceRow.parse(rows[0]);
     return { id: row.id, sandboxId: row.sandbox_id };
+  }
+
+  /**
+   * Mark the active instance row as destroyed.
+   * Called by the DO during auto-destroy of stale provisioned instances
+   * so the Postgres registry stays consistent with DO state.
+   */
+  async markDestroyed(userId: string, sandboxId: string): Promise<void> {
+    await this.query(
+      /* sql */ `
+      UPDATE ${kiloclaw_instances}
+      SET ${kiloclaw_instances.columns.destroyed_at} = NOW()
+      WHERE ${kiloclaw_instances.user_id} = $1
+        AND ${kiloclaw_instances.sandbox_id} = $2
+        AND ${kiloclaw_instances.destroyed_at} IS NULL
+      `,
+      { 1: userId, 2: sandboxId }
+    );
   }
 }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -77,12 +77,14 @@ vi.mock('../utils/env-encryption', () => ({
 import { KiloClawInstance } from './kiloclaw-instance';
 import * as flyClient from '../fly/client';
 import { FlyApiError } from '../fly/client';
+import * as db from '../db';
 import {
   ALARM_INTERVAL_RUNNING_MS,
   ALARM_INTERVAL_DESTROYING_MS,
   ALARM_INTERVAL_IDLE_MS,
   ALARM_JITTER_MS,
   SELF_HEAL_THRESHOLD,
+  STALE_PROVISION_THRESHOLD_MS,
 } from '../config';
 
 // ============================================================================
@@ -1795,5 +1797,253 @@ describe('approveDevicePairingRequest', () => {
     );
 
     expect(result).toEqual({ success: false, message: 'request not found' });
+  });
+});
+
+describe('auto-destroy stale provisioned instances', () => {
+  // Reset listMachines to return [] for each test in this block, since
+  // earlier metadata-recovery tests may have set it to return machines
+  // and vi.clearAllMocks() does not reset implementations.
+  beforeEach(() => {
+    (flyClient.listMachines as Mock).mockResolvedValue([]);
+  });
+
+  function createInstanceWithPostgres(markImpl: () => Promise<void> = () => Promise.resolve()): {
+    instance: KiloClawInstance;
+    storage: ReturnType<typeof createFakeStorage>;
+    markDestroyed: Mock;
+  } {
+    const env = {
+      ...createFakeEnv(),
+      HYPERDRIVE: { connectionString: 'postgres://test' } as unknown,
+    };
+
+    const markDestroyed = vi.fn(markImpl);
+    (db.createDatabaseConnection as Mock).mockReturnValue({});
+    (db.InstanceStore as Mock).mockImplementation(function instanceStoreMock() {
+      return {
+        markDestroyed,
+        getActiveInstance: vi.fn().mockResolvedValue(null),
+      };
+    });
+
+    const { instance, storage } = createInstance(undefined, env);
+    return { instance, storage, markDestroyed };
+  }
+
+  it('auto-destroys provisioned instance older than threshold with no machine', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000; // 1 min past threshold
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    await instance.alarm();
+
+    // DO state should be fully cleared (destroy completed)
+    expect(storage._store.size).toBe(0);
+    // Postgres mark-destroyed should have been called
+    expect(markDestroyed).toHaveBeenCalledOnce();
+    expect(markDestroyed).toHaveBeenCalledWith('user-1', 'sandbox-1');
+    // Metadata recovery ran first (listMachines), but found nothing
+    expect(flyClient.listMachines).toHaveBeenCalled();
+    // Volume reconciliation should not have run (destroyed before that)
+    expect(flyClient.getVolume).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-destroy if provisionedAt is within threshold', async () => {
+    const recentTime = Date.now() - STALE_PROVISION_THRESHOLD_MS + 60_000; // 1 min before threshold
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: recentTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // Instance should still exist, not destroyed
+    expect(storage._store.size).toBeGreaterThan(0);
+    expect(storage._store.get('status')).not.toBeNull();
+    expect(markDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-destroy if instance has a machine ID', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000;
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: 'machine-1',
+      lastStartedAt: null,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'stopped', config: {} });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // Should still exist — machine exists so it's not a stale provision
+    expect(storage._store.get('status')).not.toBeNull();
+    expect(storage._store.size).toBeGreaterThan(0);
+    expect(markDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-destroy if instance was previously started', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000;
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: staleTime + 1000, // was started at some point
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // Should still exist — was previously started so not an abandoned provision
+    expect(storage._store.size).toBeGreaterThan(0);
+    expect(storage._store.get('status')).not.toBeNull();
+    expect(markDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-destroy when metadata recovery fails with transient error', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000;
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    // Fly API fails transiently — we can't confirm whether a machine exists
+    (flyClient.listMachines as Mock).mockRejectedValue(
+      new FlyApiError('server error', 500, 'internal')
+    );
+
+    await instance.alarm();
+
+    // Should NOT auto-destroy — recovery was inconclusive
+    expect(storage._store.size).toBeGreaterThan(0);
+    expect(storage._store.get('status')).not.toBeNull();
+    expect(markDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('recovers machine via metadata before considering auto-destroy', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000;
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    // Fly still has a live machine — metadata recovery should find it
+    (flyClient.listMachines as Mock).mockResolvedValue([
+      fakeMachine({
+        id: 'recovered-machine',
+        state: 'stopped',
+        region: 'iad',
+        config: { image: 'test:latest', mounts: [{ volume: 'vol-1', path: '/root' }] },
+      }),
+    ]);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // Machine recovered — instance should NOT be auto-destroyed
+    expect(storage._store.get('flyMachineId')).toBe('recovered-machine');
+    expect(storage._store.size).toBeGreaterThan(0);
+    expect(markDestroyed).not.toHaveBeenCalled();
+  });
+
+  it('logs reconciliation action with structured details', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 3600_000; // 1 hour past threshold
+    const { instance, storage } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    await instance.alarm();
+
+    const logCalls = (console.log as Mock).mock.calls;
+    const autoDestroyLog = logCalls.find((args: unknown[]) => {
+      const msg = String(args[0]);
+      return msg.includes('auto_destroy_stale_provision');
+    });
+    expect(autoDestroyLog).toBeDefined();
+    const parsed: unknown = JSON.parse(String(autoDestroyLog![0]));
+    expect(parsed).toMatchObject({
+      tag: 'reconcile',
+      reason: 'alarm',
+      action: 'auto_destroy_stale_provision',
+      user_id: 'user-1',
+    });
+  });
+
+  it('proceeds with destroy when markDestroyedInPostgres completes', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000;
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    await instance.alarm();
+
+    // Both markDestroyedInPostgres and destroy should have completed
+    expect(markDestroyed).toHaveBeenCalledOnce();
+    expect(storage._store.size).toBe(0);
+    // Alarm should not be rescheduled (DO is fully destroyed)
+    expect(storage._getAlarm()).toBeNull();
+  });
+
+  it('retries Postgres mark on later alarms after Fly cleanup is complete', async () => {
+    const staleTime = Date.now() - STALE_PROVISION_THRESHOLD_MS - 60_000;
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    markDestroyed
+      .mockRejectedValueOnce(new Error('transient hyperdrive error'))
+      .mockResolvedValueOnce(undefined);
+
+    await seedProvisioned(storage, {
+      provisionedAt: staleTime,
+      flyMachineId: null,
+      lastStartedAt: null,
+    });
+
+    await instance.alarm();
+
+    // Fly cleanup completed, but PG mark failed so DO stays in destroying state for retry
+    expect(storage._store.get('status')).toBe('destroying');
+    expect(storage._store.get('pendingDestroyMachineId')).toBeNull();
+    expect(storage._store.get('pendingDestroyVolumeId')).toBeNull();
+    expect(storage._store.get('pendingPostgresMarkOnFinalize')).toBe(true);
+    expect(storage._getAlarm()).not.toBeNull();
+
+    await instance.alarm();
+
+    expect(markDestroyed).toHaveBeenCalledTimes(2);
+    expect(storage._store.size).toBe(0);
+    expect(storage._getAlarm()).toBeNull();
+  });
+
+  it('does not mark Postgres for manual destroy path', async () => {
+    const { instance, storage, markDestroyed } = createInstanceWithPostgres();
+    await seedRunning(storage);
+
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    await instance.destroy();
+
+    expect(markDestroyed).not.toHaveBeenCalled();
+    expect(storage._store.size).toBe(0);
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -2453,8 +2453,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private async markDestroyedInPostgres(userId: string, sandboxId: string): Promise<boolean> {
     const connectionString = this.env.HYPERDRIVE?.connectionString;
     if (!connectionString) {
-      console.error('[DO] HYPERDRIVE not configured, cannot mark Postgres row destroyed');
-      return false;
+      // Hyperdrive not available — skip rather than block finalization forever.
+      // The stale Postgres row is harmless; restoreFromPostgres handles it.
+      console.warn('[DO] HYPERDRIVE not configured, skipping Postgres mark-destroyed');
+      return true;
     }
 
     try {

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -49,6 +49,7 @@ import {
   LIVE_CHECK_THROTTLE_MS,
   HEALTH_PROBE_TIMEOUT_SECONDS,
   HEALTH_PROBE_INTERVAL_MS,
+  STALE_PROVISION_THRESHOLD_MS,
 } from '../config';
 import type { FlyClientConfig } from '../fly/client';
 import type {
@@ -64,6 +65,12 @@ import { z, type ZodType } from 'zod';
 import { resolveLatestVersion } from '../lib/image-version';
 
 type InstanceStatus = PersistedState['status'];
+
+type DestroyResult = {
+  finalized: boolean;
+  destroyedUserId: string | null;
+  destroyedSandboxId: string | null;
+};
 
 type GatewayProcessStatus = {
   state: 'stopped' | 'starting' | 'running' | 'stopping' | 'crashed' | 'shutting_down';
@@ -360,6 +367,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private healthCheckFailCount = 0;
   private pendingDestroyMachineId: string | null = null;
   private pendingDestroyVolumeId: string | null = null;
+  private pendingPostgresMarkOnFinalize = false;
   private lastMetadataRecoveryAt: number | null = null;
   private openclawVersion: string | null = null;
   private imageVariant: string | null = null;
@@ -400,6 +408,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.healthCheckFailCount = s.healthCheckFailCount;
       this.pendingDestroyMachineId = s.pendingDestroyMachineId;
       this.pendingDestroyVolumeId = s.pendingDestroyVolumeId;
+      this.pendingPostgresMarkOnFinalize = s.pendingPostgresMarkOnFinalize;
       this.lastMetadataRecoveryAt = s.lastMetadataRecoveryAt;
       this.openclawVersion = s.openclawVersion;
       this.imageVariant = s.imageVariant;
@@ -518,6 +527,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           healthCheckFailCount: 0,
           pendingDestroyMachineId: null,
           pendingDestroyVolumeId: null,
+          pendingPostgresMarkOnFinalize: false,
         })
       : storageUpdate({ ...configFields, ...versionFields });
 
@@ -542,6 +552,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.healthCheckFailCount = 0;
       this.pendingDestroyMachineId = null;
       this.pendingDestroyVolumeId = null;
+      this.pendingPostgresMarkOnFinalize = false;
     }
     this.loaded = true;
 
@@ -1156,10 +1167,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    *
    * 1. Persist pendingDestroy IDs + status='destroying'
    * 2. Attempt Fly deletions
-   * 3. Only deleteAll() when BOTH are confirmed deleted
+   * 3. Finalize only after pending Fly deletes clear, and for stale auto-destroy
+   *    also after Postgres mark-destroyed succeeds
    * 4. If either fails, alarm retries cleanup
    */
-  async destroy(): Promise<void> {
+  async destroy(): Promise<DestroyResult> {
     await this.loadState();
 
     if (!this.userId) {
@@ -1186,7 +1198,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // Phase 3: Finalize if both cleared, otherwise alarm will retry
     const finalized = await this.finalizeDestroyIfComplete();
-    if (!finalized) {
+    if (!finalized.finalized) {
       console.warn(
         '[DO] Destroy incomplete, alarm will retry. pending machine:',
         this.pendingDestroyMachineId,
@@ -1195,6 +1207,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
       await this.scheduleAlarm();
     }
+
+    return finalized;
   }
 
   // ========================================================================
@@ -1498,7 +1512,26 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // Machine first: metadata recovery can recover both machine AND volume IDs.
     // Volume second: only creates a new volume if still missing after machine recovery.
-    await this.reconcileMachine(flyConfig, reason);
+    const machineReconciled = await this.reconcileMachine(flyConfig, reason);
+
+    // Auto-destroy stale provisioned instances that never started.
+    // Checked AFTER reconcileMachine so metadata recovery has a chance to
+    // discover a live Fly machine before we decide the instance is abandoned.
+    // Only proceeds when machine reconciliation was conclusive (not skipped
+    // due to cooldown or failed due to a transient Fly API error).
+    const staleProvisionAge = this.staleProvisionAgeMs();
+    if (staleProvisionAge !== null && machineReconciled) {
+      reconcileLog(reason, 'auto_destroy_stale_provision', {
+        user_id: this.userId,
+        provisioned_at: this.provisionedAt,
+        age_hours: Math.round(staleProvisionAge / 3600000),
+      });
+      this.pendingPostgresMarkOnFinalize = true;
+      await this.ctx.storage.put(storageUpdate({ pendingPostgresMarkOnFinalize: true }));
+      await this.destroy();
+      return;
+    }
+
     await this.reconcileVolume(flyConfig, reason);
   }
 
@@ -1529,22 +1562,30 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
   // ---- Machine reconciliation ----
 
-  private async reconcileMachine(flyConfig: FlyClientConfig, reason: string): Promise<void> {
+  /**
+   * @returns true if machine state was conclusively determined (Fly API
+   *   responded successfully), false if skipped or inconclusive (transient
+   *   error, cooldown). Callers use this to gate destructive decisions
+   *   like auto-destroy of stale provisions.
+   */
+  private async reconcileMachine(flyConfig: FlyClientConfig, reason: string): Promise<boolean> {
     // If we don't have a machine ID, attempt metadata-based recovery
     if (!this.flyMachineId) {
-      await this.attemptMetadataRecovery(flyConfig, reason);
-      return;
+      return this.attemptMetadataRecovery(flyConfig, reason);
     }
 
     try {
       const machine = await fly.getMachine(flyConfig, this.flyMachineId);
       await this.syncStatusWithFly(machine.state, reason);
       await this.reconcileMachineMount(flyConfig, machine, reason);
+      return true;
     } catch (err) {
       if (fly.isFlyNotFound(err)) {
         await this.handleMachineGone(reason);
+        return true; // 404 is conclusive: machine is gone
       }
-      // Other errors: log and retry next alarm
+      // Other errors: inconclusive, retry next alarm
+      return false;
     }
   }
 
@@ -1552,16 +1593,22 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    * Attempt to recover machine (and optionally volume) from Fly metadata.
    * Only runs when flyMachineId is null. Respects a cooldown to avoid
    * hammering listMachines when there's genuinely nothing to recover.
+   *
+   * @returns true if the Fly API responded conclusively (even if no machine
+   *   was found), false if skipped (cooldown) or failed (transient error).
    */
-  private async attemptMetadataRecovery(flyConfig: FlyClientConfig, reason: string): Promise<void> {
-    if (!this.userId) return;
+  private async attemptMetadataRecovery(
+    flyConfig: FlyClientConfig,
+    reason: string
+  ): Promise<boolean> {
+    if (!this.userId) return false;
 
     // Cooldown: skip if we tried recently
     if (
       this.lastMetadataRecoveryAt &&
       Date.now() - this.lastMetadataRecoveryAt < METADATA_RECOVERY_COOLDOWN_MS
     ) {
-      return;
+      return false;
     }
 
     // Record attempt time regardless of outcome
@@ -1584,7 +1631,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
 
       const candidate = selectRecoveryCandidate(machines);
-      if (!candidate) return;
+      if (!candidate) return true; // Conclusive: no machine exists on Fly
 
       reconcileLog(reason, 'recover_machine_from_metadata', {
         machine_id: candidate.id,
@@ -1635,8 +1682,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
 
       await this.ctx.storage.put(storageUpdate(updates));
+      return true; // Conclusive: machine recovered
     } catch (err) {
       console.error('[reconcile] metadata recovery failed:', err);
+      return false; // Inconclusive: transient error
     }
   }
 
@@ -1865,19 +1914,56 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   }
 
   /**
-   * If both pending IDs are cleared, atomically wipe all DO state.
-   * Returns true if finalized, false if still pending.
+   * If both pending IDs are cleared, finalize destroy.
+   * For stale auto-destroy, this includes marking Postgres before wiping DO state.
+   * Returns finalization details for callers that need retry behavior.
    */
-  private async finalizeDestroyIfComplete(): Promise<boolean> {
+  private async finalizeDestroyIfComplete(): Promise<DestroyResult> {
     if (this.pendingDestroyMachineId || this.pendingDestroyVolumeId) {
-      return false;
+      return {
+        finalized: false,
+        destroyedUserId: null,
+        destroyedSandboxId: null,
+      };
+    }
+
+    if (!this.userId || !this.sandboxId) {
+      return {
+        finalized: false,
+        destroyedUserId: null,
+        destroyedSandboxId: null,
+      };
+    }
+
+    const destroyedUserId = this.userId;
+    const destroyedSandboxId = this.sandboxId;
+
+    if (this.pendingPostgresMarkOnFinalize) {
+      const marked = await this.markDestroyedInPostgres(destroyedUserId, destroyedSandboxId);
+      if (!marked) {
+        return {
+          finalized: false,
+          destroyedUserId,
+          destroyedSandboxId,
+        };
+      }
     }
 
     reconcileLog('finalize', 'destroy_complete', {
-      user_id: this.userId,
-      sandbox_id: this.sandboxId,
+      user_id: destroyedUserId,
+      sandbox_id: destroyedSandboxId,
     });
 
+    await this.clearDestroyedState();
+
+    return {
+      finalized: true,
+      destroyedUserId,
+      destroyedSandboxId,
+    };
+  }
+
+  private async clearDestroyedState(): Promise<void> {
     await this.ctx.storage.deleteAlarm();
     await this.ctx.storage.deleteAll();
 
@@ -1903,13 +1989,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.healthCheckFailCount = 0;
     this.pendingDestroyMachineId = null;
     this.pendingDestroyVolumeId = null;
+    this.pendingPostgresMarkOnFinalize = false;
     this.lastMetadataRecoveryAt = null;
     this.openclawVersion = null;
     this.imageVariant = null;
     this.trackedImageTag = null;
     this.loaded = false;
-
-    return true;
   }
 
   // ========================================================================
@@ -2007,6 +2092,23 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       HEALTH_PROBE_TIMEOUT_SECONDS,
       's — proceeding anyway'
     );
+  }
+
+  /**
+   * Returns the age in ms if this instance is a stale abandoned provision
+   * (provisioned, never started, no machine, older than threshold), or null.
+   */
+  private staleProvisionAgeMs(): number | null {
+    if (
+      this.status === 'provisioned' &&
+      !this.flyMachineId &&
+      !this.lastStartedAt &&
+      this.provisionedAt
+    ) {
+      const age = Date.now() - this.provisionedAt;
+      if (age > STALE_PROVISION_THRESHOLD_MS) return age;
+    }
+    return null;
   }
 
   private getFlyConfig(): FlyClientConfig {
@@ -2296,6 +2398,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           healthCheckFailCount: 0,
           pendingDestroyMachineId: null,
           pendingDestroyVolumeId: null,
+          pendingPostgresMarkOnFinalize: false,
           openclawVersion: null,
           imageVariant: null,
           trackedImageTag: null,
@@ -2319,6 +2422,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.healthCheckFailCount = 0;
       this.pendingDestroyMachineId = null;
       this.pendingDestroyVolumeId = null;
+      this.pendingPostgresMarkOnFinalize = false;
       this.lastMetadataRecoveryAt = null;
       this.openclawVersion = null;
       this.imageVariant = null;
@@ -2338,6 +2442,31 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
     } catch (err) {
       console.error('[DO] Postgres restore failed:', err);
+    }
+  }
+
+  /**
+   * Mark the Postgres registry row as destroyed during stale auto-destroy
+   * finalization. Returns true when marked (or already marked), false when
+   * a retry is needed.
+   */
+  private async markDestroyedInPostgres(userId: string, sandboxId: string): Promise<boolean> {
+    const connectionString = this.env.HYPERDRIVE?.connectionString;
+    if (!connectionString) {
+      console.error('[DO] HYPERDRIVE not configured, cannot mark Postgres row destroyed');
+      return false;
+    }
+
+    try {
+      const db = createDatabaseConnection(connectionString);
+      const store = new InstanceStore(db);
+      await store.markDestroyed(userId, sandboxId);
+      this.pendingPostgresMarkOnFinalize = false;
+      await this.ctx.storage.put(storageUpdate({ pendingPostgresMarkOnFinalize: false }));
+      return true;
+    } catch (err) {
+      console.error('[DO] Failed to mark instance destroyed in Postgres:', err);
+      return false;
     }
   }
 

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -124,6 +124,8 @@ export const PersistedStateSchema = z.object({
   // Two-phase destroy: IDs pending deletion on Fly. Cleared once Fly confirms.
   pendingDestroyMachineId: z.string().nullable().default(null),
   pendingDestroyVolumeId: z.string().nullable().default(null),
+  // For stale auto-destroy only: defer DO state wipe until Postgres row is marked destroyed.
+  pendingPostgresMarkOnFinalize: z.boolean().default(false),
   // Cooldown: last time we attempted metadata-based machine recovery from Fly.
   // Prevents hammering listMachines on every alarm when there's genuinely nothing.
   lastMetadataRecoveryAt: z.number().nullable().default(null),


### PR DESCRIPTION
## Summary

- Auto-destroy provisioned KiloClaw instances that never started after 8 hours
- Cleans up abandoned provisions where volume creation succeeded but the user never completed the flow (e.g., closed the browser during onboarding) or otherwise never hit the start instance button

To qualify for deletion:

- `status === 'provisioned'`
- `flyMachineId === null`
- `lastStartedAt === null` (never started)
- `provisionedAt` is older than our threshold (8 hours)

## How it works

During the existing 30-minute reconciliation alarm for `provisioned` instances:

1. **Metadata recovery runs first** — `reconcileMachine()` checks Fly for a live machine via `listMachines`. If a machine is found, the instance is recovered (not destroyed).
2. **Stale check runs only when conclusive** — if the Fly API responded successfully and confirmed no machine exists, `staleProvisionAgeMs()` checks: `status === 'provisioned'`, no `flyMachineId`, no `lastStartedAt`, and `provisionedAt` > 8 hours ago.
3. **Two-phase destroy with Postgres mark** — sets `pendingPostgresMarkOnFinalize = true`, then enters the standard two-phase destroy flow. `finalizeDestroyIfComplete()` marks the Postgres registry row as destroyed (via Hyperdrive) before wiping DO state.
4. **Retry on failure** — if the Postgres mark fails (Hyperdrive down, transient DB error), the DO stays in `destroying` state and the alarm retries on the next cycle.

## Safety guards

- **No orphaned machines** — metadata recovery runs before the stale check, so live machines on Fly are discovered first
- **No action on transient errors** — `reconcileMachine()` returns `false` (inconclusive) on Fly API errors; auto-destroy only proceeds on `true`
- **Manual destroy unaffected** — `pendingPostgresMarkOnFinalize` is only set by the auto-destroy path; manual `destroy()` does not mark Postgres
- **Idempotent Postgres write** — `UPDATE ... SET destroyed_at = NOW() WHERE destroyed_at IS NULL` is safe to retry

