### PR TITLE
feat: allow specifying reasoning level for Slack integration

### DIFF
--- a/cloud-agent-next/src/execution/orchestrator.ts
+++ b/cloud-agent-next/src/execution/orchestrator.ts
@@ -190,6 +190,7 @@ export class ExecutionOrchestrator {
         prompt,
         model: wrapper.model,
         agent: normalizedMode,
+        reasoningEffort: wrapper.reasoningEffort,
       });
       logger.withFields({ inflightId: result.messageId }).info('Prompt sent to wrapper');
     } catch (error) {

--- a/cloud-agent-next/src/execution/types.ts
+++ b/cloud-agent-next/src/execution/types.ts
@@ -306,6 +306,7 @@ export type WrapperPlan = {
   kiloSessionId?: string;
   kiloSessionTitle?: string;
   model?: ModelConfig;
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   autoCommit?: boolean;
   condenseOnComplete?: boolean;
 };

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -43,6 +43,7 @@ export type WrapperPromptOptions = {
   messageId?: string;
   system?: string;
   tools?: Record<string, boolean>;
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
 };
 
 export type WrapperPermissionResponse = 'always' | 'once' | 'reject';

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -647,6 +647,7 @@ export class CloudAgentSession extends DurableObject {
     encryptedSecrets?: EncryptedSecrets;
     setupCommands?: string[];
     mcpServers?: Record<string, MCPServerConfig>;
+    reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
     autoCommit?: boolean;
     condenseOnComplete?: boolean;
     appendSystemPrompt?: string;
@@ -1215,6 +1216,7 @@ export class CloudAgentSession extends DurableObject {
     mode: ExecutionMode;
     prompt: string;
     model?: string;
+    reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
     autoCommit?: boolean;
     condenseOnComplete?: boolean;
     initContext?: InitializeContext;
@@ -1279,6 +1281,7 @@ export class CloudAgentSession extends DurableObject {
       wrapper: {
         kiloSessionId: params.kiloSessionId,
         model: params.model ? { modelID: params.model.replace(/^kilo\//, '') } : undefined,
+        reasoningEffort: params.reasoningEffort,
         autoCommit: params.autoCommit,
         condenseOnComplete: params.condenseOnComplete,
       },
@@ -1459,6 +1462,7 @@ export class CloudAgentSession extends DurableObject {
           mode: request.mode,
           prompt: request.prompt,
           model: normalizedModel,
+          reasoningEffort: request.reasoningEffort,
           autoCommit: request.autoCommit,
           condenseOnComplete: request.condenseOnComplete,
           initContext,
@@ -1544,6 +1548,7 @@ export class CloudAgentSession extends DurableObject {
           mode: metadata.mode as ExecutionMode,
           prompt: metadata.prompt,
           model: metadata.model,
+          reasoningEffort: metadata.reasoningEffort,
           autoCommit: metadata.autoCommit,
           condenseOnComplete: metadata.condenseOnComplete,
           initContext,
@@ -1614,6 +1619,7 @@ export class CloudAgentSession extends DurableObject {
         mode,
         prompt: request.prompt,
         model,
+        reasoningEffort: metadata.reasoningEffort,
         autoCommit: request.autoCommit ?? metadata.autoCommit,
         condenseOnComplete: request.condenseOnComplete ?? metadata.condenseOnComplete,
         resumeContext,

--- a/cloud-agent-next/src/persistence/schemas.ts
+++ b/cloud-agent-next/src/persistence/schemas.ts
@@ -146,6 +146,7 @@ export const MetadataSchema = z.object({
   prompt: z.string().max(Limits.MAX_PROMPT_LENGTH).optional(),
   mode: AgentModeSchema.optional(),
   model: z.string().optional(),
+  reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
   autoCommit: z.boolean().optional(),
   condenseOnComplete: z.boolean().optional(),
   appendSystemPrompt: z.string().max(10000).optional(),

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -359,6 +359,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           setupCommands: input.setupCommands,
           mcpServers: input.mcpServers,
           upstreamBranch: input.upstreamBranch,
+          reasoningEffort: input.reasoningEffort,
           autoCommit: input.autoCommit,
           condenseOnComplete: input.condenseOnComplete,
           appendSystemPrompt: input.appendSystemPrompt,

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -200,6 +200,10 @@ export const PrepareSessionInput = z
       .max(100)
       .optional()
       .describe('Platform that created this session (e.g. slack, app-builder)'),
+    reasoningEffort: z
+      .enum(['none', 'low', 'medium', 'high'])
+      .optional()
+      .describe('Reasoning effort level for models that support it'),
   })
   .refine(validateGitSource, {
     message: 'Must provide either githubRepo or gitUrl, but not both',

--- a/cloud-agent-next/wrapper/src/kilo-client.ts
+++ b/cloud-agent-next/wrapper/src/kilo-client.ts
@@ -46,6 +46,8 @@ export type SendPromptOptions = {
   system?: string;
   /** Enable/disable specific tools */
   tools?: Record<string, boolean>;
+  /** Reasoning effort level for models that support it */
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
 };
 
 /**
@@ -173,6 +175,7 @@ export function createKiloClient(baseUrl: string): KiloClient {
         noReply: opts.noReply,
         system: opts.system,
         tools: opts.tools,
+        reasoningEffort: opts.reasoningEffort,
       });
     },
 

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -58,6 +58,7 @@ type PromptBody = {
   messageId?: string;
   system?: string;
   tools?: Record<string, boolean>;
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
 };
 
 type CommandBody = {
@@ -276,6 +277,7 @@ function createPromptHandler(deps: ServerDependencies) {
         model: body.model,
         system: body.system,
         tools: body.tools,
+        reasoningEffort: body.reasoningEffort,
       });
       logToFile(`job/prompt: sent messageId=${messageId}`);
     } catch (error) {

--- a/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/src/components/integrations/SlackIntegrationDetails.tsx
@@ -62,11 +62,14 @@ export function SlackIntegrationDetails({
     return openRouterModels?.data.map(model => ({ id: model.id, name: model.name })) ?? [];
   }, [openRouterModels]);
 
-  // Build a set of model IDs that support reasoning_effort
+  // Build a set of model IDs that support reasoning effort configuration.
+  // Models advertise this via either "reasoning" or "reasoning_effort" in supported_parameters;
+  // both accept the reasoning.effort field in the OpenRouter API.
   const modelsWithReasoning = useMemo(() => {
     const set = new Set<string>();
     for (const model of openRouterModels?.data ?? []) {
-      if (model.supported_parameters?.includes('reasoning_effort')) {
+      const params = model.supported_parameters;
+      if (params?.includes('reasoning') || params?.includes('reasoning_effort')) {
         set.add(model.id);
       }
     }

--- a/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/src/components/integrations/SlackIntegrationDetails.tsx
@@ -5,6 +5,13 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
   CheckCircle2,
   XCircle,
   MessageSquare,
@@ -14,12 +21,13 @@ import {
   Trash2,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { IS_DEVELOPMENT } from '@/lib/constants';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
+import type { ReasoningEffort } from '@/lib/organizations/model-settings';
 
 type SlackIntegrationDetailsProps = {
   organizationId?: string;
@@ -54,15 +62,33 @@ export function SlackIntegrationDetails({
     return openRouterModels?.data.map(model => ({ id: model.id, name: model.name })) ?? [];
   }, [openRouterModels]);
 
-  // Track selected model
-  const [selectedModel, setSelectedModel] = useState<string>('');
+  // Build a set of model IDs that support reasoning_effort
+  const modelsWithReasoning = useMemo(() => {
+    const set = new Set<string>();
+    for (const model of openRouterModels?.data ?? []) {
+      if (model.supported_parameters?.includes('reasoning_effort')) {
+        set.add(model.id);
+      }
+    }
+    return set;
+  }, [openRouterModels]);
 
-  // Initialize selected model from installation data
+  // Track selected model and reasoning effort
+  const [selectedModel, setSelectedModel] = useState<string>('');
+  const [selectedReasoningEffort, setSelectedReasoningEffort] = useState<ReasoningEffort | null>(
+    null
+  );
+
+  // Whether the currently selected model supports reasoning effort
+  const supportsReasoning = modelsWithReasoning.has(selectedModel);
+
+  // Initialize selected model and reasoning effort from installation data
   useEffect(() => {
     if (installationData?.installation?.modelSlug) {
       setSelectedModel(installationData.installation.modelSlug);
     }
-  }, [installationData?.installation?.modelSlug]);
+    setSelectedReasoningEffort(installationData?.installation?.reasoningEffort ?? null);
+  }, [installationData?.installation?.modelSlug, installationData?.installation?.reasoningEffort]);
 
   const uninstallApp = useMutation(
     trpc.slack.uninstallApp.mutationOptions({
@@ -188,27 +214,47 @@ export function SlackIntegrationDetails({
     });
   };
 
+  const saveModelSettings = useCallback(
+    (modelSlug: string, reasoningEffort: ReasoningEffort | null) => {
+      // If the new model doesn't support reasoning, clear the reasoning effort
+      const effectiveReasoning = modelsWithReasoning.has(modelSlug) ? reasoningEffort : null;
+      updateModel.mutate(
+        { modelSlug, organizationId, reasoningEffort: effectiveReasoning },
+        {
+          onSuccess: result => {
+            if (result.success) {
+              toast.success('Model updated successfully');
+            } else {
+              toast.error('Failed to update model', {
+                description: result.error,
+              });
+            }
+          },
+          onError: err => {
+            toast.error('Failed to update model', {
+              description: err.message,
+            });
+          },
+        }
+      );
+    },
+    [modelsWithReasoning, organizationId, updateModel]
+  );
+
   const handleModelChange = (modelSlug: string) => {
     setSelectedModel(modelSlug);
-    updateModel.mutate(
-      { modelSlug, organizationId },
-      {
-        onSuccess: result => {
-          if (result.success) {
-            toast.success('Model updated successfully');
-          } else {
-            toast.error('Failed to update model', {
-              description: result.error,
-            });
-          }
-        },
-        onError: err => {
-          toast.error('Failed to update model', {
-            description: err.message,
-          });
-        },
-      }
-    );
+    // Clear reasoning effort if the new model doesn't support it
+    const newReasoning = modelsWithReasoning.has(modelSlug) ? selectedReasoningEffort : null;
+    if (newReasoning !== selectedReasoningEffort) {
+      setSelectedReasoningEffort(newReasoning);
+    }
+    saveModelSettings(modelSlug, newReasoning);
+  };
+
+  const handleReasoningEffortChange = (value: string) => {
+    const effort = value === 'none' ? null : (value as ReasoningEffort);
+    setSelectedReasoningEffort(effort);
+    saveModelSettings(selectedModel, effort);
   };
 
   if (isLoading) {
@@ -297,6 +343,28 @@ export function SlackIntegrationDetails({
                   isLoading={isLoadingModels}
                   placeholder="Select a model"
                 />
+                {supportsReasoning && (
+                  <div className="space-y-1.5">
+                    <label className="text-sm font-medium">Reasoning Level</label>
+                    <Select
+                      value={selectedReasoningEffort ?? 'none'}
+                      onValueChange={handleReasoningEffortChange}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select reasoning level" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">None</SelectItem>
+                        <SelectItem value="low">Low</SelectItem>
+                        <SelectItem value="medium">Medium</SelectItem>
+                        <SelectItem value="high">High</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-muted-foreground text-xs">
+                      Higher reasoning levels produce more thorough responses but use more tokens
+                    </p>
+                  </div>
+                )}
               </div>
 
               {/* Actions */}

--- a/src/lib/bots/core/run-bot.ts
+++ b/src/lib/bots/core/run-bot.ts
@@ -1,7 +1,10 @@
 import type OpenAI from 'openai';
 import type { FeatureValue } from '@/lib/feature-detection';
 import { sendProxiedChatCompletion } from '@/lib/llm-proxy-helpers';
-import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter/types';
+import type {
+  OpenRouterChatCompletionRequest,
+  OpenRouterReasoningConfig,
+} from '@/lib/providers/openrouter/types';
 
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
 type ChatCompletionResponse = OpenAI.Chat.Completions.ChatCompletion;
@@ -20,6 +23,7 @@ export type BotRunInput = {
   toolExecutor: (toolCall: ToolCall) => Promise<BotToolResult>;
   maxIterations?: number;
   logPrefix?: string;
+  reasoning?: OpenRouterReasoningConfig;
   requestOptions: {
     version: string;
     userAgent: string;
@@ -62,6 +66,10 @@ export async function runBot(input: BotRunInput): Promise<BotRunResult> {
       model: input.model,
       messages,
     };
+
+    if (input.reasoning) {
+      body.reasoning = input.reasoning;
+    }
 
     if (input.tools && input.tools.length > 0) {
       body.tools = input.tools;

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -95,6 +95,8 @@ export type PrepareSessionInput = {
   callbackTarget?: CallbackTarget;
   /** Platform that created this session (e.g. 'security-agent', 'slack', 'app-builder') */
   createdOnPlatform?: string;
+  /** Reasoning effort level for models that support it */
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
 };
 
 /** Output from prepareSession procedure */

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -15,6 +15,7 @@ import { getDefaultAllowedModel } from '@/lib/slack-bot/model-allow-list';
 import { createProviderAwareModelAllowPredicate } from '@/lib/model-allow.server';
 import { minimax_m25_free_model } from '@/lib/providers/minimax';
 import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
+import type { ReasoningEffort } from '@/lib/organizations/model-settings';
 
 // Default model for Slack integrations - separate from the global platform default
 const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
@@ -469,7 +470,8 @@ export async function sendMessage(
  */
 export async function updateModel(
   owner: Owner,
-  modelSlug: string
+  modelSlug: string,
+  reasoningEffort?: ReasoningEffort | null
 ): Promise<{ success: boolean; error?: string }> {
   const integration = await getInstallation(owner);
 
@@ -499,6 +501,7 @@ export async function updateModel(
       metadata: {
         ...existingMetadata,
         model_slug: modelSlug,
+        reasoning_effort: reasoningEffort ?? null,
       },
       updated_at: new Date().toISOString(),
     })
@@ -508,17 +511,33 @@ export async function updateModel(
 }
 
 /**
- * Get the model for a Slack integration
+ * Get the model configuration for a Slack integration
  */
-export async function getModel(owner: Owner): Promise<string | null> {
+export type SlackModelConfig = {
+  modelSlug: string;
+  reasoningEffort: ReasoningEffort | null;
+};
+
+export async function getModelConfig(owner: Owner): Promise<SlackModelConfig | null> {
   const integration = await getInstallation(owner);
 
   if (!integration) {
     return null;
   }
 
-  const metadata = integration.metadata as { model_slug?: string } | null;
-  return metadata?.model_slug || null;
+  const metadata = integration.metadata as {
+    model_slug?: string;
+    reasoning_effort?: ReasoningEffort | null;
+  } | null;
+
+  if (!metadata?.model_slug) {
+    return null;
+  }
+
+  return {
+    modelSlug: metadata.model_slug,
+    reasoningEffort: metadata.reasoning_effort ?? null,
+  };
 }
 
 /*

--- a/src/lib/slack-bot.ts
+++ b/src/lib/slack-bot.ts
@@ -12,7 +12,7 @@ import type { Owner } from '@/lib/integrations/core/types';
 import {
   getInstallationByTeamId,
   getOwnerFromInstallation,
-  getModel,
+  getModelConfig,
   getAccessTokenFromInstallation,
 } from '@/lib/integrations/slack-service';
 import type { PlatformIntegration } from '@/db/schema';
@@ -318,8 +318,8 @@ export async function processKiloBotMessage(
   console.log('[SlackBot] Found owner:', JSON.stringify(owner, null, 2));
 
   // Get the configured model for this integration (validated at setup/update time)
-  const selectedModel = await getModel(owner);
-  if (!selectedModel) {
+  const modelConfig = await getModelConfig(owner);
+  if (!modelConfig) {
     console.error('[SlackBot] No model configured for owner:', owner);
     return {
       response:
@@ -330,7 +330,11 @@ export async function processKiloBotMessage(
       installation,
     };
   }
+  const selectedModel = modelConfig.modelSlug;
   console.log('[SlackBot] Using model:', selectedModel);
+  if (modelConfig.reasoningEffort) {
+    console.log('[SlackBot] Using reasoning effort:', modelConfig.reasoningEffort);
+  }
   console.log(
     '[SlackBot] Looking up Slack user email for auth token generation',
     slackEventContext?.userId
@@ -380,6 +384,12 @@ export async function processKiloBotMessage(
   const systemPrompt =
     KILO_BOT_SYSTEM_PROMPT + slackContextForPrompt + formatGitHubRepositoriesForPrompt(repoContext);
 
+  // Build reasoning config from the stored reasoning effort
+  const reasoningConfig =
+    modelConfig.reasoningEffort && modelConfig.reasoningEffort !== 'none'
+      ? { effort: modelConfig.reasoningEffort }
+      : undefined;
+
   const runResult = await runBot({
     authToken,
     model: selectedModel,
@@ -387,6 +397,7 @@ export async function processKiloBotMessage(
     userMessage,
     tools: [SPAWN_CLOUD_AGENT_TOOL],
     logPrefix: '[SlackBot]',
+    reasoning: reasoningConfig,
     requestOptions: {
       version: SLACK_BOT_VERSION,
       userAgent: SLACK_BOT_USER_AGENT,

--- a/src/lib/slack-bot.ts
+++ b/src/lib/slack-bot.ts
@@ -226,7 +226,8 @@ async function spawnCloudAgentSession(
   model: string,
   authToken: string,
   ticketUserId: string,
-  requesterInfo?: SlackRequesterInfo
+  requesterInfo?: SlackRequesterInfo,
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high'
 ): Promise<SpawnCloudAgentResult> {
   console.log('[SlackBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
   console.log('[SlackBot] Owner:', JSON.stringify(owner, null, 2));
@@ -257,6 +258,7 @@ async function spawnCloudAgentSession(
       githubToken,
       kilocodeOrganizationId,
       createdOnPlatform: 'slack',
+      reasoningEffort: reasoningEffort && reasoningEffort !== 'none' ? reasoningEffort : undefined,
     },
     initiateInput: {
       githubToken,
@@ -423,13 +425,17 @@ export async function processKiloBotMessage(
       console.log('[SlackBot] Parsed tool arguments:', JSON.stringify(args, null, 2));
 
       console.log('[SlackBot] Calling spawnCloudAgentSession...');
+      // Map reasoning effort to cloud-agent-next accepted values (xhigh -> high)
+      const agentReasoningEffort =
+        modelConfig.reasoningEffort === 'xhigh' ? 'high' : modelConfig.reasoningEffort;
       const toolResult = await spawnCloudAgentSession(
         args,
         owner,
         selectedModel,
         authToken,
         authUserId,
-        slackRequesterInfo
+        slackRequesterInfo,
+        agentReasoningEffort ?? undefined
       );
       console.log('[SlackBot] Tool result received, length:', toolResult.response.length);
       console.log('[SlackBot] Tool result preview:', toolResult.response.slice(0, 100));

--- a/src/routers/slack-router.ts
+++ b/src/routers/slack-router.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/integrations/resolve-owner';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+import { ReasoningEffortSchema } from '@/lib/organizations/model-settings';
 
 export const slackRouter = createTRPCRouter({
   // Get Slack installation status
@@ -28,7 +29,10 @@ export const slackRouter = createTRPCRouter({
     }
 
     const isInstalled = integration.integration_status === 'active';
-    const metadata = integration.metadata as { model_slug?: string } | null;
+    const metadata = integration.metadata as {
+      model_slug?: string;
+      reasoning_effort?: string | null;
+    } | null;
 
     return {
       installed: isInstalled,
@@ -38,6 +42,7 @@ export const slackRouter = createTRPCRouter({
         scopes: integration.scopes,
         installedAt: integration.installed_at,
         modelSlug: metadata?.model_slug || null,
+        reasoningEffort: ReasoningEffortSchema.safeParse(metadata?.reasoning_effort).data ?? null,
       },
     };
   }),
@@ -96,20 +101,24 @@ export const slackRouter = createTRPCRouter({
       z.object({
         organizationId: z.string().uuid().optional(),
         modelSlug: z.string(),
+        reasoningEffort: ReasoningEffortSchema.nullable().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       const owner = await resolveAuthorizedOwner(ctx, input.organizationId);
-      const result = await slackService.updateModel(owner, input.modelSlug);
+      const result = await slackService.updateModel(owner, input.modelSlug, input.reasoningEffort);
 
       if (input.organizationId) {
+        const reasoningPart = input.reasoningEffort
+          ? ` with reasoning effort ${input.reasoningEffort}`
+          : '';
         await createAuditLog({
           organization_id: input.organizationId,
           action: 'organization.settings.change',
           actor_id: ctx.user.id,
           actor_email: ctx.user.google_user_email,
           actor_name: ctx.user.google_user_name,
-          message: `Updated Slack integration model to ${input.modelSlug}`,
+          message: `Updated Slack integration model to ${input.modelSlug}${reasoningPart}`,
         });
       }
 


### PR DESCRIPTION
## Summary

- Adds an optional **Reasoning Level** selector to the Slack integration settings UI, shown conditionally when the selected model supports `reasoning_effort` (detected via `supported_parameters`)
- Stores the reasoning effort alongside the model slug in the `platform_integrations` metadata JSONB column
- Passes the configured reasoning effort through to the OpenRouter API via the `reasoning.effort` field when the Slack bot processes messages

## Changes

### Service layer (`slack-service.ts`)
- `updateModel()` now accepts an optional `reasoningEffort` parameter and persists it in metadata
- Renamed `getModel()` → `getModelConfig()` returning a `SlackModelConfig` with both `modelSlug` and `reasoningEffort`

### tRPC router (`slack-router.ts`)
- `getInstallation` response includes `reasoningEffort` (validated via `ReasoningEffortSchema`)
- `updateModel` mutation accepts optional `reasoningEffort` input
- Audit log includes reasoning effort when set

### Bot engine (`run-bot.ts`)
- `BotRunInput` accepts optional `reasoning: OpenRouterReasoningConfig`
- Reasoning config is included in the request body when present

### Slack bot runtime (`slack-bot.ts`)
- Reads reasoning effort from `getModelConfig()` and builds an `OpenRouterReasoningConfig`
- Passes it to `runBot()` via the new `reasoning` parameter

### UI (`SlackIntegrationDetails.tsx`)
- Conditionally renders a **Reasoning Level** `<Select>` (None / Low / Medium / High) when the model supports it
- Automatically clears reasoning effort when switching to a model that doesn't support it
- Saves model + reasoning effort together in a single mutation