### PR TITLE
fix: Make session ID visible by default in raw data table

### DIFF
--- a/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
@@ -13,6 +13,7 @@ import type {
 import { CopyJsonButton } from '@/components/admin/CopyJsonButton';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
@@ -372,10 +373,9 @@ export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
     return '';
   };
 
-  // Toggle column visibility
-  const toggleColumnVisibility = (columnKey: keyof UsageForTableDisplay) => {
+  const setColumnVisibility = (columnKey: keyof UsageForTableDisplay, visible: boolean) => {
     setColumns(prevColumns =>
-      prevColumns.map(col => (col.key === columnKey ? { ...col, visible: !col.visible } : col))
+      prevColumns.map(col => (col.key === columnKey ? { ...col, visible } : col))
     );
   };
 
@@ -544,20 +544,15 @@ export function UserAdminHeuristicAbuse({ id }: Pick<UserDetailProps, 'id'>) {
                 </DropdownMenuItem>
                 <div className="my-1 border-t"></div>
                 {columns.map(column => (
-                  <DropdownMenuItem
+                  <DropdownMenuCheckboxItem
                     key={String(column.key)}
-                    onClick={() => toggleColumnVisibility(column.key)}
+                    checked={column.visible}
+                    onCheckedChange={checked => {
+                      setColumnVisibility(column.key, checked === true);
+                    }}
                   >
-                    <label className="flex cursor-pointer items-center gap-2">
-                      <input
-                        type="checkbox"
-                        checked={column.visible}
-                        onChange={() => toggleColumnVisibility(column.key)}
-                        className="h-4 w-4"
-                      />
-                      <span className="text-sm">{column.title}</span>
-                    </label>
-                  </DropdownMenuItem>
+                    <span className="text-sm">{column.title}</span>
+                  </DropdownMenuCheckboxItem>
                 ))}
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminHeuristicAbuse.tsx
@@ -289,7 +289,7 @@ const createMicrodollarUsageColumns = (): TableColumn<UsageForTableDisplay>[] =>
     key: 'session_id',
     title: 'Session',
     render: row => row.session_id || 'N/A',
-    visible: false,
+    visible: true,
   },
   {
     key: 'upstream_id',


### PR DESCRIPTION
Followup for https://github.com/Kilo-Org/cloud/pull/398

The data is coming from API, but users need to select it from the columns dropdown to make it visible

Fix the columns selection too:

## Before

https://github.com/user-attachments/assets/987e047c-4459-4679-811d-626d0eb0f308

**Note**: it works currently if you click on the label, not the checkbox

## After

https://github.com/user-attachments/assets/d854b06c-a581-4871-bcde-02aba45c33e5

