### PR TITLE
CloudAgentNext - Improve session log retrieval and fix ingestUrl protocol mapping

### DIFF
--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -11,12 +11,7 @@ import {
   SessionService,
   fetchSessionMetadata,
 } from '../../session-service.js';
-import {
-  cleanupWorkspace,
-  getSessionWorkspacePath,
-  getSessionHomePath,
-  getWrapperLogFilePath,
-} from '../../workspace.js';
+import { cleanupWorkspace, getSessionWorkspacePath, getSessionHomePath } from '../../workspace.js';
 import { withDORetry } from '../../utils/do-retry.js';
 import { protectedProcedure, publicProcedure } from '../auth.js';
 import { sessionIdSchema, GetSessionInput, GetSessionOutput } from '../schemas.js';
@@ -420,26 +415,24 @@ export function createSessionManagementHandlers() {
       }),
 
     /**
-     * Get the wrapper log file content for a specific execution.
+     * Get all log files and running processes for a session's sandbox.
      *
-     * Returns the contents of /tmp/kilocode-wrapper-{executionId}.log from the sandbox.
-     * This is useful for debugging wrapper startup issues.
+     * Discovers wrapper logs from /tmp and CLI logs from the session home directory.
+     * Useful for debugging wrapper startup and CLI issues.
      */
     getWrapperLogs: protectedProcedure
       .input(
         z.object({
           sessionId: sessionIdSchema.describe('Session ID'),
-          executionId: z.string().describe('Execution ID to get wrapper logs for'),
         })
       )
       .query(async ({ input, ctx }) => {
         return withLogTags({ source: 'getWrapperLogs' }, async () => {
           const sessionId = input.sessionId as SessionId;
-          const { executionId } = input;
           const { userId, env } = ctx;
 
-          logger.setTags({ userId, sessionId, executionId });
-          logger.info('Fetching wrapper logs');
+          logger.setTags({ userId, sessionId });
+          logger.info('Fetching all session logs');
 
           // Fetch session metadata to get sandboxId and validate ownership
           const sessionService = new SessionService();
@@ -467,9 +460,8 @@ export function createSessionManagementHandlers() {
           logger.setTags({ sandboxId, orgId: sessionService.metadata?.orgId ?? '(personal)' });
 
           const sandbox = getSandbox(env.Sandbox, sandboxId);
-          const logFilePath = getWrapperLogFilePath(executionId);
 
-          // Get or create a session to read the file
+          // Get or create a session to read files
           const context = sessionService.buildContext({
             sandboxId,
             orgId: sessionService.metadata?.orgId,
@@ -486,58 +478,82 @@ export function createSessionManagementHandlers() {
             sessionService.metadata?.orgId
           );
 
-          logger.withTags({ logFilePath }).debug('Reading wrapper log file');
+          // Discover all log files from the sandbox
+          const logPaths: string[] = [];
 
-          // Fetch running processes for this execution (best-effort)
+          // 1. Wrapper logs: /tmp/kilocode-wrapper-*.log (one per execution)
+          try {
+            const tmpFiles = await session.listFiles('/tmp');
+            if (tmpFiles.success) {
+              for (const f of tmpFiles.files) {
+                if (
+                  f.type === 'file' &&
+                  f.name.startsWith('kilocode-wrapper-') &&
+                  f.name.endsWith('.log')
+                ) {
+                  logPaths.push(f.absolutePath);
+                }
+              }
+            }
+          } catch {
+            logger.debug('Could not list /tmp for wrapper logs');
+          }
+
+          // 2. CLI logs: {sessionHome}/.local/share/kilo/log/ (matches wrapper R2 uploader)
+          const sessionHome = getSessionHomePath(sessionId);
+          const cliLogsDir = `${sessionHome}/.local/share/kilo/log`;
+          try {
+            const cliFiles = await session.listFiles(cliLogsDir, { recursive: true });
+            if (cliFiles.success) {
+              for (const f of cliFiles.files) {
+                if (f.type === 'file') {
+                  logPaths.push(f.absolutePath);
+                }
+              }
+            }
+          } catch {
+            logger.debug('Could not list CLI logs directory', { cliLogsDir });
+          }
+
+          // Read all discovered files in parallel (best-effort per file)
+          const files: Record<string, string> = {};
+          const readResults = await Promise.allSettled(
+            logPaths.map(async path => {
+              const fileInfo = await session.readFile(path, { encoding: 'utf-8' });
+              return { path, content: fileInfo.content };
+            })
+          );
+          for (const result of readResults) {
+            if (result.status === 'fulfilled') {
+              files[result.value.path] = result.value.content;
+            }
+          }
+
+          // Fetch running processes (best-effort)
           let processes: Array<{ pid: number; command: string; status: string }> | undefined;
           try {
             type ProcessInfo = { id: string; status: string; command: string };
             const allProcesses = (await sandbox.listProcesses()) as ProcessInfo[];
-            // Filter for processes belonging to this execution
-            // The wrapper command includes --execution-id=<executionId>
-            processes = allProcesses
-              .filter((p: ProcessInfo) => p.command.includes(executionId))
-              .map((p: ProcessInfo) => ({
-                pid: parseInt(p.id, 10) || 0,
-                command: p.command,
-                status: p.status,
-              }));
+            processes = allProcesses.map((p: ProcessInfo) => ({
+              pid: parseInt(p.id, 10) || 0,
+              command: p.command,
+              status: p.status,
+            }));
           } catch (err) {
-            // Sandbox may not be available (evicted, not started, etc.)
             logger.debug('Could not fetch sandbox processes', {
               error: err instanceof Error ? err.message : String(err),
             });
           }
 
-          try {
-            const fileInfo = await session.readFile(logFilePath, { encoding: 'utf-8' });
+          logger.info('Successfully retrieved session logs', {
+            fileCount: Object.keys(files).length,
+          });
 
-            logger.info('Successfully retrieved wrapper logs');
-
-            return {
-              content: fileInfo.content,
-              sessionId,
-              executionId,
-              processes,
-            };
-          } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error);
-
-            // Check if file doesn't exist
-            if (errorMsg.includes('ENOENT') || errorMsg.includes('not found')) {
-              throw new TRPCError({
-                code: 'NOT_FOUND',
-                message: `No wrapper log file found for execution ${executionId}. The wrapper may not have started or may have crashed before logging.`,
-              });
-            }
-
-            logger.withFields({ error: errorMsg }).error('Failed to read wrapper log file');
-
-            throw new TRPCError({
-              code: 'INTERNAL_SERVER_ERROR',
-              message: `Failed to read wrapper log file: ${errorMsg}`,
-            });
-          }
+          return {
+            sessionId,
+            files,
+            processes,
+          };
         });
       }),
 

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -13,7 +13,7 @@ import {
 } from '../../session-service.js';
 import { cleanupWorkspace, getSessionWorkspacePath, getSessionHomePath } from '../../workspace.js';
 import { withDORetry } from '../../utils/do-retry.js';
-import { protectedProcedure, publicProcedure } from '../auth.js';
+import { protectedProcedure, publicProcedure, internalApiProtectedProcedure } from '../auth.js';
 import { sessionIdSchema, GetSessionInput, GetSessionOutput } from '../schemas.js';
 import { computeExecutionHealth } from '../../core/execution.js';
 
@@ -420,7 +420,7 @@ export function createSessionManagementHandlers() {
      * Discovers wrapper logs from /tmp and CLI logs from the session home directory.
      * Useful for debugging wrapper startup and CLI issues.
      */
-    getWrapperLogs: protectedProcedure
+    getWrapperLogs: internalApiProtectedProcedure
       .input(
         z.object({
           sessionId: sessionIdSchema.describe('Session ID'),

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -52,6 +52,7 @@ describe('SessionService', () => {
   });
 
   const mockedSetupWorkspace = vi.mocked(mockSetupWorkspace);
+  const mockedRestoreWorkspace = vi.mocked(mockRestoreWorkspace);
 
   // Mock environment for tests
   const mockEnv: PersistenceEnv = {
@@ -826,7 +827,7 @@ describe('SessionService', () => {
       ).rejects.toThrow('workspace is missing and metadata could not be retrieved');
     });
 
-    it('restores session snapshot before reclone when workspace is missing', async () => {
+    it('restores workspace then session snapshot when workspace is missing', async () => {
       const mockDOGetMetadata = vi.fn();
       const payload = JSON.stringify({ info: {}, messages: [] });
       const exportSessionMock = vi.fn().mockResolvedValue(payload);
@@ -901,6 +902,15 @@ describe('SessionService', () => {
       );
       expect(result.context.githubRepo).toBe('facebook/react');
       expect(result.context.githubToken).toBe('test-token');
+
+      // Verify restoreWorkspace (git clone) ran before kilo import
+      const kiloImportCallIndex = fakeSession.exec.mock.calls.findIndex(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('kilo import')
+      );
+      expect(kiloImportCallIndex).toBeGreaterThanOrEqual(0);
+      const restoreWorkspaceOrder = mockedRestoreWorkspace.mock.invocationCallOrder[0];
+      const kiloImportOrder = fakeSession.exec.mock.invocationCallOrder[kiloImportCallIndex];
+      expect(restoreWorkspaceOrder).toBeLessThan(kiloImportOrder);
     });
   });
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1275,8 +1275,10 @@ export class SessionService {
         `Session ${sessionId} has no kiloSessionId in metadata. Cannot restore snapshot.`
       );
     }
-    await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);
 
+    // Clone first so .git exists when `kilo import` runs — the CLI derives the
+    // project ID from the repo's root commit hash; without a repo the FK on
+    // session.project_id fails.
     await restoreWorkspace(session, context.workspacePath, context.branchName, {
       githubRepo: metadata.githubRepo,
       githubToken: freshGithubToken ?? metadata.githubToken,
@@ -1285,6 +1287,8 @@ export class SessionService {
       gitAuthorEnv: getGitAuthorEnv(env, metadata.githubAppType),
       lastSeenBranch: metadata.upstreamBranch,
     });
+
+    await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);
 
     // Re-run setup commands (fresh clone, need to reinstall)
     if (metadata.setupCommands && metadata.setupCommands.length > 0) {

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -188,7 +188,8 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
     let workerBaseUrl: string;
     try {
       const ingestOrigin = new URL(body.ingestUrl);
-      ingestOrigin.protocol = ingestOrigin.protocol === 'wss:' ? 'https:' : 'http:';
+      ingestOrigin.protocol =
+        ingestOrigin.protocol === 'wss:' || ingestOrigin.protocol === 'https:' ? 'https:' : 'http:';
       workerBaseUrl = ingestOrigin.origin;
     } catch {
       return errorResponse('INVALID_REQUEST', 'Invalid ingestUrl', 400);


### PR DESCRIPTION
## Summary

- **Refactored `getWrapperLogs`** to discover and return all log files from a session's sandbox instead of requiring a specific `executionId`. The endpoint now scans `/tmp` for wrapper logs (`kilocode-wrapper-*.log`) and the session home directory for CLI logs (`~/.local/share/kilo/log/`), reading all discovered files in parallel.
- **Removed `executionId` input parameter** — the endpoint now only requires `sessionId`, returning all logs and all running processes for the sandbox.
- **Protected `getWrapperLogs` with internal API token** — switched from `protectedProcedure` to `internalApiProtectedProcedure` so the endpoint requires the `x-internal-api-key` header in addition to the customer auth token.
- **Fixed `ingestUrl` protocol mapping** in the wrapper server: `https:` protocol was incorrectly falling through to `http:` because only `wss:` was mapped to `https:`. Now both `wss:` and `https:` correctly resolve to `https:`.