### PR TITLE
fix(gastown): dispatch refinery to correct rig in multi-rig towns

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1446,8 +1446,14 @@ export class TownDO extends DurableObject<Env> {
     const entry = reviewQueue.popReviewQueue(this.sql);
     if (!entry) return;
 
-    const rigList = rigs.listRigs(this.sql);
-    const rigId = rigList[0]?.id ?? '';
+    // Resolve rig from the merge_request bead — not rigList[0] which would
+    // pick the wrong rig in multi-rig towns.
+    const rigId = entry.rig_id;
+    if (!rigId) {
+      console.error(`${TOWN_LOG} processReviewQueue: entry ${entry.id} has no rig_id, skipping`);
+      reviewQueue.completeReview(this.sql, entry.id, 'failed');
+      return;
+    }
     const rigConfig = await this.getRigConfig(rigId);
     if (!rigConfig) {
       reviewQueue.completeReview(this.sql, entry.id, 'failed');

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1477,7 +1477,10 @@ export class TownDO extends DurableObject<Env> {
         polecatAgentId: entry.agent_id,
       });
 
-      agents.hookBead(this.sql, refineryAgent.id, entry.bead_id);
+      // Hook the refinery to the MR bead (entry.id), not the source bead
+      // (entry.bead_id). The source bead stays closed with its original
+      // polecat assignee preserved.
+      agents.hookBead(this.sql, refineryAgent.id, entry.id);
 
       const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
         townId: this.townId,
@@ -1487,7 +1490,7 @@ export class TownDO extends DurableObject<Env> {
         agentName: refineryAgent.name,
         role: 'refinery',
         identity: refineryAgent.identity,
-        beadId: entry.bead_id,
+        beadId: entry.id,
         beadTitle: `Review merge: ${entry.branch} → ${rigConfig.defaultBranch}`,
         beadBody: entry.summary ?? '',
         checkpoint: null,

--- a/cloudflare-gastown/src/dos/town/agents.ts
+++ b/cloudflare-gastown/src/dos/town/agents.ts
@@ -342,14 +342,14 @@ export function getOrCreateAgent(
   rigId: string,
   townId: string
 ): Agent {
-  const singletonRoles = ['witness', 'refinery', 'mayor'];
+  // Town-wide singletons: one per town, not tied to a rig.
+  const townSingletonRoles = ['witness', 'mayor'];
 
-  if (singletonRoles.includes(role)) {
-    // Try to find an existing agent with this role
+  if (townSingletonRoles.includes(role)) {
     const existing = listAgents(sql, { role });
     if (existing.length > 0) return existing[0];
   } else {
-    // For polecats, try to find an idle one without a hook in the SAME rig.
+    // Per-rig agents (polecat, refinery): reuse an idle one in the SAME rig.
     // Agents are tied to a rig's worktree/repo — reusing one from a different
     // rig would dispatch it into the wrong repository.
     const idle = [
@@ -357,13 +357,13 @@ export function getOrCreateAgent(
         sql,
         /* sql */ `
           ${AGENT_JOIN}
-          WHERE ${agent_metadata.role} = 'polecat'
+          WHERE ${agent_metadata.role} = ?
             AND ${agent_metadata.status} = 'idle'
             AND ${agent_metadata.current_hook_bead_id} IS NULL
             AND ${beads.rig_id} = ?
           LIMIT 1
         `,
-        [rigId]
+        [role, rigId]
       ),
     ];
     if (idle.length > 0) return toAgent(AgentBeadRecord.parse(idle[0]));

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -169,6 +169,9 @@ export function updateBeadStatus(
   const bead = getBead(sql, beadId);
   if (!bead) throw new Error(`Bead ${beadId} not found`);
 
+  // No-op if already in the target status — avoids redundant events
+  if (bead.status === status) return bead;
+
   const oldStatus = bead.status;
   const timestamp = now();
   const closedAt = status === 'closed' ? timestamp : bead.closed_at;

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -50,6 +50,7 @@ function toReviewQueueEntry(row: MergeRequestBeadRecord): ReviewQueueEntry {
     agent_id: row.assignee_agent_bead_id ?? row.created_by ?? '',
     bead_id:
       typeof row.metadata?.source_bead_id === 'string' ? row.metadata.source_bead_id : row.bead_id,
+    rig_id: row.rig_id ?? '',
     branch: row.branch,
     pr_url: row.pr_url,
     status:
@@ -89,7 +90,7 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
       'open',
       `Review: ${input.branch}`,
       input.summary ?? null,
-      null,
+      input.rig_id,
       null,
       input.agent_id,
       'medium',
@@ -266,6 +267,7 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   submitToReviewQueue(sql, {
     agent_id: agentId,
     bead_id: agent.current_hook_bead_id,
+    rig_id: agent.rig_id ?? '',
     branch: input.branch,
     pr_url: input.pr_url,
     summary: input.summary,

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -108,6 +108,19 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
     ]
   );
 
+  // Link MR bead → source bead via bead_dependencies so the DAG is queryable
+  query(
+    sql,
+    /* sql */ `
+      INSERT INTO ${bead_dependencies} (
+        ${bead_dependencies.columns.bead_id},
+        ${bead_dependencies.columns.depends_on_bead_id},
+        ${bead_dependencies.columns.dependency_type}
+      ) VALUES (?, ?, 'tracks')
+    `,
+    [id, input.bead_id]
+  );
+
   // Create the review_metadata satellite
   query(
     sql,

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -274,8 +274,8 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   if (!agent.current_hook_bead_id) throw new Error(`Agent ${agentId} has no hooked bead`);
 
   if (agent.role === 'refinery') {
-    // The refinery is hooked to the MR bead. Complete it and close the
-    // source bead (read from the MR's metadata).
+    // The refinery is hooked to the MR bead. Mark it as merged and log
+    // the review_completed event on the source bead.
     const mrBeadId = agent.current_hook_bead_id;
     completeReviewFromMRBead(sql, mrBeadId, agentId);
     unhookBead(sql, agentId);
@@ -283,6 +283,12 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   }
 
   const sourceBead = agent.current_hook_bead_id;
+
+  if (!agent.rig_id) {
+    console.warn(
+      `[review-queue] agentDone: agent ${agentId} has null rig_id — review entry may fail in processReviewQueue`
+    );
+  }
 
   submitToReviewQueue(sql, {
     agent_id: agentId,
@@ -302,13 +308,19 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
 
 /**
  * Complete a review given the MR bead id directly (the refinery is hooked
- * to the MR bead). Marks the MR as merged and closes the source bead
- * referenced in the MR's metadata.
+ * to the MR bead). Marks the MR as merged and logs a review_completed
+ * event on the source bead. The source bead itself is already closed by
+ * the polecat's agentDone path.
  */
 function completeReviewFromMRBead(sql: SqlStorage, mrBeadId: string, agentId: string): void {
-  // Read the source_bead_id from the MR bead's metadata
   const mrBead = getBead(sql, mrBeadId);
-  const sourceBeadId = mrBead?.metadata?.source_bead_id;
+  if (!mrBead) {
+    console.error(
+      `[review-queue] completeReviewFromMRBead: MR bead ${mrBeadId} not found — data integrity issue`
+    );
+    return;
+  }
+  const sourceBeadId = mrBead.metadata?.source_bead_id;
 
   completeReview(sql, mrBeadId, 'merged');
 

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -47,7 +47,12 @@ const REVIEW_JOIN = /* sql */ `
 function toReviewQueueEntry(row: MergeRequestBeadRecord): ReviewQueueEntry {
   return {
     id: row.bead_id,
-    agent_id: row.assignee_agent_bead_id ?? row.created_by ?? '',
+    // The polecat that submitted the review — stored in metadata (not assignee,
+    // which is set to the refinery when it claims the MR bead via hookBead).
+    agent_id:
+      typeof row.metadata?.source_agent_id === 'string'
+        ? row.metadata.source_agent_id
+        : (row.created_by ?? ''),
     bead_id:
       typeof row.metadata?.source_bead_id === 'string' ? row.metadata.source_bead_id : row.bead_id,
     rig_id: row.rig_id ?? '',
@@ -92,11 +97,11 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
       input.summary ?? null,
       input.rig_id,
       null,
-      input.agent_id,
+      null, // assignee left null — refinery claims it via hookBead
       'medium',
       JSON.stringify(['gt:merge-request']),
-      JSON.stringify({ source_bead_id: input.bead_id }),
-      input.agent_id,
+      JSON.stringify({ source_bead_id: input.bead_id, source_agent_id: input.agent_id }),
+      input.agent_id, // created_by records who submitted
       timestamp,
       timestamp,
       null,
@@ -256,66 +261,53 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   if (!agent.current_hook_bead_id) throw new Error(`Agent ${agentId} has no hooked bead`);
 
   if (agent.role === 'refinery') {
-    // Refinery agents merge the code themselves then call gt_done.
-    // Find the in-progress review entry whose source_bead_id matches the
-    // hooked bead and complete it, which also closes the original bead.
-    completeReviewForSourceBead(sql, agent.current_hook_bead_id, agentId);
+    // The refinery is hooked to the MR bead. Complete it and close the
+    // source bead (read from the MR's metadata).
+    const mrBeadId = agent.current_hook_bead_id;
+    completeReviewFromMRBead(sql, mrBeadId, agentId);
     unhookBead(sql, agentId);
     return;
   }
 
+  const sourceBead = agent.current_hook_bead_id;
+
   submitToReviewQueue(sql, {
     agent_id: agentId,
-    bead_id: agent.current_hook_bead_id,
+    bead_id: sourceBead,
     rig_id: agent.rig_id ?? '',
     branch: input.branch,
     pr_url: input.pr_url,
     summary: input.summary,
   });
 
+  // Close the source bead (matches upstream gt done behavior). The polecat's
+  // work is done — the MR bead now tracks the merge lifecycle. The source
+  // bead retains its assignee so we know which agent worked on it.
   unhookBead(sql, agentId);
+  closeBead(sql, sourceBead, agentId);
 }
 
 /**
- * Find the merge_request bead whose metadata.source_bead_id matches the
- * given bead and complete it as 'merged'. Also closes the original bead.
- *
- * Used when a refinery agent finishes: it has already merged the code
- * itself, so we just need to mark the review + source bead as done.
+ * Complete a review given the MR bead id directly (the refinery is hooked
+ * to the MR bead). Marks the MR as merged and closes the source bead
+ * referenced in the MR's metadata.
  */
-function completeReviewForSourceBead(sql: SqlStorage, sourceBeadId: string, agentId: string): void {
-  // Find the merge_request bead for this source bead (most recent first)
-  const rows = [
-    ...query(
-      sql,
-      /* sql */ `
-        ${REVIEW_JOIN}
-        WHERE ${beads.status} IN ('open', 'in_progress')
-          AND json_extract(${beads.metadata}, '$.source_bead_id') = ?
-        ORDER BY ${beads.created_at} DESC
-        LIMIT 1
-      `,
-      [sourceBeadId]
-    ),
-  ];
+function completeReviewFromMRBead(sql: SqlStorage, mrBeadId: string, agentId: string): void {
+  // Read the source_bead_id from the MR bead's metadata
+  const mrBead = getBead(sql, mrBeadId);
+  const sourceBeadId = mrBead?.metadata?.source_bead_id;
 
-  if (rows.length > 0) {
-    const parsed = MergeRequestBeadRecord.parse(rows[0]);
-    const entry = toReviewQueueEntry(parsed);
-    completeReview(sql, entry.id, 'merged');
+  completeReview(sql, mrBeadId, 'merged');
 
+  if (typeof sourceBeadId === 'string') {
     logBeadEvent(sql, {
       beadId: sourceBeadId,
       agentId,
       eventType: 'review_completed',
       newValue: 'merged',
-      metadata: { completedBy: 'refinery' },
+      metadata: { completedBy: 'refinery', mr_bead_id: mrBeadId },
     });
   }
-
-  // Close the original bead regardless of whether we found a review entry.
-  // The refinery confirmed the work is merged — the source bead is done.
-  closeBead(sql, sourceBeadId, agentId);
 }
 
 /**

--- a/cloudflare-gastown/src/handlers/rig-review-queue.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-review-queue.handler.ts
@@ -28,7 +28,7 @@ export async function handleSubmitToReviewQueue(c: Context<GastownEnv>, params: 
   }
   const townId = c.get('townId');
   const town = getTownDOStub(c.env, townId);
-  await town.submitToReviewQueue(parsed.data);
+  await town.submitToReviewQueue({ ...parsed.data, rig_id: params.rigId });
   return c.json(resSuccess({ submitted: true }), 201);
 }
 

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -119,6 +119,7 @@ export type ReviewQueueEntry = {
   id: string;
   agent_id: string;
   bead_id: string;
+  rig_id: string;
   branch: string;
   pr_url: string | null;
   status: ReviewStatus;
@@ -130,6 +131,7 @@ export type ReviewQueueEntry = {
 export type ReviewQueueInput = {
   agent_id: string;
   bead_id: string;
+  rig_id: string;
   branch: string;
   pr_url?: string;
   summary?: string;

--- a/cloudflare-gastown/test/integration/rig-alarm.test.ts
+++ b/cloudflare-gastown/test/integration/rig-alarm.test.ts
@@ -150,6 +150,7 @@ describe('Town DO Alarm', () => {
       await town.submitToReviewQueue({
         agent_id: agent.id,
         bead_id: bead.id,
+        rig_id: 'test-rig',
         branch: 'feature/review',
       });
 

--- a/cloudflare-gastown/test/integration/rig-do.test.ts
+++ b/cloudflare-gastown/test/integration/rig-do.test.ts
@@ -367,6 +367,7 @@ describe('TownDO', () => {
       await town.submitToReviewQueue({
         agent_id: agent.id,
         bead_id: bead.id,
+        rig_id: 'test-rig',
         branch: 'feature/fix-widget',
         pr_url: 'https://github.com/org/repo/pull/1',
         summary: 'Fixed the widget',
@@ -394,6 +395,7 @@ describe('TownDO', () => {
       await town.submitToReviewQueue({
         agent_id: agent.id,
         bead_id: bead.id,
+        rig_id: 'test-rig',
         branch: 'feature/fix',
       });
 
@@ -418,6 +420,7 @@ describe('TownDO', () => {
       await town.submitToReviewQueue({
         agent_id: agent.id,
         bead_id: bead.id,
+        rig_id: 'test-rig',
         branch: 'feature/merge-test',
       });
 
@@ -452,6 +455,7 @@ describe('TownDO', () => {
       await town.submitToReviewQueue({
         agent_id: agent.id,
         bead_id: bead.id,
+        rig_id: 'test-rig',
         branch: 'feature/conflict-test',
       });
 
@@ -751,6 +755,7 @@ describe('TownDO', () => {
       await town.submitToReviewQueue({
         agent_id: agent.id,
         bead_id: bead.id,
+        rig_id: 'test-rig',
         branch: 'feature/test',
       });
 

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -19,7 +19,6 @@ import {
   ChevronRight,
   Bot,
   Network,
-  ArrowUpRight,
   ArrowDownRight,
   GitPullRequest,
   CircleDot,

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -18,6 +18,11 @@ import {
   GitBranch,
   ChevronRight,
   Bot,
+  Network,
+  ArrowUpRight,
+  ArrowDownRight,
+  GitPullRequest,
+  CircleDot,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -65,6 +70,10 @@ export function BeadPanel({
     : null;
 
   const townId = rigQuery.data?.town_id;
+
+  // Build related beads from the flat list (no extra API needed)
+  const allBeads = beadsQuery.data ?? [];
+  const relatedBeads = buildRelatedBeads(bead, allBeads);
 
   return (
     <div className="flex flex-col gap-0">
@@ -156,6 +165,46 @@ export function BeadPanel({
         )}
       </div>
 
+      {/* Related Beads DAG */}
+      {relatedBeads.length > 0 && (
+        <div className="border-b border-white/[0.06] px-5 py-4">
+          <div className="mb-3 flex items-center gap-1.5">
+            <Network className="size-3 text-white/25" />
+            <span className="text-[10px] font-medium tracking-wide text-white/30 uppercase">
+              Related Beads
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            {relatedBeads.map(rel => (
+              <button
+                key={`${rel.relation}-${rel.bead.bead_id}`}
+                onClick={() => push({ type: 'bead', beadId: rel.bead.bead_id, rigId })}
+                className="group/rel flex items-center gap-2.5 rounded-md px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
+              >
+                <rel.icon className="size-3.5 shrink-0 text-white/30" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[10px] font-medium text-white/35">{rel.label}</span>
+                    <Badge variant="outline" className="px-1 py-0 text-[9px]">
+                      {rel.bead.type.replace('_', ' ')}
+                    </Badge>
+                    <span
+                      className={`ml-auto inline-flex items-center rounded-md border px-1.5 py-0 text-[9px] font-medium ${STATUS_STYLES[rel.bead.status] ?? 'border-white/10 text-white/50'}`}
+                    >
+                      {rel.bead.status.replace('_', ' ')}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-1">
+                    <span className="truncate text-xs text-white/65">{rel.bead.title}</span>
+                    <ChevronRight className="size-3 shrink-0 text-white/10 transition-colors group-hover/rel:text-white/25" />
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Body (markdown) */}
       {bead.body && bead.body.trim().length > 0 && (
         <div className="border-b border-white/[0.06] px-5 py-4">
@@ -209,4 +258,58 @@ function MetaCell({
       </div>
     </div>
   );
+}
+
+// ── Related beads DAG ─────────────────────────────────────────────────
+
+type BeadLike = {
+  bead_id: string;
+  type: string;
+  status: string;
+  title: string;
+  parent_bead_id: string | null;
+  metadata: Record<string, unknown>;
+};
+
+type RelatedBead = {
+  relation: string;
+  label: string;
+  icon: typeof Clock;
+  bead: BeadLike;
+};
+
+/** Compute the DAG neighborhood of a bead from the flat list. */
+function buildRelatedBeads(bead: BeadLike, allBeads: BeadLike[]): RelatedBead[] {
+  const related: RelatedBead[] = [];
+
+  // Parent bead (already shown in metadata grid, but include in DAG for completeness)
+  // Skip — the metadata grid already renders a clickable parent link.
+
+  // Child beads (beads whose parent_bead_id = this bead)
+  for (const b of allBeads) {
+    if (b.parent_bead_id === bead.bead_id) {
+      related.push({ relation: 'child', label: 'Child', icon: ArrowDownRight, bead: b });
+    }
+  }
+
+  // For merge_request beads: link back to the source bead
+  if (bead.type === 'merge_request' && typeof bead.metadata?.source_bead_id === 'string') {
+    const source = allBeads.find(b => b.bead_id === bead.metadata.source_bead_id);
+    if (source) {
+      related.push({ relation: 'source', label: 'Source Work', icon: CircleDot, bead: source });
+    }
+  }
+
+  // For non-MR beads: find any MR beads that track this bead
+  if (bead.type !== 'merge_request') {
+    for (const b of allBeads) {
+      if (b.type === 'merge_request' && b.metadata?.source_bead_id === bead.bead_id) {
+        related.push({ relation: 'review', label: 'Review', icon: GitPullRequest, bead: b });
+      }
+    }
+  }
+
+  // Beads that share the same parent (siblings) — skip, too noisy for now
+
+  return related;
 }


### PR DESCRIPTION
## Summary

Fixes 4 compounding bugs that caused the refinery agent to be dispatched into the wrong rig's repository in multi-rig towns, fixes 3 additional issues with MR bead assignment and the review lifecycle, and adds a Related Beads DAG section to the bead drawer UI.

Closes #657

> **Note:** This branch is based on `686-pr544-review-hardening` (PR #689) which is pending review. Once #689 merges to main, this PR will be clean against main.

Also adds UI to show relationship between related beads (like a task bead to review bead)

<img width="1567" height="1237" alt="image" src="https://github.com/user-attachments/assets/0801695b-a51a-4692-832f-07cb8d9cf2ab" />


## The bug chain (before this fix)

1. Polecat on **rig B** finishes work -> `submitToReviewQueue`
2. MR bead created with **`rig_id = null`** and **assignee = polecat** (Bugs 3, 5)
3. Alarm fires -> `processReviewQueue` pops the entry
4. Rig resolved via **`rigList[0]`** -> gets **rig A** (Bug 2)
5. `getOrCreateAgent('refinery')` returns the **existing refinery for rig A** (Bug 1)
6. Refinery hooked to the **source bead** (not the MR bead), overwriting its assignee (Bug 6)
7. Source bead left `in_progress` instead of closed (Bug 7)

## Fixes

### Bug 1: Refinery was a town-wide singleton
- **`agents.ts`**: Removed `refinery` from `singletonRoles` (now only `witness` and `mayor`)
- Refinery now uses the same per-rig idle agent reuse logic as polecats, scoped by `rig_id`

### Bug 2: `processReviewQueue` hardcoded `rigList[0]`
- **`Town.do.ts`**: Now reads `entry.rig_id` from the merge_request bead

### Bug 3: merge_request beads created with `rig_id = null`
- **`review-queue.ts`**: `submitToReviewQueue` now writes `input.rig_id` to the bead

### Bug 4: `ReviewQueueInput` type lacked `rig_id`
- **`types.ts`**: Added `rig_id: string` to both `ReviewQueueInput` and `ReviewQueueEntry`

### Bug 5: MR bead assignee set to polecat instead of left for refinery
- **`review-queue.ts`**: MR bead `assignee_agent_bead_id` now null on creation (refinery claims it via `hookBead`). Source agent stored in `metadata.source_agent_id`.

### Bug 6: Refinery hooked to source bead, not MR bead
- **`Town.do.ts`**: `processReviewQueue` now hooks the refinery to `entry.id` (MR bead), not `entry.bead_id` (source bead). This preserves the source bead's polecat assignee.
- **`review-queue.ts`**: Refinery `agentDone` path updated — `completeReviewFromMRBead` reads the source bead from the MR's metadata instead of the old `completeReviewForSourceBead` lookup.

### Bug 7: Source bead not closed after polecat submits to review
- **`review-queue.ts`**: `agentDone` (polecat path) now calls `closeBead` on the source bead after submitting to the review queue, matching upstream `gt done` behavior.

### Feature: Related Beads DAG in bead drawer
- **`BeadPanel.tsx`**: New "Related Beads" section shows the bead's DAG neighborhood:
  - **Child beads** — beads whose `parent_bead_id` matches the current bead
  - **Source Work** — for MR beads, the original issue/work bead from `metadata.source_bead_id`
  - **Review** — for non-MR beads, any `merge_request` beads that track this bead
- Each entry is clickable, pushing a new bead drawer onto the navigation stack
- Computed client-side from existing `listBeads` data — no new API endpoints
- Also adds a `bead_dependencies` 'tracks' row when creating MR beads to formally link the DAG

## Files changed

| File | Change |
|------|--------|
| `cloudflare-gastown/src/types.ts` | Added `rig_id` to `ReviewQueueInput` and `ReviewQueueEntry` |
| `cloudflare-gastown/src/dos/town/agents.ts` | Refinery per-rig, generalized idle agent lookup |
| `cloudflare-gastown/src/dos/town/review-queue.ts` | MR bead lifecycle fixes, bead_dependencies tracking |
| `cloudflare-gastown/src/dos/Town.do.ts` | Hook refinery to MR bead, resolve rig from bead |
| `cloudflare-gastown/src/handlers/rig-review-queue.handler.ts` | Pass `params.rigId` to `submitToReviewQueue` |
| `src/components/gastown/drawer-panels/BeadPanel.tsx` | Related Beads DAG section |
| `cloudflare-gastown/test/integration/rig-do.test.ts` | Add `rig_id` to test data |
| `cloudflare-gastown/test/integration/rig-alarm.test.ts` | Add `rig_id` to test data |