### PR TITLE
Security/general kiloclaw channels fixes

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1797,7 +1797,7 @@ describe('approveDevicePairingRequest', () => {
       '58f4ac67-12b4-4f6e-adee-ff3463a7c30c'
     );
 
-    expect(result).toEqual({ success: false, message: 'request not found' });
+    expect(result).toEqual({ success: false, message: 'Approval failed' });
   });
 });
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -805,9 +805,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
     }
 
+    if (!success) {
+      console.error('[DO] pairing approve failed:', result.stderr || result.stdout);
+    }
+
     return {
       success,
-      message: success ? 'Pairing approved' : result.stderr || result.stdout || 'Approval failed',
+      message: success ? 'Pairing approved' : 'Approval failed',
     };
   }
 
@@ -944,11 +948,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
     }
 
+    if (!success) {
+      console.error('[DO] device pairing approve failed:', result.stderr || result.stdout);
+    }
+
     return {
       success,
-      message: success
-        ? 'Device pairing approved'
-        : result.stderr || result.stdout || 'Approval failed',
+      message: success ? 'Device pairing approved' : 'Approval failed',
     };
   }
 

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -75,6 +75,32 @@ function jsonError(message: string, status: number): Response {
 }
 
 /**
+ * Safe error messages that can be returned to callers without leaking internals.
+ * All other error messages are replaced with a generic "Internal error" response.
+ * The raw error is always logged via console.error for Sentry/debugging.
+ */
+const SAFE_ERROR_PREFIXES = [
+  'Instance is not ', // e.g. "Instance is not running", "Instance is not provisioned"
+  'User already has an ', // duplicate provision
+  'Gateway controller ', // already sanitized at DO level
+];
+
+function sanitizeError(err: unknown, operation: string): { message: string; status: number } {
+  const raw = err instanceof Error ? err.message : 'Unknown error';
+  const status = statusCodeFromError(err);
+
+  // Log the full error for Sentry/debugging — this never reaches the caller
+  console.error(`[platform] ${operation} failed:`, raw);
+
+  // Allow known-safe messages through
+  if (SAFE_ERROR_PREFIXES.some(prefix => raw.startsWith(prefix))) {
+    return { message: raw, status };
+  }
+
+  return { message: `${operation} failed`, status };
+}
+
+/**
  * Safely parse JSON body through a zod schema.
  * Returns 400 with a consistent error shape on malformed JSON or validation failure.
  */
@@ -136,12 +162,13 @@ platform.post('/provision', async c => {
     );
     return c.json(provision, 201);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] provision failed:', message);
-    if (message.includes('duplicate key') || message.includes('unique constraint')) {
+    const raw = err instanceof Error ? err.message : 'Unknown error';
+    if (raw.includes('duplicate key') || raw.includes('unique constraint')) {
+      console.error('[platform] provision failed: duplicate instance');
       return c.json({ error: 'User already has an active instance' }, 409);
     }
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'provision');
+    return jsonError(message, status);
   }
 });
 
@@ -167,9 +194,8 @@ platform.patch('/kilocode-config', async c => {
     );
     return c.json(updated, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] kilocode-config patch failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'kilocode-config patch');
+    return jsonError(message, status);
   }
 });
 
@@ -188,9 +214,8 @@ platform.patch('/channels', async c => {
     );
     return c.json(updated, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] channels patch failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'channels patch');
+    return jsonError(message, status);
   }
 });
 
@@ -209,9 +234,8 @@ platform.get('/pairing', async c => {
     );
     return c.json(pairing, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] pairing list failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'pairing list');
+    return jsonError(message, status);
   }
 });
 
@@ -236,9 +260,8 @@ platform.post('/pairing/approve', async c => {
     );
     return c.json(approved, approved.success ? 200 : 500);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] pairing approve failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'pairing approve');
+    return jsonError(message, status);
   }
 });
 
@@ -257,9 +280,8 @@ platform.get('/device-pairing', async c => {
     );
     return c.json(pairing, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] device pairing list failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'device pairing list');
+    return jsonError(message, status);
   }
 });
 
@@ -283,9 +305,8 @@ platform.post('/device-pairing/approve', async c => {
     );
     return c.json(approved, approved.success ? 200 : 500);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] device pairing approve failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'device pairing approve');
+    return jsonError(message, status);
   }
 });
 
@@ -304,9 +325,7 @@ platform.get('/gateway/status', async c => {
     );
     return c.json(gatewayStatus, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    const status = statusCodeFromError(err);
-    console.error(`[platform] gateway status failed: ${message} status=${status}`);
+    const { message, status } = sanitizeError(err, 'gateway status');
     return jsonError(message, status);
   }
 });
@@ -324,9 +343,7 @@ platform.post('/gateway/start', async c => {
     );
     return c.json(response, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    const status = statusCodeFromError(err);
-    console.error('[platform] gateway start failed:', message);
+    const { message, status } = sanitizeError(err, 'gateway start');
     return jsonError(message, status);
   }
 });
@@ -344,9 +361,7 @@ platform.post('/gateway/stop', async c => {
     );
     return c.json(response, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    const status = statusCodeFromError(err);
-    console.error('[platform] gateway stop failed:', message);
+    const { message, status } = sanitizeError(err, 'gateway stop');
     return jsonError(message, status);
   }
 });
@@ -364,9 +379,7 @@ platform.post('/gateway/restart', async c => {
     );
     return c.json(response, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    const status = statusCodeFromError(err);
-    console.error('[platform] gateway restart failed:', message);
+    const { message, status } = sanitizeError(err, 'gateway restart');
     return jsonError(message, status);
   }
 });
@@ -384,9 +397,8 @@ platform.post('/doctor', async c => {
     );
     return c.json(doctor, 200);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] doctor failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'doctor');
+    return jsonError(message, status);
   }
 });
 
@@ -403,9 +415,8 @@ platform.post('/start', async c => {
     );
     return c.json({ ok: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] start failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'start');
+    return jsonError(message, status);
   }
 });
 
@@ -418,9 +429,8 @@ platform.post('/stop', async c => {
     await withDORetry(instanceStubFactory(c.env, result.data.userId), stub => stub.stop(), 'stop');
     return c.json({ ok: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] stop failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'stop');
+    return jsonError(message, status);
   }
 });
 
@@ -437,9 +447,8 @@ platform.post('/destroy', async c => {
     );
     return c.json({ ok: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] destroy failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'destroy');
+    return jsonError(message, status);
   }
 });
 
@@ -458,9 +467,8 @@ platform.get('/status', async c => {
     );
     return c.json(status);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] status failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'status');
+    return jsonError(message, status);
   }
 });
 
@@ -491,9 +499,8 @@ platform.get('/gateway-token', async c => {
     const gatewayToken = await deriveGatewayToken(status.sandboxId, c.env.GATEWAY_TOKEN_SECRET);
     return c.json({ gatewayToken });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] gateway-token failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'gateway-token');
+    return jsonError(message, status);
   }
 });
 
@@ -513,9 +520,8 @@ platform.get('/volume-snapshots', async c => {
     );
     return c.json({ snapshots });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[platform] volume-snapshots failed:', message);
-    return c.json({ error: message }, 500);
+    const { message, status } = sanitizeError(err, 'volume-snapshots');
+    return jsonError(message, status);
   }
 });
 

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 
 export const EncryptedEnvelopeSchema = z.object({
-  encryptedData: z.string(),
-  encryptedDEK: z.string(),
+  // AES-256-GCM ciphertext: 16-byte IV + ciphertext + 16-byte tag, base64-encoded.
+  // 8 KiB is generous for token values (typical bot tokens are < 200 bytes).
+  encryptedData: z.string().max(8192),
+  // RSA-2048 OAEP ciphertext of the 32-byte DEK, base64-encoded (~344 chars).
+  encryptedDEK: z.string().max(1024),
   algorithm: z.literal('rsa-aes-256-gcm'),
   version: z.literal(1),
 });

--- a/src/app/(app)/claw/components/InstanceTab.tsx
+++ b/src/app/(app)/claw/components/InstanceTab.tsx
@@ -88,7 +88,7 @@ export function InstanceTab({
       <p className="text-muted-foreground text-sm">
         {isControllerError
           ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
-          : `Failed to load gateway status: ${gatewayError.message}`}
+          : 'Failed to load gateway status.'}
       </p>
     );
   }

--- a/src/app/(app)/claw/components/InstanceTab.tsx
+++ b/src/app/(app)/claw/components/InstanceTab.tsx
@@ -61,7 +61,7 @@ export function InstanceTab({
   status: KiloClawDashboardStatus;
   gatewayStatus: GatewayProcessStatusResponse | undefined;
   gatewayLoading: boolean;
-  gatewayError: { message: string } | null;
+  gatewayError: { message: string; data?: { code?: string } | null } | null;
 }) {
   const isRunning = status.status === 'running';
 
@@ -83,10 +83,10 @@ export function InstanceTab({
   }
 
   if (gatewayError) {
-    const isControllerError = gatewayError.message.includes('GatewayControllerError');
+    const isControllerUnavailable = gatewayError.data?.code === 'NOT_FOUND';
     return (
       <p className="text-muted-foreground text-sm">
-        {isControllerError
+        {isControllerUnavailable
           ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
           : 'Failed to load gateway status.'}
       </p>

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -510,9 +510,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                     {gatewayStatusError instanceof Error &&
                     gatewayStatusError.message.includes('GatewayControllerError')
                       ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
-                      : gatewayStatusError instanceof Error
-                        ? gatewayStatusError.message
-                        : 'Failed to load gateway status'}
+                      : 'Failed to load gateway status'}
                   </AlertDescription>
                 </Alert>
               )}

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -507,8 +507,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <Alert>
                   <AlertTriangle className="h-4 w-4" />
                   <AlertDescription>
-                    {gatewayStatusError instanceof Error &&
-                    gatewayStatusError.message.includes('GatewayControllerError')
+                    {'data' in gatewayStatusError &&
+                    (gatewayStatusError as { data?: { code?: string } }).data?.code === 'NOT_FOUND'
                       ? 'Gateway control unavailable. Redeploy to update instance to use this feature.'
                       : 'Failed to load gateway status'}
                   </AlertDescription>

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -19,6 +19,21 @@ import type {
 } from './types';
 
 /**
+ * Error thrown when the KiloClaw API returns a non-OK response.
+ * Preserves the HTTP status code for structured error handling
+ * without leaking the raw response body.
+ */
+export class KiloClawApiError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number) {
+    super(`KiloClaw API error (${statusCode})`);
+    this.name = 'KiloClawApiError';
+    this.statusCode = statusCode;
+  }
+}
+
+/**
  * KiloClaw worker client for platform (internal) routes.
  * Uses x-internal-api-key auth. Server-only.
  */
@@ -53,7 +68,7 @@ export class KiloClawInternalClient {
         `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
         body
       );
-      throw new Error(`KiloClaw API error (${res.status})`);
+      throw new KiloClawApiError(res.status);
     }
 
     return res.json() as Promise<T>;

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -49,7 +49,11 @@ export class KiloClawInternalClient {
 
     if (!res.ok) {
       const body = await res.text();
-      throw new Error(`KiloClaw API error (${res.status}): ${body}`);
+      console.error(
+        `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
+        body
+      );
+      throw new Error(`KiloClaw API error (${res.status})`);
     }
 
     return res.json() as Promise<T>;

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -31,7 +31,11 @@ export class KiloClawUserClient {
 
     if (!res.ok) {
       const body = await res.text();
-      throw new Error(`KiloClaw API error (${res.status}): ${body}`);
+      console.error(
+        `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
+        body
+      );
+      throw new Error(`KiloClaw API error (${res.status})`);
     }
 
     return res.json() as Promise<T>;

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { KILOCLAW_API_URL } from '@/lib/config.server';
+import { KiloClawApiError } from './kiloclaw-internal-client';
 import type { UserConfigResponse, PlatformStatusResponse, RestartGatewayResponse } from './types';
 
 /**
@@ -35,7 +36,7 @@ export class KiloClawUserClient {
         `KiloClaw API error (${res.status}) ${options?.method ?? 'GET'} ${path}:`,
         body
       );
-      throw new Error(`KiloClaw API error (${res.status})`);
+      throw new KiloClawApiError(res.status);
     }
 
     return res.json() as Promise<T>;

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,7 +1,7 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { kiloclaw_instances, kilocode_users } from '@/db/schema';
-import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import {
   markActiveInstanceDestroyed,
   restoreDestroyedInstance,
@@ -281,9 +281,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         const client = new KiloClawInternalClient();
         return await client.listVolumeSnapshots(input.userId);
       } catch (err) {
+        console.error('Failed to fetch volume snapshots for user:', input.userId, err);
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
-          message: err instanceof Error ? err.message : 'Failed to fetch volume snapshots',
+          message: 'Failed to fetch volume snapshots',
         });
       }
     }),
@@ -293,9 +294,16 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.getGatewayStatus(input.userId);
     } catch (err) {
+      console.error('Failed to fetch gateway status for user:', input.userId, err);
+      if (err instanceof KiloClawApiError && (err.statusCode === 404 || err.statusCode === 409)) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Gateway control unavailable',
+        });
+      }
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to fetch gateway status',
+        message: 'Failed to fetch gateway status',
       });
     }
   }),
@@ -305,9 +313,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.startGateway(input.userId);
     } catch (err) {
+      console.error('Failed to start gateway for user:', input.userId, err);
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to start gateway',
+        message: 'Failed to start gateway',
       });
     }
   }),
@@ -317,9 +326,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.stopGateway(input.userId);
     } catch (err) {
+      console.error('Failed to stop gateway for user:', input.userId, err);
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to stop gateway',
+        message: 'Failed to stop gateway',
       });
     }
   }),
@@ -329,9 +339,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.restartGatewayProcess(input.userId);
     } catch (err) {
+      console.error('Failed to restart gateway for user:', input.userId, err);
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        message: err instanceof Error ? err.message : 'Failed to restart gateway',
+        message: 'Failed to restart gateway',
       });
     }
   }),

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import * as z from 'zod';
+import { TRPCError } from '@trpc/server';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -275,8 +276,15 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   gatewayStatus: baseProcedure.query(async ({ ctx }) => {
-    const client = new KiloClawInternalClient();
-    return client.getGatewayStatus(ctx.user.id);
+    try {
+      const client = new KiloClawInternalClient();
+      return await client.getGatewayStatus(ctx.user.id);
+    } catch (err) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to fetch gateway status',
+      });
+    }
   }),
 
   restartOpenClaw: baseProcedure.mutation(async ({ ctx }) => {

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { TRPCError } from '@trpc/server';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
-import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
 import { KILOCLAW_API_URL } from '@/lib/config.server';
@@ -280,6 +280,13 @@ export const kiloclawRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
       return await client.getGatewayStatus(ctx.user.id);
     } catch (err) {
+      console.error('Failed to fetch gateway status for user:', ctx.user.id, err);
+      if (err instanceof KiloClawApiError && (err.statusCode === 404 || err.statusCode === 409)) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Gateway control unavailable',
+        });
+      }
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to fetch gateway status',


### PR DESCRIPTION
- Sanitize all platform route error responses via sanitizeError() helper;. raw errors logged for Sentry, generic messages returned to callers
- Stop leaking raw stderr/stdout from pairing approve commands
- Add max length constraints to EncryptedEnvelopeSchema fields (encryptedData: 8KiB, encryptedDEK: 1KiB) to prevent unbounded input