### PR TITLE
Add getWorkerDb helper to @kilocode/db for Cloudflare Workers

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -40,7 +40,7 @@ export function createDrizzleClient(options: CreateDrizzleClientOptions) {
  * so we use max: 1 here. Pass env.HYPERDRIVE.connectionString directly.
  */
 export function getWorkerDb(connectionString: string) {
-  const pool = new pg.Pool({ connectionString, max: 1, ssl: false });
+  const pool = new pg.Pool({ connectionString, max: 1 });
   return drizzle(pool, { schema });
 }
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -34,4 +34,16 @@ export function createDrizzleClient(options: CreateDrizzleClientOptions) {
   return { db, pool, schema };
 }
 
+/**
+ * Convenience wrapper for Cloudflare Workers using Hyperdrive.
+ * Hyperdrive handles connection pooling at the infrastructure level,
+ * so we use max: 1 here. Pass env.HYPERDRIVE.connectionString directly.
+ */
+export function getWorkerDb(connectionString: string) {
+  const pool = new pg.Pool({ connectionString, max: 1, ssl: false });
+  return drizzle(pool, { schema });
+}
+
+export type WorkerDb = ReturnType<typeof getWorkerDb>;
+
 export { pg };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,5 +1,10 @@
 export * from './schema';
 export * from './schema-types';
-export { createDrizzleClient, type CreateDrizzleClientOptions } from './client';
+export {
+  createDrizzleClient,
+  type CreateDrizzleClientOptions,
+  getWorkerDb,
+  type WorkerDb,
+} from './client';
 export { computeDatabaseUrl, getDatabaseClientConfig } from './database-url';
 export { sql } from 'drizzle-orm';


### PR DESCRIPTION
## Summary
- Adds `getWorkerDb(connectionString)` helper to `packages/db/src/client.ts` — a convenience wrapper for Cloudflare Workers using Hyperdrive
- Uses `pg.Pool` with `max: 1` and `ssl: false` (Hyperdrive handles connection pooling at the infrastructure level)
- Exports `WorkerDb` type for use across all worker migrations

This is the shared foundation for Phase 2 of the Drizzle extraction plan — migrating all 5 Cloudflare workers from raw SQL/Kysely to the shared `@kilocode/db` package.

## Dependent PRs
- Migrate kiloclaw
- Migrate cloudflare-git-token-service
- Migrate cloud-agent
- Migrate cloudflare-webhook-agent-ingest
- Migrate cloudflare-session-ingest