### PR TITLE
Lower sync security alerts cron maxDuration to 800s

### DIFF
--- a/src/app/api/cron/sync-security-alerts/route.ts
+++ b/src/app/api/cron/sync-security-alerts/route.ts
@@ -5,7 +5,7 @@ import { CRON_SECRET, SECURITY_SYNC_BETTERSTACK_HEARTBEAT_URL } from '@/lib/conf
 import { runFullSync } from '@/lib/security-agent/services/sync-service';
 import { sentryLogger } from '@/lib/utils.server';
 
-export const maxDuration = 900;
+export const maxDuration = 800;
 
 const log = sentryLogger('security-agent:cron-sync', 'info');
 const cronWarn = sentryLogger('cron', 'warning');


### PR DESCRIPTION
## Summary
- update the sync security alerts cron route-level runtime config from `maxDuration = 900` to `maxDuration = 800`
- keep cron schedule configuration unchanged in `vercel.json`

## Why
- aligns the route with Fluid Compute default runtime limits where `800s` is the practical cap on Pro/Enterprise