### PR TITLE
CloudAgent - Add 48h free Sonnet 4.6 promotion

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -64,6 +64,7 @@ import { customLlmRequest } from '@/lib/custom-llm/customLlmRequest';
 import { normalizeModelId } from '@/lib/model-utils';
 import { isRateLimitedToDeath } from '@/lib/rate-limited-models';
 import { isActiveReviewPromo } from '@/lib/code-reviews/core/constants';
+import { isActiveCloudAgentPromo } from '@/lib/promotions/cloud-agent-promo';
 
 const MAX_TOKENS_LIMIT = 99999999999; // GPT4.1 default is ~32k
 
@@ -183,12 +184,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     authFailedResponse,
     organizationId: authOrganizationId,
     botId: authBotId,
+    tokenSource: authTokenSource,
   } = await getUserFromAuth({ adminOnly: false });
   authSpan.end();
 
   let user: typeof maybeUser | AnonymousUserContext;
   let organizationId: string | undefined = authOrganizationId;
   let botId: string | undefined = authBotId;
+  let tokenSource: string | undefined = authTokenSource;
 
   if (authFailedResponse) {
     // No valid auth
@@ -232,6 +235,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     user = createAnonymousContext(ipAddress);
     organizationId = undefined;
     botId = undefined;
+    tokenSource = undefined;
   } else {
     user = maybeUser;
   }
@@ -309,6 +313,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     user_byok: !!userByok,
     has_tools: (requestBodyParsed.tools?.length ?? 0) > 0,
     botId,
+    tokenSource,
     feature: validateFeatureHeader(request.headers.get(FEATURE_HEADER)),
     session_id: taskId ?? null,
   };
@@ -325,7 +330,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       balance <= 0 &&
       !isFreeModel(originalModelIdLowerCased) &&
       !userByok &&
-      !isActiveReviewPromo(botId, originalModelIdLowerCased)
+      !isActiveReviewPromo(botId, originalModelIdLowerCased) &&
+      !isActiveCloudAgentPromo(tokenSource, originalModelIdLowerCased)
     ) {
       return await usageLimitExceededResponse(user, balance);
     }
@@ -504,7 +510,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   if (
     provider.id !== 'custom' &&
     (isKiloFreeModel(originalModelIdLowerCased) ||
-      isActiveReviewPromo(botId, originalModelIdLowerCased))
+      isActiveReviewPromo(botId, originalModelIdLowerCased) ||
+      isActiveCloudAgentPromo(tokenSource, originalModelIdLowerCased))
   ) {
     return rewriteFreeModelResponse(response, originalModelIdLowerCased);
   }

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -40,6 +40,7 @@ import { InsufficientBalanceBanner } from '@/components/shared/InsufficientBalan
 import { AdvancedConfig } from '@/components/shared/AdvancedConfig';
 import { cn } from '@/lib/utils';
 import type { AgentMode } from './types';
+import { applyCloudAgentPromoLabel } from '@/lib/promotions/cloud-agent-promo';
 
 type CloudNextSessionsPageProps = {
   organizationId?: string;
@@ -88,6 +89,8 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
     () => allModels.map(model => ({ id: model.id, name: model.name })),
     [allModels]
   );
+
+  const promoModelOptions = useMemo(() => applyCloudAgentPromoLabel(modelOptions), [modelOptions]);
 
   // Form state
   const [prompt, setPrompt] = useState('');
@@ -536,7 +539,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
               setModel(newModel);
               setIsModelUserSelected(true);
             }}
-            modelOptions={modelOptions}
+            modelOptions={promoModelOptions}
             isLoadingModels={!modelsData}
           />
 

--- a/src/components/cloud-agent/CloudSessionsPage.tsx
+++ b/src/components/cloud-agent/CloudSessionsPage.tsx
@@ -55,6 +55,7 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import { AdvancedConfig } from '@/components/shared/AdvancedConfig';
 import { cn } from '@/lib/utils';
 import { MODES } from './ResumeConfigModal';
+import { applyCloudAgentPromoLabel } from '@/lib/promotions/cloud-agent-promo';
 
 type CloudSessionsPageProps = {
   organizationId?: string;
@@ -86,6 +87,8 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
     () => allModels.map(model => ({ id: model.id, name: model.name })),
     [allModels]
   );
+
+  const promoModelOptions = useMemo(() => applyCloudAgentPromoLabel(modelOptions), [modelOptions]);
 
   // Form state (non-profile related)
   const [prompt, setPrompt] = useState('');
@@ -661,7 +664,7 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
               setModel(newModel);
               setIsModelUserSelected(true);
             }}
-            modelOptions={modelOptions}
+            modelOptions={promoModelOptions}
             isLoadingModels={!modelsData}
           />
 

--- a/src/lib/processUsage.ts
+++ b/src/lib/processUsage.ts
@@ -30,6 +30,7 @@ import { appendKiloPassAuditLog } from '@/lib/kilo-pass/issuance';
 import { KiloPassAuditLogAction, KiloPassAuditLogResult } from '@/lib/kilo-pass/enums';
 import { reportAbuseCost } from '@/lib/abuse-service';
 import { isActiveReviewPromo } from '@/lib/code-reviews/core/constants';
+import { isActiveCloudAgentPromo } from '@/lib/promotions/cloud-agent-promo';
 
 const posthogClient = PostHogClient();
 
@@ -176,6 +177,7 @@ export type MicrodollarUsageContext = {
   user_byok: boolean;
   has_tools: boolean;
   botId?: string;
+  tokenSource?: string;
   /** Request ID from abuse service classify response, for cost tracking correlation. 0 means skip. */
   abuse_request_id?: number;
   /** Which product feature generated this API call. NULL if header not sent. */
@@ -949,7 +951,8 @@ async function processTokenData(
   if (
     isFreeModel(usageContext.requested_model) ||
     usageContext.user_byok ||
-    isActiveReviewPromo(usageContext.botId, usageContext.requested_model)
+    isActiveReviewPromo(usageContext.botId, usageContext.requested_model) ||
+    isActiveCloudAgentPromo(usageContext.tokenSource, usageContext.requested_model)
   ) {
     usageStats.cost_mUsd = 0;
     usageStats.cacheDiscount_mUsd = 0;

--- a/src/lib/promotions/cloud-agent-promo.ts
+++ b/src/lib/promotions/cloud-agent-promo.ts
@@ -1,0 +1,23 @@
+export const CLOUD_AGENT_PROMO_MODEL = 'anthropic/claude-sonnet-4.6';
+export const CLOUD_AGENT_PROMO_START = '2026-02-26T08:00:00Z'; // 9am CET (UTC+1)
+export const CLOUD_AGENT_PROMO_END = '2026-02-28T08:00:00Z'; // 48h later
+
+function isCloudAgentPromoActive(): boolean {
+  const now = Date.now();
+  return now >= Date.parse(CLOUD_AGENT_PROMO_START) && now < Date.parse(CLOUD_AGENT_PROMO_END);
+}
+
+export function isActiveCloudAgentPromo(tokenSource: string | undefined, model: string): boolean {
+  if (tokenSource !== 'cloud-agent') return false;
+  if (model !== CLOUD_AGENT_PROMO_MODEL) return false;
+  return isCloudAgentPromoActive();
+}
+
+export function applyCloudAgentPromoLabel<T extends { id: string; name: string }>(
+  options: T[]
+): T[] {
+  if (!isCloudAgentPromoActive()) return options;
+  return options.map(m =>
+    m.id === CLOUD_AGENT_PROMO_MODEL ? { ...m, name: `${m.name} (free)` } : m
+  );
+}

--- a/src/lib/promotions/cloud-agent-promo.ts
+++ b/src/lib/promotions/cloud-agent-promo.ts
@@ -17,7 +17,12 @@ export function applyCloudAgentPromoLabel<T extends { id: string; name: string }
   options: T[]
 ): T[] {
   if (!isCloudAgentPromoActive()) return options;
+  const endDate = new Date(CLOUD_AGENT_PROMO_END).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+  });
   return options.map(m =>
-    m.id === CLOUD_AGENT_PROMO_MODEL ? { ...m, name: `${m.name} (free)` } : m
+    m.id === CLOUD_AGENT_PROMO_MODEL ? { ...m, name: `${m.name} (free till ${endDate})` } : m
   );
 }

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -14,6 +14,7 @@ export type JWTTokenExtraPayload = {
   organizationRole?: OrganizationRole;
   internalApiUse?: boolean;
   createdOnPlatform?: string;
+  tokenSource?: string;
 };
 
 const FIVE_YEARS_IN_SECONDS = 5 * 365 * 24 * 60 * 60;
@@ -139,5 +140,10 @@ export function validateAuthorizationHeader(headers: Headers) {
     internalApiUse: payload.internalApiUse,
     createdOnPlatform: payload.createdOnPlatform,
     botId: payload.botId,
+    tokenSource: payload.tokenSource,
   };
+}
+
+export function generateCloudAgentToken(user: User) {
+  return generateApiToken(user, { tokenSource: 'cloud-agent' });
 }

--- a/src/lib/user.server.ts
+++ b/src/lib/user.server.ts
@@ -644,6 +644,7 @@ type GetAuthResponse =
       organizationId?: undefined;
       internalApiUse?: undefined;
       botId?: undefined;
+      tokenSource?: undefined;
     }
   | {
       user: User;
@@ -652,6 +653,7 @@ type GetAuthResponse =
       organizationId?: Organization['id'];
       internalApiUse?: boolean;
       botId?: string;
+      tokenSource?: string;
     };
 
 export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAuthResponse> {
@@ -678,6 +680,7 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
     const organizationId = headersList.get(ORGANIZATION_ID_HEADER) || undefined;
     const internalApiUse = authorizationValidationResult.internalApiUse;
     const botId = authorizationValidationResult.botId;
+    const tokenSource = authorizationValidationResult.tokenSource;
 
     return await validateUserAuthorization(
       authorizationValidationResult.kiloUserId,
@@ -687,7 +690,8 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
       organizationId,
       internalApiUse,
       readDb,
-      botId
+      botId,
+      tokenSource
     );
   }
 
@@ -755,7 +759,8 @@ async function validateUserAuthorization(
   organizationId?: Organization['id'],
   internalApiUse?: boolean,
   fromDb: typeof db = db,
-  botId?: string
+  botId?: string,
+  tokenSource?: string
 ): Promise<GetAuthResponse> {
   if (!user) {
     return authError(401, 'User not found', kiloUserId);
@@ -778,7 +783,15 @@ async function validateUserAuthorization(
     }
   }
 
-  return { user, authFailedResponse: null, isNewUser, organizationId, internalApiUse, botId };
+  return {
+    user,
+    authFailedResponse: null,
+    isNewUser,
+    organizationId,
+    internalApiUse,
+    botId,
+    tokenSource,
+  };
 }
 
 export const isUserBlacklistedByDomain = (existingUser: Pick<User, 'google_user_email'>) =>

--- a/src/routers/cloud-agent-next-router.ts
+++ b/src/routers/cloud-agent-next-router.ts
@@ -5,7 +5,7 @@ import {
   createCloudAgentNextClient,
   rethrowAsPaymentRequired,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
-import { generateApiToken } from '@/lib/tokens';
+import { generateCloudAgentToken } from '@/lib/tokens';
 import {
   mergeProfileConfiguration,
   ProfileNotFoundError,
@@ -58,7 +58,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(basePrepareSessionNextSchema)
     .output(basePrepareSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
       const { envVars, setupCommands, profileName, gitlabProject, githubRepo, ...restInput } =
@@ -125,7 +125,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseInitiateFromPreparedSessionNextSchema)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudAgentNextClient(authToken);
 
@@ -150,7 +150,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseSendMessageNextSchema)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudAgentNextClient(authToken);
 
@@ -179,7 +179,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
       return await client.interruptSession(input.sessionId);
@@ -189,7 +189,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseAnswerQuestionNextSchema)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.answerQuestion(input);
     }),
@@ -198,7 +198,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseRejectQuestionNextSchema)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.rejectQuestion(input);
     }),
@@ -211,7 +211,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .input(baseGetSessionNextSchema)
     .output(baseGetSessionNextOutputSchema)
     .query(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
       return await client.getSession(input.cloudAgentSessionId);

--- a/src/routers/cloud-agent-router.ts
+++ b/src/routers/cloud-agent-router.ts
@@ -5,7 +5,7 @@ import {
   createCloudChatClient,
   rethrowAsPaymentRequired,
 } from '@/lib/cloud-agent/cloud-agent-client';
-import { generateApiToken } from '@/lib/tokens';
+import { generateCloudAgentToken } from '@/lib/tokens';
 import {
   mergeProfileConfiguration,
   ProfileNotFoundError,
@@ -53,7 +53,7 @@ export const cloudAgentRouter = createTRPCRouter({
   initiateSessionStream: baseProcedure
     .input(baseInitiateSessionSchema)
     .subscription(async function* ({ ctx, input }) {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudChatClient(authToken);
 
@@ -80,7 +80,7 @@ export const cloudAgentRouter = createTRPCRouter({
   initiateFromKilocodeSessionStream: baseProcedure
     .input(baseInitiateFromKilocodeSessionSchema)
     .subscription(async function* ({ ctx, input }) {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudChatClient(authToken);
 
@@ -119,7 +119,7 @@ export const cloudAgentRouter = createTRPCRouter({
     .input(basePrepareSessionSchema)
     .output(basePrepareSessionOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
 
       const { envVars, setupCommands, profileName, gitlabProject, githubRepo, ...restInput } =
@@ -185,7 +185,7 @@ export const cloudAgentRouter = createTRPCRouter({
     .input(basePrepareLegacySessionSchema)
     .output(basePrepareLegacySessionOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
 
       const { envVars, setupCommands, profileName, gitlabProject, githubRepo, ...restInput } =
@@ -245,7 +245,7 @@ export const cloudAgentRouter = createTRPCRouter({
     ctx,
     input,
   }) {
-    const authToken = generateApiToken(ctx.user);
+    const authToken = generateCloudAgentToken(ctx.user);
     const githubToken = await getGitHubTokenForUser(ctx.user.id);
     const client = createCloudChatClient(authToken);
 
@@ -285,7 +285,7 @@ export const cloudAgentRouter = createTRPCRouter({
   deleteSession: baseProcedure
     .input(z.object({ sessionId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
 
       // First, delete the cloud-agent session (idempotent - returns success if already deleted)
@@ -338,7 +338,7 @@ export const cloudAgentRouter = createTRPCRouter({
   interruptSession: baseProcedure
     .input(baseInterruptSessionSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
       return await client.interruptSession(input.sessionId);
     }),
@@ -354,7 +354,7 @@ export const cloudAgentRouter = createTRPCRouter({
     .input(baseGetSessionSchema)
     .output(baseGetSessionOutputSchema)
     .query(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
       return await client.getSession(input.cloudAgentSessionId);
     }),
@@ -413,7 +413,7 @@ export const cloudAgentRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudChatClient(authToken);
 
@@ -455,7 +455,7 @@ export const cloudAgentRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudChatClient(authToken);
 

--- a/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -5,7 +5,7 @@ import {
   createCloudAgentNextClient,
   rethrowAsPaymentRequired,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
-import { generateApiToken } from '@/lib/tokens';
+import { generateCloudAgentToken } from '@/lib/tokens';
 import {
   mergeProfileConfiguration,
   ProfileNotFoundError,
@@ -100,7 +100,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(PrepareSessionInput)
     .output(basePrepareSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
       const {
@@ -175,7 +175,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(InitiateFromPreparedSessionInput)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudAgentNextClient(authToken);
 
@@ -201,7 +201,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(SendMessageInput)
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudAgentNextClient(authToken);
 
@@ -232,7 +232,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
       return await client.interruptSession(input.sessionId);
@@ -242,7 +242,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(AnswerQuestionInput)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.answerQuestion({
         sessionId: input.sessionId,
@@ -255,7 +255,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(RejectQuestionInput)
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
       return await client.rejectQuestion({
         sessionId: input.sessionId,
@@ -271,7 +271,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .input(GetSessionInput)
     .output(baseGetSessionNextOutputSchema)
     .query(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
       return await client.getSession(input.cloudAgentSessionId);

--- a/src/routers/organizations/organization-cloud-agent-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-router.ts
@@ -6,7 +6,7 @@ import {
   rethrowAsPaymentRequired,
 } from '@/lib/cloud-agent/cloud-agent-client';
 import * as z from 'zod';
-import { generateApiToken } from '@/lib/tokens';
+import { generateCloudAgentToken } from '@/lib/tokens';
 import {
   mergeProfileConfiguration,
   ProfileNotFoundError,
@@ -116,7 +116,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
   initiateSessionStream: organizationMemberProcedure
     .input(InitiateSessionInput)
     .subscription(async function* ({ ctx, input }) {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudChatClient(authToken);
 
@@ -144,7 +144,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
   initiateFromKilocodeSessionStream: organizationMemberProcedure
     .input(InitiateFromKilocodeSessionInput)
     .subscription(async function* ({ ctx, input }) {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudChatClient(authToken);
 
@@ -186,7 +186,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
     .input(PrepareSessionInput)
     .output(basePrepareSessionOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
 
       const {
@@ -260,7 +260,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
     .input(PrepareLegacySessionInput)
     .output(basePrepareLegacySessionOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
 
       const {
@@ -328,7 +328,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
   sendMessageStream: organizationMemberProcedure
     .input(SendMessageInput)
     .subscription(async function* ({ ctx, input }) {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudChatClient(authToken);
 
@@ -373,7 +373,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
 
       // First, delete the cloud-agent session (idempotent - returns success if already deleted)
@@ -427,7 +427,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
   interruptSession: organizationMemberProcedure
     .input(InterruptSessionInput)
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
       return await client.interruptSession(input.sessionId);
     }),
@@ -443,7 +443,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
     .input(GetSessionInput)
     .output(baseGetSessionOutputSchema)
     .query(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudChatClient(authToken);
       return await client.getSession(input.cloudAgentSessionId);
     }),
@@ -480,7 +480,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudChatClient(authToken);
 
@@ -525,7 +525,7 @@ export const organizationCloudAgentRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const authToken = generateApiToken(ctx.user);
+      const authToken = generateCloudAgentToken(ctx.user);
       const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudChatClient(authToken);
 


### PR DESCRIPTION
## Summary

- Adds a time-limited promotion (Feb 26–28, 2026) making `anthropic/claude-sonnet-4.6` free for cloud agent sessions.
- Introduces a `tokenSource` JWT field set to `'cloud-agent'` via a new `generateCloudAgentToken()` helper, used across all 4 cloud-agent routers (personal + org, legacy + next).
- `isActiveCloudAgentPromo()` checks `tokenSource`, model, and time window to bypass balance gates, zero costs, and rewrite responses — same pattern as the existing code review promo.
- Cloud agent UI model pickers show a `(free)` label on the promo model while the window is active.

## Files changed

| Area | File | Change |
|---|---|---|
| **New** | `src/lib/promotions/cloud-agent-promo.ts` | Promo constants, `isActiveCloudAgentPromo()`, `applyCloudAgentPromoLabel()` |
| Auth | `src/lib/tokens.ts` | `tokenSource` JWT field + `generateCloudAgentToken()` |
| Auth | `src/lib/user.server.ts` | Thread `tokenSource` through auth chain |
| API | `src/app/api/openrouter/[...path]/route.ts` | Balance gate bypass, usage context, response rewriting |
| Billing | `src/lib/processUsage.ts` | Cost zeroing for promo requests |
| Routers | 4 cloud-agent router files | Switch to `generateCloudAgentToken()` |
| UI | 2 `CloudSessionsPage` components | `(free)` label via `applyCloudAgentPromoLabel()` |