### PR TITLE
CloudAgentNext - Update container image to 0.7.5 to match SDK version

### DIFF
--- a/cloud-agent-next/Dockerfile
+++ b/cloud-agent-next/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.6.7
+FROM docker.io/cloudflare/sandbox:0.7.5
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""

--- a/cloud-agent-next/Dockerfile.dev
+++ b/cloud-agent-next/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.6.7
+FROM docker.io/cloudflare/sandbox:0.7.5
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""

--- a/cloud-agent-next/README.md
+++ b/cloud-agent-next/README.md
@@ -36,7 +36,7 @@ By default, the script looks for kilo-cli at `$HOME/projects/kilo-cli`. Override
 
 **What's in Dockerfile.dev:**
 
-- Base image: `cloudflare/sandbox:0.6.7`
+- Base image: `cloudflare/sandbox:0.7.5`
 - Pre-built `kilo` binary (from `cloud-agent-build.sh`)
 - GitHub CLI (`gh`) and GitLab CLI (`glab`)
 - Wrapper bundle built inside the container


### PR DESCRIPTION
## Summary

- Update `cloudflare/sandbox` container base image from `0.6.7` to `0.7.5` in `cloud-agent-next/Dockerfile` and `cloud-agent-next/Dockerfile.dev`
- Update README to reflect the new base image version

Fixes the runtime warning: "Version mismatch detected! SDK version (0.7.5) does not match container version (0.6.7)."