### PR TITLE
ci: add workflow_dispatch to deploy-production workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,7 +10,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure workflow runs on main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow can only be run on the main branch."
+          exit 1
+
   run-migrations:
+    needs: check-ref
     runs-on: ubuntu-latest
     environment: production
 
@@ -154,6 +164,7 @@ jobs:
 
   check-cloud-agent-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['cloud-agent'] }}
     steps:
@@ -178,6 +189,7 @@ jobs:
 
   check-cloud-agent-next-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['cloud-agent-next'] }}
     steps:
@@ -202,6 +214,7 @@ jobs:
 
   check-session-ingest-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['session-ingest'] }}
     steps:
@@ -228,6 +241,7 @@ jobs:
 
   check-o11y-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs.o11y }}
     steps:
@@ -254,6 +268,7 @@ jobs:
 
   check-git-token-service-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['git-token-service'] }}
     steps:
@@ -278,6 +293,7 @@ jobs:
 
   check-deployment-dispatcher-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['deployment-dispatcher'] }}
     steps:
@@ -302,6 +318,7 @@ jobs:
 
   check-deployment-builder-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['deployment-builder'] }}
     steps:
@@ -326,6 +343,7 @@ jobs:
 
   check-app-builder-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs['app-builder'] }}
     steps:
@@ -350,6 +368,7 @@ jobs:
 
   check-kiloclaw-changes:
     runs-on: ubuntu-latest
+    needs: check-ref
     outputs:
       changed: ${{ steps.changes.outputs.kiloclaw }}
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,7 @@ name: Deploy to Production
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: deploy-production
@@ -171,7 +172,7 @@ jobs:
 
   deploy-cloud-agent:
     needs: [check-cloud-agent-changes]
-    if: needs.check-cloud-agent-changes.outputs.changed == 'true'
+    if: needs.check-cloud-agent-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-cloud-agent.yml
     secrets: inherit
 
@@ -195,7 +196,7 @@ jobs:
 
   deploy-cloud-agent-next:
     needs: [check-cloud-agent-next-changes]
-    if: needs.check-cloud-agent-next-changes.outputs.changed == 'true'
+    if: needs.check-cloud-agent-next-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-cloud-agent-next.yml
     secrets: inherit
 
@@ -219,7 +220,7 @@ jobs:
 
   deploy-session-ingest:
     needs: [check-session-ingest-changes]
-    if: needs.check-session-ingest-changes.outputs.changed == 'true'
+    if: needs.check-session-ingest-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-session-ingest.yml
     secrets: inherit
     with:
@@ -245,7 +246,7 @@ jobs:
 
   deploy-o11y:
     needs: [check-o11y-changes]
-    if: needs.check-o11y-changes.outputs.changed == 'true'
+    if: needs.check-o11y-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-o11y.yml
     secrets: inherit
     with:
@@ -271,7 +272,7 @@ jobs:
 
   deploy-git-token-service:
     needs: [check-git-token-service-changes]
-    if: needs.check-git-token-service-changes.outputs.changed == 'true'
+    if: needs.check-git-token-service-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-git-token-service.yml
     secrets: inherit
 
@@ -295,7 +296,7 @@ jobs:
 
   deploy-deployment-dispatcher:
     needs: [check-deployment-dispatcher-changes]
-    if: needs.check-deployment-dispatcher-changes.outputs.changed == 'true'
+    if: needs.check-deployment-dispatcher-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-deployment-dispatcher.yml
     secrets: inherit
 
@@ -319,7 +320,7 @@ jobs:
 
   deploy-deployment-builder:
     needs: [check-deployment-builder-changes]
-    if: needs.check-deployment-builder-changes.outputs.changed == 'true'
+    if: needs.check-deployment-builder-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-deployment-builder.yml
     secrets: inherit
 
@@ -343,7 +344,7 @@ jobs:
 
   deploy-app-builder:
     needs: [check-app-builder-changes]
-    if: needs.check-app-builder-changes.outputs.changed == 'true'
+    if: needs.check-app-builder-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-app-builder.yml
     secrets: inherit
 
@@ -367,6 +368,6 @@ jobs:
 
   deploy-kiloclaw:
     needs: [check-kiloclaw-changes]
-    if: needs.check-kiloclaw-changes.outputs.changed == 'true'
+    if: needs.check-kiloclaw-changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/deploy-kiloclaw.yml
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Deploy to Production workflow, enabling manual deploys from the GitHub Actions UI
- Updates all conditionally-deployed sub-services to also run when triggered manually (`github.event_name == 'workflow_dispatch'`), since path-filter checks would otherwise skip them with no git diff context