### PR TITLE
fix: resolve React hooks violations in integration providers

### DIFF
--- a/src/app/(app)/integrations/IntegrationsPageClient.tsx
+++ b/src/app/(app)/integrations/IntegrationsPageClient.tsx
@@ -8,33 +8,21 @@ import {
 } from '@/lib/integrations/platform-definitions';
 import { Card, CardContent } from '@/components/ui/card';
 import { UserGitHubAppsProvider } from '@/components/integrations/UserGitHubAppsProvider';
-import { useGitHubAppsQueries } from '@/components/integrations/GitHubAppsContext';
+import { useGitHubAppsInstallation } from '@/components/integrations/GitHubAppsContext';
 import { UserSlackProvider } from '@/components/integrations/UserSlackProvider';
-import { useSlackQueries } from '@/components/integrations/SlackContext';
+import { useSlackInstallation } from '@/components/integrations/SlackContext';
 import { UserDiscordProvider } from '@/components/integrations/UserDiscordProvider';
-import { useDiscordQueries } from '@/components/integrations/DiscordContext';
+import { useDiscordInstallation } from '@/components/integrations/DiscordContext';
 import { UserGitLabProvider } from '@/components/integrations/UserGitLabProvider';
-import { useGitLabQueries } from '@/components/integrations/GitLabContext';
+import { useGitLabInstallation } from '@/components/integrations/GitLabContext';
 import { PageContainer } from '@/components/layouts/PageContainer';
 
 function IntegrationsPageContent() {
   const router = useRouter();
-  const { queries: githubQueries } = useGitHubAppsQueries();
-  const { queries: slackQueries } = useSlackQueries();
-  const { queries: discordQueries } = useDiscordQueries();
-  const { queries: gitlabQueries } = useGitLabQueries();
-
-  // Fetch GitHub App installation status
-  const { data: githubInstallation, isLoading: githubLoading } = githubQueries.getInstallation();
-
-  // Fetch Slack installation status
-  const { data: slackInstallation, isLoading: slackLoading } = slackQueries.getInstallation();
-
-  // Fetch Discord installation status
-  const { data: discordInstallation, isLoading: discordLoading } = discordQueries.getInstallation();
-
-  // Fetch GitLab installation status
-  const { data: gitlabInstallation, isLoading: gitlabLoading } = gitlabQueries.getInstallation();
+  const { data: githubInstallation, isLoading: githubLoading } = useGitHubAppsInstallation();
+  const { data: slackInstallation, isLoading: slackLoading } = useSlackInstallation();
+  const { data: discordInstallation, isLoading: discordLoading } = useDiscordInstallation();
+  const { data: gitlabInstallation, isLoading: gitlabLoading } = useGitLabInstallation();
 
   const isLoading = githubLoading || slackLoading || discordLoading || gitlabLoading;
 

--- a/src/app/(app)/organizations/[id]/integrations/IntegrationsPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/integrations/IntegrationsPageClient.tsx
@@ -8,13 +8,13 @@ import {
 } from '@/lib/integrations/platform-definitions';
 import { Card, CardContent } from '@/components/ui/card';
 import { OrgGitHubAppsProvider } from '@/components/integrations/OrgGitHubAppsProvider';
-import { useGitHubAppsQueries } from '@/components/integrations/GitHubAppsContext';
+import { useGitHubAppsInstallation } from '@/components/integrations/GitHubAppsContext';
 import { OrgSlackProvider } from '@/components/integrations/OrgSlackProvider';
-import { useSlackQueries } from '@/components/integrations/SlackContext';
+import { useSlackInstallation } from '@/components/integrations/SlackContext';
 import { OrgDiscordProvider } from '@/components/integrations/OrgDiscordProvider';
-import { useDiscordQueries } from '@/components/integrations/DiscordContext';
+import { useDiscordInstallation } from '@/components/integrations/DiscordContext';
 import { OrgGitLabProvider } from '@/components/integrations/OrgGitLabProvider';
-import { useGitLabQueries } from '@/components/integrations/GitLabContext';
+import { useGitLabInstallation } from '@/components/integrations/GitLabContext';
 
 type IntegrationsPageClientProps = {
   organizationId: string;
@@ -22,22 +22,10 @@ type IntegrationsPageClientProps = {
 
 function IntegrationsPageContent({ organizationId }: IntegrationsPageClientProps) {
   const router = useRouter();
-  const { queries: githubQueries } = useGitHubAppsQueries();
-  const { queries: slackQueries } = useSlackQueries();
-  const { queries: discordQueries } = useDiscordQueries();
-  const { queries: gitlabQueries } = useGitLabQueries();
-
-  // Fetch GitHub App installation status
-  const { data: githubInstallation, isLoading: githubLoading } = githubQueries.getInstallation();
-
-  // Fetch Slack installation status
-  const { data: slackInstallation, isLoading: slackLoading } = slackQueries.getInstallation();
-
-  // Fetch Discord installation status
-  const { data: discordInstallation, isLoading: discordLoading } = discordQueries.getInstallation();
-
-  // Fetch GitLab installation status
-  const { data: gitlabInstallation, isLoading: gitlabLoading } = gitlabQueries.getInstallation();
+  const { data: githubInstallation, isLoading: githubLoading } = useGitHubAppsInstallation();
+  const { data: slackInstallation, isLoading: slackLoading } = useSlackInstallation();
+  const { data: discordInstallation, isLoading: discordLoading } = useDiscordInstallation();
+  const { data: gitlabInstallation, isLoading: gitlabLoading } = useGitLabInstallation();
 
   const isLoading = githubLoading || slackLoading || discordLoading || gitlabLoading;
 

--- a/src/components/deployments/NewDeploymentDialog.tsx
+++ b/src/components/deployments/NewDeploymentDialog.tsx
@@ -39,7 +39,11 @@ import {
 } from './PasswordFormFields';
 import Link from 'next/link';
 import { useDeploymentQueries } from './DeploymentContext';
-import { useGitHubAppsQueries } from '@/components/integrations/GitHubAppsContext';
+import {
+  useGitHubAppsIntegrations,
+  useGitHubAppsRepositories,
+  useGitHubAppsBranches,
+} from '@/components/integrations/GitHubAppsContext';
 import { envVarKeySchema } from '@/lib/user-deployments/env-vars-validation';
 
 type NewDeploymentDialogProps = {
@@ -76,7 +80,6 @@ export function NewDeploymentDialog({
   });
 
   const { queries: deploymentQueries, mutations } = useDeploymentQueries();
-  const { queries: gitHubQueries } = useGitHubAppsQueries();
 
   // Check if password features are available (org-only)
   const hasPasswordFeature = !!mutations.setPassword;
@@ -92,7 +95,7 @@ export function NewDeploymentDialog({
     data: integrations,
     isLoading: isLoadingIntegration,
     error: integrationError,
-  } = gitHubQueries.listIntegrations();
+  } = useGitHubAppsIntegrations();
 
   // Get the selected integration
   const selectedIntegration = integrations?.find(i => i.id === selectedIntegrationId);
@@ -102,14 +105,14 @@ export function NewDeploymentDialog({
     data: repositories,
     isLoading: isLoadingRepositories,
     error: repositoriesError,
-  } = gitHubQueries.listRepositories(selectedIntegrationId);
+  } = useGitHubAppsRepositories(selectedIntegrationId);
 
   // Query branches for the selected repository
   const {
     data: branchesData,
     isLoading: isLoadingBranches,
     error: branchesError,
-  } = gitHubQueries.listBranches(selectedIntegrationId, selectedRepository);
+  } = useGitHubAppsBranches(selectedIntegrationId, selectedRepository);
 
   // Transform repositories to match RepositoryOption format
   const repositoryOptions: RepositoryOption[] =

--- a/src/components/integrations/DiscordContext.tsx
+++ b/src/components/integrations/DiscordContext.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { createContext, useContext, type ReactNode } from 'react';
-import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
 
@@ -28,9 +29,17 @@ type DiscordTestConnectionResult = {
   error?: string;
 };
 
-export type DiscordQueries = {
-  getInstallation: () => UseQueryResult<DiscordInstallationResult, DiscordError>;
-  getOAuthUrl: () => UseQueryResult<DiscordOAuthUrlResult, DiscordError>;
+/**
+ * Query options are typed loosely to accommodate TRPC's specific queryOptions return types,
+ * which are structurally compatible with useQuery but not assignable to UseQueryOptions.
+ * Type safety is enforced at the hook level via useQuery's return type inference.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CompatibleQueryOptions = Parameters<typeof useQuery<any, any, any, any>>[0];
+
+export type DiscordQueryOptions = {
+  getInstallation: CompatibleQueryOptions;
+  getOAuthUrl: CompatibleQueryOptions;
 };
 
 export type DiscordMutations = {
@@ -40,37 +49,53 @@ export type DiscordMutations = {
 };
 
 type DiscordContextValue = {
-  queries: DiscordQueries;
+  queryOptions: DiscordQueryOptions;
   mutations: DiscordMutations;
 };
 
 const DiscordContext = createContext<DiscordContextValue | null>(null);
 
-/**
- * Hook to access Discord queries and mutations from context
- * Must be used within a DiscordProvider
- */
-export function useDiscordQueries() {
+function useDiscordContext() {
   const context = useContext(DiscordContext);
   if (!context) {
-    throw new Error('useDiscordQueries must be used within a DiscordProvider');
+    throw new Error('Discord hooks must be used within a DiscordProvider');
   }
   return context;
 }
 
+/** Hook to access Discord installation query */
+export function useDiscordInstallation() {
+  const { queryOptions } = useDiscordContext();
+  return useQuery<DiscordInstallationResult, DiscordError>(queryOptions.getInstallation);
+}
+
+/** Hook to access Discord OAuth URL query */
+export function useDiscordOAuthUrl() {
+  const { queryOptions } = useDiscordContext();
+  return useQuery<DiscordOAuthUrlResult, DiscordError>(queryOptions.getOAuthUrl);
+}
+
+/** Hook to access Discord mutations */
+export function useDiscordMutations() {
+  const { mutations } = useDiscordContext();
+  return mutations;
+}
+
 /**
- * Base provider component that accepts queries and mutations
+ * Base provider component that accepts query options and mutations
  */
 export function DiscordProvider({
-  queries,
+  queryOptions,
   mutations,
   children,
 }: {
-  queries: DiscordQueries;
+  queryOptions: DiscordQueryOptions;
   mutations: DiscordMutations;
   children: ReactNode;
 }) {
   return (
-    <DiscordContext.Provider value={{ queries, mutations }}>{children}</DiscordContext.Provider>
+    <DiscordContext.Provider value={{ queryOptions, mutations }}>
+      {children}
+    </DiscordContext.Provider>
   );
 }

--- a/src/components/integrations/DiscordIntegrationDetails.tsx
+++ b/src/components/integrations/DiscordIntegrationDetails.tsx
@@ -7,7 +7,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { CheckCircle2, XCircle, MessageSquare, Settings, ExternalLink, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect } from 'react';
-import { useDiscordQueries } from './DiscordContext';
+import { useDiscordInstallation, useDiscordOAuthUrl, useDiscordMutations } from './DiscordContext';
 import { IS_DEVELOPMENT } from '@/lib/constants';
 
 type DiscordIntegrationDetailsProps = {
@@ -17,13 +17,9 @@ type DiscordIntegrationDetailsProps = {
 };
 
 export function DiscordIntegrationDetails({ success, error }: DiscordIntegrationDetailsProps) {
-  const { queries, mutations } = useDiscordQueries();
-
-  // Fetch Discord installation status
-  const { data: installationData, isLoading, refetch } = queries.getInstallation();
-
-  // Get OAuth URL for installation
-  const { data: oauthUrlData } = queries.getOAuthUrl();
+  const { data: installationData, isLoading, refetch } = useDiscordInstallation();
+  const { data: oauthUrlData } = useDiscordOAuthUrl();
+  const mutations = useDiscordMutations();
 
   // Show success/error toasts
   useEffect(() => {

--- a/src/components/integrations/GitHubAppsContext.tsx
+++ b/src/components/integrations/GitHubAppsContext.tsx
@@ -1,42 +1,90 @@
 'use client';
 
 import { createContext, useContext, type ReactNode } from 'react';
-import type { IntegrationQueries, IntegrationMutations } from '@/lib/integrations/router-types';
+import { useQuery } from '@tanstack/react-query';
+import type {
+  IntegrationQueryOptions,
+  IntegrationMutations,
+  IntegrationError,
+  InstallationResponse,
+  PendingCheckResponse,
+  ListRepositoriesResponse,
+  ListBranchesResponse,
+} from '@/lib/integrations/router-types';
+import type { PlatformIntegration } from '@/db/schema';
 
 type GitHubAppsContextValue = {
-  queries: IntegrationQueries;
+  queryOptions: IntegrationQueryOptions;
   mutations: IntegrationMutations;
 };
 
 const GitHubAppsContext = createContext<GitHubAppsContextValue | null>(null);
 
-/**
- * Hook to access GitHub Apps queries and mutations from context
- * Must be used within a GitHubAppsProvider
- */
-export function useGitHubAppsQueries() {
+function useGitHubAppsContext() {
   const context = useContext(GitHubAppsContext);
   if (!context) {
-    throw new Error('useGitHubAppsQueries must be used within a GitHubAppsProvider');
+    throw new Error('GitHub Apps hooks must be used within a GitHubAppsProvider');
   }
   return context;
 }
 
+/** Hook to access GitHub Apps installation query */
+export function useGitHubAppsInstallation() {
+  const { queryOptions } = useGitHubAppsContext();
+  return useQuery<InstallationResponse, IntegrationError>(queryOptions.getInstallation);
+}
+
+/** Hook to check for pending installation */
+export function useGitHubAppsPendingInstallation() {
+  const { queryOptions } = useGitHubAppsContext();
+  return useQuery<PendingCheckResponse, IntegrationError>(
+    queryOptions.checkUserPendingInstallation
+  );
+}
+
+/** Hook to list integrations */
+export function useGitHubAppsIntegrations() {
+  const { queryOptions } = useGitHubAppsContext();
+  return useQuery<PlatformIntegration[], IntegrationError>(queryOptions.listIntegrations);
+}
+
+/** Hook to list repositories for an integration */
+export function useGitHubAppsRepositories(integrationId: string, forceRefresh?: boolean) {
+  const { queryOptions } = useGitHubAppsContext();
+  return useQuery<ListRepositoriesResponse, IntegrationError>(
+    queryOptions.listRepositories(integrationId, forceRefresh)
+  );
+}
+
+/** Hook to list branches for a repository */
+export function useGitHubAppsBranches(integrationId: string, repositoryFullName: string) {
+  const { queryOptions } = useGitHubAppsContext();
+  return useQuery<ListBranchesResponse, IntegrationError>(
+    queryOptions.listBranches(integrationId, repositoryFullName)
+  );
+}
+
+/** Hook to access GitHub Apps mutations */
+export function useGitHubAppsMutations() {
+  const { mutations } = useGitHubAppsContext();
+  return mutations;
+}
+
 /**
- * Base provider component that accepts queries and mutations
+ * Base provider component that accepts query options and mutations
  * This is used by specific implementations (UserGitHubAppsProvider, OrgGitHubAppsProvider)
  */
 export function GitHubAppsProvider({
-  queries,
+  queryOptions,
   mutations,
   children,
 }: {
-  queries: IntegrationQueries;
+  queryOptions: IntegrationQueryOptions;
   mutations: IntegrationMutations;
   children: ReactNode;
 }) {
   return (
-    <GitHubAppsContext.Provider value={{ queries, mutations }}>
+    <GitHubAppsContext.Provider value={{ queryOptions, mutations }}>
       {children}
     </GitHubAppsContext.Provider>
   );

--- a/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -7,7 +7,11 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { CheckCircle2, XCircle, GitBranch, Settings, ExternalLink, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect, useMemo } from 'react';
-import { useGitHubAppsQueries } from './GitHubAppsContext';
+import {
+  useGitHubAppsInstallation,
+  useGitHubAppsPendingInstallation,
+  useGitHubAppsMutations,
+} from './GitHubAppsContext';
 import { useUser } from '@/hooks/useUser';
 import { DevAddGitHubInstallationCard } from './DevAddGitHubInstallationCard';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
@@ -28,7 +32,7 @@ export function GitHubIntegrationDetails({
   pendingApproval,
   existingPendingOrg,
 }: GitHubIntegrationDetailsProps) {
-  const { queries, mutations } = useGitHubAppsQueries();
+  const mutations = useGitHubAppsMutations();
 
   // Fetch organization data to check GitHub app type
   const { data: organizationData } = useOrganizationWithMembers(organizationId ?? '', {
@@ -45,10 +49,10 @@ export function GitHubIntegrationDetails({
   }, [organizationData?.settings?.github_app_type]);
 
   // Fetch GitHub App installation status
-  const { data: installationData, isLoading, refetch } = queries.getInstallation();
+  const { data: installationData, isLoading, refetch } = useGitHubAppsInstallation();
 
   // Check if user has pending installation in another org
-  const { data: pendingCheck } = queries.checkUserPendingInstallation();
+  const { data: pendingCheck } = useGitHubAppsPendingInstallation();
 
   // Show success/error/pending toasts
   useEffect(() => {

--- a/src/components/integrations/GitLabContext.tsx
+++ b/src/components/integrations/GitLabContext.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { createContext, useContext, type ReactNode } from 'react';
-import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
 import type { PlatformRepository } from '@/lib/integrations/core/types';
@@ -19,20 +20,20 @@ type GitLabInstallation = {
   tokenExpiresAt: string | null;
 };
 
-type GitLabInstallationResult = {
+export type GitLabInstallationResult = {
   installed: boolean;
   installation: GitLabInstallation | null;
 };
 
-type GitLabInstallationQueryResult_Full = UseQueryResult<GitLabInstallationResult, GitLabError>;
-// Pick only the properties we actually use to avoid excessive re-renders from observing all query changes
-type GitLabInstallationQueryResult = Pick<
-  GitLabInstallationQueryResult_Full,
-  'data' | 'status' | 'isPending' | 'isLoading' | 'isError' | 'error'
->;
+/**
+ * Query options are typed loosely to accommodate TRPC's specific queryOptions return types.
+ * Type safety is enforced at the hook level via useQuery's return type inference.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CompatibleQueryOptions = Parameters<typeof useQuery<any, any, any, any>>[0];
 
-export type GitLabQueries = {
-  getInstallation: () => GitLabInstallationQueryResult;
+export type GitLabQueryOptions = {
+  getInstallation: CompatibleQueryOptions;
 };
 
 export type GitLabMutations = {
@@ -45,35 +46,45 @@ export type GitLabMutations = {
 };
 
 type GitLabContextValue = {
-  queries: GitLabQueries;
+  queryOptions: GitLabQueryOptions;
   mutations: GitLabMutations;
 };
 
 const GitLabContext = createContext<GitLabContextValue | null>(null);
 
-/**
- * Hook to access GitLab queries and mutations from context
- * Must be used within a GitLabProvider
- */
-export function useGitLabQueries() {
+function useGitLabContext() {
   const context = useContext(GitLabContext);
   if (!context) {
-    throw new Error('useGitLabQueries must be used within a GitLabProvider');
+    throw new Error('GitLab hooks must be used within a GitLabProvider');
   }
   return context;
 }
 
+/** Hook to access GitLab installation query */
+export function useGitLabInstallation() {
+  const { queryOptions } = useGitLabContext();
+  return useQuery<GitLabInstallationResult, GitLabError>(queryOptions.getInstallation);
+}
+
+/** Hook to access GitLab mutations */
+export function useGitLabMutations() {
+  const { mutations } = useGitLabContext();
+  return mutations;
+}
+
 /**
- * Base provider component that accepts queries and mutations
+ * Base provider component that accepts query options and mutations
  */
 export function GitLabProvider({
-  queries,
+  queryOptions,
   mutations,
   children,
 }: {
-  queries: GitLabQueries;
+  queryOptions: GitLabQueryOptions;
   mutations: GitLabMutations;
   children: ReactNode;
 }) {
-  return <GitLabContext.Provider value={{ queries, mutations }}>{children}</GitLabContext.Provider>;
+  return (
+    <GitLabContext.Provider value={{ queryOptions, mutations }}>{children}</GitLabContext.Provider>
+  );
 }

--- a/src/components/integrations/GitLabIntegrationDetails.tsx
+++ b/src/components/integrations/GitLabIntegrationDetails.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect, useState, useRef } from 'react';
-import { useGitLabQueries } from './GitLabContext';
+import { useGitLabInstallation, useGitLabMutations } from './GitLabContext';
 import { useMutation } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 
@@ -89,7 +89,7 @@ export function GitLabIntegrationDetails({
     showSelfHosted && instanceUrl && instanceUrl !== 'https://gitlab.com' && instanceUrl !== ''
   );
 
-  const { queries, mutations } = useGitLabQueries();
+  const mutations = useGitLabMutations();
 
   // Instance validation mutation (shared between OAuth and PAT)
   const { mutate: validateInstanceMutate } = useMutation(
@@ -233,7 +233,7 @@ export function GitLabIntegrationDetails({
     };
   }, [instanceUrl, isSelfHostedInput, validateInstanceMutate]);
 
-  const { data: installationData, isLoading } = queries.getInstallation();
+  const { data: installationData, isLoading } = useGitLabInstallation();
 
   const isDisconnecting = mutations.disconnect.isPending;
 

--- a/src/components/integrations/OrgDiscordProvider.tsx
+++ b/src/components/integrations/OrgDiscordProvider.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { DiscordProvider, type DiscordQueries, type DiscordMutations } from './DiscordContext';
+import { DiscordProvider, type DiscordQueryOptions, type DiscordMutations } from './DiscordContext';
 
 type OrgDiscordProviderProps = {
   organizationId: string;
@@ -14,11 +14,9 @@ export function OrgDiscordProvider({ organizationId, children }: OrgDiscordProvi
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: DiscordQueries = {
-    getInstallation: () =>
-      useQuery(trpc.organizations.discord.getInstallation.queryOptions({ organizationId })),
-    getOAuthUrl: () =>
-      useQuery(trpc.organizations.discord.getOAuthUrl.queryOptions({ organizationId })),
+  const queryOptions: DiscordQueryOptions = {
+    getInstallation: trpc.organizations.discord.getInstallation.queryOptions({ organizationId }),
+    getOAuthUrl: trpc.organizations.discord.getOAuthUrl.queryOptions({ organizationId }),
   };
 
   const uninstallAppMutation = useMutation(
@@ -87,7 +85,7 @@ export function OrgDiscordProvider({ organizationId, children }: OrgDiscordProvi
   };
 
   return (
-    <DiscordProvider queries={queries} mutations={mutations}>
+    <DiscordProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </DiscordProvider>
   );

--- a/src/components/integrations/OrgGitHubAppsProvider.tsx
+++ b/src/components/integrations/OrgGitHubAppsProvider.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { GitHubAppsProvider } from './GitHubAppsContext';
-import type { IntegrationQueries, IntegrationMutations } from '@/lib/integrations/router-types';
+import type {
+  IntegrationQueryOptions,
+  IntegrationMutations,
+} from '@/lib/integrations/router-types';
 
 type OrgGitHubAppsProviderProps = {
   organizationId: string;
@@ -15,39 +18,35 @@ export function OrgGitHubAppsProvider({ organizationId, children }: OrgGitHubApp
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: IntegrationQueries = {
-    listIntegrations: () =>
-      useQuery(
-        trpc.organizations.githubApps.listIntegrations.queryOptions({ organizationId })
-      ) as IntegrationQueries['listIntegrations'] extends () => infer R ? R : never,
+  const queryOptions: IntegrationQueryOptions = {
+    listIntegrations: trpc.organizations.githubApps.listIntegrations.queryOptions({
+      organizationId,
+    }),
 
-    getInstallation: () =>
-      useQuery(trpc.organizations.githubApps.getInstallation.queryOptions({ organizationId })),
+    getInstallation: trpc.organizations.githubApps.getInstallation.queryOptions({
+      organizationId,
+    }),
 
-    checkUserPendingInstallation: () =>
-      useQuery(
-        trpc.organizations.githubApps.checkUserPendingInstallation.queryOptions({ organizationId })
-      ),
+    checkUserPendingInstallation:
+      trpc.organizations.githubApps.checkUserPendingInstallation.queryOptions({ organizationId }),
 
-    listRepositories: (integrationId: string, forceRefresh?: boolean) =>
-      useQuery({
-        ...trpc.organizations.githubApps.listRepositories.queryOptions({
-          organizationId,
-          integrationId,
-          forceRefresh: forceRefresh ?? false,
-        }),
-        enabled: !!integrationId,
+    listRepositories: (integrationId: string, forceRefresh?: boolean) => ({
+      ...trpc.organizations.githubApps.listRepositories.queryOptions({
+        organizationId,
+        integrationId,
+        forceRefresh: forceRefresh ?? false,
       }),
+      enabled: !!integrationId,
+    }),
 
-    listBranches: (integrationId: string, repositoryFullName: string) =>
-      useQuery({
-        ...trpc.organizations.githubApps.listBranches.queryOptions({
-          organizationId,
-          integrationId,
-          repositoryFullName,
-        }),
-        enabled: !!integrationId && !!repositoryFullName,
+    listBranches: (integrationId: string, repositoryFullName: string) => ({
+      ...trpc.organizations.githubApps.listBranches.queryOptions({
+        organizationId,
+        integrationId,
+        repositoryFullName,
       }),
+      enabled: !!integrationId && !!repositoryFullName,
+    }),
   };
 
   // Base mutations from TRPC
@@ -135,7 +134,7 @@ export function OrgGitHubAppsProvider({ organizationId, children }: OrgGitHubApp
   };
 
   return (
-    <GitHubAppsProvider queries={queries} mutations={mutations}>
+    <GitHubAppsProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </GitHubAppsProvider>
   );

--- a/src/components/integrations/OrgGitLabProvider.tsx
+++ b/src/components/integrations/OrgGitLabProvider.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { GitLabProvider, type GitLabMutations } from './GitLabContext';
+import { GitLabProvider, type GitLabQueryOptions, type GitLabMutations } from './GitLabContext';
 
 type OrgGitLabProviderProps = {
   organizationId: string;
@@ -14,37 +14,36 @@ export function OrgGitLabProvider({ organizationId, children }: OrgGitLabProvide
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  // Note: Casting the queries to the expected types since the underlying
-  // tRPC types are compatible but TypeScript cannot infer this automatically
-  const queries = {
-    getInstallation: () => {
-      const query = useQuery(trpc.gitlab.getIntegration.queryOptions({ organizationId }));
-      // The data transformation happens at runtime, the whole result is casted
-      const transformedData = query.data
-        ? {
-            installed: query.data.connected,
-            installation: query.data.integration
-              ? {
-                  id: query.data.integration.id,
-                  accountId: query.data.integration.accountId,
-                  accountLogin: query.data.integration.accountLogin,
-                  instanceUrl: query.data.integration.instanceUrl,
-                  repositories: query.data.integration.repositories,
-                  repositoriesSyncedAt: query.data.integration.repositoriesSyncedAt,
-                  installedAt: query.data.integration.installedAt,
-                  tokenExpiresAt: query.data.integration.tokenExpiresAt ?? null,
-                }
-              : null,
-          }
-        : undefined;
-      return {
-        data: transformedData,
-        status: query.status,
-        isPending: query.isPending,
-        isLoading: query.isLoading,
-        isError: query.isError,
-        error: query.error,
-      };
+  const queryOptions: GitLabQueryOptions = {
+    getInstallation: {
+      ...trpc.gitlab.getIntegration.queryOptions({ organizationId }),
+      select: (data: {
+        connected: boolean;
+        integration: {
+          id: string;
+          accountId: string | null;
+          accountLogin: string | null;
+          instanceUrl: string;
+          repositories: import('@/lib/integrations/core/types').PlatformRepository[] | null;
+          repositoriesSyncedAt: string | null;
+          installedAt: string;
+          tokenExpiresAt: string | null;
+        } | null;
+      }) => ({
+        installed: data.connected,
+        installation: data.integration
+          ? {
+              id: data.integration.id,
+              accountId: data.integration.accountId,
+              accountLogin: data.integration.accountLogin,
+              instanceUrl: data.integration.instanceUrl,
+              repositories: data.integration.repositories,
+              repositoriesSyncedAt: data.integration.repositoriesSyncedAt,
+              installedAt: data.integration.installedAt,
+              tokenExpiresAt: data.integration.tokenExpiresAt ?? null,
+            }
+          : null,
+      }),
     },
   };
 
@@ -106,7 +105,7 @@ export function OrgGitLabProvider({ organizationId, children }: OrgGitLabProvide
   };
 
   return (
-    <GitLabProvider queries={queries} mutations={mutations}>
+    <GitLabProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </GitLabProvider>
   );

--- a/src/components/integrations/OrgSlackProvider.tsx
+++ b/src/components/integrations/OrgSlackProvider.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { SlackProvider, type SlackQueries, type SlackMutations } from './SlackContext';
+import { SlackProvider, type SlackQueryOptions, type SlackMutations } from './SlackContext';
 
 type OrgSlackProviderProps = {
   organizationId: string;
@@ -14,11 +14,9 @@ export function OrgSlackProvider({ organizationId, children }: OrgSlackProviderP
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: SlackQueries = {
-    getInstallation: () =>
-      useQuery(trpc.organizations.slack.getInstallation.queryOptions({ organizationId })),
-    getOAuthUrl: () =>
-      useQuery(trpc.organizations.slack.getOAuthUrl.queryOptions({ organizationId })),
+  const queryOptions: SlackQueryOptions = {
+    getInstallation: trpc.organizations.slack.getInstallation.queryOptions({ organizationId }),
+    getOAuthUrl: trpc.organizations.slack.getOAuthUrl.queryOptions({ organizationId }),
   };
 
   const uninstallAppMutation = useMutation(
@@ -133,7 +131,7 @@ export function OrgSlackProvider({ organizationId, children }: OrgSlackProviderP
   };
 
   return (
-    <SlackProvider queries={queries} mutations={mutations}>
+    <SlackProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </SlackProvider>
   );

--- a/src/components/integrations/SlackContext.tsx
+++ b/src/components/integrations/SlackContext.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { createContext, useContext, type ReactNode } from 'react';
-import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
 
-// Use the same error type pattern as GitHub integration
 type SlackError = TRPCClientErrorLike<AnyRouter>;
 
 type SlackInstallation = {
@@ -41,9 +41,16 @@ type SlackUpdateModelResult = {
   error?: string;
 };
 
-export type SlackQueries = {
-  getInstallation: () => UseQueryResult<SlackInstallationResult, SlackError>;
-  getOAuthUrl: () => UseQueryResult<SlackOAuthUrlResult, SlackError>;
+/**
+ * Query options are typed loosely to accommodate TRPC's specific queryOptions return types.
+ * Type safety is enforced at the hook level via useQuery's return type inference.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CompatibleQueryOptions = Parameters<typeof useQuery<any, any, any, any>>[0];
+
+export type SlackQueryOptions = {
+  getInstallation: CompatibleQueryOptions;
+  getOAuthUrl: CompatibleQueryOptions;
 };
 
 export type SlackMutations = {
@@ -55,35 +62,51 @@ export type SlackMutations = {
 };
 
 type SlackContextValue = {
-  queries: SlackQueries;
+  queryOptions: SlackQueryOptions;
   mutations: SlackMutations;
 };
 
 const SlackContext = createContext<SlackContextValue | null>(null);
 
-/**
- * Hook to access Slack queries and mutations from context
- * Must be used within a SlackProvider
- */
-export function useSlackQueries() {
+function useSlackContext() {
   const context = useContext(SlackContext);
   if (!context) {
-    throw new Error('useSlackQueries must be used within a SlackProvider');
+    throw new Error('Slack hooks must be used within a SlackProvider');
   }
   return context;
 }
 
+/** Hook to access Slack installation query */
+export function useSlackInstallation() {
+  const { queryOptions } = useSlackContext();
+  return useQuery<SlackInstallationResult, SlackError>(queryOptions.getInstallation);
+}
+
+/** Hook to access Slack OAuth URL query */
+export function useSlackOAuthUrl() {
+  const { queryOptions } = useSlackContext();
+  return useQuery<SlackOAuthUrlResult, SlackError>(queryOptions.getOAuthUrl);
+}
+
+/** Hook to access Slack mutations */
+export function useSlackMutations() {
+  const { mutations } = useSlackContext();
+  return mutations;
+}
+
 /**
- * Base provider component that accepts queries and mutations
+ * Base provider component that accepts query options and mutations
  */
 export function SlackProvider({
-  queries,
+  queryOptions,
   mutations,
   children,
 }: {
-  queries: SlackQueries;
+  queryOptions: SlackQueryOptions;
   mutations: SlackMutations;
   children: ReactNode;
 }) {
-  return <SlackContext.Provider value={{ queries, mutations }}>{children}</SlackContext.Provider>;
+  return (
+    <SlackContext.Provider value={{ queryOptions, mutations }}>{children}</SlackContext.Provider>
+  );
 }

--- a/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/src/components/integrations/SlackIntegrationDetails.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect, useMemo, useState } from 'react';
-import { useSlackQueries } from './SlackContext';
+import { useSlackInstallation, useSlackOAuthUrl, useSlackMutations } from './SlackContext';
 import { IS_DEVELOPMENT } from '@/lib/constants';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
@@ -31,13 +31,9 @@ export function SlackIntegrationDetails({
   success,
   error,
 }: SlackIntegrationDetailsProps) {
-  const { queries, mutations } = useSlackQueries();
-
-  // Fetch Slack installation status
-  const { data: installationData, isLoading, refetch } = queries.getInstallation();
-
-  // Get OAuth URL for installation
-  const { data: oauthUrlData } = queries.getOAuthUrl();
+  const { data: installationData, isLoading, refetch } = useSlackInstallation();
+  const { data: oauthUrlData } = useSlackOAuthUrl();
+  const mutations = useSlackMutations();
 
   // Fetch models for the model selector
   const { data: openRouterModels, isLoading: isLoadingModels } =

--- a/src/components/integrations/UserDiscordProvider.tsx
+++ b/src/components/integrations/UserDiscordProvider.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { DiscordProvider, type DiscordQueries, type DiscordMutations } from './DiscordContext';
+import { DiscordProvider, type DiscordQueryOptions, type DiscordMutations } from './DiscordContext';
 
 export function UserDiscordProvider({ children }: { children: ReactNode }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: DiscordQueries = {
-    getInstallation: () => useQuery(trpc.discord.getInstallation.queryOptions()),
-    getOAuthUrl: () => useQuery(trpc.discord.getOAuthUrl.queryOptions()),
+  const queryOptions: DiscordQueryOptions = {
+    getInstallation: trpc.discord.getInstallation.queryOptions(),
+    getOAuthUrl: trpc.discord.getOAuthUrl.queryOptions(),
   };
 
   const mutations: DiscordMutations = {
@@ -39,7 +39,7 @@ export function UserDiscordProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <DiscordProvider queries={queries} mutations={mutations}>
+    <DiscordProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </DiscordProvider>
   );

--- a/src/components/integrations/UserGitHubAppsProvider.tsx
+++ b/src/components/integrations/UserGitHubAppsProvider.tsx
@@ -1,43 +1,40 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { GitHubAppsProvider } from './GitHubAppsContext';
-import type { IntegrationQueries, IntegrationMutations } from '@/lib/integrations/router-types';
+import type {
+  IntegrationQueryOptions,
+  IntegrationMutations,
+} from '@/lib/integrations/router-types';
 
 export function UserGitHubAppsProvider({ children }: { children: ReactNode }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: IntegrationQueries = {
-    listIntegrations: () =>
-      useQuery(
-        trpc.githubApps.listIntegrations.queryOptions()
-      ) as IntegrationQueries['listIntegrations'] extends () => infer R ? R : never,
+  const queryOptions: IntegrationQueryOptions = {
+    listIntegrations: trpc.githubApps.listIntegrations.queryOptions(),
 
-    getInstallation: () => useQuery(trpc.githubApps.getInstallation.queryOptions()),
+    getInstallation: trpc.githubApps.getInstallation.queryOptions(),
 
-    checkUserPendingInstallation: () =>
-      useQuery(trpc.githubApps.checkUserPendingInstallation.queryOptions()),
+    checkUserPendingInstallation: trpc.githubApps.checkUserPendingInstallation.queryOptions(),
 
-    listRepositories: (integrationId: string, forceRefresh?: boolean) =>
-      useQuery({
-        ...trpc.githubApps.listRepositories.queryOptions({
-          integrationId,
-          forceRefresh: forceRefresh ?? false,
-        }),
-        enabled: !!integrationId,
+    listRepositories: (integrationId: string, forceRefresh?: boolean) => ({
+      ...trpc.githubApps.listRepositories.queryOptions({
+        integrationId,
+        forceRefresh: forceRefresh ?? false,
       }),
+      enabled: !!integrationId,
+    }),
 
-    listBranches: (integrationId: string, repositoryFullName: string) =>
-      useQuery({
-        ...trpc.githubApps.listBranches.queryOptions({
-          integrationId,
-          repositoryFullName,
-        }),
-        enabled: !!integrationId && !!repositoryFullName,
+    listBranches: (integrationId: string, repositoryFullName: string) => ({
+      ...trpc.githubApps.listBranches.queryOptions({
+        integrationId,
+        repositoryFullName,
       }),
+      enabled: !!integrationId && !!repositoryFullName,
+    }),
   };
 
   const mutations: IntegrationMutations = {
@@ -82,7 +79,7 @@ export function UserGitHubAppsProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <GitHubAppsProvider queries={queries} mutations={mutations}>
+    <GitHubAppsProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </GitHubAppsProvider>
   );

--- a/src/components/integrations/UserGitLabProvider.tsx
+++ b/src/components/integrations/UserGitLabProvider.tsx
@@ -1,26 +1,16 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { GitLabProvider, type GitLabQueries } from './GitLabContext';
+import { GitLabProvider, type GitLabQueryOptions } from './GitLabContext';
 
 export function UserGitLabProvider({ children }: { children: ReactNode }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: GitLabQueries = {
-    getInstallation: () => {
-      const query = useQuery(trpc.gitlab.getInstallation.queryOptions());
-      return {
-        data: query.data,
-        status: query.status,
-        isPending: query.isPending,
-        isLoading: query.isLoading,
-        isError: query.isError,
-        error: query.error,
-      };
-    },
+  const queryOptions: GitLabQueryOptions = {
+    getInstallation: trpc.gitlab.getInstallation.queryOptions(),
   };
 
   const mutations = {
@@ -46,7 +36,7 @@ export function UserGitLabProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <GitLabProvider queries={queries} mutations={mutations}>
+    <GitLabProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </GitLabProvider>
   );

--- a/src/components/integrations/UserSlackProvider.tsx
+++ b/src/components/integrations/UserSlackProvider.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { SlackProvider, type SlackQueries, type SlackMutations } from './SlackContext';
+import { SlackProvider, type SlackQueryOptions, type SlackMutations } from './SlackContext';
 
 export function UserSlackProvider({ children }: { children: ReactNode }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const queries: SlackQueries = {
-    getInstallation: () => useQuery(trpc.slack.getInstallation.queryOptions()),
-    getOAuthUrl: () => useQuery(trpc.slack.getOAuthUrl.queryOptions()),
+  const queryOptions: SlackQueryOptions = {
+    getInstallation: trpc.slack.getInstallation.queryOptions(),
+    getOAuthUrl: trpc.slack.getOAuthUrl.queryOptions(),
   };
 
   const mutations: SlackMutations = {
@@ -51,7 +51,7 @@ export function UserSlackProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <SlackProvider queries={queries} mutations={mutations}>
+    <SlackProvider queryOptions={queryOptions} mutations={mutations}>
       {children}
     </SlackProvider>
   );

--- a/src/lib/integrations/router-types.ts
+++ b/src/lib/integrations/router-types.ts
@@ -1,7 +1,6 @@
-import type { UseQueryResult, UseMutationResult } from '@tanstack/react-query';
+import type { UseMutationResult, UseQueryOptions } from '@tanstack/react-query';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
-import type { PlatformIntegration } from '@/db/schema';
 import type { PlatformRepository } from '@/lib/integrations/core/types';
 
 /**
@@ -64,57 +63,52 @@ export type ListBranchesResponse = {
 };
 
 /**
- * Query interface that both user and org integration providers must implement
+ * Query options are typed loosely to accommodate TRPC's specific queryOptions return types,
+ * which are structurally compatible with useQuery but not directly assignable to UseQueryOptions.
+ * Type safety is enforced at the hook level via useQuery's return type inference.
  */
-export type IntegrationQueries = {
-  /**
-   * List all integrations
-   */
-  listIntegrations: () => UseQueryResult<PlatformIntegration[], IntegrationError>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CompatibleQueryOptions = UseQueryOptions<any, any, any, any>;
+
+/**
+ * Query options interface that both user and org integration providers must implement.
+ *
+ * Simple queries provide query options objects directly.
+ * Parameterized queries provide functions that return query options objects.
+ */
+export type IntegrationQueryOptions = {
+  /** List all integrations */
+  listIntegrations: CompatibleQueryOptions;
+
+  /** Get GitHub App installation status */
+  getInstallation: CompatibleQueryOptions;
+
+  /** Check if user has a pending installation */
+  checkUserPendingInstallation: CompatibleQueryOptions;
 
   /**
-   * Get GitHub App installation status
+   * List repositories accessible by an integration.
+   * Returns query options; the `enabled` flag is set internally based on integrationId.
    */
-  getInstallation: () => UseQueryResult<InstallationResponse, IntegrationError>;
+  listRepositories: (integrationId: string, forceRefresh?: boolean) => CompatibleQueryOptions;
 
   /**
-   * Check if user has a pending installation
+   * List branches for a repository.
+   * Returns query options; the `enabled` flag is set internally based on args.
    */
-  checkUserPendingInstallation: () => UseQueryResult<PendingCheckResponse, IntegrationError>;
-
-  /**
-   * List repositories accessible by an integration
-   */
-  listRepositories: (
-    integrationId: string,
-    forceRefresh?: boolean
-  ) => UseQueryResult<ListRepositoriesResponse, IntegrationError>;
-
-  /**
-   * List branches for a repository
-   */
-  listBranches: (
-    integrationId: string,
-    repositoryFullName: string
-  ) => UseQueryResult<ListBranchesResponse, IntegrationError>;
+  listBranches: (integrationId: string, repositoryFullName: string) => CompatibleQueryOptions;
 };
 
 /**
  * Mutation interface that both user and org integration providers must implement
  */
 export type IntegrationMutations = {
-  /**
-   * Uninstall GitHub App
-   */
+  /** Uninstall GitHub App */
   uninstallApp: UseMutationResult<{ success: boolean }, IntegrationError, void>;
 
-  /**
-   * Cancel pending installation
-   */
+  /** Cancel pending installation */
   cancelPendingInstallation: UseMutationResult<{ success: boolean }, IntegrationError, void>;
 
-  /**
-   * Refresh installation details from GitHub (permissions, events, repositories)
-   */
+  /** Refresh installation details from GitHub (permissions, events, repositories) */
   refreshInstallation: UseMutationResult<{ success: boolean }, IntegrationError, void>;
 };


### PR DESCRIPTION
## Summary

- **Fixed React rules-of-hooks violations** across all integration providers (Discord, Slack, GitHub Apps, GitLab) in both User and Org variants
- Providers were storing closures that called `useQuery()` internally (e.g., `getInstallation: () => useQuery(...)`) and passing them via context. Consumers invoked these as plain functions, hiding hook calls inside non-`use`-prefixed functions.
- Refactored to a 3-layer architecture: providers pass **query options objects** via context, context files expose **properly-named custom hooks** (`useDiscordInstallation()`, `useSlackOAuthUrl()`, `useGitHubAppsRepositories()`, etc.), and consumers call these hooks directly at the top level.

## Changes

### Context files (4)
- `DiscordContext.tsx`, `SlackContext.tsx`, `GitLabContext.tsx`, `GitHubAppsContext.tsx` — replaced `queries` object (containing `useQuery`-calling closures) with `queryOptions` object (containing options) + exported custom hooks

### Types (1)
- `router-types.ts` — renamed `IntegrationQueries` → `IntegrationQueryOptions`, changed from `UseQueryResult` return types to `CompatibleQueryOptions` storage types

### Providers (8)
- All `User*Provider` and `Org*Provider` files — now pass query options objects instead of closures, removed `useQuery` imports

### Consumers (7)
- `DiscordIntegrationDetails`, `SlackIntegrationDetails`, `GitHubIntegrationDetails`, `GitLabIntegrationDetails`, both `IntegrationsPageClient` files, `NewDeploymentDialog` — use new custom hooks directly instead of calling `queries.getInstallation()` etc.

## Verification
- TypeScript build passes with zero errors
- All lint-staged checks (prettier + typecheck) pass