### PR TITLE
Fix/sanitize kiloclaw error details

### DIFF
--- a/src/app/(app)/claw/components/InstanceTab.tsx
+++ b/src/app/(app)/claw/components/InstanceTab.tsx
@@ -88,7 +88,7 @@ export function InstanceTab({
       <p className="text-muted-foreground text-sm">
         {isControllerError
           ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
-          : `Failed to load gateway status: ${gatewayError.message}`}
+          : 'Failed to load gateway status.'}
       </p>
     );
   }

--- a/src/app/(app)/claw/components/InstanceTab.tsx
+++ b/src/app/(app)/claw/components/InstanceTab.tsx
@@ -61,7 +61,7 @@ export function InstanceTab({
   status: KiloClawDashboardStatus;
   gatewayStatus: GatewayProcessStatusResponse | undefined;
   gatewayLoading: boolean;
-  gatewayError: { message: string } | null;
+  gatewayError: { message: string; data?: { code?: string } | null } | null;
 }) {
   const isRunning = status.status === 'running';
 
@@ -83,10 +83,10 @@ export function InstanceTab({
   }
 
   if (gatewayError) {
-    const isControllerError = gatewayError.message.includes('GatewayControllerError');
+    const isControllerUnavailable = gatewayError.data?.code === 'NOT_FOUND';
     return (
       <p className="text-muted-foreground text-sm">
-        {isControllerError
+        {isControllerUnavailable
           ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
           : 'Failed to load gateway status.'}
       </p>

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -510,9 +510,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                     {gatewayStatusError instanceof Error &&
                     gatewayStatusError.message.includes('GatewayControllerError')
                       ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
-                      : gatewayStatusError instanceof Error
-                        ? gatewayStatusError.message
-                        : 'Failed to load gateway status'}
+                      : 'Failed to load gateway status'}
                   </AlertDescription>
                 </Alert>
               )}

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -507,8 +507,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <Alert>
                   <AlertTriangle className="h-4 w-4" />
                   <AlertDescription>
-                    {gatewayStatusError instanceof Error &&
-                    gatewayStatusError.message.includes('GatewayControllerError')
+                    {'data' in gatewayStatusError &&
+                    (gatewayStatusError as { data?: { code?: string } }).data?.code === 'NOT_FOUND'
                       ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
                       : 'Failed to load gateway status'}
                   </AlertDescription>

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -19,6 +19,21 @@ import type {
 } from './types';
 
 /**
+ * Error thrown when the KiloClaw API returns a non-OK response.
+ * Preserves the HTTP status code for structured error handling
+ * without leaking the raw response body.
+ */
+export class KiloClawApiError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number) {
+    super(`KiloClaw API error (${statusCode})`);
+    this.name = 'KiloClawApiError';
+    this.statusCode = statusCode;
+  }
+}
+
+/**
  * KiloClaw worker client for platform (internal) routes.
  * Uses x-internal-api-key auth. Server-only.
  */
@@ -53,7 +68,7 @@ export class KiloClawInternalClient {
         `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
         body
       );
-      throw new Error(`KiloClaw API error (${res.status})`);
+      throw new KiloClawApiError(res.status);
     }
 
     return res.json() as Promise<T>;

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -49,7 +49,11 @@ export class KiloClawInternalClient {
 
     if (!res.ok) {
       const body = await res.text();
-      throw new Error(`KiloClaw API error (${res.status}): ${body}`);
+      console.error(
+        `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
+        body
+      );
+      throw new Error(`KiloClaw API error (${res.status})`);
     }
 
     return res.json() as Promise<T>;

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -31,7 +31,11 @@ export class KiloClawUserClient {
 
     if (!res.ok) {
       const body = await res.text();
-      throw new Error(`KiloClaw API error (${res.status}): ${body}`);
+      console.error(
+        `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
+        body
+      );
+      throw new Error(`KiloClaw API error (${res.status})`);
     }
 
     return res.json() as Promise<T>;

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { KILOCLAW_API_URL } from '@/lib/config.server';
+import { KiloClawApiError } from './kiloclaw-internal-client';
 import type { UserConfigResponse, PlatformStatusResponse, RestartGatewayResponse } from './types';
 
 /**
@@ -35,7 +36,7 @@ export class KiloClawUserClient {
         `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
         body
       );
-      throw new Error(`KiloClaw API error (${res.status})`);
+      throw new KiloClawApiError(res.status);
     }
 
     return res.json() as Promise<T>;

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,7 +1,7 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { kiloclaw_instances, kilocode_users } from '@/db/schema';
-import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import {
   markActiveInstanceDestroyed,
   restoreDestroyedInstance,
@@ -281,9 +281,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         const client = new KiloClawInternalClient();
         return await client.listVolumeSnapshots(input.userId);
       } catch (err) {
+        console.error('Failed to fetch volume snapshots for user:', input.userId, err);
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
-          message: err instanceof Error ? err.message : 'Failed to fetch volume snapshots',
+          message: 'Failed to fetch volume snapshots',
         });
       }
     }),
@@ -293,9 +294,16 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.getGatewayStatus(input.userId);
     } catch (err) {
+      console.error('Failed to fetch gateway status for user:', input.userId, err);
+      if (err instanceof KiloClawApiError && (err.statusCode === 404 || err.statusCode === 409)) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Gateway control unavailable',
+        });
+      }
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to fetch gateway status',
+        message: 'Failed to fetch gateway status',
       });
     }
   }),
@@ -305,9 +313,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.startGateway(input.userId);
     } catch (err) {
+      console.error('Failed to start gateway for user:', input.userId, err);
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to start gateway',
+        message: 'Failed to start gateway',
       });
     }
   }),
@@ -317,9 +326,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.stopGateway(input.userId);
     } catch (err) {
+      console.error('Failed to stop gateway for user:', input.userId, err);
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to stop gateway',
+        message: 'Failed to stop gateway',
       });
     }
   }),
@@ -329,9 +339,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.restartGatewayProcess(input.userId);
     } catch (err) {
+      console.error('Failed to restart gateway for user:', input.userId, err);
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to restart gateway',
+        message: 'Failed to restart gateway',
       });
     }
   }),

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import * as z from 'zod';
+import { TRPCError } from '@trpc/server';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -275,8 +276,15 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   gatewayStatus: baseProcedure.query(async ({ ctx }) => {
-    const client = new KiloClawInternalClient();
-    return client.getGatewayStatus(ctx.user.id);
+    try {
+      const client = new KiloClawInternalClient();
+      return await client.getGatewayStatus(ctx.user.id);
+    } catch (err) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to fetch gateway status',
+      });
+    }
   }),
 
   restartOpenClaw: baseProcedure.mutation(async ({ ctx }) => {

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { TRPCError } from '@trpc/server';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
-import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
 import { KILOCLAW_API_URL } from '@/lib/config.server';
@@ -280,6 +280,13 @@ export const kiloclawRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.getGatewayStatus(ctx.user.id);
     } catch (err) {
+      console.error('Failed to fetch gateway status for user:', ctx.user.id, err);
+      if (err instanceof KiloClawApiError && (err.statusCode === 404 || err.statusCode === 409)) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Gateway control unavailable',
+        });
+      }
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to fetch gateway status',


### PR DESCRIPTION
Strip raw KiloClaw API response bodies from thrown errors and log them server-side instead. Add KiloClawApiError class that preserves HTTP status codes without leaking response bodies. Add missing error handling to the user-facing gatewayStatus tRPC endpoint. Replace brittle GatewayControllerError string matching in frontend with structured tRPC error code checks (NOT_FOUND). Add console.error with user context before all sanitized TRPCError throws.