### PR TITLE
Reduce enterprise seat price from $150 to $60/seat/month

### DIFF
--- a/src/components/organizations/subscription/SubscriptionQuickActions.tsx
+++ b/src/components/organizations/subscription/SubscriptionQuickActions.tsx
@@ -14,7 +14,7 @@ import { SeatChangeModal } from './SeatChangeModal';
 import Link from 'next/link';
 import {
   TEAM_SEAT_PRICE_MONTHLY_USD,
-  TEAM_SEAT_PRICE_YEARLY_USD,
+  ENTERPRISE_SEAT_PRICE_MONTHLY_USD,
 } from '@/lib/organizations/constants';
 import { useOrganizationReadOnly } from '@/lib/organizations/use-organization-read-only';
 
@@ -137,7 +137,9 @@ export function SubscriptionQuickActions({
           currentSeatCount={currentSeatCount}
           organizationId={organizationId}
           price={
-            org.data.plan === 'teams' ? TEAM_SEAT_PRICE_MONTHLY_USD : TEAM_SEAT_PRICE_YEARLY_USD
+            org.data.plan === 'teams'
+              ? TEAM_SEAT_PRICE_MONTHLY_USD
+              : ENTERPRISE_SEAT_PRICE_MONTHLY_USD
           }
         />
       )}

--- a/src/lib/organizations/constants.ts
+++ b/src/lib/organizations/constants.ts
@@ -6,7 +6,7 @@ export const STRIPE_SUB_QUERY_STRING_KEY = 'subscription_session_id';
 // maybe take this from stripe at some point?
 export const TEAM_SEAT_PRICE_MONTHLY_USD = 15;
 export const TEAM_SEAT_PRICE_YEARLY_USD = TEAM_SEAT_PRICE_MONTHLY_USD * 12;
-export const ENTERPRISE_SEAT_PRICE_MONTHLY_USD = 150;
+export const ENTERPRISE_SEAT_PRICE_MONTHLY_USD = 60;
 export const ENTERPRISE_SEAT_PRICE_YEARLY_USD = ENTERPRISE_SEAT_PRICE_MONTHLY_USD * 12;
 
 export const ENABLE_ORG_CREATION_FREE_CREDITS = false;


### PR DESCRIPTION
## Changes

- **Price update**: `ENTERPRISE_SEAT_PRICE_MONTHLY_USD` reduced from 150 to 60 in `src/lib/organizations/constants.ts`. The yearly constant is computed from it and now evaluates to $720/year.

- **Bug fix**: `SubscriptionQuickActions.tsx` was passing `TEAM_SEAT_PRICE_YEARLY_USD` ($180) to the `SeatChangeModal` for enterprise orgs instead of `ENTERPRISE_SEAT_PRICE_MONTHLY_USD`. Fixed the import and ternary so enterprise orgs see the correct price in the seat change cost preview.