### PR TITLE
Remove duplicate drizzle-kit from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "brace-expansion": "^4.0.1",
     "dependency-cruiser": "^17.3.1",
     "dotenv": "^17.2.3",
-    "drizzle-kit": "^0.31.8",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-drizzle": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,9 +358,6 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
-      drizzle-kit:
-        specifier: ^0.31.8
-        version: 0.31.8
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.6.1)
@@ -7240,10 +7237,6 @@ packages:
   drange@1.1.1:
     resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
     engines: {node: '>=4'}
-
-  drizzle-kit@0.31.8:
-    resolution: {integrity: sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==}
-    hasBin: true
 
   drizzle-kit@0.31.9:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
@@ -19089,15 +19082,6 @@ snapshots:
   dotenv@17.2.3: {}
 
   drange@1.1.1: {}
-
-  drizzle-kit@0.31.8:
-    dependencies:
-      '@drizzle-team/brocli': 0.10.2
-      '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.27.0
-      esbuild-register: 3.6.0(esbuild@0.27.0)
-    transitivePeerDependencies:
-      - supports-color
 
   drizzle-kit@0.31.9:
     dependencies:


### PR DESCRIPTION
## Summary
- Removed `drizzle-kit` from root `package.json` devDependencies — it was already declared in `packages/db/package.json`
- The duplicate caused pnpm to resolve conflicting esbuild versions (`0.27.3` host vs `0.25.10`/`0.27.0` binary), breaking `pnpm drizzle generate` with "Host version does not match binary version" errors