### PR TITLE
fix(kiloclaw): remove model allowlist so all kilocode catalog models are visible

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -190,6 +190,25 @@ describe('generateBaseConfig', () => {
     expect(config.models.providers.kilocode.models).toEqual([{ id: 'kept/model', name: 'Kept' }]);
   });
 
+  it('removes agents.defaults.models allowlist left by openclaw onboard', () => {
+    const existing = JSON.stringify({
+      agents: {
+        defaults: {
+          model: { primary: 'kilocode/anthropic/claude-opus-4.6' },
+          models: {
+            'kilocode/anthropic/claude-opus-4.6': { alias: 'Kilo Gateway' },
+          },
+        },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
+
+    expect(config.agents.defaults.models).toBeUndefined();
+    // model.primary should still be preserved
+    expect(config.agents.defaults.model.primary).toBe('kilocode/anthropic/claude-opus-4.6');
+  });
+
   it('overrides default model only when KILOCODE_DEFAULT_MODEL is set', () => {
     const { deps } = fakeDeps();
     const env = { ...minimalEnv(), KILOCODE_DEFAULT_MODEL: 'kilocode/openai/gpt-5' };

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -151,6 +151,13 @@ export function generateBaseConfig(
     console.log(`Overriding default model: ${env.KILOCODE_DEFAULT_MODEL}`);
   }
 
+  // Remove the agents.defaults.models allowlist that `openclaw onboard` creates.
+  // When non-empty it restricts visible models to only those listed, hiding the
+  // rest of the kilocode catalog. KiloClaw users should see all available models.
+  if (config.agents?.defaults?.models) {
+    delete config.agents.defaults.models;
+  }
+
   // Exec tool settings
   config.tools = config.tools ?? {};
   config.tools.exec = config.tools.exec ?? {};

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -242,6 +242,13 @@ if (process.env.KILOCODE_DEFAULT_MODEL) {
     console.log('Overriding default model: ' + process.env.KILOCODE_DEFAULT_MODEL);
 }
 
+// Remove the agents.defaults.models allowlist that `openclaw onboard` creates.
+// When non-empty it restricts visible models to only those listed, hiding the
+// rest of the kilocode catalog. KiloClaw users should see all available models.
+if (config.agents && config.agents.defaults && config.agents.defaults.models) {
+    delete config.agents.defaults.models;
+}
+
 // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
 // gateway host directly. Allowlist mode gates unknown commands via the
 // Control UI approval dialog; safe bins (jq, head, tail, etc.) auto-allow.

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -23,6 +23,23 @@ import { ConfirmActionDialog } from './ConfirmActionDialog';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
+/**
+ * Models available via the kilocode gateway's baked-in catalog in openclaw.
+ * Only these models are selectable as the default until openclaw supports
+ * dynamic model discovery from the gateway's /models endpoint.
+ */
+const KILOCODE_CATALOG_IDS = new Set([
+  'anthropic/claude-opus-4.6',
+  'z-ai/glm-5:free',
+  'minimax/minimax-m2.5:free',
+  'anthropic/claude-sonnet-4.5',
+  'openai/gpt-5.2',
+  'google/gemini-3-pro-preview',
+  'google/gemini-3-flash-preview',
+  'x-ai/grok-code-fast-1',
+  'moonshotai/kimi-k2.5',
+]);
+
 /** Returns true if calver `version` is >= `minVersion` (e.g. "2026.2.26"). Fails closed on malformed input. */
 function calverAtLeast(version: string | null | undefined, minVersion: string): boolean {
   if (!version) return false;
@@ -201,7 +218,10 @@ export function SettingsTab({
   const [confirmRestore, setConfirmRestore] = useState(false);
 
   const modelOptions = useMemo<ModelOption[]>(
-    () => (modelsData?.data || []).map(model => ({ id: model.id, name: model.name })),
+    () =>
+      (modelsData?.data || [])
+        .filter(model => KILOCODE_CATALOG_IDS.has(model.id))
+        .map(model => ({ id: model.id, name: model.name })),
     [modelsData]
   );
 

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,20 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-03-01',
+    description:
+      'Fixed model picker showing unsupported models. If you encounter model-not-found errors, use Settings > Set Default to select a supported model and restart the gateway.',
+    category: 'bugfix',
+    deployHint: null,
+  },
+  {
+    date: '2026-03-01',
+    description:
+      'Fixed an issue where only 2 models were visible in OpenClaw. All models currently available in openclaw are now visible after a redeploy.',
+    category: 'bugfix',
+    deployHint: 'redeploy_suggested',
+  },
+  {
     date: '2026-02-27',
     description:
       'Updated OpenClaw to 2026.2.26. Added 1Password CLI, build-essential, python3, ffmpeg, tmux, and mcporter to the default image.',


### PR DESCRIPTION
## Summary

**Openclaw's kilo gateway currently only supports 9 hardcoded models.**

- Strip the `agents.defaults.models` allowlist that `openclaw onboard` creates, which was restricting visible models to only the onboard default + `model.primary` (2 models instead of 9)
- Restrict the claw settings model picker to the 9 models in openclaw's baked-in kilocode catalog, since those are the only ones openclaw actually recognizes

## Problem

`openclaw onboard --kilocode-api-key` calls `applyKilocodeProviderConfig()` which adds `kilocode/anthropic/claude-opus-4.6` with alias `"Kilo Gateway"` to `agents.defaults.models`. When that map is non-empty, openclaw treats it as an allowlist — only models listed there (plus `model.primary`) appear in `/model status` and the control UI. The kiloclaw config-writer patched `model.primary` but never cleared this allowlist, so users only saw 2 models.

On the UI side, the model picker was showing the full 500+ catalog, but openclaw's baked-in kilocode provider only has 9 models. Selecting a model not in the catalog would silently fail until you went go use it.

## Changes

| File | Change |
|------|--------|
| `kiloclaw/controller/src/config-writer.ts` | Delete `agents.defaults.models` after patching config |
| `kiloclaw/start-openclaw.sh` | Same deletion in the shell script (must stay in sync) |
| `kiloclaw/controller/src/config-writer.test.ts` | Test verifying allowlist is stripped while `model.primary` is preserved |
| `src/app/(app)/claw/components/SettingsTab.tsx` | Filter model picker to the 9 baked-in kilocode catalog IDs |

## Follow-up

The UI filter is temporary. A plan for adding dynamic model discovery to openclaw's kilocode provider (fetching from `/api/gateway/models` at startup) is drafted — once implemented, the filter can be removed and users will see all 500+ models.