### PR TITLE
Upgrade openclaw to 2026.2.24 and use native kilocode provider (#583)

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -10,10 +10,12 @@ GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
 # Fly app naming prefix ("dev-") for per-user app creation.
 WORKER_ENV=development
 
-# Optional: Override KiloCode base URL (dev)
-# In dev you'll want to use ngrok or cloudflare tunnel to route back to your nextjs app
+# Optional: Override KiloCode provider base URL (local dev only)
+# OpenClaw's native kilocode provider hardcodes https://api.kilo.ai/api/gateway/.
+# In dev, set this to a Cloudflare tunnel or ngrok URL pointing to your local Next.js app
+# so that Fly machines route model requests through the tunnel instead of production.
 # e.g.: `cloudflared tunnel --url http://localhost:3000`
-# KILOCODE_API_BASE_URL=https://api.kilo.ai/api/openrouter/
+# KILOCODE_API_BASE_URL=https://<tunnel>.trycloudflare.com/api/gateway/
 
 # Fly.io Machines API
 # Get a token (run: `fly tokens create some-name-for-this-dev-token`)

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -31,7 +31,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.2.24 \
+RUN npm install -g openclaw@2026.2.25 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -55,8 +55,8 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-26-v53-add-rg-gh
-RUN echo "4"
+# Build cache bust: 2026-02-26-v54-native-kilocode-provider-migration
+RUN echo "5"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -31,7 +31,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.2.22 \
+RUN npm install -g openclaw@2026.2.24 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/kiloclaw/controller/src/index.ts
+++ b/kiloclaw/controller/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { createSupervisor } from './supervisor';
 import { registerHealthRoute } from './routes/health';
 import { registerGatewayRoutes } from './routes/gateway';
+import { registerConfigRoutes } from './routes/config';
 
 export type RuntimeConfig = {
   port: number;
@@ -117,6 +118,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   const app = new Hono();
   registerHealthRoute(app, supervisor);
   registerGatewayRoutes(app, supervisor, config.expectedToken);
+  registerConfigRoutes(app, config.expectedToken);
   app.all(
     '*',
     createHttpProxy({

--- a/kiloclaw/controller/src/routes/config.test.ts
+++ b/kiloclaw/controller/src/routes/config.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { registerConfigRoutes } from './config';
+
+// Mock fs at the module level
+vi.mock('node:fs', () => {
+  return {
+    default: {
+      readFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+    },
+  };
+});
+
+// Import the mocked module
+import fs from 'node:fs';
+
+const readMock = vi.mocked(fs.readFileSync);
+const writeMock = vi.mocked(fs.writeFileSync);
+
+function authHeaders(token = 'test-token'): HeadersInit {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+}
+
+describe('/_kilo/config routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enforces bearer auth', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, 'test-token');
+
+    const noAuth = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(noAuth.status).toBe(401);
+
+    const wrongAuth = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar' }),
+      headers: authHeaders('bad-token'),
+    });
+    expect(wrongAuth.status).toBe(401);
+  });
+
+  it('deep-merges patch into existing config', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, 'test-token');
+
+    const existingConfig = {
+      agents: { defaults: { model: { primary: 'kilocode/anthropic/claude-opus-4.6' } } },
+      gateway: { port: 3001 },
+    };
+    readMock.mockReturnValue(JSON.stringify(existingConfig));
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        agents: { defaults: { model: { primary: 'kilocode/anthropic/claude-sonnet-4.5' } } },
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ ok: true });
+
+    expect(writeMock).toHaveBeenCalledOnce();
+    const written = JSON.parse(writeMock.mock.calls[0][1] as string);
+    expect(written.agents.defaults.model.primary).toBe('kilocode/anthropic/claude-sonnet-4.5');
+    // Existing keys preserved
+    expect(written.gateway.port).toBe(3001);
+  });
+
+  it('rejects non-object body', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, 'test-token');
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify([1, 2, 3]),
+      headers: authHeaders(),
+    });
+    expect(resp.status).toBe(400);
+  });
+
+  it('rejects invalid JSON', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, 'test-token');
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: 'not json',
+      headers: authHeaders(),
+    });
+    expect(resp.status).toBe(400);
+  });
+
+  it('returns 500 when config file is missing', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, 'test-token');
+
+    readMock.mockImplementation(() => {
+      throw new Error('ENOENT: no such file');
+    });
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({ agents: {} }),
+      headers: authHeaders(),
+    });
+    expect(resp.status).toBe(500);
+  });
+});

--- a/kiloclaw/controller/src/routes/config.test.ts
+++ b/kiloclaw/controller/src/routes/config.test.ts
@@ -98,6 +98,38 @@ describe('/_kilo/config routes', () => {
     expect(resp.status).toBe(400);
   });
 
+  it('rejects prototype pollution keys', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, 'test-token');
+
+    const existingConfig = { safe: 'value' };
+    readMock.mockReturnValue(JSON.stringify(existingConfig));
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        __proto__: { polluted: true },
+        constructor: { polluted: true },
+        prototype: { polluted: true },
+        nested: { __proto__: { deep: true } },
+        legit: 'ok',
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(writeMock).toHaveBeenCalledOnce();
+    const written = JSON.parse(writeMock.mock.calls[0][1] as string);
+    // Banned keys are silently dropped at every depth
+    expect(Object.hasOwn(written, '__proto__')).toBe(false);
+    expect(Object.hasOwn(written, 'constructor')).toBe(false);
+    expect(Object.hasOwn(written, 'prototype')).toBe(false);
+    expect(Object.hasOwn(written.nested ?? {}, '__proto__')).toBe(false);
+    // Legit keys are preserved
+    expect(written.legit).toBe('ok');
+    expect(written.safe).toBe('value');
+  });
+
   it('returns 500 when config file is missing', async () => {
     const app = new Hono();
     registerConfigRoutes(app, 'test-token');

--- a/kiloclaw/controller/src/routes/config.ts
+++ b/kiloclaw/controller/src/routes/config.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import type { Hono } from 'hono';
+import { timingSafeTokenEqual } from '../auth';
+
+const CONFIG_PATH = '/root/.openclaw/openclaw.json';
+
+/**
+ * Deep-merge `patch` into `target`, creating intermediate objects as needed.
+ * Arrays and primitives in the patch overwrite the target value.
+ */
+function deepMerge(target: Record<string, unknown>, patch: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(patch)) {
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      typeof target[key] === 'object' &&
+      target[key] !== null &&
+      !Array.isArray(target[key])
+    ) {
+      deepMerge(target[key] as Record<string, unknown>, value as Record<string, unknown>);
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
+export function registerConfigRoutes(app: Hono, expectedToken: string): void {
+  app.use('/_kilo/config/*', async (c, next) => {
+    const authHeader = c.req.header('authorization');
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    if (!timingSafeTokenEqual(token, expectedToken)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    await next();
+  });
+
+  // Deep-merge a JSON patch into openclaw.json.
+  // OpenClaw's gateway watches this file and reloads on change.
+  //
+  // Example: PATCH /_kilo/config/patch
+  //   { "agents": { "defaults": { "model": { "primary": "kilocode/anthropic/claude-sonnet-4.5" } } } }
+  app.post('/_kilo/config/patch', async c => {
+    let patch: unknown;
+    try {
+      patch = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+      return c.json({ error: 'Body must be a JSON object' }, 400);
+    }
+
+    try {
+      const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+      const config = JSON.parse(raw);
+      deepMerge(config, patch as Record<string, unknown>);
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+      console.log('[controller] Config patched:', JSON.stringify(patch));
+      return c.json({ ok: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[controller] Failed to patch config:', message);
+      return c.json({ error: `Failed to patch config: ${message}` }, 500);
+    }
+  });
+}

--- a/kiloclaw/controller/src/routes/config.ts
+++ b/kiloclaw/controller/src/routes/config.ts
@@ -8,8 +8,11 @@ const CONFIG_PATH = '/root/.openclaw/openclaw.json';
  * Deep-merge `patch` into `target`, creating intermediate objects as needed.
  * Arrays and primitives in the patch overwrite the target value.
  */
+const BANNED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function deepMerge(target: Record<string, unknown>, patch: Record<string, unknown>): void {
   for (const [key, value] of Object.entries(patch)) {
+    if (BANNED_KEYS.has(key)) continue;
     if (
       value !== null &&
       typeof value === 'object' &&

--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -8,6 +8,10 @@ export const OPENCLAW_PORT = 18789;
 /** Internal loopback port for the OpenClaw gateway process (behind controller) */
 export const OPENCLAW_INTERNAL_PORT = 3001;
 
+/** OpenClaw's built-in default model when using the kilocode provider.
+ *  Used as fallback when the user clears their model selection. */
+export const OPENCLAW_BUILTIN_DEFAULT_MODEL = 'kilocode/anthropic/claude-opus-4.6';
+
 /** Maximum time to wait for the machine to reach 'started' state.
  *  Fly's /wait endpoint caps at 60s (spec.json:1538). */
 export const STARTUP_TIMEOUT_SECONDS = 60;

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -352,6 +352,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private encryptedSecrets: PersistedState['encryptedSecrets'] = null;
   private kilocodeApiKey: PersistedState['kilocodeApiKey'] = null;
   private kilocodeApiKeyExpiresAt: PersistedState['kilocodeApiKeyExpiresAt'] = null;
+  private kilocodeDefaultModel: PersistedState['kilocodeDefaultModel'] = null;
   private channels: PersistedState['channels'] = null;
   private provisionedAt: number | null = null;
   private lastStartedAt: number | null = null;
@@ -391,6 +392,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.encryptedSecrets = s.encryptedSecrets;
       this.kilocodeApiKey = s.kilocodeApiKey;
       this.kilocodeApiKeyExpiresAt = s.kilocodeApiKeyExpiresAt;
+      this.kilocodeDefaultModel = s.kilocodeDefaultModel;
       this.channels = s.channels;
       this.provisionedAt = s.provisionedAt;
       this.lastStartedAt = s.lastStartedAt;
@@ -496,6 +498,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       encryptedSecrets: config.encryptedSecrets ?? null,
       kilocodeApiKey: config.kilocodeApiKey ?? null,
       kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
+      kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
       channels: config.channels ?? null,
       machineSize: config.machineSize ?? this.machineSize ?? null,
     } satisfies Partial<PersistedState>;
@@ -534,6 +537,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.encryptedSecrets = config.encryptedSecrets ?? null;
     this.kilocodeApiKey = config.kilocodeApiKey ?? null;
     this.kilocodeApiKeyExpiresAt = config.kilocodeApiKeyExpiresAt ?? null;
+    this.kilocodeDefaultModel = config.kilocodeDefaultModel ?? null;
     this.channels = config.channels ?? null;
     this.machineSize = config.machineSize ?? this.machineSize ?? null;
     if (isNew) {
@@ -563,9 +567,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   async updateKiloCodeConfig(patch: {
     kilocodeApiKey?: string | null;
     kilocodeApiKeyExpiresAt?: string | null;
+    kilocodeDefaultModel?: string | null;
   }): Promise<{
     kilocodeApiKey: string | null;
     kilocodeApiKeyExpiresAt: string | null;
+    kilocodeDefaultModel: string | null;
   }> {
     await this.loadState();
 
@@ -579,14 +585,27 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.kilocodeApiKeyExpiresAt = patch.kilocodeApiKeyExpiresAt;
       pending.kilocodeApiKeyExpiresAt = this.kilocodeApiKeyExpiresAt;
     }
+    if (patch.kilocodeDefaultModel !== undefined) {
+      this.kilocodeDefaultModel = patch.kilocodeDefaultModel;
+      pending.kilocodeDefaultModel = this.kilocodeDefaultModel;
+    }
 
     if (Object.keys(pending).length > 0) {
       await this.ctx.storage.put(pending);
     }
 
+    // Hot-patch the running machine's config file if the default model changed.
+    // This avoids requiring a full machine restart — OpenClaw watches the config file.
+    if (patch.kilocodeDefaultModel !== undefined && this.kilocodeDefaultModel) {
+      await this.patchConfigOnMachine({
+        agents: { defaults: { model: { primary: this.kilocodeDefaultModel } } },
+      });
+    }
+
     return {
       kilocodeApiKey: this.kilocodeApiKey,
       kilocodeApiKeyExpiresAt: this.kilocodeApiKeyExpiresAt,
+      kilocodeDefaultModel: this.kilocodeDefaultModel,
     };
   }
 
@@ -1260,6 +1279,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       encryptedSecrets: this.encryptedSecrets ?? undefined,
       kilocodeApiKey: this.kilocodeApiKey ?? undefined,
       kilocodeApiKeyExpiresAt: this.kilocodeApiKeyExpiresAt ?? undefined,
+      kilocodeDefaultModel: this.kilocodeDefaultModel ?? undefined,
       channels: this.channels ?? undefined,
       machineSize: this.machineSize ?? undefined,
     };
@@ -1299,7 +1319,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private async callGatewayController<T>(
     path: string,
     method: 'GET' | 'POST',
-    responseSchema: ZodType<T>
+    responseSchema: ZodType<T>,
+    jsonBody?: unknown
   ): Promise<T> {
     const { appName, machineId, sandboxId } = this.requireGatewayControllerContext();
 
@@ -1310,15 +1331,21 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const gatewayToken = await deriveGatewayToken(sandboxId, this.env.GATEWAY_TOKEN_SECRET);
     const url = `https://${appName}.fly.dev${path}`;
 
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${gatewayToken}`,
+      Accept: 'application/json',
+      'fly-force-instance-id': machineId,
+    };
+    if (jsonBody !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+
     let response: Response;
     try {
       response = await fetch(url, {
         method,
-        headers: {
-          Authorization: `Bearer ${gatewayToken}`,
-          Accept: 'application/json',
-          'fly-force-instance-id': machineId,
-        },
+        headers,
+        body: jsonBody !== undefined ? JSON.stringify(jsonBody) : undefined,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -1392,6 +1419,31 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       'POST',
       GatewayCommandResponseSchema
     );
+  }
+
+  /**
+   * Hot-patch the openclaw.json config on the running machine.
+   * The gateway watches the config file and reloads on change.
+   * Non-fatal: if the machine isn't running, the patch is silently skipped
+   * (the next start will pick up the value from env vars anyway).
+   */
+  async patchConfigOnMachine(patch: Record<string, unknown>): Promise<void> {
+    await this.loadState();
+    if (this.status !== 'running' || !this.flyMachineId) return;
+    try {
+      await this.callGatewayController(
+        '/_kilo/config/patch',
+        'POST',
+        GatewayCommandResponseSchema,
+        patch
+      );
+    } catch (err) {
+      // Non-fatal — the config will be applied on next machine start via env vars
+      console.warn(
+        '[DO] patchConfigOnMachine failed (non-fatal):',
+        err instanceof Error ? err.message : String(err)
+      );
+    }
   }
 
   // ========================================================================
@@ -1955,6 +2007,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.encryptedSecrets = null;
     this.kilocodeApiKey = null;
     this.kilocodeApiKeyExpiresAt = null;
+    this.kilocodeDefaultModel = null;
     this.channels = null;
     this.provisionedAt = null;
     this.lastStartedAt = null;
@@ -2469,6 +2522,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         envVars: this.envVars ?? undefined,
         encryptedSecrets: this.encryptedSecrets ?? undefined,
         kilocodeApiKey: this.kilocodeApiKey ?? undefined,
+        kilocodeDefaultModel: this.kilocodeDefaultModel ?? undefined,
         channels: this.channels ?? undefined,
       }
     );

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -32,7 +32,6 @@ import {
   type InstanceConfig,
   type PersistedState,
   type EncryptedEnvelope,
-  type ModelEntry,
   type MachineSize,
 } from '../schemas/instance-config';
 import {
@@ -353,8 +352,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private encryptedSecrets: PersistedState['encryptedSecrets'] = null;
   private kilocodeApiKey: PersistedState['kilocodeApiKey'] = null;
   private kilocodeApiKeyExpiresAt: PersistedState['kilocodeApiKeyExpiresAt'] = null;
-  private kilocodeDefaultModel: PersistedState['kilocodeDefaultModel'] = null;
-  private kilocodeModels: PersistedState['kilocodeModels'] = null;
   private channels: PersistedState['channels'] = null;
   private provisionedAt: number | null = null;
   private lastStartedAt: number | null = null;
@@ -394,8 +391,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.encryptedSecrets = s.encryptedSecrets;
       this.kilocodeApiKey = s.kilocodeApiKey;
       this.kilocodeApiKeyExpiresAt = s.kilocodeApiKeyExpiresAt;
-      this.kilocodeDefaultModel = s.kilocodeDefaultModel;
-      this.kilocodeModels = s.kilocodeModels;
       this.channels = s.channels;
       this.provisionedAt = s.provisionedAt;
       this.lastStartedAt = s.lastStartedAt;
@@ -501,8 +496,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       encryptedSecrets: config.encryptedSecrets ?? null,
       kilocodeApiKey: config.kilocodeApiKey ?? null,
       kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
-      kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
-      kilocodeModels: config.kilocodeModels ?? null,
       channels: config.channels ?? null,
       machineSize: config.machineSize ?? this.machineSize ?? null,
     } satisfies Partial<PersistedState>;
@@ -541,8 +534,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.encryptedSecrets = config.encryptedSecrets ?? null;
     this.kilocodeApiKey = config.kilocodeApiKey ?? null;
     this.kilocodeApiKeyExpiresAt = config.kilocodeApiKeyExpiresAt ?? null;
-    this.kilocodeDefaultModel = config.kilocodeDefaultModel ?? null;
-    this.kilocodeModels = config.kilocodeModels ?? null;
     this.channels = config.channels ?? null;
     this.machineSize = config.machineSize ?? this.machineSize ?? null;
     if (isNew) {
@@ -572,13 +563,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   async updateKiloCodeConfig(patch: {
     kilocodeApiKey?: string | null;
     kilocodeApiKeyExpiresAt?: string | null;
-    kilocodeDefaultModel?: string | null;
-    kilocodeModels?: ModelEntry[] | null;
   }): Promise<{
     kilocodeApiKey: string | null;
     kilocodeApiKeyExpiresAt: string | null;
-    kilocodeDefaultModel: string | null;
-    kilocodeModels: ModelEntry[] | null;
   }> {
     await this.loadState();
 
@@ -592,14 +579,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.kilocodeApiKeyExpiresAt = patch.kilocodeApiKeyExpiresAt;
       pending.kilocodeApiKeyExpiresAt = this.kilocodeApiKeyExpiresAt;
     }
-    if (patch.kilocodeDefaultModel !== undefined) {
-      this.kilocodeDefaultModel = patch.kilocodeDefaultModel;
-      pending.kilocodeDefaultModel = this.kilocodeDefaultModel;
-    }
-    if (patch.kilocodeModels !== undefined) {
-      this.kilocodeModels = patch.kilocodeModels;
-      pending.kilocodeModels = this.kilocodeModels;
-    }
 
     if (Object.keys(pending).length > 0) {
       await this.ctx.storage.put(pending);
@@ -608,8 +587,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return {
       kilocodeApiKey: this.kilocodeApiKey,
       kilocodeApiKeyExpiresAt: this.kilocodeApiKeyExpiresAt,
-      kilocodeDefaultModel: this.kilocodeDefaultModel,
-      kilocodeModels: this.kilocodeModels,
     };
   }
 
@@ -1283,8 +1260,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       encryptedSecrets: this.encryptedSecrets ?? undefined,
       kilocodeApiKey: this.kilocodeApiKey ?? undefined,
       kilocodeApiKeyExpiresAt: this.kilocodeApiKeyExpiresAt ?? undefined,
-      kilocodeDefaultModel: this.kilocodeDefaultModel ?? undefined,
-      kilocodeModels: this.kilocodeModels ?? undefined,
       channels: this.channels ?? undefined,
       machineSize: this.machineSize ?? undefined,
     };
@@ -1980,8 +1955,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.encryptedSecrets = null;
     this.kilocodeApiKey = null;
     this.kilocodeApiKeyExpiresAt = null;
-    this.kilocodeDefaultModel = null;
-    this.kilocodeModels = null;
     this.channels = null;
     this.provisionedAt = null;
     this.lastStartedAt = null;
@@ -2496,8 +2469,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         envVars: this.envVars ?? undefined,
         encryptedSecrets: this.encryptedSecrets ?? undefined,
         kilocodeApiKey: this.kilocodeApiKey ?? undefined,
-        kilocodeDefaultModel: this.kilocodeDefaultModel ?? undefined,
-        kilocodeModels: this.kilocodeModels ?? undefined,
         channels: this.channels ?? undefined,
       }
     );

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -49,6 +49,7 @@ import {
   HEALTH_PROBE_TIMEOUT_SECONDS,
   HEALTH_PROBE_INTERVAL_MS,
   STALE_PROVISION_THRESHOLD_MS,
+  OPENCLAW_BUILTIN_DEFAULT_MODEL,
 } from '../config';
 import type { FlyClientConfig } from '../fly/client';
 import type {
@@ -596,9 +597,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // Hot-patch the running machine's config file if the default model changed.
     // This avoids requiring a full machine restart — OpenClaw watches the config file.
-    if (patch.kilocodeDefaultModel !== undefined && this.kilocodeDefaultModel) {
+    // When cleared (null), fall back to OpenClaw's built-in default.
+    if (patch.kilocodeDefaultModel !== undefined) {
+      const model = this.kilocodeDefaultModel ?? OPENCLAW_BUILTIN_DEFAULT_MODEL;
       await this.patchConfigOnMachine({
-        agents: { defaults: { model: { primary: this.kilocodeDefaultModel } } },
+        agents: { defaults: { model: { primary: model } } },
       });
     }
 

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -94,16 +94,25 @@ describe('buildEnvVars', () => {
     expect(result.env.NODE_ENV).toBe('production');
   });
 
-  it('puts KILOCODE_API_KEY in sensitive bucket', async () => {
+  it('puts KILOCODE_API_KEY in sensitive, default model in env', async () => {
     const env = createMockEnv({ AGENT_ENV_VARS_PRIVATE_KEY: testPrivateKey });
     const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
       kilocodeApiKey: 'kc-user-key',
+      kilocodeDefaultModel: 'kilocode/anthropic/claude-opus-4.6',
     });
 
     expect(result.sensitive.KILOCODE_API_KEY).toBe('kc-user-key');
-    // Model config is now handled natively by OpenClaw's kilocode provider
-    expect(result.env.KILOCODE_DEFAULT_MODEL).toBeUndefined();
+    expect(result.env.KILOCODE_DEFAULT_MODEL).toBe('kilocode/anthropic/claude-opus-4.6');
+    // Model catalog is handled natively by OpenClaw's kilocode provider
     expect(result.env.KILOCODE_MODELS_JSON).toBeUndefined();
+  });
+
+  it('does not set KILOCODE_DEFAULT_MODEL when absent', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      kilocodeApiKey: 'kc-key',
+    });
+    expect(result.env.KILOCODE_DEFAULT_MODEL).toBeUndefined();
   });
 
   it('puts decrypted secrets in sensitive bucket', async () => {

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -94,35 +94,16 @@ describe('buildEnvVars', () => {
     expect(result.env.NODE_ENV).toBe('production');
   });
 
-  it('puts KILOCODE_API_KEY in sensitive, model/models in env', async () => {
+  it('puts KILOCODE_API_KEY in sensitive bucket', async () => {
     const env = createMockEnv({ AGENT_ENV_VARS_PRIVATE_KEY: testPrivateKey });
-    const models = [
-      { id: 'anthropic/claude-opus-4.5', name: 'Anthropic: Claude Opus 4.5' },
-      { id: 'minimax/minimax-m2.1:free', name: 'Minimax M2.1' },
-    ];
     const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
       kilocodeApiKey: 'kc-user-key',
-      kilocodeDefaultModel: 'kilocode/anthropic/claude-opus-4.5',
-      kilocodeModels: models,
     });
 
     expect(result.sensitive.KILOCODE_API_KEY).toBe('kc-user-key');
-    expect(result.env.KILOCODE_DEFAULT_MODEL).toBe('kilocode/anthropic/claude-opus-4.5');
-    expect(result.env.KILOCODE_MODELS_JSON).toBe(JSON.stringify(models));
-  });
-
-  it('does not set KILOCODE_MODELS_JSON when kilocodeModels is null or absent', async () => {
-    const env = createMockEnv();
-    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
-      kilocodeApiKey: 'kc-key',
-      kilocodeModels: null,
-    });
+    // Model config is now handled natively by OpenClaw's kilocode provider
+    expect(result.env.KILOCODE_DEFAULT_MODEL).toBeUndefined();
     expect(result.env.KILOCODE_MODELS_JSON).toBeUndefined();
-
-    const result2 = await buildEnvVars(env, SANDBOX_ID, SECRET, {
-      kilocodeApiKey: 'kc-key',
-    });
-    expect(result2.env.KILOCODE_MODELS_JSON).toBeUndefined();
   });
 
   it('puts decrypted secrets in sensitive bucket', async () => {

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -12,6 +12,7 @@ export type UserConfig = {
   envVars?: Record<string, string>;
   encryptedSecrets?: Record<string, EncryptedEnvelope>;
   kilocodeApiKey?: string | null;
+  kilocodeDefaultModel?: string | null;
   channels?: EncryptedChannelTokens;
 };
 
@@ -109,6 +110,9 @@ export async function buildEnvVars(
 
     if (userConfig.kilocodeApiKey) {
       sensitive.KILOCODE_API_KEY = userConfig.kilocodeApiKey;
+    }
+    if (userConfig.kilocodeDefaultModel) {
+      plainEnv.KILOCODE_DEFAULT_MODEL = userConfig.kilocodeDefaultModel;
     }
 
     // Layer 4: Decrypt channel tokens and map to container env var names

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -12,8 +12,6 @@ export type UserConfig = {
   envVars?: Record<string, string>;
   encryptedSecrets?: Record<string, EncryptedEnvelope>;
   kilocodeApiKey?: string | null;
-  kilocodeDefaultModel?: string | null;
-  kilocodeModels?: Array<{ id: string; name: string }> | null;
   channels?: EncryptedChannelTokens;
 };
 
@@ -111,12 +109,6 @@ export async function buildEnvVars(
 
     if (userConfig.kilocodeApiKey) {
       sensitive.KILOCODE_API_KEY = userConfig.kilocodeApiKey;
-    }
-    if (userConfig.kilocodeDefaultModel) {
-      plainEnv.KILOCODE_DEFAULT_MODEL = userConfig.kilocodeDefaultModel;
-    }
-    if (userConfig.kilocodeModels) {
-      plainEnv.KILOCODE_MODELS_JSON = JSON.stringify(userConfig.kilocodeModels);
     }
 
     // Layer 4: Decrypt channel tokens and map to container env var names

--- a/kiloclaw/src/routes/kiloclaw.ts
+++ b/kiloclaw/src/routes/kiloclaw.ts
@@ -20,6 +20,7 @@ kiloclaw.get('/config', async c => {
   return c.json({
     envVarKeys: config.envVars ? Object.keys(config.envVars) : [],
     secretCount: config.encryptedSecrets ? Object.keys(config.encryptedSecrets).length : 0,
+    kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
     hasKiloCodeApiKey: !!config.kilocodeApiKey,
     kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
     channels: {

--- a/kiloclaw/src/routes/kiloclaw.ts
+++ b/kiloclaw/src/routes/kiloclaw.ts
@@ -20,7 +20,6 @@ kiloclaw.get('/config', async c => {
   return c.json({
     envVarKeys: config.envVars ? Object.keys(config.envVars) : [],
     secretCount: config.encryptedSecrets ? Object.keys(config.encryptedSecrets).length : 0,
-    kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
     hasKiloCodeApiKey: !!config.kilocodeApiKey,
     kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
     channels: {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -27,6 +27,14 @@ const KiloCodeConfigPatchSchema = z.object({
   userId: z.string().min(1),
   kilocodeApiKey: z.string().nullable().optional(),
   kilocodeApiKeyExpiresAt: z.string().nullable().optional(),
+  kilocodeDefaultModel: z
+    .string()
+    .regex(
+      /^kilocode\/[^/]+\/.+$/,
+      'kilocodeDefaultModel must start with kilocode/ and include a provider'
+    )
+    .nullable()
+    .optional(),
 });
 
 const platform = new Hono<AppEnv>();
@@ -96,6 +104,7 @@ platform.post('/provision', async c => {
     channels,
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
+    kilocodeDefaultModel,
     machineSize,
     region,
   } = result.data;
@@ -110,6 +119,7 @@ platform.post('/provision', async c => {
           channels,
           kilocodeApiKey,
           kilocodeApiKeyExpiresAt,
+          kilocodeDefaultModel,
           machineSize,
           region,
         }),
@@ -131,7 +141,7 @@ platform.patch('/kilocode-config', async c => {
   const result = await parseBody(c, KiloCodeConfigPatchSchema);
   if ('error' in result) return result.error;
 
-  const { userId, kilocodeApiKey, kilocodeApiKeyExpiresAt } = result.data;
+  const { userId, kilocodeApiKey, kilocodeApiKeyExpiresAt, kilocodeDefaultModel } = result.data;
 
   try {
     const updated = await withDORetry(
@@ -140,6 +150,7 @@ platform.patch('/kilocode-config', async c => {
         stub.updateKiloCodeConfig({
           kilocodeApiKey,
           kilocodeApiKeyExpiresAt,
+          kilocodeDefaultModel,
         }),
       'updateKiloCodeConfig'
     );

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -14,7 +14,6 @@ import {
   DestroyRequestSchema,
   ChannelsPatchSchema,
 } from '../schemas/instance-config';
-import type { ModelEntry } from '../schemas/instance-config';
 import {
   ImageVersionEntrySchema,
   imageVersionKey,
@@ -24,24 +23,10 @@ import { z } from 'zod';
 import { withDORetry } from '../util/do-retry';
 import { deriveGatewayToken } from '../auth/gateway-token';
 
-const modelEntrySchema: z.ZodType<ModelEntry> = z.object({
-  id: z.string(),
-  name: z.string(),
-});
-
 const KiloCodeConfigPatchSchema = z.object({
   userId: z.string().min(1),
   kilocodeApiKey: z.string().nullable().optional(),
   kilocodeApiKeyExpiresAt: z.string().nullable().optional(),
-  kilocodeDefaultModel: z
-    .string()
-    .regex(
-      /^kilocode\/[^/]+\/.+$/,
-      'kilocodeDefaultModel must start with kilocode/ and include a provider'
-    )
-    .nullable()
-    .optional(),
-  kilocodeModels: z.array(modelEntrySchema).nullable().optional(),
 });
 
 const platform = new Hono<AppEnv>();
@@ -111,8 +96,6 @@ platform.post('/provision', async c => {
     channels,
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
-    kilocodeDefaultModel,
-    kilocodeModels,
     machineSize,
     region,
   } = result.data;
@@ -127,8 +110,6 @@ platform.post('/provision', async c => {
           channels,
           kilocodeApiKey,
           kilocodeApiKeyExpiresAt,
-          kilocodeDefaultModel,
-          kilocodeModels,
           machineSize,
           region,
         }),
@@ -150,8 +131,7 @@ platform.patch('/kilocode-config', async c => {
   const result = await parseBody(c, KiloCodeConfigPatchSchema);
   if ('error' in result) return result.error;
 
-  const { userId, kilocodeApiKey, kilocodeApiKeyExpiresAt, kilocodeDefaultModel, kilocodeModels } =
-    result.data;
+  const { userId, kilocodeApiKey, kilocodeApiKeyExpiresAt } = result.data;
 
   try {
     const updated = await withDORetry(
@@ -160,8 +140,6 @@ platform.patch('/kilocode-config', async c => {
         stub.updateKiloCodeConfig({
           kilocodeApiKey,
           kilocodeApiKeyExpiresAt,
-          kilocodeDefaultModel,
-          kilocodeModels,
         }),
       'updateKiloCodeConfig'
     );

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -33,6 +33,7 @@ export const InstanceConfigSchema = z.object({
   encryptedSecrets: z.record(envVarNameSchema, EncryptedEnvelopeSchema).optional(),
   kilocodeApiKey: z.string().nullable().optional(),
   kilocodeApiKeyExpiresAt: z.string().nullable().optional(),
+  kilocodeDefaultModel: z.string().nullable().optional(),
   channels: z
     .object({
       telegramBotToken: EncryptedEnvelopeSchema.optional(),
@@ -93,6 +94,7 @@ export const PersistedStateSchema = z.object({
   encryptedSecrets: z.record(z.string(), EncryptedEnvelopeSchema).nullable().default(null),
   kilocodeApiKey: z.string().nullable().default(null),
   kilocodeApiKeyExpiresAt: z.string().nullable().default(null),
+  kilocodeDefaultModel: z.string().nullable().default(null),
   channels: z
     .object({
       telegramBotToken: EncryptedEnvelopeSchema.optional(),

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -7,10 +7,6 @@ export const EncryptedEnvelopeSchema = z.object({
   version: z.literal(1),
 });
 
-export type ModelEntry = { id: string; name: string };
-
-const ModelEntrySchema = z.object({ id: z.string(), name: z.string() });
-
 const MachineSizeSchema = z.object({
   cpus: z.number().int().min(1).max(8),
   memory_mb: z.number().int().min(256).max(16384),
@@ -37,8 +33,6 @@ export const InstanceConfigSchema = z.object({
   encryptedSecrets: z.record(envVarNameSchema, EncryptedEnvelopeSchema).optional(),
   kilocodeApiKey: z.string().nullable().optional(),
   kilocodeApiKeyExpiresAt: z.string().nullable().optional(),
-  kilocodeDefaultModel: z.string().nullable().optional(),
-  kilocodeModels: z.array(ModelEntrySchema).nullable().optional(),
   channels: z
     .object({
       telegramBotToken: EncryptedEnvelopeSchema.optional(),
@@ -99,8 +93,6 @@ export const PersistedStateSchema = z.object({
   encryptedSecrets: z.record(z.string(), EncryptedEnvelopeSchema).nullable().default(null),
   kilocodeApiKey: z.string().nullable().default(null),
   kilocodeApiKeyExpiresAt: z.string().nullable().default(null),
-  kilocodeDefaultModel: z.string().nullable().default(null),
-  kilocodeModels: z.array(ModelEntrySchema).nullable().default(null),
   channels: z
     .object({
       telegramBotToken: EncryptedEnvelopeSchema.optional(),

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -207,6 +207,16 @@ if (process.env.KILOCODE_API_BASE_URL) {
     console.log('Overriding kilocode base URL: ' + process.env.KILOCODE_API_BASE_URL);
 }
 
+// User-selected default model override.
+// OpenClaw onboard sets kilocode/anthropic/claude-opus-4.6 as the default.
+// If the user picked a different model in the UI, override it here.
+if (process.env.KILOCODE_DEFAULT_MODEL) {
+    config.agents = config.agents || {};
+    config.agents.defaults = config.agents.defaults || {};
+    config.agents.defaults.model = { primary: process.env.KILOCODE_DEFAULT_MODEL };
+    console.log('Overriding default model: ' + process.env.KILOCODE_DEFAULT_MODEL);
+}
+
 // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
 // gateway host directly. Allowlist mode gates unknown commands via the
 // Control UI approval dialog; safe bins (jq, head, tail, etc.) auto-allow.

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -127,7 +127,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
         --gateway-bind loopback \
         --skip-channels \
         --skip-skills \
-        --skip-health
+        --skip-health \
+        --kilocode-api-key "$KILOCODE_API_KEY"
 
     echo "Onboard completed"
 else
@@ -136,12 +137,15 @@ else
 fi
 
 # ============================================================
-# PATCH CONFIG (channels, gateway auth, trusted proxies)
+# PATCH CONFIG (channels, gateway auth, exec policy)
 # ============================================================
-# openclaw onboard handles provider/model config, but we need to patch in:
-# - Channel config (Telegram, Discord, Slack)
+# openclaw onboard handles provider/model config natively (kilocode provider,
+# default model, model catalog). We still need to patch in:
 # - Gateway token auth
-# - KiloCode provider + model config
+# - Channel config (Telegram, Discord, Slack)
+# - Exec policy (no Docker sandbox on Fly machines)
+# - Control UI settings (allowed origins, insecure auth for dev)
+# - Base URL override for local dev (see note below)
 node << 'EOFPATCH'
 const fs = require('fs');
 
@@ -189,57 +193,19 @@ if (process.env.OPENCLAW_ALLOWED_ORIGINS) {
         .map(function(s) { return s.trim(); });
 }
 
-// KiloCode provider configuration (required)
-const providerName = 'kilocode';
-const baseUrl = process.env.KILOCODE_API_BASE_URL || 'https://api.kilo.ai/api/openrouter/';
-const defaultModel =
-    process.env.KILOCODE_DEFAULT_MODEL || providerName + '/anthropic/claude-opus-4.5';
-const modelsPath = '/root/.openclaw/kilocode-models.json';
-const defaultModels = [
-    { id: 'anthropic/claude-opus-4.5', name: 'Anthropic: Claude Opus 4.5' },
-    { id: 'minimax/minimax-m2.1:free', name: 'Minimax: Minimax M2.1' },
-    { id: 'z-ai/glm-4.7:free', name: 'GLM-4.7 (Free - Exclusive to Kilo)' },
-];
-let models = defaultModels;
-
-// Prefer KILOCODE_MODELS_JSON env var (set by buildEnvVars from DO config).
-// Falls back to file-based override for manual use, then baked-in defaults.
-if (process.env.KILOCODE_MODELS_JSON) {
-    try {
-        const parsed = JSON.parse(process.env.KILOCODE_MODELS_JSON);
-        models = Array.isArray(parsed) ? parsed : defaultModels;
-        console.log('Using model list from KILOCODE_MODELS_JSON (' + models.length + ' models)');
-    } catch (error) {
-        console.warn('Failed to parse KILOCODE_MODELS_JSON, using defaults:', error);
-    }
-} else if (fs.existsSync(modelsPath)) {
-    const rawModels = fs.readFileSync(modelsPath, 'utf8');
-    if (rawModels.trim().length === 0) {
-        models = [];
-    } else {
-        try {
-            const parsed = JSON.parse(rawModels);
-            models = Array.isArray(parsed) ? parsed : [];
-        } catch (error) {
-            console.warn('Failed to parse KiloCode models file, using empty list:', error);
-            models = [];
-        }
-    }
+// KiloCode provider base URL override (local dev only).
+// OpenClaw's native kilocode provider hardcodes https://api.kilo.ai/api/gateway/.
+// In local dev, Fly machines need to route through a Cloudflare tunnel back to
+// localhost, so we override the base URL when KILOCODE_API_BASE_URL is set.
+// TODO: Upstream KILOCODE_API_BASE_URL env var support into OpenClaw's kilocode
+// provider so this config patch can be removed entirely.
+if (process.env.KILOCODE_API_BASE_URL) {
+    config.models = config.models || {};
+    config.models.providers = config.models.providers || {};
+    config.models.providers.kilocode = config.models.providers.kilocode || {};
+    config.models.providers.kilocode.baseUrl = process.env.KILOCODE_API_BASE_URL;
+    console.log('Overriding kilocode base URL: ' + process.env.KILOCODE_API_BASE_URL);
 }
-
-config.models = config.models || {};
-config.models.providers = config.models.providers || {};
-config.models.providers[providerName] = {
-    baseUrl: baseUrl,
-    apiKey: process.env.KILOCODE_API_KEY,
-    api: 'openai-completions',
-    models: models,
-};
-
-config.agents = config.agents || {};
-config.agents.defaults = config.agents.defaults || {};
-config.agents.defaults.model = { primary: defaultModel };
-console.log('KiloCode provider configured with base URL ' + baseUrl);
 
 // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
 // gateway host directly. Allowlist mode gates unknown commands via the

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -159,6 +159,28 @@ try {
     console.log('Starting with empty config');
 }
 
+// Migration: remove stale manually-managed kilocode provider config.
+// Pre-upgrade instances have a models.providers.kilocode entry with the old
+// /api/openrouter/ base URL and a flat model list (just {id, name}).
+// OpenClaw 2026.2.24+ has a built-in kilocode provider with the correct
+// /api/gateway/ URL and richer model definitions. Removing the stale entry
+// lets the built-in provider take over. The KILOCODE_API_BASE_URL override
+// below re-adds a minimal entry only when needed (local dev).
+if (config.models && config.models.providers && config.models.providers.kilocode) {
+    var staleBaseUrl = config.models.providers.kilocode.baseUrl || '';
+    if (staleBaseUrl.includes('/api/openrouter/') || staleBaseUrl === 'https://api.kilo.ai/api/gateway/') {
+        delete config.models.providers.kilocode;
+        console.log('Removed stale kilocode provider config (baseUrl: ' + staleBaseUrl + ')');
+        // Clean up empty providers/models objects
+        if (Object.keys(config.models.providers).length === 0) {
+            delete config.models.providers;
+        }
+        if (Object.keys(config.models).length === 0) {
+            delete config.models;
+        }
+    }
+}
+
 config.gateway = config.gateway || {};
 config.channels = config.channels || {};
 

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { useOpenRouterModels } from '@/app/api/openrouter/hooks';
+import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -15,8 +17,15 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
 export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) {
   const posthog = usePostHog();
+  const { data: modelsData, isLoading: isLoadingModels } = useOpenRouterModels();
+  const [selectedModel, setSelectedModel] = useState('');
   const [addedChannels, setAddedChannels] = useState<Set<ChannelType>>(new Set());
   const [tokens, setTokens] = useState<Record<string, string>>({});
+
+  const modelOptions = useMemo<ModelOption[]>(
+    () => (modelsData?.data || []).map(model => ({ id: model.id, name: model.name })),
+    [modelsData]
+  );
 
   function addChannel(channel: ChannelType) {
     setAddedChannels(prev => new Set([...prev, channel]));
@@ -58,6 +67,7 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
 
   function handleCreate() {
     posthog?.capture('claw_create_instance_clicked', {
+      selected_model: selectedModel || null,
       channels: [...addedChannels],
     });
 
@@ -73,6 +83,7 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
 
     mutations.provision.mutate(
       {
+        kilocodeDefaultModel: selectedModel ? `kilocode/${selectedModel}` : null,
         channels: buildChannelsPayload(),
       },
       {
@@ -88,9 +99,20 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
     <Card>
       <CardHeader>
         <CardTitle>Create Instance</CardTitle>
-        <CardDescription>Provision your first KiloClaw instance.</CardDescription>
+        <CardDescription>
+          Choose a default model to provision your first KiloClaw instance.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <ModelCombobox
+          label=""
+          models={modelOptions}
+          value={selectedModel}
+          onValueChange={setSelectedModel}
+          isLoading={isLoadingModels}
+          disabled={mutations.provision.isPending || isLoadingModels}
+        />
+
         <div className="space-y-3">
           <Label>Channels (optional)</Label>
 

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -66,6 +66,11 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
   }
 
   function handleCreate() {
+    if (isLoadingModels) {
+      toast.error('Models are still loading; try again in a moment.');
+      return;
+    }
+
     posthog?.capture('claw_create_instance_clicked', {
       selected_model: selectedModel || null,
       channels: [...addedChannels],

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { useOpenRouterModels } from '@/app/api/openrouter/hooks';
-import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -17,15 +15,8 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
 export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) {
   const posthog = usePostHog();
-  const { data: modelsData, isLoading: isLoadingModels } = useOpenRouterModels();
-  const [selectedModel, setSelectedModel] = useState('');
   const [addedChannels, setAddedChannels] = useState<Set<ChannelType>>(new Set());
   const [tokens, setTokens] = useState<Record<string, string>>({});
-
-  const modelOptions = useMemo<ModelOption[]>(
-    () => (modelsData?.data || []).map(model => ({ id: model.id, name: model.name })),
-    [modelsData]
-  );
 
   function addChannel(channel: ChannelType) {
     setAddedChannels(prev => new Set([...prev, channel]));
@@ -67,14 +58,8 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
 
   function handleCreate() {
     posthog?.capture('claw_create_instance_clicked', {
-      selected_model: selectedModel || null,
       channels: [...addedChannels],
     });
-
-    if (isLoadingModels) {
-      toast.error('Models are still loading; try again in a moment.');
-      return;
-    }
 
     // Validate Slack requires both tokens
     if (addedChannels.has('slack')) {
@@ -86,11 +71,8 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
       }
     }
 
-    const modelsPayload = modelOptions.map(({ id, name }) => ({ id, name }));
     mutations.provision.mutate(
       {
-        kilocodeDefaultModel: selectedModel ? `kilocode/${selectedModel}` : null,
-        kilocodeModels: modelsPayload.length > 0 ? modelsPayload : null,
         channels: buildChannelsPayload(),
       },
       {
@@ -106,20 +88,9 @@ export function CreateInstanceCard({ mutations }: { mutations: ClawMutations }) 
     <Card>
       <CardHeader>
         <CardTitle>Create Instance</CardTitle>
-        <CardDescription>
-          Choose a default model to provision your first KiloClaw instance.
-        </CardDescription>
+        <CardDescription>Provision your first KiloClaw instance.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <ModelCombobox
-          label=""
-          models={modelOptions}
-          value={selectedModel}
-          onValueChange={setSelectedModel}
-          isLoading={isLoadingModels}
-          disabled={mutations.provision.isPending || isLoadingModels}
-        />
-
         <div className="space-y-3">
           <Label>Channels (optional)</Label>
 

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useState } from 'react';
 import { AlertCircle, AlertTriangle, Hash, Save, Square, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
+import { useOpenRouterModels } from '@/app/api/openrouter/hooks';
+import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useKiloClawConfig } from '@/hooks/useKiloClaw';
+import { useDefaultModelSelection } from '../hooks/useDefaultModelSelection';
 
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -164,7 +167,18 @@ export function SettingsTab({
 }) {
   const posthog = usePostHog();
   const { data: config } = useKiloClawConfig();
+  const { data: modelsData, isLoading: isLoadingModels } = useOpenRouterModels();
   const [confirmDestroy, setConfirmDestroy] = useState(false);
+
+  const modelOptions = useMemo<ModelOption[]>(
+    () => (modelsData?.data || []).map(model => ({ id: model.id, name: model.name })),
+    [modelsData]
+  );
+
+  const { selectedModel, setSelectedModel } = useDefaultModelSelection(
+    config?.kilocodeDefaultModel,
+    modelOptions
+  );
 
   const isSaving = mutations.patchConfig.isPending;
   const isDestroying = status.status === 'destroying';
@@ -179,13 +193,19 @@ export function SettingsTab({
 
   function handleSave() {
     posthog?.capture('claw_save_config_clicked', {
+      selected_model: selectedModel || null,
       instance_status: status.status,
     });
 
-    mutations.patchConfig.mutate(undefined, {
-      onSuccess: () => toast.success('Configuration saved'),
-      onError: err => toast.error(`Failed to save: ${err.message}`),
-    });
+    mutations.patchConfig.mutate(
+      {
+        kilocodeDefaultModel: selectedModel ? `kilocode/${selectedModel}` : null,
+      },
+      {
+        onSuccess: () => toast.success('Configuration saved. Model change applied.'),
+        onError: err => toast.error(`Failed to save: ${err.message}`),
+      }
+    );
   }
 
   return (
@@ -205,12 +225,27 @@ export function SettingsTab({
         </p>
 
         <div className="space-y-4">
+          <ModelCombobox
+            label=""
+            models={modelOptions}
+            value={selectedModel}
+            onValueChange={setSelectedModel}
+            isLoading={isLoadingModels}
+            disabled={isSaving || isLoadingModels}
+          />
+
           <div className="flex items-center gap-2">
             <Button size="sm" onClick={handleSave} disabled={isSaving}>
               <Save className="h-4 w-4" />
               {isSaving ? 'Saving...' : 'Save & Provision'}
             </Button>
           </div>
+
+          {config && (
+            <p className="text-muted-foreground text-xs">
+              Current default model: {config.kilocodeDefaultModel || 'not set'}
+            </p>
+          )}
         </div>
       </div>
 

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { AlertCircle, AlertTriangle, Hash, Save, Square, X } from 'lucide-react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useKiloClawConfig } from '@/hooks/useKiloClaw';
-import { useOpenRouterModels } from '@/app/api/openrouter/hooks';
-import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { DetailTile } from './DetailTile';
-import { useDefaultModelSelection } from '../hooks/useDefaultModelSelection';
+
 import { ChannelTokenInput } from './ChannelTokenInput';
 import { CHANNELS, CHANNEL_TYPES, type ChannelDefinition } from './channel-config';
 
@@ -165,18 +164,7 @@ export function SettingsTab({
 }) {
   const posthog = usePostHog();
   const { data: config } = useKiloClawConfig();
-  const { data: modelsData, isLoading: isLoadingModels } = useOpenRouterModels();
   const [confirmDestroy, setConfirmDestroy] = useState(false);
-
-  const modelOptions = useMemo<ModelOption[]>(
-    () => (modelsData?.data || []).map(model => ({ id: model.id, name: model.name })),
-    [modelsData]
-  );
-
-  const { selectedModel, setSelectedModel } = useDefaultModelSelection(
-    config?.kilocodeDefaultModel,
-    modelOptions
-  );
 
   const isSaving = mutations.patchConfig.isPending;
   const isDestroying = status.status === 'destroying';
@@ -191,26 +179,13 @@ export function SettingsTab({
 
   function handleSave() {
     posthog?.capture('claw_save_config_clicked', {
-      selected_model: selectedModel || null,
       instance_status: status.status,
     });
 
-    if (isLoadingModels) {
-      toast.error('Models are still loading; try again in a moment.');
-      return;
-    }
-
-    const modelsPayload = modelOptions.map(({ id, name }) => ({ id, name }));
-    mutations.patchConfig.mutate(
-      {
-        kilocodeDefaultModel: selectedModel ? `kilocode/${selectedModel}` : null,
-        kilocodeModels: modelsPayload.length > 0 ? modelsPayload : null,
-      },
-      {
-        onSuccess: () => toast.success('Configuration saved'),
-        onError: err => toast.error(`Failed to save: ${err.message}`),
-      }
-    );
+    mutations.patchConfig.mutate(undefined, {
+      onSuccess: () => toast.success('Configuration saved'),
+      onError: err => toast.error(`Failed to save: ${err.message}`),
+    });
   }
 
   return (
@@ -230,27 +205,12 @@ export function SettingsTab({
         </p>
 
         <div className="space-y-4">
-          <ModelCombobox
-            label=""
-            models={modelOptions}
-            value={selectedModel}
-            onValueChange={setSelectedModel}
-            isLoading={isLoadingModels}
-            disabled={isSaving || isLoadingModels}
-          />
-
           <div className="flex items-center gap-2">
             <Button size="sm" onClick={handleSave} disabled={isSaving}>
               <Save className="h-4 w-4" />
               {isSaving ? 'Saving...' : 'Save & Provision'}
             </Button>
           </div>
-
-          {config && (
-            <p className="text-muted-foreground text-xs">
-              Current default model: {config.kilocodeDefaultModel || 'not set'}
-            </p>
-          )}
         </div>
       </div>
 

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -192,6 +192,11 @@ export function SettingsTab({
   };
 
   function handleSave() {
+    if (isLoadingModels) {
+      toast.error('Models are still loading; try again in a moment.');
+      return;
+    }
+
     posthog?.capture('claw_save_config_clicked', {
       selected_model: selectedModel || null,
       instance_status: status.status,

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -13,7 +13,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-02-26',
     description:
-      'Upgraded to OpenClaw 2026.2.25 with native Kilo Gateway provider support. Model config is now managed by OpenClaw directly. Default model changes apply instantly without restart.',
+      'Updated OpenClaw to the latest version. Changing the default model in the dashboard now takes effect immediately without requiring a redeploy.',
     category: 'feature',
     deployHint: 'redeploy_required',
   },

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -13,6 +13,13 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-02-26',
     description:
+      'Upgraded to OpenClaw 2026.2.25 with native Kilo Gateway provider support. Model config is now managed by OpenClaw directly. Default model changes apply instantly without restart.',
+    category: 'feature',
+    deployHint: 'redeploy_required',
+  },
+  {
+    date: '2026-02-26',
+    description:
       'Added ripgrep (rg), GitHub CLI (gh), rsync, zstd, and ClawHub CLI to the default image.',
     category: 'feature',
     deployHint: null,

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -12,16 +12,19 @@ export type ProvisionInput = {
   };
   kilocodeApiKey?: string;
   kilocodeApiKeyExpiresAt?: string;
+  kilocodeDefaultModel?: string;
 };
 
 export type KiloCodeConfigPatchInput = {
   kilocodeApiKey?: string | null;
   kilocodeApiKeyExpiresAt?: string | null;
+  kilocodeDefaultModel?: string | null;
 };
 
 export type KiloCodeConfigResponse = {
   kilocodeApiKey: string | null;
   kilocodeApiKeyExpiresAt: string | null;
+  kilocodeDefaultModel: string | null;
 };
 
 /** Input to PATCH /api/platform/channels */
@@ -128,6 +131,7 @@ export type VolumeSnapshotsResponse = {
 export type UserConfigResponse = {
   envVarKeys: string[];
   secretCount: number;
+  kilocodeDefaultModel: string | null;
   hasKiloCodeApiKey: boolean;
   kilocodeApiKeyExpiresAt?: string | null;
   channels: {

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -12,27 +12,16 @@ export type ProvisionInput = {
   };
   kilocodeApiKey?: string;
   kilocodeApiKeyExpiresAt?: string;
-  kilocodeDefaultModel?: string;
-  kilocodeModels?: KiloCodeModelEntry[];
-};
-
-export type KiloCodeModelEntry = {
-  id: string;
-  name: string;
 };
 
 export type KiloCodeConfigPatchInput = {
   kilocodeApiKey?: string | null;
   kilocodeApiKeyExpiresAt?: string | null;
-  kilocodeDefaultModel?: string | null;
-  kilocodeModels?: KiloCodeModelEntry[] | null;
 };
 
 export type KiloCodeConfigResponse = {
   kilocodeApiKey: string | null;
   kilocodeApiKeyExpiresAt: string | null;
-  kilocodeDefaultModel: string | null;
-  kilocodeModels: KiloCodeModelEntry[] | null;
 };
 
 /** Input to PATCH /api/platform/channels */
@@ -139,7 +128,6 @@ export type VolumeSnapshotsResponse = {
 export type UserConfigResponse = {
   envVarKeys: string[];
   secretCount: number;
-  kilocodeDefaultModel: string | null;
   hasKiloCodeApiKey: boolean;
   kilocodeApiKeyExpiresAt?: string | null;
   channels: {

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -25,6 +25,25 @@ const updateConfigSchema = z.object({
       slackAppToken: z.string().optional(),
     })
     .optional(),
+  kilocodeDefaultModel: z
+    .string()
+    .regex(
+      /^kilocode\/[^/]+\/.+$/,
+      'kilocodeDefaultModel must start with kilocode/ and include a provider'
+    )
+    .nullable()
+    .optional(),
+});
+
+const updateKiloCodeConfigSchema = z.object({
+  kilocodeDefaultModel: z
+    .string()
+    .regex(
+      /^kilocode\/[^/]+\/.+$/,
+      'kilocodeDefaultModel must start with kilocode/ and include a provider'
+    )
+    .nullable()
+    .optional(),
 });
 
 const patchChannelsSchema = z.object({
@@ -70,13 +89,17 @@ function buildWorkerChannelsPatch(channels: z.infer<typeof patchChannelsSchema>)
   return result;
 }
 
-type KiloCodeConfigPublicResponse = Pick<KiloCodeConfigResponse, 'kilocodeApiKeyExpiresAt'>;
+type KiloCodeConfigPublicResponse = Pick<
+  KiloCodeConfigResponse,
+  'kilocodeApiKeyExpiresAt' | 'kilocodeDefaultModel'
+>;
 
 function sanitizeKiloCodeConfigResponse(
   response: KiloCodeConfigResponse
 ): KiloCodeConfigPublicResponse {
   return {
     kilocodeApiKeyExpiresAt: response.kilocodeApiKeyExpiresAt,
+    kilocodeDefaultModel: response.kilocodeDefaultModel,
   };
 }
 
@@ -105,11 +128,13 @@ async function provisionInstance(
     channels: buildWorkerChannels(input.channels),
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
+    kilocodeDefaultModel: input.kilocodeDefaultModel ?? undefined,
   });
 }
 
 async function patchConfig(
-  user: Parameters<typeof generateApiToken>[0]
+  user: Parameters<typeof generateApiToken>[0],
+  input: z.infer<typeof updateKiloCodeConfigSchema>
 ): Promise<KiloCodeConfigPublicResponse> {
   const client = new KiloClawInternalClient();
   const expiresInSeconds = TOKEN_EXPIRY.thirtyDays;
@@ -119,6 +144,7 @@ async function patchConfig(
   const kilocodeApiKeyExpiresAt = new Date(Date.now() + expiresInSeconds * 1000).toISOString();
 
   const response = await client.patchKiloCodeConfig(user.id, {
+    ...input,
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
   });
@@ -177,8 +203,8 @@ export const kiloclawRouter = createTRPCRouter({
     return provisionInstance(ctx.user, input);
   }),
 
-  patchConfig: baseProcedure.mutation(async ({ ctx }) => {
-    return patchConfig(ctx.user);
+  patchConfig: baseProcedure.input(updateKiloCodeConfigSchema).mutation(async ({ ctx, input }) => {
+    return patchConfig(ctx.user, input);
   }),
 
   // Backward-compatible aliases.
@@ -186,9 +212,11 @@ export const kiloclawRouter = createTRPCRouter({
     return provisionInstance(ctx.user, input);
   }),
 
-  updateKiloCodeConfig: baseProcedure.mutation(async ({ ctx }) => {
-    return patchConfig(ctx.user);
-  }),
+  updateKiloCodeConfig: baseProcedure
+    .input(updateKiloCodeConfigSchema)
+    .mutation(async ({ ctx, input }) => {
+      return patchConfig(ctx.user, input);
+    }),
 
   patchChannels: baseProcedure.input(patchChannelsSchema).mutation(async ({ ctx, input }) => {
     const client = new KiloClawInternalClient();

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -14,8 +14,6 @@ import {
   restoreDestroyedInstance,
 } from '@/lib/kiloclaw/instance-registry';
 
-const modelEntrySchema = z.object({ id: z.string(), name: z.string() });
-
 const updateConfigSchema = z.object({
   envVars: z.record(z.string(), z.string()).optional(),
   secrets: z.record(z.string(), z.string()).optional(),
@@ -27,27 +25,6 @@ const updateConfigSchema = z.object({
       slackAppToken: z.string().optional(),
     })
     .optional(),
-  kilocodeDefaultModel: z
-    .string()
-    .regex(
-      /^kilocode\/[^/]+\/.+$/,
-      'kilocodeDefaultModel must start with kilocode/ and include a provider'
-    )
-    .nullable()
-    .optional(),
-  kilocodeModels: z.array(modelEntrySchema).nullable().optional(),
-});
-
-const updateKiloCodeConfigSchema = z.object({
-  kilocodeDefaultModel: z
-    .string()
-    .regex(
-      /^kilocode\/[^/]+\/.+$/,
-      'kilocodeDefaultModel must start with kilocode/ and include a provider'
-    )
-    .nullable()
-    .optional(),
-  kilocodeModels: z.array(modelEntrySchema).nullable().optional(),
 });
 
 const patchChannelsSchema = z.object({
@@ -93,18 +70,13 @@ function buildWorkerChannelsPatch(channels: z.infer<typeof patchChannelsSchema>)
   return result;
 }
 
-type KiloCodeConfigPublicResponse = Pick<
-  KiloCodeConfigResponse,
-  'kilocodeApiKeyExpiresAt' | 'kilocodeDefaultModel' | 'kilocodeModels'
->;
+type KiloCodeConfigPublicResponse = Pick<KiloCodeConfigResponse, 'kilocodeApiKeyExpiresAt'>;
 
 function sanitizeKiloCodeConfigResponse(
   response: KiloCodeConfigResponse
 ): KiloCodeConfigPublicResponse {
   return {
     kilocodeApiKeyExpiresAt: response.kilocodeApiKeyExpiresAt,
-    kilocodeDefaultModel: response.kilocodeDefaultModel,
-    kilocodeModels: response.kilocodeModels,
   };
 }
 
@@ -133,14 +105,11 @@ async function provisionInstance(
     channels: buildWorkerChannels(input.channels),
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
-    kilocodeDefaultModel: input.kilocodeDefaultModel ?? undefined,
-    kilocodeModels: input.kilocodeModels ?? undefined,
   });
 }
 
 async function patchConfig(
-  user: Parameters<typeof generateApiToken>[0],
-  input: z.infer<typeof updateKiloCodeConfigSchema>
+  user: Parameters<typeof generateApiToken>[0]
 ): Promise<KiloCodeConfigPublicResponse> {
   const client = new KiloClawInternalClient();
   const expiresInSeconds = TOKEN_EXPIRY.thirtyDays;
@@ -150,7 +119,6 @@ async function patchConfig(
   const kilocodeApiKeyExpiresAt = new Date(Date.now() + expiresInSeconds * 1000).toISOString();
 
   const response = await client.patchKiloCodeConfig(user.id, {
-    ...input,
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
   });
@@ -209,8 +177,8 @@ export const kiloclawRouter = createTRPCRouter({
     return provisionInstance(ctx.user, input);
   }),
 
-  patchConfig: baseProcedure.input(updateKiloCodeConfigSchema).mutation(async ({ ctx, input }) => {
-    return patchConfig(ctx.user, input);
+  patchConfig: baseProcedure.mutation(async ({ ctx }) => {
+    return patchConfig(ctx.user);
   }),
 
   // Backward-compatible aliases.
@@ -218,11 +186,9 @@ export const kiloclawRouter = createTRPCRouter({
     return provisionInstance(ctx.user, input);
   }),
 
-  updateKiloCodeConfig: baseProcedure
-    .input(updateKiloCodeConfigSchema)
-    .mutation(async ({ ctx, input }) => {
-      return patchConfig(ctx.user, input);
-    }),
+  updateKiloCodeConfig: baseProcedure.mutation(async ({ ctx }) => {
+    return patchConfig(ctx.user);
+  }),
 
   patchChannels: baseProcedure.input(patchChannelsSchema).mutation(async ({ ctx, input }) => {
     const client = new KiloClawInternalClient();


### PR DESCRIPTION
OpenClaw now includes Kilo Gateway as a first-class model provider, so we can remove the bespoke provider config patching from start-openclaw.sh and the entire KILOCODE_MODELS_JSON control plane pipeline that shipped the full model catalog (~300-600 models) as a JSON env var.

- Upgrade openclaw from 2026.2.22 to 2026.2.24 in Dockerfile
- Pass --kilocode-api-key to openclaw onboard for native provider setup
- Remove ~50-line KiloCode provider JSON patching block from start-openclaw.sh
- Keep minimal baseUrl override for local dev (KILOCODE_API_BASE_URL)
- Remove kilocodeModels and kilocodeDefaultModel from the full pipeline: DO state, schemas, platform routes, env.ts, tRPC router, UI components, and shared types
- Remove model selection UI from CreateInstanceCard and SettingsTab

https://github.com/user-attachments/assets/c893fe13-6f71-49cf-af7f-b56d8e750beb


