### PR TITLE
CloudAgentNext - Support standalone questions and hide plan tools

### DIFF
--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -25,6 +25,7 @@ import {
   questionRequestIdsAtom,
   sessionOrganizationIdAtom,
   autocommitStatusAtom,
+  standaloneQuestionAtom,
 } from './store/atoms';
 import { buildSessionConfig, needsResumeConfiguration } from './session-config';
 import {
@@ -87,6 +88,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   const autocommitStatus = useAtomValue(autocommitStatusAtom);
   const questionRequestIds = useAtomValue(questionRequestIdsAtom);
   const questionOrganizationId = useAtomValue(sessionOrganizationIdAtom);
+  const standaloneQuestion = useAtomValue(standaloneQuestionAtom);
 
   // Write to atoms
   const setError = useSetAtom(errorAtom);
@@ -976,6 +978,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
         isOldSession={isOldSession}
         autocommitStatus={autocommitStatus}
         getChildMessages={getChildSessionMessages}
+        standaloneQuestion={standaloneQuestion}
       />
     </QuestionContextProvider>
   );

--- a/src/components/cloud-agent-next/CloudChatPresentation.tsx
+++ b/src/components/cloud-agent-next/CloudChatPresentation.tsx
@@ -24,8 +24,10 @@ import { ArrowDown, RefreshCw } from 'lucide-react';
 import type { AgentMode, SessionConfig, StoredSession, StoredMessage } from './types';
 import { isMessageStreaming } from './types';
 import type { DbSessionDetails, IndexedDbSessionData } from './store/db-session-atoms';
+import type { StandaloneQuestion } from './store/atoms';
 import type { ModelOption } from '@/components/shared/ModelCombobox';
 import type { SlashCommand } from '@/lib/cloud-agent/slash-commands';
+import { QuestionToolCard } from './QuestionToolCard';
 
 // V2: No conversion needed - StoredMessage format is used directly by MessageBubble
 
@@ -168,6 +170,9 @@ export type CloudChatPresentationProps = {
   // Old session handling
   isOldSession?: boolean;
 
+  // Standalone question (not associated with a tool call)
+  standaloneQuestion?: StandaloneQuestion | null;
+
   // Input toolbar state and callbacks
   inputMode?: AgentMode;
   inputModel?: string;
@@ -233,6 +238,7 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
   autocommitStatus,
   isOldSession = false,
   getChildMessages,
+  standaloneQuestion,
   inputMode,
   inputModel,
   onInputModeChange,
@@ -396,6 +402,18 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
 
                 {/* Auto-commit status indicator */}
                 {autocommitStatus && <AutocommitStatus status={autocommitStatus} />}
+
+                {/* Standalone question (not attached to a tool call) */}
+                {standaloneQuestion && (
+                  <div className="my-4 ml-12">
+                    <QuestionToolCard
+                      key={standaloneQuestion.requestId}
+                      questions={standaloneQuestion.questions}
+                      requestId={standaloneQuestion.requestId}
+                      status="running"
+                    />
+                  </div>
+                )}
 
                 {/* Invisible anchor for auto-scroll */}
                 <div ref={messagesEndRef} />

--- a/src/components/cloud-agent-next/PartRenderer.tsx
+++ b/src/components/cloud-agent-next/PartRenderer.tsx
@@ -172,6 +172,11 @@ function ToolPartRenderer({
   childSessionMessages?: Map<string, StoredMessage[]>;
   getChildMessages?: (sessionId: string) => StoredMessage[];
 }) {
+  // plan_enter / plan_exit are internal mode-switching tools with no user-visible output
+  if (part.tool === 'plan_exit' || part.tool === 'plan_enter') {
+    return null;
+  }
+
   // Check if tool input is still streaming (incomplete data)
   if (!hasRequiredInput(part)) {
     return <StreamingToolPlaceholder toolName={part.tool} />;

--- a/src/components/cloud-agent-next/QuestionToolCard.tsx
+++ b/src/components/cloud-agent-next/QuestionToolCard.tsx
@@ -9,9 +9,16 @@ import { useQuestionContext } from './QuestionContext';
 import type { ToolPart } from './types';
 import type { QuestionInfo } from '@/types/opencode.gen';
 
-type QuestionToolCardProps = {
-  toolPart: ToolPart;
-};
+type QuestionToolCardProps =
+  | {
+      toolPart: ToolPart;
+    }
+  | {
+      /** Standalone question (no tool part) — provide data directly */
+      questions: QuestionInfo[];
+      requestId: string;
+      status: 'running' | 'completed' | 'error' | 'pending';
+    };
 
 type QuestionInput = {
   questions: QuestionInfo[];
@@ -259,11 +266,14 @@ function QuestionTab({
   );
 }
 
-export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
-  const state = toolPart.state;
-  const input = state.input as QuestionInput;
-  const questions = input.questions || [];
-  const isRunning = state.status === 'running';
+export function QuestionToolCard(props: QuestionToolCardProps) {
+  // Normalize: tool-part vs standalone question
+  const isStandalone = 'questions' in props;
+  const questions: QuestionInfo[] = isStandalone
+    ? props.questions
+    : (props.toolPart.state.input as QuestionInput).questions || [];
+  const status = isStandalone ? props.status : props.toolPart.state.status;
+  const isRunning = status === 'running';
 
   const [isExpanded, setIsExpanded] = useState(isRunning);
   const [activeTab, setActiveTab] = useState(0);
@@ -280,15 +290,24 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
     organizationId,
   } = useQuestionContext();
 
-  const requestId = toolPart.callID ? questionRequestIds.get(toolPart.callID) : undefined;
+  const requestId = isStandalone
+    ? props.requestId
+    : props.toolPart.callID
+      ? questionRequestIds.get(props.toolPart.callID)
+      : undefined;
 
   // Get answers from metadata for completed state
-  const completedAnswers: string[][] =
-    state.status === 'completed'
-      ? ((state.metadata as QuestionMetadata | undefined)?.answers ?? [])
-      : [];
+  const completedAnswers: string[][] = (() => {
+    if (isStandalone) return [];
+    const { state } = props.toolPart;
+    if (state.status !== 'completed') return [];
+    return (state.metadata as QuestionMetadata | undefined)?.answers ?? [];
+  })();
 
-  const error = state.status === 'error' ? state.error : undefined;
+  const error =
+    !isStandalone && status === 'error' && props.toolPart.state.status === 'error'
+      ? props.toolPart.state.error
+      : undefined;
   const questionCount = questions.length;
   const answeredCount = completedAnswers.filter(a => a && a.length > 0).length;
 
@@ -600,7 +619,7 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
         onClick={() => setIsExpanded(!isExpanded)}
         className="flex w-full items-center gap-2 px-3 py-2 text-left"
       >
-        {getStatusIndicator(state.status)}
+        {getStatusIndicator(status)}
         <span className="min-w-0 flex-1 truncate text-sm">{headerText}</span>
         <ChevronDown
           className={cn(
@@ -645,7 +664,7 @@ export function QuestionToolCard({ toolPart }: QuestionToolCardProps) {
             </div>
           )}
 
-          {state.status === 'pending' && (
+          {status === 'pending' && (
             <div className="text-muted-foreground mt-2 text-xs italic">Preparing question...</div>
           )}
         </div>

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -8,6 +8,7 @@
 import { atom } from 'jotai';
 import type { SessionConfig, StoredMessage, Part } from '../types';
 import { isMessageStreaming, isAssistantMessage } from '../types';
+import type { QuestionInfo } from '@/types/opencode.gen';
 
 // ============================================================================
 // Primary State - StoredMessage format
@@ -50,6 +51,26 @@ export const setQuestionRequestIdAtom = atom(
     set(questionRequestIdsAtom, map);
   }
 );
+
+/**
+ * A standalone question from a question.asked event that has no tool.callID.
+ * These are questions raised outside the tool-call flow (e.g. PlanFollowup).
+ * Only one standalone question can be active at a time.
+ */
+export type StandaloneQuestion = {
+  requestId: string;
+  questions: QuestionInfo[];
+};
+
+export const standaloneQuestionAtom = atom<StandaloneQuestion | null>(null);
+
+/** Clear the standalone question only if its requestId matches the resolved one. */
+export const clearStandaloneQuestionAtom = atom(null, (get, set, resolvedRequestId: string) => {
+  const current = get(standaloneQuestionAtom);
+  if (current && current.requestId === resolvedRequestId) {
+    set(standaloneQuestionAtom, null);
+  }
+});
 
 /**
  * Session status from session.status events
@@ -146,6 +167,7 @@ export const clearMessagesAtom = atom(null, (_get, set) => {
   set(partsMapAtom, new Map());
   set(questionRequestIdsAtom, new Map());
   set(autocommitStatusAtom, null);
+  set(standaloneQuestionAtom, null);
 });
 
 // ============================================================================

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -38,6 +38,8 @@ import {
   setQuestionRequestIdAtom,
   sessionOrganizationIdAtom,
   autocommitStatusAtom,
+  standaloneQuestionAtom,
+  clearStandaloneQuestionAtom,
 } from './store/atoms';
 import {
   updateHighWaterMarkAtom,
@@ -114,8 +116,10 @@ export function useCloudAgentStream({
   const updateChildSessionPart = useSetAtom(updateChildSessionPartAtom);
   const removeChildSessionPart = useSetAtom(removeChildSessionPartAtom);
 
-  // Atom for question tracking
+  // Atoms for question tracking
   const setQuestionRequestId = useSetAtom(setQuestionRequestIdAtom);
+  const setStandaloneQuestion = useSetAtom(standaloneQuestionAtom);
+  const clearStandaloneQuestion = useSetAtom(clearStandaloneQuestionAtom);
 
   // Atom for organization ID (used by QuestionToolCard for tRPC calls)
   const setSessionOrganizationId = useSetAtom(sessionOrganizationIdAtom);
@@ -313,6 +317,15 @@ export function useCloudAgentStream({
         setQuestionRequestId({ callId, requestId });
         onQuestionAskedRef.current?.();
       },
+
+      onStandaloneQuestionAsked: (requestId, questions) => {
+        setStandaloneQuestion({ requestId, questions });
+        onQuestionAskedRef.current?.();
+      },
+
+      onQuestionResolved: requestId => {
+        clearStandaloneQuestion(requestId);
+      },
     }),
     [
       updateMessage,
@@ -330,6 +343,8 @@ export function useCloudAgentStream({
       removeChildSessionPart,
       setError,
       setQuestionRequestId,
+      setStandaloneQuestion,
+      clearStandaloneQuestion,
     ]
   );
 

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -1180,6 +1180,107 @@ describe('createEventProcessor', () => {
     });
   });
 
+  describe('question events', () => {
+    it('should call onQuestionAsked with callId and requestId for tool-associated questions', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onQuestionAsked: jest.fn(),
+        onStandaloneQuestionAsked: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('question.asked', {
+          id: 'req-1',
+          sessionID: 'session-123',
+          questions: [{ question: 'Pick one', header: 'Choice', options: [], multiple: false }],
+          tool: { messageID: 'msg-1', callID: 'call-1' },
+        })
+      );
+
+      expect(callbacks.onQuestionAsked).toHaveBeenCalledWith('req-1', 'call-1');
+      expect(callbacks.onStandaloneQuestionAsked).not.toHaveBeenCalled();
+    });
+
+    it('should call onStandaloneQuestionAsked for questions without tool.callID', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onQuestionAsked: jest.fn(),
+        onStandaloneQuestionAsked: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      const questions = [
+        {
+          question: 'Ready?',
+          header: 'Implement',
+          options: [{ label: 'Yes', description: 'Go' }],
+          custom: true,
+        },
+      ];
+
+      processor.processEvent(
+        createKilocodeEvent('question.asked', {
+          id: 'req-2',
+          sessionID: 'session-123',
+          questions,
+        })
+      );
+
+      expect(callbacks.onStandaloneQuestionAsked).toHaveBeenCalledWith('req-2', questions);
+      expect(callbacks.onQuestionAsked).not.toHaveBeenCalled();
+    });
+
+    it('should call onQuestionResolved with requestId on question.rejected', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onQuestionResolved: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('question.rejected', {
+          sessionID: 'session-123',
+          requestID: 'req-1',
+        })
+      );
+
+      expect(callbacks.onQuestionResolved).toHaveBeenCalledWith('req-1');
+    });
+
+    it('should call onQuestionResolved with requestId on question.replied', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onQuestionResolved: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('question.replied', {
+          sessionID: 'session-123',
+          requestID: 'req-1',
+          answers: [['Yes']],
+        })
+      );
+
+      expect(callbacks.onQuestionResolved).toHaveBeenCalledWith('req-1');
+    });
+
+    it('should not call onStandaloneQuestionAsked when questions array is missing', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onQuestionAsked: jest.fn(),
+        onStandaloneQuestionAsked: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('question.asked', {
+          id: 'req-3',
+          sessionID: 'session-123',
+        })
+      );
+
+      expect(callbacks.onQuestionAsked).not.toHaveBeenCalled();
+      expect(callbacks.onStandaloneQuestionAsked).not.toHaveBeenCalled();
+    });
+  });
+
   describe('invalid events', () => {
     it('should ignore events with unknown types', () => {
       const callbacks: EventProcessorCallbacks = {

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -17,7 +17,7 @@
 
 import type { CloudAgentEvent } from '../event-types';
 import { isValidCloudAgentEvent } from '../event-types';
-import type { Part } from '@/types/opencode.gen';
+import type { Part, QuestionInfo } from '@/types/opencode.gen';
 import type { ProcessedMessage, EventProcessorConfig } from './types';
 import {
   stripPartContentIfFile,
@@ -46,6 +46,8 @@ const HANDLED_EVENT_TYPES = new Set([
   'session.idle',
   'session.turn.close',
   'question.asked',
+  'question.replied',
+  'question.rejected',
 ]);
 
 function isHandledEventType(type: string): boolean {
@@ -384,13 +386,21 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   }
 
   /**
-   * Handle question.asked events — extract the callID→requestId mapping.
+   * Handle question.asked events.
+   * Tool-associated questions map callID→requestId for QuestionToolCard.
+   * Standalone questions (no tool) are forwarded separately.
    */
-  function handleQuestionAsked(data: { id: string; tool?: { callID: string } }): void {
+  function handleQuestionAsked(data: {
+    id: string;
+    questions?: Array<QuestionInfo>;
+    tool?: { callID: string };
+  }): void {
     const requestId = data.id;
     const callId = data.tool?.callID;
     if (requestId && callId) {
       callbacks.onQuestionAsked?.(requestId, callId);
+    } else if (requestId && !callId && data.questions) {
+      callbacks.onStandaloneQuestionAsked?.(requestId, data.questions);
     }
   }
 
@@ -520,8 +530,23 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
         break;
 
       case 'question.asked':
-        handleQuestionAsked(data as { id: string; tool?: { callID: string } });
+        handleQuestionAsked(
+          data as {
+            id: string;
+            questions?: Array<QuestionInfo>;
+            tool?: { callID: string };
+          }
+        );
         break;
+
+      case 'question.replied':
+      case 'question.rejected': {
+        const requestID = (data as { requestID?: string }).requestID;
+        if (requestID) {
+          callbacks.onQuestionResolved?.(requestID);
+        }
+        break;
+      }
     }
   }
 

--- a/src/lib/cloud-agent-next/processor/types.ts
+++ b/src/lib/cloud-agent-next/processor/types.ts
@@ -12,6 +12,7 @@ import type {
   Session,
   UserMessage,
   AssistantMessage,
+  QuestionInfo,
 } from '@/types/opencode.gen';
 
 /**
@@ -86,6 +87,12 @@ export type EventProcessorCallbacks = {
 
   /** Called when a question.asked event maps a tool callID to a requestId */
   onQuestionAsked?: (requestId: string, callId: string) => void;
+
+  /** Called when a question.asked event has no associated tool (standalone question) */
+  onStandaloneQuestionAsked?: (requestId: string, questions: QuestionInfo[]) => void;
+
+  /** Called when a question is answered or rejected (question.replied / question.rejected) */
+  onQuestionResolved?: (requestId: string) => void;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add support for **standalone questions** — questions raised outside the tool-call flow (e.g. PlanFollowup) that have no `tool.callID`. A new `standaloneQuestionAtom` tracks the active standalone question and renders it via `QuestionToolCard` at the bottom of the message list.
- Handle `question.replied` and `question.rejected` events to clear standalone questions when resolved.
- Hide `plan_enter` / `plan_exit` tool parts in `PartRenderer` since they are internal mode-switching tools with no user-visible output.
- Refactor `QuestionToolCard` to accept either a `toolPart` prop or direct question data (`questions`, `requestId`, `status`), enabling reuse for standalone questions.
- Add comprehensive tests for question event handling (tool-associated, standalone, replied, rejected, missing data) in `event-processor.test.ts`.


## Showcase 

Standalone questions are used for example after plan mode

<img width="1088" height="661" alt="Screenshot 2026-02-26 at 23 10 49" src="https://github.com/user-attachments/assets/5a4a667e-a10e-4bf9-9626-c440e3bb7e54" />
