### PR TITLE
fix: make OpenRouterCategoryEntry.id optional to match API change

### DIFF
--- a/src/lib/providers/openrouter/openrouter-types.ts
+++ b/src/lib/providers/openrouter/openrouter-types.ts
@@ -194,7 +194,7 @@ export const OpenRouterAnalytics = z.record(z.string(), OpenRouterAnalyticsEntry
 // Categories
 export type OpenRouterCategoryEntry = z.infer<typeof OpenRouterCategoryEntry>;
 export const OpenRouterCategoryEntry = z.object({
-  id: z.number(),
+  id: z.number().optional(),
   date: z.string(),
   model: z.string(),
   category: z.string(),


### PR DESCRIPTION
## Summary
- The sync-providers cron has been failing every 10 minutes since Feb 25 (Sentry: KILOCODE-WEB-KXB, 154 occurrences)
- **Root cause**: OpenRouter's `/api/frontend/models/find` API removed the `id` field from category entries, causing a `ZodError` at `sync-providers.ts:127` during `OpenRouterSearchResponse.parse()`
- **Fix**: Make `OpenRouterCategoryEntry.id` optional (`z.number().optional()`) to match the upstream API's current response format

Fixes KILOCODE-WEB-KXB