### PR TITLE
Set route-level maxDuration for sync security alerts cron

### DIFF
--- a/src/app/api/cron/sync-security-alerts/route.ts
+++ b/src/app/api/cron/sync-security-alerts/route.ts
@@ -5,6 +5,8 @@ import { CRON_SECRET, SECURITY_SYNC_BETTERSTACK_HEARTBEAT_URL } from '@/lib/conf
 import { runFullSync } from '@/lib/security-agent/services/sync-service';
 import { sentryLogger } from '@/lib/utils.server';
 
+export const maxDuration = 900;
+
 const log = sentryLogger('security-agent:cron-sync', 'info');
 const cronWarn = sentryLogger('cron', 'warning');
 const logError = sentryLogger('security-agent:cron-sync', 'error');


### PR DESCRIPTION
## Summary
- add route-level `maxDuration` export to the sync security alerts cron handler
- keep existing cron schedule configuration in `vercel.json` unchanged
- align with Next.js App Router runtime configuration pattern for this endpoint

## Notes
- `maxDuration = 900` is subject to Vercel runtime caps (Fluid Compute/tier limits)