### PR TITLE
Fix cron sync shutdown behavior and close background handles

### DIFF
--- a/src/app/api/cron/sync-security-alerts/route.ts
+++ b/src/app/api/cron/sync-security-alerts/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { captureException } from '@sentry/nextjs';
 import { CRON_SECRET, SECURITY_SYNC_BETTERSTACK_HEARTBEAT_URL } from '@/lib/config.server';
 import { runFullSync } from '@/lib/security-agent/services/sync-service';
+import { shutdownPosthog } from '@/lib/posthog';
 import { sentryLogger } from '@/lib/utils.server';
 
 export const maxDuration = 800;
@@ -12,6 +13,30 @@ const cronWarn = sentryLogger('cron', 'warning');
 const logError = sentryLogger('security-agent:cron-sync', 'error');
 
 type HeartbeatType = 'success' | 'failure';
+
+async function shutdownPosthogWithTimeout(): Promise<void> {
+  const timeoutMs = 3000;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    await Promise.race([
+      shutdownPosthog(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`PostHog shutdown timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    cronWarn('SECURITY: PostHog shutdown failed in cron sync handler', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
 
 async function sendBetterStackHeartbeat(params: {
   heartbeatUrl: string | undefined;
@@ -147,5 +172,7 @@ export async function GET(request: NextRequest) {
       },
       { status: 500 }
     );
+  } finally {
+    await shutdownPosthogWithTimeout();
   }
 }

--- a/src/app/api/cron/sync-security-alerts/route.ts
+++ b/src/app/api/cron/sync-security-alerts/route.ts
@@ -173,6 +173,12 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   } finally {
-    await shutdownPosthogWithTimeout();
+    try {
+      await shutdownPosthogWithTimeout();
+    } catch (error) {
+      cronWarn('SECURITY: Unexpected failure during PostHog shutdown cleanup', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }

--- a/src/lib/security-agent/services/audit-log-service.ts
+++ b/src/lib/security-agent/services/audit-log-service.ts
@@ -84,6 +84,17 @@ export function logSecurityAudit(params: CreateSecurityAuditLogParams): void {
   });
 }
 
+export async function logSecurityAuditAndWait(params: CreateSecurityAuditLogParams): Promise<void> {
+  try {
+    await createSecurityAuditLog(params);
+  } catch (error) {
+    captureException(error, {
+      tags: { operation: 'createSecurityAuditLog' },
+      extra: { action: params.action, resource_type: params.resource_type },
+    });
+  }
+}
+
 /** Replace internal Kilo admin actor details with a generic placeholder for non-admin requestors. */
 export function maskKiloAdminActors<
   T extends { actor_id: string | null; actor_email: string | null; actor_name: string | null },

--- a/src/lib/security-agent/services/audit-log-service.ts
+++ b/src/lib/security-agent/services/audit-log-service.ts
@@ -84,14 +84,30 @@ export function logSecurityAudit(params: CreateSecurityAuditLogParams): void {
   });
 }
 
-export async function logSecurityAuditAndWait(params: CreateSecurityAuditLogParams): Promise<void> {
+export async function logSecurityAuditAndWait(
+  params: CreateSecurityAuditLogParams,
+  timeoutMs = 1500
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
   try {
-    await createSecurityAuditLog(params);
+    await Promise.race([
+      createSecurityAuditLog(params),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`Security audit log write timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
   } catch (error) {
     captureException(error, {
       tags: { operation: 'createSecurityAuditLog' },
       extra: { action: params.action, resource_type: params.resource_type },
     });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 

--- a/src/lib/security-agent/services/sync-service.ts
+++ b/src/lib/security-agent/services/sync-service.ts
@@ -23,7 +23,7 @@ import {
 } from '../core/types';
 import type { Owner } from '@/lib/code-reviews/core';
 import { sentryLogger } from '@/lib/utils.server';
-import { logSecurityAudit, SecurityAuditLogAction } from './audit-log-service';
+import { logSecurityAuditAndWait, SecurityAuditLogAction } from './audit-log-service';
 
 const log = sentryLogger('security-agent:sync', 'info');
 const warn = sentryLogger('security-agent:sync', 'warning');
@@ -416,7 +416,7 @@ export async function runFullSync(): Promise<{
         'organizationId' in config.owner
           ? (config.owner.organizationId ?? 'unknown')
           : (config.owner.userId ?? 'unknown');
-      logSecurityAudit({
+      await logSecurityAuditAndWait({
         owner: config.owner,
         actor_id: null,
         actor_email: null,

--- a/src/lib/security-agent/services/sync-service.ts
+++ b/src/lib/security-agent/services/sync-service.ts
@@ -416,22 +416,25 @@ export async function runFullSync(): Promise<{
         'organizationId' in config.owner
           ? (config.owner.organizationId ?? 'unknown')
           : (config.owner.userId ?? 'unknown');
-      await logSecurityAuditAndWait({
-        owner: config.owner,
-        actor_id: null,
-        actor_email: null,
-        actor_name: null,
-        action: SecurityAuditLogAction.SyncCompleted,
-        resource_type: 'agent_config',
-        resource_id: ownerId,
-        metadata: {
-          source: 'system',
-          trigger: 'cron',
-          synced: result.synced,
-          errors: result.errors,
-          repoCount: config.repositories.length,
+      await logSecurityAuditAndWait(
+        {
+          owner: config.owner,
+          actor_id: null,
+          actor_email: null,
+          actor_name: null,
+          action: SecurityAuditLogAction.SyncCompleted,
+          resource_type: 'agent_config',
+          resource_id: ownerId,
+          metadata: {
+            source: 'system',
+            trigger: 'cron',
+            synced: result.synced,
+            errors: result.errors,
+            repoCount: config.repositories.length,
+          },
         },
-      });
+        1500
+      );
     } catch (error) {
       totalErrors++;
       captureException(error, {


### PR DESCRIPTION
## Summary
- await security audit log writes during full sync so cron completion does not leave fire-and-forget database work running
- add a bounded PostHog shutdown step in the sync cron handler `finally` block so analytics transport is flushed/closed on both success and failure paths
- keep route-level runtime duration at `maxDuration = 800` for Fluid Compute compatibility

## Validation
- pre-commit hooks ran `prettier` and `pnpm typecheck` successfully during commit