### PR TITLE
CloudAgentNext - Fix stale streaming messages reordering in chat

### DIFF
--- a/src/components/app-builder/AppBuilderChat.tsx
+++ b/src/components/app-builder/AppBuilderChat.tsx
@@ -30,6 +30,7 @@ import { TypingIndicator } from '@/components/cloud-agent/TypingIndicator';
 import type { CloudMessage } from '@/components/cloud-agent/types';
 import type { StoredMessage } from '@/components/cloud-agent-next/types';
 import { isMessageStreaming } from '@/components/cloud-agent-next/types';
+import { splitByContiguousPrefix } from '@/lib/utils/splitByContiguousPrefix';
 import { MessageBubble as V2MessageBubble } from '@/components/cloud-agent-next/MessageBubble';
 import { QuestionContextProvider } from '@/components/cloud-agent-next/QuestionContext';
 import type { AppBuilderSession, V1Session, V2Session } from './project-manager/types';
@@ -328,16 +329,11 @@ function V1SessionMessages({
   );
 
   const { staticMessages, dynamicMessages } = useMemo(() => {
-    const staticMsgs: CloudMessage[] = [];
-    const dynamicMsgs: CloudMessage[] = [];
-    for (const msg of visibleMessages) {
-      if (msg.partial) {
-        dynamicMsgs.push(msg);
-      } else {
-        staticMsgs.push(msg);
-      }
-    }
-    return { staticMessages: staticMsgs, dynamicMessages: dynamicMsgs };
+    const { staticItems, dynamicItems } = splitByContiguousPrefix(
+      visibleMessages,
+      msg => !msg.partial
+    );
+    return { staticMessages: staticItems, dynamicMessages: dynamicItems };
   }, [visibleMessages]);
 
   if (visibleMessages.length === 0) {
@@ -372,17 +368,14 @@ function V2SessionMessages({
 }) {
   const sessionState = useSyncExternalStore(session.subscribe, session.getState);
 
+  // Contiguous-prefix split: prevents stale streaming messages from old
+  // executions from being reordered below newer complete messages.
   const { v2Static, v2Dynamic } = useMemo(() => {
-    const staticMsgs: StoredMessage[] = [];
-    const dynamicMsgs: StoredMessage[] = [];
-    for (const msg of sessionState.messages) {
-      if (isMessageStreaming(msg)) {
-        dynamicMsgs.push(msg);
-      } else {
-        staticMsgs.push(msg);
-      }
-    }
-    return { v2Static: staticMsgs, v2Dynamic: dynamicMsgs };
+    const { staticItems, dynamicItems } = splitByContiguousPrefix(
+      sessionState.messages,
+      msg => !isMessageStreaming(msg)
+    );
+    return { v2Static: staticItems, v2Dynamic: dynamicItems };
   }, [sessionState.messages]);
 
   // Identity changes when childSessionMessages changes, which forces memo'd

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -9,6 +9,7 @@ import { atom } from 'jotai';
 import type { SessionConfig, StoredMessage, Part } from '../types';
 import { isMessageStreaming, isAssistantMessage } from '../types';
 import type { QuestionInfo } from '@/types/opencode.gen';
+import { splitByContiguousPrefix } from '@/lib/utils/splitByContiguousPrefix';
 
 // ============================================================================
 // Primary State - StoredMessage format
@@ -130,8 +131,7 @@ export const messagesListAtom = atom(get => {
  */
 export const staticMessagesAtom = atom(get => {
   const messages = get(messagesListAtom);
-  const { staticMessages } = splitMessages(messages);
-  return staticMessages;
+  return splitByContiguousPrefix(messages, msg => !isMessageStreaming(msg)).staticItems;
 });
 
 /**
@@ -139,8 +139,7 @@ export const staticMessagesAtom = atom(get => {
  */
 export const dynamicMessagesAtom = atom(get => {
   const messages = get(messagesListAtom);
-  const { dynamicMessages } = splitMessages(messages);
-  return dynamicMessages;
+  return splitByContiguousPrefix(messages, msg => !isMessageStreaming(msg)).dynamicItems;
 });
 
 // Matches CLI's getApiMetrics logic
@@ -462,28 +461,3 @@ export const getChildSessionMessagesAtom = atom(get => {
     return childSessionsMap.get(childSessionId) || [];
   };
 });
-
-// Splits messages into static (complete) and dynamic (streaming) groups
-function splitMessages(messages: StoredMessage[]): {
-  staticMessages: StoredMessage[];
-  dynamicMessages: StoredMessage[];
-} {
-  let lastCompleteIndex = -1;
-
-  for (let i = 0; i < messages.length; i++) {
-    if (!isMessageStreaming(messages[i])) {
-      if (i === 0 || i === lastCompleteIndex + 1) {
-        lastCompleteIndex = i;
-      } else {
-        break;
-      }
-    } else {
-      break;
-    }
-  }
-
-  return {
-    staticMessages: messages.slice(0, lastCompleteIndex + 1),
-    dynamicMessages: messages.slice(lastCompleteIndex + 1),
-  };
-}

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -125,22 +125,18 @@ export const messagesListAtom = atom(get => {
 });
 
 /**
- * Static messages - all complete messages that can be memoized.
+ * Split messages into static (complete, contiguous from the start) and dynamic (everything after).
  * A message is complete when its info.time.completed is set (for assistant messages)
  * and all parts have their time.end set.
  */
-export const staticMessagesAtom = atom(get => {
+const splitMessagesAtom = atom(get => {
   const messages = get(messagesListAtom);
-  return splitByContiguousPrefix(messages, msg => !isMessageStreaming(msg)).staticItems;
+  return splitByContiguousPrefix(messages, msg => !isMessageStreaming(msg));
 });
 
-/**
- * Dynamic messages - messages that are still streaming.
- */
-export const dynamicMessagesAtom = atom(get => {
-  const messages = get(messagesListAtom);
-  return splitByContiguousPrefix(messages, msg => !isMessageStreaming(msg)).dynamicItems;
-});
+export const staticMessagesAtom = atom(get => get(splitMessagesAtom).staticItems);
+
+export const dynamicMessagesAtom = atom(get => get(splitMessagesAtom).dynamicItems);
 
 // Matches CLI's getApiMetrics logic
 export const totalCostAtom = atom(get => {

--- a/src/components/cloud-agent/store/atoms.ts
+++ b/src/components/cloud-agent/store/atoms.ts
@@ -7,6 +7,7 @@
 
 import { atom } from 'jotai';
 import type { CloudMessage, SessionConfig } from '../types';
+import { splitByContiguousPrefix } from '@/lib/utils/splitByContiguousPrefix';
 
 // Primary state
 export const messagesAtom = atom<CloudMessage[]>([]);
@@ -28,12 +29,12 @@ export const filteredMessagesAtom = atom(get => {
 
 export const staticMessagesAtom = atom(get => {
   const messages = get(filteredMessagesAtom);
-  return splitMessages(messages).staticMessages;
+  return splitByContiguousPrefix(messages, isMessageComplete).staticItems;
 });
 
 export const dynamicMessagesAtom = atom(get => {
   const messages = get(filteredMessagesAtom);
-  return splitMessages(messages).dynamicMessages;
+  return splitByContiguousPrefix(messages, isMessageComplete).dynamicItems;
 });
 
 // Matches CLI's getApiMetrics logic
@@ -190,29 +191,4 @@ function isMessageComplete(message: CloudMessage): boolean {
   }
 
   return !message.partial;
-}
-
-// Matches CLI's splitMessages logic
-function splitMessages(messages: CloudMessage[]): {
-  staticMessages: CloudMessage[];
-  dynamicMessages: CloudMessage[];
-} {
-  let lastCompleteIndex = -1;
-
-  for (let i = 0; i < messages.length; i++) {
-    if (isMessageComplete(messages[i])) {
-      if (i === 0 || i === lastCompleteIndex + 1) {
-        lastCompleteIndex = i;
-      } else {
-        break;
-      }
-    } else {
-      break;
-    }
-  }
-
-  return {
-    staticMessages: messages.slice(0, lastCompleteIndex + 1),
-    dynamicMessages: messages.slice(lastCompleteIndex + 1),
-  };
 }

--- a/src/components/cloud-agent/store/atoms.ts
+++ b/src/components/cloud-agent/store/atoms.ts
@@ -27,15 +27,14 @@ export const filteredMessagesAtom = atom(get => {
   return messages.filter(msg => shouldDisplayMessage(msg));
 });
 
-export const staticMessagesAtom = atom(get => {
+const splitMessagesAtom = atom(get => {
   const messages = get(filteredMessagesAtom);
-  return splitByContiguousPrefix(messages, isMessageComplete).staticItems;
+  return splitByContiguousPrefix(messages, isMessageComplete);
 });
 
-export const dynamicMessagesAtom = atom(get => {
-  const messages = get(filteredMessagesAtom);
-  return splitByContiguousPrefix(messages, isMessageComplete).dynamicItems;
-});
+export const staticMessagesAtom = atom(get => get(splitMessagesAtom).staticItems);
+
+export const dynamicMessagesAtom = atom(get => get(splitMessagesAtom).dynamicItems);
 
 // Matches CLI's getApiMetrics logic
 export const totalCostAtom = atom(get => {

--- a/src/lib/utils/splitByContiguousPrefix.test.ts
+++ b/src/lib/utils/splitByContiguousPrefix.test.ts
@@ -1,0 +1,94 @@
+import { splitByContiguousPrefix } from './splitByContiguousPrefix';
+
+const isEven = (n: number) => n % 2 === 0;
+
+describe('splitByContiguousPrefix', () => {
+  it('returns empty arrays for empty input', () => {
+    expect(splitByContiguousPrefix([], isEven)).toEqual({
+      staticItems: [],
+      dynamicItems: [],
+    });
+  });
+
+  it('puts all items in static when every item satisfies the predicate', () => {
+    expect(splitByContiguousPrefix([2, 4, 6], isEven)).toEqual({
+      staticItems: [2, 4, 6],
+      dynamicItems: [],
+    });
+  });
+
+  it('puts all items in dynamic when the first item fails the predicate', () => {
+    expect(splitByContiguousPrefix([1, 2, 4], isEven)).toEqual({
+      staticItems: [],
+      dynamicItems: [1, 2, 4],
+    });
+  });
+
+  it('splits at the first failing item', () => {
+    expect(splitByContiguousPrefix([2, 4, 1, 6], isEven)).toEqual({
+      staticItems: [2, 4],
+      dynamicItems: [1, 6],
+    });
+  });
+
+  it('keeps a single passing item as the prefix', () => {
+    expect(splitByContiguousPrefix([2, 1, 4], isEven)).toEqual({
+      staticItems: [2],
+      dynamicItems: [1, 4],
+    });
+  });
+
+  it('handles a single failing item', () => {
+    expect(splitByContiguousPrefix([1], isEven)).toEqual({
+      staticItems: [],
+      dynamicItems: [1],
+    });
+  });
+
+  it('handles a single passing item', () => {
+    expect(splitByContiguousPrefix([2], isEven)).toEqual({
+      staticItems: [2],
+      dynamicItems: [],
+    });
+  });
+
+  it('does not reorder items — dynamic preserves original order', () => {
+    //  complete, streaming, complete, streaming
+    const items = ['c1', 'S1', 'c2', 'S2'];
+    const complete = new Set(['c1', 'c2']);
+
+    const result = splitByContiguousPrefix(items, i => complete.has(i));
+    expect(result).toEqual({
+      staticItems: ['c1'],
+      dynamicItems: ['S1', 'c2', 'S2'],
+    });
+  });
+
+  it('stops extending the prefix at a gap even if later items pass', () => {
+    // [pass, fail, pass, pass] → prefix is just [pass]
+    expect(splitByContiguousPrefix([2, 1, 4, 6], isEven)).toEqual({
+      staticItems: [2],
+      dynamicItems: [1, 4, 6],
+    });
+  });
+
+  it('works with objects and a custom predicate', () => {
+    type Msg = { id: number; done: boolean };
+    const msgs: Msg[] = [
+      { id: 1, done: true },
+      { id: 2, done: true },
+      { id: 3, done: false },
+      { id: 4, done: true },
+    ];
+
+    const result = splitByContiguousPrefix(msgs, m => m.done);
+    expect(result.staticItems).toEqual([
+      { id: 1, done: true },
+      { id: 2, done: true },
+    ]);
+    expect(result.dynamicItems).toEqual([
+      { id: 3, done: false },
+      { id: 4, done: true },
+    ]);
+  });
+});

--- a/src/lib/utils/splitByContiguousPrefix.ts
+++ b/src/lib/utils/splitByContiguousPrefix.ts
@@ -1,0 +1,32 @@
+/**
+ * Splits an array into a "static" contiguous prefix and a "dynamic" tail.
+ *
+ * Walks from the start, extending the prefix as long as every item satisfies
+ * `isComplete`. The first item that fails the predicate (or a gap after such
+ * an item) ends the prefix; everything from that point onward goes into the
+ * dynamic portion. This keeps items in their original order — items that fail
+ * the predicate are never reordered past items that pass it.
+ */
+export function splitByContiguousPrefix<T>(
+  items: readonly T[],
+  isComplete: (item: T) => boolean
+): { staticItems: T[]; dynamicItems: T[] } {
+  let lastCompleteIndex = -1;
+
+  for (let i = 0; i < items.length; i++) {
+    if (isComplete(items[i])) {
+      if (i === 0 || i === lastCompleteIndex + 1) {
+        lastCompleteIndex = i;
+      } else {
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+
+  return {
+    staticItems: items.slice(0, lastCompleteIndex + 1),
+    dynamicItems: items.slice(lastCompleteIndex + 1),
+  };
+}


### PR DESCRIPTION
## Summary

- Extracts a generic `splitByContiguousPrefix` utility that finds the longest contiguous prefix of "complete" items and splits the array there
- Replaces pure-partition split logic in `V1SessionMessages`, `V2SessionMessages` (AppBuilderChat), and both cloud-agent/cloud-agent-next Jotai stores with the shared utility
- Prevents stale streaming messages from old executions from being reordered below newer complete messages during WebSocket event replay

## Problem

When a WebSocket connection replays events from multiple executions, old assistant messages can temporarily (or permanently, if interrupted) lack `time.completed`. The pure-partition split (`streaming? -> dynamic : static`) causes these stale messages to jump to the bottom of the chat below chronologically newer complete messages.

## Fix

The contiguous-prefix approach walks from the start of the message array, extending the "static" prefix as long as every consecutive item is complete. The first streaming message (or a gap after one) ends the prefix; everything from that point onward goes into "dynamic". This preserves chronological order regardless of streaming state.