### PR TITLE
CloudAgent - Rewrite autocommit to use direct git commands with inline status

### DIFF
--- a/cloud-agent-next/src/execution/orchestrator.ts
+++ b/cloud-agent-next/src/execution/orchestrator.ts
@@ -138,7 +138,13 @@ export class ExecutionOrchestrator {
         prepared.session,
         sessionId,
         kiloServerPort,
-        prepared.context.workspacePath
+        prepared.context.workspacePath,
+        {
+          autoCommit: wrapper.autoCommit,
+          condenseOnComplete: wrapper.condenseOnComplete,
+          upstreamBranch: prepared.context.upstreamBranch,
+          model: wrapper.model?.modelID,
+        }
       );
     } catch (error) {
       throw ExecutionError.wrapperStartFailed(

--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -550,6 +550,138 @@ describe('WrapperClient', () => {
       expect(startProcessCall[0]).toContain('KILO_SERVER_PORT=4600');
       expect(startProcessCall[0]).toContain('--agent-session test-session');
     });
+
+    it('includes AUTO_COMMIT=true in command when autoCommit is true', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        autoCommit: true,
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(startProcessCall[0]).toContain('AUTO_COMMIT=true');
+    });
+
+    it('includes CONDENSE_ON_COMPLETE=true in command when condenseOnComplete is true', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        condenseOnComplete: true,
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(startProcessCall[0]).toContain('CONDENSE_ON_COMPLETE=true');
+    });
+
+    it('includes UPSTREAM_BRANCH in command when upstreamBranch is provided', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        upstreamBranch: 'main',
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(startProcessCall[0]).toContain('UPSTREAM_BRANCH=main');
+    });
+
+    it('includes MODEL in command when model is provided', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        model: 'claude-sonnet-4-20250514',
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(startProcessCall[0]).toContain('MODEL=claude-sonnet-4-20250514');
+    });
+
+    it('omits optional env vars when not provided', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(startProcessCall[0]).not.toContain('AUTO_COMMIT');
+      expect(startProcessCall[0]).not.toContain('CONDENSE_ON_COMPLETE');
+      expect(startProcessCall[0]).not.toContain('UPSTREAM_BRANCH');
+      expect(startProcessCall[0]).not.toContain('MODEL=');
+    });
+
+    it('includes all optional env vars when all are provided', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        autoCommit: true,
+        condenseOnComplete: true,
+        upstreamBranch: 'develop',
+        model: 'gpt-4o',
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(startProcessCall[0]).toContain('AUTO_COMMIT=true');
+      expect(startProcessCall[0]).toContain('CONDENSE_ON_COMPLETE=true');
+      expect(startProcessCall[0]).toContain('UPSTREAM_BRANCH=develop');
+      expect(startProcessCall[0]).toContain('MODEL=gpt-4o');
+      // Core env vars still present
+      expect(startProcessCall[0]).toContain('WRAPPER_PORT=5000');
+      expect(startProcessCall[0]).toContain('KILO_SERVER_PORT=4600');
+      expect(startProcessCall[0]).toContain('WORKSPACE_PATH=/workspace/test');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -205,6 +205,14 @@ export class WrapperClient {
     kiloServerPort: number;
     /** Workspace path (required by wrapper) */
     workspacePath: string;
+    /** Enable auto-commit after prompt completes */
+    autoCommit?: boolean;
+    /** Enable condense-on-complete */
+    condenseOnComplete?: boolean;
+    /** Upstream branch name */
+    upstreamBranch?: string;
+    /** Model ID for the wrapper */
+    model?: string;
   }): Promise<void> {
     const {
       sessionId,
@@ -212,6 +220,10 @@ export class WrapperClient {
       maxWaitMs = 30_000,
       kiloServerPort,
       workspacePath,
+      autoCommit,
+      condenseOnComplete,
+      upstreamBranch,
+      model,
     } = options;
 
     // First, try to check health
@@ -227,7 +239,17 @@ export class WrapperClient {
     // Start the wrapper process using startProcess so it's trackable via listProcesses()
     // The command includes a session marker so we can find this wrapper later
     const sessionMarker = getWrapperSessionMarker(sessionId);
-    const command = `WRAPPER_PORT=${this.port} KILO_SERVER_PORT=${kiloServerPort} WORKSPACE_PATH=${workspacePath} bun run ${wrapperPath} ${sessionMarker}`;
+    const envParts = [
+      `WRAPPER_PORT=${this.port}`,
+      `KILO_SERVER_PORT=${kiloServerPort}`,
+      `WORKSPACE_PATH=${workspacePath}`,
+    ];
+    if (autoCommit) envParts.push('AUTO_COMMIT=true');
+    if (condenseOnComplete) envParts.push('CONDENSE_ON_COMPLETE=true');
+    if (upstreamBranch) envParts.push(`UPSTREAM_BRANCH=${upstreamBranch}`);
+    if (model) envParts.push(`MODEL=${model}`);
+
+    const command = `${envParts.join(' ')} bun run ${wrapperPath} ${sessionMarker}`;
 
     logger.debug('WrapperClient: starting wrapper process', { command, port: this.port });
 
@@ -271,7 +293,13 @@ export class WrapperClient {
     session: ExecutionSession,
     sessionId: string,
     kiloServerPort: number,
-    workspacePath: string
+    workspacePath: string,
+    wrapperConfig?: {
+      autoCommit?: boolean;
+      condenseOnComplete?: boolean;
+      upstreamBranch?: string;
+      model?: string;
+    }
   ): Promise<WrapperClient> {
     logger.withFields({ sessionId, workspacePath }).info('Ensuring wrapper is running');
 
@@ -283,7 +311,8 @@ export class WrapperClient {
       logger.withFields({ sessionId, port }).info('Found existing wrapper');
       const client = new WrapperClient({ session, port });
 
-      // Verify it's healthy
+      // Verify it's healthy. If so, reuse it — wrapperConfig env vars are
+      // immutable for the lifetime of the wrapper process (set at startup only).
       try {
         await client.health();
         return client;
@@ -303,6 +332,7 @@ export class WrapperClient {
       sessionId,
       kiloServerPort,
       workspacePath,
+      ...wrapperConfig,
     });
 
     return client;

--- a/cloud-agent-next/src/persistence/schemas.ts
+++ b/cloud-agent-next/src/persistence/schemas.ts
@@ -59,6 +59,15 @@ export const branchNameSchema = z
     'Branch name can only contain alphanumeric characters, dots, dashes, underscores, and slashes'
   );
 
+export const modelIdSchema = z
+  .string()
+  .min(1, 'Model ID cannot be empty')
+  .max(255, 'Model ID too long')
+  .regex(
+    /^[a-zA-Z0-9._\-/:]+$/,
+    'Model ID can only contain alphanumeric characters, dots, dashes, underscores, slashes, and colons'
+  );
+
 /**
  * Local MCP server configuration schema (runs a command).
  */

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -3,6 +3,7 @@ import { sessionIdSchema, githubRepoSchema, gitUrlSchema, envVarsSchema } from '
 import {
   MCPServerConfigSchema,
   branchNameSchema,
+  modelIdSchema,
   EncryptedSecretEnvelopeSchema,
   EncryptedSecretsSchema,
   CallbackTargetSchema,
@@ -11,7 +12,7 @@ import { AgentModeSchema, Limits } from '../schema.js';
 
 // Re-export schemas from types.ts and persistence/schemas.ts for convenience
 export { sessionIdSchema, githubRepoSchema, gitUrlSchema, envVarsSchema };
-export { MCPServerConfigSchema, branchNameSchema };
+export { MCPServerConfigSchema, branchNameSchema, modelIdSchema };
 export { AgentModeSchema, Limits };
 export { EncryptedSecretEnvelopeSchema, EncryptedSecretsSchema, CallbackTargetSchema };
 
@@ -41,7 +42,7 @@ export type Images = z.infer<typeof ImagesSchema>;
 export const PromptPayload = z.object({
   prompt: z.string().min(1, 'Prompt is required').describe('The task prompt for Kilo Code'),
   mode: AgentModeSchema.describe('Kilo Code execution mode (required)'),
-  model: z.string().min(1, 'Model is required').describe('AI model to use (required)'),
+  model: modelIdSchema.describe('AI model to use (required)'),
 });
 
 /**
@@ -125,7 +126,7 @@ export const PrepareSessionInput = z
       .max(Limits.MAX_PROMPT_LENGTH)
       .describe('The task prompt for Kilo Code'),
     mode: AgentModeSchema.describe('Kilo Code execution mode'),
-    model: z.string().min(1).describe('AI model to use'),
+    model: modelIdSchema.describe('AI model to use'),
 
     // Repository - one of these pairs required
     githubRepo: githubRepoSchema
@@ -229,7 +230,7 @@ export const UpdateSessionInput = z
 
     // Scalar fields - null to clear, value to set, undefined to skip
     mode: AgentModeSchema.nullable().optional().describe('Mode to set (null to clear)'),
-    model: z.string().min(1).nullable().optional().describe('Model to set (null to clear)'),
+    model: modelIdSchema.nullable().optional().describe('Model to set (null to clear)'),
     githubToken: z.string().nullable().optional().describe('GitHub token to set (null to clear)'),
     gitToken: z.string().nullable().optional().describe('Git token to set (null to clear)'),
     upstreamBranch: branchNameSchema

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -2,7 +2,8 @@
  * Event types that flow through the streaming system.
  *
  * From wrapper -> DO:
- *   started, kilocode, output, status, heartbeat, pong, error, interrupted, complete, wrapper_resumed
+ *   started, kilocode, output, status, heartbeat, pong, error, interrupted, complete, wrapper_resumed,
+ *   autocommit_started, autocommit_completed
  *
  * From DO -> /stream clients:
  *   All of the above, plus wrapper_disconnected, wrapper_reconnected
@@ -19,6 +20,8 @@ export type StreamEventType =
   | 'interrupted' // User/signal interrupt
   | 'complete' // Execution finished { exitCode, currentBranch? }
   | 'wrapper_resumed' // Wrapper reconnected after disconnect (may have lost events)
+  | 'autocommit_started' // Auto-commit process began
+  | 'autocommit_completed' // Auto-commit finished (success, skip, or failure)
   // DO -> /stream clients (connection status)
   | 'wrapper_disconnected' // Wrapper WebSocket closed unexpectedly
   | 'wrapper_reconnected'; // Wrapper reconnected successfully
@@ -52,4 +55,20 @@ export type KilocodeEventData = {
   event?: string; // e.g., 'session_created', 'token_usage'
   sessionId?: string; // Present in session_created events
   [key: string]: unknown; // Other CLI event fields
+};
+
+/**
+ * Data included in 'autocommit_started' events.
+ */
+export type AutocommitStartedData = {
+  message: string;
+};
+
+/**
+ * Data included in 'autocommit_completed' events.
+ */
+export type AutocommitCompletedData = {
+  success: boolean;
+  message: string;
+  skipped?: boolean;
 };

--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -244,7 +244,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "latest",
+            "KILOCODE_CLI_VERSION": "7.0.29",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -1,6 +1,6 @@
 import type { IngestEvent } from '../../src/shared/protocol.js';
 import type { KiloClient } from './kilo-client.js';
-import { exec, getCurrentBranch, logToFile } from './utils.js';
+import { git, getCurrentBranch, logToFile } from './utils.js';
 
 /** Timeout for local git operations (status, add, commit) */
 const GIT_LOCAL_TIMEOUT_MS = 30_000;
@@ -68,7 +68,8 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     }
 
     // Check for uncommitted changes
-    const status = await exec(`cd "${workspacePath}" && git status --porcelain`, {
+    const status = await git(['status', '--porcelain'], {
+      cwd: workspacePath,
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
     });
     if (!status.stdout.trim()) {
@@ -103,7 +104,8 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
 
     // Stage all changes
     logToFile('auto-commit: staging changes');
-    const addResult = await exec(`cd "${workspacePath}" && git add -A`, {
+    const addResult = await git(['add', '-A'], {
+      cwd: workspacePath,
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
     });
     if (addResult.exitCode !== 0) {
@@ -115,16 +117,16 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
 
     // Commit — retry with --no-verify if pre-commit hook fails
     logToFile('auto-commit: committing');
-    const escapedMessage = commitMessage.replace(/'/g, "'\\''");
-    let commitResult = await exec(`cd "${workspacePath}" && git commit -m '${escapedMessage}'`, {
+    let commitResult = await git(['commit', '-m', commitMessage], {
+      cwd: workspacePath,
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
     });
     if (commitResult.exitCode !== 0) {
       logToFile('auto-commit: commit failed, retrying with --no-verify');
-      commitResult = await exec(
-        `cd "${workspacePath}" && git commit --no-verify -m '${escapedMessage}'`,
-        { timeoutMs: GIT_LOCAL_TIMEOUT_MS }
-      );
+      commitResult = await git(['commit', '--no-verify', '-m', commitMessage], {
+        cwd: workspacePath,
+        timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+      });
       if (commitResult.exitCode !== 0) {
         const msg = `git commit failed: ${commitResult.stderr.trim()}`;
         logToFile(`auto-commit: ${msg}`);
@@ -135,15 +137,9 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
 
     // Push
     logToFile('auto-commit: pushing');
-    let pushCmd: string;
-    if (hasUpstream) {
-      pushCmd = `cd "${workspacePath}" && git push`;
-    } else {
-      // Set upstream on first push; skip push entirely for main/master (already guarded above)
-      pushCmd = `cd "${workspacePath}" && git push -u origin "${branch}"`;
-    }
+    const pushArgs = hasUpstream ? ['push'] : ['push', '-u', 'origin', branch];
 
-    const pushResult = await exec(pushCmd, { timeoutMs: GIT_PUSH_TIMEOUT_MS });
+    const pushResult = await git(pushArgs, { cwd: workspacePath, timeoutMs: GIT_PUSH_TIMEOUT_MS });
     if (pushResult.exitCode !== 0) {
       // Push failure is non-fatal — changes are committed locally
       const msg = `git push failed: ${pushResult.stderr.trim()}`;

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -2,6 +2,13 @@ import type { IngestEvent } from '../../src/shared/protocol.js';
 import type { KiloClient } from './kilo-client.js';
 import { exec, getCurrentBranch, logToFile } from './utils.js';
 
+/** Timeout for local git operations (status, add, commit) */
+const GIT_LOCAL_TIMEOUT_MS = 30_000;
+/** Timeout for git push (network-bound) */
+const GIT_PUSH_TIMEOUT_MS = 60_000;
+/** Timeout for commit message generation API call */
+const COMMIT_MESSAGE_TIMEOUT_MS = 60_000;
+
 export type AutoCommitResult = {
   success: boolean;
   skipped?: boolean;
@@ -61,7 +68,9 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     }
 
     // Check for uncommitted changes
-    const status = await exec(`cd "${workspacePath}" && git status --porcelain`);
+    const status = await exec(`cd "${workspacePath}" && git status --porcelain`, {
+      timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+    });
     if (!status.stdout.trim()) {
       emitCompleted(onEvent, { success: true, message: 'No uncommitted changes', skipped: true });
       return { success: true, skipped: true };
@@ -73,7 +82,14 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     logToFile('auto-commit: generating commit message');
     let commitMessage: string;
     try {
-      const result = await kiloClient.generateCommitMessage({ path: workspacePath });
+      const commitMsgPromise = kiloClient.generateCommitMessage({ path: workspacePath });
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error('Commit message generation timed out')),
+          COMMIT_MESSAGE_TIMEOUT_MS
+        )
+      );
+      const result = await Promise.race([commitMsgPromise, timeoutPromise]);
       commitMessage = result.message;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -87,7 +103,9 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
 
     // Stage all changes
     logToFile('auto-commit: staging changes');
-    const addResult = await exec(`cd "${workspacePath}" && git add -A`);
+    const addResult = await exec(`cd "${workspacePath}" && git add -A`, {
+      timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+    });
     if (addResult.exitCode !== 0) {
       const msg = `git add failed: ${addResult.stderr.trim()}`;
       logToFile(`auto-commit: ${msg}`);
@@ -98,11 +116,14 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     // Commit — retry with --no-verify if pre-commit hook fails
     logToFile('auto-commit: committing');
     const escapedMessage = commitMessage.replace(/'/g, "'\\''");
-    let commitResult = await exec(`cd "${workspacePath}" && git commit -m '${escapedMessage}'`);
+    let commitResult = await exec(`cd "${workspacePath}" && git commit -m '${escapedMessage}'`, {
+      timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+    });
     if (commitResult.exitCode !== 0) {
       logToFile('auto-commit: commit failed, retrying with --no-verify');
       commitResult = await exec(
-        `cd "${workspacePath}" && git commit --no-verify -m '${escapedMessage}'`
+        `cd "${workspacePath}" && git commit --no-verify -m '${escapedMessage}'`,
+        { timeoutMs: GIT_LOCAL_TIMEOUT_MS }
       );
       if (commitResult.exitCode !== 0) {
         const msg = `git commit failed: ${commitResult.stderr.trim()}`;
@@ -122,7 +143,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       pushCmd = `cd "${workspacePath}" && git push -u origin "${branch}"`;
     }
 
-    const pushResult = await exec(pushCmd);
+    const pushResult = await exec(pushCmd, { timeoutMs: GIT_PUSH_TIMEOUT_MS });
     if (pushResult.exitCode !== 0) {
       // Push failure is non-fatal — changes are committed locally
       const msg = `git push failed: ${pushResult.stderr.trim()}`;

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -2,163 +2,145 @@ import type { IngestEvent } from '../../src/shared/protocol.js';
 import type { KiloClient } from './kilo-client.js';
 import { exec, getCurrentBranch, logToFile } from './utils.js';
 
-/** Default timeout for auto-commit operation (5 minutes) */
-const DEFAULT_AUTO_COMMIT_TIMEOUT_MS = 5 * 60 * 1000;
-
 export type AutoCommitResult = {
-  /** Whether the operation was aborted (kill signal or fatal error during execution) */
-  wasAborted: boolean;
-  /** Whether the operation completed successfully */
   success: boolean;
-  /** Error message if failed */
+  skipped?: boolean;
   error?: string;
 };
 
 export type AutoCommitOptions = {
   workspacePath: string;
   upstreamBranch?: string;
-  model?: string;
   onEvent: (event: IngestEvent) => void;
   kiloClient: KiloClient;
-  kiloSessionId: string;
-  /** Arm the completion waiter before sending a prompt */
-  expectCompletion: () => void;
-  /** Wait for the completion event (call after sending prompt) */
-  waitForCompletion: () => Promise<void>;
-  /** Check if the execution was aborted (kill signal or fatal error) */
-  wasAborted: () => boolean;
-  /** Timeout for the entire operation in ms (default: 5 minutes) */
-  timeoutMs?: number;
 };
 
-function buildAutoCommitPrompt(hasUpstream: boolean): string {
-  const lines = [
-    'Commit and push all uncommitted changes. Follow these guidelines:',
-    '1. Create a clear, concise commit message summarizing the changes',
-    '2. Stage all modified and new files (git add -A)',
-    '3. If pre-commit hooks fail, retry with --no-verify',
-    '4. Push to the current branch',
-    '5. Do NOT force push',
-    '6. If you detect secrets or credentials, decline to commit and explain why',
-  ];
-  if (!hasUpstream) {
-    lines.push('7. Do NOT push to main or master branches - if on these branches, skip the push');
-  }
-  return lines.join('\n');
+function emitStarted(onEvent: AutoCommitOptions['onEvent'], message: string): void {
+  onEvent({
+    streamEventType: 'autocommit_started',
+    data: { message },
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function emitCompleted(
+  onEvent: AutoCommitOptions['onEvent'],
+  result: { success: boolean; message: string; skipped?: boolean }
+): void {
+  onEvent({
+    streamEventType: 'autocommit_completed',
+    data: result,
+    timestamp: new Date().toISOString(),
+  });
 }
 
 export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommitResult> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_AUTO_COMMIT_TIMEOUT_MS;
-  const sendStatus = (msg: string) =>
-    opts.onEvent({
-      streamEventType: 'status',
-      data: { message: msg },
-      timestamp: new Date().toISOString(),
-    });
-
-  // Check if already aborted before starting
-  if (opts.wasAborted()) {
-    logToFile('auto-commit: skipped - execution was aborted');
-    return { wasAborted: true, success: false };
-  }
+  const { workspacePath, upstreamBranch, onEvent, kiloClient } = opts;
 
   try {
     // Check current branch
-    const branch = await getCurrentBranch(opts.workspacePath);
+    const branch = await getCurrentBranch(workspacePath);
     if (!branch) {
-      sendStatus('Auto-commit skipped: detached HEAD state');
-      return { wasAborted: false, success: true };
-    }
-
-    // Branch protection
-    const hasUpstream = opts.upstreamBranch !== undefined && opts.upstreamBranch !== '';
-    if (!hasUpstream && (branch === 'main' || branch === 'master')) {
-      sendStatus(`Auto-commit skipped: cannot commit to ${branch}`);
-      return { wasAborted: false, success: true };
-    }
-
-    // Check for changes
-    const status = await exec(`cd "${opts.workspacePath}" && git status --porcelain`);
-    if (!status.stdout.trim()) {
-      sendStatus('No uncommitted changes');
-      return { wasAborted: false, success: true };
-    }
-
-    // Check again before sending prompt
-    if (opts.wasAborted()) {
-      logToFile('auto-commit: aborted before sending prompt');
-      return { wasAborted: true, success: false };
-    }
-
-    sendStatus('Auto-committing changes...');
-
-    // Select prompt based on explicit upstream branch
-    const prompt = buildAutoCommitPrompt(hasUpstream);
-
-    // Arm the completion waiter BEFORE sending the prompt
-    opts.expectCompletion();
-
-    // Send prompt via server API
-    logToFile(`auto-commit: sending prompt to session ${opts.kiloSessionId}`);
-    await opts.kiloClient.sendPromptAsync({
-      sessionId: opts.kiloSessionId,
-      prompt,
-      agent: 'code',
-      model: opts.model ? { modelID: opts.model } : undefined,
-    });
-
-    // Wait for completion with timeout
-    logToFile('auto-commit: waiting for completion');
-    const completionPromise = opts.waitForCompletion();
-    const timeoutPromise = new Promise<'timeout'>(resolve =>
-      setTimeout(() => resolve('timeout'), timeoutMs)
-    );
-
-    const result = await Promise.race([
-      completionPromise.then(() => 'done' as const),
-      timeoutPromise,
-    ]);
-
-    if (result === 'timeout') {
-      logToFile('auto-commit: timed out, aborting session');
-      // Abort the session to stop the running prompt
-      try {
-        await opts.kiloClient.abortSession({ sessionId: opts.kiloSessionId });
-        logToFile('auto-commit: session aborted after timeout');
-      } catch (abortError) {
-        logToFile(
-          `auto-commit: failed to abort session: ${abortError instanceof Error ? abortError.message : String(abortError)}`
-        );
-      }
-      opts.onEvent({
-        streamEventType: 'error',
-        data: { error: 'Auto-commit timed out', fatal: false },
-        timestamp: new Date().toISOString(),
+      emitCompleted(onEvent, {
+        success: true,
+        message: 'Skipped: detached HEAD state',
+        skipped: true,
       });
-      // Treat timeout as abort to prevent further operations on potentially inconsistent state
-      return { wasAborted: true, success: false, error: 'Timed out' };
+      return { success: true, skipped: true };
     }
 
-    // Check if aborted during execution
-    if (opts.wasAborted()) {
-      logToFile('auto-commit: aborted during execution');
-      return { wasAborted: true, success: false };
+    // Branch protection: don't commit to main/master without an explicit upstream
+    const hasUpstream = upstreamBranch !== undefined && upstreamBranch !== '';
+    if (!hasUpstream && (branch === 'main' || branch === 'master')) {
+      emitCompleted(onEvent, {
+        success: true,
+        message: `Skipped: cannot commit to ${branch}`,
+        skipped: true,
+      });
+      return { success: true, skipped: true };
     }
 
-    logToFile('auto-commit: completed');
-    sendStatus('Auto-commit completed');
-    return { wasAborted: false, success: true };
+    // Check for uncommitted changes
+    const status = await exec(`cd "${workspacePath}" && git status --porcelain`);
+    if (!status.stdout.trim()) {
+      emitCompleted(onEvent, { success: true, message: 'No uncommitted changes', skipped: true });
+      return { success: true, skipped: true };
+    }
+
+    emitStarted(onEvent, 'Committing changes...');
+
+    // Generate commit message via kilo server API
+    logToFile('auto-commit: generating commit message');
+    let commitMessage: string;
+    try {
+      const result = await kiloClient.generateCommitMessage({ path: workspacePath });
+      commitMessage = result.message;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logToFile(`auto-commit: commit message generation failed: ${msg}`);
+      emitCompleted(onEvent, {
+        success: false,
+        message: `Failed to generate commit message: ${msg}`,
+      });
+      return { success: false, error: msg };
+    }
+
+    // Stage all changes
+    logToFile('auto-commit: staging changes');
+    const addResult = await exec(`cd "${workspacePath}" && git add -A`);
+    if (addResult.exitCode !== 0) {
+      const msg = `git add failed: ${addResult.stderr.trim()}`;
+      logToFile(`auto-commit: ${msg}`);
+      emitCompleted(onEvent, { success: false, message: msg });
+      return { success: false, error: msg };
+    }
+
+    // Commit — retry with --no-verify if pre-commit hook fails
+    logToFile('auto-commit: committing');
+    const escapedMessage = commitMessage.replace(/'/g, "'\\''");
+    let commitResult = await exec(`cd "${workspacePath}" && git commit -m '${escapedMessage}'`);
+    if (commitResult.exitCode !== 0) {
+      logToFile('auto-commit: commit failed, retrying with --no-verify');
+      commitResult = await exec(
+        `cd "${workspacePath}" && git commit --no-verify -m '${escapedMessage}'`
+      );
+      if (commitResult.exitCode !== 0) {
+        const msg = `git commit failed: ${commitResult.stderr.trim()}`;
+        logToFile(`auto-commit: ${msg}`);
+        emitCompleted(onEvent, { success: false, message: msg });
+        return { success: false, error: msg };
+      }
+    }
+
+    // Push
+    logToFile('auto-commit: pushing');
+    let pushCmd: string;
+    if (hasUpstream) {
+      pushCmd = `cd "${workspacePath}" && git push`;
+    } else {
+      // Set upstream on first push; skip push entirely for main/master (already guarded above)
+      pushCmd = `cd "${workspacePath}" && git push -u origin "${branch}"`;
+    }
+
+    const pushResult = await exec(pushCmd);
+    if (pushResult.exitCode !== 0) {
+      // Push failure is non-fatal — changes are committed locally
+      const msg = `git push failed: ${pushResult.stderr.trim()}`;
+      logToFile(`auto-commit: ${msg}`);
+      emitCompleted(onEvent, {
+        success: true,
+        message: `Changes committed (push failed: ${pushResult.stderr.trim()})`,
+      });
+      return { success: true };
+    }
+
+    logToFile('auto-commit: completed successfully');
+    emitCompleted(onEvent, { success: true, message: 'Changes committed and pushed' });
+    return { success: true };
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     logToFile(`auto-commit: error - ${errorMsg}`);
-    opts.onEvent({
-      streamEventType: 'error',
-      data: {
-        error: `Auto-commit failed: ${errorMsg}`,
-        fatal: false,
-      },
-      timestamp: new Date().toISOString(),
-    });
-    return { wasAborted: false, success: false, error: errorMsg };
+    emitCompleted(onEvent, { success: false, message: `Auto-commit failed: ${errorMsg}` });
+    return { success: false, error: errorMsg };
   }
 }

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -14,84 +14,8 @@ import type { IngestEvent, WrapperCommand } from '../../src/shared/protocol.js';
 import { createSSEConsumer, isTerminalErrorEvent, type SSEConsumer } from './sse-consumer.js';
 import { logToFile } from './utils.js';
 
-// ---------------------------------------------------------------------------
-// Kilo Event Types (from kilo-cli SDK)
-// ---------------------------------------------------------------------------
-
-/**
- * Time information for messages.
- */
-type MessageTime = {
-  created: number;
-  completed?: number;
-};
-
-/**
- * Assistant message info from message.updated event.
- * Mirrors AssistantMessage from kilo-cli SDK.
- */
-type AssistantMessageInfo = {
-  id: string;
-  sessionID: string;
-  role: 'assistant';
-  time: MessageTime;
-  parentID: string;
-  modelID: string;
-  providerID: string;
-  mode: string;
-  agent: string;
-  path: { cwd: string; root: string };
-  cost: number;
-  tokens: {
-    input: number;
-    output: number;
-    reasoning: number;
-    cache: { read: number; write: number };
-  };
-  error?: unknown;
-  summary?: boolean;
-  finish?: string;
-};
-
-/**
- * User message info from message.updated event.
- */
-type UserMessageInfo = {
-  id: string;
-  sessionID: string;
-  role: 'user';
-  time: MessageTime;
-  agent: string;
-  model: { providerID: string; modelID: string };
-  summary?: { title?: string; body?: string };
-  system?: string;
-  tools?: Record<string, boolean>;
-  variant?: string;
-};
-
-/**
- * Message info can be either user or assistant message.
- */
-type MessageInfo = UserMessageInfo | AssistantMessageInfo;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
-}
-
-/**
- * Type guard for message.updated kilocode event data.
- * Kilo server sends: {type: "message.updated", properties: {info: {...}}}
- * After mapping: {type: "message.updated", properties: {info: {...}}, event: "message.updated"}
- */
-function isMessageUpdatedEvent(
-  data: unknown
-): data is { event: 'message.updated'; properties: { info: MessageInfo } } {
-  if (!isRecord(data)) return false;
-  if (data.event !== 'message.updated') return false;
-  const props = data.properties;
-  if (!isRecord(props)) return false;
-  const info = props.info;
-  return isRecord(info) && typeof info.role === 'string' && isRecord(info.time);
 }
 
 /**
@@ -106,15 +30,6 @@ export function isSessionIdleEvent(
   if (data.event !== 'session.idle') return false;
   const props = data.properties;
   return isRecord(props) && typeof props.sessionID === 'string';
-}
-
-/**
- * Type guard for completed assistant message.
- */
-function isCompletedAssistantMessage(
-  info: MessageInfo
-): info is AssistantMessageInfo & { time: { completed: number } } {
-  return info.role === 'assistant' && typeof info.time.completed === 'number';
 }
 
 // ---------------------------------------------------------------------------
@@ -312,25 +227,6 @@ export function createConnectionManager(
           if (terminal.isTerminal) {
             callbacks.onTerminalError(terminal.reason ?? 'terminal error');
             return;
-          }
-
-          // Check for completion events using typed event guards
-          if (isMessageUpdatedEvent(data)) {
-            const { info } = data.properties;
-            if (isCompletedAssistantMessage(info)) {
-              // Guard: only process completions for our current session
-              const currentSessionId = state.currentJob?.kiloSessionId;
-              if (currentSessionId && info.sessionID !== currentSessionId) {
-                logToFile(
-                  `ignoring completion for different session: event=${info.sessionID} current=${currentSessionId}`
-                );
-                return;
-              }
-
-              logToFile(`assistant message completed: ${info.id}`);
-              // Don't call onCompletionSignal here — the CLI may use multiple turns.
-              // Only session.idle means all turns are done (see below).
-            }
           }
 
           // session.idle is the primary completion signal - it means the assistant finished

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -317,9 +317,6 @@ export function createConnectionManager(
           // Check for completion events using typed event guards
           if (isMessageUpdatedEvent(data)) {
             const { info } = data.properties;
-            logToFile(
-              `message.updated: role=${info.role} hasCompleted=${typeof info.time?.completed === 'number'} msgId=${info.id}`
-            );
             if (isCompletedAssistantMessage(info)) {
               // Guard: only process completions for our current session
               const currentSessionId = state.currentJob?.kiloSessionId;
@@ -331,10 +328,8 @@ export function createConnectionManager(
               }
 
               logToFile(`assistant message completed: ${info.id}`);
-              // Signal completion for post-processing waiters
-              callbacks.onCompletionSignal();
-              // Note: We don't call onMessageComplete here because kilo's assistant message ID
-              // differs from our tracked user message ID. session.idle handles inflight cleanup.
+              // Don't call onCompletionSignal here — the CLI may use multiple turns.
+              // Only session.idle means all turns are done (see below).
             }
           }
 

--- a/cloud-agent-next/wrapper/src/kilo-client.ts
+++ b/cloud-agent-next/wrapper/src/kilo-client.ts
@@ -93,6 +93,8 @@ export type KiloClient = {
   answerQuestion: (questionId: string, answers: string[][]) => Promise<boolean>;
   /** Reject a question */
   rejectQuestion: (questionId: string) => Promise<boolean>;
+  /** Generate a commit message for staged/unstaged changes */
+  generateCommitMessage: (opts: { path: string }) => Promise<{ message: string }>;
 };
 
 /**
@@ -202,5 +204,8 @@ export function createKiloClient(baseUrl: string): KiloClient {
       await requestNoContent('POST', `/question/${questionId}/reject`, {});
       return true;
     },
+
+    generateCommitMessage: (opts: { path: string }) =>
+      requestJson<{ message: string }>('POST', '/commit-message', { path: opts.path }),
   };
 }

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -356,7 +356,7 @@ export function createLifecycleManager(
 
   /**
    * Trigger drain period and close connections.
-   * Sends complete event (unless aborted), runs post-completion tasks, then closes after drain delay.
+   * Runs post-completion tasks (auto-commit, condense), sends complete event, then closes after drain delay.
    */
   function triggerDrainAndClose(): void {
     if (isDraining) return;
@@ -364,25 +364,9 @@ export function createLifecycleManager(
 
     logToFile(`starting drain period (isAborted=${isAborted})`);
 
-    // Send complete event to ingest so DO can update execution status and trigger callbacks
-    // BUT only if not aborted - fatal errors already sent their own terminal event
-    const job = state.currentJob;
-    if (job && !isAborted) {
-      logToFile(`sending complete event for executionId=${job.executionId}`);
-      state.sendToIngest({
-        streamEventType: 'complete',
-        data: {
-          exitCode: 0,
-          executionId: job.executionId,
-          kiloSessionId: job.kiloSessionId,
-        },
-        timestamp: new Date().toISOString(),
-      });
-    } else if (job && isAborted) {
-      logToFile(`skipping complete event - execution was aborted`);
-    }
-
-    // Run post-completion tasks, then drain and close
+    // Run post-completion tasks first (auto-commit, condense), THEN send the complete event.
+    // The complete event must be sent after post-completion tasks so that clients don't
+    // disconnect before autocommit output is streamed.
     runPostCompletionTasks()
       .catch(err =>
         logToFile(
@@ -390,6 +374,24 @@ export function createLifecycleManager(
         )
       )
       .finally(() => {
+        // Send complete event to ingest so DO can update execution status and trigger callbacks
+        // BUT only if not aborted - fatal errors already sent their own terminal event
+        const job = state.currentJob;
+        if (job && !isAborted) {
+          logToFile(`sending complete event for executionId=${job.executionId}`);
+          state.sendToIngest({
+            streamEventType: 'complete',
+            data: {
+              exitCode: 0,
+              executionId: job.executionId,
+              kiloSessionId: job.kiloSessionId,
+            },
+            timestamp: new Date().toISOString(),
+          });
+        } else if (job && isAborted) {
+          logToFile(`skipping complete event - execution was aborted`);
+        }
+
         drainTimeout = setTimeout(() => {
           logToFile('drain complete, closing connections');
           connectionManager
@@ -456,7 +458,6 @@ export function createLifecycleManager(
 
     setAborted: () => {
       isAborted = true;
-      logToFile('abort flag set - post-completion tasks will be skipped');
     },
 
     getMaxRuntimeMs: () => config.maxRuntimeMs,

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -37,6 +37,9 @@ export const DEFAULT_IDLE_TIMEOUT_MS = 120_000;
 /** SSE inactivity timeout - if no SSE events for this long while active, assume broken (2 minutes) */
 const SSE_INACTIVITY_TIMEOUT_MS = 120_000;
 
+/** Overall timeout for auto-commit operation (2 minutes) */
+const AUTO_COMMIT_TIMEOUT_MS = 120_000;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -289,13 +292,26 @@ export function createLifecycleManager(
     if (config.autoCommit) {
       logToFile('running auto-commit');
       try {
-        await runAutoCommit({
+        const autoCommitPromise = runAutoCommit({
           workspacePath: config.workspacePath,
           upstreamBranch: config.upstreamBranch,
           onEvent: event => state.sendToIngest(event),
           kiloClient,
         });
-        logToFile('auto-commit complete');
+        const timeoutPromise = new Promise<'timeout'>(resolve =>
+          setTimeout(() => resolve('timeout'), AUTO_COMMIT_TIMEOUT_MS)
+        );
+        const result = await Promise.race([autoCommitPromise, timeoutPromise]);
+        if (result === 'timeout') {
+          logToFile('auto-commit timed out');
+          state.sendToIngest({
+            streamEventType: 'error',
+            data: { error: 'Auto-commit timed out', fatal: false },
+            timestamp: new Date().toISOString(),
+          });
+        } else {
+          logToFile('auto-commit complete');
+        }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         logToFile(`auto-commit error: ${msg}`);

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -285,7 +285,29 @@ export function createLifecycleManager(
     const job = state.currentJob;
     if (!job) return;
 
-    // Use the shared completion state for waiting on post-processing commands
+    // Run auto-commit if enabled
+    if (config.autoCommit) {
+      logToFile('running auto-commit');
+      try {
+        await runAutoCommit({
+          workspacePath: config.workspacePath,
+          upstreamBranch: config.upstreamBranch,
+          onEvent: event => state.sendToIngest(event),
+          kiloClient,
+        });
+        logToFile('auto-commit complete');
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logToFile(`auto-commit error: ${msg}`);
+        state.sendToIngest({
+          streamEventType: 'error',
+          data: { error: `Auto-commit failed: ${msg}`, fatal: false },
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+
+    // Completion/abort helpers are only needed for condense (which still uses the prompt-based approach)
     const expectCompletion = () => {
       postProcessingCompleted = false;
       postProcessingResolve = null;
@@ -299,33 +321,6 @@ export function createLifecycleManager(
     };
 
     const wasAborted = () => isAborted;
-
-    // Run auto-commit if enabled
-    if (config.autoCommit) {
-      logToFile('running auto-commit');
-      try {
-        await runAutoCommit({
-          workspacePath: config.workspacePath,
-          upstreamBranch: config.upstreamBranch,
-          model: config.model,
-          onEvent: event => state.sendToIngest(event),
-          kiloClient,
-          kiloSessionId: job.kiloSessionId,
-          expectCompletion,
-          waitForCompletion,
-          wasAborted,
-        });
-        logToFile('auto-commit complete');
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        logToFile(`auto-commit error: ${msg}`);
-        state.sendToIngest({
-          streamEventType: 'error',
-          data: { error: `Auto-commit failed: ${msg}`, fatal: false },
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
 
     // Run condense if enabled
     if (config.condenseOnComplete) {

--- a/cloud-agent-next/wrapper/src/utils.ts
+++ b/cloud-agent-next/wrapper/src/utils.ts
@@ -7,9 +7,16 @@ export type ExecResult = {
   exitCode: number;
 };
 
-export function exec(command: string, opts?: { timeoutMs?: number }): Promise<ExecResult> {
+/** Spawn a git command with an argv array (no shell interpolation). */
+export function git(
+  args: string[],
+  opts?: { cwd?: string; timeoutMs?: number }
+): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('sh', ['-c', command], { stdio: ['pipe', 'pipe', 'pipe'] });
+    const proc = spawn('git', args, {
+      cwd: opts?.cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
     let stdout = '';
     let stderr = '';
     let settled = false;
@@ -46,7 +53,7 @@ export function exec(command: string, opts?: { timeoutMs?: number }): Promise<Ex
 
 export async function getCurrentBranch(workspacePath: string): Promise<string> {
   try {
-    const result = await exec(`cd ${workspacePath} && git branch --show-current`);
+    const result = await git(['branch', '--show-current'], { cwd: workspacePath });
     return result.stdout.trim();
   } catch {
     return '';

--- a/cloud-agent-next/wrapper/src/utils.ts
+++ b/cloud-agent-next/wrapper/src/utils.ts
@@ -7,16 +7,40 @@ export type ExecResult = {
   exitCode: number;
 };
 
-export function exec(command: string): Promise<ExecResult> {
+export function exec(command: string, opts?: { timeoutMs?: number }): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
     const proc = spawn('sh', ['-c', command], { stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
+    let settled = false;
+
+    const timer =
+      opts?.timeoutMs !== undefined
+        ? setTimeout(() => {
+            if (!settled) {
+              settled = true;
+              proc.kill('SIGTERM');
+              resolve({ stdout, stderr: stderr + '\nexec timeout reached', exitCode: 124 });
+            }
+          }, opts.timeoutMs)
+        : undefined;
 
     proc.stdout.on('data', d => (stdout += d));
     proc.stderr.on('data', d => (stderr += d));
-    proc.on('exit', code => resolve({ stdout, stderr, exitCode: code ?? 0 }));
-    proc.on('error', reject);
+    proc.on('exit', code => {
+      if (!settled) {
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve({ stdout, stderr, exitCode: code ?? 0 });
+      }
+    });
+    proc.on('error', err => {
+      if (!settled) {
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
+    });
   });
 }
 

--- a/src/components/cloud-agent-next/AutocommitStatus.tsx
+++ b/src/components/cloud-agent-next/AutocommitStatus.tsx
@@ -1,0 +1,40 @@
+import { Loader2, Check, X } from 'lucide-react';
+import type { AutocommitStatus as AutocommitStatusType } from './store/atoms';
+
+export function AutocommitStatus({ status }: { status: AutocommitStatusType }) {
+  return (
+    <div className="flex items-center gap-3 py-4">
+      <div className="bg-border h-px flex-1" />
+      <div className="flex items-center gap-2 text-xs">
+        <StatusIndicator status={status} />
+      </div>
+      <div className="bg-border h-px flex-1" />
+    </div>
+  );
+}
+
+function StatusIndicator({ status }: { status: AutocommitStatusType }) {
+  switch (status.status) {
+    case 'in_progress':
+      return (
+        <span className="text-muted-foreground flex items-center gap-2">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span>{status.message}</span>
+        </span>
+      );
+    case 'completed':
+      return (
+        <span className="text-muted-foreground flex items-center gap-2">
+          <Check className="h-3 w-3" />
+          <span>{status.message}</span>
+        </span>
+      );
+    case 'failed':
+      return (
+        <span className="text-destructive flex items-center gap-2">
+          <X className="h-3 w-3" />
+          <span>{status.message}</span>
+        </span>
+      );
+  }
+}

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -24,6 +24,7 @@ import {
   getChildSessionMessagesAtom,
   questionRequestIdsAtom,
   sessionOrganizationIdAtom,
+  autocommitStatusAtom,
 } from './store/atoms';
 import { buildSessionConfig, needsResumeConfiguration } from './session-config';
 import {
@@ -83,6 +84,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   const currentSessionId = useAtomValue(currentSessionIdAtom);
   const sessionConfig = useAtomValue(sessionConfigAtom);
   const totalCost = useAtomValue(totalCostAtom);
+  const autocommitStatus = useAtomValue(autocommitStatusAtom);
   const questionRequestIds = useAtomValue(questionRequestIdsAtom);
   const questionOrganizationId = useAtomValue(sessionOrganizationIdAtom);
 
@@ -972,6 +974,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
         onInputModeChange={handleInputModeChange}
         onInputModelChange={handleInputModelChange}
         isOldSession={isOldSession}
+        autocommitStatus={autocommitStatus}
         getChildMessages={getChildSessionMessages}
       />
     </QuestionContextProvider>

--- a/src/components/cloud-agent-next/CloudChatPresentation.tsx
+++ b/src/components/cloud-agent-next/CloudChatPresentation.tsx
@@ -16,6 +16,8 @@ import { ChatInput } from './ChatInput';
 import { ErrorBanner } from './ErrorBanner';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
 import { MessageBubble } from './MessageBubble';
+import { AutocommitStatus } from './AutocommitStatus';
+import type { AutocommitStatus as AutocommitStatusType } from './store/atoms';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ArrowDown, RefreshCw } from 'lucide-react';
@@ -160,6 +162,9 @@ export type CloudChatPresentationProps = {
   onMenuClick: () => void;
   onMobileSheetOpenChange: (open: boolean) => void;
 
+  /** Autocommit status to display after messages */
+  autocommitStatus?: AutocommitStatusType | null;
+
   // Old session handling
   isOldSession?: boolean;
 
@@ -225,6 +230,7 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
   onToggleSound,
   onMenuClick,
   onMobileSheetOpenChange,
+  autocommitStatus,
   isOldSession = false,
   getChildMessages,
   inputMode,
@@ -387,6 +393,9 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
 
                 {/* Dynamic messages - re-render during streaming */}
                 <DynamicMessages messages={dynamicMessages} getChildMessages={getChildMessages} />
+
+                {/* Auto-commit status indicator */}
+                {autocommitStatus && <AutocommitStatus status={autocommitStatus} />}
 
                 {/* Invisible anchor for auto-scroll */}
                 <div ref={messagesEndRef} />

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -61,6 +61,18 @@ export const sessionStatusAtom = atom<
   | { type: 'retry'; attempt: number; message: string; next: number }
 >({ type: 'idle' });
 
+/**
+ * Autocommit status — one per execution, transitions in-place.
+ * Reset to null when a new execution starts.
+ */
+export type AutocommitStatus = {
+  status: 'in_progress' | 'completed' | 'failed';
+  message: string;
+  timestamp: string;
+};
+
+export const autocommitStatusAtom = atom<AutocommitStatus | null>(null);
+
 // ============================================================================
 // Common State
 // ============================================================================
@@ -133,6 +145,7 @@ export const clearMessagesAtom = atom(null, (_get, set) => {
   set(messagesMapAtom, new Map());
   set(partsMapAtom, new Map());
   set(questionRequestIdsAtom, new Map());
+  set(autocommitStatusAtom, null);
 });
 
 // ============================================================================

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -24,7 +24,6 @@ import {
 import type { CloudAgentEvent, StreamError } from '@/lib/cloud-agent-next/event-types';
 import { createEventProcessor, type EventProcessor } from '@/lib/cloud-agent-next/processor';
 import type { EventProcessorCallbacks } from '@/lib/cloud-agent-next/processor';
-import type { AutocommitStatus } from './store/atoms';
 import {
   currentSessionIdAtom,
   isStreamingAtom,

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -24,6 +24,7 @@ import {
 import type { CloudAgentEvent, StreamError } from '@/lib/cloud-agent-next/event-types';
 import { createEventProcessor, type EventProcessor } from '@/lib/cloud-agent-next/processor';
 import type { EventProcessorCallbacks } from '@/lib/cloud-agent-next/processor';
+import type { AutocommitStatus } from './store/atoms';
 import {
   currentSessionIdAtom,
   isStreamingAtom,
@@ -37,6 +38,7 @@ import {
   removeChildSessionPartAtom,
   setQuestionRequestIdAtom,
   sessionOrganizationIdAtom,
+  autocommitStatusAtom,
 } from './store/atoms';
 import {
   updateHighWaterMarkAtom,
@@ -118,6 +120,9 @@ export function useCloudAgentStream({
 
   // Atom for organization ID (used by QuestionToolCard for tRPC calls)
   const setSessionOrganizationId = useSetAtom(sessionOrganizationIdAtom);
+
+  // Atom for autocommit status
+  const setAutocommitStatus = useSetAtom(autocommitStatusAtom);
 
   // Common atoms
   const setCurrentSessionId = useSetAtom(currentSessionIdAtom);
@@ -340,12 +345,38 @@ export function useCloudAgentStream({
 
   const handleEvent = useCallback(
     (event: CloudAgentEvent) => {
+      // Intercept autocommit events — update atom directly, don't pass to EventProcessor
+      if (event.streamEventType === 'autocommit_started') {
+        const data = event.data as { message?: string } | undefined;
+        setAutocommitStatus({
+          status: 'in_progress',
+          message: data?.message ?? 'Committing changes...',
+          timestamp: event.timestamp,
+        });
+        return;
+      }
+      if (event.streamEventType === 'autocommit_completed') {
+        const data = event.data as
+          | { success?: boolean; message?: string; skipped?: boolean }
+          | undefined;
+        if (data?.skipped) {
+          setAutocommitStatus(null);
+        } else {
+          setAutocommitStatus({
+            status: data?.success ? 'completed' : 'failed',
+            message: data?.message ?? (data?.success ? 'Changes committed' : 'Commit failed'),
+            timestamp: event.timestamp,
+          });
+        }
+        return;
+      }
+
       if (!processorRef.current) {
         getProcessor();
       }
       processorRef.current?.processEvent(event);
     },
-    [getProcessor]
+    [getProcessor, setAutocommitStatus]
   );
 
   // Cleanup processor on unmount
@@ -518,6 +549,7 @@ export function useCloudAgentStream({
 
     setLocalError(null);
     setError(null);
+    setAutocommitStatus(null);
     setIsStreaming(true);
 
     try {
@@ -647,6 +679,7 @@ export function useCloudAgentStream({
     async (message: string, cloudAgentSessionId: string, mode: string, model: string) => {
       setLocalError(null);
       setError(null);
+      setAutocommitStatus(null);
       setIsStreaming(true);
 
       // Use provided cloudAgentSessionId, falling back to ref for backward compatibility


### PR DESCRIPTION
## Summary

- Rewrites the autocommit flow to use direct git commands (`git add`, `git commit`, `git push`) and the kilo server's `/commit-message` API instead of spawning a full agent prompt. This eliminates the complexity of managing a secondary kilo session for auto-commit and makes the operation faster and more predictable.
- Adds dedicated `autocommit_started` / `autocommit_completed` stream events so the frontend can show real-time autocommit progress instead of generic status messages.
- Moves the `complete` event to fire **after** post-completion tasks (autocommit, condense), so clients don't disconnect before autocommit output is streamed.
- Passes `autoCommit`, `condenseOnComplete`, `upstreamBranch`, and `model` as environment variables to the wrapper process, with a new `modelIdSchema` for validation.
- Adds a compact `AutocommitStatus` UI component that renders between the message list and the scroll anchor, showing in-progress/completed/failed states.
- Includes tests for the new wrapper env var propagation.