### PR TITLE
fix: filter getInstallation to only return active integrations in Discord and Slack services

### DIFF
--- a/src/lib/integrations/discord-service.ts
+++ b/src/lib/integrations/discord-service.ts
@@ -112,7 +112,11 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
     .select()
     .from(platform_integrations)
     .where(
-      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DISCORD))
+      and(
+        ...getOwnershipConditions(owner),
+        eq(platform_integrations.platform, PLATFORM.DISCORD),
+        eq(platform_integrations.integration_status, INTEGRATION_STATUS.ACTIVE)
+      )
     )
     .limit(1);
 
@@ -166,7 +170,14 @@ export async function upsertDiscordInstallation(
     );
   }
 
-  const existing = await getInstallation(owner);
+  // Find existing integration regardless of status so we update rather than create duplicates
+  const [existing] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DISCORD))
+    )
+    .limit(1);
 
   const guildId = oauthResponse.guild.id;
   const guildName = oauthResponse.guild.name || 'Unknown Server';
@@ -222,7 +233,7 @@ export async function upsertDiscordInstallation(
 export async function uninstallApp(owner: Owner) {
   const integration = await getInstallation(owner);
 
-  if (!integration || integration.integration_status !== INTEGRATION_STATUS.ACTIVE) {
+  if (!integration) {
     throw new TRPCError({
       code: 'NOT_FOUND',
       message: 'Discord installation not found',
@@ -239,7 +250,14 @@ export async function uninstallApp(owner: Owner) {
  * Useful for development when you want to re-test the OAuth flow.
  */
 export async function removeDbRowOnly(owner: Owner) {
-  const integration = await getInstallation(owner);
+  // Find integration regardless of status since this is a dev utility for cleaning up DB rows
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DISCORD))
+    )
+    .limit(1);
 
   if (!integration) {
     throw new TRPCError({

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -131,7 +131,11 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
     .select()
     .from(platform_integrations)
     .where(
-      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.SLACK))
+      and(
+        ...getOwnershipConditions(owner),
+        eq(platform_integrations.platform, PLATFORM.SLACK),
+        eq(platform_integrations.integration_status, INTEGRATION_STATUS.ACTIVE)
+      )
     )
     .limit(1);
 
@@ -177,7 +181,14 @@ export async function upsertSlackInstallation(
   owner: Owner,
   oauthResponse: OAuthV2Response
 ): Promise<PlatformIntegration> {
-  const existing = await getInstallation(owner);
+  // Find existing integration regardless of status so we update rather than create duplicates
+  const [existing] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.SLACK))
+    )
+    .limit(1);
 
   const teamId = oauthResponse.team?.id || '';
   const teamName = oauthResponse.team?.name || 'Unknown Team';
@@ -246,7 +257,7 @@ export async function upsertSlackInstallation(
 export async function uninstallApp(owner: Owner) {
   const integration = await getInstallation(owner);
 
-  if (!integration || integration.integration_status !== INTEGRATION_STATUS.ACTIVE) {
+  if (!integration) {
     throw new TRPCError({
       code: 'NOT_FOUND',
       message: 'Slack installation not found',
@@ -274,7 +285,14 @@ export async function uninstallApp(owner: Owner) {
  * having to re-install the app in Slack.
  */
 export async function removeDbRowOnly(owner: Owner) {
-  const integration = await getInstallation(owner);
+  // Find integration regardless of status since this is a dev utility for cleaning up DB rows
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.SLACK))
+    )
+    .limit(1);
 
   if (!integration) {
     throw new TRPCError({


### PR DESCRIPTION
## Summary

- Adds `integration_status = ACTIVE` filter to `getInstallation` in both `discord-service.ts` and `slack-service.ts`, consistent with the existing pattern in `gitlab-service.ts` and `github-apps-service.ts`.
- Updates `upsertSlackInstallation` and `removeDbRowOnly` in the Slack service to use their own unfiltered queries, since they need to find integrations regardless of status (to avoid creating duplicates during re-activation, and to support dev cleanup respectively).

## Why

Without the active filter, `getInstallation` could return pending or suspended integrations to callers like `testConnection`, `sendMessage`, `updateModel`, etc., which should only operate on active integrations.