### PR TITLE
CloudAgentNext - Fix CLI import by cloning workspace first on cold-start resume

### DIFF
--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -52,6 +52,7 @@ describe('SessionService', () => {
   });
 
   const mockedSetupWorkspace = vi.mocked(mockSetupWorkspace);
+  const mockedRestoreWorkspace = vi.mocked(mockRestoreWorkspace);
 
   // Mock environment for tests
   const mockEnv: PersistenceEnv = {
@@ -826,7 +827,7 @@ describe('SessionService', () => {
       ).rejects.toThrow('workspace is missing and metadata could not be retrieved');
     });
 
-    it('restores session snapshot before reclone when workspace is missing', async () => {
+    it('restores workspace then session snapshot when workspace is missing', async () => {
       const mockDOGetMetadata = vi.fn();
       const payload = JSON.stringify({ info: {}, messages: [] });
       const exportSessionMock = vi.fn().mockResolvedValue(payload);
@@ -901,6 +902,15 @@ describe('SessionService', () => {
       );
       expect(result.context.githubRepo).toBe('facebook/react');
       expect(result.context.githubToken).toBe('test-token');
+
+      // Verify restoreWorkspace (git clone) ran before kilo import
+      const kiloImportCallIndex = fakeSession.exec.mock.calls.findIndex(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('kilo import')
+      );
+      expect(kiloImportCallIndex).toBeGreaterThanOrEqual(0);
+      const restoreWorkspaceOrder = mockedRestoreWorkspace.mock.invocationCallOrder[0];
+      const kiloImportOrder = fakeSession.exec.mock.invocationCallOrder[kiloImportCallIndex];
+      expect(restoreWorkspaceOrder).toBeLessThan(kiloImportOrder);
     });
   });
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1275,8 +1275,10 @@ export class SessionService {
         `Session ${sessionId} has no kiloSessionId in metadata. Cannot restore snapshot.`
       );
     }
-    await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);
 
+    // Clone first so .git exists when `kilo import` runs — the CLI derives the
+    // project ID from the repo's root commit hash; without a repo the FK on
+    // session.project_id fails.
     await restoreWorkspace(session, context.workspacePath, context.branchName, {
       githubRepo: metadata.githubRepo,
       githubToken: freshGithubToken ?? metadata.githubToken,
@@ -1285,6 +1287,8 @@ export class SessionService {
       gitAuthorEnv: getGitAuthorEnv(env, metadata.githubAppType),
       lastSeenBranch: metadata.upstreamBranch,
     });
+
+    await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);
 
     // Re-run setup commands (fresh clone, need to reinstall)
     if (metadata.setupCommands && metadata.setupCommands.length > 0) {


### PR DESCRIPTION
## Summary

- **Fix cold-start resume ordering**: Swap `restoreWorkspace` (git clone) and `restoreSessionSnapshot` (`kilo import`) so the repo exists before the CLI runs. The CLI derives the project ID from the repo's root commit hash, and without a `.git` directory the FK on `session.project_id` fails.
- **Protect `getWrapperLogs` with internal API token**: Change the endpoint from `protectedProcedure` to `internalApiProtectedProcedure` and broaden it to discover all wrapper and CLI log files from the sandbox rather than requiring a specific execution ID.
- **Fix `ingestUrl` protocol mapping in wrapper**: Handle `https:` protocol in addition to `wss:` when deriving `workerBaseUrl`, so HTTPS ingest URLs are no longer incorrectly downgraded to HTTP.
- **Add test coverage**: Verify that `restoreWorkspace` is invoked before `kilo import` using `invocationCallOrder` assertions.