### PR TITLE
Cloud Agent Next - Fix feedback submission failing for V2 sessions

### DIFF
--- a/src/routers/cloud-agent-next-feedback-router.ts
+++ b/src/routers/cloud-agent-next-feedback-router.ts
@@ -15,7 +15,7 @@ const recentMessageSchema = z.object({
 
 const CreateCloudAgentFeedbackInputSchema = z.object({
   cloud_agent_session_id: z.string().max(500).optional(),
-  kilo_session_id: z.string().uuid().optional(),
+  kilo_session_id: z.string().max(500).optional(),
   organization_id: z.string().uuid().optional(),
   feedback_text: z.string().min(1).max(10_000),
   model: z.string().max(255).optional(),


### PR DESCRIPTION
## Summary

- Feedback submission was failing with "Failed to send feedback" for all V2 sessions
- Root cause: `kilo_session_id` was validated as `z.string().uuid()`, but V2 sessions use `ses_xxx` format IDs (not UUIDs)
- Fix: relaxed validation to `z.string().max(500)` to match the `cloud_agent_session_id` field — this field is only used for the Slack notification link and the DB column is `text()`