### PR TITLE
Add split model selection for Security Agent triage and analysis

### DIFF
--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
@@ -145,6 +145,8 @@ const baseAnalysis: SecurityFindingAnalysis = {
   },
   analyzedAt: '2025-01-01T00:00:00.000Z',
   modelUsed: 'anthropic/claude-sonnet-4',
+  triageModel: 'anthropic/claude-sonnet-4',
+  analysisModel: 'anthropic/claude-opus-4.6',
   triggeredByUserId: 'user-trigger-1',
   correlationId: 'corr-123',
 };
@@ -354,7 +356,7 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       expect(mockFinalizeAnalysis).toHaveBeenCalledWith(
         FINDING_ID,
         'Analysis result markdown',
-        'anthropic/claude-sonnet-4',
+        'anthropic/claude-opus-4.6',
         { userId: 'user-trigger-1' }, // owner derived from owned_by_user_id
         'user-trigger-1',
         'fresh-token',
@@ -393,7 +395,7 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       expect(mockFinalizeAnalysis).toHaveBeenCalledWith(
         FINDING_ID,
         'Org analysis',
-        'anthropic/claude-sonnet-4',
+        'anthropic/claude-opus-4.6',
         { organizationId: orgId }, // owner is org-based
         'user-trigger-1',
         'fresh-token',
@@ -588,7 +590,7 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
 
     it('uses default model when modelUsed is missing from analysis context', async () => {
       const finding = createMockFinding({
-        analysis: { ...baseAnalysis, modelUsed: undefined },
+        analysis: { ...baseAnalysis, modelUsed: undefined, analysisModel: undefined },
       });
       mockGetSecurityFindingById.mockResolvedValue(finding);
 
@@ -615,7 +617,90 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       expect(mockFinalizeAnalysis).toHaveBeenCalledWith(
         FINDING_ID,
         'Result',
-        'anthropic/claude-sonnet-4',
+        'anthropic/claude-opus-4.6',
+        expect.anything(),
+        'user-trigger-1',
+        'fresh-token',
+        expect.any(String),
+        undefined
+      );
+    });
+
+    it('falls back to legacy modelUsed when analysisModel is missing', async () => {
+      const legacyModelSlug = 'anthropic/claude-sonnet-4';
+      const finding = createMockFinding({
+        analysis: {
+          ...baseAnalysis,
+          analysisModel: undefined,
+          modelUsed: legacyModelSlug,
+        },
+      });
+      mockGetSecurityFindingById.mockResolvedValue(finding);
+
+      mockFetchSessionSnapshot.mockResolvedValue({
+        info: {},
+        messages: [
+          {
+            info: { id: 'msg-1', role: 'assistant' },
+            parts: [{ id: 'p-1', type: 'text', text: 'Result' }],
+          },
+        ],
+      });
+      mockExtractLastAssistantMessage.mockReturnValue('Result');
+
+      const mockUser = { id: 'user-trigger-1', api_token_pepper: 'pepper' } as User;
+      mockDbSelect.mockResolvedValue([mockUser]);
+      mockGenerateApiToken.mockReturnValue('fresh-token');
+
+      const req = makeRequest(FINDING_ID, completedPayload);
+      await POST(req, makeParams(FINDING_ID));
+      await flushAfterCallbacks();
+
+      expect(mockFinalizeAnalysis).toHaveBeenCalledWith(
+        FINDING_ID,
+        'Result',
+        legacyModelSlug,
+        expect.anything(),
+        'user-trigger-1',
+        'fresh-token',
+        expect.any(String),
+        undefined
+      );
+    });
+
+    it('uses stored analysisModel over legacy modelUsed for finalization', async () => {
+      const finding = createMockFinding({
+        analysis: {
+          ...baseAnalysis,
+          modelUsed: 'anthropic/claude-sonnet-4',
+          analysisModel: 'x-ai/grok-code-fast-1',
+        },
+      });
+      mockGetSecurityFindingById.mockResolvedValue(finding);
+
+      mockFetchSessionSnapshot.mockResolvedValue({
+        info: {},
+        messages: [
+          {
+            info: { id: 'msg-1', role: 'assistant' },
+            parts: [{ id: 'p-1', type: 'text', text: 'Result' }],
+          },
+        ],
+      });
+      mockExtractLastAssistantMessage.mockReturnValue('Result');
+
+      const mockUser = { id: 'user-trigger-1', api_token_pepper: 'pepper' } as User;
+      mockDbSelect.mockResolvedValue([mockUser]);
+      mockGenerateApiToken.mockReturnValue('fresh-token');
+
+      const req = makeRequest(FINDING_ID, completedPayload);
+      await POST(req, makeParams(FINDING_ID));
+      await flushAfterCallbacks();
+
+      expect(mockFinalizeAnalysis).toHaveBeenCalledWith(
+        FINDING_ID,
+        'Result',
+        'x-ai/grok-code-fast-1',
         expect.anything(),
         'user-trigger-1',
         'fresh-token',
@@ -688,6 +773,8 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
         organizationId: undefined,
         findingId: FINDING_ID,
         model: 'anthropic/claude-sonnet-4',
+        triageModel: 'anthropic/claude-sonnet-4',
+        analysisModel: 'anthropic/claude-opus-4.6',
         triageOnly: false,
         durationMs: expect.any(Number),
       });

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -32,6 +32,10 @@ import {
   logSecurityAudit,
   SecurityAuditLogAction,
 } from '@/lib/security-agent/services/audit-log-service';
+import {
+  DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+  DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+} from '@/lib/security-agent/core/constants';
 
 const log = sentryLogger('security-agent:callback', 'info');
 const warn = sentryLogger('security-agent:callback', 'warning');
@@ -129,12 +133,19 @@ export async function POST(
 function readAnalysisContext(analysis: SecurityFindingAnalysis | null | undefined): {
   correlationId: string;
   modelUsed: string;
+  triageModel: string;
+  analysisModel: string;
   triggeredByUserId: string;
 } {
-  const defaultModel = 'anthropic/claude-sonnet-4';
+  const analysisModel =
+    analysis?.analysisModel ?? analysis?.modelUsed ?? DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
+  const triageModel =
+    analysis?.triageModel ?? analysis?.modelUsed ?? DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
   return {
     correlationId: analysis?.correlationId ?? '',
-    modelUsed: analysis?.modelUsed ?? defaultModel,
+    modelUsed: analysis?.modelUsed ?? analysisModel,
+    triageModel,
+    analysisModel,
     triggeredByUserId: analysis?.triggeredByUserId ?? '',
   };
 }
@@ -147,6 +158,8 @@ async function handleAnalysisCompleted(
   const {
     correlationId,
     modelUsed: model,
+    triageModel,
+    analysisModel,
     triggeredByUserId,
   } = readAnalysisContext(finding.analysis);
   const organizationId = finding.owned_by_organization_id ?? undefined;
@@ -265,13 +278,20 @@ async function handleAnalysisCompleted(
     action: SecurityAuditLogAction.FindingAnalysisCompleted,
     resource_type: 'security_finding',
     resource_id: findingId,
-    metadata: { source: 'system', model, correlationId, triggeredByUserId },
+    metadata: {
+      source: 'system',
+      model,
+      triageModel,
+      analysisModel,
+      correlationId,
+      triggeredByUserId,
+    },
   });
 
   await finalizeAnalysis(
     findingId,
     rawMarkdown,
-    model,
+    analysisModel,
     owner,
     triggeredByUserId,
     authToken,
@@ -289,6 +309,8 @@ async function handleAnalysisFailed(
     correlationId,
     triggeredByUserId,
     modelUsed: model,
+    triageModel,
+    analysisModel,
   } = readAnalysisContext(finding.analysis);
   const organizationId = finding.owned_by_organization_id ?? undefined;
 
@@ -321,6 +343,8 @@ async function handleAnalysisFailed(
     organizationId,
     findingId,
     model,
+    triageModel,
+    analysisModel,
     triageOnly: false,
     durationMs: finding.analysis_started_at
       ? Date.now() - new Date(finding.analysis_started_at).getTime()

--- a/src/components/security-agent/AnalysisResultCard.tsx
+++ b/src/components/security-agent/AnalysisResultCard.tsx
@@ -15,6 +15,15 @@ type AnalysisResultCardProps = {
   showSandboxReasoning?: boolean;
 };
 
+function getOptionalStringField(source: unknown, key: string): string | undefined {
+  if (typeof source !== 'object' || source === null) {
+    return undefined;
+  }
+
+  const value = Reflect.get(source, key);
+  return typeof value === 'string' ? value : undefined;
+}
+
 /**
  * Get the markdown content to display from an analysis result.
  * Prefers sandboxAnalysis.rawMarkdown if available, falls back to rawMarkdown.
@@ -179,8 +188,8 @@ function SandboxSummary({
         <div className="mt-2">
           <span className="text-muted-foreground text-xs font-medium">Usage locations:</span>
           <ul className="text-muted-foreground mt-1 list-inside list-disc text-xs">
-            {sandboxAnalysis.usageLocations.slice(0, 5).map((loc, i) => (
-              <li key={i} className="truncate">
+            {sandboxAnalysis.usageLocations.slice(0, 5).map(loc => (
+              <li key={loc} className="truncate">
                 {loc}
               </li>
             ))}
@@ -209,6 +218,23 @@ export function AnalysisResultCard({
   const markdown = getAnalysisMarkdown(analysis);
   const hasTriage = !!analysis.triage;
   const hasSandbox = !!analysis.sandboxAnalysis;
+  const triageModelUsed =
+    getOptionalStringField(analysis.triage, 'modelUsed') ??
+    getOptionalStringField(analysis, 'triageModelUsed') ??
+    getOptionalStringField(analysis, 'triageModel');
+  const analysisModelUsed =
+    analysis.sandboxAnalysis?.modelUsed ??
+    getOptionalStringField(analysis, 'analysisModelUsed') ??
+    getOptionalStringField(analysis, 'analysisModel');
+  const modelSummary =
+    triageModelUsed || analysisModelUsed
+      ? [
+          triageModelUsed ? `Triage: ${triageModelUsed}` : null,
+          analysisModelUsed ? `Analysis: ${analysisModelUsed}` : null,
+        ]
+          .filter(Boolean)
+          .join(' • ')
+      : analysis.modelUsed;
 
   return (
     <Card className="w-full min-w-0 overflow-hidden">
@@ -221,7 +247,7 @@ export function AnalysisResultCard({
             <CardTitle className="text-lg font-bold">AI Analysis</CardTitle>
             <p className="text-muted-foreground text-xs">
               Analyzed {new Date(analysis.analyzedAt).toLocaleDateString()}
-              {analysis.modelUsed && ` • ${analysis.modelUsed}`}
+              {modelSummary && ` • ${modelSummary}`}
             </p>
           </div>
         </div>

--- a/src/components/security-agent/AnalysisResultCard.tsx
+++ b/src/components/security-agent/AnalysisResultCard.tsx
@@ -188,11 +188,20 @@ function SandboxSummary({
         <div className="mt-2">
           <span className="text-muted-foreground text-xs font-medium">Usage locations:</span>
           <ul className="text-muted-foreground mt-1 list-inside list-disc text-xs">
-            {sandboxAnalysis.usageLocations.slice(0, 5).map(loc => (
-              <li key={loc} className="truncate">
-                {loc}
-              </li>
-            ))}
+            {(() => {
+              const occurrenceByLocation = new Map<string, number>();
+
+              return sandboxAnalysis.usageLocations.slice(0, 5).map(loc => {
+                const occurrence = occurrenceByLocation.get(loc) ?? 0;
+                occurrenceByLocation.set(loc, occurrence + 1);
+
+                return (
+                  <li key={`${loc}-${occurrence}`} className="truncate">
+                    {loc}
+                  </li>
+                );
+              });
+            })()}
             {sandboxAnalysis.usageLocations.length > 5 && (
               <li className="text-muted-foreground/70">
                 ...and {sandboxAnalysis.usageLocations.length - 5} more

--- a/src/components/security-agent/SecurityAgentPageClient.tsx
+++ b/src/components/security-agent/SecurityAgentPageClient.tsx
@@ -32,6 +32,15 @@ type SecurityAgentPageClientProps = {
 
 const PAGE_SIZE = 20;
 
+function getOptionalStringField(source: unknown, key: string): string | undefined {
+  if (typeof source !== 'object' || source === null) {
+    return undefined;
+  }
+
+  const value = Reflect.get(source, key);
+  return typeof value === 'string' ? value : undefined;
+}
+
 // Helper to detect GitHub integration errors from error messages
 function isGitHubIntegrationError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
@@ -474,12 +483,20 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
       config: SlaConfig & {
         repositorySelectionMode: 'all' | 'selected';
         selectedRepositoryIds: number[];
-        modelSlug: string;
+        triageModelSlug: string;
+        analysisModelSlug: string;
+        modelSlug?: string;
         analysisMode: 'auto' | 'shallow' | 'deep';
         autoDismissEnabled: boolean;
         autoDismissConfidenceThreshold: 'high' | 'medium' | 'low';
       }
     ) => {
+      const modelConfigPayload = {
+        triageModelSlug: config.triageModelSlug,
+        analysisModelSlug: config.analysisModelSlug,
+        modelSlug: config.modelSlug,
+      };
+
       if (isOrg && organizationId) {
         orgSaveConfigMutate({
           organizationId,
@@ -489,10 +506,10 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
           slaLowDays: config.low,
           repositorySelectionMode: config.repositorySelectionMode,
           selectedRepositoryIds: config.selectedRepositoryIds,
-          modelSlug: config.modelSlug,
           analysisMode: config.analysisMode,
           autoDismissEnabled: config.autoDismissEnabled,
           autoDismissConfidenceThreshold: config.autoDismissConfidenceThreshold,
+          ...modelConfigPayload,
         });
       } else if (!isOrg) {
         personalSaveConfigMutate({
@@ -502,10 +519,10 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
           slaLowDays: config.low,
           repositorySelectionMode: config.repositorySelectionMode,
           selectedRepositoryIds: config.selectedRepositoryIds,
-          modelSlug: config.modelSlug,
           analysisMode: config.analysisMode,
           autoDismissEnabled: config.autoDismissEnabled,
           autoDismissConfidenceThreshold: config.autoDismissConfidenceThreshold,
+          ...modelConfigPayload,
         });
       }
     },
@@ -633,6 +650,8 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
   const allRepositories = reposData ?? [];
   const repositorySelectionMode = configData?.repositorySelectionMode ?? 'selected';
   const selectedRepositoryIds = configData?.selectedRepositoryIds ?? [];
+  const triageModelSlug = getOptionalStringField(configData, 'triageModelSlug');
+  const analysisModelSlug = getOptionalStringField(configData, 'analysisModelSlug');
 
   // For the findings tab, only show repositories that are selected for security reviews
   const filteredRepositories =
@@ -820,11 +839,14 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
         {hasIntegration && (
           <TabsContent value="config" className="space-y-6">
             <SecurityConfigForm
+              organizationId={organizationId}
               enabled={isEnabled}
               slaConfig={slaConfig}
               repositorySelectionMode={configData?.repositorySelectionMode ?? 'selected'}
               selectedRepositoryIds={configData?.selectedRepositoryIds ?? []}
-              modelSlug={configData?.modelSlug ?? ''}
+              modelSlug={configData?.modelSlug}
+              triageModelSlug={triageModelSlug}
+              analysisModelSlug={analysisModelSlug}
               analysisMode={configData?.analysisMode ?? 'auto'}
               autoDismissEnabled={configData?.autoDismissEnabled ?? false}
               autoDismissConfidenceThreshold={configData?.autoDismissConfidenceThreshold ?? 'high'}

--- a/src/components/security-agent/SecurityConfigForm.tsx
+++ b/src/components/security-agent/SecurityConfigForm.tsx
@@ -8,13 +8,6 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
   Save,
   Clock,
   AlertTriangle,
@@ -32,9 +25,11 @@ import {
   RepositoryMultiSelect,
   type Repository,
 } from '@/components/code-reviews/RepositoryMultiSelect';
+import { ModelCombobox } from '@/components/shared/ModelCombobox';
+import { useOrganizationModels } from '@/components/cloud-agent/hooks/useOrganizationModels';
 import {
-  SECURITY_AGENT_MODELS,
-  DEFAULT_SECURITY_AGENT_MODEL,
+  DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+  DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
 } from '@/lib/security-agent/core/constants';
 
 type SlaConfig = {
@@ -56,11 +51,14 @@ type RepositoryData = {
 };
 
 type SecurityConfigFormProps = {
+  organizationId?: string;
   enabled: boolean;
   slaConfig: SlaConfig;
   repositorySelectionMode: 'all' | 'selected';
   selectedRepositoryIds: number[];
-  modelSlug: string;
+  modelSlug?: string;
+  triageModelSlug?: string;
+  analysisModelSlug?: string;
   analysisMode: AnalysisMode;
   autoDismissEnabled: boolean;
   autoDismissConfidenceThreshold: AutoDismissConfidenceThreshold;
@@ -71,7 +69,9 @@ type SecurityConfigFormProps = {
     config: SlaConfig & {
       repositorySelectionMode: 'all' | 'selected';
       selectedRepositoryIds: number[];
-      modelSlug: string;
+      triageModelSlug: string;
+      analysisModelSlug: string;
+      modelSlug?: string;
       analysisMode: AnalysisMode;
       autoDismissEnabled: boolean;
       autoDismissConfidenceThreshold: AutoDismissConfidenceThreshold;
@@ -168,11 +168,14 @@ const SEVERITY_INFO = [
 ];
 
 export function SecurityConfigForm({
+  organizationId,
   enabled,
   slaConfig,
   repositorySelectionMode: initialSelectionMode,
   selectedRepositoryIds: initialSelectedIds,
   modelSlug: initialModelSlug,
+  triageModelSlug: initialTriageModelSlug,
+  analysisModelSlug: initialAnalysisModelSlug,
   analysisMode: initialAnalysisMode,
   autoDismissEnabled: initialAutoDismissEnabled,
   autoDismissConfidenceThreshold: initialAutoDismissThreshold,
@@ -186,14 +189,20 @@ export function SecurityConfigForm({
   isToggling,
   isRefreshingRepositories,
 }: SecurityConfigFormProps) {
+  const { modelOptions, isLoadingModels } = useOrganizationModels(organizationId);
+
+  const initialTriageModel =
+    initialTriageModelSlug || initialModelSlug || DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+  const initialAnalysisModel =
+    initialAnalysisModelSlug || initialModelSlug || DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
+
   const [localConfig, setLocalConfig] = useState<SlaConfig>(slaConfig);
   const [repositorySelectionMode, setRepositorySelectionMode] = useState<'all' | 'selected'>(
     initialSelectionMode
   );
   const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>(initialSelectedIds);
-  const [selectedModel, setSelectedModel] = useState<string>(
-    initialModelSlug || DEFAULT_SECURITY_AGENT_MODEL
-  );
+  const [selectedTriageModel, setSelectedTriageModel] = useState<string>(initialTriageModel);
+  const [selectedAnalysisModel, setSelectedAnalysisModel] = useState<string>(initialAnalysisModel);
   const [analysisMode, setAnalysisMode] = useState<AnalysisMode>(initialAnalysisMode);
   const [autoDismissEnabled, setAutoDismissEnabled] = useState(initialAutoDismissEnabled);
   const [autoDismissConfidenceThreshold, setAutoDismissConfidenceThreshold] =
@@ -204,7 +213,8 @@ export function SecurityConfigForm({
     setLocalConfig(slaConfig);
     setRepositorySelectionMode(initialSelectionMode);
     setSelectedRepositoryIds(initialSelectedIds);
-    setSelectedModel(initialModelSlug || DEFAULT_SECURITY_AGENT_MODEL);
+    setSelectedTriageModel(initialTriageModel);
+    setSelectedAnalysisModel(initialAnalysisModel);
     setAnalysisMode(initialAnalysisMode);
     setAutoDismissEnabled(initialAutoDismissEnabled);
     setAutoDismissConfidenceThreshold(initialAutoDismissThreshold);
@@ -213,7 +223,8 @@ export function SecurityConfigForm({
     slaConfig,
     initialSelectionMode,
     initialSelectedIds,
-    initialModelSlug,
+    initialTriageModel,
+    initialAnalysisModel,
     initialAnalysisMode,
     initialAutoDismissEnabled,
     initialAutoDismissThreshold,
@@ -224,7 +235,8 @@ export function SecurityConfigForm({
       newConfig: SlaConfig,
       newMode: 'all' | 'selected',
       newSelectedIds: number[],
-      newModel: string,
+      newTriageModel: string,
+      newAnalysisModel: string,
       newAnalysisMode: AnalysisMode,
       newAutoDismissEnabled: boolean,
       newAutoDismissThreshold: AutoDismissConfidenceThreshold
@@ -238,7 +250,8 @@ export function SecurityConfigForm({
       const modeChanged = newMode !== initialSelectionMode;
       const idsChanged =
         JSON.stringify(newSelectedIds.sort()) !== JSON.stringify(initialSelectedIds.sort());
-      const modelChanged = newModel !== (initialModelSlug || DEFAULT_SECURITY_AGENT_MODEL);
+      const triageModelChanged = newTriageModel !== initialTriageModel;
+      const analysisModelChanged = newAnalysisModel !== initialAnalysisModel;
       const analysisModeChanged = newAnalysisMode !== initialAnalysisMode;
       const autoDismissEnabledChanged = newAutoDismissEnabled !== initialAutoDismissEnabled;
       const autoDismissThresholdChanged = newAutoDismissThreshold !== initialAutoDismissThreshold;
@@ -247,7 +260,8 @@ export function SecurityConfigForm({
         configChanged ||
           modeChanged ||
           idsChanged ||
-          modelChanged ||
+          triageModelChanged ||
+          analysisModelChanged ||
           analysisModeChanged ||
           autoDismissEnabledChanged ||
           autoDismissThresholdChanged
@@ -257,7 +271,8 @@ export function SecurityConfigForm({
       slaConfig,
       initialSelectionMode,
       initialSelectedIds,
-      initialModelSlug,
+      initialTriageModel,
+      initialAnalysisModel,
       initialAnalysisMode,
       initialAutoDismissEnabled,
       initialAutoDismissThreshold,
@@ -274,7 +289,8 @@ export function SecurityConfigForm({
       newConfig,
       repositorySelectionMode,
       selectedRepositoryIds,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       analysisMode,
       autoDismissEnabled,
       autoDismissConfidenceThreshold
@@ -287,7 +303,8 @@ export function SecurityConfigForm({
       localConfig,
       mode,
       selectedRepositoryIds,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       analysisMode,
       autoDismissEnabled,
       autoDismissConfidenceThreshold
@@ -300,19 +317,35 @@ export function SecurityConfigForm({
       localConfig,
       repositorySelectionMode,
       ids,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       analysisMode,
       autoDismissEnabled,
       autoDismissConfidenceThreshold
     );
   };
 
-  const handleModelChange = (model: string) => {
-    setSelectedModel(model);
+  const handleTriageModelChange = (model: string) => {
+    setSelectedTriageModel(model);
     checkForChanges(
       localConfig,
       repositorySelectionMode,
       selectedRepositoryIds,
+      model,
+      selectedAnalysisModel,
+      analysisMode,
+      autoDismissEnabled,
+      autoDismissConfidenceThreshold
+    );
+  };
+
+  const handleAnalysisModelChange = (model: string) => {
+    setSelectedAnalysisModel(model);
+    checkForChanges(
+      localConfig,
+      repositorySelectionMode,
+      selectedRepositoryIds,
+      selectedTriageModel,
       model,
       analysisMode,
       autoDismissEnabled,
@@ -326,7 +359,8 @@ export function SecurityConfigForm({
       localConfig,
       repositorySelectionMode,
       selectedRepositoryIds,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       mode,
       autoDismissEnabled,
       autoDismissConfidenceThreshold
@@ -339,7 +373,8 @@ export function SecurityConfigForm({
       localConfig,
       repositorySelectionMode,
       selectedRepositoryIds,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       analysisMode,
       newEnabled,
       autoDismissConfidenceThreshold
@@ -352,7 +387,8 @@ export function SecurityConfigForm({
       localConfig,
       repositorySelectionMode,
       selectedRepositoryIds,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       analysisMode,
       autoDismissEnabled,
       threshold
@@ -364,7 +400,9 @@ export function SecurityConfigForm({
       ...localConfig,
       repositorySelectionMode,
       selectedRepositoryIds,
-      modelSlug: selectedModel,
+      triageModelSlug: selectedTriageModel,
+      analysisModelSlug: selectedAnalysisModel,
+      modelSlug: selectedAnalysisModel,
       analysisMode,
       autoDismissEnabled,
       autoDismissConfidenceThreshold,
@@ -377,7 +415,8 @@ export function SecurityConfigForm({
       DEFAULT_SLA_CONFIG,
       repositorySelectionMode,
       selectedRepositoryIds,
-      selectedModel,
+      selectedTriageModel,
+      selectedAnalysisModel,
       analysisMode,
       autoDismissEnabled,
       autoDismissConfidenceThreshold
@@ -534,32 +573,31 @@ export function SecurityConfigForm({
                 <Bot className="h-5 w-5 text-cyan-400" />
               </div>
               <div>
-                <CardTitle className="text-lg font-bold">AI Model</CardTitle>
+                <CardTitle className="text-lg font-bold">AI Models</CardTitle>
                 <p className="text-muted-foreground text-xs">
-                  Choose the AI model to use for security analysis
+                  Configure dedicated models for quick triage and deep analysis
                 </p>
               </div>
             </div>
           </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              <Label htmlFor="model-select">Analysis Model</Label>
-              <Select value={selectedModel} onValueChange={handleModelChange}>
-                <SelectTrigger id="model-select" className="w-full">
-                  <SelectValue placeholder="Select a model" />
-                </SelectTrigger>
-                <SelectContent>
-                  {SECURITY_AGENT_MODELS.map(model => (
-                    <SelectItem key={model.id} value={model.id}>
-                      {model.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-muted-foreground text-xs">
-                This model will be used when analyzing security findings
-              </p>
-            </div>
+          <CardContent className="space-y-4">
+            <ModelCombobox
+              label="Triage Model"
+              models={modelOptions}
+              value={selectedTriageModel}
+              onValueChange={handleTriageModelChange}
+              isLoading={isLoadingModels}
+              helperText="Used for initial triage and exploitability recommendation"
+            />
+
+            <ModelCombobox
+              label="Analysis Model"
+              models={modelOptions}
+              value={selectedAnalysisModel}
+              onValueChange={handleAnalysisModelChange}
+              isLoading={isLoadingModels}
+              helperText="Used for sandbox/codebase analysis and final extraction"
+            />
           </CardContent>
         </Card>
       )}

--- a/src/components/security-agent/SecurityConfigForm.tsx
+++ b/src/components/security-agent/SecurityConfigForm.tsx
@@ -249,7 +249,8 @@ export function SecurityConfigForm({
 
       const modeChanged = newMode !== initialSelectionMode;
       const idsChanged =
-        JSON.stringify(newSelectedIds.sort()) !== JSON.stringify(initialSelectedIds.sort());
+        JSON.stringify([...newSelectedIds].sort()) !==
+        JSON.stringify([...initialSelectedIds].sort());
       const triageModelChanged = newTriageModel !== initialTriageModel;
       const analysisModelChanged = newAnalysisModel !== initialAnalysisModel;
       const analysisModeChanged = newAnalysisMode !== initialAnalysisMode;

--- a/src/components/security-agent/SecurityConfigForm.tsx
+++ b/src/components/security-agent/SecurityConfigForm.tsx
@@ -581,24 +581,26 @@ export function SecurityConfigForm({
               </div>
             </div>
           </CardHeader>
-          <CardContent className="space-y-4">
-            <ModelCombobox
-              label="Triage Model"
-              models={modelOptions}
-              value={selectedTriageModel}
-              onValueChange={handleTriageModelChange}
-              isLoading={isLoadingModels}
-              helperText="Used for initial triage and exploitability recommendation"
-            />
+          <CardContent>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <ModelCombobox
+                label="Triage Model"
+                models={modelOptions}
+                value={selectedTriageModel}
+                onValueChange={handleTriageModelChange}
+                isLoading={isLoadingModels}
+                helperText="Used for initial triage and exploitability recommendation"
+              />
 
-            <ModelCombobox
-              label="Analysis Model"
-              models={modelOptions}
-              value={selectedAnalysisModel}
-              onValueChange={handleAnalysisModelChange}
-              isLoading={isLoadingModels}
-              helperText="Used for sandbox/codebase analysis and final extraction"
-            />
+              <ModelCombobox
+                label="Analysis Model"
+                models={modelOptions}
+                value={selectedAnalysisModel}
+                onValueChange={handleAnalysisModelChange}
+                isLoading={isLoadingModels}
+                helperText="Used for sandbox/codebase analysis and final extraction"
+              />
+            </div>
           </CardContent>
         </Card>
       )}

--- a/src/lib/security-agent/core/constants.ts
+++ b/src/lib/security-agent/core/constants.ts
@@ -22,6 +22,9 @@ export const SECURITY_AGENT_MODELS = [
  */
 export const DEFAULT_SECURITY_AGENT_MODEL = SECURITY_AGENT_MODELS[0].id;
 
+export const DEFAULT_SECURITY_AGENT_TRIAGE_MODEL = SECURITY_AGENT_MODELS[0].id;
+export const DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL = SECURITY_AGENT_MODELS[0].id;
+
 /**
  * Default configuration for the security agent
  */
@@ -32,7 +35,9 @@ export const DEFAULT_SECURITY_AGENT_CONFIG: SecurityAgentConfig = {
   sla_low_days: 90,
   auto_sync_enabled: true,
   repository_selection_mode: 'all',
-  model_slug: DEFAULT_SECURITY_AGENT_MODEL,
+  model_slug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+  triage_model_slug: DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+  analysis_model_slug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
   // Analysis mode: auto (triage → conditional sandbox), shallow (triage only), deep (always sandbox)
   analysis_mode: 'auto',
   // Auto-dismiss is off by default - users manually review and dismiss findings

--- a/src/lib/security-agent/core/schemas.ts
+++ b/src/lib/security-agent/core/schemas.ts
@@ -65,6 +65,8 @@ export const SaveSecurityConfigInputSchema = z.object({
   repositorySelectionMode: RepositorySelectionModeSchema.optional(),
   selectedRepositoryIds: z.array(z.number()).optional(),
   modelSlug: z.string().optional(),
+  triageModelSlug: z.string().optional(),
+  analysisModelSlug: z.string().optional(),
   // Analysis mode configuration
   analysisMode: AnalysisModeSchema.optional(),
   // Auto-dismiss configuration
@@ -215,6 +217,8 @@ export const AnalysisResponseSchema = z.object({
   rawMarkdown: z.string().optional(), // Present in legacy format or as fallback
   analyzedAt: z.string(),
   modelUsed: z.string().optional(),
+  triageModel: z.string().optional(),
+  analysisModel: z.string().optional(),
   triggeredByUserId: z.string().optional(), // User ID who triggered the analysis (for audit tracking)
 });
 
@@ -234,6 +238,8 @@ export const AnalysisResponseLegacySchema = z.object({
 export const StartAnalysisInputSchema = z.object({
   findingId: z.string().uuid(),
   model: z.string().optional(),
+  triageModel: z.string().optional(),
+  analysisModel: z.string().optional(),
   retrySandboxOnly: z.boolean().optional(), // Skip triage, reuse existing triage data, retry only sandbox
 });
 

--- a/src/lib/security-agent/core/types.ts
+++ b/src/lib/security-agent/core/types.ts
@@ -69,6 +69,8 @@ export const SecurityAgentConfigSchema = z.object({
   repository_selection_mode: z.enum(['all', 'selected']).default('all'),
   selected_repository_ids: z.array(z.number()).optional(),
   model_slug: z.string().optional(),
+  triage_model_slug: z.string().optional(),
+  analysis_model_slug: z.string().optional(),
   // Analysis mode: auto (default), shallow (triage only), deep (always sandbox)
   analysis_mode: z.enum(['auto', 'shallow', 'deep']).default('auto'),
   // Auto-dismiss configuration (off by default)
@@ -292,6 +294,10 @@ export type SecurityFindingAnalysis = {
   analyzedAt: string;
   /** Model used for analysis */
   modelUsed?: string;
+  /** Model used for triage */
+  triageModel?: string;
+  /** Model used for sandbox/extraction analysis */
+  analysisModel?: string;
   /** User ID who triggered the analysis (for audit tracking) */
   triggeredByUserId?: string;
   /** Correlation ID for tracing across triage → sandbox → extraction → auto-dismiss */

--- a/src/lib/security-agent/db/security-config.ts
+++ b/src/lib/security-agent/db/security-config.ts
@@ -45,7 +45,11 @@ export async function getSecurityAgentConfig(
 export async function getSecurityAgentConfigWithStatus(
   owner: Owner,
   platform: string = DEFAULT_PLATFORM
-): Promise<{ config: SecurityAgentConfig; isEnabled: boolean } | null> {
+): Promise<{
+  config: SecurityAgentConfig;
+  storedConfig: Partial<SecurityAgentConfig>;
+  isEnabled: boolean;
+} | null> {
   const agentConfig = await getAgentConfigForOwner(owner, AGENT_TYPE, platform);
 
   if (!agentConfig) {
@@ -53,6 +57,7 @@ export async function getSecurityAgentConfigWithStatus(
   }
 
   return {
+    storedConfig: agentConfig.config as Partial<SecurityAgentConfig>,
     config: {
       ...DEFAULT_SECURITY_AGENT_CONFIG,
       ...(agentConfig.config as Partial<SecurityAgentConfig>),

--- a/src/lib/security-agent/db/security-config.ts
+++ b/src/lib/security-agent/db/security-config.ts
@@ -75,8 +75,10 @@ export async function upsertSecurityAgentConfig(
   createdBy: string,
   platform: string = DEFAULT_PLATFORM
 ): Promise<void> {
+  const existingConfig = await getAgentConfigForOwner(owner, AGENT_TYPE, platform);
   const fullConfig = {
     ...DEFAULT_SECURITY_AGENT_CONFIG,
+    ...(existingConfig?.config as Partial<SecurityAgentConfig> | undefined),
     ...config,
   };
 

--- a/src/lib/security-agent/posthog-tracking.ts
+++ b/src/lib/security-agent/posthog-tracking.ts
@@ -31,6 +31,8 @@ type SecurityAgentConfigSavedEvent = BaseSecurityAgentEvent & {
   autoDismissEnabled?: boolean;
   autoDismissConfidenceThreshold?: string;
   modelSlug?: string;
+  triageModelSlug?: string;
+  analysisModelSlug?: string;
   repositorySelectionMode?: string;
   selectedRepoCount?: number;
 };
@@ -45,12 +47,16 @@ type SecurityAgentSyncEvent = BaseSecurityAgentEvent & {
 type SecurityAgentAnalysisStartedEvent = BaseSecurityAgentEvent & {
   findingId: string;
   model: string;
+  triageModel?: string;
+  analysisModel?: string;
   analysisMode?: string;
 };
 
 type SecurityAgentAnalysisCompletedEvent = BaseSecurityAgentEvent & {
   findingId: string;
   model: string;
+  triageModel?: string;
+  analysisModel?: string;
   triageOnly: boolean;
   needsSandboxAnalysis?: boolean;
   triageSuggestedAction?: string;

--- a/src/lib/security-agent/services/analysis-service.test.ts
+++ b/src/lib/security-agent/services/analysis-service.test.ts
@@ -127,7 +127,8 @@ describe('analysis-service', () => {
       user,
       githubRepo: 'acme/repo',
       githubToken: 'gh-token',
-      model: 'anthropic/claude-sonnet-4',
+      triageModel: 'anthropic/claude-sonnet-4',
+      analysisModel: 'anthropic/claude-opus-4.6',
       organizationId,
     });
 
@@ -139,16 +140,80 @@ describe('analysis-service', () => {
         githubRepo: 'acme/repo',
         githubToken: 'gh-token',
         mode: 'code',
-        model: 'anthropic/claude-sonnet-4',
+        model: 'anthropic/claude-opus-4.6',
         callbackTarget: expect.objectContaining({
           url: expect.stringContaining(`/api/internal/security-analysis-callback/${findingId}`),
           headers: expect.objectContaining({ 'X-Internal-Secret': expect.any(String) }),
         }),
       })
     );
+    expect(mockTriageSecurityFinding).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'anthropic/claude-sonnet-4' })
+    );
     expect(mockInitiateFromPreparedSession).toHaveBeenCalledWith({
       cloudAgentSessionId: 'ses-agent-123',
     });
+  });
+
+  it('uses triageModel for triage and analysisModel for sandbox session', async () => {
+    const findingId = 'finding-model-split';
+    const user = { id: 'user-1', google_user_email: 'test@example.com' } as User;
+
+    const mockFinding = {
+      id: findingId,
+      analysis_status: 'new',
+      repo_full_name: 'acme/repo',
+      package_name: 'lodash',
+      package_ecosystem: 'npm',
+      severity: 'high',
+      dependency_scope: 'runtime',
+      cve_id: null,
+      ghsa_id: null,
+      title: 'Test vulnerability',
+      description: null,
+      vulnerable_version_range: null,
+      patched_version: null,
+      manifest_path: null,
+    };
+
+    mockGetSecurityFindingById.mockResolvedValue(
+      mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
+    );
+    mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+    mockTriageSecurityFinding.mockResolvedValue({
+      needsSandboxAnalysis: true,
+      needsSandboxReasoning: 'Needs analysis',
+      suggestedAction: 'analyze_codebase',
+      confidence: 'high',
+      triageAt: new Date().toISOString(),
+    });
+    mockGenerateApiToken.mockReturnValue('test-token');
+    mockPrepareSession.mockResolvedValue({
+      cloudAgentSessionId: 'agent-session-split',
+      kiloSessionId: 'ses_kilo-split',
+    });
+    mockInitiateFromPreparedSession.mockResolvedValue({
+      cloudAgentSessionId: 'agent-session-split',
+      executionId: 'exec-split',
+      status: 'started',
+      streamUrl: 'wss://example.com/stream',
+    });
+
+    await startSecurityAnalysis({
+      findingId,
+      user,
+      githubRepo: 'acme/repo',
+      githubToken: 'gh-token',
+      triageModel: 'anthropic/claude-sonnet-4.5',
+      analysisModel: 'x-ai/grok-code-fast-1',
+    });
+
+    expect(mockTriageSecurityFinding).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'anthropic/claude-sonnet-4.5' })
+    );
+    expect(mockPrepareSession).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'x-ai/grok-code-fast-1' })
+    );
   });
 
   it('stores session IDs after prepareSession', async () => {
@@ -339,7 +404,8 @@ describe('analysis-service', () => {
       user,
       githubRepo: 'acme/repo',
       githubToken: 'gh-token',
-      model: 'anthropic/claude-sonnet-4' as const,
+      triageModel: 'anthropic/claude-sonnet-4' as const,
+      analysisModel: 'anthropic/claude-opus-4.6' as const,
     };
 
     beforeEach(() => {

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -38,6 +38,10 @@ import { sentryLogger } from '@/lib/utils.server';
 import { APP_URL } from '@/lib/constants';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
 import type { SessionSnapshot } from '@/lib/session-ingest-client';
+import {
+  DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+  DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+} from '../core/constants';
 
 const log = sentryLogger('security-agent:analysis', 'info');
 const logError = sentryLogger('security-agent:analysis', 'error');
@@ -197,6 +201,8 @@ export async function finalizeAnalysis(
     rawMarkdown: existingAnalysis?.rawMarkdown,
     analyzedAt: new Date().toISOString(),
     modelUsed: model,
+    triageModel: existingAnalysis?.triageModel,
+    analysisModel: existingAnalysis?.analysisModel ?? model,
     triggeredByUserId: existingAnalysis?.triggeredByUserId,
     correlationId,
   };
@@ -210,6 +216,8 @@ export async function finalizeAnalysis(
     organizationId,
     findingId,
     model,
+    triageModel: existingAnalysis?.triageModel,
+    analysisModel: existingAnalysis?.analysisModel ?? model,
     triageOnly: false,
     needsSandboxAnalysis: existingAnalysis?.triage?.needsSandboxAnalysis,
     triageSuggestedAction: existingAnalysis?.triage?.suggestedAction,
@@ -246,7 +254,8 @@ export async function startSecurityAnalysis(params: {
   user: User;
   githubRepo: string;
   githubToken?: string;
-  model?: string;
+  triageModel?: string;
+  analysisModel?: string;
   analysisMode?: AnalysisMode;
   forceSandbox?: boolean;
   retrySandboxOnly?: boolean;
@@ -257,7 +266,8 @@ export async function startSecurityAnalysis(params: {
     user,
     githubRepo,
     githubToken,
-    model = 'anthropic/claude-sonnet-4',
+    triageModel = DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+    analysisModel = DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
     analysisMode = 'auto',
     forceSandbox = false,
     retrySandboxOnly = false,
@@ -322,21 +332,25 @@ export async function startSecurityAnalysis(params: {
         userId: user.id,
         organizationId,
         findingId,
-        model,
+        model: analysisModel,
+        triageModel,
+        analysisModel,
         analysisMode,
       });
     } else {
       // =========================================================================
       // Tier 1: Quick Triage (always runs)
       // =========================================================================
-      log('Starting Tier 1 triage', { correlationId, findingId, model });
+      log('Starting Tier 1 triage', { correlationId, findingId, triageModel });
 
       trackSecurityAgentAnalysisStarted({
         distinctId: user.id,
         userId: user.id,
         organizationId,
         findingId,
-        model,
+        model: analysisModel,
+        triageModel,
+        analysisModel,
         analysisMode,
       });
 
@@ -344,7 +358,7 @@ export async function startSecurityAnalysis(params: {
       triage = await triageSecurityFinding({
         finding,
         authToken,
-        model,
+        model: triageModel,
         correlationId,
         userId: user.id,
         organizationId,
@@ -391,7 +405,9 @@ export async function startSecurityAnalysis(params: {
       const analysis: SecurityFindingAnalysis = {
         triage,
         analyzedAt: new Date().toISOString(),
-        modelUsed: model,
+        modelUsed: triageModel,
+        triageModel,
+        analysisModel,
         triggeredByUserId: user.id,
         correlationId,
       };
@@ -403,7 +419,9 @@ export async function startSecurityAnalysis(params: {
         userId: user.id,
         organizationId,
         findingId,
-        model,
+        model: triageModel,
+        triageModel,
+        analysisModel,
         triageOnly: true,
         needsSandboxAnalysis: triage.needsSandboxAnalysis,
         triageSuggestedAction: triage.suggestedAction,
@@ -442,7 +460,9 @@ export async function startSecurityAnalysis(params: {
     const partialAnalysis: SecurityFindingAnalysis = {
       triage,
       analyzedAt: new Date().toISOString(),
-      modelUsed: model,
+      modelUsed: analysisModel,
+      triageModel,
+      analysisModel,
       triggeredByUserId: user.id,
       correlationId,
     };
@@ -456,7 +476,7 @@ export async function startSecurityAnalysis(params: {
     const { cloudAgentSessionId, kiloSessionId } = await client.prepareSession({
       prompt,
       mode: 'code',
-      model,
+      model: analysisModel,
       githubRepo,
       githubToken,
       kilocodeOrganizationId: organizationId,

--- a/src/lib/security-agent/services/extraction-service.ts
+++ b/src/lib/security-agent/services/extraction-service.ts
@@ -17,6 +17,7 @@ import { addBreadcrumb, captureException, startSpan } from '@sentry/nextjs';
 import { sentryLogger } from '@/lib/utils.server';
 import { emitApiMetrics } from '@/lib/o11y/api-metrics.server';
 import { O11Y_KILO_GATEWAY_CLIENT_SECRET } from '@/lib/config.server';
+import { DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL } from '../core/constants';
 
 const VALID_SUGGESTED_ACTIONS: SandboxSuggestedAction[] = [
   'dismiss',
@@ -235,7 +236,7 @@ function createFallbackExtraction(
  * @param options.finding - The security finding being analyzed
  * @param options.rawMarkdown - Raw markdown output from sandbox analysis
  * @param options.authToken - Auth token for the LLM proxy
- * @param options.model - Model to use for extraction (default: anthropic/claude-sonnet-4)
+ * @param options.model - Model to use for extraction (defaults to DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL)
  * @param options.correlationId - Correlation ID for tracing across the analysis pipeline
  * @param options.userId - User ID for metrics tracking
  * @param options.organizationId - Optional organization ID for usage tracking
@@ -253,7 +254,7 @@ export async function extractSandboxAnalysis(options: {
     finding,
     rawMarkdown,
     authToken,
-    model = 'anthropic/claude-sonnet-4',
+    model = DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
     correlationId = '',
     userId = '',
     organizationId,

--- a/src/lib/security-agent/services/triage-service.ts
+++ b/src/lib/security-agent/services/triage-service.ts
@@ -16,6 +16,7 @@ import { addBreadcrumb, captureException, startSpan } from '@sentry/nextjs';
 import { sentryLogger } from '@/lib/utils.server';
 import { emitApiMetrics } from '@/lib/o11y/api-metrics.server';
 import { O11Y_KILO_GATEWAY_CLIENT_SECRET } from '@/lib/config.server';
+import { DEFAULT_SECURITY_AGENT_TRIAGE_MODEL } from '../core/constants';
 
 const log = sentryLogger('security-agent:triage', 'info');
 const logError = sentryLogger('security-agent:triage', 'error');
@@ -190,7 +191,7 @@ function createFallbackTriage(reason: string): SecurityFindingTriage {
  *
  * @param options.finding - The security finding to triage
  * @param options.authToken - Auth token for the LLM proxy
- * @param options.model - Model to use for triage (default: anthropic/claude-sonnet-4)
+ * @param options.model - Model to use for triage (defaults to DEFAULT_SECURITY_AGENT_TRIAGE_MODEL)
  * @param options.correlationId - Correlation ID for tracing across the analysis pipeline
  * @param options.userId - User ID for metrics tracking
  * @param options.organizationId - Optional organization ID for usage tracking
@@ -206,7 +207,7 @@ export async function triageSecurityFinding(options: {
   const {
     finding,
     authToken,
-    model = 'anthropic/claude-sonnet-4',
+    model = DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
     correlationId = '',
     userId = '',
     organizationId,

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -58,7 +58,10 @@ import {
   ListAnalysisJobsInputSchema,
   DeleteFindingsByRepoInputSchema,
 } from '@/lib/security-agent/core/schemas';
-import { DEFAULT_SECURITY_AGENT_MODEL } from '@/lib/security-agent/core/constants';
+import {
+  DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+  DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+} from '@/lib/security-agent/core/constants';
 import {
   trackSecurityAgentEnabled,
   trackSecurityAgentConfigSaved,
@@ -134,7 +137,9 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
         autoSyncEnabled: true,
         repositorySelectionMode: 'selected' as const,
         selectedRepositoryIds: [] as number[],
-        modelSlug: DEFAULT_SECURITY_AGENT_MODEL,
+        modelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+        triageModelSlug: DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+        analysisModelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
         // Analysis mode default
         analysisMode: 'auto' as const,
         // Auto-dismiss defaults (off by default)
@@ -142,6 +147,15 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
         autoDismissConfidenceThreshold: 'high' as const,
       };
     }
+
+    const triageModelSlug =
+      result.config.triage_model_slug ||
+      result.config.model_slug ||
+      DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+    const analysisModelSlug =
+      result.config.analysis_model_slug ||
+      result.config.model_slug ||
+      DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
 
     return {
       isEnabled: result.isEnabled,
@@ -152,7 +166,9 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
       autoSyncEnabled: result.config.auto_sync_enabled,
       repositorySelectionMode: result.config.repository_selection_mode || 'selected',
       selectedRepositoryIds: result.config.selected_repository_ids || [],
-      modelSlug: result.config.model_slug || DEFAULT_SECURITY_AGENT_MODEL,
+      modelSlug: result.config.model_slug || analysisModelSlug,
+      triageModelSlug,
+      analysisModelSlug,
       // Analysis mode configuration
       analysisMode: result.config.analysis_mode ?? 'auto',
       // Auto-dismiss configuration
@@ -170,6 +186,14 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
       const owner = { type: 'org' as const, id: input.organizationId, userId: ctx.user.id };
 
       const existingConfig = await getSecurityAgentConfigWithStatus(owner);
+      const existingTriageModelSlug =
+        existingConfig?.config.triage_model_slug ??
+        existingConfig?.config.model_slug ??
+        DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+      const existingAnalysisModelSlug =
+        existingConfig?.config.analysis_model_slug ??
+        existingConfig?.config.model_slug ??
+        DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
       const beforeState = existingConfig
         ? {
             autoSyncEnabled: existingConfig.config.auto_sync_enabled,
@@ -177,6 +201,8 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
             autoDismissEnabled: existingConfig.config.auto_dismiss_enabled,
             autoDismissConfidenceThreshold: existingConfig.config.auto_dismiss_confidence_threshold,
             modelSlug: existingConfig.config.model_slug,
+            triageModelSlug: existingTriageModelSlug,
+            analysisModelSlug: existingAnalysisModelSlug,
             repositorySelectionMode: existingConfig.config.repository_selection_mode,
             selectedRepositoryIds: existingConfig.config.selected_repository_ids,
             slaCriticalDays: existingConfig.config.sla_critical_days,
@@ -185,6 +211,12 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
             slaLowDays: existingConfig.config.sla_low_days,
           }
         : undefined;
+
+      const triageModelSlug =
+        input.triageModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
+      const analysisModelSlug =
+        input.analysisModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
+      const modelSlug = input.modelSlug ?? analysisModelSlug ?? triageModelSlug;
 
       await upsertSecurityAgentConfig(
         owner,
@@ -196,7 +228,9 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           auto_sync_enabled: input.autoSyncEnabled,
           repository_selection_mode: input.repositorySelectionMode,
           selected_repository_ids: input.selectedRepositoryIds,
-          model_slug: input.modelSlug,
+          model_slug: modelSlug,
+          triage_model_slug: triageModelSlug,
+          analysis_model_slug: analysisModelSlug,
           // Analysis mode configuration
           analysis_mode: input.analysisMode,
           // Auto-dismiss configuration
@@ -214,7 +248,9 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
         analysisMode: input.analysisMode,
         autoDismissEnabled: input.autoDismissEnabled,
         autoDismissConfidenceThreshold: input.autoDismissConfidenceThreshold,
-        modelSlug: input.modelSlug,
+        modelSlug,
+        triageModelSlug,
+        analysisModelSlug,
         repositorySelectionMode: input.repositorySelectionMode,
         selectedRepoCount: input.selectedRepositoryIds?.length,
       });
@@ -233,7 +269,9 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           analysisMode: input.analysisMode,
           autoDismissEnabled: input.autoDismissEnabled,
           autoDismissConfidenceThreshold: input.autoDismissConfidenceThreshold,
-          modelSlug: input.modelSlug,
+          modelSlug,
+          triageModelSlug,
+          analysisModelSlug,
           repositorySelectionMode: input.repositorySelectionMode,
           selectedRepositoryIds: input.selectedRepositoryIds,
           slaCriticalDays: input.slaCriticalDays,
@@ -809,9 +847,20 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
         });
       }
 
-      // Get model and analysis mode from input or fall back to configured values
+      // Resolve triage/analysis models with legacy fallbacks
       const config = await getSecurityAgentConfigWithStatus(owner);
-      const model = input.model || config?.config.model_slug || DEFAULT_SECURITY_AGENT_MODEL;
+      const triageModel =
+        input.triageModel ||
+        input.model ||
+        config?.config.triage_model_slug ||
+        config?.config.model_slug ||
+        DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+      const analysisModel =
+        input.analysisModel ||
+        input.model ||
+        config?.config.analysis_model_slug ||
+        config?.config.model_slug ||
+        DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
       const analysisMode = config?.config.analysis_mode ?? 'auto';
 
       try {
@@ -820,7 +869,8 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           user: ctx.user,
           githubRepo: finding.repo_full_name,
           githubToken,
-          model,
+          triageModel,
+          analysisModel,
           analysisMode,
           retrySandboxOnly: input.retrySandboxOnly,
           organizationId: input.organizationId,
@@ -841,7 +891,13 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           action: SecurityAuditLogAction.FindingAnalysisStarted,
           resource_type: 'security_finding',
           resource_id: input.findingId,
-          metadata: { model, analysisMode, triageOnly: result.triageOnly },
+          metadata: {
+            model: analysisModel,
+            triageModel,
+            analysisModel,
+            analysisMode,
+            triageOnly: result.triageOnly,
+          },
         });
 
         return { success: true, triageOnly: result.triageOnly };

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -149,12 +149,14 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
     }
 
     const triageModelSlug =
+      result.storedConfig.triage_model_slug ||
+      result.storedConfig.model_slug ||
       result.config.triage_model_slug ||
-      result.config.model_slug ||
       DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
     const analysisModelSlug =
+      result.storedConfig.analysis_model_slug ||
+      result.storedConfig.model_slug ||
       result.config.analysis_model_slug ||
-      result.config.model_slug ||
       DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
 
     return {
@@ -187,12 +189,14 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
 
       const existingConfig = await getSecurityAgentConfigWithStatus(owner);
       const existingTriageModelSlug =
+        existingConfig?.storedConfig.triage_model_slug ??
+        existingConfig?.storedConfig.model_slug ??
         existingConfig?.config.triage_model_slug ??
-        existingConfig?.config.model_slug ??
         DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
       const existingAnalysisModelSlug =
+        existingConfig?.storedConfig.analysis_model_slug ??
+        existingConfig?.storedConfig.model_slug ??
         existingConfig?.config.analysis_model_slug ??
-        existingConfig?.config.model_slug ??
         DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
       const beforeState = existingConfig
         ? {
@@ -852,14 +856,16 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
       const triageModel =
         input.triageModel ||
         input.model ||
+        config?.storedConfig.triage_model_slug ||
+        config?.storedConfig.model_slug ||
         config?.config.triage_model_slug ||
-        config?.config.model_slug ||
         DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
       const analysisModel =
         input.analysisModel ||
         input.model ||
+        config?.storedConfig.analysis_model_slug ||
+        config?.storedConfig.model_slug ||
         config?.config.analysis_model_slug ||
-        config?.config.model_slug ||
         DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
       const analysisMode = config?.config.analysis_mode ?? 'auto';
 

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -217,10 +217,18 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
         : undefined;
 
       const triageModelSlug =
-        input.triageModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
+        input.triageModelSlug ??
+        (input.modelSlug ? input.modelSlug : undefined) ??
+        existingTriageModelSlug;
       const analysisModelSlug =
-        input.analysisModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
-      const modelSlug = input.modelSlug ?? analysisModelSlug ?? triageModelSlug;
+        input.analysisModelSlug ??
+        (input.modelSlug ? input.modelSlug : undefined) ??
+        existingAnalysisModelSlug;
+      const modelSlug =
+        input.modelSlug ??
+        existingConfig?.storedConfig.model_slug ??
+        analysisModelSlug ??
+        triageModelSlug;
 
       await upsertSecurityAgentConfig(
         owner,

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -53,7 +53,10 @@ import {
   ListAnalysisJobsInputSchema,
   DeleteFindingsByRepoInputSchema,
 } from '@/lib/security-agent/core/schemas';
-import { DEFAULT_SECURITY_AGENT_MODEL } from '@/lib/security-agent/core/constants';
+import {
+  DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+  DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+} from '@/lib/security-agent/core/constants';
 import {
   trackSecurityAgentEnabled,
   trackSecurityAgentConfigSaved,
@@ -115,7 +118,9 @@ export const securityAgentRouter = createTRPCRouter({
         autoSyncEnabled: true,
         repositorySelectionMode: 'selected' as const,
         selectedRepositoryIds: [] as number[],
-        modelSlug: DEFAULT_SECURITY_AGENT_MODEL,
+        modelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
+        triageModelSlug: DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
+        analysisModelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
         // Analysis mode default
         analysisMode: 'auto' as const,
         // Auto-dismiss defaults (off by default)
@@ -123,6 +128,15 @@ export const securityAgentRouter = createTRPCRouter({
         autoDismissConfidenceThreshold: 'high' as const,
       };
     }
+
+    const triageModelSlug =
+      result.config.triage_model_slug ||
+      result.config.model_slug ||
+      DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+    const analysisModelSlug =
+      result.config.analysis_model_slug ||
+      result.config.model_slug ||
+      DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
 
     return {
       isEnabled: result.isEnabled,
@@ -133,7 +147,9 @@ export const securityAgentRouter = createTRPCRouter({
       autoSyncEnabled: result.config.auto_sync_enabled,
       repositorySelectionMode: result.config.repository_selection_mode || 'selected',
       selectedRepositoryIds: result.config.selected_repository_ids || [],
-      modelSlug: result.config.model_slug || DEFAULT_SECURITY_AGENT_MODEL,
+      modelSlug: result.config.model_slug || analysisModelSlug,
+      triageModelSlug,
+      analysisModelSlug,
       // Analysis mode configuration
       analysisMode: result.config.analysis_mode ?? 'auto',
       // Auto-dismiss configuration
@@ -151,6 +167,14 @@ export const securityAgentRouter = createTRPCRouter({
       const owner = { type: 'user' as const, id: ctx.user.id, userId: ctx.user.id };
 
       const existingConfig = await getSecurityAgentConfigWithStatus(owner);
+      const existingTriageModelSlug =
+        existingConfig?.config.triage_model_slug ??
+        existingConfig?.config.model_slug ??
+        DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+      const existingAnalysisModelSlug =
+        existingConfig?.config.analysis_model_slug ??
+        existingConfig?.config.model_slug ??
+        DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
       const beforeState = existingConfig
         ? {
             autoSyncEnabled: existingConfig.config.auto_sync_enabled,
@@ -158,6 +182,8 @@ export const securityAgentRouter = createTRPCRouter({
             autoDismissEnabled: existingConfig.config.auto_dismiss_enabled,
             autoDismissConfidenceThreshold: existingConfig.config.auto_dismiss_confidence_threshold,
             modelSlug: existingConfig.config.model_slug,
+            triageModelSlug: existingTriageModelSlug,
+            analysisModelSlug: existingAnalysisModelSlug,
             repositorySelectionMode: existingConfig.config.repository_selection_mode,
             selectedRepositoryIds: existingConfig.config.selected_repository_ids,
             slaCriticalDays: existingConfig.config.sla_critical_days,
@@ -166,6 +192,12 @@ export const securityAgentRouter = createTRPCRouter({
             slaLowDays: existingConfig.config.sla_low_days,
           }
         : undefined;
+
+      const triageModelSlug =
+        input.triageModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
+      const analysisModelSlug =
+        input.analysisModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
+      const modelSlug = input.modelSlug ?? analysisModelSlug ?? triageModelSlug;
 
       await upsertSecurityAgentConfig(
         owner,
@@ -177,7 +209,9 @@ export const securityAgentRouter = createTRPCRouter({
           auto_sync_enabled: input.autoSyncEnabled,
           repository_selection_mode: input.repositorySelectionMode,
           selected_repository_ids: input.selectedRepositoryIds,
-          model_slug: input.modelSlug,
+          model_slug: modelSlug,
+          triage_model_slug: triageModelSlug,
+          analysis_model_slug: analysisModelSlug,
           // Analysis mode configuration
           analysis_mode: input.analysisMode,
           // Auto-dismiss configuration
@@ -194,7 +228,9 @@ export const securityAgentRouter = createTRPCRouter({
         analysisMode: input.analysisMode,
         autoDismissEnabled: input.autoDismissEnabled,
         autoDismissConfidenceThreshold: input.autoDismissConfidenceThreshold,
-        modelSlug: input.modelSlug,
+        modelSlug,
+        triageModelSlug,
+        analysisModelSlug,
         repositorySelectionMode: input.repositorySelectionMode,
         selectedRepoCount: input.selectedRepositoryIds?.length,
       });
@@ -213,7 +249,9 @@ export const securityAgentRouter = createTRPCRouter({
           analysisMode: input.analysisMode,
           autoDismissEnabled: input.autoDismissEnabled,
           autoDismissConfidenceThreshold: input.autoDismissConfidenceThreshold,
-          modelSlug: input.modelSlug,
+          modelSlug,
+          triageModelSlug,
+          analysisModelSlug,
           repositorySelectionMode: input.repositorySelectionMode,
           selectedRepositoryIds: input.selectedRepositoryIds,
           slaCriticalDays: input.slaCriticalDays,
@@ -783,9 +821,20 @@ export const securityAgentRouter = createTRPCRouter({
       });
     }
 
-    // Get model and analysis mode from input or fall back to configured values
+    // Resolve triage/analysis models with legacy fallbacks
     const config = await getSecurityAgentConfigWithStatus(owner);
-    const model = input.model || config?.config.model_slug || DEFAULT_SECURITY_AGENT_MODEL;
+    const triageModel =
+      input.triageModel ||
+      input.model ||
+      config?.config.triage_model_slug ||
+      config?.config.model_slug ||
+      DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
+    const analysisModel =
+      input.analysisModel ||
+      input.model ||
+      config?.config.analysis_model_slug ||
+      config?.config.model_slug ||
+      DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
     const analysisMode = config?.config.analysis_mode ?? 'auto';
 
     try {
@@ -794,7 +843,8 @@ export const securityAgentRouter = createTRPCRouter({
         user: ctx.user,
         githubRepo: finding.repo_full_name,
         githubToken,
-        model,
+        triageModel,
+        analysisModel,
         analysisMode,
         retrySandboxOnly: input.retrySandboxOnly,
         // Personal user - no organizationId
@@ -815,7 +865,13 @@ export const securityAgentRouter = createTRPCRouter({
         action: SecurityAuditLogAction.FindingAnalysisStarted,
         resource_type: 'security_finding',
         resource_id: input.findingId,
-        metadata: { model, analysisMode, triageOnly: result.triageOnly },
+        metadata: {
+          model: analysisModel,
+          triageModel,
+          analysisModel,
+          analysisMode,
+          triageOnly: result.triageOnly,
+        },
       });
 
       return { success: true, triageOnly: result.triageOnly };

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -130,12 +130,14 @@ export const securityAgentRouter = createTRPCRouter({
     }
 
     const triageModelSlug =
+      result.storedConfig.triage_model_slug ||
+      result.storedConfig.model_slug ||
       result.config.triage_model_slug ||
-      result.config.model_slug ||
       DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
     const analysisModelSlug =
+      result.storedConfig.analysis_model_slug ||
+      result.storedConfig.model_slug ||
       result.config.analysis_model_slug ||
-      result.config.model_slug ||
       DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
 
     return {
@@ -168,12 +170,14 @@ export const securityAgentRouter = createTRPCRouter({
 
       const existingConfig = await getSecurityAgentConfigWithStatus(owner);
       const existingTriageModelSlug =
+        existingConfig?.storedConfig.triage_model_slug ??
+        existingConfig?.storedConfig.model_slug ??
         existingConfig?.config.triage_model_slug ??
-        existingConfig?.config.model_slug ??
         DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
       const existingAnalysisModelSlug =
+        existingConfig?.storedConfig.analysis_model_slug ??
+        existingConfig?.storedConfig.model_slug ??
         existingConfig?.config.analysis_model_slug ??
-        existingConfig?.config.model_slug ??
         DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
       const beforeState = existingConfig
         ? {
@@ -826,14 +830,16 @@ export const securityAgentRouter = createTRPCRouter({
     const triageModel =
       input.triageModel ||
       input.model ||
+      config?.storedConfig.triage_model_slug ||
+      config?.storedConfig.model_slug ||
       config?.config.triage_model_slug ||
-      config?.config.model_slug ||
       DEFAULT_SECURITY_AGENT_TRIAGE_MODEL;
     const analysisModel =
       input.analysisModel ||
       input.model ||
+      config?.storedConfig.analysis_model_slug ||
+      config?.storedConfig.model_slug ||
       config?.config.analysis_model_slug ||
-      config?.config.model_slug ||
       DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL;
     const analysisMode = config?.config.analysis_mode ?? 'auto';
 

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -198,10 +198,18 @@ export const securityAgentRouter = createTRPCRouter({
         : undefined;
 
       const triageModelSlug =
-        input.triageModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
+        input.triageModelSlug ??
+        (input.modelSlug ? input.modelSlug : undefined) ??
+        existingTriageModelSlug;
       const analysisModelSlug =
-        input.analysisModelSlug ?? (input.modelSlug ? input.modelSlug : undefined);
-      const modelSlug = input.modelSlug ?? analysisModelSlug ?? triageModelSlug;
+        input.analysisModelSlug ??
+        (input.modelSlug ? input.modelSlug : undefined) ??
+        existingAnalysisModelSlug;
+      const modelSlug =
+        input.modelSlug ??
+        existingConfig?.storedConfig.model_slug ??
+        analysisModelSlug ??
+        triageModelSlug;
 
       await upsertSecurityAgentConfig(
         owner,


### PR DESCRIPTION
## Summary
- add split Security Agent model configuration (`triage_model_slug`, `analysis_model_slug`) while preserving legacy `model_slug` fallback behavior for read/write/start-analysis flows
- wire stage-specific model resolution through personal/org routers, analysis pipeline, callback finalization, and PostHog/audit metadata so triage and sandbox/extraction can use different models
- upgrade Security Agent settings UI to use organization-aware `ModelCombobox` selectors for Triage Model and Analysis Model, with legacy config fallback and updated tests for split-model + callback fallback behavior

## Screenshots

| Before | After |
|--------|--------|
| <img width="2148" height="460" alt="20260226-144636@2x" src="https://github.com/user-attachments/assets/1ed90233-a618-443f-a489-c2fd4592d06c" /> | <img width="2158" height="434" alt="20260226-144626@2x" src="https://github.com/user-attachments/assets/b534a6fb-643a-4262-8733-206b0fef8e46" /> | 

## Validation
- pnpm lint
- pnpm typecheck
- Manual verification in the app