### PR TITLE
Add gateway.kilo.ai rewrites for LLM and indexing routes

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,8 +43,37 @@ const nextConfig = {
           ]
         : [];
 
+    const gatewayApiRewrites =
+      process.env.KILO_GATEWAY_BACKEND !== 'true'
+        ? [
+            {
+              source: '/api/openrouter/:path*',
+              destination: 'https://gateway.kilo.ai/api/openrouter/:path*',
+            },
+            {
+              source: '/api/gateway/:path*',
+              destination: 'https://gateway.kilo.ai/api/gateway/:path*',
+            },
+            {
+              source: '/api/models/stats',
+              destination: 'https://gateway.kilo.ai/api/models/stats',
+            },
+            {
+              source: '/api/models/stats/:path*',
+              destination: 'https://gateway.kilo.ai/api/models/stats/:path*',
+            },
+            { source: '/api/modelstats', destination: 'https://gateway.kilo.ai/api/modelstats' },
+            { source: '/api/models/up', destination: 'https://gateway.kilo.ai/api/models/up' },
+            { source: '/api/defaults', destination: 'https://gateway.kilo.ai/api/defaults' },
+            {
+              source: '/api/code-indexing/upsert-by-file',
+              destination: 'https://gateway.kilo.ai/api/code-indexing/upsert-by-file',
+            },
+          ]
+        : [];
+
     return {
-      beforeFiles: globalApiRewrites,
+      beforeFiles: [...globalApiRewrites, ...gatewayApiRewrites],
       afterFiles: [
         {
           source: '/config.json',


### PR DESCRIPTION
## Summary

- Adds `beforeFiles` rewrites to proxy LLM gateway and code-indexing routes to `gateway.kilo.ai` when `KILO_GATEWAY_BACKEND` is not set
- Routes proxied: `/api/openrouter/*`, `/api/gateway/*`, `/api/models/stats`, `/api/models/stats/*`, `/api/modelstats`, `/api/models/up`, `/api/defaults`, `/api/code-indexing/upsert-by-file`
- Follows the same pattern as the existing `GLOBAL_KILO_BACKEND` / `global-api.kilo.ai` rewrites
- The gateway deployment itself should have `KILO_GATEWAY_BACKEND=true` set so it serves these routes locally

## Notes

- This PR should be merged **after** the gateway Vercel project is created and the deploy job PR (#651) is merged, so traffic doesn't route to a nonexistent backend
- FIM completions stays on `global-api.kilo.ai` — unchanged