### PR TITLE
CloudAgentNext - Fix controller disconnect handling and execution lifecycle

### DIFF
--- a/cloud-agent-next/src/core/lease.test.ts
+++ b/cloud-agent-next/src/core/lease.test.ts
@@ -18,8 +18,8 @@ describe('Lease Logic', () => {
       expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
     });
 
-    it('should have STALE_THRESHOLD_MS set to 10 minutes', () => {
-      expect(STALE_THRESHOLD_MS).toBe(10 * 60 * 1000);
+    it('should have STALE_THRESHOLD_MS set to 90 seconds', () => {
+      expect(STALE_THRESHOLD_MS).toBe(90_000);
     });
   });
 

--- a/cloud-agent-next/src/core/lease.ts
+++ b/cloud-agent-next/src/core/lease.ts
@@ -16,8 +16,9 @@ export const LEASE_TTL_MS = 90_000;
 /** Interval for heartbeat messages in milliseconds (30 seconds) */
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 
-/** Threshold for considering an execution stale (10 minutes) - used by reaper */
-export const STALE_THRESHOLD_MS = 10 * 60 * 1000;
+/** Threshold for considering an execution stale (90 seconds) - used by reaper.
+ * Wrapper heartbeats every 20s (debounced to 30s), so 90s ≈ 3 missed heartbeats. */
+export const STALE_THRESHOLD_MS = 90_000;
 
 // ---------------------------------------------------------------------------
 // Lease Helpers

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -72,6 +72,8 @@ import { stopKiloServer } from '../kilo/server-manager.js';
 
 /** Reaper alarm interval: 5 minutes */
 const REAPER_INTERVAL_MS_DEFAULT = 5 * 60 * 1000;
+/** Shorter reaper interval while execution is active: 2 minutes */
+const REAPER_ACTIVE_INTERVAL_MS = 2 * 60 * 1000;
 const PENDING_START_TIMEOUT_MS_DEFAULT = 5 * 60 * 1000;
 
 /** Event retention period: 90 days (aligns with session TTL) */
@@ -367,7 +369,56 @@ export class CloudAgentSession extends DurableObject {
     // Clean up ingest connection tracking
     if (tags.some(tag => tag.startsWith('ingest:'))) {
       const ingestHandler = await this.getIngestHandler();
-      ingestHandler.handleIngestClose(ws);
+      const disconnectedExecutionId = ingestHandler.handleIngestClose(ws);
+
+      // If the wrapper disconnected while its execution was still active, fail it immediately
+      if (disconnectedExecutionId) {
+        const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+        if (activeExecutionId === disconnectedExecutionId) {
+          const execution = await this.executionQueries.get(activeExecutionId);
+          // Only act if execution is still running or pending (not already terminal)
+          if (execution && (execution.status === 'running' || execution.status === 'pending')) {
+            logger
+              .withFields({
+                sessionId: this.sessionId,
+                executionId: activeExecutionId,
+                wsCloseCode: code,
+                wsCloseReason: reason,
+              })
+              .warn('Wrapper disconnected while execution active - marking as failed');
+
+            const now = Date.now();
+
+            // Mark execution as failed
+            await this.updateExecutionStatus({
+              executionId: activeExecutionId,
+              status: 'failed',
+              error: 'Wrapper disconnected',
+              completedAt: now,
+            });
+
+            // Clear active execution (updateStatus should do this, but ensure it)
+            await this.executionQueries.clearActiveExecution();
+
+            // Clear interrupt flag if set
+            await this.executionQueries.clearInterrupt();
+
+            // Insert a synthetic wrapper_disconnected event so /stream clients are notified
+            const sessionId = await this.requireSessionId();
+            this.insertAndBroadcastEvent({
+              executionId: activeExecutionId,
+              sessionId,
+              streamEventType: 'wrapper_disconnected',
+              payload: JSON.stringify({
+                reason: 'Wrapper disconnected',
+                wsCloseCode: code,
+                wsCloseReason: reason,
+              }),
+              timestamp: now,
+            });
+          }
+        }
+      }
     }
 
     logger.debug(`WebSocket closed: code=${code}, reason=${reason}, wasClean=${wasClean}`);
@@ -413,6 +464,30 @@ export class CloudAgentSession extends DurableObject {
           })
           .warn('Failed to broadcast event - stream handler unavailable');
       });
+  }
+
+  private insertAndBroadcastEvent(params: {
+    executionId: ExecutionId;
+    sessionId: string;
+    streamEventType: string;
+    payload: string;
+    timestamp: number;
+  }): void {
+    const eventId = this.eventQueries.insert({
+      executionId: params.executionId,
+      sessionId: params.sessionId,
+      streamEventType: params.streamEventType,
+      payload: params.payload,
+      timestamp: params.timestamp,
+    });
+    this.broadcastEvent({
+      id: eventId,
+      execution_id: params.executionId,
+      session_id: params.sessionId,
+      stream_event_type: params.streamEventType,
+      payload: params.payload,
+      timestamp: params.timestamp,
+    });
   }
 
   /**
@@ -832,8 +907,10 @@ export class CloudAgentSession extends DurableObject {
         .error('Error during alarm reaper');
     }
 
-    // Schedule next alarm run
-    await this.ctx.storage.setAlarm(now + this.getReaperIntervalMs());
+    // Schedule next alarm run — use shorter interval while an execution is active
+    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const nextInterval = activeExecutionId ? REAPER_ACTIVE_INTERVAL_MS : this.getReaperIntervalMs();
+    await this.ctx.storage.setAlarm(now + nextInterval);
   }
 
   /**
@@ -905,6 +982,20 @@ export class CloudAgentSession extends DurableObject {
 
         // Clear interrupt flag if set
         await this.executionQueries.clearInterrupt();
+
+        // Notify /stream clients that the execution was reaped
+        const sessionId = await this.requireSessionId();
+        const errorPayload = JSON.stringify({
+          error: 'Execution timeout - no heartbeat received',
+          fatal: true,
+        });
+        this.insertAndBroadcastEvent({
+          executionId: activeExecutionId,
+          sessionId,
+          streamEventType: 'error',
+          payload: errorPayload,
+          timestamp: now,
+        });
       }
     }
 
@@ -931,6 +1022,20 @@ export class CloudAgentSession extends DurableObject {
 
         await this.executionQueries.clearActiveExecution();
         await this.executionQueries.clearInterrupt();
+
+        // Notify /stream clients that the pending execution timed out
+        const sessionId = await this.requireSessionId();
+        const errorPayload = JSON.stringify({
+          error: 'Execution timeout - wrapper never connected',
+          fatal: true,
+        });
+        this.insertAndBroadcastEvent({
+          executionId: activeExecutionId,
+          sessionId,
+          streamEventType: 'error',
+          payload: errorPayload,
+          timestamp: now,
+        });
       }
     }
   }
@@ -1110,6 +1215,25 @@ export class CloudAgentSession extends DurableObject {
    */
   async clearActiveExecution(): Promise<void> {
     return this.executionQueries.clearActiveExecution();
+  }
+
+  /**
+   * Insert and broadcast an error event for an execution.
+   * Used by external callers (e.g. interrupt handler) to notify /stream clients.
+   */
+  async emitExecutionError(executionId: ExecutionId, errorMessage: string): Promise<void> {
+    const sessionId = await this.requireSessionId();
+    const payload = JSON.stringify({
+      error: errorMessage,
+      fatal: true,
+    });
+    this.insertAndBroadcastEvent({
+      executionId,
+      sessionId,
+      streamEventType: 'error',
+      payload,
+      timestamp: Date.now(),
+    });
   }
 
   /**

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -914,9 +914,17 @@ export class CloudAgentSession extends DurableObject {
         .error('Error during alarm reaper');
     }
 
-    // Schedule next alarm run — use shorter interval while an execution is active
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
-    const nextInterval = activeExecutionId ? REAPER_ACTIVE_INTERVAL_MS : this.getReaperIntervalMs();
+    // Schedule next alarm run — use shorter interval while an execution is active.
+    // Wrapped in try/catch so a failure here never prevents rescheduling the alarm.
+    let nextInterval = this.getReaperIntervalMs();
+    try {
+      const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+      if (activeExecutionId) {
+        nextInterval = REAPER_ACTIVE_INTERVAL_MS;
+      }
+    } catch {
+      // Fall through with default interval
+    }
     await this.ctx.storage.setAlarm(now + nextInterval);
   }
 

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -977,13 +977,21 @@ export class CloudAgentSession extends DurableObject {
           })
           .info('Marking stale execution as failed');
 
-        // Mark as failed
-        await this.updateExecutionStatus({
+        // Mark as failed — if another codepath already moved it to a terminal
+        // state (e.g. webSocketClose), skip cleanup and broadcast.
+        const statusResult = await this.updateExecutionStatus({
           executionId: activeExecutionId,
           status: 'failed',
           error: 'Execution timeout - no heartbeat received',
           completedAt: now,
         });
+
+        if (!statusResult.ok) {
+          logger
+            .withFields({ executionId: activeExecutionId, error: statusResult.error })
+            .info('Skipping reaper cleanup - status transition failed');
+          return;
+        }
 
         // Clear active execution (updateStatus should do this, but ensure it)
         await this.executionQueries.clearActiveExecution();
@@ -1021,12 +1029,21 @@ export class CloudAgentSession extends DurableObject {
           })
           .info('Marking stuck pending execution as failed');
 
-        await this.updateExecutionStatus({
+        // Mark as failed — if another codepath already moved it to a terminal
+        // state, skip cleanup and broadcast.
+        const statusResult = await this.updateExecutionStatus({
           executionId: activeExecutionId,
           status: 'failed',
           error: 'Execution timeout - wrapper never connected',
           completedAt: now,
         });
+
+        if (!statusResult.ok) {
+          logger
+            .withFields({ executionId: activeExecutionId, error: statusResult.error })
+            .info('Skipping pending timeout cleanup - status transition failed');
+          return;
+        }
 
         await this.executionQueries.clearActiveExecution();
         await this.executionQueries.clearInterrupt();

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -402,28 +402,27 @@ export class CloudAgentSession extends DurableObject {
               logger
                 .withFields({ executionId: activeExecutionId, error: statusResult.error })
                 .info('Skipping disconnect cleanup - status transition failed');
-              return;
+            } else {
+              // Clear active execution (updateStatus should do this, but ensure it)
+              await this.executionQueries.clearActiveExecution();
+
+              // Clear interrupt flag if set
+              await this.executionQueries.clearInterrupt();
+
+              // Insert a synthetic wrapper_disconnected event so /stream clients are notified
+              const sessionId = await this.requireSessionId();
+              this.insertAndBroadcastEvent({
+                executionId: activeExecutionId,
+                sessionId,
+                streamEventType: 'wrapper_disconnected',
+                payload: JSON.stringify({
+                  reason: 'Wrapper disconnected',
+                  wsCloseCode: code,
+                  wsCloseReason: reason,
+                }),
+                timestamp: now,
+              });
             }
-
-            // Clear active execution (updateStatus should do this, but ensure it)
-            await this.executionQueries.clearActiveExecution();
-
-            // Clear interrupt flag if set
-            await this.executionQueries.clearInterrupt();
-
-            // Insert a synthetic wrapper_disconnected event so /stream clients are notified
-            const sessionId = await this.requireSessionId();
-            this.insertAndBroadcastEvent({
-              executionId: activeExecutionId,
-              sessionId,
-              streamEventType: 'wrapper_disconnected',
-              payload: JSON.stringify({
-                reason: 'Wrapper disconnected',
-                wsCloseCode: code,
-                wsCloseReason: reason,
-              }),
-              timestamp: now,
-            });
           }
         }
       }

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -389,13 +389,21 @@ export class CloudAgentSession extends DurableObject {
 
             const now = Date.now();
 
-            // Mark execution as failed
-            await this.updateExecutionStatus({
+            // Mark execution as failed — if another codepath already moved it
+            // to a terminal state, skip the broadcast and cleanup.
+            const statusResult = await this.updateExecutionStatus({
               executionId: activeExecutionId,
               status: 'failed',
               error: 'Wrapper disconnected',
               completedAt: now,
             });
+
+            if (!statusResult.ok) {
+              logger
+                .withFields({ executionId: activeExecutionId, error: statusResult.error })
+                .info('Skipping disconnect cleanup - status transition failed');
+              return;
+            }
 
             // Clear active execution (updateStatus should do this, but ensure it)
             await this.executionQueries.clearActiveExecution();

--- a/cloud-agent-next/src/router.test.ts
+++ b/cloud-agent-next/src/router.test.ts
@@ -242,9 +242,8 @@ describe('router sessionId validation', () => {
           vi.clearAllMocks();
           interruptMock.mockResolvedValue({
             success: true,
-            killedProcessIds: ['p1'],
-            failedProcessIds: [],
             message: 'stopped',
+            processesFound: true,
           });
           buildContextMock.mockImplementation(({ sandboxId, orgId, userId, sessionId }) => ({
             sandboxId,

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -288,6 +288,12 @@ export function createSessionManagementHandlers() {
 
                 await withDORetry(
                   getStub,
+                  stub => stub.clearInterruptRequest(),
+                  'clearInterruptRequest'
+                );
+
+                await withDORetry(
+                  getStub,
                   stub =>
                     stub.emitExecutionError(
                       activeExecutionId,

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -252,6 +252,43 @@ export function createSessionManagementHandlers() {
               })
               .info('Session interruption completed');
 
+            // If no processes were killed but there's still an active execution,
+            // the wrapper is already dead — clear the stale execution immediately
+            if (result.killedProcessIds.length === 0 && activeExecutionId) {
+              logger
+                .withFields({ executionId: activeExecutionId })
+                .info('No processes found during interrupt - clearing stale active execution');
+
+              await withDORetry(
+                getStub,
+                async stub => {
+                  await stub.updateExecutionStatus({
+                    executionId: activeExecutionId,
+                    status: 'failed',
+                    error: 'Interrupted - no running processes found',
+                    completedAt: Date.now(),
+                  });
+                },
+                'updateExecutionStatus'
+              );
+
+              await withDORetry(
+                getStub,
+                stub => stub.clearActiveExecution(),
+                'clearActiveExecution'
+              );
+
+              await withDORetry(
+                getStub,
+                stub =>
+                  stub.emitExecutionError(
+                    activeExecutionId,
+                    'Interrupted - no running processes found'
+                  ),
+                'emitExecutionError'
+              );
+            }
+
             return result;
           } catch (error) {
             const errorMsg = error instanceof Error ? error.message : String(error);

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -259,34 +259,43 @@ export function createSessionManagementHandlers() {
                 .withFields({ executionId: activeExecutionId })
                 .info('No processes found during interrupt - clearing stale active execution');
 
-              await withDORetry(
+              const statusResult = await withDORetry(
                 getStub,
                 async stub => {
-                  await stub.updateExecutionStatus({
+                  const r = await stub.updateExecutionStatus({
                     executionId: activeExecutionId,
                     status: 'failed',
                     error: 'Interrupted - no running processes found',
                     completedAt: Date.now(),
                   });
+                  return { ok: r.ok } as { ok: boolean };
                 },
                 'updateExecutionStatus'
               );
 
-              await withDORetry(
-                getStub,
-                stub => stub.clearActiveExecution(),
-                'clearActiveExecution'
-              );
+              // If another codepath already moved the execution to a terminal
+              // state, skip cleanup to avoid spurious events.
+              if (!statusResult.ok) {
+                logger
+                  .withFields({ executionId: activeExecutionId })
+                  .info('Skipping interrupt cleanup - status transition failed');
+              } else {
+                await withDORetry(
+                  getStub,
+                  stub => stub.clearActiveExecution(),
+                  'clearActiveExecution'
+                );
 
-              await withDORetry(
-                getStub,
-                stub =>
-                  stub.emitExecutionError(
-                    activeExecutionId,
-                    'Interrupted - no running processes found'
-                  ),
-                'emitExecutionError'
-              );
+                await withDORetry(
+                  getStub,
+                  stub =>
+                    stub.emitExecutionError(
+                      activeExecutionId,
+                      'Interrupted - no running processes found'
+                    ),
+                  'emitExecutionError'
+                );
+              }
             }
 
             return result;

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -170,9 +170,8 @@ export function createSessionManagementHandlers() {
               logger.info('Session not found');
               return {
                 success: false,
-                killedProcessIds: [],
-                failedProcessIds: [],
                 message: 'Session not found',
+                processesFound: false,
               };
             }
 
@@ -245,16 +244,13 @@ export function createSessionManagementHandlers() {
               activeExecutionId ?? undefined
             );
 
-            logger
-              .withFields({
-                killedCount: result.killedProcessIds.length,
-                failedCount: result.failedProcessIds.length,
-              })
-              .info('Session interruption completed');
+            logger.info('Session interruption completed');
 
-            // If no processes were killed but there's still an active execution,
-            // the wrapper is already dead — clear the stale execution immediately
-            if (result.killedProcessIds.length === 0 && activeExecutionId) {
+            // If no processes were found but there's still an active execution,
+            // the wrapper is already dead — clear the stale execution immediately.
+            // Note: pkill always returns killedProcessIds: [], so we check
+            // processesFound instead to distinguish "killed" from "nothing to kill".
+            if (!result.processesFound && activeExecutionId) {
               logger
                 .withFields({ executionId: activeExecutionId })
                 .info('No processes found during interrupt - clearing stale active execution');

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -2420,8 +2420,7 @@ describe('SessionService', () => {
       const result = await SessionService.interrupt(mockSandbox, mockSession, sessionContext);
 
       expect(result.success).toBe(true);
-      expect(result.killedProcessIds).toEqual(['proc1', 'proc2']);
-      expect(result.failedProcessIds).toEqual([]);
+      expect(result.processesFound).toBe(true);
       expect(mockKillProcess).toHaveBeenCalledTimes(2);
       expect(mockKillProcess).toHaveBeenCalledWith('proc1', 'SIGTERM');
       expect(mockKillProcess).toHaveBeenCalledWith('proc2', 'SIGTERM');
@@ -2473,8 +2472,7 @@ describe('SessionService', () => {
 
       // Should only kill proc1 (the one matching our workspace)
       expect(result.success).toBe(true);
-      expect(result.killedProcessIds).toEqual(['proc1']);
-      expect(result.failedProcessIds).toEqual([]);
+      expect(result.processesFound).toBe(true);
       expect(mockKillProcess).toHaveBeenCalledTimes(1);
       expect(mockKillProcess).toHaveBeenCalledWith('proc1', 'SIGTERM');
     });
@@ -2524,8 +2522,7 @@ describe('SessionService', () => {
 
       // Should only kill proc1 (status='running')
       expect(result.success).toBe(true);
-      expect(result.killedProcessIds).toEqual(['proc1']);
-      expect(result.failedProcessIds).toEqual([]);
+      expect(result.processesFound).toBe(true);
       expect(mockKillProcess).toHaveBeenCalledTimes(1);
       expect(mockKillProcess).toHaveBeenCalledWith('proc1', 'SIGTERM');
     });
@@ -2580,8 +2577,7 @@ describe('SessionService', () => {
 
       // Should only kill proc1 (contains 'kilocode')
       expect(result.success).toBe(true);
-      expect(result.killedProcessIds).toEqual(['proc1']);
-      expect(result.failedProcessIds).toEqual([]);
+      expect(result.processesFound).toBe(true);
       expect(mockKillProcess).toHaveBeenCalledTimes(1);
       expect(mockKillProcess).toHaveBeenCalledWith('proc1', 'SIGTERM');
     });
@@ -2614,8 +2610,7 @@ describe('SessionService', () => {
       const result = await SessionService.interrupt(mockSandbox, mockSession, sessionContext);
 
       expect(result.success).toBe(true);
-      expect(result.killedProcessIds).toEqual([]);
-      expect(result.failedProcessIds).toEqual([]);
+      expect(result.processesFound).toBe(false);
       expect(result.message).toContain('No running kilocode processes found');
       expect(mockKillProcess).not.toHaveBeenCalled();
     });
@@ -2670,8 +2665,7 @@ describe('SessionService', () => {
       const result = await SessionService.interrupt(mockSandbox, mockSession, sessionContext);
 
       expect(result.success).toBe(true); // success because at least one was killed
-      expect(result.killedProcessIds).toEqual(['proc1', 'proc3']);
-      expect(result.failedProcessIds).toEqual(['proc2']);
+      expect(result.processesFound).toBe(true);
       expect(result.message).toContain('killed 2 process(es)');
       expect(result.message).toContain('1 failed');
       expect(mockKillProcess).toHaveBeenCalledTimes(3);

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1338,7 +1338,7 @@ export class SessionService {
           label,
           pattern,
         });
-        return session.exec(`pkill -f '${pattern}'`);
+        return session.exec(`pkill -f -- '${pattern}'`);
       };
 
       let execIdError: string | null = null;

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1350,9 +1350,8 @@ export class SessionService {
         if (execResult.exitCode === 0) {
           return {
             success: true,
-            killedProcessIds: [], // pkill doesn't report individual PIDs
-            failedProcessIds: [],
             message: 'Interrupted execution using pkill (executionId)',
+            processesFound: true,
           };
         }
         if (execResult.exitCode !== 1) {
@@ -1378,11 +1377,10 @@ export class SessionService {
 
         return {
           success: true,
-          killedProcessIds: [], // pkill doesn't report individual PIDs
-          failedProcessIds: [],
           message: execIdError
             ? `Interrupted execution using pkill (sessionId fallback). ${execIdError}`
             : 'Interrupted execution using pkill',
+          processesFound: true,
         };
       }
       if (sessionResult.exitCode === 1) {
@@ -1393,11 +1391,10 @@ export class SessionService {
 
         return {
           success: true,
-          killedProcessIds: [],
-          failedProcessIds: [],
           message: execIdError
             ? `No running processes found for this session. ${execIdError}`
             : 'No running processes found for this session',
+          processesFound: false,
         };
       }
 
@@ -1410,11 +1407,10 @@ export class SessionService {
 
       return {
         success: false,
-        killedProcessIds: [],
-        failedProcessIds: [],
         message: execIdError
           ? `${execIdError}; sessionId pkill failed with exit code ${sessionResult.exitCode}: ${sessionResult.stderr}`
           : `pkill failed with exit code ${sessionResult.exitCode}: ${sessionResult.stderr}`,
+        processesFound: false,
       };
     } catch (error) {
       logger.error('Interrupt with pkill failed', {
@@ -1464,9 +1460,8 @@ export class SessionService {
 
         return {
           success: true,
-          killedProcessIds: [],
-          failedProcessIds: [],
           message: 'No running kilocode processes found for this session',
+          processesFound: false,
         };
       }
 
@@ -1503,12 +1498,11 @@ export class SessionService {
 
       return {
         success: killed.length > 0,
-        killedProcessIds: killed,
-        failedProcessIds: failed,
         message:
           killed.length > 0
             ? `Interrupted execution: killed ${killed.length} process(es)${failed.length > 0 ? `, ${failed.length} failed` : ''}`
             : `Failed to kill any processes (${failed.length} attempts failed)`,
+        processesFound: true,
       };
     } catch (error) {
       logger.error('Interrupt operation failed', {

--- a/cloud-agent-next/src/types.ts
+++ b/cloud-agent-next/src/types.ts
@@ -72,9 +72,9 @@ export type SessionContext = {
 /** Result of interrupting a session's running processes */
 export type InterruptResult = {
   success: boolean;
-  killedProcessIds: string[];
-  failedProcessIds: string[];
   message: string;
+  /** Whether matching processes were found by pkill/sandbox API */
+  processesFound: boolean;
 };
 
 export type TokenPayload = {

--- a/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/cloud-agent-next/src/websocket/ingest.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createIngestHandler, type IngestDOContext, type IngestAttachment } from './ingest.js';
+import type { EventQueries } from '../session/queries/index.js';
+import type { SessionId, ExecutionId } from '../types/ids.js';
+
+const SESSION_ID = 'sess_test' as SessionId;
+
+function createFakeState() {
+  return {
+    acceptWebSocket: vi.fn(),
+    getWebSockets: vi.fn().mockReturnValue([]),
+    getTags: vi.fn().mockReturnValue([]),
+  } as unknown as DurableObjectState;
+}
+
+function createFakeEventQueries() {
+  return {
+    insert: vi.fn().mockReturnValue(1),
+    findByFilters: vi.fn().mockReturnValue([]),
+    deleteOlderThan: vi.fn().mockReturnValue(0),
+    iterateByFilters: vi.fn(),
+    countByExecutionId: vi.fn(),
+    getLatestEventId: vi.fn(),
+  } as unknown as EventQueries;
+}
+
+function createFakeDOContext(): IngestDOContext {
+  return {
+    updateKiloSessionId: vi.fn().mockResolvedValue(undefined),
+    updateUpstreamBranch: vi.fn().mockResolvedValue(undefined),
+    clearActiveExecution: vi.fn().mockResolvedValue(undefined),
+    getExecution: vi.fn().mockResolvedValue(null),
+    transitionToRunning: vi.fn().mockResolvedValue(true),
+    updateHeartbeat: vi.fn().mockResolvedValue(undefined),
+    updateExecutionStatus: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createFakeWebSocket(attachment: unknown = null) {
+  return {
+    deserializeAttachment: vi.fn().mockReturnValue(attachment),
+    serializeAttachment: vi.fn(),
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+  } as unknown as WebSocket;
+}
+
+function createHandler() {
+  return createIngestHandler(
+    createFakeState(),
+    createFakeEventQueries(),
+    SESSION_ID,
+    vi.fn(),
+    createFakeDOContext()
+  );
+}
+
+describe('createIngestHandler', () => {
+  describe('handleIngestClose', () => {
+    it('returns null when WebSocket has no attachment', () => {
+      const handler = createHandler();
+      const ws = createFakeWebSocket(null);
+
+      const result = handler.handleIngestClose(ws);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when WebSocket is not the active connection', () => {
+      const handler = createHandler();
+      const attachment: IngestAttachment = {
+        executionId: 'exc_test' as ExecutionId,
+        connectedAt: Date.now(),
+        kiloSessionState: { captured: false },
+        lastHeartbeatUpdate: Date.now(),
+      };
+      const ws = createFakeWebSocket(attachment);
+
+      // This WS was never registered via handleIngestRequest,
+      // so it won't be in the internal activeConnections map.
+      const result = handler.handleIngestClose(ws);
+
+      expect(result).toBeNull();
+    });
+
+    // The positive case (returns executionId when the WS is the active connection)
+    // requires going through handleIngestRequest, which uses WebSocketPair and
+    // state.acceptWebSocket — Cloudflare Worker APIs unavailable in vitest Node.
+    // That path is covered by integration tests in test/.
+  });
+});

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -432,15 +432,17 @@ export function createIngestHandler(
      *
      * @param ws - The WebSocket that closed
      */
-    handleIngestClose(ws: WebSocket): void {
+    handleIngestClose(ws: WebSocket): ExecutionId | null {
       const attachment = ws.deserializeAttachment() as IngestAttachment | null;
       if (attachment) {
         const { executionId } = attachment;
         // Only remove from tracking if this is the current connection for this execution
         if (activeConnections.get(executionId) === ws) {
           activeConnections.delete(executionId);
+          return executionId;
         }
       }
+      return null;
     },
 
     /**

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration tests for disconnect handling (Fix 1), reaper event emission (Fix 4),
+ * and dynamic alarm scheduling (Fix 5).
+ *
+ * Uses @cloudflare/vitest-pool-workers to test against real SQLite in DOs.
+ * Each test gets isolated storage automatically.
+ *
+ * Note: webSocketClose cannot be tested directly in integration because it
+ * requires a real ingest WebSocket established via handleIngestRequest inside
+ * the DO. Instead we test the reaper (alarm) path which exercises the same
+ * cleanup and event-insertion logic.
+ */
+
+import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createEventQueries } from '../../../src/session/queries/events.js';
+import type { ExecutionId } from '../../../src/types/ids.js';
+
+describe('Disconnect handling & reaper', () => {
+  beforeEach(async () => {
+    const ids = await listDurableObjectIds(env.CLOUD_AGENT_SESSION);
+    expect(ids).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 4: Reaper inserts synthetic error events when marking executions failed
+  // ---------------------------------------------------------------------------
+
+  it('reaper marks stale running execution as failed and inserts error event', async () => {
+    const userId = 'user_reaper_1';
+    const sessionId = 'agent_reaper_1';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      // Setup session metadata
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      // Add an execution and make it active
+      const excId = 'exc_stale_running' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      // Transition to running
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Set a heartbeat old enough to be stale (>90s threshold)
+      const staleHeartbeat = now - 200_000;
+      await instance.updateExecutionHeartbeat(excId, staleHeartbeat);
+
+      // Run the alarm (reaper)
+      await instance.alarm();
+
+      // Check execution status
+      const execution = await instance.getExecution(excId);
+
+      // Check events for synthetic error event
+      const eventQueries = createEventQueries(state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorEvents = events.filter(e => e.stream_event_type === 'error');
+
+      // Check active execution was cleared
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { execution, errorEvents, activeExecId };
+    });
+
+    expect(result.execution?.status).toBe('failed');
+    expect(result.execution?.error).toContain('no heartbeat');
+    expect(result.activeExecId).toBeNull();
+    expect(result.errorEvents).toHaveLength(1);
+
+    const payload = JSON.parse(result.errorEvents[0].payload);
+    expect(payload.fatal).toBe(true);
+    expect(payload.error).toContain('no heartbeat');
+  });
+
+  it('reaper marks stuck pending execution as failed and inserts error event', async () => {
+    const userId = 'user_reaper_2';
+    const sessionId = 'agent_reaper_2';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_stale_pending' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+      // Execution starts as 'pending' — leave it there.
+
+      // The pending timeout is 5 minutes by default. We need the execution's
+      // startedAt to be far enough in the past. Because addExecution uses
+      // Date.now() internally, we can't control it directly. Instead we
+      // manipulate the execution storage to backdate startedAt.
+      const executions =
+        await state.storage.get<
+          Array<{ executionId: string; startedAt: number; [k: string]: unknown }>
+        >('executions');
+      if (executions) {
+        const idx = executions.findIndex(e => e.executionId === excId);
+        if (idx !== -1) {
+          // 6 minutes ago — exceeds the 5-minute default pending timeout
+          executions[idx].startedAt = now - 6 * 60 * 1000;
+          await state.storage.put('executions', executions);
+        }
+      }
+
+      // Run the alarm (reaper)
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+
+      const eventQueries = createEventQueries(state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorEvents = events.filter(e => e.stream_event_type === 'error');
+
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { execution, errorEvents, activeExecId };
+    });
+
+    expect(result.execution?.status).toBe('failed');
+    expect(result.execution?.error).toContain('wrapper never connected');
+    expect(result.activeExecId).toBeNull();
+    expect(result.errorEvents).toHaveLength(1);
+
+    const payload = JSON.parse(result.errorEvents[0].payload);
+    expect(payload.fatal).toBe(true);
+    expect(payload.error).toContain('wrapper never connected');
+  });
+
+  it('reaper does NOT mark execution as failed when heartbeat is fresh', async () => {
+    const userId = 'user_reaper_3';
+    const sessionId = 'agent_reaper_3';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_fresh' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Set a recent heartbeat (10 seconds ago — well within 90s threshold)
+      await instance.updateExecutionHeartbeat(excId, now - 10_000);
+
+      // Run the alarm (reaper)
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+
+      const eventQueries = createEventQueries(state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorEvents = events.filter(e => e.stream_event_type === 'error');
+
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { execution, errorEvents, activeExecId };
+    });
+
+    expect(result.execution?.status).toBe('running');
+    expect(result.activeExecId).toBe('exc_fresh');
+    expect(result.errorEvents).toHaveLength(0);
+  });
+
+  it('reaper clears orphaned active execution ID', async () => {
+    const userId = 'user_reaper_4';
+    const sessionId = 'agent_reaper_4';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      // Write a dangling active execution ID directly into storage — the
+      // execution itself was never added, simulating an orphan.
+      await state.storage.put('active_execution_id', 'exc_orphan');
+
+      // Run the alarm (reaper)
+      await instance.alarm();
+
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { activeExecId };
+    });
+
+    expect(result.activeExecId).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 5: Dynamic alarm scheduling — 2-min interval when active, 5-min idle
+  // ---------------------------------------------------------------------------
+
+  it('alarm schedules 2-minute interval when an active execution exists', async () => {
+    const userId = 'user_alarm_1';
+    const sessionId = 'agent_alarm_1';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_active_alarm' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Fresh heartbeat so the reaper won't kill it
+      await instance.updateExecutionHeartbeat(excId, now - 5_000);
+
+      // Run the alarm
+      await instance.alarm();
+
+      // Read the scheduled alarm time
+      const nextAlarm = await state.storage.getAlarm();
+
+      return { nextAlarm, now };
+    });
+
+    // 2-minute active interval = 120_000 ms
+    expect(result.nextAlarm).toBeDefined();
+    const delta = (result.nextAlarm as number) - result.now;
+    // Allow ± 5s for clock drift inside the DO
+    expect(delta).toBeGreaterThanOrEqual(115_000);
+    expect(delta).toBeLessThanOrEqual(125_000);
+  });
+
+  it('alarm schedules 5-minute interval when no active execution exists', async () => {
+    const userId = 'user_alarm_2';
+    const sessionId = 'agent_alarm_2';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      // No active execution — just metadata
+
+      // Run the alarm
+      await instance.alarm();
+
+      const nextAlarm = await state.storage.getAlarm();
+
+      return { nextAlarm, now };
+    });
+
+    // 5-minute default interval = 300_000 ms
+    expect(result.nextAlarm).toBeDefined();
+    const delta = (result.nextAlarm as number) - result.now;
+    // Allow ± 5s for clock drift
+    expect(delta).toBeGreaterThanOrEqual(295_000);
+    expect(delta).toBeLessThanOrEqual(305_000);
+  });
+});

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { ExecutionId } from '../../../src/types/ids.js';
@@ -70,7 +71,8 @@ describe('Disconnect handling & reaper', () => {
       const execution = await instance.getExecution(excId);
 
       // Check events for synthetic error event
-      const eventQueries = createEventQueries(state.storage.sql);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 
@@ -138,7 +140,8 @@ describe('Disconnect handling & reaper', () => {
 
       const execution = await instance.getExecution(excId);
 
-      const eventQueries = createEventQueries(state.storage.sql);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 
@@ -195,7 +198,8 @@ describe('Disconnect handling & reaper', () => {
 
       const execution = await instance.getExecution(excId);
 
-      const eventQueries = createEventQueries(state.storage.sql);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 

--- a/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -471,6 +471,86 @@ describe('createLifecycleManager', () => {
   });
 
   // -------------------------------------------------------------------------
+  // reset
+  // -------------------------------------------------------------------------
+
+  describe('reset', () => {
+    it('reset clears aborted flag - allows complete event after reset', async () => {
+      const mgr = createManager();
+      state.startJob(createJobContext());
+      state.addInflight('msg_1', Date.now() + 60000);
+
+      mgr.setAborted();
+      mgr.reset();
+
+      (connectionManager.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const sendToIngestSpy = vi.fn();
+      state.setSendToIngestFn(sendToIngestSpy);
+
+      // Completing the last inflight triggers drain
+      mgr.onMessageComplete('msg_1');
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // complete event should be sent because isAborted was reset
+      expect(sendToIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streamEventType: 'complete',
+        })
+      );
+    });
+
+    it('reset clears draining flag - allows new drain after reset', async () => {
+      const mgr = createManager();
+      state.startJob(createJobContext());
+      (connectionManager.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      // First drain
+      mgr.triggerDrainAndClose();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(connectionManager.close).toHaveBeenCalledTimes(1);
+
+      // Reset clears isDraining so a second drain can happen
+      mgr.reset();
+
+      // Start a fresh job
+      state.clearJob();
+      state.startJob(createJobContext({ executionId: 'exc_second' }));
+      state.addInflight('msg_2', Date.now() + 60000);
+
+      // Completing last inflight triggers a new drain
+      mgr.onMessageComplete('msg_2');
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(connectionManager.close).toHaveBeenCalledTimes(2);
+    });
+
+    it('reset enables post-completion flow after previous abort', async () => {
+      const mgr = createManager({ autoCommit: false });
+      state.startJob(createJobContext());
+      state.addInflight('msg_1', Date.now() + 60000);
+
+      mgr.setAborted();
+      mgr.reset();
+
+      (connectionManager.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const sendToIngestSpy = vi.fn();
+      state.setSendToIngestFn(sendToIngestSpy);
+
+      mgr.onMessageComplete('msg_1');
+      mgr.signalCompletion();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // complete event should be sent (not skipped due to stale aborted flag)
+      expect(sendToIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streamEventType: 'complete',
+        })
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // signalCompletion
   // -------------------------------------------------------------------------
 

--- a/cloud-agent-next/test/unit/wrapper/state.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/state.test.ts
@@ -145,6 +145,18 @@ describe('WrapperState', () => {
 
         expect(state.currentJob?.executionId).toBe('exc_second');
       });
+
+      it('resets SSE activity tracking', () => {
+        state.startJob(createJobContext({ executionId: 'exc_first' }));
+        state.recordSseEvent();
+        expect(state.hasSseActivity()).toBe(true);
+
+        state.clearJob();
+        state.startJob(createJobContext({ executionId: 'exc_second' }));
+
+        expect(state.hasSseActivity()).toBe(false);
+        expect(state.getSseInactivityMs(Date.now())).toBeNull();
+      });
     });
 
     describe('clearJob', () => {

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -102,6 +102,10 @@ export function createLifecycleManager(
   let isDraining = false;
   let isAborted = false;
 
+  // Incremented on reset() so in-flight triggerDrainAndClose chains from
+  // a previous execution can detect they are stale and bail out.
+  let generation = 0;
+
   // Completion waiter for post-processing tasks (auto-commit, condense)
   let postProcessingResolve: (() => void) | null = null;
   let postProcessingCompleted = false;
@@ -377,6 +381,10 @@ export function createLifecycleManager(
     if (isDraining) return;
     isDraining = true;
 
+    // Capture generation so the async chain can detect if reset() was called
+    // (which starts a new execution) before it reaches the finally block.
+    const drainGeneration = generation;
+
     logToFile(`starting drain period (isAborted=${isAborted})`);
 
     // Run post-completion tasks first (auto-commit, condense), THEN send the complete event.
@@ -403,6 +411,14 @@ export function createLifecycleManager(
         }
       })
       .finally(() => {
+        // If reset() was called while post-completion tasks were running,
+        // a new execution has started — bail out to avoid sending a spurious
+        // complete event or tearing down the new execution's connection.
+        if (drainGeneration !== generation) {
+          logToFile('drain chain cancelled - lifecycle was reset');
+          return;
+        }
+
         // Send complete event to ingest so DO can update execution status and trigger callbacks
         // BUT only if not aborted - fatal errors already sent their own terminal event
         const job = state.currentJob;
@@ -492,6 +508,7 @@ export function createLifecycleManager(
     getMaxRuntimeMs: () => config.maxRuntimeMs,
 
     reset: () => {
+      generation++;
       isAborted = false;
       isDraining = false;
       postProcessingCompleted = false;

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -82,6 +82,8 @@ export type LifecycleManager = {
   signalCompletion: () => void;
   /** Set the aborted flag to prevent post-completion tasks from running */
   setAborted: () => void;
+  /** Reset lifecycle state for a new execution (clears isAborted, isDraining, etc.) */
+  reset: () => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -488,5 +490,16 @@ export function createLifecycleManager(
     },
 
     getMaxRuntimeMs: () => config.maxRuntimeMs,
+
+    reset: () => {
+      isAborted = false;
+      isDraining = false;
+      postProcessingCompleted = false;
+      postProcessingResolve = null;
+      if (drainTimeout) {
+        clearTimeout(drainTimeout);
+        drainTimeout = null;
+      }
+    },
   };
 }

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -240,6 +240,7 @@ async function main() {
       openConnection: () => connectionManager.open(),
       getMaxRuntimeMs: () => getLifecycleManager().getMaxRuntimeMs(),
       setAborted: () => getLifecycleManager().setAborted(),
+      resetLifecycle: () => getLifecycleManager().reset(),
     },
     () => getLifecycleManager().triggerDrainAndClose()
   );

--- a/cloud-agent-next/wrapper/src/server.ts
+++ b/cloud-agent-next/wrapper/src/server.ts
@@ -37,6 +37,8 @@ export type ServerDependencies = {
   getMaxRuntimeMs: () => number;
   /** Set the aborted flag to skip post-completion tasks */
   setAborted: () => void;
+  /** Reset lifecycle state for a new execution */
+  resetLifecycle: () => void;
 };
 
 // Request body types
@@ -228,6 +230,9 @@ function createStartJobHandler(deps: ServerDependencies, kiloClient: KiloClient)
       ingestToken: body.ingestToken,
       kilocodeToken: body.kilocodeToken,
     };
+
+    // Reset lifecycle state from previous execution (clears stale isAborted, isDraining, etc.)
+    deps.resetLifecycle();
 
     // Start the job (this stores context but doesn't connect yet)
     try {

--- a/cloud-agent-next/wrapper/src/state.ts
+++ b/cloud-agent-next/wrapper/src/state.ts
@@ -133,6 +133,7 @@ export class WrapperState {
     this.job = context;
     this._lastError = null;
     this.messageCounter = 0;
+    this.lastSseEventAt = 0;
     this.updateActivity();
   }
 

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -236,9 +236,8 @@ export type UpdateSessionOutput = {
 /** Result of interrupting a session */
 export type InterruptResult = {
   success: boolean;
-  killedProcessIds: string[];
-  failedProcessIds: string[];
   message: string;
+  processesFound: boolean;
 };
 
 export type AnswerQuestionInput = {

--- a/src/routers/cloud-agent-next-router.ts
+++ b/src/routers/cloud-agent-next-router.ts
@@ -173,9 +173,8 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .output(
       z.object({
         success: z.boolean(),
-        killedProcessIds: z.array(z.string()),
-        failedProcessIds: z.array(z.string()),
         message: z.string(),
+        processesFound: z.boolean(),
       })
     )
     .mutation(async ({ ctx, input }) => {

--- a/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -226,9 +226,8 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .output(
       z.object({
         success: z.boolean(),
-        killedProcessIds: z.array(z.string()),
-        failedProcessIds: z.array(z.string()),
         message: z.string(),
+        processesFound: z.boolean(),
       })
     )
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

- **Immediate disconnect detection**: When a wrapper WebSocket disconnects while an execution is active, the controller now marks the execution as `failed` immediately and emits a synthetic `wrapper_disconnected` event to notify `/stream` clients — instead of waiting for the reaper to discover the stale execution minutes later.
- **Reaper event emission**: When the reaper marks stale running or timed-out pending executions as failed, it now emits synthetic `error` events so `/stream` clients are notified of the failure.
- **Faster stale detection**: `STALE_THRESHOLD_MS` reduced from 10 minutes to 90 seconds (~3 missed heartbeats). Reaper alarm interval drops from 5 minutes to 2 minutes while an execution is active.
- **Lifecycle reset between executions**: The wrapper's lifecycle manager now resets `isAborted`, `isDraining`, and drain timeouts when a new job starts, preventing stale state from a previous execution from interfering.
- **SSE activity tracking reset**: `WrapperState.startJob` now resets `lastSseEventAt` so stale inactivity data from a prior execution doesn't carry over.
- **Interrupt handler cleanup**: When interrupt finds no running processes but there's still an active execution, it now clears the stale execution and emits an error event to `/stream` clients.
- **pkill fix**: Added `--` separator to `pkill -f` to prevent pattern misinterpretation.
- **Tests**: Added unit tests for ingest close return value, lifecycle reset, state SSE tracking reset, and an integration test for reaper disconnect handling.