### PR TITLE
refactor(security-agent): centralize error classification and display for analysis failures

### DIFF
--- a/src/components/security-agent/AnalysisJobsCard.tsx
+++ b/src/components/security-agent/AnalysisJobsCard.tsx
@@ -24,6 +24,7 @@ import { FindingDetailDialog } from './FindingDetailDialog';
 import { DismissFindingDialog, type DismissReason } from './DismissFindingDialog';
 import { cn } from '@/lib/utils';
 import type { SecurityFinding } from '@kilocode/db/schema';
+import { isGitHubIntegrationError } from '@/lib/security-agent/core/error-display';
 
 type AnalysisJobsCardProps = {
   organizationId?: string;
@@ -73,17 +74,6 @@ function formatCompactTimeAgo(date: Date) {
   if (hours >= 1) return `${hours}h ago`;
   const minutes = Math.abs(differenceInMinutes(now, date));
   return `${minutes}m ago`;
-}
-
-function isGitHubIntegrationError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes('GitHub token') ||
-    message.includes('GitHub installation') ||
-    message.includes('installation_id') ||
-    message.includes('Bad credentials') ||
-    message.includes('Not Found')
-  );
 }
 
 // ─── Row sub-components ──────────────────────────────────────────────────────

--- a/src/components/security-agent/SecurityAgentPageClient.tsx
+++ b/src/components/security-agent/SecurityAgentPageClient.tsx
@@ -25,6 +25,7 @@ import {
 import { toast } from 'sonner';
 import type { SecurityFinding } from '@kilocode/db/schema';
 import Link from 'next/link';
+import { isGitHubIntegrationError } from '@/lib/security-agent/core/error-display';
 
 type SecurityAgentPageClientProps = {
   organizationId?: string;
@@ -39,20 +40,6 @@ function getOptionalStringField(source: unknown, key: string): string | undefine
 
   const value = Reflect.get(source, key);
   return typeof value === 'string' ? value : undefined;
-}
-
-// Helper to detect GitHub integration errors from error messages
-function isGitHubIntegrationError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes('GitHub token') ||
-    message.includes('GitHub installation') ||
-    message.includes('installation_id') ||
-    message.includes('Bad credentials') ||
-    message.includes('Not Found') || // GitHub API returns 404 for uninstalled apps
-    message.includes('Forbidden') || // GitHub API returns 403 for permission issues
-    message.includes('Resource not accessible') // GitHub returns this for missing permissions
-  );
 }
 
 export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageClientProps) {

--- a/src/lib/security-agent/core/error-classification.test.ts
+++ b/src/lib/security-agent/core/error-classification.test.ts
@@ -44,7 +44,8 @@ describe('classifyAnalysisError', () => {
       'repository not found',
       'repo not found',
       'Not found - repo foo/bar',
-      'Error 404: resource not available',
+      '404 repo not available',
+      'repository 404',
       'Repository does not exist',
       'no such repository: foo/bar',
     ])('classifies %j as REPO_NOT_FOUND', message => {
@@ -54,6 +55,21 @@ describe('classifyAnalysisError', () => {
     it('does not match generic "not found" without repo context', () => {
       expect(classifyAnalysisError(new Error('Module not found')).code).not.toBe('REPO_NOT_FOUND');
       expect(classifyAnalysisError(new Error('Config file not found')).code).not.toBe(
+        'REPO_NOT_FOUND'
+      );
+    });
+
+    it('does not match generic 404 without repo context', () => {
+      expect(classifyAnalysisError(new Error('HTTP 404: endpoint not found')).code).not.toBe(
+        'REPO_NOT_FOUND'
+      );
+    });
+
+    it('does not match generic "does not exist" without repo context', () => {
+      expect(classifyAnalysisError(new Error('file does not exist')).code).not.toBe(
+        'REPO_NOT_FOUND'
+      );
+      expect(classifyAnalysisError(new Error('branch does not exist')).code).not.toBe(
         'REPO_NOT_FOUND'
       );
     });
@@ -100,7 +116,7 @@ describe('isUserActionableError', () => {
     ['REPO_NOT_FOUND', true],
     ['SANDBOX_FAILED', false],
     ['UNKNOWN', false],
-  ])('returns %s for %s', (code, expected) => {
+  ])('%s → isUserActionable = %s', (code, expected) => {
     expect(isUserActionableError(code)).toBe(expected);
   });
 });
@@ -113,7 +129,7 @@ describe('trpcCodeForAnalysisError', () => {
     ['SANDBOX_FAILED', 'INTERNAL_SERVER_ERROR'],
     ['UNKNOWN', 'INTERNAL_SERVER_ERROR'],
     [undefined, 'INTERNAL_SERVER_ERROR'],
-  ])('returns %s for code %s', (code, expected) => {
+  ])('%s → trpcCode = %s', (code, expected) => {
     expect(trpcCodeForAnalysisError(code)).toBe(expected);
   });
 });

--- a/src/lib/security-agent/core/error-classification.test.ts
+++ b/src/lib/security-agent/core/error-classification.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  classifyAnalysisError,
+  isUserActionableError,
+  trpcCodeForAnalysisError,
+} from './error-classification';
+import type { AnalysisErrorCode } from './error-classification';
+
+describe('classifyAnalysisError', () => {
+  describe('CLONE_FAILED', () => {
+    it.each([
+      'fatal: git clone https://github.com/foo/bar failed',
+      'Failed to clone repository',
+      'failed to clone foo/bar',
+      'Could not read repository from remote',
+    ])('classifies %j as CLONE_FAILED', message => {
+      expect(classifyAnalysisError(new Error(message)).code).toBe('CLONE_FAILED');
+    });
+
+    it('does not match unrelated uses of "clone"', () => {
+      // "structured clone algorithm" should NOT match
+      expect(classifyAnalysisError(new Error('structured clone algorithm failed')).code).not.toBe(
+        'CLONE_FAILED'
+      );
+    });
+  });
+
+  describe('AUTH_FAILED', () => {
+    it.each([
+      'Bad credentials',
+      'Authentication failed for repo',
+      'credential rejected by server',
+      'credentials expired',
+      'HTTP status: 401',
+      'error: 403',
+      'permission denied',
+    ])('classifies %j as AUTH_FAILED', message => {
+      expect(classifyAnalysisError(new Error(message)).code).toBe('AUTH_FAILED');
+    });
+  });
+
+  describe('REPO_NOT_FOUND', () => {
+    it.each([
+      'repository not found',
+      'repo not found',
+      'Not found - repo foo/bar',
+      'Error 404: resource not available',
+      'Repository does not exist',
+      'no such repository: foo/bar',
+    ])('classifies %j as REPO_NOT_FOUND', message => {
+      expect(classifyAnalysisError(new Error(message)).code).toBe('REPO_NOT_FOUND');
+    });
+
+    it('does not match generic "not found" without repo context', () => {
+      expect(classifyAnalysisError(new Error('Module not found')).code).not.toBe('REPO_NOT_FOUND');
+      expect(classifyAnalysisError(new Error('Config file not found')).code).not.toBe(
+        'REPO_NOT_FOUND'
+      );
+    });
+  });
+
+  describe('UNKNOWN', () => {
+    it('returns UNKNOWN for unrecognized errors', () => {
+      const result = classifyAnalysisError(new Error('something unexpected'));
+      expect(result.code).toBe('UNKNOWN');
+    });
+
+    it('returns a generic message instead of the raw error', () => {
+      const result = classifyAnalysisError(new Error('internal path: /var/secrets/key.pem'));
+      expect(result.userMessage).toBe('An unexpected error occurred. Please try again.');
+      expect(result.userMessage).not.toContain('/var/secrets');
+    });
+
+    it('handles non-Error values', () => {
+      expect(classifyAnalysisError('string error').code).toBe('UNKNOWN');
+      expect(classifyAnalysisError(42).code).toBe('UNKNOWN');
+      expect(classifyAnalysisError(null).code).toBe('UNKNOWN');
+    });
+  });
+
+  describe('priority ordering', () => {
+    it('classifies a clone error containing "not found" as CLONE_FAILED', () => {
+      const result = classifyAnalysisError(
+        new Error('failed to clone: repository not found on remote')
+      );
+      expect(result.code).toBe('CLONE_FAILED');
+    });
+
+    it('classifies a clone error with auth substring as CLONE_FAILED', () => {
+      const result = classifyAnalysisError(new Error('git clone failed: authentication required'));
+      expect(result.code).toBe('CLONE_FAILED');
+    });
+  });
+});
+
+describe('isUserActionableError', () => {
+  it.each<[AnalysisErrorCode, boolean]>([
+    ['CLONE_FAILED', true],
+    ['AUTH_FAILED', true],
+    ['REPO_NOT_FOUND', true],
+    ['SANDBOX_FAILED', false],
+    ['UNKNOWN', false],
+  ])('returns %s for %s', (code, expected) => {
+    expect(isUserActionableError(code)).toBe(expected);
+  });
+});
+
+describe('trpcCodeForAnalysisError', () => {
+  it.each<[AnalysisErrorCode | undefined, string]>([
+    ['CLONE_FAILED', 'BAD_REQUEST'],
+    ['AUTH_FAILED', 'PRECONDITION_FAILED'],
+    ['REPO_NOT_FOUND', 'NOT_FOUND'],
+    ['SANDBOX_FAILED', 'INTERNAL_SERVER_ERROR'],
+    ['UNKNOWN', 'INTERNAL_SERVER_ERROR'],
+    [undefined, 'INTERNAL_SERVER_ERROR'],
+  ])('returns %s for code %s', (code, expected) => {
+    expect(trpcCodeForAnalysisError(code)).toBe(expected);
+  });
+});

--- a/src/lib/security-agent/core/error-classification.ts
+++ b/src/lib/security-agent/core/error-classification.ts
@@ -12,7 +12,7 @@ type ClassifiedError = {
   userMessage: string;
 };
 
-const CLONE_PATTERNS = [/\bclone\b/i, /\brepository\b.*\bfrom\b/i];
+const CLONE_PATTERNS = [/\bgit\b.*\bclone\b/i, /\bfailed to clone\b/i, /\brepository\b.*\bfrom\b/i];
 
 const AUTH_PATTERNS = [
   /\bauthenticat/i,
@@ -23,7 +23,8 @@ const AUTH_PATTERNS = [
 ];
 
 const NOT_FOUND_PATTERNS = [
-  /\bnot found\b/i,
+  /\brepo(sitory)?\b.*\bnot found\b/i,
+  /\bnot found\b.*\brepo(sitory)?\b/i,
   /\b404\b/,
   /\bdoes not exist\b/i,
   /\bno such\b.*\brepository\b/i,
@@ -63,13 +64,21 @@ export function classifyAnalysisError(error: unknown): ClassifiedError {
 
   return {
     code: 'UNKNOWN',
-    userMessage: raw,
+    userMessage: 'An unexpected error occurred. Please try again.',
   };
 }
 
 /** User-actionable errors that should not be reported as Sentry exceptions. */
 export function isUserActionableError(code: AnalysisErrorCode): boolean {
-  return code === 'CLONE_FAILED' || code === 'AUTH_FAILED' || code === 'REPO_NOT_FOUND';
+  switch (code) {
+    case 'CLONE_FAILED':
+    case 'AUTH_FAILED':
+    case 'REPO_NOT_FOUND':
+      return true;
+    case 'SANDBOX_FAILED':
+    case 'UNKNOWN':
+      return false;
+  }
 }
 
 export function trpcCodeForAnalysisError(code: AnalysisErrorCode | undefined): TRPCError['code'] {

--- a/src/lib/security-agent/core/error-classification.ts
+++ b/src/lib/security-agent/core/error-classification.ts
@@ -25,8 +25,9 @@ const AUTH_PATTERNS = [
 const NOT_FOUND_PATTERNS = [
   /\brepo(sitory)?\b.*\bnot found\b/i,
   /\bnot found\b.*\brepo(sitory)?\b/i,
-  /\b404\b/,
-  /\bdoes not exist\b/i,
+  /\b404\b.*\brepo(sitory)?\b/i,
+  /\brepo(sitory)?\b.*\b404\b/i,
+  /\brepo(sitory)?\b.*\bdoes not exist\b/i,
   /\bno such\b.*\brepository\b/i,
 ];
 

--- a/src/lib/security-agent/core/error-classification.ts
+++ b/src/lib/security-agent/core/error-classification.ts
@@ -38,7 +38,7 @@ const NOT_FOUND_PATTERNS = [
 export function classifyAnalysisError(error: unknown): ClassifiedError {
   const raw = error instanceof Error ? error.message : String(error);
 
-  if (CLONE_PATTERNS.some((p) => p.test(raw))) {
+  if (CLONE_PATTERNS.some(p => p.test(raw))) {
     return {
       code: 'CLONE_FAILED',
       userMessage:
@@ -46,7 +46,7 @@ export function classifyAnalysisError(error: unknown): ClassifiedError {
     };
   }
 
-  if (AUTH_PATTERNS.some((p) => p.test(raw))) {
+  if (AUTH_PATTERNS.some(p => p.test(raw))) {
     return {
       code: 'AUTH_FAILED',
       userMessage:
@@ -54,11 +54,10 @@ export function classifyAnalysisError(error: unknown): ClassifiedError {
     };
   }
 
-  if (NOT_FOUND_PATTERNS.some((p) => p.test(raw))) {
+  if (NOT_FOUND_PATTERNS.some(p => p.test(raw))) {
     return {
       code: 'REPO_NOT_FOUND',
-      userMessage:
-        'Repository not found. It may have been deleted, renamed, or made private.',
+      userMessage: 'Repository not found. It may have been deleted, renamed, or made private.',
     };
   }
 

--- a/src/lib/security-agent/core/error-classification.ts
+++ b/src/lib/security-agent/core/error-classification.ts
@@ -68,6 +68,11 @@ export function classifyAnalysisError(error: unknown): ClassifiedError {
   };
 }
 
+/** User-actionable errors that should not be reported as Sentry exceptions. */
+export function isUserActionableError(code: AnalysisErrorCode): boolean {
+  return code === 'CLONE_FAILED' || code === 'AUTH_FAILED' || code === 'REPO_NOT_FOUND';
+}
+
 export function trpcCodeForAnalysisError(code: AnalysisErrorCode | undefined): TRPCError['code'] {
   switch (code) {
     case 'CLONE_FAILED':

--- a/src/lib/security-agent/core/error-classification.ts
+++ b/src/lib/security-agent/core/error-classification.ts
@@ -1,0 +1,84 @@
+import type { TRPCError } from '@trpc/server';
+
+export type AnalysisErrorCode =
+  | 'CLONE_FAILED'
+  | 'AUTH_FAILED'
+  | 'REPO_NOT_FOUND'
+  | 'SANDBOX_FAILED'
+  | 'UNKNOWN';
+
+type ClassifiedError = {
+  code: AnalysisErrorCode;
+  userMessage: string;
+};
+
+const CLONE_PATTERNS = [/\bclone\b/i, /\brepository\b.*\bfrom\b/i];
+
+const AUTH_PATTERNS = [
+  /\bauthenticat/i,
+  /\bBad credentials\b/i,
+  /\bcredentials?\b.*\b(failed|invalid|expired|rejected)\b/i,
+  /\b(status|error|returned|HTTP)\s*:?\s*40[13]\b/i,
+  /\bpermission\b.*\bdenied\b/i,
+];
+
+const NOT_FOUND_PATTERNS = [
+  /\bnot found\b/i,
+  /\b404\b/,
+  /\bdoes not exist\b/i,
+  /\bno such\b.*\brepository\b/i,
+];
+
+/**
+ * Classify a raw error into a structured code and user-friendly message.
+ *
+ * Order matters: clone patterns are checked first because a clone failure
+ * message often also contains "not found" or auth-related substrings.
+ */
+export function classifyAnalysisError(error: unknown): ClassifiedError {
+  const raw = error instanceof Error ? error.message : String(error);
+
+  if (CLONE_PATTERNS.some((p) => p.test(raw))) {
+    return {
+      code: 'CLONE_FAILED',
+      userMessage:
+        'Failed to clone the repository. Please verify it exists and your GitHub integration has access.',
+    };
+  }
+
+  if (AUTH_PATTERNS.some((p) => p.test(raw))) {
+    return {
+      code: 'AUTH_FAILED',
+      userMessage:
+        'GitHub authentication failed. Please reconnect your GitHub integration and try again.',
+    };
+  }
+
+  if (NOT_FOUND_PATTERNS.some((p) => p.test(raw))) {
+    return {
+      code: 'REPO_NOT_FOUND',
+      userMessage:
+        'Repository not found. It may have been deleted, renamed, or made private.',
+    };
+  }
+
+  return {
+    code: 'UNKNOWN',
+    userMessage: raw,
+  };
+}
+
+export function trpcCodeForAnalysisError(code: AnalysisErrorCode | undefined): TRPCError['code'] {
+  switch (code) {
+    case 'CLONE_FAILED':
+      return 'BAD_REQUEST';
+    case 'AUTH_FAILED':
+      return 'PRECONDITION_FAILED';
+    case 'REPO_NOT_FOUND':
+      return 'NOT_FOUND';
+    case 'SANDBOX_FAILED':
+    case 'UNKNOWN':
+    default:
+      return 'INTERNAL_SERVER_ERROR';
+  }
+}

--- a/src/lib/security-agent/core/error-display.ts
+++ b/src/lib/security-agent/core/error-display.ts
@@ -3,9 +3,12 @@ const GITHUB_INTEGRATION_ERROR_NEEDLES = [
   'GitHub installation',
   'installation_id',
   'Bad credentials',
-  'Not Found',
   'Forbidden',
   'Resource not accessible',
+  // Match user-friendly messages from classifyAnalysisError
+  'GitHub authentication failed',
+  'Failed to clone the repository',
+  'Repository not found',
 ];
 
 /** Detect GitHub integration errors so the UI can show "reconnect your GitHub App" guidance. */

--- a/src/lib/security-agent/core/error-display.ts
+++ b/src/lib/security-agent/core/error-display.ts
@@ -11,5 +11,5 @@ const GITHUB_INTEGRATION_ERROR_NEEDLES = [
 /** Detect GitHub integration errors so the UI can show "reconnect your GitHub App" guidance. */
 export function isGitHubIntegrationError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return GITHUB_INTEGRATION_ERROR_NEEDLES.some((needle) => message.includes(needle));
+  return GITHUB_INTEGRATION_ERROR_NEEDLES.some(needle => message.includes(needle));
 }

--- a/src/lib/security-agent/core/error-display.ts
+++ b/src/lib/security-agent/core/error-display.ts
@@ -1,0 +1,15 @@
+const GITHUB_INTEGRATION_ERROR_NEEDLES = [
+  'GitHub token',
+  'GitHub installation',
+  'installation_id',
+  'Bad credentials',
+  'Not Found',
+  'Forbidden',
+  'Resource not accessible',
+];
+
+/** Detect GitHub integration errors so the UI can show "reconnect your GitHub App" guidance. */
+export function isGitHubIntegrationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return GITHUB_INTEGRATION_ERROR_NEEDLES.some((needle) => message.includes(needle));
+}

--- a/src/lib/security-agent/services/analysis-service.test.ts
+++ b/src/lib/security-agent/services/analysis-service.test.ts
@@ -369,12 +369,13 @@ describe('analysis-service', () => {
     });
 
     expect(result.started).toBe(false);
-    expect(result.error).toBe('Sandbox unavailable');
+    expect(result.error).toBe('Sandbox analysis failed to start. Please try again.');
+    expect(result.errorCode).toBe('SANDBOX_FAILED');
     // Should attempt to clean up the prepared session
     expect(mockDeleteSession).toHaveBeenCalledWith('agent-session-xyz');
     // Should mark finding as failed
     expect(mockUpdateAnalysisStatus).toHaveBeenCalledWith(findingId, 'failed', {
-      error: 'Sandbox unavailable',
+      error: 'Sandbox analysis failed to start. Please try again.',
     });
   });
 

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -530,12 +530,13 @@ export async function startSecurityAnalysis(params: {
       const classified = classifyAnalysisError(initiateError);
       // Default to SANDBOX_FAILED for initiation errors unless a more specific code applies
       const isUnknown = classified.code === 'UNKNOWN';
-      const errorCode = isUnknown ? ('SANDBOX_FAILED' as const) : classified.code;
+      const errorCode: AnalysisErrorCode = isUnknown ? 'SANDBOX_FAILED' : classified.code;
       const userMessage = isUnknown
         ? 'Sandbox analysis failed to start. Please try again.'
         : classified.userMessage;
 
-      const logFn = isUserActionableError(errorCode) ? warn : logError;
+      const isActionable = isUserActionableError(errorCode);
+      const logFn = isActionable ? warn : logError;
       logFn('initiateFromPreparedSession failed', {
         correlationId,
         findingId,
@@ -543,6 +544,13 @@ export async function startSecurityAnalysis(params: {
         errorCode,
         error: initiateError,
       });
+
+      if (!isActionable) {
+        captureException(initiateError, {
+          tags: { operation: 'initiateFromPreparedSession', errorCode },
+          extra: { findingId, cloudAgentSessionId, correlationId },
+        });
+      }
 
       await updateAnalysisStatus(findingId, 'failed', { error: userMessage });
       return { started: false, error: userMessage, errorCode };

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -263,7 +263,12 @@ export async function startSecurityAnalysis(params: {
   forceSandbox?: boolean;
   retrySandboxOnly?: boolean;
   organizationId?: string;
-}): Promise<{ started: boolean; error?: string; errorCode?: AnalysisErrorCode; triageOnly?: boolean }> {
+}): Promise<{
+  started: boolean;
+  error?: string;
+  errorCode?: AnalysisErrorCode;
+  triageOnly?: boolean;
+}> {
   const {
     findingId,
     user,

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -26,7 +26,7 @@ import type {
   SecurityReviewOwner,
 } from '../core/types';
 import type { AnalysisErrorCode } from '../core/error-classification';
-import { classifyAnalysisError } from '../core/error-classification';
+import { classifyAnalysisError, isUserActionableError } from '../core/error-classification';
 import type { User, SecurityFinding } from '@kilocode/db/schema';
 import {
   trackSecurityAgentAnalysisStarted,
@@ -519,12 +519,6 @@ export async function startSecurityAnalysis(params: {
         throw initiateError;
       }
 
-      logError('initiateFromPreparedSession failed', {
-        correlationId,
-        findingId,
-        cloudAgentSessionId,
-        error: initiateError,
-      });
       // Clean up the prepared session
       void client.deleteSession(cloudAgentSessionId).catch(() => {});
 
@@ -535,6 +529,15 @@ export async function startSecurityAnalysis(params: {
       const userMessage = isUnknown
         ? 'Sandbox analysis failed to start. Please try again.'
         : classified.userMessage;
+
+      const logFn = isUserActionableError(errorCode) ? warn : logError;
+      logFn('initiateFromPreparedSession failed', {
+        correlationId,
+        findingId,
+        cloudAgentSessionId,
+        errorCode,
+        error: initiateError,
+      });
 
       await updateAnalysisStatus(findingId, 'failed', { error: userMessage });
       return { started: false, error: userMessage, errorCode };
@@ -553,10 +556,20 @@ export async function startSecurityAnalysis(params: {
     await updateAnalysisStatus(findingId, 'failed', {
       error: classified.userMessage,
     });
-    captureException(error, {
-      tags: { operation: 'startSecurityAnalysis', errorCode: classified.code },
-      extra: { findingId, githubRepo, correlationId },
-    });
+    if (isUserActionableError(classified.code)) {
+      warn('Analysis failed (user-actionable)', {
+        correlationId,
+        findingId,
+        githubRepo,
+        errorCode: classified.code,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      captureException(error, {
+        tags: { operation: 'startSecurityAnalysis', errorCode: classified.code },
+        extra: { findingId, githubRepo, correlationId },
+      });
+    }
     return { started: false, error: classified.userMessage, errorCode: classified.code };
   }
 }

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -25,6 +25,8 @@ import type {
   SecurityFindingTriage,
   SecurityReviewOwner,
 } from '../core/types';
+import type { AnalysisErrorCode } from '../core/error-classification';
+import { classifyAnalysisError } from '../core/error-classification';
 import type { User, SecurityFinding } from '@kilocode/db/schema';
 import {
   trackSecurityAgentAnalysisStarted,
@@ -261,7 +263,7 @@ export async function startSecurityAnalysis(params: {
   forceSandbox?: boolean;
   retrySandboxOnly?: boolean;
   organizationId?: string;
-}): Promise<{ started: boolean; error?: string; triageOnly?: boolean }> {
+}): Promise<{ started: boolean; error?: string; errorCode?: AnalysisErrorCode; triageOnly?: boolean }> {
   const {
     findingId,
     user,
@@ -526,13 +528,16 @@ export async function startSecurityAnalysis(params: {
       // Clean up the prepared session
       void client.deleteSession(cloudAgentSessionId).catch(() => {});
 
-      await updateAnalysisStatus(findingId, 'failed', {
-        error: initiateError instanceof Error ? initiateError.message : String(initiateError),
-      });
-      return {
-        started: false,
-        error: initiateError instanceof Error ? initiateError.message : String(initiateError),
-      };
+      const classified = classifyAnalysisError(initiateError);
+      // Default to SANDBOX_FAILED for initiation errors unless a more specific code applies
+      const isUnknown = classified.code === 'UNKNOWN';
+      const errorCode = isUnknown ? ('SANDBOX_FAILED' as const) : classified.code;
+      const userMessage = isUnknown
+        ? 'Sandbox analysis failed to start. Please try again.'
+        : classified.userMessage;
+
+      await updateAnalysisStatus(findingId, 'failed', { error: userMessage });
+      return { started: false, error: userMessage, errorCode };
     }
 
     return { started: true, triageOnly: false };
@@ -543,13 +548,15 @@ export async function startSecurityAnalysis(params: {
       throw error;
     }
 
+    const classified = classifyAnalysisError(error);
+
     await updateAnalysisStatus(findingId, 'failed', {
-      error: error instanceof Error ? error.message : String(error),
+      error: classified.userMessage,
     });
     captureException(error, {
-      tags: { operation: 'startSecurityAnalysis' },
+      tags: { operation: 'startSecurityAnalysis', errorCode: classified.code },
       extra: { findingId, githubRepo, correlationId },
     });
-    return { started: false, error: error instanceof Error ? error.message : String(error) };
+    return { started: false, error: classified.userMessage, errorCode: classified.code };
   }
 }

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -38,6 +38,7 @@ import {
   syncAllReposForOwner,
 } from '@/lib/security-agent/services/sync-service';
 import { startSecurityAnalysis } from '@/lib/security-agent/services/analysis-service';
+import { trpcCodeForAnalysisError } from '@/lib/security-agent/core/error-classification';
 import {
   autoDismissEligibleFindings,
   countEligibleForAutoDismiss,
@@ -892,7 +893,7 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
 
         if (!result.started) {
           throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
+            code: trpcCodeForAnalysisError(result.errorCode),
             message: result.error || 'Failed to start analysis',
           });
         }

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -33,6 +33,7 @@ import {
   syncAllReposForOwner,
 } from '@/lib/security-agent/services/sync-service';
 import { startSecurityAnalysis } from '@/lib/security-agent/services/analysis-service';
+import { trpcCodeForAnalysisError } from '@/lib/security-agent/core/error-classification';
 import {
   autoDismissEligibleFindings,
   countEligibleForAutoDismiss,
@@ -866,7 +867,7 @@ export const securityAgentRouter = createTRPCRouter({
 
       if (!result.started) {
         throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
+          code: trpcCodeForAnalysisError(result.errorCode),
           message: result.error || 'Failed to start analysis',
         });
       }


### PR DESCRIPTION
## Summary

Fixes [KILOCODE-WEB-N5G](https://kilo-code.sentry.io/issues/7293886713/) — `TRPCError: Failed to clone repository` was reported as an unhandled Sentry error when it's actually a user-actionable problem (repo access/permissions).

- **Structured error classification**: New `error-classification.ts` classifies raw cloud-agent-next errors into typed codes (`CLONE_FAILED`, `AUTH_FAILED`, `REPO_NOT_FOUND`, `SANDBOX_FAILED`, `UNKNOWN`) with user-friendly messages.
- **Appropriate tRPC status codes**: Routers now return semantically correct HTTP codes (e.g. `BAD_REQUEST` for clone failures) instead of always `INTERNAL_SERVER_ERROR`.
- **Reduced Sentry noise**: User-actionable errors (clone, auth, not-found) are logged as warnings instead of captured as Sentry exceptions. Only unexpected server failures still trigger `captureException`.
- **Consolidated `isGitHubIntegrationError`**: Deduplicated from two components into a shared `error-display.ts` module, fixing a bug where `AnalysisJobsCard` was missing two pattern checks (`Forbidden`, `Resource not accessible`).