### PR TITLE
Cloud Agent - Filter child session events in event processor

### DIFF
--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -601,6 +601,201 @@ describe('createEventProcessor', () => {
     });
   });
 
+  describe('child session event filtering', () => {
+    // Helper: register a child session
+    function registerChildSession(
+      processor: ReturnType<typeof createEventProcessor>,
+      childId: string,
+      parentId: string
+    ) {
+      processor.processEvent(
+        createKilocodeEvent('session.created', {
+          info: {
+            id: childId,
+            slug: 'child',
+            projectID: 'proj-1',
+            directory: '/test',
+            parentID: parentId,
+            title: 'Child Session',
+            version: '1.0',
+            time: { created: Date.now(), updated: Date.now() },
+          },
+        })
+      );
+    }
+
+    it('should not fire onSessionStatusChanged or onStreamingChanged for child session status events', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onSessionStatusChanged: jest.fn(),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      registerChildSession(processor, 'child-1', 'session-123');
+
+      // Child session goes busy
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'child-1',
+          status: { type: 'busy' },
+        })
+      );
+
+      expect(callbacks.onSessionStatusChanged).not.toHaveBeenCalled();
+      expect(callbacks.onStreamingChanged).not.toHaveBeenCalled();
+
+      // Child session goes idle
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'child-1',
+          status: { type: 'idle' },
+        })
+      );
+
+      expect(callbacks.onSessionStatusChanged).not.toHaveBeenCalled();
+      expect(callbacks.onStreamingChanged).not.toHaveBeenCalled();
+    });
+
+    it('should not toggle streaming when child session emits session.idle', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onMessageCompleted: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      registerChildSession(processor, 'child-1', 'session-123');
+
+      // Root session goes busy (sets streaming = true)
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
+
+      // Child session emits idle — should NOT set streaming false
+      processor.processEvent(createKilocodeEvent('session.idle', { sessionID: 'child-1' }));
+
+      // onStreamingChanged should only have been called once (the busy=true)
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still complete user messages when child session goes idle', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      registerChildSession(processor, 'child-1', 'session-123');
+
+      // Create a user message in the child session
+      processor.processEvent(
+        createKilocodeEvent(
+          'message.updated',
+          { info: createUserInfo('child-user-msg', 'child-1') },
+          'child-1'
+        )
+      );
+
+      expect(callbacks.onMessageCompleted).not.toHaveBeenCalled();
+
+      // Child session goes idle — user messages should still complete
+      processor.processEvent(createKilocodeEvent('session.idle', { sessionID: 'child-1' }));
+
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledWith(
+        'child-1',
+        'child-user-msg',
+        expect.objectContaining({ info: expect.objectContaining({ role: 'user' }) }),
+        'session-123'
+      );
+    });
+
+    it('should not toggle streaming for child session error, but still fire onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onError: jest.fn(),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      registerChildSession(processor, 'child-1', 'session-123');
+
+      // Root session goes busy
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
+
+      // Child session error — should NOT toggle streaming
+      processor.processEvent(
+        createKilocodeEvent('session.error', {
+          sessionID: 'child-1',
+          error: 'Child failed',
+        })
+      );
+
+      // onError should fire for child sessions
+      expect(callbacks.onError).toHaveBeenCalledWith('Child failed', 'child-1');
+      // streaming should still be true (only 1 call: the busy=true)
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not toggle streaming for child session turn close error, but still complete messages', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      registerChildSession(processor, 'child-1', 'session-123');
+
+      // Root session goes busy
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Create an in-flight assistant message in the child session
+      processor.processEvent(
+        createKilocodeEvent(
+          'message.updated',
+          { info: createAssistantInfo('child-msg-1', 'child-1') },
+          'child-1'
+        )
+      );
+
+      // Child turn closes with error
+      processor.processEvent(
+        createKilocodeEvent('session.turn.close', {
+          sessionID: 'child-1',
+          reason: 'error',
+        })
+      );
+
+      // Message should be force-completed
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+      // onError should fire
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'The model failed to generate a response',
+        'child-1'
+      );
+      // streaming should still be true (only 1 call: the busy=true)
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('session.error events', () => {
     it('should call onError callback and stop streaming', () => {
       const callbacks: EventProcessorCallbacks = {

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -141,6 +141,16 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   }
 
   /**
+   * Check if a session is a child/sub-agent session.
+   * A session is a child if it has a non-null parent in sessionParents.
+   * Unknown/unregistered sessions are treated as root (safe default).
+   */
+  function isChildSession(sessionId: string | undefined): boolean {
+    if (!sessionId) return false;
+    return getParentSessionId(sessionId) !== null;
+  }
+
+  /**
    * Apply pending parts to a message if any exist.
    */
   function applyPendingParts(
@@ -307,23 +317,28 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
   /**
    * Handle session.status events.
+   * Child session status events still trigger user message completion
+   * but do NOT fire onSessionStatusChanged, onStreamingChanged, or toggle the streaming flag.
    */
   function handleSessionStatus(data: EventSessionStatus['properties']): void {
-    const { status } = data;
+    const { status, sessionID } = data;
+    const fromChild = isChildSession(sessionID);
 
-    callbacks.onSessionStatusChanged?.(status);
+    if (!fromChild) {
+      callbacks.onSessionStatusChanged?.(status);
+    }
 
     // Update streaming state based on status
     if (status.type === 'idle') {
-      // Complete user messages when session becomes idle
+      // Complete user messages when session becomes idle (for both root and child)
       completeUserMessages();
 
-      if (streaming) {
+      if (!fromChild && streaming) {
         streaming = false;
         callbacks.onStreamingChanged?.(false);
       }
     } else if (status.type === 'busy') {
-      if (!streaming) {
+      if (!fromChild && !streaming) {
         streaming = true;
         callbacks.onStreamingChanged?.(true);
       }
@@ -353,11 +368,14 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
   /**
    * Handle session.error events.
+   * onError fires for all sessions (root and child).
+   * Streaming toggle only fires for root sessions.
    */
   function handleSessionError(data: { sessionID?: string; error?: unknown }): void {
     const errorMessage = typeof data.error === 'string' ? data.error : 'Session error occurred';
+    const fromChild = isChildSession(data.sessionID);
 
-    if (streaming) {
+    if (!fromChild && streaming) {
       streaming = false;
       callbacks.onStreamingChanged?.(false);
     }
@@ -379,11 +397,16 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   /**
    * Handle session.idle events.
    * Completes all pending user messages since they don't have their own completion signals.
+   * Child session idle events still trigger user message completion
+   * but do NOT toggle the streaming flag or fire onStreamingChanged.
    */
-  function handleSessionIdle(): void {
+  function handleSessionIdle(data: { sessionID: string }): void {
+    const fromChild = isChildSession(data.sessionID);
+
+    // Complete user messages for both root and child sessions
     completeUserMessages();
 
-    if (streaming) {
+    if (!fromChild && streaming) {
       streaming = false;
       callbacks.onStreamingChanged?.(false);
     }
@@ -392,9 +415,10 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   /**
    * Force-complete all in-flight messages.
    * Stamps synthetic time.completed on assistant messages and completes user messages.
-   * Sets streaming to false via callback.
+   * Sets streaming to false via callback unless skipStreamingToggle is true
+   * (used when called for child session events that shouldn't affect root streaming state).
    */
-  function forceCompleteAllMessages(): void {
+  function forceCompleteAllMessages(skipStreamingToggle = false): void {
     const now = Date.now();
     for (const [key, message] of messagesMap) {
       if (isAssistantMessage(message.info) && !isAssistantMessageComplete(message)) {
@@ -413,7 +437,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
     completeUserMessages();
 
-    if (streaming) {
+    if (!skipStreamingToggle && streaming) {
       streaming = false;
       callbacks.onStreamingChanged?.(false);
     }
@@ -423,13 +447,16 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * Handle session.turn.close events.
    * When reason is "error", force-complete all in-flight assistant messages
    * that never received time.completed from the server.
+   * Child session turn close events still complete messages and fire onError,
+   * but skip the streaming toggle.
    */
   function handleSessionTurnClose(data: { sessionID?: string; reason?: string }): void {
     if (data.reason !== 'error') {
       return;
     }
 
-    forceCompleteAllMessages();
+    const fromChild = isChildSession(data.sessionID);
+    forceCompleteAllMessages(fromChild);
 
     callbacks.onError?.('The model failed to generate a response', data.sessionID);
   }
@@ -485,7 +512,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
         break;
 
       case 'session.idle':
-        handleSessionIdle();
+        handleSessionIdle(data as { sessionID: string });
         break;
 
       case 'session.turn.close':


### PR DESCRIPTION
## Summary

- Filter child/sub-agent session events in `event-processor.ts` so that `onSessionStatusChanged`, `onStreamingChanged`, and the `streaming` flag are only toggled by root session events.
- Prevents consumers (e.g. Slack bot via `run-session.ts`) from prematurely disconnecting when a child session emits `idle` while the parent session is still running.
- Child sessions still get user message completion and `onError` callbacks — only status/streaming propagation is suppressed.

## Changes

**`event-processor.ts`**
- Added `isChildSession()` helper using the existing `sessionParents` map
- `handleSessionStatus`: skips `onSessionStatusChanged`/`onStreamingChanged` for child sessions
- `handleSessionIdle`: accepts `{ sessionID }` param; skips streaming toggle for child sessions
- `handleSessionError`: skips streaming toggle for child sessions; `onError` still fires for all
- `handleSessionTurnClose`: passes `skipStreamingToggle` to `forceCompleteAllMessages` for child sessions
- `forceCompleteAllMessages`: accepts optional `skipStreamingToggle` parameter

**`event-processor.test.ts`**
- Added 5 test cases in a `child session event filtering` describe block covering all filtering scenarios