### PR TITLE
fix: harden security-agent error handling in analysis pipeline

### DIFF
--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
@@ -89,6 +89,7 @@ jest.mock('@sentry/nextjs', () => ({
 
 jest.mock('@/lib/utils.server', () => ({
   sentryLogger: () => jest.fn(),
+  logExceptInTest: jest.fn(),
 }));
 
 jest.mock('@/lib/drizzle', () => {

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -26,7 +26,7 @@ import { generateApiToken } from '@/lib/tokens';
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
-import { sentryLogger } from '@/lib/utils.server';
+import { logExceptInTest, sentryLogger } from '@/lib/utils.server';
 import type { SecurityFindingAnalysis, SecurityReviewOwner } from '@/lib/security-agent/core/types';
 import {
   logSecurityAudit,
@@ -319,13 +319,21 @@ async function handleAnalysisFailed(
       ? `Analysis interrupted: ${payload.errorMessage ?? 'unknown reason'}`
       : (payload.errorMessage ?? 'Analysis failed');
 
-  const logger = payload.status === 'interrupted' ? log : logError;
-  logger('Analysis failed/interrupted', {
-    findingId,
-    correlationId,
-    status: payload.status,
-    errorMessage,
-  });
+  if (payload.status === 'interrupted') {
+    logExceptInTest('Analysis interrupted by user', {
+      findingId,
+      correlationId,
+      status: payload.status,
+      errorMessage,
+    });
+  } else {
+    logError('Analysis failed/interrupted', {
+      findingId,
+      correlationId,
+      status: payload.status,
+      errorMessage,
+    });
+  }
 
   await updateAnalysisStatus(findingId, 'failed', { error: errorMessage });
 

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -299,6 +299,20 @@ function isInsufficientCreditsError(err: unknown): boolean {
   return false;
 }
 
+function normalizeCloudAgentProtocolError(error: unknown): unknown {
+  if (!(error instanceof Error)) {
+    return error;
+  }
+
+  if (!error.message.includes('is not valid JSON')) {
+    return error;
+  }
+
+  const normalized = new Error('Cloud agent returned a non-JSON error response', { cause: error });
+  normalized.name = 'CloudAgentProtocolError';
+  return normalized;
+}
+
 /**
  * Minimal TRPC client interface for cloud-agent-next API
  * Note: This uses only V2 procedures (WebSocket streaming)
@@ -476,21 +490,23 @@ export class CloudAgentNextClient {
       });
       return result;
     } catch (error) {
+      const normalizedError = normalizeCloudAgentProtocolError(error);
+
       console.log('[CloudAgentNextClient.prepareSession] Request failed', {
         elapsed: Date.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
+        error: normalizedError instanceof Error ? normalizedError.message : String(normalizedError),
       });
 
       // Check for insufficient credits error
-      if (isInsufficientCreditsError(error)) {
+      if (isInsufficientCreditsError(normalizedError)) {
         throw new InsufficientCreditsError();
       }
 
-      captureException(error, {
+      captureException(normalizedError, {
         tags: { source: 'cloud-agent-next-client', endpoint: 'prepareSession' },
         extra: { input },
       });
-      throw error;
+      throw normalizedError;
     }
   }
 
@@ -526,16 +542,18 @@ export class CloudAgentNextClient {
     try {
       return await this.client.initiateFromKilocodeSessionV2.mutate(input);
     } catch (error) {
+      const normalizedError = normalizeCloudAgentProtocolError(error);
+
       // Check for insufficient credits error
-      if (isInsufficientCreditsError(error)) {
+      if (isInsufficientCreditsError(normalizedError)) {
         throw new InsufficientCreditsError();
       }
 
-      captureException(error, {
+      captureException(normalizedError, {
         tags: { source: 'cloud-agent-next-client', endpoint: 'initiateFromPreparedSession' },
         extra: { input },
       });
-      throw error;
+      throw normalizedError;
     }
   }
 
@@ -549,16 +567,18 @@ export class CloudAgentNextClient {
     try {
       return await this.client.sendMessageV2.mutate(input);
     } catch (error) {
+      const normalizedError = normalizeCloudAgentProtocolError(error);
+
       // Check for insufficient credits error
-      if (isInsufficientCreditsError(error)) {
+      if (isInsufficientCreditsError(normalizedError)) {
         throw new InsufficientCreditsError();
       }
 
-      captureException(error, {
+      captureException(normalizedError, {
         tags: { source: 'cloud-agent-next-client', endpoint: 'sendMessage' },
         extra: { input },
       });
-      throw error;
+      throw normalizedError;
     }
   }
 

--- a/src/lib/security-agent/github/dependabot-api.ts
+++ b/src/lib/security-agent/github/dependabot-api.ts
@@ -108,7 +108,30 @@ function toInternalAlert(alert: GitHubDependabotAlert): DependabotAlertRaw {
 export type FetchAlertsResult =
   | { status: 'success'; alerts: DependabotAlertRaw[] }
   | { status: 'repo_not_found' }
-  | { status: 'alerts_disabled' };
+  | { status: 'alerts_disabled' }
+  | { status: 'alerts_unavailable' };
+
+function normalizeErrorMessage(message?: string): string {
+  return (message ?? '').toLowerCase();
+}
+
+function isDependabotAlertsDisabledMessage(message?: string): boolean {
+  const normalized = normalizeErrorMessage(message);
+  return (
+    normalized.includes('dependabot alerts are disabled') ||
+    normalized.includes('dependabot alerts are not available')
+  );
+}
+
+function isDependabotAlertsUnavailableMessage(message?: string): boolean {
+  const normalized = normalizeErrorMessage(message);
+  return (
+    normalized.includes('repository access blocked') ||
+    normalized.includes('archived repositories') ||
+    normalized.includes('archived repository') ||
+    normalized.includes('dependabot alerts are not available')
+  );
+}
 
 /**
  * Fetch ALL Dependabot alerts for a repository (including fixed/dismissed)
@@ -166,13 +189,20 @@ export async function fetchAllDependabotAlerts(
     const message = (error as { message?: string }).message;
 
     // Handle case where Dependabot alerts are disabled or unavailable for the repository
-    if (
-      httpStatus === 403 &&
-      (message?.includes('Dependabot alerts are disabled') ||
-        message?.includes('Dependabot alerts are not available'))
-    ) {
+    if (httpStatus === 403 && isDependabotAlertsDisabledMessage(message)) {
       log(`Dependabot alerts are not available for ${owner}/${repo}, skipping`);
       return { status: 'alerts_disabled' };
+    }
+
+    // Handle geo/policy/blocked access cases as non-fatal skips.
+    if (
+      httpStatus === 451 ||
+      ((httpStatus === 403 || httpStatus === 422) && isDependabotAlertsUnavailableMessage(message))
+    ) {
+      warn(`Dependabot alerts are unavailable for ${owner}/${repo}, skipping`, {
+        status: httpStatus,
+      });
+      return { status: 'alerts_unavailable' };
     }
 
     // Handle case where repository no longer exists or is inaccessible

--- a/src/lib/security-agent/github/dependabot-api.ts
+++ b/src/lib/security-agent/github/dependabot-api.ts
@@ -108,34 +108,28 @@ function toInternalAlert(alert: GitHubDependabotAlert): DependabotAlertRaw {
 export type FetchAlertsResult =
   | { status: 'success'; alerts: DependabotAlertRaw[] }
   | { status: 'repo_not_found' }
-  | { status: 'alerts_disabled' }
   | { status: 'alerts_unavailable' };
 
-type FetchAlertsSkipStatus = 'repo_not_found' | 'alerts_disabled' | 'alerts_unavailable';
+type FetchAlertsSkipStatus = 'repo_not_found' | 'alerts_unavailable';
+
+const DEPENDABOT_NOT_ACTIONABLE_MESSAGE_HINTS = [
+  'dependabot alerts are disabled',
+  'dependabot alerts are not available',
+  'repository access blocked',
+  'archived repositories',
+  'archived repository',
+] as const;
 
 function normalizeErrorMessage(message?: string): string {
   return (message ?? '').toLowerCase();
 }
 
-function isDependabotAlertsDisabledMessage(message?: string): boolean {
+function isDependabotNotActionableMessage(message?: string): boolean {
   const normalized = normalizeErrorMessage(message);
-  return (
-    normalized.includes('dependabot alerts are disabled') ||
-    normalized.includes('dependabot alerts are not available')
-  );
+  return DEPENDABOT_NOT_ACTIONABLE_MESSAGE_HINTS.some(hint => normalized.includes(hint));
 }
 
-function isDependabotAlertsUnavailableMessage(message?: string): boolean {
-  const normalized = normalizeErrorMessage(message);
-  return (
-    normalized.includes('repository access blocked') ||
-    normalized.includes('archived repositories') ||
-    normalized.includes('archived repository') ||
-    normalized.includes('dependabot alerts are not available')
-  );
-}
-
-function isDependabotServiceUnavailableStatus(httpStatus?: number): boolean {
+function isDependabotUnavailableStatus(httpStatus?: number): boolean {
   return (
     httpStatus === 451 || (typeof httpStatus === 'number' && httpStatus >= 500 && httpStatus < 600)
   );
@@ -149,15 +143,11 @@ function classifyFetchAlertsError(
     return 'repo_not_found';
   }
 
-  if (httpStatus === 403 && isDependabotAlertsDisabledMessage(message)) {
-    return 'alerts_disabled';
-  }
-
-  if (isDependabotServiceUnavailableStatus(httpStatus)) {
+  if (isDependabotUnavailableStatus(httpStatus)) {
     return 'alerts_unavailable';
   }
 
-  if ((httpStatus === 403 || httpStatus === 422) && isDependabotAlertsUnavailableMessage(message)) {
+  if ((httpStatus === 403 || httpStatus === 422) && isDependabotNotActionableMessage(message)) {
     return 'alerts_unavailable';
   }
 
@@ -219,11 +209,6 @@ export async function fetchAllDependabotAlerts(
     const httpStatus = (error as { status?: number }).status;
     const message = (error as { message?: string }).message;
     const skipStatus = classifyFetchAlertsError(httpStatus, message);
-
-    if (skipStatus === 'alerts_disabled') {
-      log(`Dependabot alerts are not available for ${owner}/${repo}, skipping`);
-      return { status: 'alerts_disabled' };
-    }
 
     if (skipStatus === 'alerts_unavailable') {
       warn(`Dependabot alerts are unavailable for ${owner}/${repo}, skipping`, {

--- a/src/lib/security-agent/github/dependabot-api.ts
+++ b/src/lib/security-agent/github/dependabot-api.ts
@@ -111,6 +111,8 @@ export type FetchAlertsResult =
   | { status: 'alerts_disabled' }
   | { status: 'alerts_unavailable' };
 
+type FetchAlertsSkipStatus = 'repo_not_found' | 'alerts_disabled' | 'alerts_unavailable';
+
 function normalizeErrorMessage(message?: string): string {
   return (message ?? '').toLowerCase();
 }
@@ -131,6 +133,35 @@ function isDependabotAlertsUnavailableMessage(message?: string): boolean {
     normalized.includes('archived repository') ||
     normalized.includes('dependabot alerts are not available')
   );
+}
+
+function isDependabotServiceUnavailableStatus(httpStatus?: number): boolean {
+  return (
+    httpStatus === 451 || (typeof httpStatus === 'number' && httpStatus >= 500 && httpStatus < 600)
+  );
+}
+
+function classifyFetchAlertsError(
+  httpStatus?: number,
+  message?: string
+): FetchAlertsSkipStatus | null {
+  if (httpStatus === 404) {
+    return 'repo_not_found';
+  }
+
+  if (httpStatus === 403 && isDependabotAlertsDisabledMessage(message)) {
+    return 'alerts_disabled';
+  }
+
+  if (isDependabotServiceUnavailableStatus(httpStatus)) {
+    return 'alerts_unavailable';
+  }
+
+  if ((httpStatus === 403 || httpStatus === 422) && isDependabotAlertsUnavailableMessage(message)) {
+    return 'alerts_unavailable';
+  }
+
+  return null;
 }
 
 /**
@@ -187,26 +218,22 @@ export async function fetchAllDependabotAlerts(
     const apiDurationMs = Math.round(performance.now() - apiStartTime);
     const httpStatus = (error as { status?: number }).status;
     const message = (error as { message?: string }).message;
+    const skipStatus = classifyFetchAlertsError(httpStatus, message);
 
-    // Handle case where Dependabot alerts are disabled or unavailable for the repository
-    if (httpStatus === 403 && isDependabotAlertsDisabledMessage(message)) {
+    if (skipStatus === 'alerts_disabled') {
       log(`Dependabot alerts are not available for ${owner}/${repo}, skipping`);
       return { status: 'alerts_disabled' };
     }
 
-    // Handle geo/policy/blocked access cases as non-fatal skips.
-    if (
-      httpStatus === 451 ||
-      ((httpStatus === 403 || httpStatus === 422) && isDependabotAlertsUnavailableMessage(message))
-    ) {
+    if (skipStatus === 'alerts_unavailable') {
       warn(`Dependabot alerts are unavailable for ${owner}/${repo}, skipping`, {
         status: httpStatus,
+        message,
       });
       return { status: 'alerts_unavailable' };
     }
 
-    // Handle case where repository no longer exists or is inaccessible
-    if (httpStatus === 404) {
+    if (skipStatus === 'repo_not_found') {
       warn(
         `Repository ${owner}/${repo} not found (may have been deleted or transferred), skipping`
       );

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -44,6 +44,7 @@ import {
 } from '../core/constants';
 
 const log = sentryLogger('security-agent:analysis', 'info');
+const warn = sentryLogger('security-agent:analysis', 'warning');
 const logError = sentryLogger('security-agent:analysis', 'error');
 
 const ANALYSIS_PROMPT_TEMPLATE = `You are a security analyst reviewing a dependency vulnerability alert for a codebase.
@@ -504,6 +505,18 @@ export async function startSecurityAnalysis(params: {
     try {
       await client.initiateFromPreparedSession({ cloudAgentSessionId });
     } catch (initiateError) {
+      // Re-throw InsufficientCreditsError so it propagates to the caller
+      if (initiateError instanceof InsufficientCreditsError) {
+        warn('Sandbox initiation blocked by insufficient credits', {
+          correlationId,
+          findingId,
+          cloudAgentSessionId,
+        });
+        // Clean up the prepared session
+        void client.deleteSession(cloudAgentSessionId).catch(() => {});
+        throw initiateError;
+      }
+
       logError('initiateFromPreparedSession failed', {
         correlationId,
         findingId,
@@ -512,11 +525,6 @@ export async function startSecurityAnalysis(params: {
       });
       // Clean up the prepared session
       void client.deleteSession(cloudAgentSessionId).catch(() => {});
-
-      // Re-throw InsufficientCreditsError so it propagates to the caller
-      if (initiateError instanceof InsufficientCreditsError) {
-        throw initiateError;
-      }
 
       await updateAnalysisStatus(findingId, 'failed', {
         error: initiateError instanceof Error ? initiateError.message : String(initiateError),

--- a/src/lib/security-agent/services/extraction-service.ts
+++ b/src/lib/security-agent/services/extraction-service.ts
@@ -165,16 +165,20 @@ function parseExtractionResult(
   try {
     const parsed = JSON.parse(args);
 
-    let isExploitable = parsed.isExploitable;
-    if (typeof isExploitable === 'string') {
-      const normalized = isExploitable.trim().toLowerCase();
-      if (normalized === 'true') {
-        warn('Coercing string isExploitable to boolean true');
-        isExploitable = true;
-      } else if (normalized === 'false') {
-        warn('Coercing string isExploitable to boolean false');
-        isExploitable = false;
-      }
+    const normalizedIsExploitable =
+      typeof parsed.isExploitable === 'string'
+        ? parsed.isExploitable.trim().toLowerCase()
+        : parsed.isExploitable;
+
+    const isExploitable =
+      normalizedIsExploitable === 'true'
+        ? true
+        : normalizedIsExploitable === 'false'
+          ? false
+          : normalizedIsExploitable;
+
+    if (typeof parsed.isExploitable === 'string' && typeof isExploitable === 'boolean') {
+      warn(`Coercing string isExploitable to boolean ${String(isExploitable)}`);
     }
 
     if (typeof isExploitable !== 'boolean' && isExploitable !== 'unknown') {

--- a/src/lib/security-agent/services/extraction-service.ts
+++ b/src/lib/security-agent/services/extraction-service.ts
@@ -27,6 +27,7 @@ const VALID_SUGGESTED_ACTIONS: SandboxSuggestedAction[] = [
 ];
 
 const log = sentryLogger('security-agent:extraction', 'info');
+const warn = sentryLogger('security-agent:extraction', 'warning');
 const logError = sentryLogger('security-agent:extraction', 'error');
 
 // Version string for API requests - must be >= 4.69.1 to pass LLM proxy version check
@@ -164,7 +165,19 @@ function parseExtractionResult(
   try {
     const parsed = JSON.parse(args);
 
-    if (typeof parsed.isExploitable !== 'boolean' && parsed.isExploitable !== 'unknown') {
+    let isExploitable = parsed.isExploitable;
+    if (typeof isExploitable === 'string') {
+      const normalized = isExploitable.trim().toLowerCase();
+      if (normalized === 'true') {
+        warn('Coercing string isExploitable to boolean true');
+        isExploitable = true;
+      } else if (normalized === 'false') {
+        warn('Coercing string isExploitable to boolean false');
+        isExploitable = false;
+      }
+    }
+
+    if (typeof isExploitable !== 'boolean' && isExploitable !== 'unknown') {
       logError('Invalid isExploitable', { value: parsed.isExploitable });
       return null;
     }
@@ -195,7 +208,7 @@ function parseExtractionResult(
     }
 
     return {
-      isExploitable: parsed.isExploitable,
+      isExploitable,
       exploitabilityReasoning: parsed.exploitabilityReasoning,
       usageLocations: parsed.usageLocations.map(String),
       suggestedFix: parsed.suggestedFix,

--- a/src/lib/security-agent/services/sync-service.ts
+++ b/src/lib/security-agent/services/sync-service.ts
@@ -86,6 +86,11 @@ export async function syncDependabotAlertsForRepo(params: {
       return result;
     }
 
+    if (fetchResult.status === 'alerts_unavailable') {
+      warn(`Dependabot alerts unavailable for ${repoFullName}, skipping`);
+      return result;
+    }
+
     const alerts = fetchResult.alerts;
     log(`Fetched ${alerts.length} alerts from GitHub for ${repoFullName}`);
 

--- a/src/lib/security-agent/services/sync-service.ts
+++ b/src/lib/security-agent/services/sync-service.ts
@@ -81,11 +81,6 @@ export async function syncDependabotAlertsForRepo(params: {
       return result;
     }
 
-    if (fetchResult.status === 'alerts_disabled') {
-      log(`Dependabot alerts disabled for ${repoFullName}, skipping`);
-      return result;
-    }
-
     if (fetchResult.status === 'alerts_unavailable') {
       warn(`Dependabot alerts unavailable for ${repoFullName}, skipping`);
       return result;

--- a/src/lib/security-agent/services/triage-service.ts
+++ b/src/lib/security-agent/services/triage-service.ts
@@ -13,7 +13,7 @@ import { sendProxiedChatCompletion } from '@/lib/llm-proxy-helpers';
 import type { SecurityFinding } from '@/db/schema';
 import type { SecurityFindingTriage } from '../core/types';
 import { addBreadcrumb, captureException, startSpan } from '@sentry/nextjs';
-import { sentryLogger } from '@/lib/utils.server';
+import { logExceptInTest, sentryLogger } from '@/lib/utils.server';
 import { emitApiMetrics } from '@/lib/o11y/api-metrics.server';
 import { O11Y_KILO_GATEWAY_CLIENT_SECRET } from '@/lib/config.server';
 import { DEFAULT_SECURITY_AGENT_TRIAGE_MODEL } from '../core/constants';
@@ -256,6 +256,31 @@ export async function triageSecurityFinding(options: {
         span.setAttribute('security_agent.duration_ms', durationMs);
 
         if (!result.ok) {
+          if (result.status === 402) {
+            logExceptInTest('Triage skipped due to insufficient credits', {
+              correlationId,
+              findingId: finding.id,
+              status: result.status,
+            });
+
+            span.setAttribute('security_agent.status', 'payment_required');
+            span.setAttribute('security_agent.is_fallback', true);
+
+            addBreadcrumb({
+              category: 'security-agent.triage',
+              message: 'Triage fallback used (insufficient credits)',
+              level: 'info',
+              data: {
+                correlationId,
+                findingId: finding.id,
+                status: result.status,
+                isFallback: true,
+              },
+            });
+
+            return createFallbackTriage('Insufficient credits for triage API');
+          }
+
           logError('Triage API error', {
             correlationId,
             findingId: finding.id,


### PR DESCRIPTION
## Summary
- normalize cloud-agent protocol parse failures into a clearer error shape and preserve payment-required handling across prepare/initiate/send calls
- treat interrupted analysis and triage/payment-required paths as non-error operational outcomes with targeted logging and fallback behavior
- classify blocked or archived Dependabot alert responses as `alerts_unavailable` so repo sync can skip non-actionable failures safely

## Testing
- pnpm typecheck
- pnpm test --runTestsByPath \"src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts\"
- pnpm test -- \"src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts\" \"src/lib/security-agent/services/analysis-service.test.ts\"