### PR TITLE
CLI install notification appearing in the CLI

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -49,6 +49,7 @@ const normalUnconditionalNotifications: KiloNotification[] = [
       actionText: 'Learn more',
       actionURL: 'https://kilo.ai/docs/cli',
     },
+    showIn: ['extension'],
   },
   {
     id: 'kilo-cloud-agents-jan-15',


### PR DESCRIPTION

The notification _"_Prefer the terminal? Install the Kilo CLI with npm install -g @kilocode/cli_"_ should not appear in the CLI.

Added this change and tested along with the change in https://github.com/Kilo-Org/kilocode/pull/6452

Without this change, the CLI would still display the notification, as all notifications without `shownIn` will get displayed

### Testing

- I tested locally with `cloud` in this branch, and `kilocode` in [fix/cli-notification-filter](https://github.com/Kilo-Org/kilocode/tree/fix/cli-notification-filter) branch, the following:
    - Logged-out users don't get notifications in CLI or extension
    - Logged-in users get notifications
    - Logged-in users in CLI don't get the notification for installing the CLI
    - Logged-in users in Extension get the notification for installing the CLI