### PR TITLE
Add 'Redeploy or Upgrade' button with radio selector dialog:

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -54,6 +54,15 @@ vi.mock('../fly/client', async () => {
   };
 });
 
+// -- Mock image-version --
+vi.mock('../lib/image-version', async () => {
+  const actual = await vi.importActual('../lib/image-version');
+  return {
+    ...actual,
+    resolveLatestVersion: vi.fn().mockResolvedValue(null),
+  };
+});
+
 // -- Mock db --
 vi.mock('../db', () => ({
   createDatabaseConnection: vi.fn(),
@@ -78,6 +87,7 @@ import { KiloClawInstance } from './kiloclaw-instance';
 import * as flyClient from '../fly/client';
 import { FlyApiError } from '../fly/client';
 import * as db from '../db';
+import { resolveLatestVersion } from '../lib/image-version';
 import {
   ALARM_INTERVAL_RUNNING_MS,
   ALARM_INTERVAL_DESTROYING_MS,
@@ -2084,5 +2094,88 @@ describe('auto-destroy stale provisioned instances', () => {
 
     expect(markDestroyed).not.toHaveBeenCalled();
     expect(storage._store.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// restartGateway image tag override
+// ============================================================================
+
+describe('restartGateway image tag override', () => {
+  beforeEach(() => {
+    (flyClient.stopMachineAndWait as Mock).mockResolvedValue(undefined);
+    (flyClient.updateMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      id: 'machine-1',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+  });
+
+  it('uses existing trackedImageTag when no options provided', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { trackedImageTag: 'old-tag-123' });
+
+    const result = await instance.restartGateway();
+
+    expect(result.success).toBe(true);
+    expect(resolveLatestVersion).not.toHaveBeenCalled();
+    expect(storage._store.get('trackedImageTag')).toBe('old-tag-123');
+  });
+
+  it('fetches latest from KV when imageTag is "latest"', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, {
+      trackedImageTag: 'old-tag',
+      openclawVersion: '1.0.0',
+      imageVariant: 'default',
+    });
+
+    (resolveLatestVersion as Mock).mockResolvedValueOnce({
+      openclawVersion: '2.0.0',
+      variant: 'default',
+      imageTag: 'new-tag-from-kv',
+      imageDigest: null,
+      publishedAt: new Date().toISOString(),
+    });
+
+    const result = await instance.restartGateway({ imageTag: 'latest' });
+
+    expect(result.success).toBe(true);
+    expect(resolveLatestVersion).toHaveBeenCalledOnce();
+    expect(storage._store.get('trackedImageTag')).toBe('new-tag-from-kv');
+    expect(storage._store.get('openclawVersion')).toBe('2.0.0');
+    expect(storage._store.get('imageVariant')).toBe('default');
+  });
+
+  it('falls back gracefully when "latest" but KV is empty', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { trackedImageTag: 'old-tag' });
+
+    (resolveLatestVersion as Mock).mockResolvedValueOnce(null);
+
+    const result = await instance.restartGateway({ imageTag: 'latest' });
+
+    expect(result.success).toBe(true);
+    expect(resolveLatestVersion).toHaveBeenCalledOnce();
+    // trackedImageTag unchanged — resolveImageTag will use existing value
+    expect(storage._store.get('trackedImageTag')).toBe('old-tag');
+  });
+
+  it('pins to specific tag without KV lookup and clears version metadata', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, {
+      trackedImageTag: 'old-tag',
+      openclawVersion: '1.0.0',
+      imageVariant: 'default',
+    });
+
+    const result = await instance.restartGateway({ imageTag: '2026.2.25-abc123' });
+
+    expect(result.success).toBe(true);
+    expect(resolveLatestVersion).not.toHaveBeenCalled();
+    expect(storage._store.get('trackedImageTag')).toBe('2026.2.25-abc123');
+    expect(storage._store.get('openclawVersion')).toBeNull();
+    expect(storage._store.get('imageVariant')).toBeNull();
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -1453,14 +1453,49 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   // User-facing operations
   // ========================================================================
 
-  async restartGateway(): Promise<{ success: boolean; error?: string }> {
+  async restartGateway(options?: {
+    imageTag?: string;
+  }): Promise<{ success: boolean; error?: string }> {
     await this.loadState();
 
     if (this.status !== 'running' || !this.flyMachineId) {
       return { success: false, error: 'Instance is not running' };
     }
 
+    const action = options?.imageTag
+      ? options.imageTag === 'latest'
+        ? 'upgrade-to-latest'
+        : `pin-to-tag:${options.imageTag}`
+      : 'redeploy-same-image';
+    console.log('[DO] restartGateway:', action, '| current trackedImageTag:', this.trackedImageTag);
+
     try {
+      // If imageTag override requested, resolve and persist before restart
+      if (options?.imageTag) {
+        if (options.imageTag === 'latest') {
+          const variant = 'default';
+          const latest = await resolveLatestVersion(this.env.KV_CLAW_CACHE, variant);
+          if (latest) {
+            this.openclawVersion = latest.openclawVersion;
+            this.imageVariant = latest.variant;
+            this.trackedImageTag = latest.imageTag;
+          }
+          // If KV empty, fall through to existing resolveImageTag() fallback
+        } else {
+          // Custom tag: clear version metadata since we don't know what version this tag represents
+          this.trackedImageTag = options.imageTag;
+          this.openclawVersion = null;
+          this.imageVariant = null;
+        }
+        await this.ctx.storage.put(
+          storageUpdate({
+            openclawVersion: this.openclawVersion,
+            imageVariant: this.imageVariant,
+            trackedImageTag: this.trackedImageTag,
+          })
+        );
+      }
+
       const flyConfig = this.getFlyConfig();
 
       // Backfill machineSize from live Fly machine config for legacy instances
@@ -1480,6 +1515,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
       const guest = guestFromSize(this.machineSize);
       const imageTag = this.resolveImageTag();
+      console.log('[DO] restartGateway: deploying with imageTag:', imageTag);
       const identity = {
         userId: this.userId ?? '',
         sandboxId: this.sandboxId ?? '',

--- a/kiloclaw/src/lib/image-tag-validation.test.ts
+++ b/kiloclaw/src/lib/image-tag-validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { isValidImageTag, IMAGE_TAG_MAX_LENGTH } from './image-tag-validation';
+
+describe('image tag validation', () => {
+  describe('valid tags', () => {
+    const valid = [
+      'latest',
+      'dev-1771888037',
+      '2026.2.25-abc123',
+      'v1.0.0',
+      'my_tag',
+      'a',
+      '1',
+      'sha-abc123def',
+      'release-2026.02.25_build.42',
+    ];
+
+    it.each(valid)('accepts %s', tag => {
+      expect(isValidImageTag(tag)).toBe(true);
+    });
+  });
+
+  describe('invalid tags', () => {
+    const invalid: [string, string][] = [
+      ['', 'empty string'],
+      [' ', 'whitespace only'],
+      ['tag with spaces', 'contains spaces'],
+      ['-starts-with-dash', 'starts with dash'],
+      ['.starts-with-dot', 'starts with dot'],
+      ['_starts-with-underscore', 'starts with underscore'],
+      ['tag:colon', 'contains colon'],
+      ['tag/slash', 'contains slash'],
+      ['../../../etc/passwd', 'path traversal'],
+      ['tag;rm -rf /', 'command injection with semicolon'],
+      ['tag$(whoami)', 'command injection with subshell'],
+      ['tag`whoami`', 'command injection with backticks'],
+      ['tag\nnewline', 'contains newline'],
+      ['tag\ttab', 'contains tab'],
+      ['tag<script>', 'contains angle brackets'],
+      ['tag&amp;', 'contains ampersand'],
+      ['tag|pipe', 'contains pipe'],
+      ['tag\\backslash', 'contains backslash'],
+    ];
+
+    it.each(invalid)('rejects "%s" (%s)', (tag, _desc) => {
+      expect(isValidImageTag(tag)).toBe(false);
+    });
+  });
+
+  describe('length limits', () => {
+    it('accepts tag at max length', () => {
+      const tag = 'a'.repeat(IMAGE_TAG_MAX_LENGTH);
+      expect(isValidImageTag(tag)).toBe(true);
+    });
+
+    it('rejects tag exceeding max length', () => {
+      const tag = 'a'.repeat(IMAGE_TAG_MAX_LENGTH + 1);
+      expect(isValidImageTag(tag)).toBe(false);
+    });
+  });
+});

--- a/kiloclaw/src/lib/image-tag-validation.ts
+++ b/kiloclaw/src/lib/image-tag-validation.ts
@@ -1,0 +1,10 @@
+/**
+ * Docker/Fly image tag validation.
+ * Must start with alphanumeric, then allow alphanumeric, dots, hyphens, underscores.
+ */
+export const IMAGE_TAG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+export const IMAGE_TAG_MAX_LENGTH = 128;
+
+export function isValidImageTag(tag: string): boolean {
+  return tag.length <= IMAGE_TAG_MAX_LENGTH && IMAGE_TAG_RE.test(tag);
+}

--- a/kiloclaw/src/routes/api.ts
+++ b/kiloclaw/src/routes/api.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
+import { isValidImageTag } from '../lib/image-tag-validation';
 
 /**
  * API routes
@@ -39,13 +40,22 @@ adminApi.post('/storage/sync', async c => {
 // POST /api/admin/gateway/restart - Restart the Fly Machine via the DO
 adminApi.post('/gateway/restart', async c => {
   const stub = resolveStub(c);
+  const body = await c.req.json().catch(() => ({}));
+  const rawTag = typeof body?.imageTag === 'string' ? body.imageTag : undefined;
 
-  const result = await stub.restartGateway();
+  if (rawTag && !isValidImageTag(rawTag)) {
+    return c.json({ success: false, error: 'Invalid image tag format' }, 400);
+  }
+
+  const imageTag = rawTag;
+  const result = await stub.restartGateway(imageTag ? { imageTag } : undefined);
 
   if (result.success) {
     return c.json({
       success: true,
-      message: 'Machine restarting with updated configuration...',
+      message: imageTag
+        ? `Machine restarting with image tag: ${imageTag}...`
+        : 'Machine restarting with updated configuration...',
     });
   } else {
     return c.json({ success: false, error: result.error }, 500);

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -181,7 +181,9 @@ export function InstanceControls({
           </DialogHeader>
           <RadioGroup
             value={redeployMode}
-            onValueChange={v => setRedeployMode(v as 'redeploy' | 'upgrade')}
+            onValueChange={v => {
+              if (v === 'redeploy' || v === 'upgrade') setRedeployMode(v);
+            }}
             className="gap-3 py-2"
           >
             <div className="flex items-start gap-3">

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -7,6 +7,16 @@ import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
 import { RunDoctorDialog } from './RunDoctorDialog';
@@ -42,6 +52,7 @@ export function InstanceControls({
   const [doctorOpen, setDoctorOpen] = useState(false);
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmRedeploy, setConfirmRedeploy] = useState(false);
+  const [redeployMode, setRedeployMode] = useState<'redeploy' | 'upgrade'>('redeploy');
 
   return (
     <div>
@@ -105,11 +116,12 @@ export function InstanceControls({
           disabled={!isRunning || mutations.restartGateway.isPending || isDestroying}
           onClick={() => {
             posthog?.capture('claw_redeploy_prompted', { instance_status: status.status });
+            setRedeployMode('redeploy');
             setConfirmRedeploy(true);
           }}
         >
           <RotateCw className="h-4 w-4" />
-          Redeploy
+          Redeploy or Upgrade
         </Button>
         <Button
           size="sm"
@@ -151,31 +163,92 @@ export function InstanceControls({
           });
         }}
       />
-      <ConfirmActionDialog
+      <Dialog
         open={confirmRedeploy}
         onOpenChange={open => {
+          if (mutations.restartGateway.isPending) return;
           if (!open) posthog?.capture('claw_redeploy_cancelled');
           setConfirmRedeploy(open);
         }}
-        title="Redeploy Gateway"
-        description="This will stop the machine, rebuild environment variables and secrets, apply any pending image updates, and restart it. The machine will be briefly offline."
-        confirmLabel="Redeploy"
-        confirmIcon={<RotateCw className="h-4 w-4" />}
-        isPending={mutations.restartGateway.isPending}
-        pendingLabel="Redeploying"
-        className="border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:text-amber-300"
-        onConfirm={() => {
-          posthog?.capture('claw_redeploy_clicked', { instance_status: status.status });
-          mutations.restartGateway.mutate(undefined, {
-            onSuccess: () => {
-              toast.success('Gateway restarting');
-              setConfirmRedeploy(false);
-              onRedeploySuccess?.();
-            },
-            onError: err => toast.error(err.message),
-          });
-        }}
-      />
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Redeploy or Upgrade</DialogTitle>
+            <DialogDescription>
+              This will stop the machine, rebuild environment variables and secrets, and restart it.
+              The machine will be briefly offline.
+            </DialogDescription>
+          </DialogHeader>
+          <RadioGroup
+            value={redeployMode}
+            onValueChange={v => setRedeployMode(v as 'redeploy' | 'upgrade')}
+            className="gap-3 py-2"
+          >
+            <div className="flex items-start gap-3">
+              <RadioGroupItem value="redeploy" id="redeploy" className="mt-0.5" />
+              <Label htmlFor="redeploy" className="block cursor-pointer leading-tight">
+                <span className="text-foreground text-sm font-medium">Redeploy</span>
+                <span className="text-muted-foreground mt-0.5 block text-xs">
+                  Restart with your current version of KiloClaw and apply pending config changes.
+                </span>
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <RadioGroupItem value="upgrade" id="upgrade" className="mt-0.5" />
+              <Label htmlFor="upgrade" className="block cursor-pointer leading-tight">
+                <span className="text-foreground text-sm font-medium">Upgrade to latest</span>
+                <span className="text-muted-foreground mt-0.5 block text-xs">
+                  Upgrade to the latest KiloClaw version, redeploy and apply pending config changes.
+                </span>
+              </Label>
+            </div>
+          </RadioGroup>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmRedeploy(false)}
+              disabled={mutations.restartGateway.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:text-amber-300"
+              onClick={() => {
+                const imageTag = redeployMode === 'upgrade' ? 'latest' : undefined;
+                posthog?.capture('claw_redeploy_clicked', {
+                  instance_status: status.status,
+                  redeploy_mode: redeployMode,
+                });
+                mutations.restartGateway.mutate(imageTag ? { imageTag } : undefined, {
+                  onSuccess: () => {
+                    toast.success(
+                      redeployMode === 'upgrade'
+                        ? 'Upgrading to latest image'
+                        : 'Gateway restarting'
+                    );
+                    setConfirmRedeploy(false);
+                    onRedeploySuccess?.();
+                  },
+                  onError: err => toast.error(err.message),
+                });
+              }}
+              disabled={mutations.restartGateway.isPending}
+            >
+              {mutations.restartGateway.isPending ? (
+                <>
+                  {redeployMode === 'redeploy' ? 'Redeploying' : 'Upgrading'}
+                  <AnimatedDots />
+                </>
+              ) : (
+                <>
+                  <RotateCw className="h-4 w-4" />
+                  {redeployMode === 'redeploy' ? 'Redeploy' : 'Upgrade & Redeploy'}
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <RunDoctorDialog
         open={doctorOpen}
         onOpenChange={setDoctorOpen}

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -50,7 +50,10 @@ export class KiloClawUserClient {
     return this.request('/api/kiloclaw/status');
   }
 
-  async restartGateway(): Promise<RestartGatewayResponse> {
-    return this.request('/api/admin/gateway/restart', { method: 'POST' });
+  async restartGateway(options?: { imageTag?: string }): Promise<RestartGatewayResponse> {
+    return this.request('/api/admin/gateway/restart', {
+      method: 'POST',
+      body: options?.imageTag ? JSON.stringify({ imageTag: options.imageTag }) : undefined,
+    });
   }
 }

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -234,12 +234,27 @@ export const kiloclawRouter = createTRPCRouter({
     return client.getConfig();
   }),
 
-  restartGateway: baseProcedure.mutation(async ({ ctx }) => {
-    const client = new KiloClawUserClient(
-      generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
-    );
-    return client.restartGateway();
-  }),
+  restartGateway: baseProcedure
+    .input(
+      z
+        .object({
+          imageTag: z
+            .string()
+            .max(128, 'Image tag too long')
+            .regex(
+              /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
+              'Image tag must be alphanumeric with dots, hyphens, or underscores'
+            )
+            .optional(),
+        })
+        .optional()
+    )
+    .mutation(async ({ ctx, input }) => {
+      const client = new KiloClawUserClient(
+        generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+      );
+      return client.restartGateway(input?.imageTag ? { imageTag: input.imageTag } : undefined);
+    }),
 
   listPairingRequests: baseProcedure
     .input(z.object({ refresh: z.boolean().optional() }).optional())


### PR DESCRIPTION
  - Redeploy: restarts with current image (existing behavior)
  - Upgrade to latest: fetches newest KiloClaw image from KV
  - Custom tag pinning supported via API, when ready for that. When pinning to a custom tag, version metadata is cleared since it cannot be inferred from the tag alone.
  - Server-side validation on imageTag at both tRPC (zod) and worker (shared isValidImageTag) layers — rejects path traversal, command injection, and oversized tags. 29 validation tests added.
  - Logging added to DO restartGateway for action tracing