### PR TITLE
fix: align V1 cloud-agent execution schema with DO response

### DIFF
--- a/src/lib/cloud-agent/cloud-agent-client.ts
+++ b/src/lib/cloud-agent/cloud-agent-client.ts
@@ -208,9 +208,9 @@ export type GetSessionInput = {
 /** Execution state from cloud-agent DO */
 export type ExecutionState = {
   id: string;
-  status: 'queued' | 'running' | 'completed' | 'failed' | 'interrupted';
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'interrupted';
   startedAt?: number;
-  lastHeartbeat?: number;
+  lastHeartbeat?: number | null;
   processId?: string | null;
   error?: string | null;
   health?: 'healthy' | 'stale' | 'unknown';

--- a/src/routers/cloud-agent-schemas.ts
+++ b/src/routers/cloud-agent-schemas.ts
@@ -168,9 +168,9 @@ export const baseGetSessionSchema = z.object({
 
 const executionStateSchema = z.object({
   id: z.string(),
-  status: z.enum(['queued', 'running', 'completed', 'failed', 'interrupted']),
+  status: z.enum(['pending', 'running', 'completed', 'failed', 'interrupted']),
   startedAt: z.number().optional(),
-  lastHeartbeat: z.number().optional(),
+  lastHeartbeat: z.number().nullable().optional(),
   processId: z.string().nullable().optional(),
   error: z.string().nullable().optional(),
   health: z.enum(['healthy', 'stale', 'unknown']).optional(),


### PR DESCRIPTION
## Summary

- Fixes V1 `executionStateSchema` status enum: `'queued'` → `'pending'` to match what the Durable Object actually returns
- Fixes `lastHeartbeat` type: `z.number().optional()` → `z.number().nullable().optional()` since the DO explicitly returns `null`

## Context

Resolves [KILOCODE-WEB-NTD](https://kilo-code.sentry.io/issues/7294675813/) — `TRPCError: Output validation failed` on `GET /api/trpc/cloudAgent.getSession` (144 events, escalating since Feb 26).

The V1 Zod output schema for `getSession` had two mismatches with the Durable Object's actual response:

1. **`execution.status`**: The DO defines status as `'pending' | 'running' | 'completed' | 'failed' | 'interrupted'` but the V1 schema used `'queued'` instead of `'pending'`. The V2/next schemas already had the correct value.
2. **`execution.lastHeartbeat`**: The DO handler converts `undefined` → `null` via `?? null`, but the V1 schema only accepted `number | undefined`, not `null`. The V2/next schemas already used `.nullable()`.

No frontend or backend code branches on `execution.status === 'queued'`, so this is a safe correction with no behavioral change.