### PR TITLE
chore: drizzle migration base (docs + coding-style rules)

### DIFF
--- a/.kilocode/rules/coding-style.md
+++ b/.kilocode/rules/coding-style.md
@@ -19,25 +19,6 @@
   a side effect. Where necessary refactor a dependency that really can't be tested indirectly into an explicit argument instead, and then pass a fake implementation if needed.
 - Keep functions simple: if an argument is merely used to splat in a bunch of options in a return value an the caller can do that equally well, KISS and don't add an argument. Every function argument has a small cost; add them only where they meaningfully simplify the caller somehow.
 
-# SQL Query Style (cloudflare-ai-attribution)
+# Durable Object SQLite
 
-When writing SQL queries in the cloudflare-ai-attribution worker using the table query interpolator objects:
-
-- NEVER use table aliases (e.g., `la`, `am`). Use the table interpolator object directly.
-- Use `${table_name.column_name}` to reference columns with their table prefix (translates to `"table_name"."column_name"`).
-- Use `${table_name.columns.column_name}` ONLY when you need the column name without the table prefix (translates to `"column_name"`).
-
-Example:
-
-```sql
--- GOOD: No aliases, direct table references
-SELECT ${lines_added.line_hash}, ${lines_added.line_number}
-FROM ${lines_added}
-INNER JOIN ${attributions_metadata} ON ${lines_added.attributions_metadata_id} = ${attributions_metadata.id}
-WHERE ${attributions_metadata.status} = 'accepted'
-
--- BAD: Using aliases
-SELECT la.line_hash, la.line_number
-FROM ${lines_added} la
-INNER JOIN ${attributions_metadata} am ON la.attributions_metadata_id = am.id
-```
+All Durable Object SQLite code uses `drizzle-orm/durable-sqlite`. Use Drizzle's query builder API for all queries. See `docs/do-sqlite-drizzle.md` for conventions.

--- a/docs/do-sqlite-drizzle.md
+++ b/docs/do-sqlite-drizzle.md
@@ -1,0 +1,47 @@
+# Drizzle ORM + Durable Object SQLite Migration Workflow
+
+## Schema location
+
+Each worker defines its schema in `src/db/sqlite-schema.ts` using `sqliteTable` from `drizzle-orm/sqlite-core`.
+
+## Configuration
+
+Each worker root contains a `drizzle.config.ts` that configures `drizzle-kit` with `dialect: "sqlite"` and `driver: "durable-sqlite"`. This tells drizzle-kit to generate migration SQL compatible with DO-embedded SQLite.
+
+## Adding a migration
+
+1. Edit `src/db/sqlite-schema.ts` in the relevant worker.
+2. From the worker directory, run:
+   ```
+   pnpm drizzle-kit generate
+   ```
+3. Commit the three generated/updated artifacts:
+   - The new `.sql` file in `drizzle/`
+   - The updated `drizzle/migrations.js` (barrel file)
+   - The updated snapshot in `drizzle/meta/`
+
+## How migrations run
+
+In each Durable Object constructor, `blockConcurrencyWhile` calls:
+
+```ts
+migrate(db, migrations);
+```
+
+This checks the `__drizzle_migrations` table in the DO's SQLite database and applies any pending SQL files in order. No migration runs twice; the table tracks what has already been applied.
+
+## Important caveat
+
+Each Durable Object instance has its own isolated SQLite database. Migrations apply **per-instance on first access after deploy** -- there is no centralized "run migrations" step. A migration only executes when a request routes to that specific DO instance for the first time post-deploy.
+
+## Workers using this pattern
+
+| Worker                            | Description                  |
+| --------------------------------- | ---------------------------- |
+| `cloud-agent`                     | Agent orchestration          |
+| `cloud-agent-next`                | Next-gen agent orchestration |
+| `cloudflare-ai-attribution`       | AI code attribution          |
+| `cloudflare-app-builder`          | App builder                  |
+| `cloudflare-o11y`                 | Observability                |
+| `cloudflare-session-ingest`       | Session ingestion            |
+| `cloudflare-webhook-agent-ingest` | Webhook agent ingestion      |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ catalog:
   '@octokit/auth-app': ^8.1.2
   '@types/jsonwebtoken': ^9.0.10
   aws4fetch: ^1.0.20
+  drizzle-kit: ^0.31.9
   drizzle-orm: ^0.45.1
   eslint: ^9.39.3
   hono: ^4.12.1


### PR DESCRIPTION
## Summary
- Adds `docs/do-sqlite-drizzle.md` — ongoing reference for the Drizzle + DO SQLite pattern
- Updates `.kilocode/rules/coding-style.md` — replaces ai-attribution table interpolator rules with Drizzle convention

Foundation for per-worker Drizzle migration PRs.