### PR TITLE
Add deploy-gateway job to production workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -151,6 +151,61 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
+  deploy-gateway:
+    runs-on: ubuntu-24.04-8core
+    needs: run-migrations
+    environment: production
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_GATEWAY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+
+      - name: Install Vercel CLI
+        run: pnpm install --global vercel@latest
+
+      - run: vercel link --project=kilocode-gateway --token=${{ secrets.VERCEL_TOKEN }} --yes
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
   check-cloud-agent-changes:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Summary

- Adds a `deploy-gateway` job to the production deploy workflow, parallel to `deploy-app` and `deploy-global-app`
- The new job deploys the `kilocode-gateway` Vercel project at `gateway.kilo.ai`
- Uses `VERCEL_PROJECT_ID_GATEWAY` secret (needs to be added to the `production` environment)

## Manual steps required before merging

1. Create the `kilocode-gateway` Vercel project with domain `gateway.kilo.ai` and `KILO_GATEWAY_BACKEND=true` env var
2. Add `VERCEL_PROJECT_ID_GATEWAY` to the repo's `production` environment secrets
3. Copy all required env vars from the main app to the new project