### PR TITLE
feat: add llm-gateway worker and @kilocode/llm-shared package

### DIFF
--- a/docs/llm-gateway-phase2-plan.md
+++ b/docs/llm-gateway-phase2-plan.md
@@ -1,0 +1,384 @@
+# llm-gateway Worker — Phase 2 Plan (Stub Completion)
+
+PR #724 landed the `@kilocode/llm-shared` package and the `llm-gateway` worker scaffold
+with the full 17-step request flow wired up. Several services were stubbed. This document
+covers everything needed to reach feature parity with the Next.js route.
+
+---
+
+## Phase A: Usage Accounting
+
+**Stub**: `llm-gateway/src/background/usage-accounting.ts` — currently a no-op.
+
+Port `countAndStoreUsage` from `src/lib/processUsage.ts`. This is the largest piece of
+work because it touches many tables and external services.
+
+### Steps
+
+1. **Parse usage from response** — use `eventsource-parser` to walk SSE events from the
+   cloned response. Extract `usage` (token counts, cost), `model`, `messageId`,
+   `provider`, `finish_reason`, and aggregate `responseContent`. For non-streaming
+   responses, parse the full JSON body.
+
+2. **Fetch authoritative cost from OpenRouter** — call the `/generation` endpoint
+   (`fetchGeneration` in `src/lib/providers/index.ts:336`) to reconcile cost data. The
+   worker makes this as a plain `fetch()` with the OpenRouter API key.
+
+3. **Report cost to abuse service** — fire-and-forget `POST /api/usage/cost` with
+   `request_id`, `message_id`, `cost`, and token counts. Shares the abuse service client
+   from Phase B.
+
+4. **Zero-cost logic** — zero out cost for free models, BYOK users, and active promotions
+   (review promo, cloud agent promo). This logic already exists in `@kilocode/llm-shared`.
+
+5. **Insert usage record** — port `insertUsageAndMetadataWithBalanceUpdate`
+   (`src/lib/processUsage.ts:483–644`), a single SQL CTE that atomically:
+   - Inserts into `microdollar_usage`.
+   - Upserts 9 normalized lookup tables (`http_user_agent`, `http_ip`,
+     `vercel_ip_country`, `vercel_ip_city`, `ja4_digest`, `system_prompt_prefix`,
+     `finish_reason`, `editor_name`, `feature`).
+   - Inserts into `microdollar_usage_metadata`.
+   - Updates `kilocode_users.microdollars_used` (for non-org, positive-cost usage).
+   - Returns new balance and `kilo_pass_threshold`.
+
+6. **Organization token usage** — port `ingestOrganizationTokenUsage`
+   (`src/lib/organizations/organization-usage.ts:209`). Within a transaction:
+   - Increment `organizations.microdollars_used`, decrement
+     `organizations.microdollars_balance`.
+   - Upsert `organization_user_usage` (per-user daily tracking).
+   - Check `minimum_balance` threshold → fire alert email if crossed.
+
+7. **Kilo Pass threshold check** — if `insertUsageAndMetadataWithBalanceUpdate` returns a
+   crossed threshold, fire `maybeIssueKiloPassBonusFromUsageThreshold`
+   (`src/lib/kilo-pass/usage-triggered-bonus.ts:296`) in `ctx.waitUntil()`.
+
+8. **PostHog events** — `posthog-node` is not Workers-compatible. Use the PostHog HTTP
+   Capture API directly (`POST https://us.i.posthog.com/capture/`) for `first_usage` and
+   `first_microdollar_usage` events. Add `POSTHOG_API_KEY` to wrangler.jsonc secrets.
+
+### New dependencies
+
+- `eventsource-parser` (already used in the Next.js app)
+
+### DB tables written
+
+`microdollar_usage`, `microdollar_usage_metadata`, 9 lookup tables, `kilocode_users`,
+`organizations`, `organization_user_usage`, `kilo_pass_*` tables (via threshold bonus).
+
+---
+
+## Phase B: Abuse Classification
+
+**Stub**: `llm-gateway/src/services/abuse.ts` — returns `null` (fail-open).
+
+Port the HTTP call to the abuse service from `src/lib/abuse-service.ts`.
+
+### Steps
+
+1. **Classify request** — `POST ${ABUSE_SERVICE_URL}/api/classify` with:
+   - CF Access headers (`CF-Access-Client-Id`, `CF-Access-Client-Secret`)
+   - Payload: identity fields (`kilo_user_id`, `organization_id`, `project_id`), network
+     fingerprints (`ip_address`, geo fields, `ja4_digest`, `user_agent`), model info
+     (`provider`, `requested_model`), full prompts (`user_prompt`, `system_prompt`),
+     request metadata (`max_tokens`, `has_tools`, `streamed`, `is_user_byok`,
+     `editor_name`).
+
+2. **Response handling** — parse `AbuseClassificationResponse` (`verdict`, `risk_score`,
+   `signals`, `action_metadata`, `context`, `request_id`). Attach `request_id` to usage
+   context.
+
+3. **Report cost** — `POST ${ABUSE_SERVICE_URL}/api/usage/cost` (also called from
+   Phase A). Same CF Access headers. Payload: `request_id`, `message_id`, `cost`,
+   token counts.
+
+4. **Fail-open** — on timeout (2s) or error, return `null` so the request proceeds.
+
+### New wrangler.jsonc secrets
+
+```jsonc
+{
+  "binding": "ABUSE_SERVICE_URL",
+  "secret_name": "ABUSE_SERVICE_URL",
+  "store_id": "342a86d9e3a94da698e82d0c6e2a36f0"
+},
+{
+  "binding": "ABUSE_SERVICE_CF_ACCESS_CLIENT_ID",
+  "secret_name": "ABUSE_SERVICE_CF_ACCESS_CLIENT_ID",
+  "store_id": "342a86d9e3a94da698e82d0c6e2a36f0"
+},
+{
+  "binding": "ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET",
+  "secret_name": "ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET",
+  "store_id": "342a86d9e3a94da698e82d0c6e2a36f0"
+}
+```
+
+---
+
+## Phase C: Response Transforms
+
+**Missing**: neither `rewriteFreeModelResponse` nor `makeErrorReadable` exist in the
+worker.
+
+### C1: `rewriteFreeModelResponse`
+
+Port from `src/lib/rewriteModelResponse.ts:35–123`. Applied to free models, review promos,
+and cloud agent promos (when provider is not `custom`).
+
+**JSON responses**: replace `response.model` with the requested model ID, convert
+`reasoning_content` to `reasoning` + `reasoning_details` (OpenRouter format), strip
+`cost`/`cost_details`/`is_byok` from usage.
+
+**SSE streams**: create a `TransformStream` that rewrites each SSE event:
+
+- Replace `model` with requested model ID.
+- Delete `delta.role` if null.
+- Convert reasoning format.
+- Ensure `choices` array is always present.
+- Strip cost info from usage chunks.
+- Pass through SSE comments as `: KILO PROCESSING\n\n`.
+- Append `data: [DONE]\n\n` at end.
+
+### C2: `makeErrorReadable`
+
+Port from `src/lib/llm-proxy-helpers.ts:131–174`. Applied to all error responses
+(status >= 400) before returning to the client.
+
+- **BYOK errors**: map 401 → invalid key, 402 → insufficient funds, 403 → bad
+  permissions, 429 → rate limit.
+- **Context length exceeded**: for Kilo free models, estimate tokens and compare against
+  model's `context_length`. Return a clear message.
+- **Stealth model errors**: for `isKiloStealthModel`, return a generic error hiding the
+  model identity.
+
+### Integration point
+
+Both transforms are applied in `routes/chat-completions.ts` step 17, between receiving the
+upstream response and returning to the client. `makeErrorReadable` runs first (on errors),
+then `rewriteFreeModelResponse` (on success for free/promo models).
+
+---
+
+## Phase D: BYOK Provider Lookup + KV Cache
+
+**Missing**: `getProvider` always returns `userByok: null`. The `BYOK_CACHE` KV binding is
+declared but unused.
+
+### Steps
+
+1. **Port BYOK lookup queries** — `getBYOKforUser` and `getBYOKforOrganization` from
+   `src/lib/byok/index.ts`. Query `byok_api_keys` table for enabled keys matching the
+   user/org and provider ID.
+
+2. **Port `decryptApiKey`** — from `src/lib/byok/encryption.ts`. AES-256-GCM decryption.
+   Workers support `crypto.subtle` for AES-GCM; port from Node.js `crypto` module to
+   Web Crypto API (`crypto.subtle.decrypt`).
+
+3. **Port `getModelUserByokProviders`** — query `models_by_provider` table for Vercel
+   model metadata, filter through `VercelUserByokInferenceProviderIdSchema`.
+
+4. **KV caching** — replace `unstable_cache` with `BYOK_CACHE` KV binding:
+   - Key: `byok-providers:${modelId}` (for provider ID lookups, 5-min TTL).
+   - Key: `byok-keys:${userId}:${providerId}` or
+     `byok-keys:org:${orgId}:${providerId}` (for decrypted keys, 5-min TTL).
+   - On cache miss, query Hyperdrive and write to KV.
+
+5. **Wire into `getProvider`** — if BYOK keys are found, route to
+   `PROVIDERS.VERCEL_AI_GATEWAY` and set `userByok` on the result.
+
+### New wrangler.jsonc secret
+
+```jsonc
+{
+  "binding": "BYOK_ENCRYPTION_KEY",
+  "secret_name": "BYOK_ENCRYPTION_KEY",
+  "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+}
+```
+
+### KV namespace
+
+Create the `BYOK_CACHE` KV namespace and update the `id` in `wrangler.jsonc` (currently
+`<to-be-created>`).
+
+---
+
+## Phase E: Vercel AI Gateway Routing
+
+**Missing**: `shouldRouteToVercel` was not extracted into `@kilocode/llm-shared` and is not
+called in the worker.
+
+### Steps
+
+1. **Extract `shouldRouteToVercel`** into `@kilocode/llm-shared` — from
+   `src/lib/providers/vercel/index.ts:53–92`. The function is mostly pure logic
+   (preferred model list, anthropic exclusion, data_collection check). The only
+   impure dependency is `getGatewayErrorRate`.
+
+2. **Port `getGatewayErrorRate`** — query `microdollar_usage_view` via Hyperdrive for
+   error rates of `openrouter` and `vercel` over the last 10 minutes. Cache in KV with
+   60s TTL (replacing `unstable_cache`). Key: `gateway-error-rate`.
+
+3. **Wire into `getProvider`** — after checking BYOK and custom LLM, call
+   `shouldRouteToVercel` to decide whether to use `PROVIDERS.VERCEL_AI_GATEWAY`.
+
+4. **Add Vercel AI Gateway API key** to wrangler.jsonc secrets if not already present.
+
+---
+
+## Phase F: Custom LLM (AI SDK)
+
+**Stub**: `llm-gateway/src/services/custom-llm.ts` — returns HTTP 501.
+
+Port `customLlmRequest` from `src/lib/custom-llm/customLlmRequest.ts`.
+
+### Steps
+
+1. **Message conversion** — port `convertMessages` (OpenRouter format → AI SDK
+   `ModelMessage[]`). Handles system/user/assistant/tool roles, reasoning details
+   (encrypted/text), tool calls, image/file/audio parts.
+
+2. **Tool conversion** — port `convertTools` using AI SDK `jsonSchema`.
+
+3. **Model creation** — port `createModel`: pick `createAnthropic` or `createOpenAI`
+   based on `customLlm.provider`, using the custom LLM's `api_key` and `base_url`.
+   For OpenAI with native base URL, patch fetch to inject `phase` params from
+   `temp_phase` DB table (Hyperdrive query).
+
+4. **Common params** — port `buildCommonParams`: provider options including
+   `anthropic.thinking`, `verbosity`, `reasoningEffort`, `disableParallelToolUse`,
+   `openai.forceReasoning`, `promptCacheKey`, `safetyIdentifier`.
+
+5. **Non-streaming** — call `generateText`, convert result to OpenRouter-compatible JSON
+   via `convertGenerateResultToResponse`, return `Response.json(...)`.
+
+6. **Streaming** — call `streamText` with `includeRawChunks: true`, iterate
+   `result.fullStream`, convert each `TextStreamPart` to an OpenRouter-format
+   `ChatCompletionChunk` via `createStreamPartConverter`. Handle `text-delta`,
+   `reasoning-start/delta/end`, `tool-input-start/delta`, `tool-call`, `finish-step`.
+   Emit SSE `data: {...}\n\n` format. Return `new Response(stream, { headers })`.
+
+7. **`NextResponse` → `Response`** — 3 `.json()` calls and 1 streaming `new Response()`.
+
+### DB tables read
+
+`custom_llm`, `temp_phase`.
+
+### Key differences from Next.js
+
+The AI SDK uses standard `fetch` internally and is documented as edge-compatible. The main
+risk is `temp_phase` DB access — route through Hyperdrive.
+
+---
+
+## Phase G: Organization Balance + Usage Limit Response
+
+**Stub**: `llm-gateway/src/services/balance.ts` — returns `{ balance: Infinity }` for org
+users. The 402 response uses a hardcoded message.
+
+### Steps
+
+1. **Port `getBalanceForOrganizationUser`** — from
+   `src/lib/organizations/organization-usage.ts:52`. Joins `organizations` →
+   `organization_memberships` → `organization_user_limits` → `organization_user_usage`.
+   Computes org balance from `total_microdollars_acquired - microdollars_used`, applies
+   credit expiration (`processOrganizationExpirations`), applies per-user daily caps.
+
+2. **Port org settings** — return `settings.model_allow_list`,
+   `settings.provider_allow_list`, `settings.data_collection` from the `organizations`
+   row. These are already consumed in `checkOrganizationModelRestrictions` (shared
+   package).
+
+3. **Port `usageLimitExceededResponse`** — from `src/lib/llm-proxy-helpers.ts:67–88`.
+   Query `credit_transactions` via `summarizeUserPayments` to determine if the user has
+   ever paid. Show different messages for first-time vs returning users.
+
+### DB tables read
+
+`organizations`, `organization_memberships`, `organization_user_limits`,
+`organization_user_usage`, `credit_transactions`, `kilo_pass_issuance_items`.
+
+---
+
+## Phase H: Request Logging
+
+**Stub**: `llm-gateway/src/background/request-log.ts` — no-op.
+
+Port `handleRequestLogging` from `src/lib/handleRequestLogging.ts:8–46`.
+
+### Steps
+
+1. Check if user is a Kilo employee (email ends in `@kilo.ai` or `@kilocode.ai`, or is in
+   the Kilo organization).
+2. If yes, insert into `api_request_log` table with: `kilo_user_id`, `organization_id`,
+   `status_code`, `model`, `provider`, full request JSON, full response text.
+3. Run in `ctx.waitUntil()` (already wired up in the handler).
+
+### DB table written
+
+`api_request_log`.
+
+---
+
+## Phase I: Tests
+
+**Missing**: zero test files exist. `vitest.config.ts` is present but
+`@cloudflare/vitest-pool-workers` is not in devDependencies.
+
+### Steps
+
+1. **Add `@cloudflare/vitest-pool-workers`** to `llm-gateway/package.json`
+   devDependencies. Update `vitest.config.ts` to use the Workers pool.
+
+2. **Unit tests** (pure logic, no bindings):
+   - Auth: JWT validation with valid/invalid/expired tokens, pepper mismatch, blocked
+     users.
+   - Provider selection: each provider type (OpenRouter, Vercel, BYOK, custom LLM, free
+     model gateway).
+   - Rate limit: threshold checks, promotion limits.
+   - Request body mutations: `stream_options` injection, tool repair, provider-specific
+     logic.
+   - Response rewriting: `rewriteFreeModelResponse` (JSON + SSE), `makeErrorReadable`
+     (BYOK errors, context length, stealth).
+   - Abuse classification: payload construction, fail-open on timeout.
+
+3. **Integration tests** (`@cloudflare/vitest-pool-workers`):
+   - Full handler tests with mocked upstream providers.
+   - Hyperdrive PG integration with test database.
+   - KV cache read/write for BYOK.
+   - `ctx.waitUntil()` background task execution and verification.
+   - Custom LLM with mocked AI SDK providers.
+
+---
+
+## New wrangler.jsonc Secrets (All Phases)
+
+| Binding                                 | Secret Name                             | Phase |
+| --------------------------------------- | --------------------------------------- | ----- |
+| `BYOK_ENCRYPTION_KEY`                   | `BYOK_ENCRYPTION_KEY`                   | D     |
+| `ABUSE_SERVICE_URL`                     | `ABUSE_SERVICE_URL`                     | B     |
+| `ABUSE_SERVICE_CF_ACCESS_CLIENT_ID`     | `ABUSE_SERVICE_CF_ACCESS_CLIENT_ID`     | B     |
+| `ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET` | `ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET` | B     |
+| `POSTHOG_API_KEY`                       | `POSTHOG_API_KEY`                       | A     |
+| `O11Y_SERVICE_URL`                      | `O11Y_SERVICE_URL`                      | A     |
+| `O11Y_CLIENT_SECRET`                    | `O11Y_CLIENT_SECRET`                    | A     |
+
+All use the existing secrets store (`342a86d9e3a94da698e82d0c6e2a36f0`).
+
+---
+
+## Suggested Order
+
+Phases are mostly independent, but some share code:
+
+1. **B** (Abuse) — unblocks the abuse client used by both classification and cost
+   reporting.
+2. **C** (Response Transforms) — no dependencies, high user-facing impact.
+3. **D** (BYOK) — unblocks paying BYOK users.
+4. **E** (Vercel Routing) — depends on D for BYOK context.
+5. **G** (Org Balance) — unblocks org users hitting the `Infinity` balance stub.
+6. **A** (Usage Accounting) — depends on B (cost reporting) and benefits from G (org
+   usage). Largest scope.
+7. **F** (Custom LLM) — self-contained, can be done in parallel with A.
+8. **H** (Request Logging) — smallest scope, no dependencies.
+9. **I** (Tests) — ongoing, but a dedicated pass after all stubs are ported.

--- a/docs/llm-gateway-plan.md
+++ b/docs/llm-gateway-plan.md
@@ -1,0 +1,405 @@
+# llm-gateway Worker — Implementation Plan
+
+## Overview
+
+Move the LLM proxy route (`src/app/api/openrouter/[...path]/route.ts`) from a Next.js
+Vercel serverless function to a Cloudflare Worker called `llm-gateway`. The worker
+exposes the same paths (`/api/gateway/chat/completions`, `/api/openrouter/chat/completions`),
+the same auth, and the same request/response contracts — clients never notice the change.
+
+### Why
+
+- **Performance**: eliminate cold starts, run on Cloudflare's edge with smart placement
+  near the database. Workers have 6-hour wall time vs Vercel's 800s limit.
+- **Cost**: Workers pricing is more favorable for high-volume streaming requests.
+- **Ownership**: the hottest path in the product lives in its own deployable unit with its
+  own CI, scaling, and observability.
+
+---
+
+## Architecture
+
+```
+Client (extension)
+  │
+  ▼
+llm-gateway (CF Worker)          ← NEW
+  ├─ Hyperdrive ──► PostgreSQL
+  ├─ KV (BYOK cache)
+  ├─ fetch() ──► upstream LLM provider (OpenRouter / Vercel AI Gateway / Mistral / etc.)
+  ├─ fetch() ──► abuse-service
+  ├─ fetch() ──► o11y service
+  └─ ctx.waitUntil() background:
+       ├─ usage accounting (PG write + generation fetch + PostHog)
+       ├─ API metrics (o11y POST)
+       ├─ error capture (Sentry)
+       └─ request logging (PG write, Kilo employees only)
+```
+
+---
+
+## Key Design Decisions
+
+| Decision              | Choice                                                  | Rationale                                                                                |
+| --------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Shared pure functions | New `@kilocode/llm-shared` package                      | Clean separation; both Next.js route and worker import from one source of truth          |
+| Worker route paths    | Same as Next.js (`/api/gateway/…`, `/api/openrouter/…`) | Seamless cutover; clients don't change                                                   |
+| BYOK provider cache   | KV binding                                              | Durable across Worker restarts, globally distributed                                     |
+| Sentry                | Day 1, via `@sentry/cloudflare`                         | Critical hot path needs observability from the start                                     |
+| Custom LLM (AI SDK)   | Included in initial implementation                      | Full feature parity from day 1                                                           |
+| Response builders     | Worker uses plain `Response`                            | Re-implement response helpers in the worker; Next.js route keeps `NextResponse` versions |
+| `after()` equivalent  | `ctx.waitUntil()`                                       | Direct equivalent; already used in other workers                                         |
+
+---
+
+## Phase 1: Create `@kilocode/llm-shared` Package
+
+**New directory**: `packages/llm-shared/`
+
+Extract pure, runtime-agnostic functions so both the Next.js route and the worker import
+from one source of truth. These functions have no `db` imports and no Next.js API usage.
+
+### What moves here
+
+| Source File                               | Exports                                                                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/models.ts`                       | `isFreeModel`, `isKiloFreeModel`, `isDeadFreeModel`, `isDataCollectionRequiredOnKiloCodeOnly`                              |
+| `src/lib/rate-limited-models.ts`          | `isRateLimitedToDeath`                                                                                                     |
+| `src/lib/kilo-auto-model.ts`              | `isKiloAutoModel`, `resolveAutoModel`                                                                                      |
+| `src/lib/model-utils.ts`                  | `normalizeModelId`                                                                                                         |
+| `src/lib/providerHash.ts`                 | `generateProviderSpecificHash`                                                                                             |
+| `src/lib/feature-detection.ts`            | `validateFeatureHeader`, `FEATURE_HEADER`                                                                                  |
+| `src/lib/tool-calling.ts`                 | `repairTools`, `ENABLE_TOOL_REPAIR`, `normalizeToolCallIds`, `dropToolStrictProperties`                                    |
+| `src/lib/processUsage.ts`                 | `extractPromptInfo`, `MicrodollarUsageContext` type                                                                        |
+| `src/lib/providers/openrouter/types.ts`   | `OpenRouterChatCompletionRequest`, `isFreePromptTrainingAllowed`                                                           |
+| `src/lib/anonymous.ts`                    | `AnonymousUserContext`, `createAnonymousContext`, `isAnonymousContext`, `getAnonymousUserId`                               |
+| `src/lib/llm-proxy-helpers.ts`            | `estimateChatTokens`, `extractFraudAndProjectHeaders`, `extractHeaderAndLimitLength`, `checkOrganizationModelRestrictions` |
+| `src/lib/o11y/api-metrics.server.ts`      | `getToolsAvailable`, `getToolsUsed`                                                                                        |
+| `src/lib/providers/index.ts`              | `PROVIDERS` object, `applyProviderSpecificLogic`, `shouldRouteToVercel`                                                    |
+| `src/lib/code-reviews/core/constants.ts`  | `isActiveReviewPromo`                                                                                                      |
+| `src/lib/promotions/cloud-agent-promo.ts` | `isActiveCloudAgentPromo`                                                                                                  |
+| `src/lib/constants.ts`                    | `PROMOTION_MAX_REQUESTS`, `PROMOTION_WINDOW_HOURS`                                                                         |
+
+### What does NOT move
+
+Response builders that return `NextResponse` stay in `src/lib/`. The worker will have its
+own plain `Response` equivalents in `src/responses.ts`.
+
+### Migration step
+
+Update the Next.js route to import from `@kilocode/llm-shared` instead of `src/lib/` for
+every extracted function. Run the full test suite to verify nothing breaks.
+
+---
+
+## Phase 2: Worker Scaffold
+
+**New directory**: `llm-gateway/`
+
+```
+llm-gateway/
+├── wrangler.jsonc
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── src/
+│   ├── index.ts                    # Hono app, Sentry.withSentry() wrapper
+│   ├── types.ts                    # Env bindings type
+│   ├── logger.ts                   # workers-tagged-logger setup
+│   ├── responses.ts                # Plain Response error builders
+│   ├── routes/
+│   │   └── chat-completions.ts     # POST handler
+│   ├── services/
+│   │   ├── auth.ts                 # JWT validation (Authorization header only)
+│   │   ├── provider.ts             # Provider selection (BYOK, custom LLM, etc.)
+│   │   ├── balance.ts              # Balance / org settings queries
+│   │   ├── rate-limit.ts           # Free model IP rate limiting + promotion limits
+│   │   ├── upstream.ts             # fetch to upstream LLM provider
+│   │   ├── custom-llm.ts           # AI SDK direct provider calls
+│   │   └── abuse.ts                # classifyAbuse HTTP call
+│   ├── background/                 # All ctx.waitUntil() work
+│   │   ├── usage-accounting.ts     # countAndStoreUsage → PG + generation fetch
+│   │   ├── metrics.ts              # POST to o11y service
+│   │   ├── error-capture.ts        # Sentry captureMessage for proxy errors
+│   │   └── request-log.ts          # api_request_log insert (Kilo employees only)
+│   └── lib/
+│       └── db.ts                   # getWorkerDb wrapper
+```
+
+### wrangler.jsonc
+
+```jsonc
+{
+  "name": "llm-gateway",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-02-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "placement": { "mode": "smart" },
+  "observability": { "enabled": true },
+  "upload_source_maps": true,
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "624ec80650dd414199349f4e217ddb10",
+      "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "BYOK_CACHE",
+      "id": "<to-be-created>",
+    },
+  ],
+  "secrets_store_secrets": [
+    {
+      "binding": "NEXTAUTH_SECRET",
+      "secret_name": "NEXTAUTH_SECRET",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "OPENROUTER_API_KEY",
+      "secret_name": "OPENROUTER_API_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "SENTRY_DSN",
+      "secret_name": "LLM_GATEWAY_SENTRY_DSN",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+  ],
+  "vars": {
+    "ENVIRONMENT": "production",
+  },
+}
+```
+
+### package.json dependencies
+
+```json
+{
+  "dependencies": {
+    "hono": "catalog:",
+    "zod": "catalog:",
+    "drizzle-orm": "catalog:",
+    "pg": "catalog:",
+    "@kilocode/worker-utils": "workspace:*",
+    "@kilocode/db": "workspace:*",
+    "@kilocode/llm-shared": "workspace:*",
+    "@sentry/cloudflare": "^10.25.0",
+    "workers-tagged-logger": "catalog:",
+    "jsonwebtoken": "catalog:",
+    "ai": "catalog:",
+    "@ai-sdk/anthropic": "catalog:",
+    "@ai-sdk/openai": "catalog:"
+  },
+  "devDependencies": {
+    "wrangler": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "@cloudflare/vitest-pool-workers": "catalog:",
+    "@cloudflare/workers-types": "catalog:"
+  }
+}
+```
+
+---
+
+## Phase 3: Core Handler Implementation
+
+The handler in `routes/chat-completions.ts` follows the exact same sequence as the
+existing route. Each numbered step maps 1:1 to the Next.js implementation.
+
+### Request flow
+
+1. **Parse & validate** request body — same JSON parse, `stream_options.include_usage`
+   injection, `models` field deletion, model string validation.
+
+2. **Auto-model resolution** — `isKiloAutoModel` → `resolveAutoModel` with
+   `x-kilocode-mode` header.
+
+3. **IP extraction** — use `CF-Connecting-IP` (more reliable than `X-Forwarded-For` in
+   CF Workers). Fall back to `X-Forwarded-For` for compatibility.
+
+4. **Free model rate limit** — PG query against `free_model_usage` table via Hyperdrive.
+   Return 429 if exceeded.
+
+5. **Auth** — JWT validation only (no NextAuth cookie/session path). Verify HS256 JWT
+   signed with `NEXTAUTH_SECRET`, look up user in `kilocode_users` via Hyperdrive.
+   Validate `api_token_pepper`, check blacklist/blocked status, check org membership.
+
+6. **Anonymous fallback** — if auth fails and model is free,
+   `createAnonymousContext(ipAddress)`. Check promotion limit for anonymous users.
+
+7. **Free model request logging** — PG insert into `free_model_usage`.
+
+8. **Provider selection** — port `getProvider` logic. BYOK lookups use Hyperdrive + KV
+   cache (TTL-based). Custom LLM lookup via Hyperdrive.
+
+9. **Abuse classification** — non-blocking HTTP call to abuse service, raced with 2s
+   timeout. Fail-open.
+
+10. **Max tokens check** — reject if `max_tokens > 99999999999`.
+
+11. **Dead/rate-limited model check** — return early if model is dead or rate-limited.
+
+12. **Balance/org checks** — PG query via Hyperdrive. Check org model/provider
+    restrictions.
+
+13. **Provider-specific mutations** — `applyProviderSpecificLogic` (from
+    `@kilocode/llm-shared`).
+
+14. **Tool repair** — `repairTools` (from `@kilocode/llm-shared`).
+
+15. **Prompt cache key + safety identifier** — `generateProviderSpecificHash`.
+
+16. **Upstream request** — standard `fetch()` to the provider URL.
+
+17. **Response processing**:
+    - `ctx.waitUntil()`: usage accounting, API metrics, error capture, request logging
+    - Blocking: error readability transform, free model response rewriting
+    - Return response to client
+
+### Key differences from Next.js version
+
+| Next.js                             | Worker                                                       |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `after(promise)`                    | `c.executionCtx.waitUntil(promise)`                          |
+| `NextResponse`                      | `Response`                                                   |
+| `headers()` from `next/headers`     | `c.req.header()` (Hono)                                      |
+| `db` singleton from `@/lib/drizzle` | `getWorkerDb(c.env.HYPERDRIVE.connectionString)` per-request |
+| `@sentry/nextjs`                    | `@sentry/cloudflare`                                         |
+| `unstable_cache`                    | KV binding                                                   |
+| `getUserFromAuth` (cookie + JWT)    | JWT-only auth                                                |
+| `X-Forwarded-For` for IP            | `CF-Connecting-IP` (fallback: `X-Forwarded-For`)             |
+| `getServerSession(authOptions)`     | Not needed — API clients use Bearer tokens                   |
+
+---
+
+## Phase 4: Custom LLM Support
+
+Port `src/lib/custom-llm/customLlmRequest.ts` into `services/custom-llm.ts`.
+
+Changes required:
+
+- `NextResponse.json(...)` → `Response.json(...)` (3 occurrences)
+- `new NextResponse(stream, ...)` → `new Response(stream, ...)`
+- The `temp_phase` DB lookup routes through Hyperdrive instead of the `db` singleton
+- The AI SDK (`streamText`, `generateText`, `createAnthropic`, `createOpenAI`) uses
+  standard `fetch` internally and is edge-compatible
+
+---
+
+## Phase 5: Observability
+
+### Sentry
+
+Follow the `cloudflare-deploy-infra/builder/` pattern:
+
+```ts
+// src/index.ts
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    release: env.CF_VERSION_METADATA.id,
+    environment: env.ENVIRONMENT || 'production',
+  }),
+  app
+);
+```
+
+Post-deploy script uploads sourcemaps via `@sentry/cli`.
+
+### Structured logging
+
+```ts
+// src/logger.ts
+import { WorkersLogger } from 'workers-tagged-logger';
+
+export type LlmGatewayTags = {
+  userId?: string;
+  organizationId?: string;
+  model?: string;
+  provider?: string;
+  requestId?: string;
+};
+
+export const logger = new WorkersLogger<LlmGatewayTags>({ minimumLogLevel: 'debug' });
+export { withLogTags } from 'workers-tagged-logger';
+```
+
+### API metrics
+
+Same POST to o11y service (`/ingest/api-metrics`) via `ctx.waitUntil()`. Identical
+payload shape.
+
+---
+
+## Phase 6: Testing
+
+### Unit tests (Vitest)
+
+- Auth JWT validation with valid/invalid/expired tokens
+- Provider selection logic for each provider type (OpenRouter, Vercel, BYOK, custom)
+- Rate limit threshold checks
+- Request body mutations (stream_options injection, tool repair, etc.)
+- Response rewriting (free model response, error readability)
+
+### Integration tests (`@cloudflare/vitest-pool-workers`)
+
+- Full handler tests with mocked upstream providers
+- Hyperdrive PG integration with test database
+- KV cache read/write for BYOK
+- `ctx.waitUntil()` background task execution
+
+### Comparison tests
+
+- Send identical requests to both Next.js route and Worker
+- Diff response status, headers, and body (byte-level for streaming)
+- Verify usage records appear identically in the database
+- Verify metrics reach the o11y service
+
+---
+
+## Phase 7: Deployment & Traffic Cutover
+
+### Step 1 — Deploy to staging
+
+Deploy the worker. Verify it works end-to-end against the staging database.
+
+### Step 2 — Shadow mode
+
+Update the Next.js route to also forward a clone of the request to the worker (fire-and-
+forget via `after()`). Log and compare responses for correctness validation. Do not
+serve the worker's response to the client yet.
+
+### Step 3 — Gradual rollout
+
+Route increasing traffic percentages to the worker. Options:
+
+- Cloudflare Workers route on the domain with percentage-based splitting
+- Client-side feature flag (extension sends requests to the worker URL)
+- Header-based routing in a Cloudflare rule
+
+### Step 4 — Full cutover
+
+All traffic goes to the worker. Next.js routes become thin proxies that forward to the
+worker (for clients that haven't updated their URL).
+
+### Step 5 — Deprecation
+
+Remove the Next.js routes once all clients have migrated to the worker URL.
+
+---
+
+## Risk Mitigations
+
+| Risk                                  | Mitigation                                                                                                                                                                        |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PG connection issues via Hyperdrive   | Smart placement keeps worker near DB; Hyperdrive handles pooling. Monitor connection errors.                                                                                      |
+| Missing side-effects (usage, metrics) | Shadow mode comparison catches discrepancies before cutover.                                                                                                                      |
+| AI SDK incompatibility in Workers     | SDK uses standard `fetch`, documented as edge-compatible. Test early with integration tests.                                                                                      |
+| JWT validation differences            | Same `jsonwebtoken` library, same secret. Unit test with production-format tokens.                                                                                                |
+| Streaming response byte differences   | `rewriteFreeModelResponse` must produce identical SSE output. Integration test with byte-level streaming assertions.                                                              |
+| KV cache staleness for BYOK           | Set reasonable TTL (5 min). KV eventual consistency is acceptable — worst case a user sees their old provider for a few minutes after changing BYOK keys.                         |
+| Worker CPU time limits (30s)          | The hot path is I/O-bound (PG queries, upstream fetch), not CPU-bound. Streaming responses don't count against CPU time. `ctx.waitUntil()` background work has its own allowance. |

--- a/llm-gateway/package.json
+++ b/llm-gateway/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "llm-gateway",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy --outdir dist --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version)",
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=kilo-code --project=llm-gateway && sentry-cli sourcemaps upload --org=kilo-code --project=llm-gateway --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
+    "postdeploy": "pnpm sentry:sourcemaps"
+  },
+  "dependencies": {
+    "hono": "catalog:",
+    "zod": "catalog:",
+    "drizzle-orm": "catalog:",
+    "pg": "^8.16.3",
+    "@kilocode/worker-utils": "workspace:*",
+    "@kilocode/db": "workspace:*",
+    "@kilocode/llm-shared": "workspace:*",
+    "@sentry/cloudflare": "^10.25.0",
+    "workers-tagged-logger": "catalog:",
+    "jsonwebtoken": "catalog:",
+    "ai": "^6.0.78",
+    "@ai-sdk/anthropic": "^3.0.41",
+    "@ai-sdk/openai": "^3.0.27"
+  },
+  "devDependencies": {
+    "wrangler": "catalog:",
+    "typescript": "catalog:",
+    "@cloudflare/workers-types": "^4.20260120.0",
+    "@sentry/cli": "^2.58.2",
+    "@types/jsonwebtoken": "catalog:",
+    "@types/pg": "^8.11.0"
+  }
+}

--- a/llm-gateway/package.json
+++ b/llm-gateway/package.json
@@ -25,7 +25,8 @@
     "jsonwebtoken": "catalog:",
     "ai": "^6.0.78",
     "@ai-sdk/anthropic": "^3.0.41",
-    "@ai-sdk/openai": "^3.0.27"
+    "@ai-sdk/openai": "^3.0.27",
+    "eventsource-parser": "^3.0.6"
   },
   "devDependencies": {
     "wrangler": "catalog:",

--- a/llm-gateway/src/background/error-capture.ts
+++ b/llm-gateway/src/background/error-capture.ts
@@ -1,0 +1,43 @@
+import * as Sentry from '@sentry/cloudflare';
+import { logger } from '../logger.js';
+
+export async function captureProxyError(params: {
+  errorMessage: string;
+  userId: string;
+  response: Response;
+  organizationId: string | undefined;
+  model: string;
+  trackInSentry: boolean;
+}): Promise<void> {
+  const { errorMessage, userId, response, organizationId, model, trackInSentry } = params;
+
+  const extraData: Record<string, string | number> = {
+    kiloUserId: userId,
+    model,
+    status: response.status,
+    statusText: response.statusText,
+    responseContentType: response.headers.get('content-type') || '',
+  };
+
+  if (organizationId) {
+    extraData.organizationId = organizationId;
+  }
+
+  try {
+    const cloned = response.clone();
+    extraData.first4kOfResponse = (await cloned.text()).slice(0, 4096);
+  } catch {
+    // ignore
+  }
+
+  logger.error(errorMessage, extraData);
+
+  if (trackInSentry) {
+    Sentry.captureMessage(errorMessage, {
+      level: 'error',
+      extra: extraData,
+      tags: { source: 'llm-gateway-proxy' },
+      user: { id: userId },
+    });
+  }
+}

--- a/llm-gateway/src/background/metrics.ts
+++ b/llm-gateway/src/background/metrics.ts
@@ -1,0 +1,25 @@
+import type { ApiMetricsParams } from '@kilocode/llm-shared';
+import { logger } from '../logger.js';
+
+// Background task: emit API metrics to the o11y service
+export async function emitApiMetrics(
+  params: ApiMetricsParams,
+  o11yServiceUrl: string | undefined,
+  clientSecret: string | undefined
+): Promise<void> {
+  if (!o11yServiceUrl || !clientSecret) return;
+
+  try {
+    const metricsUrl = new URL('/ingest/api-metrics', o11yServiceUrl);
+    await fetch(metricsUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-O11Y-ADMIN-TOKEN': clientSecret,
+      },
+      body: JSON.stringify(params),
+    });
+  } catch {
+    logger.warn('Failed to emit API metrics (best-effort)');
+  }
+}

--- a/llm-gateway/src/background/request-log.ts
+++ b/llm-gateway/src/background/request-log.ts
@@ -1,0 +1,16 @@
+import { logger } from '../logger.js';
+
+// Background task: log API requests to the database (Kilo employees only)
+export async function handleRequestLogging(_params: {
+  clonedResponse: Response;
+  userId: string | undefined;
+  isAdmin: boolean;
+  organizationId: string | null;
+  provider: string;
+  model: string;
+  request: unknown;
+}): Promise<void> {
+  // TODO: Port request logging from src/lib/handleRequestLogging.ts
+  // Only logs for Kilo employees (is_admin check)
+  logger.debug('Request logging not yet implemented in worker');
+}

--- a/llm-gateway/src/background/request-log.ts
+++ b/llm-gateway/src/background/request-log.ts
@@ -1,16 +1,50 @@
+import { api_request_log } from '@kilocode/db/schema';
+import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
+import type { WorkerDb } from '../lib/db.js';
 import { logger } from '../logger.js';
 
-// Background task: log API requests to the database (Kilo employees only)
-export async function handleRequestLogging(_params: {
+const KILO_ORGANIZATION_ID = '9d278969-5453-4ae3-a51f-a8d2274a7b56';
+
+function isKiloEmployee(userEmail: string | undefined, organizationId: string | null): boolean {
+  if (organizationId === KILO_ORGANIZATION_ID) return true;
+  if (!userEmail) return false;
+  return userEmail.endsWith('@kilo.ai') || userEmail.endsWith('@kilocode.ai');
+}
+
+export async function handleRequestLogging(params: {
   clonedResponse: Response;
   userId: string | undefined;
-  isAdmin: boolean;
+  userEmail: string | undefined;
   organizationId: string | null;
   provider: string;
   model: string;
-  request: unknown;
+  request: OpenRouterChatCompletionRequest;
+  db: WorkerDb;
 }): Promise<void> {
-  // TODO: Port request logging from src/lib/handleRequestLogging.ts
-  // Only logs for Kilo employees (is_admin check)
-  logger.debug('Request logging not yet implemented in worker');
+  const { clonedResponse, userId, userEmail, organizationId, provider, model, request, db } =
+    params;
+
+  if (!isKiloEmployee(userEmail, organizationId)) {
+    return;
+  }
+
+  try {
+    const responseText = await clonedResponse.text();
+    const result = await db
+      .insert(api_request_log)
+      .values({
+        kilo_user_id: userId,
+        organization_id: organizationId,
+        status_code: clonedResponse.status,
+        model,
+        provider,
+        request,
+        response: responseText,
+      })
+      .returning({ id: api_request_log.id });
+
+    logger.debug('Inserted into api_request_log', { requestLogId: String(result[0]?.id) });
+  } catch (e) {
+    logger.error('Failed to insert api_request_log', { error: String(e) });
+  }
 }

--- a/llm-gateway/src/background/usage-accounting.ts
+++ b/llm-gateway/src/background/usage-accounting.ts
@@ -1,0 +1,20 @@
+import type { MicrodollarUsageContext } from '@kilocode/llm-shared';
+import { logger } from '../logger.js';
+
+// Background task: count tokens and store usage in the database
+export async function countAndStoreUsage(
+  clonedResponse: Response,
+  usageContext: MicrodollarUsageContext
+): Promise<void> {
+  // TODO: Port full usage accounting from src/lib/processUsage.ts
+  // This involves:
+  // 1. Parsing SSE stream or JSON body for usage info
+  // 2. Fetching generation data from OpenRouter
+  // 3. Inserting microdollar_usage record
+  // 4. Updating user balance
+  // 5. PostHog events
+  logger.debug('Usage accounting not yet fully implemented', {
+    model: usageContext.requested_model,
+    userId: usageContext.kiloUserId,
+  });
+}

--- a/llm-gateway/src/background/usage-accounting.ts
+++ b/llm-gateway/src/background/usage-accounting.ts
@@ -1,20 +1,891 @@
-import type { MicrodollarUsageContext } from '@kilocode/llm-shared';
+import { randomUUID } from 'crypto';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import * as Sentry from '@sentry/cloudflare';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
+import {
+  type MicrodollarUsageContext,
+  type OpenRouterGeneration,
+  isFreeModel,
+  isKiloStealthModel,
+  isActiveReviewPromo,
+  isActiveCloudAgentPromo,
+} from '@kilocode/llm-shared';
+import {
+  microdollar_usage,
+  organizations,
+  organization_user_usage,
+  payment_methods,
+} from '@kilocode/db/schema';
+import type { MicrodollarUsage } from '@kilocode/db/schema';
+import type { WorkerDb } from '../lib/db.js';
+import { getWorkerDb } from '../lib/db.js';
+import { reportAbuseCost, type AbuseEnv } from '../services/abuse.js';
 import { logger } from '../logger.js';
+import type { Env } from '../types.js';
 
-// Background task: count tokens and store usage in the database
+function toMicrodollars(amount: number): number {
+  return Math.round(amount * 1000000);
+}
+
+// For BYOK requests, OpenRouter only reports 5% of the actual cost.
+// Although we now use upstream_inference_cost, we still do some sanity checks.
+const OPENROUTER_BYOK_COST_MULTIPLIER = 20.0;
+
+// --- Types ---
+
+type OpenRouterUsage = {
+  cost?: number;
+  is_byok?: boolean | null;
+  cost_details?: { upstream_inference_cost: number };
+  completion_tokens: number;
+  completion_tokens_details: { reasoning_tokens: number };
+  prompt_tokens: number;
+  prompt_tokens_details: { cached_tokens: number };
+  total_tokens: number;
+};
+
+type NotYetCostedUsageStats = {
+  messageId: string | null;
+  model: string | null;
+  responseContent: string;
+  hasError: boolean;
+  inference_provider: string | null;
+  upstream_id: string | null;
+  finish_reason: string | null;
+  latency: number | null;
+  moderation_latency: number | null;
+  generation_time: number | null;
+  streamed: boolean | null;
+  cancelled: boolean | null;
+};
+
+type JustTheCostsUsageStats = {
+  cost_mUsd: number;
+  cacheDiscount_mUsd?: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheWriteTokens: number;
+  cacheHitTokens: number;
+  is_byok: boolean | null;
+};
+
+type MicrodollarUsageStats = NotYetCostedUsageStats & JustTheCostsUsageStats;
+
+type UsageMetaData = {
+  id: string;
+  message_id: string;
+  created_at: string;
+  http_x_forwarded_for: string | null;
+  http_x_vercel_ip_city: string | null;
+  http_x_vercel_ip_country: string | null;
+  http_x_vercel_ip_latitude: number | null;
+  http_x_vercel_ip_longitude: number | null;
+  http_x_vercel_ja4_digest: string | null;
+  user_prompt_prefix: string | null;
+  system_prompt_prefix: string | null;
+  system_prompt_length: number | null;
+  http_user_agent: string | null;
+  max_tokens: number | null;
+  has_middle_out_transform: boolean | null;
+  status_code: number | null;
+  upstream_id: string | null;
+  finish_reason: string | null;
+  latency: number | null;
+  moderation_latency: number | null;
+  generation_time: number | null;
+  is_byok: boolean | null;
+  is_user_byok: boolean;
+  streamed: boolean | null;
+  cancelled: boolean | null;
+  editor_name: string | null;
+  has_tools: boolean | null;
+  machine_id: string | null;
+  feature: string | null;
+  session_id: string | null;
+};
+
+type ChatCompletionChunk = {
+  id?: string;
+  model?: string;
+  usage?: OpenRouterUsage | null;
+  provider?: string | null;
+  error?: { message: string; code: string };
+  choices?: {
+    delta?: {
+      content?: string;
+      provider_metadata?: { gateway?: { routing?: { finalProvider?: string } } };
+    };
+    finish_reason?: string | null;
+  }[];
+};
+
+// --- Parsing ---
+
+function processOpenRouterUsage(
+  usage: OpenRouterUsage | null | undefined,
+  coreProps: NotYetCostedUsageStats
+): JustTheCostsUsageStats {
+  const is_byok = usage?.is_byok ?? null;
+  const openrouterCost_USD = usage?.cost ?? 0;
+  const upstream_inference_cost_USD = usage?.cost_details?.upstream_inference_cost ?? 0;
+  const cost_mUsd = toMicrodollars(is_byok ? upstream_inference_cost_USD : openrouterCost_USD);
+
+  // Sanity-check BYOK cost accounting
+  const inferredUpstream_USD = openrouterCost_USD * OPENROUTER_BYOK_COST_MULTIPLIER;
+  const microdollar_error = (inferredUpstream_USD - upstream_inference_cost_USD) * 1000000;
+  if (
+    (is_byok == null && (openrouterCost_USD || upstream_inference_cost_USD)) ||
+    (is_byok && usage?.cost !== 0 && 1.1 < Math.abs(microdollar_error))
+  ) {
+    const { responseContent: _ignore, ...corePropsCopy } = coreProps;
+    logger.error("SUSPICIOUS: openrouter cost accounting doesn't make sense", {
+      ...corePropsCopy,
+      cost_mUsd: String(cost_mUsd),
+      is_byok: String(is_byok),
+      openrouterCost_USD: String(openrouterCost_USD),
+      upstream_inference_cost_USD: String(upstream_inference_cost_USD),
+    });
+  }
+
+  return {
+    inputTokens: usage?.prompt_tokens ?? 0,
+    cacheHitTokens: usage?.prompt_tokens_details?.cached_tokens ?? 0,
+    cacheWriteTokens: 0,
+    outputTokens: usage?.completion_tokens ?? 0,
+    cost_mUsd,
+    is_byok,
+  };
+}
+
+async function parseMicrodollarUsageFromStream(
+  stream: ReadableStream,
+  kiloUserId: string,
+  provider: string,
+  statusCode: number
+): Promise<MicrodollarUsageStats> {
+  let messageId: string | null = null;
+  let model: string | null = null;
+  let responseContent = '';
+  let reportedError = statusCode >= 400;
+  let usage: OpenRouterUsage | null = null;
+  let inference_provider: string | null = null;
+  let finish_reason: string | null = null;
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const sseStreamParser = createParser({
+    onEvent(event: EventSourceMessage) {
+      if (event.data === '[DONE]') return;
+
+      let json: ChatCompletionChunk;
+      try {
+        json = JSON.parse(event.data);
+      } catch {
+        logger.warn('Failed to parse SSE event data');
+        return;
+      }
+      if (!json) return;
+
+      if ('error' in json && json.error) {
+        reportedError = true;
+        logger.error(`OpenRouter error in stream: ${json.error.message}`);
+      }
+
+      model = json.model ?? model;
+      messageId = json.id ?? messageId;
+      usage = (json.usage as OpenRouterUsage) ?? usage;
+      const choice = json.choices?.[0];
+      inference_provider =
+        json.provider ??
+        choice?.delta?.provider_metadata?.gateway?.routing?.finalProvider ??
+        inference_provider;
+      finish_reason = choice?.finish_reason ?? finish_reason;
+
+      const contentDelta = choice?.delta?.content;
+      if (contentDelta) {
+        responseContent += contentDelta;
+      }
+    },
+  });
+
+  let wasAborted = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      sseStreamParser.feed(decoder.decode(value, { stream: true }));
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'ResponseAborted') {
+      wasAborted = true;
+    } else {
+      throw error;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (!reportedError && !usage) {
+    logger.warn('No usage chunk in stream', { kiloUserId, provider, messageId, model });
+  }
+
+  const coreProps: NotYetCostedUsageStats = {
+    messageId,
+    hasError: reportedError || wasAborted,
+    model,
+    responseContent,
+    inference_provider,
+    finish_reason,
+    upstream_id: null,
+    latency: null,
+    moderation_latency: null,
+    generation_time: null,
+    streamed: true,
+    cancelled: null,
+  };
+
+  return { ...coreProps, ...processOpenRouterUsage(usage, coreProps) };
+}
+
+function parseMicrodollarUsageFromString(
+  fullResponse: string,
+  kiloUserId: string,
+  statusCode: number
+): MicrodollarUsageStats {
+  const responseJson = JSON.parse(fullResponse) as {
+    id?: string;
+    model?: string;
+    usage?: OpenRouterUsage | null;
+    provider?: string | null;
+    choices?: {
+      message?: {
+        content?: string;
+        provider_metadata?: { gateway?: { routing?: { finalProvider?: string } } };
+      };
+      finish_reason?: string | null;
+    }[];
+  } | null;
+
+  if (responseJson?.usage?.is_byok == null && responseJson?.usage?.cost) {
+    logger.error('SUSPICIOUS: is_byok is null', { kiloUserId });
+  }
+
+  const choice = responseJson?.choices?.[0];
+  const coreProps: NotYetCostedUsageStats = {
+    messageId: responseJson?.id ?? null,
+    hasError: !responseJson?.model || statusCode >= 400,
+    model: responseJson?.model ?? null,
+    responseContent: choice?.message?.content ?? '',
+    inference_provider:
+      responseJson?.provider ??
+      choice?.message?.provider_metadata?.gateway?.routing?.finalProvider ??
+      null,
+    upstream_id: null,
+    finish_reason: choice?.finish_reason ?? null,
+    latency: null,
+    moderation_latency: null,
+    generation_time: null,
+    streamed: false,
+    cancelled: null,
+  };
+
+  return { ...coreProps, ...processOpenRouterUsage(responseJson?.usage, coreProps) };
+}
+
+// --- Generation fetch with retry ---
+
+async function fetchGeneration(
+  messageId: string,
+  providerApiUrl: string,
+  apiKey: string
+): Promise<OpenRouterGeneration | undefined> {
+  // Small delay — OpenRouter returns 404 when called too soon
+  await new Promise(res => setTimeout(res, 200));
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const response = await fetch(`${providerApiUrl}/generation?id=${messageId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'HTTP-Referer': 'https://kilocode.ai',
+          'X-Title': 'Kilo Code',
+        },
+      });
+
+      if (response.ok) {
+        return (await response.json()) as OpenRouterGeneration;
+      }
+
+      if (response.status >= 500 || attempt >= 2) {
+        logger.warn('Failed to fetch generation', {
+          messageId,
+          status: String(response.status),
+        });
+        return undefined;
+      }
+
+      // Retry on 4xx (OpenRouter returns 404 when called too soon)
+      await new Promise(r => setTimeout(r, 200 * (attempt + 1)));
+    } catch (error) {
+      logger.warn('Error fetching generation', { messageId, error: String(error) });
+      if (attempt >= 2) return undefined;
+      await new Promise(r => setTimeout(r, 200 * (attempt + 1)));
+    }
+  }
+  return undefined;
+}
+
+function mapToUsageStats(
+  generation: OpenRouterGeneration,
+  responseContent: string,
+  kiloUserId: string
+): MicrodollarUsageStats {
+  const { data } = generation;
+  let llmCostUsd: number;
+
+  if (!data.is_byok) {
+    llmCostUsd = data.total_cost;
+  } else if (data.upstream_inference_cost == undefined) {
+    logger.error('openrouter missing upstream_inference_cost', { kiloUserId });
+    llmCostUsd = data.total_cost * OPENROUTER_BYOK_COST_MULTIPLIER;
+  } else {
+    llmCostUsd = data.upstream_inference_cost;
+  }
+
+  return {
+    messageId: data.id,
+    hasError: false,
+    model: data.model,
+    responseContent,
+    inputTokens: data.native_tokens_prompt ?? 0,
+    cacheHitTokens: data.native_tokens_cached ?? 0,
+    cacheWriteTokens: 0,
+    outputTokens: data.native_tokens_completion ?? 0,
+    cost_mUsd: toMicrodollars(llmCostUsd),
+    is_byok: data.is_byok ?? null,
+    cacheDiscount_mUsd:
+      data.cache_discount == undefined ? undefined : toMicrodollars(data.cache_discount),
+    inference_provider: data.provider_name ?? null,
+    upstream_id: data.upstream_id ?? null,
+    finish_reason: data.finish_reason ?? null,
+    latency: data.latency ?? null,
+    moderation_latency: data.moderation_latency ?? null,
+    generation_time: data.generation_time ?? null,
+    streamed: data.streamed ?? null,
+    cancelled: data.cancelled ?? null,
+  };
+}
+
+// --- DB record construction ---
+
+function extractUsageContextInfo(usageContext: MicrodollarUsageContext) {
+  return {
+    kilo_user_id: usageContext.kiloUserId,
+    organization_id: usageContext.organizationId ?? null,
+    ...usageContext.fraudHeaders,
+    provider: usageContext.provider,
+    ...usageContext.promptInfo,
+    max_tokens: usageContext.max_tokens,
+    has_middle_out_transform: usageContext.has_middle_out_transform,
+    project_id: usageContext.project_id,
+    requested_model: usageContext.requested_model,
+    status_code: usageContext.status_code,
+    editor_name: usageContext.editor_name,
+    machine_id: usageContext.machine_id,
+    is_user_byok: usageContext.user_byok,
+    has_tools: usageContext.has_tools,
+    feature: usageContext.feature,
+    session_id: usageContext.session_id,
+  };
+}
+
+function toInsertableDbUsageRecord(
+  usageStats: MicrodollarUsageStats,
+  usageContextInfo: ReturnType<typeof extractUsageContextInfo>
+) {
+  const id = randomUUID();
+  const created_at = new Date().toISOString();
+
+  const { kilo_user_id, organization_id, project_id, provider, ...metadataFromContext } =
+    usageContextInfo;
+
+  const core: MicrodollarUsage = {
+    id,
+    kilo_user_id,
+    organization_id,
+    provider,
+    cost: usageStats.cost_mUsd,
+    input_tokens: usageStats.inputTokens,
+    output_tokens: usageStats.outputTokens,
+    cache_write_tokens: usageStats.cacheWriteTokens,
+    cache_hit_tokens: usageStats.cacheHitTokens,
+    created_at,
+    model: usageStats.model,
+    requested_model: usageContextInfo.requested_model,
+    cache_discount: usageStats.cacheDiscount_mUsd ?? null,
+    has_error: usageStats.hasError,
+    abuse_classification: 0,
+    inference_provider: usageStats.inference_provider,
+    project_id,
+  };
+
+  const metadata: UsageMetaData = {
+    ...metadataFromContext,
+    id,
+    created_at,
+    message_id: usageStats.messageId ?? '<missing>',
+    upstream_id: usageStats.upstream_id,
+    finish_reason: usageStats.finish_reason,
+    latency: usageStats.latency,
+    moderation_latency: usageStats.moderation_latency,
+    generation_time: usageStats.generation_time,
+    is_byok: usageStats.is_byok,
+    streamed: usageStats.streamed,
+    cancelled: usageStats.cancelled,
+  };
+
+  // Never log sensitive prompt data for org usage
+  if (organization_id) {
+    metadata.user_prompt_prefix = null;
+    metadata.system_prompt_prefix = null;
+  }
+
+  return { core, metadata };
+}
+
+// --- CTE-based upsert for metadata lookup tables ---
+
+/**
+ * Creates CTE fragments for upserting a metadata value into a lookup table.
+ *
+ * Returns CTEs: `{name}_value`, `{name}_existing`, `{name}_ins`, `{name}_cte`
+ * The final `{name}_cte` contains the ID of the (possibly newly inserted) row.
+ *
+ * Uses `WHERE NOT EXISTS` to skip the INSERT when the value already exists,
+ * avoiding WAL writes in the common case. The `ON CONFLICT DO UPDATE` handles
+ * rare concurrent insert races where two transactions both see no existing row
+ * (due to CTE snapshot semantics) and both attempt to insert.
+ */
+const createUpsertCTE = (metaDataKindName: ReturnType<typeof sql>, value: string | null) => sql`
+${metaDataKindName}_value AS (
+  SELECT value
+  FROM (VALUES (${value})) v(value)
+  WHERE value IS NOT NULL
+),
+${metaDataKindName}_existing AS (
+  SELECT ${metaDataKindName}_id
+  FROM ${metaDataKindName}, ${metaDataKindName}_value
+  WHERE ${metaDataKindName}.${metaDataKindName} = ${metaDataKindName}_value.value
+),
+${metaDataKindName}_ins AS (
+  INSERT INTO ${metaDataKindName} (${metaDataKindName})
+  SELECT ${metaDataKindName}_value.value FROM ${metaDataKindName}_value
+  WHERE NOT EXISTS (SELECT 1 FROM ${metaDataKindName}_existing)
+  ON CONFLICT (${metaDataKindName}) DO UPDATE SET ${metaDataKindName} = EXCLUDED.${metaDataKindName}
+  RETURNING ${metaDataKindName}_id
+),
+${metaDataKindName}_cte AS (
+  SELECT ${metaDataKindName}_id FROM ${metaDataKindName}_existing
+  UNION ALL
+  SELECT ${metaDataKindName}_id FROM ${metaDataKindName}_ins
+)`;
+
+// --- DB writes ---
+
+async function insertUsageAndMetadataWithBalanceUpdate(
+  coreUsageFields: MicrodollarUsage,
+  metadataFields: UsageMetaData,
+  db: WorkerDb
+): Promise<{ newMicrodollarsUsed: number } | null> {
+  const result = await db.execute<{
+    new_microdollars_used: number;
+    kilo_pass_threshold: number | null;
+  }>(sql`
+    WITH microdollar_usage_ins AS (
+      INSERT INTO microdollar_usage (
+        id, kilo_user_id, organization_id, provider, cost,
+        input_tokens, output_tokens, cache_write_tokens, cache_hit_tokens,
+        created_at, model, requested_model, cache_discount, has_error, abuse_classification,
+        inference_provider, project_id
+      ) VALUES (
+        ${coreUsageFields.id},
+        ${coreUsageFields.kilo_user_id},
+        ${coreUsageFields.organization_id},
+        ${coreUsageFields.provider},
+        ${coreUsageFields.cost},
+        ${coreUsageFields.input_tokens},
+        ${coreUsageFields.output_tokens},
+        ${coreUsageFields.cache_write_tokens},
+        ${coreUsageFields.cache_hit_tokens},
+        ${coreUsageFields.created_at},
+        ${coreUsageFields.model},
+        ${coreUsageFields.requested_model},
+        ${coreUsageFields.cache_discount},
+        ${coreUsageFields.has_error},
+        ${coreUsageFields.abuse_classification},
+        ${coreUsageFields.inference_provider},
+        ${coreUsageFields.project_id}
+      )
+    )
+    , ${createUpsertCTE(sql`http_user_agent`, metadataFields.http_user_agent)}
+    , ${createUpsertCTE(sql`http_ip`, metadataFields.http_x_forwarded_for)}
+    , ${createUpsertCTE(sql`vercel_ip_country`, metadataFields.http_x_vercel_ip_country)}
+    , ${createUpsertCTE(sql`vercel_ip_city`, metadataFields.http_x_vercel_ip_city)}
+    , ${createUpsertCTE(sql`ja4_digest`, metadataFields.http_x_vercel_ja4_digest)}
+    , ${createUpsertCTE(sql`system_prompt_prefix`, metadataFields.system_prompt_prefix)}
+    , ${createUpsertCTE(sql`finish_reason`, metadataFields.finish_reason)}
+    , ${createUpsertCTE(sql`editor_name`, metadataFields.editor_name)}
+    , ${createUpsertCTE(sql`feature`, metadataFields.feature)}
+    , metadata_ins AS (
+      INSERT INTO microdollar_usage_metadata (
+        id,
+        message_id,
+        created_at,
+        user_prompt_prefix,
+        vercel_ip_latitude,
+        vercel_ip_longitude,
+        system_prompt_length,
+        max_tokens,
+        has_middle_out_transform,
+        status_code,
+        upstream_id,
+        latency,
+        moderation_latency,
+        generation_time,
+        is_byok,
+        is_user_byok,
+        streamed,
+        cancelled,
+        has_tools,
+        machine_id,
+        session_id,
+
+        http_user_agent_id,
+        http_ip_id,
+        vercel_ip_country_id,
+        vercel_ip_city_id,
+        ja4_digest_id,
+        system_prompt_prefix_id,
+        finish_reason_id,
+        editor_name_id,
+        feature_id
+      )
+      SELECT
+        ${metadataFields.id},
+        ${metadataFields.message_id ?? '<missing>'},
+        ${metadataFields.created_at},
+        ${metadataFields.user_prompt_prefix},
+        ${metadataFields.http_x_vercel_ip_latitude},
+        ${metadataFields.http_x_vercel_ip_longitude},
+        ${metadataFields.system_prompt_length},
+        ${metadataFields.max_tokens},
+        ${metadataFields.has_middle_out_transform},
+        ${metadataFields.status_code},
+        ${metadataFields.upstream_id},
+        ${metadataFields.latency},
+        ${metadataFields.moderation_latency},
+        ${metadataFields.generation_time},
+        ${metadataFields.is_byok},
+        ${metadataFields.is_user_byok},
+        ${metadataFields.streamed},
+        ${metadataFields.cancelled},
+        ${metadataFields.has_tools},
+        ${metadataFields.machine_id},
+        ${metadataFields.session_id},
+
+        (SELECT http_user_agent_id FROM http_user_agent_cte),
+        (SELECT http_ip_id FROM http_ip_cte),
+        (SELECT vercel_ip_country_id FROM vercel_ip_country_cte),
+        (SELECT vercel_ip_city_id FROM vercel_ip_city_cte),
+        (SELECT ja4_digest_id FROM ja4_digest_cte),
+        (SELECT system_prompt_prefix_id FROM system_prompt_prefix_cte),
+        (SELECT finish_reason_id FROM finish_reason_cte),
+        (SELECT editor_name_id FROM editor_name_cte),
+        (SELECT feature_id FROM feature_cte)
+    )
+    UPDATE kilocode_users
+    SET microdollars_used = microdollars_used + ${coreUsageFields.cost}
+    WHERE id = ${coreUsageFields.kilo_user_id}
+      AND ${coreUsageFields.organization_id}::uuid IS NULL
+      AND ${coreUsageFields.cost} > 0
+    RETURNING microdollars_used AS new_microdollars_used, kilo_pass_threshold
+  `);
+
+  // No rows returned means either: org usage (no user balance update), zero cost, or missing user
+  if (!result.rows[0]) {
+    if (!coreUsageFields.organization_id && coreUsageFields.cost && coreUsageFields.cost > 0) {
+      Sentry.captureMessage('impossible: missing user in usage update', {
+        level: 'fatal',
+        extra: { coreUsageFields },
+      });
+    }
+    return null;
+  }
+
+  const newMicrodollarsUsed = Number(result.rows[0].new_microdollars_used);
+
+  // Kilo Pass threshold check — bonus credits when usage crosses (threshold - $1)
+  const kiloPassThreshold =
+    result.rows[0].kilo_pass_threshold == null ? null : Number(result.rows[0].kilo_pass_threshold);
+  const effectiveThreshold =
+    kiloPassThreshold === null ? null : Math.max(0, kiloPassThreshold - 1_000_000);
+
+  if (effectiveThreshold !== null && newMicrodollarsUsed >= effectiveThreshold) {
+    // TODO: Port maybeIssueKiloPassBonusFromUsageThreshold
+    // Non-critical background task — log and move on.
+    logger.info('Kilo Pass threshold crossed, bonus pending implementation', {
+      userId: coreUsageFields.kilo_user_id,
+    });
+  }
+
+  return { newMicrodollarsUsed };
+}
+
+async function insertUsageRecord(
+  coreUsageFields: MicrodollarUsage,
+  metadataFields: UsageMetaData,
+  db: WorkerDb
+): Promise<{ newMicrodollarsUsed: number } | null> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await insertUsageAndMetadataWithBalanceUpdate(coreUsageFields, metadataFields, db);
+    } catch (error) {
+      if (attempt >= 2) {
+        logger.error('insertUsageRecord failed after retries', { error: String(error) });
+        Sentry.captureException(error, { tags: { source: 'insertUsageRecord' } });
+        return null;
+      }
+      logger.warn('insertUsageRecord concurrency failure, retrying', { error: String(error) });
+      await new Promise(r => setTimeout(r, Math.random() * 100));
+      attempt++;
+    }
+  }
+}
+
+// --- Organization token usage ---
+
+async function ingestOrganizationTokenUsage(usage: MicrodollarUsage, db: WorkerDb): Promise<void> {
+  const { cost, kilo_user_id, organization_id } = usage;
+  if (!organization_id) return;
+
+  try {
+    // Update organization usage
+    await db
+      .update(organizations)
+      .set({
+        microdollars_used: sql`${organizations.microdollars_used} + ${cost}`,
+        microdollars_balance: sql`${organizations.microdollars_balance} - ${cost}`,
+      })
+      .where(eq(organizations.id, organization_id));
+
+    // Upsert user daily usage
+    await db.execute(sql`
+      INSERT INTO ${organization_user_usage} (
+        organization_id,
+        kilo_user_id,
+        usage_date,
+        limit_type,
+        microdollar_usage,
+        created_at,
+        updated_at
+      )
+      SELECT
+        ${organization_id},
+        ${kilo_user_id},
+        CURRENT_DATE,
+        'daily',
+        ${cost},
+        NOW(),
+        NOW()
+      ON CONFLICT (organization_id, kilo_user_id, limit_type, usage_date)
+      DO UPDATE SET
+        microdollar_usage = ${organization_user_usage.microdollar_usage} + ${cost},
+        updated_at = NOW()
+    `);
+
+    // TODO: Port balance alert threshold email check
+  } catch (error) {
+    logger.error('Failed to ingest organization token usage', { error: String(error) });
+  }
+}
+
+// --- PostHog events via HTTP Capture API ---
+
+async function sendPostHogEvent(
+  distinctId: string,
+  event: string,
+  properties: Record<string, unknown>,
+  posthogApiKey: string
+): Promise<void> {
+  try {
+    await fetch('https://us.i.posthog.com/capture/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: posthogApiKey,
+        distinct_id: distinctId,
+        event,
+        properties: {
+          ...properties,
+          $lib: 'llm-gateway-worker',
+        },
+      }),
+    });
+  } catch (error) {
+    logger.warn('PostHog event failed', { event, error: String(error) });
+  }
+}
+
+async function hasPaymentMethod(userId: string, db: WorkerDb): Promise<boolean> {
+  const result = await db
+    .select({ id: payment_methods.id })
+    .from(payment_methods)
+    .where(and(eq(payment_methods.user_id, userId), isNull(payment_methods.deleted_at)))
+    .limit(1);
+  return result.length > 0;
+}
+
+async function isFirstUsage(
+  usage: MicrodollarUsage,
+  priorMicrodollarUsage: number,
+  db: WorkerDb
+): Promise<boolean> {
+  if (priorMicrodollarUsage || usage.organization_id) return false;
+  // Only pay the cost of querying prior usage for non-org users with zero cost so far
+  const existing = await db
+    .select({ created_at: microdollar_usage.created_at })
+    .from(microdollar_usage)
+    .where(eq(microdollar_usage.kilo_user_id, usage.kilo_user_id))
+    .limit(1);
+  return existing.length === 0;
+}
+
+// --- Main entry point ---
+
 export async function countAndStoreUsage(
   clonedResponse: Response,
-  usageContext: MicrodollarUsageContext
+  usageContext: MicrodollarUsageContext,
+  env: Env
 ): Promise<void> {
-  // TODO: Port full usage accounting from src/lib/processUsage.ts
-  // This involves:
-  // 1. Parsing SSE stream or JSON body for usage info
-  // 2. Fetching generation data from OpenRouter
-  // 3. Inserting microdollar_usage record
-  // 4. Updating user balance
-  // 5. PostHog events
-  logger.debug('Usage accounting not yet fully implemented', {
-    model: usageContext.requested_model,
-    userId: usageContext.kiloUserId,
-  });
+  const { db, connect, end } = getWorkerDb(env.HYPERDRIVE.connectionString);
+  await connect();
+
+  try {
+    // 1. Parse usage from response
+    if (!clonedResponse.body) {
+      logger.error('No response body for usage accounting');
+      return;
+    }
+
+    let usageStats: MicrodollarUsageStats;
+
+    if (usageContext.isStreaming) {
+      usageStats = await parseMicrodollarUsageFromStream(
+        clonedResponse.body,
+        usageContext.kiloUserId,
+        usageContext.provider,
+        clonedResponse.status
+      );
+    } else {
+      const content = await clonedResponse.text();
+      usageStats = parseMicrodollarUsageFromString(
+        content,
+        usageContext.kiloUserId,
+        clonedResponse.status
+      );
+    }
+
+    // 2. Fetch authoritative generation data from OpenRouter
+    const providerApiUrl = 'https://openrouter.ai/api/v1';
+    const generation =
+      usageStats.messageId &&
+      usageContext.provider === 'openrouter' &&
+      (await fetchGeneration(usageStats.messageId, providerApiUrl, env.OPENROUTER_API_KEY));
+
+    if (generation) {
+      const genStats = mapToUsageStats(
+        generation,
+        usageStats.responseContent,
+        usageContext.kiloUserId
+      );
+      genStats.model = usageStats.model; // openrouter bug: generation may report different model
+      genStats.hasError = usageStats.hasError; // retain stream-observed error state
+      genStats.streamed ??= usageContext.isStreaming;
+      usageStats = genStats;
+    }
+
+    // Fallback model to requested_model for failure cases or stealth models
+    if (!usageStats.model || isKiloStealthModel(usageContext.requested_model)) {
+      usageStats.model = usageContext.requested_model;
+    }
+
+    // 3. Report upstream cost to abuse service BEFORE zeroing for free/BYOK
+    reportAbuseCost(usageContext, usageStats, env).catch(error => {
+      logger.error('[Abuse] Failed to report cost', { error: String(error) });
+    });
+
+    // 4. Zero cost for free models, BYOK, and active promos
+    if (
+      isFreeModel(usageContext.requested_model) ||
+      usageContext.user_byok ||
+      isActiveReviewPromo(usageContext.botId, usageContext.requested_model) ||
+      isActiveCloudAgentPromo(usageContext.tokenSource, usageContext.requested_model)
+    ) {
+      usageStats.cost_mUsd = 0;
+      usageStats.cacheDiscount_mUsd = 0;
+    }
+
+    // 5. Build and insert usage record
+    const contextInfo = extractUsageContextInfo(usageContext);
+    const { core, metadata } = toInsertableDbUsageRecord(usageStats, contextInfo);
+
+    const isFirst = await isFirstUsage(core, usageContext.prior_microdollar_usage, db);
+
+    // PostHog: first_usage event
+    if (isFirst && usageContext.posthog_distinct_id && env.POSTHOG_API_KEY) {
+      const userHasPaymentMethod = await hasPaymentMethod(core.kilo_user_id, db);
+      await sendPostHogEvent(
+        usageContext.posthog_distinct_id,
+        'first_usage',
+        {
+          model: core.model,
+          cost_mUsd: core.cost,
+          has_payment_method: userHasPaymentMethod,
+        },
+        env.POSTHOG_API_KEY
+      );
+    }
+
+    const balanceResult = await insertUsageRecord(core, metadata, db);
+
+    // PostHog: first_microdollar_usage event (first time user incurs non-zero cost)
+    if (balanceResult && usageContext.posthog_distinct_id && env.POSTHOG_API_KEY) {
+      const priorTotal = Math.abs(balanceResult.newMicrodollarsUsed - core.cost);
+      if (priorTotal < 1) {
+        const userHasPaymentMethod = await hasPaymentMethod(core.kilo_user_id, db);
+        await sendPostHogEvent(
+          usageContext.posthog_distinct_id,
+          'first_microdollar_usage',
+          {
+            model: core.model,
+            cost_mUsd: core.cost,
+            has_payment_method: userHasPaymentMethod,
+            has_prior_free_usage: !isFirst,
+          },
+          env.POSTHOG_API_KEY
+        );
+      }
+    }
+
+    // 6. Organization token usage tracking
+    await ingestOrganizationTokenUsage(core, db);
+  } catch (error) {
+    logger.error('Usage accounting failed', { error: String(error) });
+    Sentry.captureException(error, { tags: { source: 'usage_accounting' } });
+  } finally {
+    await end().catch(() => {});
+  }
 }

--- a/llm-gateway/src/index.ts
+++ b/llm-gateway/src/index.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono';
+import * as Sentry from '@sentry/cloudflare';
+import { createErrorHandler, createNotFoundHandler } from '@kilocode/worker-utils';
+import type { HonoEnv } from './types.js';
+import { handleChatCompletions } from './routes/chat-completions.js';
+
+const app = new Hono<HonoEnv>();
+
+// Routes — same paths as Next.js for seamless cutover
+app.post('/api/gateway/chat/completions', handleChatCompletions);
+app.post('/api/openrouter/chat/completions', handleChatCompletions);
+
+// Health check
+app.get('/health', c => c.json({ status: 'ok' }));
+
+// Error handling
+app.onError(createErrorHandler());
+app.notFound(createNotFoundHandler());
+
+// Sentry-wrapped export
+export default Sentry.withSentry(
+  (env: HonoEnv['Bindings']) => ({
+    dsn: env.SENTRY_DSN,
+    release: env.CF_VERSION_METADATA?.id,
+    environment: env.ENVIRONMENT || 'production',
+  }),
+  app
+);

--- a/llm-gateway/src/lib/db.ts
+++ b/llm-gateway/src/lib/db.ts
@@ -1,0 +1,16 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+
+// Per-request DB connection via Hyperdrive
+export function getWorkerDb(connectionString: string) {
+  const client = new pg.Client({ connectionString });
+  // Hyperdrive manages the actual pool; we create a lightweight wrapper per-request.
+  // The connection is established lazily on first query.
+  return {
+    db: drizzle({ client }),
+    connect: () => client.connect(),
+    end: () => client.end(),
+  };
+}
+
+export type WorkerDb = ReturnType<typeof getWorkerDb>['db'];

--- a/llm-gateway/src/logger.ts
+++ b/llm-gateway/src/logger.ts
@@ -1,0 +1,12 @@
+import { WorkersLogger } from 'workers-tagged-logger';
+
+export type LlmGatewayTags = {
+  userId?: string;
+  organizationId?: string;
+  model?: string;
+  provider?: string;
+  requestId?: string;
+};
+
+export const logger = new WorkersLogger<LlmGatewayTags>({ minimumLogLevel: 'debug' });
+export { withLogTags } from 'workers-tagged-logger';

--- a/llm-gateway/src/responses.ts
+++ b/llm-gateway/src/responses.ts
@@ -1,0 +1,141 @@
+function jsonError(body: Record<string, unknown>, status: number): Response {
+  return Response.json(body, { status });
+}
+
+export function invalidPathResponse() {
+  return jsonError(
+    {
+      error: 'Invalid path',
+      message: 'This endpoint only accepts the path `/chat/completions`.',
+    },
+    400
+  );
+}
+
+export function invalidRequestResponse() {
+  return jsonError(
+    {
+      error: 'Invalid request',
+      message: 'Could not parse request body. Please ensure it is valid JSON.',
+    },
+    400
+  );
+}
+
+export function temporarilyUnavailableResponse() {
+  return jsonError(
+    {
+      error: 'Service Unavailable',
+      message: 'The service is temporarily unavailable. Please try again later.',
+    },
+    503
+  );
+}
+
+export function rateLimitExceededResponse() {
+  return jsonError(
+    {
+      error: 'Rate limit exceeded',
+      message: 'Free model usage limit reached. Please try again later or upgrade to a paid model.',
+    },
+    429
+  );
+}
+
+export function paidModelAuthRequiredResponse() {
+  return jsonError(
+    {
+      error: {
+        code: 'PAID_MODEL_AUTH_REQUIRED',
+        message: 'You need to sign in to use this model.',
+      },
+    },
+    401
+  );
+}
+
+export function promotionLimitReachedResponse() {
+  return jsonError(
+    {
+      error: {
+        code: 'PROMOTION_MODEL_LIMIT_REACHED',
+        message:
+          'Sign up for free to continue and explore 500 other models. ' +
+          'Takes 2 minutes, no credit card required. Or come back later.',
+      },
+    },
+    401
+  );
+}
+
+export function usageLimitExceededResponse(params: {
+  title: string;
+  message: string;
+  balance?: number;
+  buyCreditsUrl: string;
+}) {
+  return jsonError(
+    {
+      error: {
+        title: params.title,
+        message: params.message,
+        balance: params.balance,
+        buyCreditsUrl: params.buyCreditsUrl,
+      },
+    },
+    402
+  );
+}
+
+export function dataCollectionRequiredResponse() {
+  const error =
+    'Data collection is required for this model. Please enable data collection to use this model or choose another model.';
+  return jsonError({ error, message: error }, 400);
+}
+
+export function alphaPeriodEndedResponse() {
+  const error = 'The alpha period for this model has ended.';
+  return jsonError({ error, message: error }, 404);
+}
+
+export function modelNotAllowedResponse() {
+  return jsonError(
+    {
+      error: 'Model not allowed for your team.',
+      message: 'The requested model is not allowed for your team.',
+    },
+    404
+  );
+}
+
+export function modelDoesNotExistResponse() {
+  return jsonError(
+    {
+      error: 'Model not found',
+      message: 'The requested model could not be found.',
+    },
+    404
+  );
+}
+
+export function ipRequiredResponse() {
+  return jsonError({ error: 'Unable to determine client IP' }, 400);
+}
+
+export function getOutputHeaders(response: Response): Headers {
+  const outputHeaders = new Headers();
+  for (const headerKey of ['date', 'content-type', 'request-id']) {
+    const value = response.headers.get(headerKey);
+    if (value) outputHeaders.set(headerKey, value);
+  }
+  outputHeaders.set('Content-Encoding', 'identity');
+  return outputHeaders;
+}
+
+export function wrapResponse(response: Response): Response {
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: getOutputHeaders(response),
+  });
+}

--- a/llm-gateway/src/routes/chat-completions.ts
+++ b/llm-gateway/src/routes/chat-completions.ts
@@ -1,0 +1,409 @@
+import type { Context } from 'hono';
+import type { HonoEnv } from '../types.js';
+import {
+  type OpenRouterChatCompletionRequest,
+  type MicrodollarUsageContext,
+  type AnonymousUserContext,
+  isKiloAutoModel,
+  resolveAutoModel,
+  isKiloFreeModel,
+  isFreeModel,
+  isDeadFreeModel,
+  isDataCollectionRequiredOnKiloCodeOnly,
+  isRateLimitedToDeath,
+  isActiveReviewPromo,
+  isActiveCloudAgentPromo,
+  normalizeModelId,
+  generateProviderSpecificHash,
+  extractPromptInfo,
+  estimateChatTokens,
+  validateFeatureHeader,
+  FEATURE_HEADER,
+  ENABLE_TOOL_REPAIR,
+  repairTools,
+  isFreePromptTrainingAllowed,
+  checkOrganizationModelRestrictions,
+  applyProviderSpecificLogic,
+  getToolsAvailable,
+  getToolsUsed,
+  createAnonymousContext,
+  isAnonymousContext,
+  PROMOTION_MAX_REQUESTS,
+  PROMOTION_WINDOW_HOURS,
+} from '@kilocode/llm-shared';
+import type { User } from '@kilocode/db/schema';
+import {
+  invalidRequestResponse,
+  temporarilyUnavailableResponse,
+  rateLimitExceededResponse,
+  paidModelAuthRequiredResponse,
+  promotionLimitReachedResponse,
+  dataCollectionRequiredResponse,
+  alphaPeriodEndedResponse,
+  modelDoesNotExistResponse,
+  modelNotAllowedResponse,
+  ipRequiredResponse,
+  wrapResponse,
+} from '../responses.js';
+import { getWorkerDb } from '../lib/db.js';
+import { authenticateRequest } from '../services/auth.js';
+import { getProvider, createProviders } from '../services/provider.js';
+import { getBalanceAndOrgSettings } from '../services/balance.js';
+import {
+  checkFreeModelRateLimit,
+  logFreeModelRequest,
+  checkPromotionLimit,
+} from '../services/rate-limit.js';
+import { upstreamRequest } from '../services/upstream.js';
+import { classifyAbuse } from '../services/abuse.js';
+import { customLlmRequest } from '../services/custom-llm.js';
+import { countAndStoreUsage } from '../background/usage-accounting.js';
+import { captureProxyError } from '../background/error-capture.js';
+import { logger } from '../logger.js';
+
+const MAX_TOKENS_LIMIT = 99999999999;
+
+export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Response> {
+  const requestStartedAt = performance.now();
+  const env = c.env;
+
+  // 1. Parse & validate request body
+  let requestBodyParsed: OpenRouterChatCompletionRequest;
+  try {
+    const text = await c.req.text();
+    requestBodyParsed = JSON.parse(text);
+    requestBodyParsed.stream_options = {
+      ...(requestBodyParsed.stream_options || {}),
+      include_usage: true,
+    };
+  } catch {
+    return invalidRequestResponse();
+  }
+
+  delete requestBodyParsed.models;
+  if (typeof requestBodyParsed.model !== 'string' || requestBodyParsed.model.trim().length === 0) {
+    return modelDoesNotExistResponse();
+  }
+
+  const requestedModel = requestBodyParsed.model.trim();
+  const requestedModelLowerCased = requestedModel.toLowerCase();
+
+  // 2. Auto-model resolution
+  if (isKiloAutoModel(requestedModelLowerCased)) {
+    const modeHeader = c.req.header('x-kilocode-mode') ?? null;
+    Object.assign(requestBodyParsed, resolveAutoModel(requestedModelLowerCased, modeHeader));
+  }
+
+  const originalModelIdLowerCased = requestBodyParsed.model.toLowerCase();
+
+  // 3. IP extraction — prefer CF-Connecting-IP, fall back to X-Forwarded-For
+  const ipAddress =
+    c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for')?.split(',')[0]?.trim();
+  if (!ipAddress) {
+    return ipRequiredResponse();
+  }
+
+  // Set up DB connection via Hyperdrive
+  const { db, connect, end } = getWorkerDb(env.HYPERDRIVE.connectionString);
+  await connect();
+
+  try {
+    // 4. Free model rate limit
+    if (isKiloFreeModel(originalModelIdLowerCased)) {
+      const rateLimitResult = await checkFreeModelRateLimit(ipAddress, db);
+      if (!rateLimitResult.allowed) {
+        logger.warn('Free model rate limit exceeded', {
+          model: originalModelIdLowerCased,
+        });
+        return rateLimitExceededResponse();
+      }
+    }
+
+    // 5. Auth — JWT only
+    const authResult = await authenticateRequest(
+      c.req.header('authorization'),
+      c.req.header('x-kilocode-organizationid'),
+      db,
+      env.NEXTAUTH_SECRET
+    );
+
+    let user: User | AnonymousUserContext;
+    let organizationId: string | undefined;
+    let botId: string | undefined;
+    let tokenSource: string | undefined;
+
+    if ('error' in authResult) {
+      // 6. Anonymous fallback for free models
+      if (!isFreeModel(originalModelIdLowerCased)) {
+        return paidModelAuthRequiredResponse();
+      }
+
+      const promotionLimit = await checkPromotionLimit(
+        ipAddress,
+        PROMOTION_MAX_REQUESTS,
+        PROMOTION_WINDOW_HOURS,
+        db
+      );
+      if (!promotionLimit.allowed) {
+        return promotionLimitReachedResponse();
+      }
+
+      user = createAnonymousContext(ipAddress);
+      organizationId = undefined;
+      botId = undefined;
+      tokenSource = undefined;
+    } else {
+      user = authResult.user;
+      organizationId = authResult.organizationId;
+      botId = authResult.botId;
+      tokenSource = authResult.tokenSource;
+    }
+
+    // 7. Free model request logging
+    if (isKiloFreeModel(originalModelIdLowerCased)) {
+      await logFreeModelRequest(
+        ipAddress,
+        originalModelIdLowerCased,
+        isAnonymousContext(user) ? undefined : user.id,
+        db
+      );
+    }
+
+    // 8. Provider selection
+    const providers = createProviders({ openrouterApiKey: env.OPENROUTER_API_KEY });
+    const taskId = c.req.header('x-kilocode-taskid')?.slice(0, 500)?.trim() || undefined;
+    const {
+      provider,
+      userByok,
+      customLlm: customLlmRecord,
+    } = await getProvider(
+      originalModelIdLowerCased,
+      requestBodyParsed,
+      user,
+      organizationId,
+      taskId,
+      db,
+      providers
+    );
+
+    logger.debug(`Routing request to ${provider.id}`, { provider: provider.id });
+
+    // 9. Abuse classification (non-blocking, 2s timeout)
+    const classifyPromise = classifyAbuse(c.req.raw, requestBodyParsed, {
+      kiloUserId: user.id,
+      organizationId,
+      projectId: c.req.header('x-kilocode-projectid')?.slice(0, 500)?.trim() || null,
+      provider: provider.id,
+      isByok: !!userByok,
+    });
+
+    // 10. Max tokens check
+    if (requestBodyParsed.max_tokens && requestBodyParsed.max_tokens > MAX_TOKENS_LIMIT) {
+      logger.warn('Max tokens limit exceeded', { userId: user.id });
+      return temporarilyUnavailableResponse();
+    }
+
+    // 11. Dead/rate-limited model checks
+    if (isDeadFreeModel(originalModelIdLowerCased)) {
+      return alphaPeriodEndedResponse();
+    }
+    if (isRateLimitedToDeath(originalModelIdLowerCased)) {
+      return modelDoesNotExistResponse();
+    }
+
+    // 12. Balance/org checks
+    const tokenEstimates = estimateChatTokens(requestBodyParsed);
+    const promptInfo = extractPromptInfo(requestBodyParsed);
+
+    // Extract fraud detection headers
+    const fraudHeaders = {
+      http_x_forwarded_for: c.req.header('x-forwarded-for') || null,
+      http_x_vercel_ip_city: c.req.header('x-vercel-ip-city') || null,
+      http_x_vercel_ip_country: c.req.header('x-vercel-ip-country') || null,
+      http_x_vercel_ip_latitude: c.req.header('x-vercel-ip-latitude')
+        ? Number(c.req.header('x-vercel-ip-latitude'))
+        : null,
+      http_x_vercel_ip_longitude: c.req.header('x-vercel-ip-longitude')
+        ? Number(c.req.header('x-vercel-ip-longitude'))
+        : null,
+      http_x_vercel_ja4_digest: c.req.header('x-vercel-ja4-digest') || null,
+      http_user_agent: c.req.header('user-agent') || null,
+    };
+
+    const projectId = c.req.header('x-kilocode-projectid')?.slice(0, 500)?.trim() || null;
+
+    const usageContext: MicrodollarUsageContext = {
+      kiloUserId: user.id,
+      provider: provider.id,
+      requested_model: originalModelIdLowerCased,
+      promptInfo,
+      max_tokens: requestBodyParsed.max_tokens ?? null,
+      has_middle_out_transform: requestBodyParsed.transforms?.includes('middle-out') ?? false,
+      estimatedInputTokens: tokenEstimates.estimatedInputTokens,
+      estimatedOutputTokens: tokenEstimates.estimatedOutputTokens,
+      fraudHeaders,
+      isStreaming: requestBodyParsed.stream === true,
+      organizationId,
+      prior_microdollar_usage: isAnonymousContext(user) ? 0 : user.microdollars_used,
+      posthog_distinct_id: isAnonymousContext(user) ? undefined : user.google_user_email,
+      project_id: projectId,
+      status_code: null,
+      editor_name: c.req.header('x-kilocode-editorname')?.slice(0, 500)?.trim() || null,
+      machine_id: c.req.header('x-kilocode-machineid')?.slice(0, 500)?.trim() || null,
+      user_byok: !!userByok,
+      has_tools: (requestBodyParsed.tools?.length ?? 0) > 0,
+      botId,
+      tokenSource,
+      feature: validateFeatureHeader(c.req.header(FEATURE_HEADER) ?? null),
+      session_id: taskId ?? null,
+    };
+
+    const bypassAccessCheckForCustomLlm =
+      !!customLlmRecord &&
+      !!organizationId &&
+      customLlmRecord.organization_ids.includes(organizationId);
+
+    if (!isAnonymousContext(user) && !bypassAccessCheckForCustomLlm) {
+      const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, db);
+
+      if (
+        balance <= 0 &&
+        !isFreeModel(originalModelIdLowerCased) &&
+        !userByok &&
+        !isActiveReviewPromo(botId, originalModelIdLowerCased) &&
+        !isActiveCloudAgentPromo(tokenSource, originalModelIdLowerCased)
+      ) {
+        // TODO: Port full usageLimitExceededResponse with payment history
+        return Response.json(
+          {
+            error: {
+              title: 'Low Credit Warning!',
+              message: 'Add credits to continue, or switch to a free model',
+              balance,
+              buyCreditsUrl: 'https://app.kilo.ai/profile',
+            },
+          },
+          { status: 402 }
+        );
+      }
+
+      const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
+        modelId: originalModelIdLowerCased,
+        settings,
+        organizationPlan: plan,
+      });
+      if (modelRestrictionError) {
+        return modelNotAllowedResponse();
+      }
+
+      if (providerConfig) {
+        requestBodyParsed.provider = providerConfig;
+      }
+    }
+
+    // 13. Provider-specific mutations
+    if (
+      isDataCollectionRequiredOnKiloCodeOnly(originalModelIdLowerCased) &&
+      !isFreePromptTrainingAllowed(requestBodyParsed.provider)
+    ) {
+      return dataCollectionRequiredResponse();
+    }
+
+    // 14. Prompt cache key + safety identifier
+    if (taskId) {
+      requestBodyParsed.prompt_cache_key = generateProviderSpecificHash(user.id + taskId, provider);
+    }
+    requestBodyParsed.safety_identifier = generateProviderSpecificHash(user.id, provider);
+    requestBodyParsed.user = requestBodyParsed.safety_identifier;
+
+    // 15. Tool repair
+    if (ENABLE_TOOL_REPAIR) {
+      repairTools(requestBodyParsed);
+    }
+
+    const toolsAvailable = getToolsAvailable(requestBodyParsed.tools);
+    const toolsUsed = getToolsUsed(requestBodyParsed.messages);
+
+    const extraHeaders: Record<string, string> = {};
+    applyProviderSpecificLogic(
+      provider,
+      originalModelIdLowerCased,
+      requestBodyParsed,
+      extraHeaders,
+      userByok
+    );
+
+    // 16. Upstream request
+    const response = customLlmRecord
+      ? await customLlmRequest(
+          customLlmRecord,
+          requestBodyParsed,
+          user.id,
+          taskId,
+          !!fraudHeaders.http_user_agent?.startsWith('Kilo-Code/')
+        )
+      : await upstreamRequest({
+          path: '/chat/completions',
+          search: '',
+          method: 'POST',
+          body: requestBodyParsed,
+          extraHeaders,
+          provider,
+        });
+
+    const ttfbMs = Math.max(0, Math.round(performance.now() - requestStartedAt));
+    usageContext.status_code = response.status;
+
+    // 17. Response processing — background tasks via ctx.waitUntil()
+
+    // Await abuse classification (with 2s timeout)
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const classifyResult = await Promise.race([
+      classifyPromise.finally(() => timeoutId && clearTimeout(timeoutId)),
+      new Promise<null>(resolve => {
+        timeoutId = setTimeout(() => resolve(null), 2000);
+      }),
+    ]);
+    if (classifyResult) {
+      usageContext.abuse_request_id = classifyResult.request_id;
+    }
+
+    // Background: usage accounting
+    const clonedResponse = response.clone();
+    c.executionCtx.waitUntil(countAndStoreUsage(clonedResponse, usageContext));
+
+    // Background: error capture
+    if (response.status === 402 && !userByok) {
+      c.executionCtx.waitUntil(
+        captureProxyError({
+          errorMessage: `${provider.id} returned 402 Payment Required`,
+          userId: user.id,
+          response: response.clone(),
+          organizationId,
+          model: requestBodyParsed.model,
+          trackInSentry: true,
+        })
+      );
+      return temporarilyUnavailableResponse();
+    }
+
+    if (response.status >= 400) {
+      c.executionCtx.waitUntil(
+        captureProxyError({
+          errorMessage: `${provider.id} returned error ${response.status}`,
+          userId: user.id,
+          response: response.clone(),
+          organizationId,
+          model: requestBodyParsed.model,
+          trackInSentry: response.status >= 500,
+        })
+      );
+    }
+
+    // Return response to client
+    return wrapResponse(response);
+  } finally {
+    // Clean up DB connection
+    await end().catch(() => {});
+  }
+}

--- a/llm-gateway/src/routes/chat-completions.ts
+++ b/llm-gateway/src/routes/chat-completions.ts
@@ -48,7 +48,7 @@ import {
 import { getWorkerDb } from '../lib/db.js';
 import { authenticateRequest } from '../services/auth.js';
 import { getProvider, createProviders } from '../services/provider.js';
-import { getBalanceAndOrgSettings } from '../services/balance.js';
+import { getBalanceAndOrgSettings, usageLimitExceededResponse } from '../services/balance.js';
 import {
   checkFreeModelRateLimit,
   logFreeModelRequest,
@@ -57,8 +57,11 @@ import {
 import { upstreamRequest } from '../services/upstream.js';
 import { classifyAbuse } from '../services/abuse.js';
 import { customLlmRequest } from '../services/custom-llm.js';
+import { rewriteFreeModelResponse, makeErrorReadable } from '../services/response-transforms.js';
 import { countAndStoreUsage } from '../background/usage-accounting.js';
 import { captureProxyError } from '../background/error-capture.js';
+import { handleRequestLogging } from '../background/request-log.js';
+import { emitApiMetrics } from '../background/metrics.js';
 import { logger } from '../logger.js';
 
 const MAX_TOKENS_LIMIT = 99999999999;
@@ -170,7 +173,10 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
     }
 
     // 8. Provider selection
-    const providers = createProviders({ openrouterApiKey: env.OPENROUTER_API_KEY });
+    const providers = createProviders({
+      openrouterApiKey: env.OPENROUTER_API_KEY,
+      vercelApiKey: env.VERCEL_AI_GATEWAY_API_KEY,
+    });
     const taskId = c.req.header('x-kilocode-taskid')?.slice(0, 500)?.trim() || undefined;
     const {
       provider,
@@ -183,19 +189,41 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
       organizationId,
       taskId,
       db,
-      providers
+      providers,
+      env.BYOK_CACHE,
+      env.BYOK_ENCRYPTION_KEY
     );
 
     logger.debug(`Routing request to ${provider.id}`, { provider: provider.id });
 
     // 9. Abuse classification (non-blocking, 2s timeout)
-    const classifyPromise = classifyAbuse(c.req.raw, requestBodyParsed, {
-      kiloUserId: user.id,
-      organizationId,
-      projectId: c.req.header('x-kilocode-projectid')?.slice(0, 500)?.trim() || null,
-      provider: provider.id,
-      isByok: !!userByok,
-    });
+    // Fraud headers & editor name are extracted later; read them early for classify
+    const classifyFraudHeaders = {
+      http_x_forwarded_for: c.req.header('x-forwarded-for') || null,
+      http_x_vercel_ip_city: c.req.header('x-vercel-ip-city') || null,
+      http_x_vercel_ip_country: c.req.header('x-vercel-ip-country') || null,
+      http_x_vercel_ip_latitude: c.req.header('x-vercel-ip-latitude')
+        ? Number(c.req.header('x-vercel-ip-latitude'))
+        : null,
+      http_x_vercel_ip_longitude: c.req.header('x-vercel-ip-longitude')
+        ? Number(c.req.header('x-vercel-ip-longitude'))
+        : null,
+      http_x_vercel_ja4_digest: c.req.header('x-vercel-ja4-digest') || null,
+      http_user_agent: c.req.header('user-agent') || null,
+    };
+    const classifyPromise = classifyAbuse(
+      requestBodyParsed,
+      classifyFraudHeaders,
+      c.req.header('x-kilocode-editorname')?.slice(0, 500)?.trim() || null,
+      {
+        kiloUserId: user.id,
+        organizationId,
+        projectId: c.req.header('x-kilocode-projectid')?.slice(0, 500)?.trim() || null,
+        provider: provider.id,
+        isByok: !!userByok,
+      },
+      env
+    );
 
     // 10. Max tokens check
     if (requestBodyParsed.max_tokens && requestBodyParsed.max_tokens > MAX_TOKENS_LIMIT) {
@@ -215,20 +243,8 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
     const tokenEstimates = estimateChatTokens(requestBodyParsed);
     const promptInfo = extractPromptInfo(requestBodyParsed);
 
-    // Extract fraud detection headers
-    const fraudHeaders = {
-      http_x_forwarded_for: c.req.header('x-forwarded-for') || null,
-      http_x_vercel_ip_city: c.req.header('x-vercel-ip-city') || null,
-      http_x_vercel_ip_country: c.req.header('x-vercel-ip-country') || null,
-      http_x_vercel_ip_latitude: c.req.header('x-vercel-ip-latitude')
-        ? Number(c.req.header('x-vercel-ip-latitude'))
-        : null,
-      http_x_vercel_ip_longitude: c.req.header('x-vercel-ip-longitude')
-        ? Number(c.req.header('x-vercel-ip-longitude'))
-        : null,
-      http_x_vercel_ja4_digest: c.req.header('x-vercel-ja4-digest') || null,
-      http_user_agent: c.req.header('user-agent') || null,
-    };
+    // Reuse fraud detection headers extracted earlier for abuse classification
+    const fraudHeaders = classifyFraudHeaders;
 
     const projectId = c.req.header('x-kilocode-projectid')?.slice(0, 500)?.trim() || null;
 
@@ -273,18 +289,7 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
         !isActiveReviewPromo(botId, originalModelIdLowerCased) &&
         !isActiveCloudAgentPromo(tokenSource, originalModelIdLowerCased)
       ) {
-        // TODO: Port full usageLimitExceededResponse with payment history
-        return Response.json(
-          {
-            error: {
-              title: 'Low Credit Warning!',
-              message: 'Add credits to continue, or switch to a free model',
-              balance,
-              buyCreditsUrl: 'https://app.kilo.ai/profile',
-            },
-          },
-          { status: 402 }
-        );
+        return usageLimitExceededResponse(user.id, balance, db);
       }
 
       const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
@@ -340,7 +345,8 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
           requestBodyParsed,
           user.id,
           taskId,
-          !!fraudHeaders.http_user_agent?.startsWith('Kilo-Code/')
+          !!fraudHeaders.http_user_agent?.startsWith('Kilo-Code/'),
+          db
         )
       : await upstreamRequest({
           path: '/chat/completions',
@@ -370,9 +376,59 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
 
     // Background: usage accounting
     const clonedResponse = response.clone();
-    c.executionCtx.waitUntil(countAndStoreUsage(clonedResponse, usageContext));
+    c.executionCtx.waitUntil(countAndStoreUsage(clonedResponse, usageContext, env));
 
-    // Background: error capture
+    // Background: request logging (needs its own DB connection since main handler closes in finally)
+    c.executionCtx.waitUntil(
+      (async () => {
+        const {
+          db: logDb,
+          connect: logConnect,
+          end: logEnd,
+        } = getWorkerDb(env.HYPERDRIVE.connectionString);
+        await logConnect();
+        try {
+          await handleRequestLogging({
+            clonedResponse: response.clone(),
+            userId: isAnonymousContext(user) ? undefined : user.id,
+            userEmail: isAnonymousContext(user) ? undefined : user.google_user_email,
+            organizationId: organizationId ?? null,
+            provider: provider.id,
+            model: requestBodyParsed.model,
+            request: requestBodyParsed,
+            db: logDb,
+          });
+        } finally {
+          await logEnd().catch(() => {});
+        }
+      })()
+    );
+
+    // Background: metrics emission
+    c.executionCtx.waitUntil(
+      emitApiMetrics(
+        {
+          clientSecret: env.O11Y_CLIENT_SECRET,
+          kiloUserId: user.id,
+          organizationId,
+          isAnonymous: isAnonymousContext(user),
+          isStreaming: requestBodyParsed.stream === true,
+          userByok: !!userByok,
+          provider: provider.id,
+          requestedModel: originalModelIdLowerCased,
+          resolvedModel: requestBodyParsed.model,
+          toolsAvailable,
+          toolsUsed,
+          ttfbMs,
+          completeRequestMs: Math.max(0, Math.round(performance.now() - requestStartedAt)),
+          statusCode: response.status,
+        },
+        env.O11Y_SERVICE_URL,
+        env.O11Y_CLIENT_SECRET
+      )
+    );
+
+    // Background: error capture for 402
     if (response.status === 402 && !userByok) {
       c.executionCtx.waitUntil(
         captureProxyError({
@@ -387,6 +443,20 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
       return temporarilyUnavailableResponse();
     }
 
+    // Error readability transform for 400+
+    if (response.status >= 400) {
+      const readableError = await makeErrorReadable({
+        requestedModel: originalModelIdLowerCased,
+        request: requestBodyParsed,
+        response: response.clone(),
+        isUserByok: !!userByok,
+      });
+      if (readableError) {
+        return readableError;
+      }
+    }
+
+    // Background: error capture for other 400+
     if (response.status >= 400) {
       c.executionCtx.waitUntil(
         captureProxyError({
@@ -398,6 +468,17 @@ export async function handleChatCompletions(c: Context<HonoEnv>): Promise<Respon
           trackInSentry: response.status >= 500,
         })
       );
+    }
+
+    // Free model response rewrite
+    const shouldRewrite =
+      !customLlmRecord &&
+      (isFreeModel(originalModelIdLowerCased) ||
+        isActiveReviewPromo(botId, originalModelIdLowerCased) ||
+        isActiveCloudAgentPromo(tokenSource, originalModelIdLowerCased));
+
+    if (shouldRewrite) {
+      return rewriteFreeModelResponse(response, originalModelIdLowerCased);
     }
 
     // Return response to client

--- a/llm-gateway/src/services/abuse.ts
+++ b/llm-gateway/src/services/abuse.ts
@@ -1,27 +1,283 @@
+import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
 import { logger } from '../logger.js';
 
-type ClassifyResult = {
-  verdict: string;
+type Verdict = 'ALLOW' | 'CHALLENGE' | 'SOFT_BLOCK' | 'HARD_BLOCK';
+
+type AbuseSignal =
+  | 'high_velocity'
+  | 'free_tier_exhausted'
+  | 'premium_harvester'
+  | 'suspicious_fingerprint'
+  | 'datacenter_ip'
+  | 'known_abuser';
+
+type ClassificationContext = {
+  identity_key: string;
+  current_spend_1h: number;
+  is_new_user: boolean;
+  requests_per_second: number;
+};
+
+export type AbuseClassificationResponse = {
+  verdict: Verdict;
   risk_score: number;
-  signals: string[];
-  context: { identity_key: string; requests_per_second: number };
+  signals: AbuseSignal[];
+  action_metadata: {
+    challenge_type?: 'turnstile' | 'payment_verification';
+    model_override?: string;
+    retry_after_seconds?: number;
+  };
+  context: ClassificationContext;
   request_id: number;
 };
 
+type UsagePayload = {
+  kilo_user_id?: string | null;
+  organization_id?: string | null;
+  project_id?: string | null;
+  ip_address?: string | null;
+  geo_city?: string | null;
+  geo_country?: string | null;
+  geo_latitude?: number | null;
+  geo_longitude?: number | null;
+  ja4_digest?: string | null;
+  user_agent?: string | null;
+  provider?: string | null;
+  requested_model?: string | null;
+  user_prompt?: string | null;
+  system_prompt?: string | null;
+  max_tokens?: number | null;
+  has_middle_out_transform?: boolean | null;
+  has_tools?: boolean | null;
+  streamed?: boolean | null;
+  is_user_byok?: boolean | null;
+  editor_name?: string | null;
+};
+
+export type AbuseEnv = {
+  ABUSE_SERVICE_URL?: string;
+  ABUSE_SERVICE_CF_ACCESS_CLIENT_ID?: string;
+  ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET?: string;
+};
+
+type AbuseClassificationContext = {
+  kiloUserId: string;
+  organizationId: string | undefined;
+  projectId: string | null;
+  provider: string;
+  isByok: boolean;
+};
+
+type Message = {
+  role: string;
+  content?: string | { type?: string; text?: string }[];
+};
+
+function extractMessageTextContent(m: Message): string {
+  if (typeof m.content === 'string') {
+    return m.content;
+  }
+  if (Array.isArray(m.content)) {
+    return m.content
+      .filter(c => c.type === 'text')
+      .map(c => c.text ?? '')
+      .join('\n');
+  }
+  return '';
+}
+
+function extractFullPrompts(body: OpenRouterChatCompletionRequest): {
+  systemPrompt: string | null;
+  userPrompt: string | null;
+} {
+  const messages = (body.messages ?? []) as Message[];
+
+  const systemPrompt =
+    messages
+      .filter(m => m.role === 'system' || m.role === 'developer')
+      .map(extractMessageTextContent)
+      .join('\n') || null;
+
+  const userPrompt =
+    messages
+      .filter(m => m.role === 'user')
+      .map(extractMessageTextContent)
+      .at(-1) ?? null;
+
+  return { systemPrompt, userPrompt };
+}
+
+async function classifyRequest(
+  payload: UsagePayload,
+  env: AbuseEnv
+): Promise<AbuseClassificationResponse | null> {
+  if (!env.ABUSE_SERVICE_URL) {
+    return null;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (env.ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && env.ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
+      headers['CF-Access-Client-Id'] = env.ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
+      headers['CF-Access-Client-Secret'] = env.ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
+    }
+
+    const response = await fetch(`${env.ABUSE_SERVICE_URL}/api/classify`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      logger.error(`Abuse service error (${response.status}): ${await response.text()}`);
+      return null;
+    }
+
+    return (await response.json()) as AbuseClassificationResponse;
+  } catch (error) {
+    logger.error('Abuse classification failed', { error: String(error) });
+    return null;
+  }
+}
+
+export type CostUpdatePayload = {
+  kilo_user_id?: string | null;
+  ip_address?: string | null;
+  ja4_digest?: string | null;
+  user_agent?: string | null;
+  request_id: number;
+  message_id: string;
+  cost: number;
+  requested_model?: string | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_write_tokens?: number | null;
+  cache_hit_tokens?: number | null;
+};
+
+export async function reportCost(
+  payload: CostUpdatePayload,
+  env: AbuseEnv
+): Promise<{ success: boolean } | null> {
+  if (!env.ABUSE_SERVICE_URL) {
+    return null;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (env.ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && env.ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
+      headers['CF-Access-Client-Id'] = env.ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
+      headers['CF-Access-Client-Secret'] = env.ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
+    }
+
+    const response = await fetch(`${env.ABUSE_SERVICE_URL}/api/usage/cost`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      logger.error(`[Abuse] Cost update failed (${response.status}): ${await response.text()}`);
+      return null;
+    }
+
+    return (await response.json()) as { success: boolean };
+  } catch (error) {
+    logger.error('[Abuse] Failed to report cost', { error: String(error) });
+    return null;
+  }
+}
+
+export async function reportAbuseCost(
+  usageContext: {
+    kiloUserId: string;
+    fraudHeaders: {
+      http_x_forwarded_for: string | null;
+      http_x_vercel_ja4_digest: string | null;
+      http_user_agent: string | null;
+    };
+    requested_model: string;
+    abuse_request_id?: number;
+  },
+  usageStats: {
+    messageId: string | null;
+    cost_mUsd: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheWriteTokens: number;
+    cacheHitTokens: number;
+  },
+  env: AbuseEnv
+): Promise<{ success: boolean } | null> {
+  if (!usageContext.abuse_request_id || !usageStats.messageId) {
+    return null;
+  }
+
+  return reportCost(
+    {
+      kilo_user_id: usageContext.kiloUserId,
+      ip_address: usageContext.fraudHeaders.http_x_forwarded_for,
+      ja4_digest: usageContext.fraudHeaders.http_x_vercel_ja4_digest,
+      user_agent: usageContext.fraudHeaders.http_user_agent,
+      request_id: usageContext.abuse_request_id,
+      message_id: usageStats.messageId,
+      cost: usageStats.cost_mUsd,
+      requested_model: usageContext.requested_model,
+      input_tokens: usageStats.inputTokens,
+      output_tokens: usageStats.outputTokens,
+      cache_write_tokens: usageStats.cacheWriteTokens,
+      cache_hit_tokens: usageStats.cacheHitTokens,
+    },
+    env
+  );
+}
+
 // Non-blocking abuse classification call — fail-open with 2s timeout
 export async function classifyAbuse(
-  _request: Request,
-  _body: unknown,
-  _context: {
-    kiloUserId: string;
-    organizationId: string | undefined;
-    projectId: string | null;
-    provider: string;
-    isByok: boolean;
-  }
-): Promise<ClassifyResult | null> {
-  // TODO: Port abuse service HTTP call from Next.js
-  // For now, fail open (return null) so the request proceeds
-  logger.debug('Abuse classification not yet implemented in worker');
-  return null;
+  body: OpenRouterChatCompletionRequest,
+  fraudHeaders: {
+    http_x_forwarded_for: string | null;
+    http_x_vercel_ip_city: string | null;
+    http_x_vercel_ip_country: string | null;
+    http_x_vercel_ip_latitude: number | null;
+    http_x_vercel_ip_longitude: number | null;
+    http_x_vercel_ja4_digest: string | null;
+    http_user_agent: string | null;
+  },
+  editorName: string | null,
+  context: AbuseClassificationContext,
+  env: AbuseEnv
+): Promise<AbuseClassificationResponse | null> {
+  const { systemPrompt, userPrompt } = extractFullPrompts(body);
+
+  const payload: UsagePayload = {
+    kilo_user_id: context.kiloUserId,
+    organization_id: context.organizationId ?? null,
+    project_id: context.projectId,
+    ip_address: fraudHeaders.http_x_forwarded_for,
+    geo_city: fraudHeaders.http_x_vercel_ip_city,
+    geo_country: fraudHeaders.http_x_vercel_ip_country,
+    geo_latitude: fraudHeaders.http_x_vercel_ip_latitude,
+    geo_longitude: fraudHeaders.http_x_vercel_ip_longitude,
+    ja4_digest: fraudHeaders.http_x_vercel_ja4_digest,
+    user_agent: fraudHeaders.http_user_agent,
+    provider: context.provider,
+    requested_model: body.model?.toLowerCase() ?? null,
+    user_prompt: userPrompt,
+    system_prompt: systemPrompt,
+    max_tokens: body.max_tokens ?? null,
+    has_middle_out_transform: body.transforms?.includes('middle-out') ?? false,
+    has_tools: (body.tools?.length ?? 0) > 0,
+    streamed: body.stream === true,
+    is_user_byok: context.isByok,
+    editor_name: editorName,
+  };
+
+  return classifyRequest(payload, env);
 }

--- a/llm-gateway/src/services/abuse.ts
+++ b/llm-gateway/src/services/abuse.ts
@@ -1,0 +1,27 @@
+import { logger } from '../logger.js';
+
+type ClassifyResult = {
+  verdict: string;
+  risk_score: number;
+  signals: string[];
+  context: { identity_key: string; requests_per_second: number };
+  request_id: number;
+};
+
+// Non-blocking abuse classification call — fail-open with 2s timeout
+export async function classifyAbuse(
+  _request: Request,
+  _body: unknown,
+  _context: {
+    kiloUserId: string;
+    organizationId: string | undefined;
+    projectId: string | null;
+    provider: string;
+    isByok: boolean;
+  }
+): Promise<ClassifyResult | null> {
+  // TODO: Port abuse service HTTP call from Next.js
+  // For now, fail open (return null) so the request proceeds
+  logger.debug('Abuse classification not yet implemented in worker');
+  return null;
+}

--- a/llm-gateway/src/services/auth.ts
+++ b/llm-gateway/src/services/auth.ts
@@ -1,0 +1,68 @@
+import jwt from 'jsonwebtoken';
+import { eq } from 'drizzle-orm';
+import { kilocode_users } from '@kilocode/db/schema';
+import type { User } from '@kilocode/db/schema';
+import type { WorkerDb } from '../lib/db.js';
+import { logger } from '../logger.js';
+
+type AuthResult =
+  | {
+      user: User;
+      organizationId: string | undefined;
+      botId: string | undefined;
+      tokenSource: string | undefined;
+    }
+  | { error: string; status: number };
+
+export async function authenticateRequest(
+  authHeader: string | undefined,
+  orgHeader: string | undefined,
+  db: WorkerDb,
+  secret: string
+): Promise<AuthResult> {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return { error: 'Missing or invalid Authorization header', status: 401 };
+  }
+
+  const token = authHeader.slice(7);
+
+  let decoded: jwt.JwtPayload;
+  try {
+    decoded = jwt.verify(token, secret, { algorithms: ['HS256'] }) as jwt.JwtPayload;
+  } catch (err) {
+    logger.warn('JWT verification failed', { error: String(err) });
+    return { error: 'Invalid or expired token', status: 401 };
+  }
+
+  const userId = decoded.sub;
+  if (!userId) {
+    return { error: 'Token missing sub claim', status: 401 };
+  }
+
+  // Look up user in the database
+  const [user] = await db
+    .select()
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, userId))
+    .limit(1);
+
+  if (!user) {
+    return { error: 'User not found', status: 401 };
+  }
+
+  // Validate API token pepper if present
+  if (decoded.pepper && user.api_token_pepper !== decoded.pepper) {
+    return { error: 'Token has been revoked', status: 401 };
+  }
+
+  // Check if user is blocked
+  if (user.blocked_reason) {
+    return { error: 'Account is suspended', status: 403 };
+  }
+
+  const organizationId = orgHeader?.trim() || undefined;
+  const botId = decoded.botId ?? undefined;
+  const tokenSource = decoded.tokenSource ?? undefined;
+
+  return { user, organizationId, botId, tokenSource };
+}

--- a/llm-gateway/src/services/balance.ts
+++ b/llm-gateway/src/services/balance.ts
@@ -1,17 +1,33 @@
-import { eq } from 'drizzle-orm';
-import { kilocode_users } from '@kilocode/db/schema';
+import { eq, and, not, sql, gt, notExists } from 'drizzle-orm';
+import {
+  kilocode_users,
+  organizations,
+  organization_memberships,
+  organization_user_limits,
+  organization_user_usage,
+  credit_transactions,
+  kilo_pass_issuance_items,
+} from '@kilocode/db/schema';
 import type { User } from '@kilocode/db/schema';
 import type { WorkerDb } from '../lib/db.js';
+import { logger } from '../logger.js';
+
+type OrganizationSettings = {
+  model_allow_list?: string[];
+  provider_allow_list?: string[];
+  data_collection?: 'allow' | 'deny';
+  minimum_balance?: number;
+  minimum_balance_alert_email?: string[];
+};
 
 type BalanceResult = {
   balance: number;
-  settings?: {
-    model_allow_list?: string[];
-    provider_allow_list?: string[];
-    data_collection?: 'allow' | 'deny';
-  };
+  settings?: OrganizationSettings;
   plan?: 'teams' | 'enterprise';
 };
+
+const APP_URL = 'https://app.kilo.ai';
+const FIRST_TOPUP_BONUS_AMOUNT = 20;
 
 export async function getBalanceAndOrgSettings(
   organizationId: string | undefined,
@@ -19,9 +35,7 @@ export async function getBalanceAndOrgSettings(
   db: WorkerDb
 ): Promise<BalanceResult> {
   if (organizationId) {
-    // For org users, query organization balance and settings
-    // TODO: Port full organization balance query from Next.js
-    return { balance: Infinity };
+    return getBalanceForOrganizationUser(organizationId, user.id, db);
   }
 
   // For individual users, balance = credits - usage
@@ -39,6 +53,156 @@ export async function getBalanceAndOrgSettings(
   }
 
   const balance =
-    Number(freshUser.total_microdollars_acquired) - Number(freshUser.microdollars_used);
+    (Number(freshUser.total_microdollars_acquired) - Number(freshUser.microdollars_used)) /
+    1_000_000;
   return { balance };
+}
+
+async function getBalanceForOrganizationUser(
+  organizationId: string,
+  userId: string,
+  db: WorkerDb
+): Promise<BalanceResult> {
+  const result = await db
+    .select({
+      microdollar_limit: organization_user_limits.microdollar_limit,
+      microdollar_usage: organization_user_usage.microdollar_usage,
+      total_microdollars_acquired: organizations.total_microdollars_acquired,
+      microdollars_used: organizations.microdollars_used,
+      settings: organizations.settings,
+      require_seats: organizations.require_seats,
+      plan: organizations.plan,
+    })
+    .from(organizations)
+    .innerJoin(
+      organization_memberships,
+      eq(organization_memberships.organization_id, organizations.id)
+    )
+    .leftJoin(
+      organization_user_limits,
+      and(
+        eq(organization_user_limits.organization_id, organizations.id),
+        eq(organization_user_limits.kilo_user_id, userId),
+        eq(organization_user_limits.limit_type, 'daily')
+      )
+    )
+    .leftJoin(
+      organization_user_usage,
+      and(
+        eq(organization_user_usage.organization_id, organizations.id),
+        eq(organization_user_usage.kilo_user_id, userId),
+        eq(organization_user_usage.limit_type, 'daily'),
+        eq(organization_user_usage.usage_date, sql`CURRENT_DATE`)
+      )
+    )
+    .where(
+      and(
+        eq(organizations.id, organizationId),
+        eq(organization_memberships.kilo_user_id, userId),
+        not(eq(organization_memberships.role, 'billing_manager'))
+      )
+    )
+    .limit(1);
+
+  if (result.length === 0) {
+    logger.debug('User is not a member of the organization');
+    return { balance: 0, settings: {} };
+  }
+
+  const {
+    microdollar_limit,
+    microdollar_usage,
+    total_microdollars_acquired,
+    microdollars_used,
+    settings,
+    require_seats,
+    plan,
+  } = result[0];
+
+  // TODO: Port credit expiration processing (processOrganizationExpirations)
+  const organization_balance = total_microdollars_acquired - microdollars_used;
+
+  // If organization requires seats, ignore any user limits
+  if (require_seats) {
+    return {
+      balance: organization_balance / 1_000_000,
+      settings: settings as OrganizationSettings,
+      plan: plan as BalanceResult['plan'],
+    };
+  }
+
+  // If user has no limits set, return organization's total balance
+  if (microdollar_limit == null) {
+    return {
+      balance: organization_balance / 1_000_000,
+      settings: settings as OrganizationSettings,
+      plan: plan as BalanceResult['plan'],
+    };
+  }
+
+  // User has limits - calculate remaining allowance
+  const usageAmount = microdollar_usage || 0;
+  const remainingAllowance = microdollar_limit - usageAmount;
+  const cappedBalance = Math.min(remainingAllowance, organization_balance);
+
+  return {
+    balance: cappedBalance / 1_000_000,
+    settings: settings as OrganizationSettings,
+    plan: plan as BalanceResult['plan'],
+  };
+}
+
+// --- usageLimitExceededResponse ---
+
+async function summarizeUserPayments(
+  userId: string,
+  db: WorkerDb
+): Promise<{ payments_count: number; payments_total_microdollars: number }> {
+  const result = await db
+    .select({
+      payments_count: sql<number>`count(*)::int`,
+      payments_total_microdollars: sql<number>`coalesce(sum(${credit_transactions.amount_microdollars}), 0)::float`,
+    })
+    .from(credit_transactions)
+    .where(
+      and(
+        eq(credit_transactions.kilo_user_id, userId),
+        eq(credit_transactions.is_free, false),
+        gt(credit_transactions.amount_microdollars, 0),
+        notExists(
+          db
+            .select({ id: kilo_pass_issuance_items.id })
+            .from(kilo_pass_issuance_items)
+            .where(eq(kilo_pass_issuance_items.credit_transaction_id, credit_transactions.id))
+        )
+      )
+    );
+
+  return result[0] ?? { payments_count: 0, payments_total_microdollars: 0 };
+}
+
+export async function usageLimitExceededResponse(
+  userId: string,
+  balance: number | undefined,
+  db: WorkerDb
+): Promise<Response> {
+  const payments = await summarizeUserPayments(userId, db);
+
+  const title = !payments.payments_count ? 'Paid Model - Credits Required' : 'Low Credit Warning!';
+
+  const message = !payments.payments_count
+    ? `This is a paid model. To use paid models, you need to add credits. Get $${FIRST_TOPUP_BONUS_AMOUNT} free on your first topup!`
+    : 'Add credits to continue, or switch to a free model';
+
+  return Response.json(
+    {
+      error: {
+        title,
+        message,
+        balance,
+        buyCreditsUrl: APP_URL + '/profile',
+      },
+    },
+    { status: 402 }
+  );
 }

--- a/llm-gateway/src/services/balance.ts
+++ b/llm-gateway/src/services/balance.ts
@@ -1,0 +1,44 @@
+import { eq } from 'drizzle-orm';
+import { kilocode_users } from '@kilocode/db/schema';
+import type { User } from '@kilocode/db/schema';
+import type { WorkerDb } from '../lib/db.js';
+
+type BalanceResult = {
+  balance: number;
+  settings?: {
+    model_allow_list?: string[];
+    provider_allow_list?: string[];
+    data_collection?: 'allow' | 'deny';
+  };
+  plan?: 'teams' | 'enterprise';
+};
+
+export async function getBalanceAndOrgSettings(
+  organizationId: string | undefined,
+  user: User,
+  db: WorkerDb
+): Promise<BalanceResult> {
+  if (organizationId) {
+    // For org users, query organization balance and settings
+    // TODO: Port full organization balance query from Next.js
+    return { balance: Infinity };
+  }
+
+  // For individual users, balance = credits - usage
+  const [freshUser] = await db
+    .select({
+      microdollars_used: kilocode_users.microdollars_used,
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+    })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, user.id))
+    .limit(1);
+
+  if (!freshUser) {
+    return { balance: 0 };
+  }
+
+  const balance =
+    Number(freshUser.total_microdollars_acquired) - Number(freshUser.microdollars_used);
+  return { balance };
+}

--- a/llm-gateway/src/services/byok.ts
+++ b/llm-gateway/src/services/byok.ts
@@ -1,0 +1,193 @@
+import { createDecipheriv } from 'crypto';
+import { byok_api_keys, modelsByProvider } from '@kilocode/db/schema';
+import type { EncryptedData } from '@kilocode/db/schema-types';
+import {
+  UserByokProviderIdSchema,
+  VercelUserByokInferenceProviderIdSchema,
+  isCodestralModel,
+  kiloFreeModels,
+  inferVercelFirstPartyInferenceProviderForModel,
+  type UserByokProviderId,
+  type VercelUserByokInferenceProviderId,
+} from '@kilocode/llm-shared';
+import { eq, and, inArray, desc } from 'drizzle-orm';
+import type { WorkerDb } from '../lib/db.js';
+import { logger } from '../logger.js';
+
+export type BYOKResult = {
+  decryptedAPIKey: string;
+  providerId: UserByokProviderId;
+};
+
+// --- Encryption (ported to use Node.js crypto via nodejs_compat) ---
+
+function decryptApiKey(encrypted: EncryptedData, keyBase64: string): string {
+  const key = Buffer.from(keyBase64, 'base64');
+
+  if (key.length !== 32) {
+    throw new Error('Encryption key must be 32 bytes (256 bits)');
+  }
+
+  const iv = Buffer.from(encrypted.iv, 'base64');
+  const encryptedData = Buffer.from(encrypted.data, 'base64');
+  const authTag = Buffer.from(encrypted.authTag, 'base64');
+
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(encryptedData, undefined, 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+}
+
+// --- Model ID mapping (inline port from vercel/mapModelIdToVercel.ts) ---
+
+const vercelModelIdMapping: Record<string, string | undefined> = {
+  'arcee-ai/trinity-large-preview:free': 'arcee-ai/trinity-large-preview',
+  'mistralai/codestral-2508': 'mistral/codestral',
+  'mistralai/devstral-2512': 'mistral/devstral-2',
+};
+
+function mapModelIdToVercel(modelId: string): string {
+  const hardcodedVercelId = vercelModelIdMapping[modelId];
+  if (hardcodedVercelId) {
+    return hardcodedVercelId;
+  }
+
+  const internalId =
+    kiloFreeModels.find(m => m.public_id === modelId && m.is_enabled && m.gateway === 'openrouter')
+      ?.internal_id ?? modelId;
+
+  const slashIndex = internalId.indexOf('/');
+  if (slashIndex < 0) {
+    return internalId;
+  }
+
+  const firstPartyProvider = inferVercelFirstPartyInferenceProviderForModel(internalId);
+  return firstPartyProvider ? firstPartyProvider + internalId.slice(slashIndex) : internalId;
+}
+
+// --- BYOK provider resolution with KV caching ---
+
+async function getModelUserByokProviders_fromDb(
+  modelId: string,
+  db: WorkerDb
+): Promise<UserByokProviderId[]> {
+  const vercelModelMetadata = (
+    await db
+      .select({ vercel: modelsByProvider.vercel })
+      .from(modelsByProvider)
+      .orderBy(desc(modelsByProvider.id))
+      .limit(1)
+  ).at(0)?.vercel;
+
+  if (!vercelModelMetadata) {
+    logger.error('no Vercel model metadata in the database');
+    return [];
+  }
+
+  const vercelModelId = mapModelIdToVercel(modelId);
+  const endpoints = vercelModelMetadata[vercelModelId]?.endpoints;
+
+  const providers: UserByokProviderId[] =
+    endpoints
+      ?.map(ep => VercelUserByokInferenceProviderIdSchema.safeParse(ep.tag).data)
+      .filter(
+        (providerId): providerId is VercelUserByokInferenceProviderId => providerId !== undefined
+      ) ?? [];
+
+  if (providers.length === 0) {
+    logger.debug(`no user byok providers for ${modelId}`);
+    return [];
+  }
+
+  logger.debug(`found user byok providers for ${modelId}: ${providers.join(', ')}`);
+  return providers;
+}
+
+export async function getModelUserByokProviders(
+  model: string,
+  db: WorkerDb,
+  kv: KVNamespace
+): Promise<UserByokProviderId[]> {
+  if (isCodestralModel(model)) {
+    return ['codestral'];
+  }
+
+  const cacheKey = `byok-providers:${model}`;
+  const cached = await kv.get(cacheKey, 'json');
+  if (cached) {
+    return cached as UserByokProviderId[];
+  }
+
+  const providers = await getModelUserByokProviders_fromDb(model, db);
+  await kv.put(cacheKey, JSON.stringify(providers), { expirationTtl: 300 });
+  return providers;
+}
+
+function decryptByokRow(
+  row: { encrypted_api_key: EncryptedData; provider_id: string },
+  encryptionKey: string
+): BYOKResult {
+  return {
+    decryptedAPIKey: decryptApiKey(row.encrypted_api_key, encryptionKey),
+    providerId: UserByokProviderIdSchema.parse(row.provider_id),
+  };
+}
+
+export async function getBYOKforUser(
+  db: WorkerDb,
+  userId: string,
+  providerIds: UserByokProviderId[],
+  encryptionKey: string
+): Promise<BYOKResult[] | null> {
+  const rows = await db
+    .select({
+      encrypted_api_key: byok_api_keys.encrypted_api_key,
+      provider_id: byok_api_keys.provider_id,
+    })
+    .from(byok_api_keys)
+    .where(
+      and(
+        eq(byok_api_keys.kilo_user_id, userId),
+        eq(byok_api_keys.is_enabled, true),
+        inArray(byok_api_keys.provider_id, providerIds)
+      )
+    )
+    .orderBy(byok_api_keys.created_at);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return rows.map(row => decryptByokRow(row, encryptionKey));
+}
+
+export async function getBYOKforOrganization(
+  db: WorkerDb,
+  organizationId: string,
+  providerIds: UserByokProviderId[],
+  encryptionKey: string
+): Promise<BYOKResult[] | null> {
+  const rows = await db
+    .select({
+      encrypted_api_key: byok_api_keys.encrypted_api_key,
+      provider_id: byok_api_keys.provider_id,
+    })
+    .from(byok_api_keys)
+    .where(
+      and(
+        eq(byok_api_keys.organization_id, organizationId),
+        eq(byok_api_keys.is_enabled, true),
+        inArray(byok_api_keys.provider_id, providerIds)
+      )
+    )
+    .orderBy(byok_api_keys.created_at);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return rows.map(row => decryptByokRow(row, encryptionKey));
+}

--- a/llm-gateway/src/services/custom-llm.ts
+++ b/llm-gateway/src/services/custom-llm.ts
@@ -1,22 +1,1272 @@
 import type { CustomLlm } from '@kilocode/db/schema';
+import { temp_phase } from '@kilocode/db/schema';
+import { VerbositySchema, ReasoningEffortSchema } from '@kilocode/db/schema-types';
+import { ReasoningDetailType } from '@kilocode/llm-shared';
 import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import type { OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
+import {
+  APICallError,
+  generateText,
+  jsonSchema,
+  streamText,
+  type ModelMessage,
+  type TextStreamPart,
+  type ToolChoice,
+  type ToolSet,
+} from 'ai';
+import { createHash } from 'crypto';
+import { inArray } from 'drizzle-orm';
+import type { WorkerDb } from '../lib/db.js';
 
-// Custom LLM request handler using Vercel AI SDK
-// Full implementation to be ported from src/lib/custom-llm/customLlmRequest.ts
-export async function customLlmRequest(
-  customLlm: CustomLlm,
-  body: OpenRouterChatCompletionRequest,
+// ---------------------------------------------------------------------------
+// Reasoning format enum (from custom-llm/format.ts — different from llm-shared ReasoningFormat)
+// ---------------------------------------------------------------------------
+
+enum ReasoningFormat {
+  Unknown = 'unknown',
+  OpenAIResponsesV1 = 'openai-responses-v1',
+  XAIResponsesV1 = 'xai-responses-v1',
+  AnthropicClaudeV1 = 'anthropic-claude-v1',
+  GoogleGeminiV1 = 'google-gemini-v1',
+  // hack to prevent the extension from stripping ids
+  OpenAIResponsesV1_Obscured = 'openai-responses-v1-obscured',
+}
+
+// Local reasoning detail types — broader than @kilocode/llm-shared's ReasoningDetailUnion
+// because the format field here includes provider-specific values from the ReasoningFormat enum.
+type ReasoningDetailText = {
+  type: ReasoningDetailType.Text;
+  text?: string | null;
+  signature?: string | null;
+  id?: string | null;
+  format?: string | null;
+  index?: number;
+};
+
+type ReasoningDetailEncrypted = {
+  type: ReasoningDetailType.Encrypted;
+  data: string;
+  id?: string | null;
+  format?: string | null;
+  index?: number;
+};
+
+type ReasoningDetailSummary = {
+  type: ReasoningDetailType.Summary;
+  summary: string;
+  id?: string | null;
+  format?: string | null;
+  index?: number;
+};
+
+type ReasoningDetailUnion = ReasoningDetailText | ReasoningDetailEncrypted | ReasoningDetailSummary;
+
+// ---------------------------------------------------------------------------
+// OpenRouter chat completions input types (inlined)
+// ---------------------------------------------------------------------------
+
+type OpenRouterCacheControl = { type: 'ephemeral' };
+
+type OpenRouterChatCompletionsInput = ChatCompletionMessageParam[];
+
+type ChatCompletionMessageParam =
+  | ChatCompletionSystemMessageParam
+  | ChatCompletionUserMessageParam
+  | ChatCompletionAssistantMessageParam
+  | ChatCompletionToolMessageParam;
+
+type ChatCompletionSystemMessageParam = {
+  role: 'system';
+  content: string | ChatCompletionContentPartText[];
+};
+
+type ChatCompletionUserMessageParam = {
+  role: 'user';
+  content: string | ChatCompletionContentPart[];
+  cache_control?: OpenRouterCacheControl;
+};
+
+type ChatCompletionContentPart =
+  | ChatCompletionContentPartText
+  | ChatCompletionContentPartImage
+  | ChatCompletionContentPartFile
+  | ChatCompletionContentPartInputAudio;
+
+type ChatCompletionContentPartText = {
+  type: 'text';
+  text: string;
+  reasoning?: string | null;
+  cache_control?: OpenRouterCacheControl;
+};
+
+type ChatCompletionContentPartImage = {
+  type: 'image_url';
+  image_url: { url: string };
+  cache_control?: OpenRouterCacheControl;
+};
+
+type ChatCompletionContentPartFile = {
+  type: 'file';
+  file: { filename?: string; file_data?: string; file_id?: string };
+  cache_control?: OpenRouterCacheControl;
+};
+
+type ChatCompletionContentPartInputAudio = {
+  type: 'input_audio';
+  input_audio: { data: string; format: string };
+  cache_control?: OpenRouterCacheControl;
+};
+
+type ChatCompletionAssistantMessageParam = {
+  role: 'assistant';
+  content?: string | null;
+  reasoning?: string | null;
+  reasoning_details?: ReasoningDetailUnion[];
+  tool_calls?: ChatCompletionMessageToolCall[];
+  cache_control?: OpenRouterCacheControl;
+};
+
+type ChatCompletionMessageToolCall = {
+  type: 'function';
+  id: string;
+  function: { arguments: string; name: string };
+};
+
+type ChatCompletionToolMessageParam = {
+  role: 'tool';
+  content: string | ChatCompletionContentPart[];
+  tool_call_id: string;
+  cache_control?: OpenRouterCacheControl;
+};
+
+// ---------------------------------------------------------------------------
+// Lightweight output chunk types (we produce these, not parse)
+// ---------------------------------------------------------------------------
+
+type ChatCompletionChunkChoice = {
+  delta: {
+    role?: 'assistant';
+    content?: string | null;
+    reasoning?: string | null;
+    reasoning_details?: ReasoningDetailUnion[];
+    tool_calls?: {
+      index: number;
+      id?: string;
+      type?: 'function';
+      function: { name?: string; arguments?: string };
+    }[];
+  };
+  finish_reason?: string | null;
+};
+
+type ChatCompletionChunk = {
+  id?: string;
+  model: string;
+  choices: ChatCompletionChunkChoice[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    prompt_tokens_details?: {
+      cached_tokens: number;
+      cache_write_tokens?: number;
+    };
+    completion_tokens_details?: {
+      reasoning_tokens: number;
+    };
+  };
+};
+
+// ---------------------------------------------------------------------------
+// AI SDK reasoning part (mirrors @ai-sdk/provider-utils ReasoningPart)
+// ---------------------------------------------------------------------------
+
+type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+type AiSdkProviderOptions = Record<string, Record<string, JsonValue>>;
+
+type AiSdkReasoningPart = {
+  type: 'reasoning';
+  text: string;
+  providerOptions?: AiSdkProviderOptions;
+};
+
+// ---------------------------------------------------------------------------
+// Reasoning provider metadata helpers (from reasoning-provider-metadata.ts)
+// ---------------------------------------------------------------------------
+
+type ProviderMetadata = Record<string, Record<string, unknown>> | undefined;
+
+function extractSignature(meta: ProviderMetadata): string | null {
+  if (!meta) return null;
+  const anthropicSig = meta.anthropic?.signature;
+  if (typeof anthropicSig === 'string') return anthropicSig;
+  const googleSig = meta.google?.thoughtSignature;
+  if (typeof googleSig === 'string') return googleSig;
+  const vertexSig = meta.vertex?.thoughtSignature;
+  if (typeof vertexSig === 'string') return vertexSig;
+  return null;
+}
+
+function extractEncryptedData(meta: ProviderMetadata): string | null {
+  if (!meta) return null;
+  const anthropic = meta.anthropic?.redactedData;
+  if (typeof anthropic === 'string') return anthropic;
+  const openai = meta.openai?.reasoningEncryptedContent;
+  if (typeof openai === 'string') return openai;
+  const xai = meta.xai?.reasoningEncryptedContent;
+  if (typeof xai === 'string') return xai;
+  return null;
+}
+
+function extractItemId(meta: ProviderMetadata): string | null {
+  if (!meta) return null;
+  const openaiId = meta.openai?.itemId;
+  if (typeof openaiId === 'string') return openaiId;
+  const xaiId = meta.xai?.itemId;
+  if (typeof xaiId === 'string') return xaiId;
+  return null;
+}
+
+function extractFormat(meta: ProviderMetadata): ReasoningFormat | null {
+  if (!meta) return null;
+  if (meta.anthropic) return ReasoningFormat.AnthropicClaudeV1;
+  if (meta.openai) return ReasoningFormat.OpenAIResponsesV1;
+  if (meta.xai) return ReasoningFormat.XAIResponsesV1;
+  if (meta.google || meta.vertex) return ReasoningFormat.GoogleGeminiV1;
+  return null;
+}
+
+const FORMAT_TO_PROVIDER_KEY: Partial<Record<ReasoningFormat, string>> = {
+  [ReasoningFormat.AnthropicClaudeV1]: 'anthropic',
+  [ReasoningFormat.OpenAIResponsesV1]: 'openai',
+  [ReasoningFormat.XAIResponsesV1]: 'xai',
+  [ReasoningFormat.GoogleGeminiV1]: 'google',
+};
+
+function detailToAiSdkPart(detail: ReasoningDetailUnion): AiSdkReasoningPart | null {
+  switch (detail.type) {
+    case ReasoningDetailType.Text: {
+      const text = (detail as ReasoningDetailText).text ?? '';
+      const opts = buildTextProviderOptions(detail as ReasoningDetailText);
+      return { type: 'reasoning', text, ...(opts ? { providerOptions: opts } : {}) };
+    }
+    case ReasoningDetailType.Encrypted: {
+      const opts = buildEncryptedProviderOptions(detail as ReasoningDetailEncrypted);
+      return { type: 'reasoning', text: '', ...(opts ? { providerOptions: opts } : {}) };
+    }
+    case ReasoningDetailType.Summary:
+      return { type: 'reasoning', text: (detail as { summary: string }).summary };
+  }
+}
+
+function buildTextProviderOptions(detail: ReasoningDetailText): AiSdkProviderOptions | null {
+  const format = (detail as Record<string, unknown>).format as ReasoningFormat | undefined;
+  switch (format) {
+    case ReasoningFormat.AnthropicClaudeV1: {
+      if (!detail.signature) return null;
+      return { anthropic: { signature: detail.signature } };
+    }
+    case ReasoningFormat.OpenAIResponsesV1: {
+      if (!detail.id) return null;
+      return { openai: { itemId: detail.id } };
+    }
+    case ReasoningFormat.XAIResponsesV1: {
+      if (!detail.id) return null;
+      return { xai: { itemId: detail.id } };
+    }
+    case ReasoningFormat.GoogleGeminiV1: {
+      if (!detail.signature) return null;
+      return { google: { thoughtSignature: detail.signature } };
+    }
+    default:
+      return null;
+  }
+}
+
+function buildEncryptedProviderOptions(
+  detail: ReasoningDetailEncrypted
+): AiSdkProviderOptions | null {
+  const format = (detail as Record<string, unknown>).format as ReasoningFormat | undefined;
+  switch (format) {
+    case ReasoningFormat.AnthropicClaudeV1:
+      return { anthropic: { redactedData: detail.data } };
+    case ReasoningFormat.OpenAIResponsesV1: {
+      const inner: Record<string, JsonValue> = { reasoningEncryptedContent: detail.data };
+      if (detail.id) inner.itemId = detail.id;
+      return { openai: inner };
+    }
+    case ReasoningFormat.XAIResponsesV1: {
+      const inner: Record<string, JsonValue> = { reasoningEncryptedContent: detail.data };
+      if (detail.id) inner.itemId = detail.id;
+      return { xai: inner };
+    }
+    default:
+      return null;
+  }
+}
+
+function mergeEncryptedIntoTextParts(details: ReasoningDetailUnion[]): AiSdkReasoningPart[] {
+  const encryptedById = new Map<string, string>();
+  for (const d of details) {
+    if (d.type === ReasoningDetailType.Encrypted && d.id) {
+      encryptedById.set(d.id, (d as ReasoningDetailEncrypted).data);
+    }
+  }
+
+  const usedEncryptedIds = new Set<string>();
+  const parts: AiSdkReasoningPart[] = [];
+
+  for (const detail of details) {
+    if (detail.type === ReasoningDetailType.Encrypted) continue;
+
+    const part = detailToAiSdkPart(detail);
+    if (!part) continue;
+
+    if (detail.type === ReasoningDetailType.Text && detail.id) {
+      const encryptedData = encryptedById.get(detail.id);
+      if (encryptedData) {
+        const format = (detail as Record<string, unknown>).format as ReasoningFormat | undefined;
+        const providerKey = format ? FORMAT_TO_PROVIDER_KEY[format] : undefined;
+        if (providerKey) {
+          const existing = (part.providerOptions?.[providerKey] ?? {}) as Record<string, JsonValue>;
+          part.providerOptions = {
+            ...part.providerOptions,
+            [providerKey]: { ...existing, reasoningEncryptedContent: encryptedData },
+          };
+          usedEncryptedIds.add(detail.id);
+        }
+      }
+    }
+
+    parts.push(part);
+  }
+
+  for (const detail of details) {
+    if (detail.type !== ReasoningDetailType.Encrypted) continue;
+    if (detail.id && usedEncryptedIds.has(detail.id)) continue;
+    const part = detailToAiSdkPart(detail);
+    if (part) parts.push(part);
+  }
+
+  return parts;
+}
+
+function reasoningDetailsToAiSdkParts(details: ReasoningDetailUnion[]): AiSdkReasoningPart[] {
+  const needsMerge = details.some(d => {
+    const format = (d as Record<string, unknown>).format as string | undefined;
+    return (
+      format === ReasoningFormat.OpenAIResponsesV1 || format === ReasoningFormat.XAIResponsesV1
+    );
+  });
+
+  if (needsMerge) return mergeEncryptedIntoTextParts(details);
+
+  const parts: AiSdkReasoningPart[] = [];
+  for (const detail of details) {
+    const part = detailToAiSdkPart(detail);
+    if (part) parts.push(part);
+  }
+  return parts;
+}
+
+function reasoningOutputToDetails(
+  reasoning: ReadonlyArray<{ type: 'reasoning'; text: string; providerMetadata?: ProviderMetadata }>
+): ReasoningDetailUnion[] {
+  const details: ReasoningDetailUnion[] = [];
+
+  for (const part of reasoning) {
+    const signature = extractSignature(part.providerMetadata);
+    const encryptedData = extractEncryptedData(part.providerMetadata);
+    const itemId = extractItemId(part.providerMetadata);
+    const format = extractFormat(part.providerMetadata);
+    const optionalFields = {
+      ...(itemId ? { id: itemId } : {}),
+      ...(format ? { format } : {}),
+    };
+
+    if (part.text) {
+      details.push({
+        type: ReasoningDetailType.Text,
+        text: part.text,
+        ...(signature ? { signature } : {}),
+        ...optionalFields,
+      });
+    }
+
+    if (encryptedData) {
+      details.push({
+        type: ReasoningDetailType.Encrypted,
+        data: encryptedData,
+        ...optionalFields,
+      });
+    }
+  }
+
+  return details;
+}
+
+// ---------------------------------------------------------------------------
+// Message conversion
+// ---------------------------------------------------------------------------
+
+function convertMessages(messages: OpenRouterChatCompletionsInput): ModelMessage[] {
+  const toolNameByCallId = new Map<string, string>();
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.tool_calls) {
+      for (const tc of msg.tool_calls) {
+        toolNameByCallId.set(tc.id, tc.function.name);
+      }
+    }
+  }
+
+  return messages.map((msg): ModelMessage => {
+    switch (msg.role) {
+      case 'system':
+        return {
+          role: 'system',
+          content:
+            typeof msg.content === 'string'
+              ? msg.content
+              : msg.content.map(part => part.text).join(''),
+          providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+          },
+        };
+
+      case 'user': {
+        const content =
+          typeof msg.content === 'string' ? msg.content : msg.content.map(convertUserContentPart);
+        return {
+          role: 'user',
+          content,
+          ...(msg.cache_control && {
+            providerOptions: { anthropic: { cacheControl: msg.cache_control } },
+          }),
+        };
+      }
+
+      case 'assistant':
+        return {
+          role: 'assistant',
+          content: convertAssistantContent(msg),
+        };
+
+      case 'tool':
+        return {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: msg.tool_call_id,
+              toolName: toolNameByCallId.get(msg.tool_call_id) ?? '',
+              output: convertToolOutput(msg.content),
+            },
+          ],
+        };
+    }
+  });
+}
+
+function convertUserContentPart(part: ChatCompletionContentPart) {
+  const providerOptions = part.cache_control
+    ? { anthropic: { cacheControl: part.cache_control } }
+    : undefined;
+
+  switch (part.type) {
+    case 'text':
+      return {
+        type: 'text' as const,
+        text: part.text,
+        ...(providerOptions && { providerOptions }),
+      };
+
+    case 'image_url':
+      return {
+        type: 'image' as const,
+        image: new URL(part.image_url.url),
+        ...(providerOptions && { providerOptions }),
+      };
+
+    case 'file':
+      return {
+        type: 'file' as const,
+        data: part.file.file_data ?? '',
+        filename: part.file.filename,
+        mediaType: parseDataUrl(part.file.file_data ?? '')?.mediaType ?? 'application/octet-stream',
+        ...(providerOptions && { providerOptions }),
+      };
+
+    case 'input_audio':
+      return {
+        type: 'file' as const,
+        data: part.input_audio.data,
+        mediaType: audioFormatToMediaType(part.input_audio.format),
+        ...(providerOptions && { providerOptions }),
+      };
+  }
+}
+
+type ToolOutputContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'media'; data: string; mediaType: string };
+
+function convertToolOutput(content: string | ChatCompletionContentPart[]) {
+  if (typeof content === 'string') {
+    return { type: 'text' as const, value: content };
+  }
+  const parts: ToolOutputContentPart[] = content.map(convertToolOutputPart);
+  return { type: 'content' as const, value: parts };
+}
+
+function convertToolOutputPart(part: ChatCompletionContentPart): ToolOutputContentPart {
+  switch (part.type) {
+    case 'text':
+      return { type: 'text', text: part.text };
+
+    case 'image_url': {
+      const parsed = parseDataUrl(part.image_url.url);
+      if (parsed) return { type: 'media', data: parsed.data, mediaType: parsed.mediaType };
+      return { type: 'text', text: part.image_url.url };
+    }
+
+    case 'file': {
+      const parsed = part.file.file_data ? parseDataUrl(part.file.file_data) : null;
+      if (parsed) return { type: 'media', data: parsed.data, mediaType: parsed.mediaType };
+      return { type: 'text', text: part.file.file_data ?? '' };
+    }
+
+    case 'input_audio':
+      return {
+        type: 'media',
+        data: part.input_audio.data,
+        mediaType: audioFormatToMediaType(part.input_audio.format),
+      };
+  }
+}
+
+function parseDataUrl(url: string): { data: string; mediaType: string } | null {
+  const match = url.match(/^data:([^;]+);base64,(.+)$/);
+  if (match) return { mediaType: match[1], data: match[2] };
+  return null;
+}
+
+const AUDIO_MEDIA_TYPES: Record<string, string> = {
+  wav: 'audio/wav',
+  mp3: 'audio/mpeg',
+  aiff: 'audio/aiff',
+  aac: 'audio/aac',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  pcm16: 'audio/pcm',
+  pcm24: 'audio/pcm',
+};
+
+function audioFormatToMediaType(format: string): string {
+  return AUDIO_MEDIA_TYPES[format] ?? 'application/octet-stream';
+}
+
+type AssistantContentPart =
+  | { type: 'text'; text: string }
+  | AiSdkReasoningPart
+  | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown };
+
+function convertAssistantContent(msg: ChatCompletionAssistantMessageParam) {
+  const parts: AssistantContentPart[] = [];
+
+  if (msg.reasoning_details && msg.reasoning_details.length > 0) {
+    for (const sdkPart of reasoningDetailsToAiSdkParts(msg.reasoning_details)) {
+      parts.push(sdkPart);
+    }
+  } else if (msg.reasoning) {
+    parts.push({ type: 'reasoning', text: msg.reasoning });
+  }
+
+  if (msg.content) {
+    parts.push({ type: 'text', text: msg.content });
+  }
+
+  if (msg.tool_calls) {
+    for (const tc of msg.tool_calls) {
+      parts.push({
+        type: 'tool-call',
+        toolCallId: tc.id,
+        toolName: tc.function.name,
+        input: JSON.parse(tc.function.arguments),
+      });
+    }
+  }
+
+  if (parts.length === 1 && parts[0].type === 'text') {
+    return parts[0].text;
+  }
+
+  return parts.length > 0 ? parts : '';
+}
+
+// ---------------------------------------------------------------------------
+// Tool conversion
+// ---------------------------------------------------------------------------
+
+function convertTools(tools: OpenRouterChatCompletionRequest['tools']): ToolSet | undefined {
+  if (!tools || tools.length === 0) return undefined;
+
+  const result: ToolSet = {};
+  for (const t of tools) {
+    if (t.type !== 'function') continue;
+    result[t.function.name] = {
+      description: t.function.description,
+      strict: (t.type === 'function' && t.function.strict) ?? undefined,
+      inputSchema: jsonSchema(t.function.parameters ?? { type: 'object' }),
+    };
+  }
+  return result;
+}
+
+function convertToolChoice(
+  toolChoice: OpenRouterChatCompletionRequest['tool_choice']
+): ToolChoice<ToolSet> | undefined {
+  if (toolChoice === undefined || toolChoice === null) return undefined;
+  if (toolChoice === 'none' || toolChoice === 'auto' || toolChoice === 'required') {
+    return toolChoice;
+  }
+  if (typeof toolChoice === 'object' && 'type' in toolChoice && toolChoice.type === 'function') {
+    return { type: 'tool', toolName: toolChoice.function.name };
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Finish reason mapping
+// ---------------------------------------------------------------------------
+
+const FINISH_REASON_MAP: Record<string, string> = {
+  stop: 'stop',
+  length: 'length',
+  'content-filter': 'content_filter',
+  'tool-calls': 'tool_calls',
+  error: 'error',
+  other: 'stop',
+};
+
+// ---------------------------------------------------------------------------
+// Phase key (for OpenAI phase param patching)
+// ---------------------------------------------------------------------------
+
+function phaseKey(userId: string, taskId: string | undefined, content: string[]) {
+  return createHash('sha256')
+    .update([userId, taskId, ...content].join('|'))
+    .digest('hex');
+}
+
+function extractMessageTextParts(content: unknown): string[] {
+  if (typeof content === 'string') return [content];
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(
+      (part): part is { type: string; text: string } =>
+        part !== null &&
+        typeof part === 'object' &&
+        (part.type === 'input_text' || part.type === 'output_text') &&
+        typeof part.text === 'string'
+    )
+    .map(part => part.text);
+}
+
+// ---------------------------------------------------------------------------
+// Stream part → SSE chunk converter
+// ---------------------------------------------------------------------------
+
+function createStreamPartConverter(
   userId: string,
   taskId: string | undefined,
-  isKiloClient: boolean
-): Promise<Response> {
-  // TODO: Port full custom LLM implementation
-  // For now, return a not-implemented error
-  return Response.json(
-    {
-      error: 'Custom LLM support is not yet available in the worker',
-      message: 'Please use the main API endpoint for custom LLM requests.',
+  model: string,
+  db: WorkerDb
+) {
+  const toolCallIndices = new Map<string, number>();
+  let nextToolIndex = 0;
+  let nextReasoningIndex = 0;
+  let currentTextBlockIndex: number | null = null;
+  let inReasoningBlock = false;
+  let responseId: string | undefined;
+
+  return async function convertStreamPartToChunk(
+    part: TextStreamPart<ToolSet>
+  ): Promise<ChatCompletionChunk | null> {
+    const id = responseId;
+    switch (part.type) {
+      case 'raw': {
+        // Minimal type for the response stream event we care about
+        const event = part.rawValue as {
+          type: string;
+          item: {
+            type: string;
+            phase?: string;
+            content: { type: string; text: string }[];
+          };
+        };
+        if (event.type === 'response.output_item.done') {
+          const item = event.item;
+          const phase = typeof item.phase === 'string' ? item.phase : null;
+          if (item.type === 'message' && phase) {
+            await db
+              .insert(temp_phase)
+              .values({
+                key: phaseKey(
+                  userId,
+                  taskId,
+                  item.content.filter(c => c.type === 'output_text').map(c => c.text)
+                ),
+                value: phase,
+              })
+              .onConflictDoNothing();
+          }
+        }
+        return null;
+      }
+
+      case 'text-delta':
+        return {
+          ...(id !== undefined ? { id } : {}),
+          model,
+          choices: [{ delta: { content: part.text } }],
+        };
+
+      case 'reasoning-start': {
+        const encData = extractEncryptedData(part.providerMetadata);
+        if (encData) {
+          const itemId = extractItemId(part.providerMetadata);
+          const format = extractFormat(part.providerMetadata);
+          const index = nextReasoningIndex++;
+          return {
+            ...(id !== undefined ? { id } : {}),
+            model,
+            choices: [
+              {
+                delta: {
+                  reasoning_details: [
+                    {
+                      type: ReasoningDetailType.Encrypted,
+                      data: encData,
+                      index,
+                      ...(itemId ? { id: itemId } : {}),
+                      ...(format ? { format } : {}),
+                    },
+                  ],
+                },
+              },
+            ],
+          };
+        }
+        inReasoningBlock = true;
+        return null;
+      }
+
+      case 'reasoning-delta': {
+        const details: ReasoningDetailUnion[] = [];
+        const signature = extractSignature(part.providerMetadata);
+        const format = extractFormat(part.providerMetadata);
+
+        if (part.text) {
+          if (inReasoningBlock) {
+            currentTextBlockIndex = nextReasoningIndex++;
+            inReasoningBlock = false;
+          }
+          const itemId = extractItemId(part.providerMetadata);
+          details.push({
+            type: ReasoningDetailType.Text,
+            text: part.text,
+            index: currentTextBlockIndex ?? 0,
+            ...(signature ? { signature } : {}),
+            ...(itemId ? { id: itemId } : {}),
+            ...(format ? { format } : {}),
+          });
+        } else if (signature) {
+          details.push({
+            type: ReasoningDetailType.Text,
+            text: '',
+            signature,
+            index: currentTextBlockIndex ?? 0,
+            ...(format ? { format } : {}),
+          });
+        }
+
+        if (details.length === 0) return null;
+
+        return {
+          ...(id !== undefined ? { id } : {}),
+          model,
+          choices: [
+            {
+              delta: {
+                reasoning: part.text || '',
+                reasoning_details: details,
+              },
+            },
+          ],
+        };
+      }
+
+      case 'reasoning-end': {
+        const encData = extractEncryptedData(part.providerMetadata);
+        const signature = extractSignature(part.providerMetadata);
+
+        if (!encData && !signature) return null;
+
+        const details: ReasoningDetailUnion[] = [];
+        const itemId = extractItemId(part.providerMetadata);
+        const format = extractFormat(part.providerMetadata);
+
+        if (encData) {
+          const index = nextReasoningIndex++;
+          details.push({
+            type: ReasoningDetailType.Encrypted,
+            data: encData,
+            index,
+            ...(itemId ? { id: itemId } : {}),
+            ...(format ? { format } : {}),
+          });
+        }
+
+        if (signature) {
+          details.push({
+            type: ReasoningDetailType.Text,
+            text: '',
+            signature,
+            index: currentTextBlockIndex ?? 0,
+            ...(itemId ? { id: itemId } : {}),
+            ...(format ? { format } : {}),
+          });
+        }
+
+        return {
+          ...(id !== undefined ? { id } : {}),
+          model,
+          choices: [{ delta: { reasoning_details: details } }],
+        };
+      }
+
+      case 'tool-input-start': {
+        const index = nextToolIndex++;
+        toolCallIndices.set(part.id, index);
+        return {
+          ...(id !== undefined ? { id } : {}),
+          model,
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index,
+                    id: part.id,
+                    type: 'function' as const,
+                    function: { name: part.toolName },
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      }
+
+      case 'tool-input-delta': {
+        const index = toolCallIndices.get(part.id) ?? 0;
+        return {
+          ...(id !== undefined ? { id } : {}),
+          model,
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ index, function: { arguments: part.delta } }],
+              },
+            },
+          ],
+        };
+      }
+
+      case 'tool-call': {
+        if (toolCallIndices.has(part.toolCallId)) return null;
+        const index = nextToolIndex++;
+        return {
+          ...(id !== undefined ? { id } : {}),
+          model,
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index,
+                    id: part.toolCallId,
+                    type: 'function' as const,
+                    function: {
+                      name: part.toolName,
+                      arguments: JSON.stringify(part.input),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      }
+
+      case 'finish-step': {
+        responseId = part.response.id;
+        const cacheReadTokens = part.usage.inputTokenDetails.cacheReadTokens;
+        const cacheWriteTokens = part.usage.inputTokenDetails.cacheWriteTokens;
+        const reasoningTokens = part.usage.outputTokenDetails.reasoningTokens;
+        return {
+          id: responseId,
+          model,
+          choices: [
+            {
+              delta: {},
+              finish_reason: FINISH_REASON_MAP[part.finishReason] ?? 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: part.usage.inputTokens ?? 0,
+            completion_tokens: part.usage.outputTokens ?? 0,
+            total_tokens: part.usage.totalTokens ?? 0,
+            ...(cacheReadTokens != null || cacheWriteTokens != null
+              ? {
+                  prompt_tokens_details: {
+                    cached_tokens: cacheReadTokens ?? 0,
+                    ...(cacheWriteTokens != null && { cache_write_tokens: cacheWriteTokens }),
+                  },
+                }
+              : {}),
+            ...(reasoningTokens != null
+              ? {
+                  completion_tokens_details: {
+                    reasoning_tokens: reasoningTokens,
+                  },
+                }
+              : {}),
+          },
+        };
+      }
+
+      default:
+        return null;
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming result converter
+// ---------------------------------------------------------------------------
+
+function convertGenerateResultToResponse(
+  result: Awaited<ReturnType<typeof generateText>>,
+  model: string
+) {
+  const toolCalls = result.toolCalls.map((tc, i) => ({
+    id: tc.toolCallId,
+    type: 'function' as const,
+    index: i,
+    function: {
+      name: tc.toolName,
+      arguments: JSON.stringify(tc.input),
     },
-    { status: 501 }
+  }));
+
+  const reasoning_details =
+    result.reasoning.length > 0 ? reasoningOutputToDetails(result.reasoning) : undefined;
+
+  return {
+    id: result.response.id,
+    model,
+    choices: [
+      {
+        message: {
+          role: 'assistant' as const,
+          content: result.text || null,
+          ...(result.reasoningText ? { reasoning: result.reasoningText } : {}),
+          ...(reasoning_details ? { reasoning_details } : {}),
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: FINISH_REASON_MAP[result.finishReason] ?? 'stop',
+        index: 0,
+      },
+    ],
+    usage: {
+      prompt_tokens: result.usage.inputTokens ?? 0,
+      completion_tokens: result.usage.outputTokens ?? 0,
+      total_tokens: result.usage.totalTokens ?? 0,
+      ...(result.usage.inputTokenDetails.cacheReadTokens != null ||
+      result.usage.inputTokenDetails.cacheWriteTokens != null
+        ? {
+            prompt_tokens_details: {
+              cached_tokens: result.usage.inputTokenDetails.cacheReadTokens ?? 0,
+              ...(result.usage.inputTokenDetails.cacheWriteTokens != null && {
+                cache_write_tokens: result.usage.inputTokenDetails.cacheWriteTokens,
+              }),
+            },
+          }
+        : {}),
+      ...(result.usage.outputTokenDetails.reasoningTokens != null
+        ? {
+            completion_tokens_details: {
+              reasoning_tokens: result.usage.outputTokenDetails.reasoningTokens,
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Common params builder
+// ---------------------------------------------------------------------------
+
+function buildCommonParams(
+  customLlm: CustomLlm,
+  messages: ModelMessage[],
+  request: OpenRouterChatCompletionRequest,
+  isLegacyExtension: boolean
+) {
+  // Access extension-specific fields via loose typing
+  const req = request as unknown as Record<string, unknown>;
+  const verbosity = VerbositySchema.safeParse(
+    (req.verbosity as string) ?? customLlm.verbosity
+  ).data;
+  const reasoningConfig = request.reasoning as { effort?: string } | undefined;
+  const reasoningEffort = ReasoningEffortSchema.safeParse(
+    reasoningConfig?.effort ?? customLlm.reasoning_effort
+  ).data;
+  return {
+    messages,
+    tools: convertTools(request.tools),
+    toolChoice: convertToolChoice(request.tool_choice),
+    maxOutputTokens: request.max_completion_tokens ?? request.max_tokens ?? undefined,
+    temperature: request.temperature ?? undefined,
+    headers: {
+      'anthropic-beta': 'context-1m-2025-08-07',
+    },
+    providerOptions: {
+      anthropic: {
+        thinking: { type: 'adaptive' },
+        effort: verbosity,
+        disableParallelToolUse: request.parallel_tool_calls === false || isLegacyExtension,
+      } satisfies AnthropicProviderOptions,
+      openai: {
+        forceReasoning: (reasoningEffort !== 'none' && customLlm.force_reasoning) || undefined,
+        reasoningSummary: 'auto',
+        textVerbosity: verbosity === 'max' ? 'high' : verbosity,
+        reasoningEffort: reasoningEffort,
+        include: ['reasoning.encrypted_content'],
+        parallelToolCalls: (request.parallel_tool_calls ?? true) && !isLegacyExtension,
+        store: false,
+        promptCacheKey: req.prompt_cache_key as string | undefined,
+        safetyIdentifier: req.safety_identifier as string | undefined,
+        user: request.user,
+      } satisfies OpenAILanguageModelResponsesOptions,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Model creation
+// ---------------------------------------------------------------------------
+
+function createModel(
+  customLlm: CustomLlm,
+  userId: string,
+  taskId: string | undefined,
+  db: WorkerDb
+) {
+  if (customLlm.provider === 'anthropic') {
+    const anthropic = createAnthropic({
+      apiKey: customLlm.api_key,
+      baseURL: customLlm.base_url,
+    });
+    return anthropic(customLlm.internal_id);
+  }
+  if (customLlm.provider === 'openai') {
+    const openai = createOpenAI({
+      apiKey: customLlm.api_key,
+      baseURL: customLlm.base_url,
+      fetch:
+        customLlm.base_url === 'https://api.openai.com/v1'
+          ? responseCreateParamsPatchFetch(userId, taskId, db)
+          : undefined,
+    });
+    return openai(customLlm.internal_id);
+  }
+  throw new Error(`Unknown provider: ${customLlm.provider}`);
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI phase param patching fetch wrapper
+// ---------------------------------------------------------------------------
+
+function responseCreateParamsPatchFetch(userId: string, taskId: string | undefined, db: WorkerDb) {
+  return async function (input: string | URL | Request, init?: RequestInit) {
+    if (typeof init?.body === 'string') {
+      const json = JSON.parse(init.body) as {
+        input?: Array<{ role?: string; content?: unknown; phase?: string }>;
+      };
+      if (Array.isArray(json.input)) {
+        type AssistantMessage = { role: 'assistant'; content?: unknown; phase?: string };
+        const assistantMessages = json.input.filter(
+          (message): message is AssistantMessage =>
+            'role' in message && message.role === 'assistant'
+        );
+
+        if (assistantMessages.length > 0) {
+          const keyByMessage = new Map(
+            assistantMessages.map(message => [
+              message,
+              phaseKey(userId, taskId, extractMessageTextParts(message.content)),
+            ])
+          );
+
+          const keys = [...new Set(keyByMessage.values())];
+          const rows = await db
+            .select({ key: temp_phase.key, phase: temp_phase.value })
+            .from(temp_phase)
+            .where(inArray(temp_phase.key, keys));
+          const phaseByKey = new Map(rows.map(row => [row.key, row.phase]));
+
+          for (const message of assistantMessages) {
+            const phase = phaseByKey.get(keyByMessage.get(message) ?? '');
+            if (phase) {
+              Object.assign(message, { phase });
+            } else {
+              console.error(
+                `[responseCreateParamsPatchFetch] failed to find phase param for userId: ${userId}, taskId: ${taskId}`
+              );
+            }
+          }
+
+          init.body = JSON.stringify(json);
+        }
+      }
+    }
+    return await fetch(input, init);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy extension hacks (reasoning format obscuring)
+// ---------------------------------------------------------------------------
+
+function reverseLegacyExtensionHack(messages: OpenRouterChatCompletionsInput) {
+  for (const msg of messages) {
+    if (msg.role === 'assistant') {
+      for (const rd of msg.reasoning_details ?? []) {
+        const record = rd as Record<string, unknown>;
+        if (record.format === ReasoningFormat.OpenAIResponsesV1_Obscured) {
+          record.format = ReasoningFormat.OpenAIResponsesV1;
+        }
+      }
+    }
+  }
+}
+
+function applyLegacyExtensionHack(choice: ChatCompletionChunkChoice | undefined) {
+  for (const rd of choice?.delta?.reasoning_details ?? []) {
+    const record = rd as Record<string, unknown>;
+    if (record.format === ReasoningFormat.OpenAIResponsesV1) {
+      record.format = ReasoningFormat.OpenAIResponsesV1_Obscured;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error response helper
+// ---------------------------------------------------------------------------
+
+function errorResponse(status: number, message: string) {
+  return Response.json({ error: { message, code: status, type: 'error' } }, { status });
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function customLlmRequest(
+  customLlm: CustomLlm,
+  request: OpenRouterChatCompletionRequest,
+  userId: string,
+  taskId: string | undefined,
+  isLegacyExtension: boolean,
+  db: WorkerDb
+): Promise<Response> {
+  const messages = request.messages as unknown as OpenRouterChatCompletionsInput;
+  if (isLegacyExtension) {
+    reverseLegacyExtensionHack(messages);
+  }
+
+  const model = createModel(customLlm, userId, taskId, db);
+  const commonParams = buildCommonParams(
+    customLlm,
+    convertMessages(messages),
+    request,
+    isLegacyExtension
   );
+
+  const modelId = customLlm.public_id;
+
+  if (!request.stream) {
+    try {
+      const result = await generateText({ model, ...commonParams });
+      const convertedResponse = convertGenerateResultToResponse(result, modelId);
+      return Response.json(convertedResponse);
+    } catch (e) {
+      console.error('Caught exception while processing non-streaming request', e);
+      const status = APICallError.isInstance(e) ? (e.statusCode ?? 500) : 500;
+      const msg = e instanceof Error ? e.message : 'Generation failed';
+      return errorResponse(status, msg);
+    }
+  }
+
+  const result = streamText({ model, ...commonParams, includeRawChunks: true });
+
+  const convertStreamPartToChunk = createStreamPartConverter(userId, taskId, modelId, db);
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const chunk of result.fullStream) {
+          const converted = await convertStreamPartToChunk(chunk);
+          if (converted) {
+            if (isLegacyExtension) {
+              applyLegacyExtensionHack(converted.choices[0]);
+            }
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(converted)}\n\n`));
+          }
+        }
+
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      } catch (e) {
+        console.error('Caught exception while processing streaming request', e);
+        const errorChunk = {
+          error: {
+            message: e instanceof Error ? e.message : 'Stream error',
+            code: APICallError.isInstance(e) ? (e.statusCode ?? 500) : 500,
+            ...(APICallError.isInstance(e) && e.responseBody
+              ? { metadata: { raw: e.responseBody } }
+              : {}),
+            type: 'error',
+          },
+        };
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(errorChunk)}\n\n`));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+    },
+  });
 }

--- a/llm-gateway/src/services/custom-llm.ts
+++ b/llm-gateway/src/services/custom-llm.ts
@@ -1,0 +1,22 @@
+import type { CustomLlm } from '@kilocode/db/schema';
+import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
+
+// Custom LLM request handler using Vercel AI SDK
+// Full implementation to be ported from src/lib/custom-llm/customLlmRequest.ts
+export async function customLlmRequest(
+  customLlm: CustomLlm,
+  body: OpenRouterChatCompletionRequest,
+  userId: string,
+  taskId: string | undefined,
+  isKiloClient: boolean
+): Promise<Response> {
+  // TODO: Port full custom LLM implementation
+  // For now, return a not-implemented error
+  return Response.json(
+    {
+      error: 'Custom LLM support is not yet available in the worker',
+      message: 'Please use the main API endpoint for custom LLM requests.',
+    },
+    { status: 501 }
+  );
+}

--- a/llm-gateway/src/services/provider.ts
+++ b/llm-gateway/src/services/provider.ts
@@ -1,0 +1,88 @@
+import { eq } from 'drizzle-orm';
+import { custom_llm, type CustomLlm, type User } from '@kilocode/db/schema';
+import {
+  type Provider,
+  type AnonymousUserContext,
+  isAnonymousContext,
+  kiloFreeModels,
+} from '@kilocode/llm-shared';
+import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
+import type { WorkerDb } from '../lib/db.js';
+
+// BYOKResult is a simplified version for the worker
+type BYOKResult = {
+  providerId: string;
+  decryptedAPIKey: string;
+};
+
+type GetProviderResult = {
+  provider: Provider;
+  userByok: BYOKResult[] | null;
+  customLlm: CustomLlm | null;
+};
+
+// The worker uses env-injected API keys instead of process.env
+type ProviderConfig = {
+  openrouterApiKey: string;
+};
+
+export function createProviders(config: ProviderConfig) {
+  const PROVIDERS = {
+    OPENROUTER: {
+      id: 'openrouter' as const,
+      apiUrl: 'https://openrouter.ai/api/v1',
+      apiKey: config.openrouterApiKey,
+      hasGenerationEndpoint: true,
+    },
+    VERCEL_AI_GATEWAY: {
+      id: 'vercel' as const,
+      apiUrl: 'https://ai-gateway.vercel.sh/v1',
+      apiKey: '', // Populated from secrets if needed
+      hasGenerationEndpoint: true,
+    },
+  } satisfies Record<string, Provider>;
+
+  return PROVIDERS;
+}
+
+export async function getProvider(
+  requestedModel: string,
+  request: OpenRouterChatCompletionRequest,
+  user: User | AnonymousUserContext,
+  organizationId: string | undefined,
+  taskId: string | undefined,
+  db: WorkerDb,
+  providers: ReturnType<typeof createProviders>
+): Promise<GetProviderResult> {
+  // Custom LLM check for org users
+  if (requestedModel.startsWith('kilo/') && organizationId) {
+    const [customLlmRecord] = await db
+      .select()
+      .from(custom_llm)
+      .where(eq(custom_llm.public_id, requestedModel));
+    if (customLlmRecord && customLlmRecord.organization_ids.includes(organizationId)) {
+      return {
+        provider: {
+          id: 'custom',
+          apiUrl: customLlmRecord.base_url,
+          apiKey: customLlmRecord.api_key,
+          hasGenerationEndpoint: true,
+        },
+        userByok: null,
+        customLlm: customLlmRecord,
+      };
+    }
+  }
+
+  // Check kilo free models
+  const kiloFreeModel = kiloFreeModels.find(m => m.public_id === requestedModel);
+  const freeModelProvider = kiloFreeModel
+    ? Object.values(providers).find(p => p.id === kiloFreeModel.gateway)
+    : undefined;
+
+  return {
+    provider: (freeModelProvider ?? providers.OPENROUTER) as Provider,
+    userByok: null,
+    customLlm: null,
+  };
+}

--- a/llm-gateway/src/services/provider.ts
+++ b/llm-gateway/src/services/provider.ts
@@ -8,12 +8,15 @@ import {
 } from '@kilocode/llm-shared';
 import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
 import type { WorkerDb } from '../lib/db.js';
+import {
+  getModelUserByokProviders,
+  getBYOKforUser,
+  getBYOKforOrganization,
+  type BYOKResult,
+} from './byok.js';
+import { shouldRouteToVercel } from './vercel-routing.js';
 
-// BYOKResult is a simplified version for the worker
-type BYOKResult = {
-  providerId: string;
-  decryptedAPIKey: string;
-};
+export type { BYOKResult };
 
 type GetProviderResult = {
   provider: Provider;
@@ -24,6 +27,7 @@ type GetProviderResult = {
 // The worker uses env-injected API keys instead of process.env
 type ProviderConfig = {
   openrouterApiKey: string;
+  vercelApiKey: string;
 };
 
 export function createProviders(config: ProviderConfig) {
@@ -37,7 +41,7 @@ export function createProviders(config: ProviderConfig) {
     VERCEL_AI_GATEWAY: {
       id: 'vercel' as const,
       apiUrl: 'https://ai-gateway.vercel.sh/v1',
-      apiKey: '', // Populated from secrets if needed
+      apiKey: config.vercelApiKey,
       hasGenerationEndpoint: true,
     },
   } satisfies Record<string, Provider>;
@@ -52,9 +56,25 @@ export async function getProvider(
   organizationId: string | undefined,
   taskId: string | undefined,
   db: WorkerDb,
-  providers: ReturnType<typeof createProviders>
+  providers: ReturnType<typeof createProviders>,
+  kv: KVNamespace,
+  encryptionKey: string
 ): Promise<GetProviderResult> {
-  // Custom LLM check for org users
+  // 1. BYOK check (if user has own keys) → route to VERCEL_AI_GATEWAY
+  if (!isAnonymousContext(user)) {
+    const modelProviders = await getModelUserByokProviders(requestedModel, db, kv);
+    const userByok =
+      modelProviders.length === 0
+        ? null
+        : organizationId
+          ? await getBYOKforOrganization(db, organizationId, modelProviders, encryptionKey)
+          : await getBYOKforUser(db, user.id, modelProviders, encryptionKey);
+    if (userByok) {
+      return { provider: providers.VERCEL_AI_GATEWAY, userByok, customLlm: null };
+    }
+  }
+
+  // 2. Custom LLM check for kilo/ models
   if (requestedModel.startsWith('kilo/') && organizationId) {
     const [customLlmRecord] = await db
       .select()
@@ -74,12 +94,45 @@ export async function getProvider(
     }
   }
 
-  // Check kilo free models
+  // 3. shouldRouteToVercel check → route to VERCEL_AI_GATEWAY
+  if (await shouldRouteToVercel(requestedModel, request, taskId || user.id, db, kv)) {
+    return { provider: providers.VERCEL_AI_GATEWAY, userByok: null, customLlm: null };
+  }
+
+  // 4. Kilo free model check (including martian → custom LLM wrapping)
   const kiloFreeModel = kiloFreeModels.find(m => m.public_id === requestedModel);
   const freeModelProvider = kiloFreeModel
     ? Object.values(providers).find(p => p.id === kiloFreeModel.gateway)
     : undefined;
 
+  // Martian models are wrapped as custom LLMs (gateway: 'martian' in kiloFreeModels).
+  // Currently no martian provider in the worker, so this branch is inert until one is added.
+  if (kiloFreeModel && freeModelProvider && (freeModelProvider.id as string) === 'martian') {
+    return {
+      provider: { ...freeModelProvider, id: 'custom' as const },
+      userByok: null,
+      customLlm: {
+        public_id: kiloFreeModel.public_id,
+        internal_id: kiloFreeModel.internal_id,
+        display_name: kiloFreeModel.display_name,
+        context_length: kiloFreeModel.context_length,
+        max_completion_tokens: kiloFreeModel.max_completion_tokens,
+        verbosity: null,
+        provider: 'openai',
+        organization_ids: [],
+        base_url: freeModelProvider.apiUrl,
+        api_key: freeModelProvider.apiKey,
+        reasoning_effort: null,
+        included_tools: null,
+        excluded_tools: null,
+        supports_image_input: kiloFreeModel.flags.includes('vision'),
+        force_reasoning: true,
+        opencode_settings: null,
+      },
+    };
+  }
+
+  // 5. Default → OPENROUTER
   return {
     provider: (freeModelProvider ?? providers.OPENROUTER) as Provider,
     userByok: null,

--- a/llm-gateway/src/services/rate-limit.ts
+++ b/llm-gateway/src/services/rate-limit.ts
@@ -1,0 +1,55 @@
+import { sql } from 'drizzle-orm';
+import type { WorkerDb } from '../lib/db.js';
+
+const FREE_MODEL_RATE_LIMIT_WINDOW_HOURS = 1;
+const FREE_MODEL_MAX_REQUESTS_PER_WINDOW = 200;
+
+export async function checkFreeModelRateLimit(
+  ipAddress: string,
+  db: WorkerDb
+): Promise<{ allowed: boolean; requestCount: number }> {
+  const result = await db.execute<{ count: string }>(sql`
+    SELECT COUNT(*) as count
+    FROM free_model_usage
+    WHERE ip_address = ${ipAddress}
+      AND created_at > NOW() - INTERVAL '${sql.raw(String(FREE_MODEL_RATE_LIMIT_WINDOW_HOURS))} hours'
+  `);
+
+  const requestCount = Number(result.rows[0]?.count ?? 0);
+  return {
+    allowed: requestCount < FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
+    requestCount,
+  };
+}
+
+export async function logFreeModelRequest(
+  ipAddress: string,
+  model: string,
+  userId: string | undefined,
+  db: WorkerDb
+): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO free_model_usage (ip_address, model, kilo_user_id)
+    VALUES (${ipAddress}, ${model}, ${userId ?? null})
+  `);
+}
+
+export async function checkPromotionLimit(
+  ipAddress: string,
+  maxRequests: number,
+  windowHours: number,
+  db: WorkerDb
+): Promise<{ allowed: boolean; requestCount: number }> {
+  const result = await db.execute<{ count: string }>(sql`
+    SELECT COUNT(*) as count
+    FROM free_model_usage
+    WHERE ip_address = ${ipAddress}
+      AND created_at > NOW() - INTERVAL '${sql.raw(String(windowHours))} hours'
+  `);
+
+  const requestCount = Number(result.rows[0]?.count ?? 0);
+  return {
+    allowed: requestCount < maxRequests,
+    requestCount,
+  };
+}

--- a/llm-gateway/src/services/response-transforms.ts
+++ b/llm-gateway/src/services/response-transforms.ts
@@ -1,0 +1,222 @@
+import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
+import { isKiloStealthModel, kiloFreeModels, ReasoningDetailType } from '@kilocode/llm-shared';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
+import { getOutputHeaders } from '../responses.js';
+import { logger } from '../logger.js';
+
+type MessageWithReasoning = {
+  reasoning_content?: string;
+  reasoning?: string;
+  reasoning_details?: unknown[];
+  [key: string]: unknown;
+};
+
+type OpenRouterUsage = {
+  cost?: number;
+  cost_details?: unknown;
+  is_byok?: boolean | null;
+  [key: string]: unknown;
+};
+
+type ChatCompletionChunk = {
+  model?: string;
+  choices?: {
+    delta?: MessageWithReasoning & { role?: string | null };
+    [key: string]: unknown;
+  }[];
+  usage?: OpenRouterUsage;
+  [key: string]: unknown;
+};
+
+function convertReasoningToOpenRouterFormat(message: MessageWithReasoning) {
+  if (!message.reasoning_content) {
+    return;
+  }
+  if (!message.reasoning) {
+    message.reasoning = message.reasoning_content;
+  }
+  if (!message.reasoning_details) {
+    message.reasoning_details = [
+      {
+        type: ReasoningDetailType.Text,
+        text: message.reasoning_content,
+      },
+    ];
+  }
+  delete message.reasoning_content;
+}
+
+function removeCostInfo(usage: OpenRouterUsage) {
+  delete usage.cost;
+  delete usage.cost_details;
+  delete usage.is_byok;
+}
+
+export async function rewriteFreeModelResponse(
+  response: Response,
+  model: string
+): Promise<Response> {
+  const headers = getOutputHeaders(response);
+
+  if (headers.get('content-type')?.includes('application/json')) {
+    const json = (await response.json()) as Record<string, unknown>;
+    if (json.model) {
+      json.model = model;
+    }
+
+    const choices = json.choices as { message?: MessageWithReasoning }[] | undefined;
+    const message = choices?.[0]?.message;
+    if (message) {
+      convertReasoningToOpenRouterFormat(message);
+    }
+
+    const usage = json.usage as OpenRouterUsage | undefined;
+    if (usage) {
+      removeCostInfo(usage);
+    }
+
+    return Response.json(json, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  // Streaming SSE response
+  const stream = new ReadableStream({
+    async start(controller) {
+      const reader = response.body?.getReader();
+      if (!reader) {
+        controller.close();
+        return;
+      }
+
+      const parser = createParser({
+        onEvent(event: EventSourceMessage) {
+          if (event.data === '[DONE]') {
+            return;
+          }
+          const json = JSON.parse(event.data) as ChatCompletionChunk;
+          if (json.model) {
+            json.model = model;
+          }
+
+          const delta = json.choices?.[0]?.delta;
+          if (delta) {
+            // Some APIs set null here, which is not accepted by OpenCode
+            if (delta.role === null) {
+              delete delta.role;
+            }
+            convertReasoningToOpenRouterFormat(delta);
+          }
+
+          if (!json.choices) {
+            // Some APIs leave this out when returning usage, which is not accepted by OpenCode
+            json.choices = [];
+          }
+
+          if (json.usage) {
+            removeCostInfo(json.usage);
+          }
+
+          controller.enqueue('data: ' + JSON.stringify(json) + '\n\n');
+        },
+        onComment() {
+          controller.enqueue(': KILO PROCESSING\n\n');
+        },
+      });
+
+      const decoder = new TextDecoder();
+      const encoder = new TextEncoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          controller.close();
+          break;
+        }
+        parser.feed(decoder.decode(value, { stream: true }));
+      }
+    },
+  });
+
+  // The ReadableStream start() enqueues strings via the parser callbacks but
+  // also uses encoder.encode for the final [DONE]. We need a TransformStream
+  // to handle mixed string/Uint8Array - simpler to just encode everything.
+  const encoder = new TextEncoder();
+  const encodingTransform = new TransformStream<string | Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      if (typeof chunk === 'string') {
+        controller.enqueue(encoder.encode(chunk));
+      } else {
+        controller.enqueue(chunk);
+      }
+    },
+  });
+
+  return new Response(stream.pipeThrough(encodingTransform), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+const byokErrorMessages: Record<number, string> = {
+  401: '[BYOK] Your API key is invalid or has been revoked. Please check your API key configuration.',
+  402: '[BYOK] Your API account has insufficient funds. Please check your billing details with your API provider.',
+  403: '[BYOK] Your API key does not have permission to access this resource. Please check your API key permissions.',
+  429: '[BYOK] Your API key has hit its rate limit. Please try again later or check your rate limit settings with your API provider.',
+};
+
+function estimateTokenCount(request: OpenRouterChatCompletionRequest) {
+  return Math.round(
+    JSON.stringify(request).length / 4 + (request.max_completion_tokens ?? request.max_tokens ?? 0)
+  );
+}
+
+export async function makeErrorReadable({
+  requestedModel,
+  request,
+  response,
+  isUserByok,
+}: {
+  requestedModel: string;
+  request: OpenRouterChatCompletionRequest;
+  response: Response;
+  isUserByok: boolean;
+}): Promise<Response | undefined> {
+  if (response.status < 400) {
+    return undefined;
+  }
+
+  if (isUserByok) {
+    const byokMessage = byokErrorMessages[response.status];
+    if (byokMessage) {
+      logger.warn(`Responding with ${response.status} ${byokMessage}`);
+      return Response.json(
+        { error: byokMessage, message: byokMessage },
+        { status: response.status }
+      );
+    }
+  }
+
+  // Sometimes we get generic or nonsensical errors when the context length is exceeded
+  // (such as "Internal Server Error" or "No allowed providers are available for the selected model")
+  const model = kiloFreeModels.find(m => m.public_id === requestedModel);
+  if (model) {
+    const estimatedTokenCount = estimateTokenCount(request);
+    if (estimatedTokenCount >= model.context_length) {
+      const error = `The maximum context length is ${model.context_length} tokens. However, about ${estimatedTokenCount} tokens were requested.`;
+      logger.warn(`Responding with ${response.status} ${error}`);
+      return Response.json({ error, message: error }, { status: response.status });
+    }
+  }
+
+  if (isKiloStealthModel(requestedModel)) {
+    const error = 'Stealth model unable to process request';
+    logger.warn(`Responding with ${response.status} ${error}`);
+    return Response.json({ error, message: error }, { status: response.status });
+  }
+
+  return undefined;
+}

--- a/llm-gateway/src/services/upstream.ts
+++ b/llm-gateway/src/services/upstream.ts
@@ -1,0 +1,44 @@
+import type { OpenRouterChatCompletionRequest, Provider } from '@kilocode/llm-shared';
+
+export async function upstreamRequest({
+  path,
+  search,
+  method,
+  body,
+  extraHeaders,
+  provider,
+  signal,
+}: {
+  path: string;
+  search: string;
+  method: string;
+  body: OpenRouterChatCompletionRequest;
+  extraHeaders: Record<string, string>;
+  provider: Provider;
+  signal?: AbortSignal;
+}): Promise<Response> {
+  const headers = new Headers();
+  headers.set('HTTP-Referer', 'https://kilocode.ai');
+  headers.set('X-Title', 'Kilo Code');
+  headers.set('Authorization', `Bearer ${provider.apiKey}`);
+  headers.set('Content-Type', 'application/json');
+
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headers.set(key, value);
+  }
+
+  const targetUrl = `${provider.apiUrl}${path}${search}`;
+
+  const TEN_MINUTES_MS = 10 * 60 * 1000;
+  const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
+  const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+
+  return await fetch(targetUrl, {
+    method,
+    headers,
+    body: JSON.stringify(body),
+    // @ts-expect-error duplex needed for streaming request bodies
+    duplex: 'half',
+    signal: combinedSignal,
+  });
+}

--- a/llm-gateway/src/services/vercel-routing.ts
+++ b/llm-gateway/src/services/vercel-routing.ts
@@ -1,0 +1,256 @@
+import { createHash } from 'crypto';
+import { sql } from 'drizzle-orm';
+import * as z from 'zod';
+import type { OpenRouterChatCompletionRequest } from '@kilocode/llm-shared';
+import {
+  isAnthropicModel,
+  kiloFreeModels,
+  preferredModels,
+  AutocompleteUserByokProviderIdSchema,
+  AwsCredentialsSchema,
+  openRouterToVercelInferenceProviderId,
+  inferVercelFirstPartyInferenceProviderForModel,
+  VercelUserByokInferenceProviderIdSchema,
+  type VercelUserByokInferenceProviderId,
+  type VercelProviderConfig,
+  type VercelInferenceProviderConfig,
+} from '@kilocode/llm-shared';
+import type { OpenRouterProviderConfig } from '@kilocode/llm-shared';
+import type { WorkerDb } from '../lib/db.js';
+import type { BYOKResult } from './byok.js';
+import { logger } from '../logger.js';
+
+// --- mapModelIdToVercel (inline, not exported from llm-shared) ---
+
+const vercelModelIdMapping: Record<string, string | undefined> = {
+  'arcee-ai/trinity-large-preview:free': 'arcee-ai/trinity-large-preview',
+  'mistralai/codestral-2508': 'mistral/codestral',
+  'mistralai/devstral-2512': 'mistral/devstral-2',
+};
+
+function mapModelIdToVercel(modelId: string): string {
+  const hardcodedVercelId = vercelModelIdMapping[modelId];
+  if (hardcodedVercelId) return hardcodedVercelId;
+
+  const internalId =
+    kiloFreeModels.find(m => m.public_id === modelId && m.is_enabled && m.gateway === 'openrouter')
+      ?.internal_id ?? modelId;
+
+  const slashIndex = internalId.indexOf('/');
+  if (slashIndex < 0) return internalId;
+
+  const firstPartyProvider = inferVercelFirstPartyInferenceProviderForModel(internalId);
+  return firstPartyProvider ? firstPartyProvider + internalId.slice(slashIndex) : internalId;
+}
+
+// --- Gateway error rate with KV caching ---
+
+// Emergency switch: routes all OpenRouter-eligible models to Vercel.
+// Only use when OpenRouter is down and automatic failover is inadequate.
+const ENABLE_UNIVERSAL_VERCEL_ROUTING = false;
+
+const ERROR_RATE_THRESHOLD = 0.5;
+
+function getRandomNumberLessThan100(randomSeed: string) {
+  return createHash('sha256').update(randomSeed).digest().readUInt32BE(0) % 100;
+}
+
+async function getGatewayErrorRate(
+  db: WorkerDb,
+  kv: KVNamespace
+): Promise<{ openrouter: number; vercel: number }> {
+  const cacheKey = 'gateway-error-rate';
+  const cached = await kv.get(cacheKey, 'json');
+  if (cached) {
+    return cached as { openrouter: number; vercel: number };
+  }
+
+  try {
+    const start = performance.now();
+    const result = await Promise.race([
+      db.execute(sql`
+        select
+          provider as "gateway",
+          1.0 * count(*) filter(where has_error = true) / count(*) as "errorRate"
+        from microdollar_usage_view
+        where true
+          and created_at >= now() - interval '10 minutes'
+          and is_user_byok = false
+          and provider in ('openrouter', 'vercel')
+        group by provider
+      `),
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
+    ]);
+
+    if (result === 'timeout') {
+      logger.debug(`[getGatewayErrorRate] query timeout after ${performance.now() - start}ms`);
+      return { openrouter: 0, vercel: 0 };
+    }
+
+    const rows = z
+      .array(z.object({ gateway: z.string(), errorRate: z.coerce.number() }))
+      .parse(result.rows);
+
+    const errorRate = {
+      openrouter: rows.find(r => r.gateway === 'openrouter')?.errorRate ?? 0,
+      vercel: rows.find(r => r.gateway === 'vercel')?.errorRate ?? 0,
+    };
+
+    await kv.put(cacheKey, JSON.stringify(errorRate), { expirationTtl: 60 });
+    return errorRate;
+  } catch (e) {
+    logger.debug('[getGatewayErrorRate] query error', { error: String(e) });
+    return { openrouter: 0, vercel: 0 };
+  }
+}
+
+async function getVercelRoutingPercentage(db: WorkerDb, kv: KVNamespace) {
+  const errorRate = await getGatewayErrorRate(db, kv);
+  const isOpenRouterErrorRateHigh =
+    errorRate.openrouter > ERROR_RATE_THRESHOLD && errorRate.vercel < ERROR_RATE_THRESHOLD;
+  if (isOpenRouterErrorRateHigh) {
+    logger.error(`OpenRouter error rate is high: ${errorRate.openrouter}`);
+  }
+  return isOpenRouterErrorRateHigh ? 90 : 10;
+}
+
+function isLikelyAvailableOnAllGateways(requestedModel: string) {
+  return (
+    !requestedModel.startsWith('openrouter/') &&
+    (kiloFreeModels.find(m => m.public_id === requestedModel && m.is_enabled)?.gateway ??
+      'openrouter') === 'openrouter'
+  );
+}
+
+// --- Routing decision ---
+
+export async function shouldRouteToVercel(
+  requestedModel: string,
+  request: OpenRouterChatCompletionRequest,
+  randomSeed: string,
+  db: WorkerDb,
+  kv: KVNamespace
+): Promise<boolean> {
+  if (request.provider?.data_collection === 'deny') {
+    logger.debug('not routing to Vercel because data_collection=deny is not supported');
+    return false;
+  }
+
+  if (!isLikelyAvailableOnAllGateways(requestedModel)) {
+    logger.debug('model not available on all gateways');
+    return false;
+  }
+
+  if (ENABLE_UNIVERSAL_VERCEL_ROUTING) {
+    logger.debug('universal Vercel routing is enabled');
+    return true;
+  }
+
+  if (isAnthropicModel(requestedModel)) {
+    logger.debug(
+      'Anthropic models are not routed to Vercel pending fine-grained tool streaming support'
+    );
+    return false;
+  }
+
+  if (!preferredModels.includes(requestedModel)) {
+    logger.debug('only recommended models are tested for Vercel routing');
+    return false;
+  }
+
+  logger.debug('randomizing user to either OpenRouter or Vercel');
+  return (
+    getRandomNumberLessThan100('vercel_routing_' + randomSeed) <
+    (await getVercelRoutingPercentage(db, kv))
+  );
+}
+
+// --- Vercel settings (pure functions) ---
+
+function convertProviderOptions(
+  provider: OpenRouterProviderConfig | undefined
+): VercelProviderConfig | undefined {
+  return {
+    gateway: {
+      only: provider?.only?.map(p => openRouterToVercelInferenceProviderId(p)),
+      order: provider?.order?.map(p => openRouterToVercelInferenceProviderId(p)),
+      zeroDataRetention: provider?.zdr,
+    },
+  };
+}
+
+function parseAwsCredentials(input: string) {
+  try {
+    return AwsCredentialsSchema.parse(JSON.parse(input));
+  } catch {
+    throw new Error('Failed to parse AWS credentials');
+  }
+}
+
+export function getVercelInferenceProviderConfigForUserByok(
+  provider: BYOKResult
+): [VercelUserByokInferenceProviderId, VercelInferenceProviderConfig[]] {
+  const key =
+    provider.providerId === AutocompleteUserByokProviderIdSchema.enum.codestral
+      ? VercelUserByokInferenceProviderIdSchema.enum.mistral
+      : provider.providerId;
+  const list = new Array<VercelInferenceProviderConfig>();
+
+  if (key === VercelUserByokInferenceProviderIdSchema.enum.zai) {
+    list.push({
+      apiKey: provider.decryptedAPIKey,
+      baseURL: 'https://api.z.ai/api/coding/paas/v4',
+    });
+  }
+
+  if (key === VercelUserByokInferenceProviderIdSchema.enum.bedrock) {
+    list.push(parseAwsCredentials(provider.decryptedAPIKey));
+  } else {
+    list.push({ apiKey: provider.decryptedAPIKey });
+  }
+  return [key, list];
+}
+
+export function applyVercelSettings(
+  requestedModel: string,
+  requestToMutate: OpenRouterChatCompletionRequest,
+  extraHeaders: Record<string, string>,
+  userByok: BYOKResult[] | null
+) {
+  requestToMutate.model = mapModelIdToVercel(requestedModel);
+
+  if (isAnthropicModel(requestedModel)) {
+    extraHeaders['anthropic-beta'] = [extraHeaders['x-anthropic-beta'], 'context-1m-2025-08-07']
+      .filter(Boolean)
+      .join(',');
+    delete extraHeaders['x-anthropic-beta'];
+  }
+
+  if (userByok) {
+    if (userByok.length === 0) {
+      throw new Error('Invalid state: userByok should be null or not empty');
+    }
+    const byokProviders: Record<string, VercelInferenceProviderConfig[]> = {};
+    for (const provider of userByok) {
+      const [key, list] = getVercelInferenceProviderConfigForUserByok(provider);
+      byokProviders[key] = [...(byokProviders[key] ?? []), ...list];
+    }
+
+    requestToMutate.providerOptions = {
+      gateway: {
+        only: Object.keys(byokProviders),
+        byok: byokProviders,
+      },
+    };
+  } else {
+    requestToMutate.providerOptions = convertProviderOptions(requestToMutate.provider);
+  }
+
+  if (requestToMutate.providerOptions && requestToMutate.verbosity) {
+    requestToMutate.providerOptions.anthropic = {
+      effort: requestToMutate.verbosity,
+    };
+  }
+
+  delete requestToMutate.provider;
+}

--- a/llm-gateway/src/types.ts
+++ b/llm-gateway/src/types.ts
@@ -1,0 +1,24 @@
+import type { Hono } from 'hono';
+
+export type Env = {
+  // Hyperdrive binding for Postgres
+  HYPERDRIVE: Hyperdrive;
+
+  // KV binding for BYOK cache
+  BYOK_CACHE: KVNamespace;
+
+  // Secrets
+  NEXTAUTH_SECRET: string;
+  OPENROUTER_API_KEY: string;
+  SENTRY_DSN: string;
+
+  // Vars
+  ENVIRONMENT: string;
+
+  // Version metadata
+  CF_VERSION_METADATA: { id: string; tag: string; timestamp: string };
+};
+
+export type HonoEnv = { Bindings: Env };
+
+export type AppType = Hono<HonoEnv>;

--- a/llm-gateway/src/types.ts
+++ b/llm-gateway/src/types.ts
@@ -11,6 +11,18 @@ export type Env = {
   NEXTAUTH_SECRET: string;
   OPENROUTER_API_KEY: string;
   SENTRY_DSN: string;
+  BYOK_ENCRYPTION_KEY: string;
+  VERCEL_AI_GATEWAY_API_KEY: string;
+
+  // Abuse service
+  ABUSE_SERVICE_URL: string;
+  ABUSE_SERVICE_CF_ACCESS_CLIENT_ID: string;
+  ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET: string;
+
+  // Observability
+  POSTHOG_API_KEY: string;
+  O11Y_SERVICE_URL: string;
+  O11Y_CLIENT_SECRET: string;
 
   // Vars
   ENVIRONMENT: string;

--- a/llm-gateway/tsconfig.json
+++ b/llm-gateway/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types", "@types/node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/llm-gateway/vitest.config.ts
+++ b/llm-gateway/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/llm-gateway/wrangler.jsonc
+++ b/llm-gateway/wrangler.jsonc
@@ -36,6 +36,46 @@
       "secret_name": "LLM_GATEWAY_SENTRY_DSN",
       "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
     },
+    {
+      "binding": "BYOK_ENCRYPTION_KEY",
+      "secret_name": "BYOK_ENCRYPTION_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "ABUSE_SERVICE_URL",
+      "secret_name": "ABUSE_SERVICE_URL",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "ABUSE_SERVICE_CF_ACCESS_CLIENT_ID",
+      "secret_name": "ABUSE_SERVICE_CF_ACCESS_CLIENT_ID",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET",
+      "secret_name": "ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "POSTHOG_API_KEY",
+      "secret_name": "POSTHOG_API_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "O11Y_SERVICE_URL",
+      "secret_name": "O11Y_SERVICE_URL",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "O11Y_CLIENT_SECRET",
+      "secret_name": "O11Y_CLIENT_SECRET",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "VERCEL_AI_GATEWAY_API_KEY",
+      "secret_name": "VERCEL_AI_GATEWAY_API_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
   ],
   "vars": {
     "ENVIRONMENT": "production",

--- a/llm-gateway/wrangler.jsonc
+++ b/llm-gateway/wrangler.jsonc
@@ -1,0 +1,43 @@
+{
+  "name": "llm-gateway",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-02-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "placement": { "mode": "smart" },
+  "observability": { "enabled": true },
+  "upload_source_maps": true,
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "624ec80650dd414199349f4e217ddb10",
+      "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "BYOK_CACHE",
+      "id": "<to-be-created>",
+    },
+  ],
+  "secrets_store_secrets": [
+    {
+      "binding": "NEXTAUTH_SECRET",
+      "secret_name": "NEXTAUTH_SECRET",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "OPENROUTER_API_KEY",
+      "secret_name": "OPENROUTER_API_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+    {
+      "binding": "SENTRY_DSN",
+      "secret_name": "LLM_GATEWAY_SENTRY_DSN",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+    },
+  ],
+  "vars": {
+    "ENVIRONMENT": "production",
+  },
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/s3-request-presigner": "^3.980.0",
     "@kilocode/db": "workspace:*",
     "@kilocode/encryption": "workspace:*",
+    "@kilocode/llm-shared": "workspace:*",
     "@kilocode/worker-utils": "workspace:*",
     "@lottiefiles/dotlottie-react": "^0.17.6",
     "@mdx-js/loader": "^3.1.1",

--- a/packages/llm-shared/package.json
+++ b/packages/llm-shared/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@kilocode/llm-shared",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "catalog:",
+    "openai": "^6.22.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@ai-sdk/gateway": "^3.0.16",
+    "@ai-sdk/anthropic": "^3.0.41"
+  }
+}

--- a/packages/llm-shared/src/anonymous.ts
+++ b/packages/llm-shared/src/anonymous.ts
@@ -1,0 +1,31 @@
+export function getAnonymousUserId(ipAddress: string): string {
+  return `anon:${ipAddress}`;
+}
+
+export function isAnonymousUserId(userId: string): boolean {
+  return userId.startsWith('anon:');
+}
+
+export type AnonymousUserContext = {
+  isAnonymous: true;
+  ipAddress: string;
+  id: string;
+  microdollars_used: number;
+  is_admin: false;
+};
+
+export function createAnonymousContext(ipAddress: string): AnonymousUserContext {
+  return {
+    isAnonymous: true,
+    ipAddress,
+    id: getAnonymousUserId(ipAddress),
+    microdollars_used: 0,
+    is_admin: false,
+  };
+}
+
+export function isAnonymousContext(user: unknown): user is AnonymousUserContext {
+  return (
+    typeof user === 'object' && user !== null && 'isAnonymous' in user && user.isAnonymous === true
+  );
+}

--- a/packages/llm-shared/src/api-metrics-types.ts
+++ b/packages/llm-shared/src/api-metrics-types.ts
@@ -1,0 +1,105 @@
+import type OpenAI from 'openai';
+import type { CompletionUsage } from 'openai/resources/completions';
+
+export type ApiMetricsTokens = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheWriteTokens?: number;
+  cacheHitTokens?: number;
+  totalTokens?: number;
+};
+
+export type ApiMetricsParams = {
+  clientSecret: string;
+  kiloUserId: string;
+  organizationId?: string;
+  isAnonymous: boolean;
+  isStreaming: boolean;
+  userByok: boolean;
+  mode?: string;
+  provider: string;
+  inferenceProvider?: string;
+  requestedModel: string;
+  resolvedModel: string;
+  toolsAvailable: string[];
+  toolsUsed: string[];
+  ttfbMs: number;
+  completeRequestMs: number;
+  statusCode: number;
+  tokens?: ApiMetricsTokens;
+};
+
+export function getTokensFromCompletionUsage(
+  usage: CompletionUsage | null | undefined
+): ApiMetricsTokens | undefined {
+  if (!usage) return undefined;
+
+  const tokens: ApiMetricsTokens = {
+    inputTokens: usage.prompt_tokens,
+    outputTokens: usage.completion_tokens,
+    cacheHitTokens: usage.prompt_tokens_details?.cached_tokens,
+    totalTokens: usage.total_tokens,
+    cacheWriteTokens: undefined,
+  };
+
+  const hasAny =
+    tokens.inputTokens !== undefined ||
+    tokens.outputTokens !== undefined ||
+    tokens.cacheWriteTokens !== undefined ||
+    tokens.cacheHitTokens !== undefined ||
+    tokens.totalTokens !== undefined;
+
+  return hasAny ? tokens : undefined;
+}
+
+export function getToolsAvailable(
+  tools: Array<OpenAI.Chat.Completions.ChatCompletionTool> | undefined
+): string[] {
+  if (!tools) return [];
+
+  return tools.map((tool): string => {
+    if (tool.type === 'function') {
+      const toolName = typeof tool.function?.name === 'string' ? tool.function.name.trim() : '';
+      return toolName ? `function:${toolName}` : 'function:unknown';
+    }
+
+    if (tool.type === 'custom') {
+      const toolName = typeof tool.custom?.name === 'string' ? tool.custom.name.trim() : '';
+      return toolName ? `custom:${toolName}` : 'custom:unknown';
+    }
+
+    return 'unknown:unknown';
+  });
+}
+
+export function getToolsUsed(
+  messages: Array<OpenAI.Chat.Completions.ChatCompletionMessageParam> | undefined
+): string[] {
+  if (!messages) return [];
+
+  const used = new Array<string>();
+
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue;
+
+    for (const toolCall of message.tool_calls ?? []) {
+      if (toolCall.type === 'function') {
+        const toolName =
+          typeof toolCall.function?.name === 'string' ? toolCall.function.name.trim() : '';
+        used.push(toolName ? `function:${toolName}` : 'function:unknown');
+        continue;
+      }
+
+      if (toolCall.type === 'custom') {
+        const toolName =
+          typeof toolCall.custom?.name === 'string' ? toolCall.custom.name.trim() : '';
+        used.push(toolName ? `custom:${toolName}` : 'custom:unknown');
+        continue;
+      }
+
+      used.push('unknown:unknown');
+    }
+  }
+
+  return used;
+}

--- a/packages/llm-shared/src/cloud-agent-promo.ts
+++ b/packages/llm-shared/src/cloud-agent-promo.ts
@@ -1,0 +1,28 @@
+export const CLOUD_AGENT_PROMO_MODEL = 'anthropic/claude-sonnet-4.6';
+export const CLOUD_AGENT_PROMO_START = '2026-02-26T08:00:00Z';
+export const CLOUD_AGENT_PROMO_END = '2026-02-28T08:00:00Z';
+
+function isCloudAgentPromoActive(): boolean {
+  const now = Date.now();
+  return now >= Date.parse(CLOUD_AGENT_PROMO_START) && now < Date.parse(CLOUD_AGENT_PROMO_END);
+}
+
+export function isActiveCloudAgentPromo(tokenSource: string | undefined, model: string): boolean {
+  if (tokenSource !== 'cloud-agent') return false;
+  if (model !== CLOUD_AGENT_PROMO_MODEL) return false;
+  return isCloudAgentPromoActive();
+}
+
+export function applyCloudAgentPromoLabel<T extends { id: string; name: string }>(
+  options: T[]
+): T[] {
+  if (!isCloudAgentPromoActive()) return options;
+  const endDate = new Date(CLOUD_AGENT_PROMO_END).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+  });
+  return options.map(m =>
+    m.id === CLOUD_AGENT_PROMO_MODEL ? { ...m, name: `${m.name} (free till ${endDate})` } : m
+  );
+}

--- a/packages/llm-shared/src/code-review-promo.ts
+++ b/packages/llm-shared/src/code-review-promo.ts
@@ -1,0 +1,8 @@
+export const REVIEW_PROMO_MODEL = 'anthropic/claude-sonnet-4.6';
+export const REVIEW_PROMO_END = '2026-02-25T14:00:00Z';
+
+export function isActiveReviewPromo(botId: string | undefined, model: string): boolean {
+  if (botId !== 'reviewer') return false;
+  if (model !== REVIEW_PROMO_MODEL) return false;
+  return Date.now() < Date.parse(REVIEW_PROMO_END);
+}

--- a/packages/llm-shared/src/constants.ts
+++ b/packages/llm-shared/src/constants.ts
@@ -1,0 +1,2 @@
+export const PROMOTION_MAX_REQUESTS = 10000;
+export const PROMOTION_WINDOW_HOURS = 24;

--- a/packages/llm-shared/src/feature-detection.ts
+++ b/packages/llm-shared/src/feature-detection.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const FEATURE_VALUES = [
+  'vscode-extension',
+  'jetbrains-extension',
+  'autocomplete',
+  'parallel-agent',
+  'managed-indexing',
+  'cli',
+  'cloud-agent',
+  'code-review',
+  'auto-triage',
+  'autofix',
+  'app-builder',
+  'agent-manager',
+  'security-agent',
+  'slack',
+  'webhook',
+  'kilo-claw',
+  'direct-gateway',
+] as const;
+
+const featureSchema = z.enum(FEATURE_VALUES);
+
+export type FeatureValue = z.infer<typeof featureSchema>;
+
+export const FEATURE_HEADER = 'x-kilocode-feature';
+
+export function validateFeatureHeader(headerValue: string | null): FeatureValue | null {
+  if (!headerValue) return null;
+  const result = featureSchema.safeParse(headerValue.trim().toLowerCase());
+  return result.success ? result.data : null;
+}

--- a/packages/llm-shared/src/index.ts
+++ b/packages/llm-shared/src/index.ts
@@ -1,0 +1,174 @@
+// Provider types
+export type { ProviderId } from './provider-id.js';
+export type { Provider } from './provider.js';
+export type { KiloFreeModel, KiloFreeModelFlag } from './kilo-free-model.js';
+export { convertFromKiloModel } from './kilo-free-model.js';
+
+// OpenRouter types
+export type {
+  OpenRouterChatCompletionRequest,
+  OpenRouterProviderConfig,
+  OpenRouterReasoningConfig,
+  OpenRouterGeneration,
+  MessageWithReasoning,
+  VercelProviderConfig,
+  VercelInferenceProviderConfig,
+} from './openrouter-types.js';
+export { isFreePromptTrainingAllowed } from './openrouter-types.js';
+
+// Inference provider IDs
+export {
+  OpenRouterInferenceProviderIdSchema,
+  VercelUserByokInferenceProviderIdSchema,
+  AutocompleteUserByokProviderIdSchema,
+  UserByokProviderIdSchema,
+  UserByokTestModels,
+  VercelNonUserByokInferenceProviderIdSchema,
+  VercelInferenceProviderIdSchema,
+  openRouterToVercelInferenceProviderId,
+  inferVercelFirstPartyInferenceProviderForModel,
+  AwsCredentialsSchema,
+} from './inference-provider-id.js';
+export type {
+  OpenRouterInferenceProviderId,
+  VercelUserByokInferenceProviderId,
+  UserByokAutocompleteProviderId,
+  UserByokProviderId,
+  VercelInferenceProviderId,
+  AwsCredentials,
+} from './inference-provider-id.js';
+
+// Free model definitions
+export {
+  CLAUDE_SONNET_CURRENT_MODEL_ID,
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  corethink_free_model,
+  giga_potato_model,
+  giga_potato_thinking_model,
+  minimax_m25_free_model,
+  kimi_k25_free_model,
+  grok_code_fast_1_optimized_free_model,
+  zai_glm5_free_model,
+} from './kilo-free-models.js';
+
+// Model utilities
+export {
+  DEFAULT_MODEL_CHOICES,
+  PRIMARY_DEFAULT_MODEL,
+  preferredModels,
+  getFirstFreeModel,
+  isFreeModel,
+  isKiloFreeModel,
+  isDataCollectionRequiredOnKiloCodeOnly,
+  kiloFreeModels,
+  isKiloStealthModel,
+  extraRequiredProviders,
+  isDeadFreeModel,
+} from './models.js';
+
+export { isRateLimitedToDeath } from './rate-limited-models.js';
+
+export {
+  KILO_AUTO_FRONTIER_MODEL,
+  KILO_AUTO_FREE_MODEL,
+  KILO_AUTO_SMALL_MODEL,
+  AUTO_MODELS,
+  isKiloAutoModel,
+  resolveAutoModel,
+} from './kilo-auto-model.js';
+
+export { normalizeModelId } from './model-utils.js';
+
+export { generateProviderSpecificHash } from './provider-hash.js';
+
+// Feature detection
+export { FEATURE_VALUES, FEATURE_HEADER, validateFeatureHeader } from './feature-detection.js';
+export type { FeatureValue } from './feature-detection.js';
+
+// Tool calling
+export {
+  ENABLE_TOOL_REPAIR,
+  repairTools,
+  hasAttemptCompletionTool,
+  dropToolStrictProperties,
+  normalizeToolCallIds,
+} from './tool-calling.js';
+
+// Process usage types
+export { extractPromptInfo } from './process-usage-types.js';
+export type { MicrodollarUsageContext, PromptInfo } from './process-usage-types.js';
+
+// Anonymous user
+export {
+  getAnonymousUserId,
+  isAnonymousUserId,
+  createAnonymousContext,
+  isAnonymousContext,
+} from './anonymous.js';
+export type { AnonymousUserContext } from './anonymous.js';
+
+// Proxy helpers
+export { estimateChatTokens, checkOrganizationModelRestrictions } from './llm-proxy-helpers.js';
+export type {
+  OrganizationRestrictionResult,
+  OrganizationSettings,
+  OrganizationPlan,
+} from './llm-proxy-helpers.js';
+
+// API metrics
+export {
+  getTokensFromCompletionUsage,
+  getToolsAvailable,
+  getToolsUsed,
+} from './api-metrics-types.js';
+export type { ApiMetricsTokens, ApiMetricsParams } from './api-metrics-types.js';
+
+// Provider-specific logic
+export {
+  applyProviderSpecificLogic,
+  isAnthropicModel,
+  isHaikuModel,
+  isMistralModel,
+  isCodestralModel,
+  isXaiModel,
+  isGeminiModel,
+  isGemini3Model,
+  isOpenAiModel,
+  isMoonshotModel,
+  isQwenModel,
+  isZaiModel,
+  addCacheBreakpoints,
+} from './provider-specific-logic.js';
+export type { BYOKResult } from './provider-specific-logic.js';
+
+// Promotions
+export { isActiveReviewPromo, REVIEW_PROMO_MODEL, REVIEW_PROMO_END } from './code-review-promo.js';
+export {
+  isActiveCloudAgentPromo,
+  applyCloudAgentPromoLabel,
+  CLOUD_AGENT_PROMO_MODEL,
+  CLOUD_AGENT_PROMO_START,
+  CLOUD_AGENT_PROMO_END,
+} from './cloud-agent-promo.js';
+
+// Constants
+export { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from './constants.js';
+
+// Reasoning details
+export {
+  ReasoningDetailType,
+  ReasoningFormat,
+  CommonReasoningDetailSchema,
+  ReasoningDetailSummarySchema,
+  ReasoningDetailEncryptedSchema,
+  ReasoningDetailTextSchema,
+  ReasoningDetailUnionSchema,
+  ReasoningDetailArraySchema,
+  OutputUnionToReasoningDetailsSchema,
+} from './reasoning-details.js';
+export type {
+  ReasoningDetailSummary,
+  ReasoningDetailEncrypted,
+  ReasoningDetailText,
+  ReasoningDetailUnion,
+} from './reasoning-details.js';

--- a/packages/llm-shared/src/inference-provider-id.ts
+++ b/packages/llm-shared/src/inference-provider-id.ts
@@ -1,0 +1,117 @@
+import * as z from 'zod';
+
+export const OpenRouterInferenceProviderIdSchema = z.enum([
+  'alibaba',
+  'amazon-bedrock',
+  'anthropic',
+  'arcee-ai',
+  'deepinfra',
+  'fireworks',
+  'google-ai-studio',
+  'google-vertex',
+  'inception',
+  'moonshotai',
+  'xai',
+  'minimax',
+  'mistral',
+  'novita',
+  'streamlake',
+  'stealth',
+  'z-ai',
+
+  // not real OpenRouter providers
+  'corethink',
+]);
+
+export const VercelUserByokInferenceProviderIdSchema = z.enum([
+  'anthropic',
+  'bedrock',
+  'google',
+  'openai',
+  'minimax',
+  'mistral',
+  'xai',
+  'zai',
+]);
+
+export type VercelUserByokInferenceProviderId = z.infer<
+  typeof VercelUserByokInferenceProviderIdSchema
+>;
+
+export const AutocompleteUserByokProviderIdSchema = z.enum(['codestral']);
+
+export type UserByokAutocompleteProviderId = z.infer<typeof AutocompleteUserByokProviderIdSchema>;
+
+export const UserByokProviderIdSchema = VercelUserByokInferenceProviderIdSchema.or(
+  AutocompleteUserByokProviderIdSchema
+);
+
+export type UserByokProviderId = z.infer<typeof UserByokProviderIdSchema>;
+
+export const UserByokTestModels = {
+  [VercelUserByokInferenceProviderIdSchema.enum.anthropic]: 'anthropic/claude-haiku-4.5',
+  [VercelUserByokInferenceProviderIdSchema.enum.bedrock]: 'anthropic/claude-haiku-4.5',
+  [VercelUserByokInferenceProviderIdSchema.enum.google]: 'google/gemini-2.5-flash-lite',
+  [VercelUserByokInferenceProviderIdSchema.enum.minimax]: 'minimax/minimax-m2.5',
+  [VercelUserByokInferenceProviderIdSchema.enum.mistral]: 'mistral/devstral-2',
+  [VercelUserByokInferenceProviderIdSchema.enum.openai]: 'openai/gpt-5-nano',
+  [VercelUserByokInferenceProviderIdSchema.enum.xai]: 'xai/grok-4.1-fast-non-reasoning',
+  [VercelUserByokInferenceProviderIdSchema.enum.zai]: 'zai/glm-4.7-flash',
+  [AutocompleteUserByokProviderIdSchema.enum.codestral]: 'mistral/codestral',
+} satisfies Record<UserByokProviderId, string>;
+
+export const VercelNonUserByokInferenceProviderIdSchema = z.enum(['alibaba', 'vertex']);
+
+export const VercelInferenceProviderIdSchema = VercelUserByokInferenceProviderIdSchema.or(
+  VercelNonUserByokInferenceProviderIdSchema
+);
+
+export type OpenRouterInferenceProviderId = z.infer<typeof OpenRouterInferenceProviderIdSchema>;
+
+export type VercelInferenceProviderId = z.infer<typeof VercelInferenceProviderIdSchema>;
+
+const openRouterToVercelInferenceProviderMapping = {
+  [OpenRouterInferenceProviderIdSchema.enum['amazon-bedrock']]:
+    VercelUserByokInferenceProviderIdSchema.enum.bedrock,
+  [OpenRouterInferenceProviderIdSchema.enum['google-ai-studio']]:
+    VercelUserByokInferenceProviderIdSchema.enum.google,
+  [OpenRouterInferenceProviderIdSchema.enum['google-vertex']]:
+    VercelNonUserByokInferenceProviderIdSchema.enum.vertex,
+  [OpenRouterInferenceProviderIdSchema.enum['z-ai']]:
+    VercelUserByokInferenceProviderIdSchema.enum.zai,
+} as Record<string, VercelInferenceProviderId | undefined>;
+
+export function openRouterToVercelInferenceProviderId(providerId: string) {
+  const slashIndex = providerId.indexOf('/');
+  const normalizedProviderId = (
+    slashIndex >= 0 ? providerId.slice(0, slashIndex) : providerId
+  ).toLowerCase();
+  return openRouterToVercelInferenceProviderMapping[normalizedProviderId] ?? normalizedProviderId;
+}
+
+const modelPrefixToVercelInferenceProviderMapping = {
+  anthropic: VercelUserByokInferenceProviderIdSchema.enum.anthropic,
+  google: VercelUserByokInferenceProviderIdSchema.enum.google,
+  openai: VercelUserByokInferenceProviderIdSchema.enum.openai,
+  minimax: VercelUserByokInferenceProviderIdSchema.enum.minimax,
+  mistralai: VercelUserByokInferenceProviderIdSchema.enum.mistral,
+  qwen: VercelNonUserByokInferenceProviderIdSchema.enum.alibaba,
+  'x-ai': VercelUserByokInferenceProviderIdSchema.enum.xai,
+  'z-ai': VercelUserByokInferenceProviderIdSchema.enum.zai,
+} as Record<string, VercelInferenceProviderId | undefined>;
+
+export function inferVercelFirstPartyInferenceProviderForModel(
+  model: string
+): VercelInferenceProviderId | null {
+  return model.startsWith('openai/gpt-oss')
+    ? null
+    : (modelPrefixToVercelInferenceProviderMapping[model.split('/')[0]] ?? null);
+}
+
+export const AwsCredentialsSchema = z.object({
+  accessKeyId: z.string(),
+  secretAccessKey: z.string(),
+  region: z.string(),
+});
+
+export type AwsCredentials = z.infer<typeof AwsCredentialsSchema>;

--- a/packages/llm-shared/src/kilo-auto-model.ts
+++ b/packages/llm-shared/src/kilo-auto-model.ts
@@ -1,0 +1,133 @@
+import type { OpenRouterReasoningConfig } from './openrouter-types.js';
+import {
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  CLAUDE_SONNET_CURRENT_MODEL_ID,
+  minimax_m25_free_model,
+} from './kilo-free-models.js';
+
+// Re-export ModelSettings and related types from @kilocode/db/schema-types
+// These are used by the original kilo-auto-model.ts
+export type { ModelSettings, OpenCodeSettings, Verbosity } from '@kilocode/db/schema-types';
+
+type AutoModel = {
+  id: string;
+  name: string;
+  description: string;
+  context_length: number;
+  max_completion_tokens: number;
+  prompt_price: string;
+  completion_price: string;
+  supports_images: boolean;
+  roocode_settings: import('@kilocode/db/schema-types').ModelSettings | undefined;
+  opencode_settings: import('@kilocode/db/schema-types').OpenCodeSettings | undefined;
+};
+
+export const KILO_AUTO_FRONTIER_MODEL: AutoModel = {
+  id: 'kilo/auto',
+  name: 'Kilo: Auto',
+  description: 'Automatically routes your request to the best model for the task.',
+  context_length: 1_000_000,
+  max_completion_tokens: 128_000,
+  prompt_price: '0.000005',
+  completion_price: '0.000025',
+  supports_images: true,
+  roocode_settings: undefined,
+  opencode_settings: {
+    family: 'claude',
+    prompt: 'anthropic',
+  },
+};
+
+export const KILO_AUTO_FREE_MODEL: AutoModel = {
+  id: 'kilo/auto-free',
+  name: 'Kilo: Auto Free',
+  description: 'Automatically routes your request to a free model.',
+  context_length: minimax_m25_free_model.context_length,
+  max_completion_tokens: minimax_m25_free_model.max_completion_tokens,
+  prompt_price: '0',
+  completion_price: '0',
+  supports_images: false,
+  roocode_settings: {
+    included_tools: ['search_and_replace'],
+    excluded_tools: ['apply_diff', 'edit_file'],
+  },
+  opencode_settings: undefined,
+};
+
+export const KILO_AUTO_SMALL_MODEL: AutoModel = {
+  id: 'kilo/auto-small',
+  name: 'Kilo: Auto Small',
+  description: 'Automatically routes your request to a small model.',
+  context_length: 400_000,
+  max_completion_tokens: 128_000,
+  prompt_price: '0.00000005',
+  completion_price: '0.0000004',
+  supports_images: true,
+  roocode_settings: undefined,
+  opencode_settings: {
+    family: 'gpt',
+    prompt: 'codex',
+  },
+};
+
+export const AUTO_MODELS = [KILO_AUTO_FRONTIER_MODEL, KILO_AUTO_FREE_MODEL, KILO_AUTO_SMALL_MODEL];
+
+export function isKiloAutoModel(model: string) {
+  return AUTO_MODELS.some(m => m.id === model);
+}
+
+type ResolvedAutoModel = {
+  model: string;
+  reasoning?: OpenRouterReasoningConfig;
+  verbosity?: import('@kilocode/db/schema-types').Verbosity;
+};
+
+const CODE_MODEL: ResolvedAutoModel = {
+  model: CLAUDE_SONNET_CURRENT_MODEL_ID,
+  reasoning: { enabled: true },
+  verbosity: 'low',
+};
+
+const MODE_TO_MODEL = new Map<string, ResolvedAutoModel>([
+  [
+    'plan',
+    { model: CLAUDE_OPUS_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'high' },
+  ],
+  [
+    'general',
+    { model: CLAUDE_OPUS_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'medium' },
+  ],
+  [
+    'architect',
+    { model: CLAUDE_OPUS_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'high' },
+  ],
+  [
+    'orchestrator',
+    { model: CLAUDE_OPUS_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'high' },
+  ],
+  ['ask', { model: CLAUDE_OPUS_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'high' }],
+  [
+    'debug',
+    { model: CLAUDE_OPUS_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'high' },
+  ],
+  [
+    'build',
+    { model: CLAUDE_SONNET_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'medium' },
+  ],
+  [
+    'explore',
+    { model: CLAUDE_SONNET_CURRENT_MODEL_ID, reasoning: { enabled: true }, verbosity: 'medium' },
+  ],
+  ['code', CODE_MODEL],
+]);
+
+export function resolveAutoModel(model: string, modeHeader: string | null): ResolvedAutoModel {
+  if (model === KILO_AUTO_FREE_MODEL.id) {
+    return { model: minimax_m25_free_model.public_id };
+  }
+  if (model === KILO_AUTO_SMALL_MODEL.id) {
+    return { model: 'openai/gpt-5-nano' };
+  }
+  const mode = modeHeader?.trim().toLowerCase() ?? '';
+  return MODE_TO_MODEL.get(mode) ?? CODE_MODEL;
+}

--- a/packages/llm-shared/src/kilo-free-model.ts
+++ b/packages/llm-shared/src/kilo-free-model.ts
@@ -1,0 +1,55 @@
+import type { OpenRouterInferenceProviderId } from './inference-provider-id.js';
+import type { ProviderId } from './provider-id.js';
+
+export type KiloFreeModelFlag = 'reasoning' | 'prompt_cache' | 'vision';
+
+export type KiloFreeModel = {
+  public_id: string;
+  display_name: string;
+  description: string;
+  context_length: number;
+  max_completion_tokens: number;
+  is_enabled: boolean;
+  flags: KiloFreeModelFlag[];
+  gateway: ProviderId;
+  internal_id: string;
+  inference_providers: OpenRouterInferenceProviderId[];
+};
+
+export function convertFromKiloModel(model: KiloFreeModel) {
+  return {
+    id: model.public_id,
+    canonical_slug: model.public_id,
+    hugging_face_id: '',
+    name: model.display_name,
+    created: 1756238927,
+    description: model.description,
+    context_length: model.context_length,
+    architecture: {
+      modality: model.flags.includes('vision') ? 'text+image-\u003Etext' : 'text-\u003Etext',
+      input_modalities: ['text'].concat(model.flags.includes('vision') ? ['image'] : []),
+      output_modalities: ['text'],
+      tokenizer: 'Other',
+      instruct_type: null,
+    },
+    pricing: {
+      prompt: '0.0000000',
+      completion: '0.0000000',
+      request: '0',
+      image: '0',
+      web_search: '0',
+      internal_reasoning: '0',
+      input_cache_read: model.flags.includes('prompt_cache') ? '0.00000000' : undefined,
+    },
+    top_provider: {
+      context_length: model.context_length,
+      max_completion_tokens: model.max_completion_tokens,
+      is_moderated: false,
+    },
+    per_request_limits: null,
+    supported_parameters: ['max_tokens', 'temperature', 'tools'].concat(
+      model.flags.includes('reasoning') ? ['reasoning', 'include_reasoning'] : []
+    ),
+    default_parameters: {},
+  };
+}

--- a/packages/llm-shared/src/kilo-free-models.ts
+++ b/packages/llm-shared/src/kilo-free-models.ts
@@ -1,0 +1,104 @@
+import type { KiloFreeModel } from './kilo-free-model.js';
+
+// Anthropic model IDs
+export const CLAUDE_SONNET_CURRENT_MODEL_ID = 'anthropic/claude-sonnet-4.6';
+export const CLAUDE_OPUS_CURRENT_MODEL_ID = 'anthropic/claude-opus-4.6';
+
+// CoreThink
+export const corethink_free_model = {
+  public_id: 'corethink:free',
+  display_name: 'CoreThink (free)',
+  description:
+    'CoreThink - AI that reasons through problems instead of guessing. Available free of charge in Kilo for a limited time.',
+  context_length: 78_000,
+  max_completion_tokens: 8192,
+  is_enabled: true,
+  flags: [],
+  gateway: 'corethink',
+  internal_id: 'corethink',
+  inference_providers: ['corethink'],
+} as KiloFreeModel;
+
+// Giga Potato
+export const giga_potato_model = {
+  public_id: 'giga-potato',
+  display_name: 'Giga Potato (free)',
+  description:
+    'Giga Potato is a stealth model deeply optimized for agentic programming, with visual understanding capability. ' +
+    'It is provided free of charge in Kilo Code for a limited time.\n' +
+    '**Note:** Prompts and completions are logged and may be used to improve the model.',
+  context_length: 256_000,
+  max_completion_tokens: 32_000,
+  is_enabled: true,
+  flags: ['prompt_cache', 'vision'],
+  gateway: 'gigapotato',
+  internal_id: 'ep-20260109111813-hztxv',
+  inference_providers: ['stealth'],
+} as KiloFreeModel;
+
+export const giga_potato_thinking_model = {
+  ...giga_potato_model,
+  public_id: 'giga-potato-thinking',
+  display_name: 'Giga Potato Thinking (free)',
+  flags: giga_potato_model.flags.concat(['reasoning']),
+} as KiloFreeModel;
+
+// MiniMax
+export const minimax_m25_free_model = {
+  public_id: 'minimax/minimax-m2.5:free',
+  display_name: 'MiniMax: MiniMax M2.5 (free)',
+  description:
+    'MiniMax-M2.5 is a SOTA large language model designed for real-world productivity. Trained in a diverse range of complex real-world digital working environments, M2.5 builds upon the coding expertise of M2.1 to extend into general office work, reaching fluency in generating and operating Word, Excel, and Powerpoint files, context switching between diverse software environments, and working across different agent and human teams. Scoring 80.2% on SWE-Bench Verified, 51.3% on Multi-SWE-Bench, and 76.3% on BrowseComp, M2.5 is also more token efficient than previous generations, having been trained to optimize its actions and output through planning.',
+  context_length: 204800,
+  max_completion_tokens: 131072,
+  is_enabled: true,
+  flags: ['reasoning', 'prompt_cache'],
+  gateway: 'openrouter',
+  internal_id: 'minimax/minimax-m2.5',
+  inference_providers: [],
+} as KiloFreeModel;
+
+// MoonshotAI
+export const kimi_k25_free_model: KiloFreeModel = {
+  public_id: 'moonshotai/kimi-k2.5:free',
+  display_name: 'MoonshotAI: Kimi K2.5 (free)',
+  description:
+    "Kimi K2.5 is Moonshot AI's native multimodal model, delivering state-of-the-art visual coding capability and a self-directed agent swarm paradigm. Built on Kimi K2 with continued pretraining over approximately 15T mixed visual and text tokens, it delivers strong performance in general reasoning, visual coding, and agentic tool-calling.",
+  context_length: 262144,
+  max_completion_tokens: 65536,
+  is_enabled: true,
+  flags: ['reasoning', 'prompt_cache', 'vision'],
+  gateway: 'openrouter',
+  internal_id: 'moonshotai/kimi-k2.5',
+  inference_providers: [],
+};
+
+// xAI
+export const grok_code_fast_1_optimized_free_model = {
+  public_id: 'x-ai/grok-code-fast-1:optimized:free',
+  display_name: 'xAI: Grok Code Fast 1 Optimized (experimental, free)',
+  description:
+    'An optimized variant of Grok Code Fast 1, provided free of charge for a limited time. **Note:** All prompts and completions for this model are logged by the provider and may be used to improve their services.',
+  context_length: 256_000,
+  max_completion_tokens: 10_000,
+  is_enabled: false,
+  flags: ['reasoning', 'prompt_cache'],
+  gateway: 'martian',
+  internal_id: 'x-ai/grok-code-fast-1:optimized',
+  inference_providers: ['stealth'],
+} satisfies KiloFreeModel;
+
+// Z.AI
+export const zai_glm5_free_model = {
+  public_id: 'z-ai/glm-5:free',
+  display_name: 'Z.ai: GLM 5 (free)',
+  description:
+    "GLM-5 is Z.ai's flagship open-source foundation model engineered for complex systems design and long-horizon agent workflows. Built for expert developers, it delivers production-grade performance on large-scale programming tasks, rivaling leading closed-source models. With advanced agentic planning, deep backend reasoning, and iterative self-correction, GLM-5 moves beyond code generation to full-system construction and autonomous execution.",
+  context_length: 202800,
+  max_completion_tokens: 131072,
+  is_enabled: false,
+  flags: ['reasoning', 'prompt_cache'],
+  gateway: 'openrouter',
+  internal_id: 'z-ai/glm-5',
+  inference_providers: [],
+} as KiloFreeModel;

--- a/packages/llm-shared/src/llm-proxy-helpers.ts
+++ b/packages/llm-shared/src/llm-proxy-helpers.ts
@@ -1,0 +1,99 @@
+import type {
+  OpenRouterChatCompletionRequest,
+  OpenRouterProviderConfig,
+} from './openrouter-types.js';
+import { normalizeModelId } from './model-utils.js';
+import { extraRequiredProviders } from './models.js';
+
+export function estimateChatTokens(body: OpenRouterChatCompletionRequest): {
+  estimatedInputTokens: number;
+  estimatedOutputTokens: number;
+} {
+  if (!body.messages || !Array.isArray(body.messages)) {
+    return { estimatedInputTokens: 0, estimatedOutputTokens: 0 };
+  }
+  const overallLength = body.messages.reduce(
+    (sum, m) =>
+      sum +
+      (typeof m.content === 'string'
+        ? m.content?.length
+        : Array.isArray(m.content)
+          ? m.content
+              .filter(c => c.type === 'text')
+              .map(c => c.text.length)
+              .reduce((l, str) => str + 1 + l, 0)
+          : 0),
+    0
+  );
+  return {
+    estimatedInputTokens: overallLength / 4,
+    estimatedOutputTokens: overallLength / 4,
+  };
+}
+
+export type OrganizationPlan = 'teams' | 'enterprise';
+
+export type OrganizationSettings = {
+  model_allow_list?: string[];
+  provider_allow_list?: string[];
+  data_collection?: 'allow' | 'deny';
+};
+
+export type OrganizationRestrictionResult = {
+  error: { status: number; message: string } | null;
+  providerConfig?: OpenRouterProviderConfig;
+};
+
+export function checkOrganizationModelRestrictions(params: {
+  modelId: string;
+  settings?: OrganizationSettings;
+  organizationPlan?: OrganizationPlan;
+}): OrganizationRestrictionResult {
+  if (!params.settings) return { error: null };
+
+  const normalizedModelId = normalizeModelId(params.modelId);
+
+  if (params.organizationPlan === 'enterprise') {
+    const modelAllowList = params.settings.model_allow_list || [];
+
+    if (modelAllowList.length > 0) {
+      const isExactMatch = modelAllowList.includes(normalizedModelId);
+
+      const providerSlug = normalizedModelId.split('/')[0];
+      const wildcardEntry = `${providerSlug}/*`;
+      const isWildcardMatch = modelAllowList.includes(wildcardEntry);
+
+      if (!isExactMatch && !isWildcardMatch) {
+        return { error: { status: 404, message: 'Model not allowed for your team.' } };
+      }
+    }
+  }
+
+  const providerAllowList = params.settings.provider_allow_list || [];
+  const dataCollection = params.settings.data_collection;
+
+  const providerConfig: OpenRouterProviderConfig = {};
+
+  if (params.organizationPlan === 'enterprise' && providerAllowList.length > 0) {
+    const requiredProviders = extraRequiredProviders(normalizedModelId);
+    if (
+      requiredProviders.length > 0 &&
+      !requiredProviders.every(p => providerAllowList.includes(p))
+    ) {
+      console.error(
+        `This FREE model requires ALL of these providers to be allowed: ${requiredProviders.join(', ')}`
+      );
+      return { error: { status: 404, message: 'Model not allowed for your team.' } };
+    }
+    providerConfig.only = providerAllowList;
+  }
+
+  if (dataCollection) {
+    providerConfig.data_collection = dataCollection;
+  }
+
+  return {
+    error: null,
+    providerConfig: Object.keys(providerConfig).length > 0 ? providerConfig : undefined,
+  };
+}

--- a/packages/llm-shared/src/model-utils.ts
+++ b/packages/llm-shared/src/model-utils.ts
@@ -1,0 +1,4 @@
+export function normalizeModelId(modelId: string): string {
+  const colonIndex = modelId.indexOf(':');
+  return colonIndex >= 0 ? modelId.substring(0, colonIndex) : modelId;
+}

--- a/packages/llm-shared/src/models.ts
+++ b/packages/llm-shared/src/models.ts
@@ -1,0 +1,82 @@
+import type { KiloFreeModel } from './kilo-free-model.js';
+import {
+  CLAUDE_SONNET_CURRENT_MODEL_ID,
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  corethink_free_model,
+  giga_potato_model,
+  giga_potato_thinking_model,
+  kimi_k25_free_model,
+  minimax_m25_free_model,
+  grok_code_fast_1_optimized_free_model,
+  zai_glm5_free_model,
+} from './kilo-free-models.js';
+import { KILO_AUTO_FRONTIER_MODEL, KILO_AUTO_FREE_MODEL } from './kilo-auto-model.js';
+
+export const DEFAULT_MODEL_CHOICES = [CLAUDE_SONNET_CURRENT_MODEL_ID, CLAUDE_OPUS_CURRENT_MODEL_ID];
+
+export const PRIMARY_DEFAULT_MODEL = DEFAULT_MODEL_CHOICES[0];
+
+export const preferredModels = [
+  KILO_AUTO_FRONTIER_MODEL.id,
+  KILO_AUTO_FREE_MODEL.id,
+  minimax_m25_free_model.is_enabled ? minimax_m25_free_model.public_id : 'minimax/minimax-m2.5',
+  kimi_k25_free_model.is_enabled ? kimi_k25_free_model.public_id : 'moonshotai/kimi-k2.5',
+  giga_potato_thinking_model.is_enabled ? giga_potato_thinking_model.public_id : null,
+  'arcee-ai/trinity-large-preview:free',
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  CLAUDE_SONNET_CURRENT_MODEL_ID,
+  'openai/gpt-5.2',
+  'openai/gpt-5.3-codex',
+  'google/gemini-3.1-pro-preview',
+  'z-ai/glm-5',
+  'x-ai/grok-code-fast-1',
+].filter(m => m !== null);
+
+export function getFirstFreeModel() {
+  return preferredModels.find(m => isFreeModel(m)) ?? PRIMARY_DEFAULT_MODEL;
+}
+
+export function isFreeModel(model: string): boolean {
+  return (
+    kiloFreeModels.some(m => m.public_id === model && m.is_enabled) ||
+    (model ?? '').endsWith(':free') ||
+    model === 'openrouter/free' ||
+    isOpenRouterStealthModel(model ?? '')
+  );
+}
+
+export function isKiloFreeModel(model: string): boolean {
+  return kiloFreeModels.some(m => m.public_id === model && m.is_enabled);
+}
+
+export function isDataCollectionRequiredOnKiloCodeOnly(model: string): boolean {
+  return kiloFreeModels.some(m => m.public_id === model && m.is_enabled);
+}
+
+export const kiloFreeModels = [
+  corethink_free_model,
+  giga_potato_model,
+  giga_potato_thinking_model,
+  kimi_k25_free_model,
+  minimax_m25_free_model,
+  grok_code_fast_1_optimized_free_model,
+  zai_glm5_free_model,
+] as KiloFreeModel[];
+
+export function isKiloStealthModel(model: string): boolean {
+  return kiloFreeModels.some(
+    m => m.public_id === model && m.inference_providers.includes('stealth')
+  );
+}
+
+function isOpenRouterStealthModel(model: string): boolean {
+  return model.startsWith('openrouter/') && (model.endsWith('-alpha') || model.endsWith('-beta'));
+}
+
+export function extraRequiredProviders(model: string) {
+  return kiloFreeModels.find(m => m.public_id === model)?.inference_providers ?? [];
+}
+
+export function isDeadFreeModel(model: string): boolean {
+  return !!kiloFreeModels.find(m => m.public_id === model && !m.is_enabled);
+}

--- a/packages/llm-shared/src/openrouter-types.ts
+++ b/packages/llm-shared/src/openrouter-types.ts
@@ -1,0 +1,89 @@
+import type OpenAI from 'openai';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import type { ReasoningDetailUnion } from './reasoning-details.js';
+import type { AwsCredentials } from './inference-provider-id.js';
+
+export type OpenRouterProviderConfig = {
+  order?: string[];
+  only?: string[];
+  data_collection?: 'allow' | 'deny';
+  zdr?: boolean;
+};
+
+export type VercelInferenceProviderConfig = { apiKey: string; baseURL?: string } | AwsCredentials;
+
+export type VercelProviderConfig = {
+  gateway?: GatewayProviderOptions & {
+    byok?: Record<string, VercelInferenceProviderConfig[]>;
+  };
+  anthropic?: AnthropicProviderOptions;
+};
+
+export function isFreePromptTrainingAllowed(provider: OpenRouterProviderConfig | undefined) {
+  return provider?.data_collection !== 'deny' && !provider?.zdr;
+}
+
+export type OpenRouterReasoningConfig = {
+  effort?: OpenAI.Chat.Completions.ChatCompletionReasoningEffort | 'none';
+  max_tokens?: number;
+  exclude?: boolean;
+  enabled?: boolean;
+};
+
+type OpenCodeSpecificRequestProperties = {
+  description?: string;
+  usage?: { include: boolean };
+  reasoningEffort?: string;
+};
+
+export type OpenRouterChatCompletionRequest = OpenAI.Chat.ChatCompletionCreateParams &
+  OpenCodeSpecificRequestProperties & {
+    max_tokens?: number;
+    transforms?: string[];
+    provider?: OpenRouterProviderConfig;
+    providerOptions?: VercelProviderConfig;
+    reasoning?: OpenRouterReasoningConfig;
+    reasoning_split?: boolean;
+    thinking?: { type?: 'enabled' | 'disabled' };
+    models?: string[];
+  };
+
+export type MessageWithReasoning = {
+  reasoning?: string;
+  reasoning_content?: string;
+  reasoning_details?: ReasoningDetailUnion[];
+};
+
+export type OpenRouterGeneration = {
+  data: {
+    id: string;
+    is_byok?: boolean | null;
+    total_cost: number;
+    upstream_inference_cost?: number | null;
+    created_at: string;
+    model: string;
+    origin: string;
+    usage: number;
+    upstream_id?: string | null;
+    cache_discount?: number | null;
+    app_id?: number | null;
+    streamed?: boolean | null;
+    cancelled?: boolean | null;
+    provider_name?: string | null;
+    latency?: number | null;
+    moderation_latency?: number | null;
+    generation_time?: number | null;
+    finish_reason?: string | null;
+    native_finish_reason?: string | null;
+    tokens_prompt?: number | null;
+    tokens_completion?: number | null;
+    native_tokens_prompt?: number | null;
+    native_tokens_completion?: number | null;
+    native_tokens_reasoning?: number | null;
+    native_tokens_cached?: number | null;
+    num_media_prompt?: number | null;
+    num_media_completion?: number | null;
+    num_search_results?: number | null;
+  };
+};

--- a/packages/llm-shared/src/process-usage-types.ts
+++ b/packages/llm-shared/src/process-usage-types.ts
@@ -1,0 +1,88 @@
+import type { FeatureValue } from './feature-detection.js';
+import type { ProviderId } from './provider-id.js';
+import type { OpenRouterChatCompletionRequest } from './openrouter-types.js';
+
+type FraudDetectionHeaders = {
+  http_x_forwarded_for: string | null;
+  http_x_vercel_ip_city: string | null;
+  http_x_vercel_ip_country: string | null;
+  http_x_vercel_ip_latitude: number | null;
+  http_x_vercel_ip_longitude: number | null;
+  http_x_vercel_ja4_digest: string | null;
+  http_user_agent: string | null;
+};
+
+export type MicrodollarUsageContext = {
+  kiloUserId: string;
+  fraudHeaders: FraudDetectionHeaders;
+  organizationId?: string;
+  provider: ProviderId;
+  requested_model: string;
+  promptInfo: PromptInfo;
+  max_tokens: number | null;
+  has_middle_out_transform: boolean | null;
+  estimatedInputTokens: number;
+  estimatedOutputTokens: number;
+  isStreaming: boolean;
+  prior_microdollar_usage: number;
+  posthog_distinct_id?: string;
+  project_id: string | null;
+  status_code: number | null;
+  editor_name: string | null;
+  machine_id: string | null;
+  user_byok: boolean;
+  has_tools: boolean;
+  botId?: string;
+  tokenSource?: string;
+  abuse_request_id?: number;
+  feature: FeatureValue | null;
+  session_id: string | null;
+};
+
+export type PromptInfo = {
+  system_prompt_prefix: string;
+  system_prompt_length: number;
+  user_prompt_prefix: string;
+};
+
+interface Message {
+  role: string;
+  content?: string | { type?: string; text?: string }[];
+  parts?: { text?: string }[];
+}
+
+const extractMessageTextContent = (m: Message) =>
+  typeof m.content === 'string'
+    ? m.content
+    : Array.isArray(m.content)
+      ? m.content
+          .filter(c => c.type === 'text')
+          .map(c => c.text)
+          .join('\n')
+      : '';
+
+export function extractPromptInfo(body: OpenRouterChatCompletionRequest): PromptInfo {
+  try {
+    const messages = body.messages ?? [];
+
+    const systemPrompt = messages
+      .filter(m => m.role === 'system' || m.role === 'developer')
+      .map(extractMessageTextContent)
+      .join('\n');
+
+    const system_prompt_prefix = systemPrompt.slice(0, 100);
+    const system_prompt_length = systemPrompt.length;
+
+    const lastUserMessage =
+      messages
+        .filter(m => m.role === 'user')
+        .slice(-1)
+        .map(extractMessageTextContent)[0] ?? '';
+
+    const user_prompt_prefix = lastUserMessage.slice(0, 100);
+
+    return { system_prompt_prefix, system_prompt_length, user_prompt_prefix };
+  } catch {
+    return { system_prompt_prefix: '', system_prompt_length: -1, user_prompt_prefix: '' };
+  }
+}

--- a/packages/llm-shared/src/provider-hash.ts
+++ b/packages/llm-shared/src/provider-hash.ts
@@ -1,0 +1,11 @@
+import crypto from 'crypto';
+import type { Provider } from './provider.js';
+
+export function generateProviderSpecificHash(payload: string, provider: Provider): string {
+  const salt = 'd20250815';
+  const pepper = provider.id === 'openrouter' ? 'henk is a boss' : provider.id;
+  return crypto
+    .createHash('sha256')
+    .update(salt + pepper + payload)
+    .digest('base64');
+}

--- a/packages/llm-shared/src/provider-id.ts
+++ b/packages/llm-shared/src/provider-id.ts
@@ -1,0 +1,9 @@
+export type ProviderId =
+  | 'openrouter'
+  | 'gigapotato'
+  | 'corethink'
+  | 'martian'
+  | 'mistral'
+  | 'vercel'
+  | 'custom'
+  | 'dev-tools';

--- a/packages/llm-shared/src/provider-specific-logic.ts
+++ b/packages/llm-shared/src/provider-specific-logic.ts
@@ -1,0 +1,421 @@
+import type { OpenRouterChatCompletionRequest, MessageWithReasoning } from './openrouter-types.js';
+import type { Provider } from './provider.js';
+import type { ProviderId } from './provider-id.js';
+import type { OpenRouterInferenceProviderId } from './inference-provider-id.js';
+import { OpenRouterInferenceProviderIdSchema } from './inference-provider-id.js';
+import { kiloFreeModels } from './models.js';
+import {
+  dropToolStrictProperties,
+  hasAttemptCompletionTool,
+  normalizeToolCallIds,
+} from './tool-calling.js';
+import { ReasoningDetailType } from './reasoning-details.js';
+import type OpenAI from 'openai';
+
+// ---- Model identification helpers ----
+
+export function isAnthropicModel(requestedModel: string) {
+  return requestedModel.startsWith('anthropic/');
+}
+
+export function isHaikuModel(requestedModel: string) {
+  return requestedModel.startsWith('anthropic/claude-haiku');
+}
+
+export function isMistralModel(model: string) {
+  return model.startsWith('mistralai/');
+}
+
+export function isCodestralModel(model: string) {
+  return model.startsWith('mistralai/codestral');
+}
+
+export function isXaiModel(requestedModel: string) {
+  return requestedModel.startsWith('x-ai/');
+}
+
+export function isGeminiModel(model: string) {
+  return model.startsWith('google/gemini');
+}
+
+export function isGemini3Model(model: string) {
+  return model.startsWith('google/gemini-3');
+}
+
+export function isOpenAiModel(requestedModel: string) {
+  return requestedModel.startsWith('openai/') && !requestedModel.startsWith('openai/gpt-oss');
+}
+
+export function isMoonshotModel(model: string) {
+  return model.startsWith('moonshotai/');
+}
+
+export function isQwenModel(requestedModelId: string) {
+  return requestedModelId.startsWith('qwen/');
+}
+
+export function isZaiModel(model: string) {
+  return model.startsWith('z-ai/');
+}
+
+// ---- Anthropic-specific logic ----
+
+function appendAnthropicBetaHeader(extraHeaders: Record<string, string>, betaFlag: string) {
+  extraHeaders['x-anthropic-beta'] = [extraHeaders['x-anthropic-beta'], betaFlag]
+    .filter(Boolean)
+    .join(',');
+}
+
+function hasCacheControl(message: OpenAI.ChatCompletionMessageParam) {
+  return (
+    'cache_control' in message ||
+    (Array.isArray(message.content) && message.content.some(content => 'cache_control' in content))
+  );
+}
+
+function setCacheControl(message: OpenAI.ChatCompletionMessageParam) {
+  if (typeof message.content === 'string') {
+    message.content = [
+      {
+        type: 'text',
+        text: message.content,
+        // @ts-expect-error non-standard extension
+        cache_control: { type: 'ephemeral' },
+      },
+    ];
+  } else if (Array.isArray(message.content)) {
+    const lastItem = message.content.at(-1);
+    if (lastItem) {
+      // @ts-expect-error non-standard extension
+      lastItem.cache_control = { type: 'ephemeral' };
+    }
+  }
+}
+
+export function addCacheBreakpoints(messages: OpenAI.Chat.ChatCompletionMessageParam[]) {
+  const systemPrompt = messages.find(msg => msg.role === 'system');
+  if (!systemPrompt) {
+    return;
+  }
+
+  if (hasCacheControl(systemPrompt)) {
+    return;
+  }
+
+  setCacheControl(systemPrompt);
+
+  const lastUserMessage = messages.findLast(msg => msg.role === 'user' || msg.role === 'tool');
+  if (lastUserMessage) {
+    setCacheControl(lastUserMessage);
+  }
+}
+
+function applyAnthropicModelSettings(
+  requestedModel: string,
+  requestToMutate: OpenRouterChatCompletionRequest,
+  extraHeaders: Record<string, string>
+) {
+  appendAnthropicBetaHeader(extraHeaders, 'fine-grained-tool-streaming-2025-05-14');
+  addCacheBreakpoints(requestToMutate.messages);
+  normalizeToolCallIds(requestToMutate, toolCallId => toolCallId.includes('.'), undefined);
+}
+
+// ---- xAI-specific logic ----
+
+function convertReasoningDetailsToReasoningContent(
+  requestToMutate: OpenRouterChatCompletionRequest
+) {
+  for (const message of requestToMutate.messages) {
+    if (message.role !== 'assistant') {
+      continue;
+    }
+    const msgWithReasoning = message as MessageWithReasoning;
+    const reasoningDetailsText = (msgWithReasoning.reasoning_details ?? [])
+      .filter(r => r.type === ReasoningDetailType.Text)
+      .map(r => r.text)
+      .join('');
+    if (reasoningDetailsText) {
+      msgWithReasoning.reasoning_content = reasoningDetailsText;
+      delete msgWithReasoning.reasoning_details;
+      delete msgWithReasoning.reasoning;
+    }
+  }
+}
+
+function applyXaiModelSettings(
+  requestToMutate: OpenRouterChatCompletionRequest,
+  extraHeaders: Record<string, string>
+) {
+  extraHeaders['x-grok-conv-id'] = requestToMutate.prompt_cache_key || crypto.randomUUID();
+  extraHeaders['x-grok-req-id'] = crypto.randomUUID();
+}
+
+// ---- Mistral-specific logic ----
+
+function applyMistralModelSettings(requestToMutate: OpenRouterChatCompletionRequest) {
+  if (requestToMutate.temperature === undefined) {
+    requestToMutate.temperature = 0.2;
+  }
+  normalizeToolCallIds(requestToMutate, toolCallId => toolCallId.length !== 9, 9);
+  dropToolStrictProperties(requestToMutate);
+  if (hasAttemptCompletionTool(requestToMutate)) {
+    requestToMutate.tool_choice = 'required';
+  }
+}
+
+function applyMistralProviderSettings(
+  requestToMutate: OpenRouterChatCompletionRequest,
+  extraHeaders: Record<string, string>
+) {
+  if (requestToMutate.prompt_cache_key) {
+    extraHeaders['x-affinity'] = requestToMutate.prompt_cache_key;
+  }
+  for (const message of requestToMutate.messages) {
+    if ('reasoning_details' in message) {
+      delete message.reasoning_details;
+    }
+  }
+  delete requestToMutate.reasoning;
+  delete requestToMutate.reasoning_effort;
+  delete requestToMutate.transforms;
+  delete requestToMutate.safety_identifier;
+  delete requestToMutate.prompt_cache_key;
+  delete requestToMutate.user;
+  delete requestToMutate.provider;
+  applyMistralModelSettings(requestToMutate);
+}
+
+// ---- Google-specific logic ----
+
+type ReadFileParametersSchema = {
+  properties?: {
+    files?: {
+      items?: {
+        properties?: {
+          line_ranges?: {
+            type?: unknown;
+            items?: unknown;
+            anyOf?: unknown;
+          };
+        };
+      };
+    };
+  };
+};
+
+function applyGoogleModelSettings(
+  provider: ProviderId,
+  requestToMutate: OpenRouterChatCompletionRequest
+) {
+  if (provider !== 'vercel') {
+    return;
+  }
+
+  const readFileTool = requestToMutate.tools?.find(
+    tool => tool.type === 'function' && tool.function.name === 'read_file'
+  );
+  if (!readFileTool || readFileTool.type !== 'function') {
+    return;
+  }
+
+  const lineRanges = (readFileTool.function.parameters as ReadFileParametersSchema | undefined)
+    ?.properties?.files?.items?.properties?.line_ranges;
+  if (lineRanges?.type && lineRanges?.items) {
+    lineRanges.anyOf = [{ type: 'null' }, { type: 'array', items: lineRanges.items }];
+    delete lineRanges.type;
+    delete lineRanges.items;
+  }
+}
+
+// ---- Moonshot-specific logic ----
+
+function applyMoonshotProviderSettings(requestToMutate: OpenRouterChatCompletionRequest) {
+  delete requestToMutate.temperature;
+}
+
+// ---- Qwen-specific logic ----
+
+function applyQwenModelSettings(requestToMutate: OpenRouterChatCompletionRequest) {
+  if (requestToMutate.max_tokens) {
+    requestToMutate.max_tokens = Math.min(requestToMutate.max_tokens, 32768);
+  }
+  if (requestToMutate.max_completion_tokens) {
+    requestToMutate.max_completion_tokens = Math.min(requestToMutate.max_completion_tokens, 32768);
+  }
+}
+
+// ---- GigaPotato-specific logic ----
+
+import { giga_potato_thinking_model } from './kilo-free-models.js';
+
+function applyGigaPotatoProviderSettings(
+  requestedModel: string,
+  requestToMutate: OpenRouterChatCompletionRequest
+) {
+  const nonDisclosureRule = {
+    type: 'text' as const,
+    text:
+      'You are an AI assistant in Kilo. Your name is Giga Potato. ' +
+      'Do not reveal your model size, architecture, or any information that could hint at your origin or capabilities.',
+  };
+  const systemPrompt = requestToMutate.messages.find(m => m.role === 'system');
+  if (systemPrompt) {
+    if (Array.isArray(systemPrompt.content)) {
+      systemPrompt.content.push(nonDisclosureRule);
+    } else if (systemPrompt.content) {
+      systemPrompt.content = [{ type: 'text', text: systemPrompt.content }, nonDisclosureRule];
+    } else {
+      systemPrompt.content = [nonDisclosureRule];
+    }
+  } else {
+    requestToMutate.messages.splice(0, 0, { role: 'system', content: [nonDisclosureRule] });
+  }
+  requestToMutate.thinking = {
+    type: giga_potato_thinking_model.public_id === requestedModel ? 'enabled' : 'disabled',
+  };
+}
+
+// ---- CoreThink-specific logic ----
+
+function applyCoreThinkProviderSettings(requestToMutate: OpenRouterChatCompletionRequest) {
+  delete requestToMutate.transforms;
+  delete requestToMutate.prompt_cache_key;
+  delete requestToMutate.safety_identifier;
+  delete requestToMutate.description;
+  delete requestToMutate.usage;
+  for (const message of requestToMutate.messages) {
+    if ('reasoning' in message) {
+      delete message.reasoning;
+    }
+    if ('reasoning_details' in message) {
+      delete message.reasoning_details;
+    }
+  }
+}
+
+// ---- Tool choice logic ----
+
+function applyToolChoiceSetting(
+  requestedModel: string,
+  requestToMutate: OpenRouterChatCompletionRequest
+) {
+  if (!hasAttemptCompletionTool(requestToMutate)) {
+    return;
+  }
+  const isReasoningEnabled =
+    (requestToMutate.reasoning?.enabled ?? false) === true ||
+    (requestToMutate.reasoning?.effort ?? 'none') !== 'none' ||
+    (requestToMutate.reasoning?.max_tokens ?? 0) > 0;
+  if (
+    isXaiModel(requestedModel) ||
+    isOpenAiModel(requestedModel) ||
+    isGeminiModel(requestedModel) ||
+    (isHaikuModel(requestedModel) && !isReasoningEnabled)
+  ) {
+    requestToMutate.tool_choice = 'required';
+  }
+}
+
+// ---- Preferred provider routing ----
+
+function getPreferredProviderOrder(requestedModel: string): OpenRouterInferenceProviderId[] {
+  if (isAnthropicModel(requestedModel)) {
+    return [
+      OpenRouterInferenceProviderIdSchema.enum['amazon-bedrock'],
+      OpenRouterInferenceProviderIdSchema.enum.anthropic,
+    ];
+  }
+  if (requestedModel.startsWith('minimax/')) {
+    return [OpenRouterInferenceProviderIdSchema.enum.minimax];
+  }
+  if (isMistralModel(requestedModel)) {
+    return [OpenRouterInferenceProviderIdSchema.enum.mistral];
+  }
+  if (isMoonshotModel(requestedModel)) {
+    return [OpenRouterInferenceProviderIdSchema.enum.moonshotai];
+  }
+  if (isZaiModel(requestedModel)) {
+    return [OpenRouterInferenceProviderIdSchema.enum['z-ai']];
+  }
+  return [];
+}
+
+function applyPreferredProvider(
+  requestedModel: string,
+  requestToMutate: OpenRouterChatCompletionRequest
+) {
+  const preferredProviderOrder = getPreferredProviderOrder(requestedModel);
+  if (preferredProviderOrder.length === 0) {
+    return;
+  }
+  if (!requestToMutate.provider) {
+    requestToMutate.provider = { order: preferredProviderOrder };
+  } else if (!requestToMutate.provider.order) {
+    requestToMutate.provider.order = preferredProviderOrder;
+  }
+}
+
+// ---- Main entry point ----
+
+export type BYOKResult = {
+  providerId: string;
+  decryptedAPIKey: string;
+};
+
+export function applyProviderSpecificLogic(
+  provider: Provider,
+  requestedModel: string,
+  requestToMutate: OpenRouterChatCompletionRequest,
+  extraHeaders: Record<string, string>,
+  userByok: BYOKResult[] | null
+) {
+  const kiloFreeModel = kiloFreeModels.find(m => m.public_id === requestedModel);
+  if (kiloFreeModel) {
+    requestToMutate.model = kiloFreeModel.internal_id;
+    if (kiloFreeModel.inference_providers.length > 0) {
+      requestToMutate.provider = { only: kiloFreeModel.inference_providers };
+    }
+  }
+
+  if (isAnthropicModel(requestedModel)) {
+    applyAnthropicModelSettings(requestedModel, requestToMutate, extraHeaders);
+  }
+
+  applyToolChoiceSetting(requestedModel, requestToMutate);
+
+  applyPreferredProvider(requestedModel, requestToMutate);
+
+  if (isXaiModel(requestedModel)) {
+    applyXaiModelSettings(requestToMutate, extraHeaders);
+  }
+
+  if (isGeminiModel(requestedModel)) {
+    applyGoogleModelSettings(provider.id, requestToMutate);
+  }
+
+  if (isMoonshotModel(requestedModel)) {
+    applyMoonshotProviderSettings(requestToMutate);
+  }
+
+  if (isQwenModel(requestedModel)) {
+    applyQwenModelSettings(requestToMutate);
+  }
+
+  if (provider.id === 'gigapotato') {
+    applyGigaPotatoProviderSettings(requestedModel, requestToMutate);
+  }
+
+  if (provider.id === 'corethink') {
+    applyCoreThinkProviderSettings(requestToMutate);
+  }
+
+  if (provider.id === 'mistral') {
+    applyMistralProviderSettings(requestToMutate, extraHeaders);
+  } else if (isMistralModel(requestedModel)) {
+    applyMistralModelSettings(requestToMutate);
+  }
+
+  // NOTE: Vercel settings (applyVercelSettings) are NOT included here because they
+  // depend on server-specific BYOK/mapModelIdToVercel logic. Each consumer must
+  // handle Vercel routing separately.
+}

--- a/packages/llm-shared/src/provider.ts
+++ b/packages/llm-shared/src/provider.ts
@@ -1,0 +1,8 @@
+import type { ProviderId } from './provider-id.js';
+
+export type Provider = {
+  id: ProviderId;
+  apiUrl: string;
+  apiKey: string;
+  hasGenerationEndpoint: boolean;
+};

--- a/packages/llm-shared/src/rate-limited-models.ts
+++ b/packages/llm-shared/src/rate-limited-models.ts
@@ -1,0 +1,30 @@
+const rateLimitedToDeathModelIds: ReadonlySet<string> = new Set([
+  'arcee-ai/trinity-mini:free',
+  'cognitivecomputations/dolphin-mistral-24b-venice-edition:free',
+  'deepseek/deepseek-r1-0528:free',
+  'google/gemma-3-12b-it:free',
+  'google/gemma-3-27b-it:free',
+  'google/gemma-3-4b-it:free',
+  'google/gemma-3n-e2b-it:free',
+  'google/gemma-3n-e4b-it:free',
+  'liquid/lfm-2.5-1.2b-instruct:free',
+  'liquid/lfm-2.5-1.2b-thinking:free',
+  'meta-llama/llama-3.2-3b-instruct:free',
+  'meta-llama/llama-3.3-70b-instruct:free',
+  'mistralai/mistral-small-3.1-24b-instruct:free',
+  'nousresearch/hermes-3-llama-3.1-405b:free',
+  'nvidia/nemotron-3-nano-30b-a3b:free',
+  'nvidia/nemotron-nano-12b-v2-vl:free',
+  'nvidia/nemotron-nano-9b-v2:free',
+  'openai/gpt-oss-120b:free',
+  'openai/gpt-oss-20b:free',
+  'qwen/qwen3-4b:free',
+  'qwen/qwen3-coder:free',
+  'qwen/qwen3-next-80b-a3b-instruct:free',
+  'upstage/solar-pro-3:free',
+  'z-ai/glm-4.5-air:free',
+]);
+
+export function isRateLimitedToDeath(modelId: string): boolean {
+  return rateLimitedToDeathModelIds.has(modelId);
+}

--- a/packages/llm-shared/src/reasoning-details.ts
+++ b/packages/llm-shared/src/reasoning-details.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+// Inlined from custom-llm/type-guards.ts
+function isDefinedAndNotNull<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+// Inlined from custom-llm/format.ts
+export const ReasoningFormat = ['raw', 'parsed', 'none'] as const;
+
+export enum ReasoningDetailType {
+  Summary = 'reasoning.summary',
+  Encrypted = 'reasoning.encrypted',
+  Text = 'reasoning.text',
+}
+
+export const CommonReasoningDetailSchema = z
+  .object({
+    id: z.string().nullish(),
+    format: z.enum(ReasoningFormat).nullish(),
+    index: z.number().optional(),
+  })
+  .passthrough();
+
+export const ReasoningDetailSummarySchema = z
+  .object({
+    type: z.literal(ReasoningDetailType.Summary),
+    summary: z.string(),
+  })
+  .extend(CommonReasoningDetailSchema.shape);
+export type ReasoningDetailSummary = z.infer<typeof ReasoningDetailSummarySchema>;
+
+export const ReasoningDetailEncryptedSchema = z
+  .object({
+    type: z.literal(ReasoningDetailType.Encrypted),
+    data: z.string(),
+  })
+  .extend(CommonReasoningDetailSchema.shape);
+
+export type ReasoningDetailEncrypted = z.infer<typeof ReasoningDetailEncryptedSchema>;
+
+export const ReasoningDetailTextSchema = z
+  .object({
+    type: z.literal(ReasoningDetailType.Text),
+    text: z.string().nullish(),
+    signature: z.string().nullish(),
+  })
+  .extend(CommonReasoningDetailSchema.shape);
+
+export type ReasoningDetailText = z.infer<typeof ReasoningDetailTextSchema>;
+
+export const ReasoningDetailUnionSchema = z.union([
+  ReasoningDetailSummarySchema,
+  ReasoningDetailEncryptedSchema,
+  ReasoningDetailTextSchema,
+]);
+
+export type ReasoningDetailUnion = z.infer<typeof ReasoningDetailUnionSchema>;
+
+const ReasoningDetailsWithUnknownSchema = z.union([
+  ReasoningDetailUnionSchema,
+  z.unknown().transform(() => null),
+]);
+
+export const ReasoningDetailArraySchema = z
+  .array(ReasoningDetailsWithUnknownSchema)
+  .transform(d => d.filter((d): d is ReasoningDetailUnion => !!d));
+
+export const OutputUnionToReasoningDetailsSchema = z.union([
+  z
+    .object({
+      delta: z.object({
+        reasoning_details: z.array(ReasoningDetailsWithUnknownSchema),
+      }),
+    })
+    .transform(data => data.delta.reasoning_details.filter(isDefinedAndNotNull)),
+  z
+    .object({
+      message: z.object({
+        reasoning_details: z.array(ReasoningDetailsWithUnknownSchema),
+      }),
+    })
+    .transform(data => data.message.reasoning_details.filter(isDefinedAndNotNull)),
+  z
+    .object({
+      text: z.string(),
+      reasoning_details: z.array(ReasoningDetailsWithUnknownSchema),
+    })
+    .transform(data => data.reasoning_details.filter(isDefinedAndNotNull)),
+]);

--- a/packages/llm-shared/src/tool-calling.ts
+++ b/packages/llm-shared/src/tool-calling.ts
@@ -1,0 +1,135 @@
+import type { OpenRouterChatCompletionRequest } from './openrouter-types.js';
+import crypto from 'crypto';
+import type OpenAI from 'openai';
+
+function normalizeToolCallId(toolCallId: string, maxIdLength: number | undefined) {
+  return crypto.hash('sha256', toolCallId).slice(0, maxIdLength);
+}
+
+export function dropToolStrictProperties(requestToMutate: OpenRouterChatCompletionRequest) {
+  for (const tool of requestToMutate.tools ?? []) {
+    if (tool.type === 'function') {
+      delete tool.function.strict;
+    }
+  }
+}
+
+export function normalizeToolCallIds(
+  requestToMutate: OpenRouterChatCompletionRequest,
+  filter: (toolCallId: string) => boolean,
+  maxIdLength: number | undefined
+) {
+  for (const msg of requestToMutate.messages) {
+    if (msg.role === 'assistant') {
+      for (const toolCall of msg.tool_calls ?? []) {
+        if (filter(toolCall.id)) {
+          toolCall.id = normalizeToolCallId(toolCall.id, maxIdLength);
+        }
+      }
+    }
+    if (msg.role === 'tool' && filter(msg.tool_call_id)) {
+      msg.tool_call_id = normalizeToolCallId(msg.tool_call_id, maxIdLength);
+    }
+  }
+}
+
+export const ENABLE_TOOL_REPAIR = true;
+
+function groupByAssistantMessage(messages: OpenAI.ChatCompletionMessageParam[]) {
+  const groups = new Array<{
+    assistantMessage?: OpenAI.ChatCompletionAssistantMessageParam;
+    otherMessages: OpenAI.ChatCompletionMessageParam[];
+  }>();
+
+  groups.push({
+    assistantMessage: undefined,
+    otherMessages: [],
+  });
+
+  for (const msg of messages) {
+    if (msg.role === 'assistant') {
+      groups.push({
+        assistantMessage: msg,
+        otherMessages: [],
+      });
+    } else {
+      const lastGroup = groups.at(-1);
+      if (lastGroup) lastGroup.otherMessages.push(msg);
+    }
+  }
+
+  return groups;
+}
+
+function deduplicateToolUses(assistantMessage: OpenAI.ChatCompletionAssistantMessageParam) {
+  if (!assistantMessage.tool_calls) {
+    return;
+  }
+  const toolCallIds = new Set<string>();
+  assistantMessage.tool_calls = assistantMessage.tool_calls.filter(toolCall => {
+    if (toolCallIds.has(toolCall.id)) {
+      const toolName = toolCall.type === 'function' ? toolCall.function.name : 'unknown';
+      console.warn(
+        `[repairTools] removing duplicate use of tool ${toolName} with tool call id ${toolCall.id}`
+      );
+      return false;
+    }
+    toolCallIds.add(toolCall.id);
+    return true;
+  });
+}
+
+export function repairTools(requestToMutate: OpenRouterChatCompletionRequest) {
+  if (!Array.isArray(requestToMutate.messages)) {
+    return;
+  }
+  const groups = groupByAssistantMessage(requestToMutate.messages);
+
+  for (const group of groups) {
+    if (group.assistantMessage) {
+      deduplicateToolUses(group.assistantMessage);
+    }
+
+    const toolCallIdsToVerify = new Set<string>();
+
+    const missingResults = new Array<OpenAI.ChatCompletionToolMessageParam>();
+    for (const toolCall of group.assistantMessage?.tool_calls ?? []) {
+      toolCallIdsToVerify.add(toolCall.id);
+      if (
+        group.otherMessages.some(msg => msg.role === 'tool' && msg.tool_call_id === toolCall.id)
+      ) {
+        continue;
+      }
+      const toolName = toolCall.type === 'function' ? toolCall.function.name : 'unknown';
+      console.warn(
+        `[repairTools] inserting missing result for tool ${toolName} with tool call id ${toolCall.id}`
+      );
+      missingResults.push({
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        content: 'Tool execution was interrupted before completion.',
+      });
+    }
+    group.otherMessages.splice(0, 0, ...missingResults);
+
+    group.otherMessages = group.otherMessages.filter(message => {
+      if (message.role === 'tool' && !toolCallIdsToVerify.delete(message.tool_call_id)) {
+        console.warn(
+          `[repairTools] deleting duplicate/orphan tool result for tool call id ${message.tool_call_id}`
+        );
+        return false;
+      }
+      return true;
+    });
+  }
+
+  requestToMutate.messages = groups.flatMap(g =>
+    g.assistantMessage ? [g.assistantMessage, ...g.otherMessages] : g.otherMessages
+  );
+}
+
+export function hasAttemptCompletionTool(request: OpenRouterChatCompletionRequest) {
+  return (request.tools ?? []).some(
+    tool => tool.type === 'function' && tool.function?.name === 'attempt_completion'
+  );
+}

--- a/packages/llm-shared/tsconfig.json
+++ b/packages/llm-shared/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@kilocode/db/schema-types": ["../db/src/schema-types.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1276,6 +1276,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.1(@cloudflare/workers-types@4.20260130.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(bun-types@1.3.9)(pg@8.18.0)
+      eventsource-parser:
+        specifier: ^3.0.6
+        version: 3.0.6
       hono:
         specifier: 'catalog:'
         version: 4.12.2
@@ -17861,7 +17864,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@kilocode/encryption':
         specifier: workspace:*
         version: link:packages/encryption
+      '@kilocode/llm-shared':
+        specifier: workspace:*
+        version: link:packages/llm-shared
       '@kilocode/worker-utils':
         specifier: workspace:*
         version: link:packages/worker-utils
@@ -1247,6 +1250,67 @@ importers:
         specifier: 'catalog:'
         version: 4.68.1(@cloudflare/workers-types@4.20260130.0)
 
+  llm-gateway:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.41
+        version: 3.0.41(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: ^3.0.27
+        version: 3.0.27(zod@4.3.6)
+      '@kilocode/db':
+        specifier: workspace:*
+        version: link:../packages/db
+      '@kilocode/llm-shared':
+        specifier: workspace:*
+        version: link:../packages/llm-shared
+      '@kilocode/worker-utils':
+        specifier: workspace:*
+        version: link:../packages/worker-utils
+      '@sentry/cloudflare':
+        specifier: ^10.25.0
+        version: 10.25.0(@cloudflare/workers-types@4.20260130.0)
+      ai:
+        specifier: ^6.0.78
+        version: 6.0.78(zod@4.3.6)
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.1(@cloudflare/workers-types@4.20260130.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(bun-types@1.3.9)(pg@8.18.0)
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.2
+      jsonwebtoken:
+        specifier: 'catalog:'
+        version: 9.0.3
+      pg:
+        specifier: ^8.16.3
+        version: 8.18.0
+      workers-tagged-logger:
+        specifier: 'catalog:'
+        version: 1.0.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260120.0
+        version: 4.20260130.0
+      '@sentry/cli':
+        specifier: ^2.58.2
+        version: 2.58.2
+      '@types/jsonwebtoken':
+        specifier: 'catalog:'
+        version: 9.0.10
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.16.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.68.1(@cloudflare/workers-types@4.20260130.0)
+
   packages/db:
     dependencies:
       drizzle-orm:
@@ -1280,6 +1344,25 @@ importers:
       vitest:
         specifier: ~3.2.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  packages/llm-shared:
+    dependencies:
+      openai:
+        specifier: ^6.22.0
+        version: 6.22.0(ws@8.18.2)(zod@4.3.6)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.41
+        version: 3.0.41(zod@4.3.6)
+      '@ai-sdk/gateway':
+        specifier: ^3.0.16
+        version: 3.0.39(zod@4.3.6)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/worker-utils:
     dependencies:
@@ -8262,10 +8345,6 @@ packages:
       unstorage:
         optional: true
 
-  hono@4.11.7:
-    resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
-    engines: {node: '>=16.9.0'}
-
   hono@4.12.2:
     resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
     engines: {node: '>=16.9.0'}
@@ -9949,9 +10028,6 @@ packages:
     resolution: {integrity: sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==}
     peerDependencies:
       pg: '>=8.0'
-
-  pg-protocol@1.10.3:
-    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
 
   pg-protocol@1.11.0:
     resolution: {integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==}
@@ -17367,7 +17443,7 @@ snapshots:
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 22.19.1
-      pg-protocol: 1.10.3
+      pg-protocol: 1.11.0
       pg-types: 2.2.0
 
   '@types/pg@8.16.0':
@@ -20041,9 +20117,6 @@ snapshots:
     dependencies:
       hono: 4.12.2
 
-  hono@4.11.7:
-    optional: true
-
   hono@4.12.2: {}
 
   html-entities@2.6.0: {}
@@ -22484,8 +22557,6 @@ snapshots:
     dependencies:
       pg: 8.18.0
 
-  pg-protocol@1.10.3: {}
-
   pg-protocol@1.11.0: {}
 
   pg-types@2.2.0:
@@ -24578,7 +24649,7 @@ snapshots:
     dependencies:
       zod: 4.3.6
     optionalDependencies:
-      hono: 4.11.7
+      hono: 4.12.2
 
   wrangler@4.61.1(@cloudflare/workers-types@4.20260130.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
 
 packages:
   - 'packages/db'
+  - 'packages/llm-shared'
   - 'packages/worker-utils'
   - 'packages/encryption'
   - 'storybook'
@@ -41,6 +42,7 @@ packages:
   - 'kiloclaw'
   - 'cloudflare-gastown'
   - 'cloudflare-gastown/container'
+  - 'llm-gateway'
 
 ignoredBuiltDependencies:
   - '@sentry/cli'

--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -1,28 +1,48 @@
 import { NextResponse, type NextResponse as NextResponseType } from 'next/server';
 import { type NextRequest } from 'next/server';
+
+import {
+  createAnonymousContext,
+  isAnonymousContext,
+  type AnonymousUserContext,
+  ENABLE_TOOL_REPAIR,
+  repairTools,
+  estimateChatTokens,
+  extractPromptInfo,
+  type MicrodollarUsageContext,
+  FEATURE_HEADER,
+  validateFeatureHeader,
+  generateProviderSpecificHash,
+  getToolsAvailable,
+  getToolsUsed,
+  isActiveCloudAgentPromo,
+  isActiveReviewPromo,
+  isDataCollectionRequiredOnKiloCodeOnly,
+  isDeadFreeModel,
+  isFreeModel,
+  isFreePromptTrainingAllowed,
+  isKiloAutoModel,
+  resolveAutoModel,
+  isKiloFreeModel,
+  isRateLimitedToDeath,
+  normalizeModelId,
+  type OpenRouterChatCompletionRequest,
+  PROMOTION_MAX_REQUESTS,
+  PROMOTION_WINDOW_HOURS,
+} from '@kilocode/llm-shared';
+
 import { stripRequiredPrefix } from '@/lib/utils';
-import { generateProviderSpecificHash } from '@/lib/providerHash';
-import { extractPromptInfo, type MicrodollarUsageContext } from '@/lib/processUsage';
-import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
-import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter/types';
 import { applyProviderSpecificLogic, getProvider, openRouterRequest } from '@/lib/providers';
 import { debugSaveProxyRequest } from '@/lib/debugUtils';
 import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
 import { getUserFromAuth } from '@/lib/user.server';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import {
-  isFreeModel,
-  isDataCollectionRequiredOnKiloCodeOnly,
-  isDeadFreeModel,
-  isKiloFreeModel,
-} from '@/lib/models';
-import {
   accountForMicrodollarUsage,
   alphaPeriodEndedResponse,
   captureProxyError,
   checkOrganizationModelRestrictions,
   dataCollectionRequiredResponse,
-  estimateChatTokens,
   extractFraudAndProjectHeaders,
   invalidPathResponse,
   invalidRequestResponse,
@@ -34,33 +54,16 @@ import {
   wrapInSafeNextResponse,
 } from '@/lib/llm-proxy-helpers';
 import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
-import { ENABLE_TOOL_REPAIR, repairTools } from '@/lib/tool-calling';
-import { isFreePromptTrainingAllowed } from '@/lib/providers/openrouter/types';
 import { rewriteFreeModelResponse } from '@/lib/rewriteModelResponse';
-import {
-  createAnonymousContext,
-  isAnonymousContext,
-  type AnonymousUserContext,
-} from '@/lib/anonymous';
 import {
   checkFreeModelRateLimit,
   logFreeModelRequest,
   checkPromotionLimit,
 } from '@/lib/free-model-rate-limiter';
-import { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from '@/lib/constants';
 import { classifyAbuse } from '@/lib/abuse-service';
-import {
-  emitApiMetricsForResponse,
-  getToolsAvailable,
-  getToolsUsed,
-} from '@/lib/o11y/api-metrics.server';
+import { emitApiMetricsForResponse } from '@/lib/o11y/api-metrics.server';
 import { handleRequestLogging } from '@/lib/handleRequestLogging';
 import { customLlmRequest } from '@/lib/custom-llm/customLlmRequest';
-import { normalizeModelId } from '@/lib/model-utils';
-import { isRateLimitedToDeath } from '@/lib/rate-limited-models';
-import { isActiveReviewPromo } from '@/lib/code-reviews/core/constants';
-import { isActiveCloudAgentPromo } from '@/lib/promotions/cloud-agent-promo';
-import { isKiloAutoModel, resolveAutoModel } from '@/lib/kilo-auto-model';
 
 const MAX_TOKENS_LIMIT = 99999999999; // GPT4.1 default is ~32k
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
       "@/*": ["./src/*"],
       "@kilocode/db": ["./packages/db/src/index.ts"],
       "@kilocode/db/*": ["./packages/db/src/*"],
-      "@kilocode/encryption": ["./packages/encryption/src/index.ts"]
+      "@kilocode/encryption": ["./packages/encryption/src/index.ts"],
+      "@kilocode/llm-shared": ["./packages/llm-shared/src/index.ts"]
     },
     "allowJs": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

- **New `@kilocode/llm-shared` package** (22 source files) — extracts pure, runtime-agnostic functions (model utils, provider logic, tool repair, feature detection, anonymous user, usage types, promo helpers) so both the Next.js route and the worker import from one source of truth.
- **New `llm-gateway/` Cloudflare Worker** (21 source files) — Sentry-wrapped Hono app reimplementing the `/api/gateway/chat/completions` and `/api/openrouter/chat/completions` endpoints with JWT-only auth, Hyperdrive Postgres, rate limiting, upstream fetch, and `ctx.waitUntil()` background tasks.
- **Migrated Next.js route** to import shared functions from `@kilocode/llm-shared` instead of `@/lib/` for all pure logic.

## Architecture

Per `docs/llm-gateway-plan.md`. The worker follows the exact same 17-step request flow as the existing Next.js route, with `NextResponse` → `Response`, `after()` → `ctx.waitUntil()`, cookie auth removed (JWT-only), and `CF-Connecting-IP` preferred for IP extraction.

## Stubs for follow-up

Abuse classification, custom LLM (AI SDK), full usage accounting, and request logging are stubbed in the worker — ready for porting in subsequent PRs.

## Typecheck

All three packages (`@kilocode/llm-shared`, `llm-gateway`, main app) typecheck cleanly.