### PR TITLE
refactor: derive ExecutionState type from Zod schema

### DIFF
--- a/src/lib/cloud-agent/cloud-agent-client.ts
+++ b/src/lib/cloud-agent/cloud-agent-client.ts
@@ -12,6 +12,8 @@ import { EventSourcePolyfill } from 'event-source-polyfill';
 import type { StreamEvent } from '@/components/cloud-agent/types';
 import type { EncryptedEnvelope } from '@/lib/encryption';
 import type { Images } from '@/lib/images-schema';
+import type { z } from 'zod';
+import type { executionStateSchema } from '@/routers/cloud-agent-schemas';
 import { getEnvVariable } from '@/lib/dotenvx';
 import { captureException } from '@sentry/nextjs';
 import { createNoRetryEventSource } from '@/lib/trpc/noRetryEventSource';
@@ -205,16 +207,8 @@ export type GetSessionInput = {
   cloudAgentSessionId: string;
 };
 
-/** Execution state from cloud-agent DO */
-export type ExecutionState = {
-  id: string;
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'interrupted';
-  startedAt?: number;
-  lastHeartbeat?: number | null;
-  processId?: string | null;
-  error?: string | null;
-  health?: 'healthy' | 'stale' | 'unknown';
-};
+/** Execution state from cloud-agent DO — derived from the Zod schema */
+export type ExecutionState = z.infer<typeof executionStateSchema>;
 
 /** Output from getSession procedure (sanitized, no secrets) */
 export type GetSessionOutput = {

--- a/src/routers/cloud-agent-schemas.ts
+++ b/src/routers/cloud-agent-schemas.ts
@@ -166,7 +166,7 @@ export const baseGetSessionSchema = z.object({
   cloudAgentSessionId: z.string(),
 });
 
-const executionStateSchema = z.object({
+export const executionStateSchema = z.object({
   id: z.string(),
   status: z.enum(['pending', 'running', 'completed', 'failed', 'interrupted']),
   startedAt: z.number().optional(),


### PR DESCRIPTION
## Summary

- Derive `ExecutionState` type from `executionStateSchema` via `z.infer<>` instead of manually duplicating the shape, ensuring the type and schema stay in sync.
- Export `executionStateSchema` from `cloud-agent-schemas.ts` so it can be referenced as a type-only import.

Addresses [PR #694 review feedback](https://github.com/Kilo-Org/cloud/pull/694#discussion_r2009363420).