### PR TITLE
ci: add workflow to check for new OpenClaw releases

### DIFF
--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -62,15 +62,19 @@ jobs:
               --jq '.object.url' \
             | xargs gh api --jq '.tagger.date // .author.date'
           )
+          if [ -z "$tag_date" ]; then
+            echo "::error::Failed to retrieve tag date for v${LATEST_VERSION}"
+            exit 1
+          fi
           tag_epoch=$(date -d "$tag_date" +%s)
           now_epoch=$(date +%s)
           age_hours=$(( (now_epoch - tag_epoch) / 3600 ))
           echo "Tag created $age_hours hours ago ($tag_date)"
-          if [ "$age_hours" -lt 24 ]; then
+          if [ "$age_hours" -lt 12 ]; then
             echo "recent=true" >> "$GITHUB_OUTPUT"
           else
             echo "recent=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — release is older than 24 hours"
+            echo "Skipping — release is older than 12 hours"
           fi
 
       - name: Notify webhook of new release

--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -17,7 +17,11 @@ jobs:
       - name: Get current pinned version
         id: current
         run: |
-          version=$(grep -oP 'openclaw@\K[0-9]+\.[0-9]+\.[0-9]+' kiloclaw/Dockerfile)
+          version=$(grep -oP 'openclaw@\K[0-9]+\.[0-9]+\.[0-9]+' kiloclaw/Dockerfile || true)
+          if [ -z "$version" ]; then
+            echo "::error::Failed to extract openclaw version from kiloclaw/Dockerfile"
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Current pinned version: $version"
 
@@ -34,6 +38,15 @@ jobs:
             | sort -V \
             | tail -1
           )
+          if [ -z "$version" ]; then
+            echo "::error::Failed to find any stable openclaw release tags"
+            exit 1
+          fi
+          # Validate the version looks like a version number (no shell metacharacters)
+          if ! echo "$version" | grep -qP '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Latest tag does not look like a valid version: $version"
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Latest stable release: $version"
 
@@ -42,9 +55,10 @@ jobs:
         if: steps.latest.outputs.version != steps.current.outputs.version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_VERSION: ${{ steps.latest.outputs.version }}
         run: |
           tag_date=$(
-            gh api "repos/openclaw/openclaw/git/refs/tags/v${{ steps.latest.outputs.version }}" \
+            gh api "repos/openclaw/openclaw/git/refs/tags/v${LATEST_VERSION}" \
               --jq '.object.url' \
             | xargs gh api --jq '.tagger.date // .author.date'
           )
@@ -63,19 +77,23 @@ jobs:
         if: steps.age.outputs.recent == 'true'
         env:
           WEBHOOK_SECRET: ${{ secrets.KILOCLAW_GITHUB_WEBHOOK_TRIGGER_TOKEN }}
+          NEW_VERSION: ${{ steps.latest.outputs.version }}
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
         run: |
-          new_version="${{ steps.latest.outputs.version }}"
-          echo "New openclaw version available: $new_version (current: ${{ steps.current.outputs.version }})"
+          echo "New openclaw version available: $NEW_VERSION (current: $CURRENT_VERSION)"
           curl -sf -X POST \
             -H "Content-Type: application/json" \
             -H "x-webhook-secret: $WEBHOOK_SECRET" \
-            -d "{\"new_openclaw_version\": \"$new_version\"}" \
+            -d "{\"new_openclaw_version\": \"$NEW_VERSION\"}" \
             "https://hooks.kilosessions.ai/inbound/org/9d278969-5453-4ae3-a51f-a8d2274a7b56/openclaw-bump"
 
       - name: Notify Slack
         if: steps.age.outputs.recent == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v2
+        env:
+          CURRENT_VERSION: ${{ steps.current.outputs.version }}
+          NEW_VERSION: ${{ steps.latest.outputs.version }}
         with:
           webhook: ${{ secrets.DEPLOY_NOTIFY_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -94,11 +112,11 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Current Version:*\n${{ steps.current.outputs.version }}"
+                      "text": "*Current Version:*\n${{ env.CURRENT_VERSION }}"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*New Version:*\n${{ steps.latest.outputs.version }}"
+                      "text": "*New Version:*\n${{ env.NEW_VERSION }}"
                     }
                   ]
                 },
@@ -106,7 +124,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<https://github.com/openclaw/openclaw/releases/tag/v${{ steps.latest.outputs.version }}|View release notes>"
+                    "text": "<https://github.com/openclaw/openclaw/releases/tag/v${{ env.NEW_VERSION }}|View release notes>"
                   }
                 }
               ]

--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -81,15 +81,16 @@ jobs:
         if: steps.age.outputs.recent == 'true'
         env:
           WEBHOOK_SECRET: ${{ secrets.KILOCLAW_GITHUB_WEBHOOK_TRIGGER_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.OPENCLAW_BUMP_WEBHOOK_URL }}
           NEW_VERSION: ${{ steps.latest.outputs.version }}
           CURRENT_VERSION: ${{ steps.current.outputs.version }}
         run: |
           echo "New openclaw version available: $NEW_VERSION (current: $CURRENT_VERSION)"
-          curl -sf -X POST \
+          curl -sf -o /dev/null -X POST \
             -H "Content-Type: application/json" \
             -H "x-webhook-secret: $WEBHOOK_SECRET" \
             -d "{\"new_openclaw_version\": \"$NEW_VERSION\"}" \
-            "https://hooks.kilosessions.ai/inbound/org/9d278969-5453-4ae3-a51f-a8d2274a7b56/openclaw-bump"
+            "$WEBHOOK_URL"
 
       - name: Notify Slack
         if: steps.age.outputs.recent == 'true'

--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -1,0 +1,113 @@
+name: Check for new OpenClaw release
+
+on:
+  schedule:
+    - cron: '0 */12 * * *' # Every 12 hours (midnight and noon UTC)
+  workflow_dispatch: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: kiloclaw/Dockerfile
+          sparse-checkout-cone-mode: false
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          version=$(grep -oP 'openclaw@\K[0-9]+\.[0-9]+\.[0-9]+' kiloclaw/Dockerfile)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Current pinned version: $version"
+
+      - name: Get latest stable release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(
+            gh api repos/openclaw/openclaw/git/refs/tags \
+              --paginate --jq '.[].ref' \
+            | sed 's|refs/tags/v||' \
+            | grep -vE '-' \
+            | sort -V \
+            | tail -1
+          )
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Latest stable release: $version"
+
+      - name: Check if release is less than 24 hours old
+        id: age
+        if: steps.latest.outputs.version != steps.current.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_date=$(
+            gh api "repos/openclaw/openclaw/git/refs/tags/v${{ steps.latest.outputs.version }}" \
+              --jq '.object.url' \
+            | xargs gh api --jq '.tagger.date // .author.date'
+          )
+          tag_epoch=$(date -d "$tag_date" +%s)
+          now_epoch=$(date +%s)
+          age_hours=$(( (now_epoch - tag_epoch) / 3600 ))
+          echo "Tag created $age_hours hours ago ($tag_date)"
+          if [ "$age_hours" -lt 24 ]; then
+            echo "recent=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "recent=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping — release is older than 24 hours"
+          fi
+
+      - name: Notify webhook of new release
+        if: steps.age.outputs.recent == 'true'
+        env:
+          WEBHOOK_SECRET: ${{ secrets.KILOCLAW_GITHUB_WEBHOOK_TRIGGER_TOKEN }}
+        run: |
+          new_version="${{ steps.latest.outputs.version }}"
+          echo "New openclaw version available: $new_version (current: ${{ steps.current.outputs.version }})"
+          curl -sf -X POST \
+            -H "Content-Type: application/json" \
+            -H "x-webhook-secret: $WEBHOOK_SECRET" \
+            -d "{\"new_openclaw_version\": \"$new_version\"}" \
+            "https://hooks.kilosessions.ai/inbound/org/9d278969-5453-4ae3-a51f-a8d2274a7b56/openclaw-bump"
+
+      - name: Notify Slack
+        if: steps.age.outputs.recent == 'true'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.DEPLOY_NOTIFY_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "New OpenClaw Release Available"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Current Version:*\n${{ steps.current.outputs.version }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*New Version:*\n${{ steps.latest.outputs.version }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/openclaw/openclaw/releases/tag/v${{ steps.latest.outputs.version }}|View release notes>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -70,11 +70,11 @@ jobs:
           now_epoch=$(date +%s)
           age_hours=$(( (now_epoch - tag_epoch) / 3600 ))
           echo "Tag created $age_hours hours ago ($tag_date)"
-          if [ "$age_hours" -lt 12 ]; then
+          if [ "$age_hours" -lt 24 ]; then
             echo "recent=true" >> "$GITHUB_OUTPUT"
           else
             echo "recent=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — release is older than 12 hours"
+            echo "Skipping — release is older than 24 hours"
           fi
 
       - name: Notify webhook of new release

--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Notify webhook of new release
         if: steps.age.outputs.recent == 'true'
+        continue-on-error: true
         env:
           WEBHOOK_SECRET: ${{ secrets.KILOCLAW_GITHUB_WEBHOOK_TRIGGER_TOKEN }}
           WEBHOOK_URL: ${{ secrets.OPENCLAW_BUMP_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow (`.github/workflows/bump-openclaw.yml`) that checks for new stable OpenClaw releases every 12 hours.

When a new non-beta release is detected that:
1. Differs from the version pinned in `kiloclaw/Dockerfile`
2. Was published less than 24 hours ago

It will:
- POST to the `openclaw-bump` webhook at `hooks.kilosessions.ai`
- Send a Slack notification (same channel as deploy notifications) with current/new versions and a link to the release notes

### Required secrets
- `KILOCLAW_GITHUB_WEBHOOK_TRIGGER_TOKEN` — used as `x-webhook-secret` header for the webhook POST
- `DEPLOY_NOTIFY_SLACK_WEBHOOK_URL` — already exists (used by deploy-kiloclaw workflow)