### PR TITLE
CloudAgentNext - Upload session logs to R2

### DIFF
--- a/cloud-agent-next/src/router.test.ts
+++ b/cloud-agent-next/src/router.test.ts
@@ -278,6 +278,7 @@ describe('router sessionId validation', () => {
               SESSION_INGEST: {
                 fetch: vi.fn(),
               } as unknown as TRPCContext['env']['SESSION_INGEST'],
+              R2_BUCKET: {} as TRPCContext['env']['R2_BUCKET'],
               NEXTAUTH_SECRET: 'test-secret',
             },
           };
@@ -619,6 +620,7 @@ describe('router sessionId validation', () => {
             SESSION_INGEST: {
               fetch: vi.fn(),
             } as unknown as TRPCContext['env']['SESSION_INGEST'],
+            R2_BUCKET: {} as TRPCContext['env']['R2_BUCKET'],
             NEXTAUTH_SECRET: 'test-secret',
           },
         };

--- a/cloud-agent-next/src/server.ts
+++ b/cloud-agent-next/src/server.ts
@@ -109,6 +109,64 @@ app.all('/sessions/:userId/:sessionId/ingest', async (c: Context<HonoContext>) =
   return stub.fetch(doRequest);
 });
 
+const ALLOWED_LOG_FILENAMES = new Set(['logs.tar.gz']);
+const MAX_LOG_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
+app.put(
+  '/sessions/:userId/:sessionId/logs/:executionId/:filename',
+  async (c: Context<HonoContext>) => {
+    let userId: string;
+    try {
+      userId = decodeURIComponent(c.req.param('userId'));
+    } catch {
+      return c.text('Invalid userId encoding', 400);
+    }
+
+    const filename = c.req.param('filename');
+    if (!ALLOWED_LOG_FILENAMES.has(filename)) {
+      return c.text('Invalid filename', 400);
+    }
+
+    const authHeader = c.req.header('Authorization');
+    const authResult = validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
+    if (!authResult.success) {
+      return c.text(authResult.error, 401);
+    }
+    if (authResult.userId !== userId) {
+      return c.text('Token does not match session user', 403);
+    }
+
+    const contentLength = parseInt(c.req.header('Content-Length') ?? '', 10);
+    if (contentLength > MAX_LOG_UPLOAD_BYTES) {
+      return c.text('Request body too large', 413);
+    }
+
+    const body = c.req.raw.body;
+    if (!body) {
+      return c.text('Missing request body', 400);
+    }
+
+    const sessionId = c.req.param('sessionId');
+    const executionId = c.req.param('executionId');
+    const safeUserId = encodeURIComponent(userId);
+
+    try {
+      await c.env.R2_BUCKET.put(
+        `logs/${safeUserId}/${sessionId}/${executionId}/${filename}`,
+        body,
+        { httpMetadata: { contentType: 'application/gzip' } }
+      );
+    } catch (err) {
+      logger
+        .withFields({ error: err instanceof Error ? err.message : String(err) })
+        .error('R2 put failed for log upload');
+      return c.text('R2 write failed', 500);
+    }
+
+    return c.body(null, 204);
+  }
+);
+
 app.use('/trpc/*', authMiddleware);
 app.use('/trpc/*', balanceMiddleware);
 

--- a/cloud-agent-next/src/server.ts
+++ b/cloud-agent-next/src/server.ts
@@ -137,7 +137,7 @@ app.put(
     }
 
     const contentLength = parseInt(c.req.header('Content-Length') ?? '', 10);
-    if (contentLength > MAX_LOG_UPLOAD_BYTES) {
+    if (isNaN(contentLength) || contentLength > MAX_LOG_UPLOAD_BYTES) {
       return c.text('Request body too large', 413);
     }
 
@@ -153,10 +153,12 @@ app.put(
     const sessionId = c.req.param('sessionId');
     const executionId = c.req.param('executionId');
     const safeUserId = encodeURIComponent(userId);
+    const safeSessionId = encodeURIComponent(sessionId);
+    const safeExecutionId = encodeURIComponent(executionId);
 
     try {
       await c.env.R2_BUCKET.put(
-        `logs/${safeUserId}/${sessionId}/${executionId}/${filename}`,
+        `logs/${safeUserId}/${safeSessionId}/${safeExecutionId}/${filename}`,
         body,
         { httpMetadata: { contentType: 'application/gzip' } }
       );

--- a/cloud-agent-next/src/server.ts
+++ b/cloud-agent-next/src/server.ts
@@ -141,9 +141,13 @@ app.put(
       return c.text('Request body too large', 413);
     }
 
-    const body = c.req.raw.body;
-    if (!body) {
+    // Buffer the body — R2 requires a known-length value (ArrayBuffer, string, etc.)
+    const body = await c.req.arrayBuffer();
+    if (body.byteLength === 0) {
       return c.text('Missing request body', 400);
+    }
+    if (body.byteLength > MAX_LOG_UPLOAD_BYTES) {
+      return c.text('Request body too large', 413);
     }
 
     const sessionId = c.req.param('sessionId');

--- a/cloud-agent-next/src/server.ts
+++ b/cloud-agent-next/src/server.ts
@@ -137,7 +137,7 @@ app.put(
     }
 
     const contentLength = parseInt(c.req.header('Content-Length') ?? '', 10);
-    if (isNaN(contentLength) || contentLength > MAX_LOG_UPLOAD_BYTES) {
+    if (contentLength > MAX_LOG_UPLOAD_BYTES) {
       return c.text('Request body too large', 413);
     }
 

--- a/cloud-agent-next/src/shared/index.ts
+++ b/cloud-agent-next/src/shared/index.ts
@@ -4,4 +4,5 @@ export {
   type WrapperCommand,
   type CompleteEventData,
   type KilocodeEventData,
+  SESSION_ID_RE,
 } from './protocol.js';

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -72,3 +72,10 @@ export type AutocommitCompletedData = {
   message: string;
   skipped?: boolean;
 };
+
+/**
+ * Regex for validating session IDs (agent_<uuid>).
+ * Shared between worker (zod schema) and wrapper (defense-in-depth validation).
+ */
+export const SESSION_ID_RE =
+  /^agent_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/cloud-agent-next/src/types.ts
+++ b/cloud-agent-next/src/types.ts
@@ -95,6 +95,8 @@ export type Env = {
   CLOUD_AGENT_SESSION: DurableObjectNamespace<CloudAgentSession>;
   /** Service binding for the session ingest worker */
   SESSION_INGEST: SessionIngestBinding;
+  /** R2 bucket for storing session logs */
+  R2_BUCKET: R2Bucket;
   /** Queue for callback messages (optional - supports incremental rollout) */
   CALLBACK_QUEUE?: Queue<CallbackJob>;
   /** KV namespace for caching GitHub installation tokens */

--- a/cloud-agent-next/src/types.ts
+++ b/cloud-agent-next/src/types.ts
@@ -4,13 +4,9 @@ import type { CallbackJob } from './callbacks/index.js';
 import type { SessionIngestBinding } from './session-ingest-binding.js';
 import * as z from 'zod';
 import { Limits } from './schema.js';
+import { SESSION_ID_RE } from './shared/protocol.js';
 
-export const sessionIdSchema = z
-  .string()
-  .regex(
-    /^agent_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-    'Invalid session ID format'
-  );
+export const sessionIdSchema = z.string().regex(SESSION_ID_RE, 'Invalid session ID format');
 
 export const githubRepoSchema = z
   .string()

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -384,6 +384,20 @@ export function createLifecycleManager(
           `post-completion tasks failed: ${err instanceof Error ? err.message : String(err)}`
         )
       )
+      .then(async () => {
+        // Final log upload before closing
+        const uploader = state.logUploader;
+        if (uploader) {
+          await uploader
+            .uploadNow()
+            .catch(err =>
+              logToFile(
+                `final log upload failed: ${err instanceof Error ? err.message : String(err)}`
+              )
+            );
+          uploader.stop();
+        }
+      })
       .finally(() => {
         // Send complete event to ingest so DO can update execution status and trigger callbacks
         // BUT only if not aborted - fatal errors already sent their own terminal event

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -378,7 +378,7 @@ export function createLifecycleManager(
     // Run post-completion tasks first (auto-commit, condense), THEN send the complete event.
     // The complete event must be sent after post-completion tasks so that clients don't
     // disconnect before autocommit output is streamed.
-    runPostCompletionTasks()
+    void runPostCompletionTasks()
       .catch(err =>
         logToFile(
           `post-completion tasks failed: ${err instanceof Error ? err.message : String(err)}`

--- a/cloud-agent-next/wrapper/src/log-uploader.ts
+++ b/cloud-agent-next/wrapper/src/log-uploader.ts
@@ -1,0 +1,114 @@
+import { existsSync } from 'node:fs';
+import { basename, dirname } from 'node:path';
+import { spawn } from 'node:child_process';
+import { logToFile } from './utils.js';
+
+type LogUploaderOpts = {
+  workerBaseUrl: string;
+  sessionId: string;
+  executionId: string;
+  userId: string;
+  kilocodeToken: string;
+  cliLogPath: string;
+  wrapperLogPath: string;
+};
+
+type LogUploader = {
+  start: (intervalMs?: number) => void;
+  uploadNow: () => Promise<void>;
+  stop: () => void;
+};
+
+const UPLOAD_TIMEOUT_MS = 15_000;
+
+type TarStream = {
+  stream: ReadableStream<Uint8Array>;
+  kill: () => void;
+};
+
+function createTarStream(files: Array<string>): TarStream | undefined {
+  const existing = files.filter(f => existsSync(f));
+  if (existing.length === 0) return undefined;
+
+  // Use -C dir basename for each file so the archive contains only filenames, not full paths
+  const tarArgs = ['czf', '-'];
+  for (const f of existing) {
+    tarArgs.push('-C', dirname(f), basename(f));
+  }
+  const proc = spawn('tar', tarArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const { stdout, stderr: stderrStream } = proc;
+  if (!stdout || !stderrStream) return undefined;
+
+  let stderr = '';
+  stderrStream.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  proc.on('close', code => {
+    if (code !== 0) logToFile(`tar exited with code ${code}: ${stderr}`);
+  });
+
+  const stream = new ReadableStream({
+    start(controller) {
+      stdout.on('data', (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
+      stdout.on('end', () => controller.close());
+      stdout.on('error', err => controller.error(err));
+      proc.on('error', err => {
+        logToFile(`tar spawn error: ${err.message}`);
+        controller.error(err);
+      });
+    },
+  });
+
+  return { stream, kill: () => proc.kill() };
+}
+
+export function createLogUploader(opts: LogUploaderOpts): LogUploader {
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  async function uploadNow(): Promise<void> {
+    const tar = createTarStream([opts.cliLogPath, opts.wrapperLogPath]);
+    if (!tar) return;
+
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), UPLOAD_TIMEOUT_MS);
+    try {
+      const url = `${opts.workerBaseUrl}/sessions/${encodeURIComponent(opts.userId)}/${encodeURIComponent(opts.sessionId)}/logs/${encodeURIComponent(opts.executionId)}/logs.tar.gz`;
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${opts.kilocodeToken}` },
+        body: tar.stream,
+        // @ts-expect-error -- Node/Bun fetch supports duplex for streaming request bodies
+        duplex: 'half',
+        signal: abort.signal,
+      });
+      if (!response.ok) {
+        logToFile(`Log upload failed: ${response.status} ${response.statusText}`);
+      }
+    } catch (error) {
+      if (abort.signal.aborted) {
+        logToFile(`Log upload timed out after ${UPLOAD_TIMEOUT_MS}ms`);
+      } else {
+        logToFile(`Log upload error: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } finally {
+      clearTimeout(timer);
+      tar.kill();
+    }
+  }
+
+  function start(intervalMs = 30_000): void {
+    stop();
+    intervalId = setInterval(() => {
+      uploadNow().catch(() => {});
+    }, intervalMs);
+  }
+
+  function stop(): void {
+    if (intervalId !== undefined) {
+      clearInterval(intervalId);
+      intervalId = undefined;
+    }
+  }
+
+  return { start, uploadNow, stop };
+}

--- a/cloud-agent-next/wrapper/src/log-uploader.ts
+++ b/cloud-agent-next/wrapper/src/log-uploader.ts
@@ -14,7 +14,7 @@ type LogUploaderOpts = {
   wrapperLogPath: string;
 };
 
-type LogUploader = {
+export type LogUploader = {
   start: (intervalMs?: number) => void;
   uploadNow: () => Promise<void>;
   stop: () => void;

--- a/cloud-agent-next/wrapper/src/log-uploader.ts
+++ b/cloud-agent-next/wrapper/src/log-uploader.ts
@@ -9,7 +9,8 @@ type LogUploaderOpts = {
   executionId: string;
   userId: string;
   kilocodeToken: string;
-  cliLogPath: string;
+  /** Directory containing CLI log files (e.g. ~/.local/share/kilo/log/) */
+  cliLogDir: string;
   wrapperLogPath: string;
 };
 
@@ -26,11 +27,12 @@ type TarStream = {
   kill: () => void;
 };
 
-function createTarStream(files: Array<string>): TarStream | undefined {
-  const existing = files.filter(f => existsSync(f));
+function createTarStream(paths: Array<string>): TarStream | undefined {
+  const existing = paths.filter(f => existsSync(f));
   if (existing.length === 0) return undefined;
 
-  // Use -C dir basename for each file so the archive contains only filenames, not full paths
+  // Use -C parent basename for each path so the archive contains relative names, not full paths.
+  // Works for both files and directories.
   const tarArgs = ['czf', '-'];
   for (const f of existing) {
     tarArgs.push('-C', dirname(f), basename(f));
@@ -66,7 +68,7 @@ export function createLogUploader(opts: LogUploaderOpts): LogUploader {
   let intervalId: ReturnType<typeof setInterval> | undefined;
 
   async function uploadNow(): Promise<void> {
-    const tar = createTarStream([opts.cliLogPath, opts.wrapperLogPath]);
+    const tar = createTarStream([opts.cliLogDir, opts.wrapperLogPath]);
     if (!tar) return;
 
     const abort = new AbortController();

--- a/cloud-agent-next/wrapper/src/log-uploader.ts
+++ b/cloud-agent-next/wrapper/src/log-uploader.ts
@@ -51,12 +51,27 @@ function createTarStream(paths: Array<string>): TarStream | undefined {
 
   const stream = new ReadableStream({
     start(controller) {
-      stdout.on('data', (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
-      stdout.on('end', () => controller.close());
-      stdout.on('error', err => controller.error(err));
+      let done = false;
+      const close = () => {
+        if (!done) {
+          done = true;
+          controller.close();
+        }
+      };
+      const error = (err: Error) => {
+        if (!done) {
+          done = true;
+          controller.error(err);
+        }
+      };
+      stdout.on('data', (chunk: Buffer) => {
+        if (!done) controller.enqueue(new Uint8Array(chunk));
+      });
+      stdout.on('end', close);
+      stdout.on('error', error);
       proc.on('error', err => {
         logToFile(`tar spawn error: ${err.message}`);
-        controller.error(err);
+        error(err);
       });
     },
   });
@@ -66,10 +81,16 @@ function createTarStream(paths: Array<string>): TarStream | undefined {
 
 export function createLogUploader(opts: LogUploaderOpts): LogUploader {
   let intervalId: ReturnType<typeof setInterval> | undefined;
+  let isUploading = false;
 
   async function uploadNow(): Promise<void> {
+    if (isUploading) return;
+    isUploading = true;
     const tar = createTarStream([opts.cliLogDir, opts.wrapperLogPath]);
-    if (!tar) return;
+    if (!tar) {
+      isUploading = false;
+      return;
+    }
 
     const abort = new AbortController();
     const timer = setTimeout(() => abort.abort(), UPLOAD_TIMEOUT_MS);
@@ -95,6 +116,7 @@ export function createLogUploader(opts: LogUploaderOpts): LogUploader {
     } finally {
       clearTimeout(timer);
       tar.kill();
+      isUploading = false;
     }
   }
 

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -270,6 +270,13 @@ async function main() {
     // Stop lifecycle timers
     getLifecycleManager().stop();
 
+    // Best-effort final log upload
+    const uploader = state.logUploader;
+    if (uploader) {
+      uploader.uploadNow().catch(() => {});
+      uploader.stop();
+    }
+
     // Abort kilo session if running
     const job = state.currentJob;
     if (job) {

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -253,7 +253,7 @@ async function main() {
   // Graceful shutdown handler
   let isShuttingDown = false;
 
-  function handleShutdown(signal: string): void {
+  async function handleShutdown(signal: string): Promise<void> {
     if (isShuttingDown) return;
     isShuttingDown = true;
 
@@ -270,10 +270,17 @@ async function main() {
     // Stop lifecycle timers
     getLifecycleManager().stop();
 
-    // Best-effort final log upload
+    // Force exit after timeout
+    setTimeout(() => {
+      logToFile('force exit after timeout');
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+
+    // Best-effort final log upload (with short timeout to avoid blocking shutdown)
     const uploader = state.logUploader;
     if (uploader) {
-      uploader.uploadNow().catch(() => {});
+      const uploadTimeout = new Promise<void>(resolve => setTimeout(resolve, 5_000));
+      await Promise.race([uploader.uploadNow().catch(() => {}), uploadTimeout]);
       uploader.stop();
     }
 
@@ -289,12 +296,6 @@ async function main() {
     // Stop HTTP server
     server.stop();
 
-    // Force exit after timeout
-    setTimeout(() => {
-      logToFile('force exit after timeout');
-      process.exit(1);
-    }, SHUTDOWN_TIMEOUT_MS);
-
     // Try graceful exit
     setTimeout(() => {
       logToFile('graceful exit');
@@ -302,8 +303,8 @@ async function main() {
     }, 1000);
   }
 
-  process.on('SIGTERM', () => handleShutdown('SIGTERM'));
-  process.on('SIGINT', () => handleShutdown('SIGINT'));
+  process.on('SIGTERM', () => void handleShutdown('SIGTERM'));
+  process.on('SIGINT', () => void handleShutdown('SIGINT'));
 }
 
 main().catch(err => {

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -15,6 +15,7 @@
 
 import type { WrapperState, JobContext } from './state.js';
 import type { KiloClient } from './kilo-client.js';
+import { createLogUploader } from './log-uploader.js';
 import { logToFile } from './utils.js';
 
 // ---------------------------------------------------------------------------
@@ -218,6 +219,25 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
       logToFile(`job/start: state.startJob failed: ${msg}`);
       return errorResponse('JOB_CONFLICT', msg, 409);
     }
+
+    // Create and start log uploader for this job
+    const ingestOrigin = new URL(body.ingestUrl);
+    ingestOrigin.protocol = ingestOrigin.protocol === 'wss:' ? 'https:' : 'http:';
+    const workerBaseUrl = ingestOrigin.origin;
+    const cliLogPath = `/home/${body.sessionId}/.kilocode/cli/logs/cli.txt`;
+    const wrapperLogPath = process.env.WRAPPER_LOG_PATH ?? '/tmp/kilocode-wrapper.log';
+    const logUploader = createLogUploader({
+      workerBaseUrl,
+      sessionId: body.sessionId,
+      executionId: body.executionId,
+      userId: body.userId,
+      kilocodeToken: body.kilocodeToken,
+      cliLogPath,
+      wrapperLogPath,
+    });
+    state.setLogUploader(logUploader);
+    logUploader.start();
+    logToFile(`job/start: log uploader started (url=${workerBaseUrl})`);
 
     logToFile(
       `job/start: job started executionId=${body.executionId} kiloSessionId=${kiloSessionId}`

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -16,6 +16,7 @@
 import type { WrapperState, JobContext } from './state.js';
 import type { KiloClient } from './kilo-client.js';
 import { createLogUploader } from './log-uploader.js';
+import { SESSION_ID_RE } from '../../src/shared/protocol.js';
 import { logToFile } from './utils.js';
 
 // ---------------------------------------------------------------------------
@@ -178,6 +179,21 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
       );
     }
 
+    // Validate sessionId format before using in filesystem path (defense-in-depth)
+    if (!SESSION_ID_RE.test(body.sessionId)) {
+      return errorResponse('INVALID_REQUEST', 'Invalid sessionId format', 400);
+    }
+
+    // Parse ingest URL to derive worker base URL for log uploads
+    let workerBaseUrl: string;
+    try {
+      const ingestOrigin = new URL(body.ingestUrl);
+      ingestOrigin.protocol = ingestOrigin.protocol === 'wss:' ? 'https:' : 'http:';
+      workerBaseUrl = ingestOrigin.origin;
+    } catch {
+      return errorResponse('INVALID_REQUEST', 'Invalid ingestUrl', 400);
+    }
+
     // Create or resume kilo session
     let kiloSessionId: string;
     try {
@@ -221,14 +237,6 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
     }
 
     // Create and start log uploader for this job
-    const ingestOrigin = new URL(body.ingestUrl);
-    ingestOrigin.protocol = ingestOrigin.protocol === 'wss:' ? 'https:' : 'http:';
-    const workerBaseUrl = ingestOrigin.origin;
-    // Validate sessionId format before using in filesystem path (defense-in-depth)
-    const SESSION_ID_RE = /^agent_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!SESSION_ID_RE.test(body.sessionId)) {
-      return errorResponse('INVALID_REQUEST', 'Invalid sessionId format', 400);
-    }
     const cliLogDir = `/home/${body.sessionId}/.local/share/kilo/log`;
     const wrapperLogPath = process.env.WRAPPER_LOG_PATH ?? '/tmp/kilocode-wrapper.log';
     const logUploader = createLogUploader({

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -224,6 +224,11 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
     const ingestOrigin = new URL(body.ingestUrl);
     ingestOrigin.protocol = ingestOrigin.protocol === 'wss:' ? 'https:' : 'http:';
     const workerBaseUrl = ingestOrigin.origin;
+    // Validate sessionId format before using in filesystem path (defense-in-depth)
+    const SESSION_ID_RE = /^agent_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!SESSION_ID_RE.test(body.sessionId)) {
+      return errorResponse('INVALID_REQUEST', 'Invalid sessionId format', 400);
+    }
     const cliLogDir = `/home/${body.sessionId}/.local/share/kilo/log`;
     const wrapperLogPath = process.env.WRAPPER_LOG_PATH ?? '/tmp/kilocode-wrapper.log';
     const logUploader = createLogUploader({

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -224,7 +224,7 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
     const ingestOrigin = new URL(body.ingestUrl);
     ingestOrigin.protocol = ingestOrigin.protocol === 'wss:' ? 'https:' : 'http:';
     const workerBaseUrl = ingestOrigin.origin;
-    const cliLogPath = `/home/${body.sessionId}/.kilocode/cli/logs/cli.txt`;
+    const cliLogDir = `/home/${body.sessionId}/.local/share/kilo/log`;
     const wrapperLogPath = process.env.WRAPPER_LOG_PATH ?? '/tmp/kilocode-wrapper.log';
     const logUploader = createLogUploader({
       workerBaseUrl,
@@ -232,7 +232,7 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
       executionId: body.executionId,
       userId: body.userId,
       kilocodeToken: body.kilocodeToken,
-      cliLogPath,
+      cliLogDir,
       wrapperLogPath,
     });
     state.setLogUploader(logUploader);

--- a/cloud-agent-next/wrapper/src/state.ts
+++ b/cloud-agent-next/wrapper/src/state.ts
@@ -39,6 +39,12 @@ export interface LastError {
   timestamp: number;
 }
 
+export type LogUploader = {
+  start: (intervalMs?: number) => void;
+  uploadNow: () => Promise<void>;
+  stop: () => void;
+};
+
 export interface WrapperStatus {
   state: 'idle' | 'active';
   executionId?: string;
@@ -75,6 +81,9 @@ export class WrapperState {
 
   // Callbacks for sending events to ingest
   private _sendToIngestFn: ((event: IngestEvent) => void) | null = null;
+
+  // Log uploader (set per-job, cleared on job end)
+  private _logUploader: LogUploader | null = null;
 
   // ---------------------------------------------------------------------------
   // State Queries
@@ -135,6 +144,8 @@ export class WrapperState {
    * Clear job context. Called on idle timeout or explicit reset.
    */
   clearJob(): void {
+    this._logUploader?.stop();
+    this._logUploader = null;
     this.job = null;
     this.inflight.clear();
     this.messageCounter = 0;
@@ -254,6 +265,18 @@ export class WrapperState {
       return;
     }
     this._sendToIngestFn(event);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Log Uploader
+  // ---------------------------------------------------------------------------
+
+  get logUploader(): LogUploader | null {
+    return this._logUploader;
+  }
+
+  setLogUploader(uploader: LogUploader | null): void {
+    this._logUploader = uploader;
   }
 
   // ---------------------------------------------------------------------------

--- a/cloud-agent-next/wrapper/src/state.ts
+++ b/cloud-agent-next/wrapper/src/state.ts
@@ -276,6 +276,7 @@ export class WrapperState {
   }
 
   setLogUploader(uploader: LogUploader | null): void {
+    this._logUploader?.stop();
     this._logUploader = uploader;
   }
 

--- a/cloud-agent-next/wrapper/src/state.ts
+++ b/cloud-agent-next/wrapper/src/state.ts
@@ -11,6 +11,8 @@
  */
 
 import type { IngestEvent } from '../../src/shared/protocol.js';
+import type { LogUploader } from './log-uploader.js';
+export type { LogUploader } from './log-uploader.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,12 +40,6 @@ export interface LastError {
   message: string;
   timestamp: number;
 }
-
-export type LogUploader = {
-  start: (intervalMs?: number) => void;
-  uploadNow: () => Promise<void>;
-  stop: () => void;
-};
 
 export interface WrapperStatus {
   state: 'idle' | 'active';


### PR DESCRIPTION
## Summary

- Add periodic log upload (every 30s) of CLI and wrapper logs to R2, with a final upload on session drain and process shutdown.
- New `PUT /sessions/:userId/:sessionId/logs/:executionId/:filename` Hono route on the worker that validates auth, enforces a filename whitelist (`logs.tar.gz`), caps request size at 50 MB, and streams the body to R2.
- New `createLogUploader` closure factory in `wrapper/src/log-uploader.ts` that spawns `tar czf -` to compress logs and PUTs the stream to the worker endpoint with a 15s timeout.
- Wire the uploader into `WrapperState` (created on job start, stopped on `clearJob()`), lifecycle drain (`triggerDrainAndClose`), and `handleShutdown`.
- Add `R2_BUCKET: R2Bucket` binding to the `Env` type and update test mocks.

## R2 key structure

```
logs/{url-encoded-userId}/{sessionId}/{executionId}/logs.tar.gz
```