### PR TITLE
CloudAgentNext - Trim large payloads before DO storage

### DIFF
--- a/cloud-agent-next/src/shared/trim-payload.test.ts
+++ b/cloud-agent-next/src/shared/trim-payload.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  trimPayload,
+  MAX_TOOL_OUTPUT_LENGTH,
+  MAX_RAW_INPUT_LENGTH,
+  MAX_STDOUT_LENGTH,
+} from './trim-payload.js';
+
+function createKilocodeEvent(event: string, properties: unknown) {
+  return { type: event, properties, event };
+}
+
+describe('trimPayload', () => {
+  describe('message.part.updated — text/reasoning parts', () => {
+    it('passes text parts through unchanged', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: { type: 'text', content: 'hello world' },
+      });
+      expect(trimPayload('kilocode', data)).toEqual(data);
+    });
+  });
+
+  describe('message.part.updated — tool completed', () => {
+    it('truncates large output', () => {
+      const largeOutput = 'x'.repeat(20_000);
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'tool',
+          state: { status: 'completed', output: largeOutput },
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { state: { output: string } } };
+      };
+
+      expect(result.properties.part.state.output.length).toBe(
+        MAX_TOOL_OUTPUT_LENGTH + '\n\n[…truncated]'.length
+      );
+      expect(result.properties.part.state.output).toEqual(
+        largeOutput.slice(0, MAX_TOOL_OUTPUT_LENGTH) + '\n\n[…truncated]'
+      );
+    });
+
+    it('leaves small output unchanged', () => {
+      const smallOutput = 'x'.repeat(100);
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'tool',
+          state: { status: 'completed', output: smallOutput },
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { state: { output: string } } };
+      };
+
+      expect(result.properties.part.state.output).toBe(smallOutput);
+    });
+
+    it('strips content from attachment file parts', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'tool',
+          state: {
+            status: 'completed',
+            output: 'ok',
+            attachments: [
+              {
+                type: 'file',
+                url: 'data:image/png;base64,iVBORw0KGgo=',
+                name: 'screenshot.png',
+                source: {
+                  text: { value: 'large content', start: 0, end: 100 },
+                  type: 'file',
+                  path: '/foo',
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: {
+          part: {
+            state: {
+              attachments: Array<{
+                url: string;
+                name: string;
+                source: {
+                  text: { value: string; start: number; end: number };
+                  type: string;
+                  path: string;
+                };
+              }>;
+            };
+          };
+        };
+      };
+
+      const attachment = result.properties.part.state.attachments[0];
+      expect(attachment.url).toBe('');
+      expect(attachment.source.text.value).toBe('');
+      expect(attachment.name).toBe('screenshot.png');
+      expect(attachment.source.type).toBe('file');
+      expect(attachment.source.path).toBe('/foo');
+      expect(attachment.source.text.start).toBe(0);
+      expect(attachment.source.text.end).toBe(100);
+    });
+  });
+
+  describe('message.part.updated — tool pending', () => {
+    it('truncates large raw input', () => {
+      const largeRaw = 'y'.repeat(20_000);
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'tool',
+          state: { status: 'pending', raw: largeRaw },
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { state: { raw: string } } };
+      };
+
+      expect(result.properties.part.state.raw.length).toBe(
+        MAX_RAW_INPUT_LENGTH + '\n\n[…truncated]'.length
+      );
+      expect(result.properties.part.state.raw).toEqual(
+        largeRaw.slice(0, MAX_RAW_INPUT_LENGTH) + '\n\n[…truncated]'
+      );
+    });
+
+    it('leaves small raw input unchanged', () => {
+      const smallRaw = 'y'.repeat(100);
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'tool',
+          state: { status: 'pending', raw: smallRaw },
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { state: { raw: string } } };
+      };
+
+      expect(result.properties.part.state.raw).toBe(smallRaw);
+    });
+  });
+
+  describe('message.part.updated — step-start / step-finish / snapshot', () => {
+    it('strips snapshot from step-start', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: { type: 'step-start', snapshot: 'large data', title: 'Step 1' },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { snapshot: unknown; title: string } };
+      };
+
+      expect(result.properties.part.snapshot).toBeUndefined();
+      expect(result.properties.part.title).toBe('Step 1');
+    });
+
+    it('strips snapshot from step-finish', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: { type: 'step-finish', snapshot: 'large data', duration: 123 },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { snapshot: unknown; duration: number } };
+      };
+
+      expect(result.properties.part.snapshot).toBeUndefined();
+      expect(result.properties.part.duration).toBe(123);
+    });
+
+    it('strips snapshot from snapshot part', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: { type: 'snapshot', snapshot: 'data' },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { snapshot: unknown } };
+      };
+
+      expect(result.properties.part.snapshot).toBeUndefined();
+    });
+  });
+
+  describe('message.part.updated — file part', () => {
+    it('strips url and source.text.value', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'file',
+          url: 'data:image/png;base64,abc123',
+          name: 'image.png',
+          source: {
+            text: { value: 'file content here', start: 0, end: 50 },
+            type: 'file',
+            path: '/foo',
+          },
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: {
+          part: {
+            url: string;
+            name: string;
+            source: {
+              text: { value: string; start: number; end: number };
+              type: string;
+              path: string;
+            };
+          };
+        };
+      };
+
+      expect(result.properties.part.url).toBe('');
+      expect(result.properties.part.source.text.value).toBe('');
+      expect(result.properties.part.name).toBe('image.png');
+      expect(result.properties.part.source.type).toBe('file');
+      expect(result.properties.part.source.path).toBe('/foo');
+    });
+
+    it('strips only url when source is absent', () => {
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'file',
+          url: 'data:image/png;base64,abc123',
+          name: 'image.png',
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: { part: { url: string; name: string } };
+      };
+
+      expect(result.properties.part.url).toBe('');
+      expect(result.properties.part.name).toBe('image.png');
+    });
+  });
+
+  describe('session.updated', () => {
+    it('strips diffs but preserves other summary fields', () => {
+      const data = createKilocodeEvent('session.updated', {
+        info: {
+          summary: {
+            additions: 10,
+            deletions: 5,
+            files: 3,
+            diffs: [{ file: 'a.ts', patch: '...' }],
+          },
+          other: 'preserved',
+        },
+      });
+
+      const result = trimPayload('kilocode', data) as {
+        properties: {
+          info: {
+            summary: { additions: number; deletions: number; files: number; diffs: unknown };
+            other: string;
+          };
+        };
+      };
+
+      expect(result.properties.info.summary.diffs).toBeUndefined();
+      expect(result.properties.info.summary.additions).toBe(10);
+      expect(result.properties.info.summary.deletions).toBe(5);
+      expect(result.properties.info.summary.files).toBe(3);
+      expect(result.properties.info.other).toBe('preserved');
+    });
+
+    it('passes through when summary is absent', () => {
+      const data = createKilocodeEvent('session.updated', {
+        info: { other: 'data' },
+      });
+
+      expect(trimPayload('kilocode', data)).toEqual(data);
+    });
+  });
+
+  describe('output event', () => {
+    it('truncates large content', () => {
+      const largeContent = 'x'.repeat(20_000);
+      const data = { content: largeContent };
+
+      const result = trimPayload('output', data) as { content: string };
+
+      expect(result.content.length).toBe(MAX_STDOUT_LENGTH + '\n\n[…truncated]'.length);
+      expect(result.content).toEqual(largeContent.slice(0, MAX_STDOUT_LENGTH) + '\n\n[…truncated]');
+    });
+
+    it('leaves small content unchanged', () => {
+      const smallContent = 'x'.repeat(100);
+      const data = { content: smallContent };
+
+      const result = trimPayload('output', data) as { content: string };
+
+      expect(result.content).toBe(smallContent);
+    });
+  });
+
+  describe('passthrough event types', () => {
+    it('returns heartbeat data unchanged', () => {
+      const data = { ts: Date.now() };
+      expect(trimPayload('heartbeat', data)).toEqual(data);
+    });
+
+    it('returns complete data unchanged', () => {
+      const data = { exitCode: 0, currentBranch: 'main' };
+      expect(trimPayload('complete', data)).toEqual(data);
+    });
+
+    it('returns error data unchanged', () => {
+      const data = { error: 'something broke', fatal: true };
+      expect(trimPayload('error', data)).toEqual(data);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the original data', () => {
+      const largeOutput = 'x'.repeat(20_000);
+      const data = createKilocodeEvent('message.part.updated', {
+        part: {
+          type: 'tool',
+          state: { status: 'completed', output: largeOutput },
+        },
+      });
+
+      const snapshot = JSON.parse(JSON.stringify(data));
+
+      trimPayload('kilocode', data);
+
+      expect(data).toEqual(snapshot);
+    });
+  });
+
+  describe('non-object data', () => {
+    it('returns a plain string unchanged', () => {
+      expect(trimPayload('kilocode', 'just a string')).toBe('just a string');
+    });
+  });
+});

--- a/cloud-agent-next/src/shared/trim-payload.ts
+++ b/cloud-agent-next/src/shared/trim-payload.ts
@@ -33,7 +33,7 @@ function trimToolCompleted(state: Record<string, unknown>): Record<string, unkno
   }
   const attachments = out.attachments;
   if (Array.isArray(attachments)) {
-    out.attachments = attachments.map(a => (isRecord(a) ? stripFilePartFields(a) : a));
+    out.attachments = attachments.map((a: unknown) => (isRecord(a) ? stripFilePartFields(a) : a));
   }
   return out;
 }

--- a/cloud-agent-next/src/shared/trim-payload.ts
+++ b/cloud-agent-next/src/shared/trim-payload.ts
@@ -1,0 +1,131 @@
+import type { StreamEventType } from './protocol.js';
+
+export const MAX_TOOL_OUTPUT_LENGTH = 10_000;
+export const MAX_RAW_INPUT_LENGTH = 10_000;
+export const MAX_STDOUT_LENGTH = 10_000;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + '\n\n[…truncated]';
+}
+
+function stripFilePartFields(part: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...part, url: '' };
+  const source = part.source;
+  if (isRecord(source)) {
+    const text = source.text;
+    if (isRecord(text)) {
+      out.source = { ...source, text: { ...text, value: '' } };
+    }
+  }
+  return out;
+}
+
+function trimToolCompleted(state: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...state };
+  const output = out.output;
+  if (typeof output === 'string') {
+    out.output = truncate(output, MAX_TOOL_OUTPUT_LENGTH);
+  }
+  const attachments = out.attachments;
+  if (Array.isArray(attachments)) {
+    out.attachments = attachments.map(a => (isRecord(a) ? stripFilePartFields(a) : a));
+  }
+  return out;
+}
+
+function trimToolPending(state: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...state };
+  const raw = out.raw;
+  if (typeof raw === 'string') {
+    out.raw = truncate(raw, MAX_RAW_INPUT_LENGTH);
+  }
+  return out;
+}
+
+function trimPartUpdated(properties: Record<string, unknown>): Record<string, unknown> {
+  const part = properties.part;
+  if (!isRecord(part)) return properties;
+
+  const partType = part.type;
+
+  if (partType === 'step-start' || partType === 'step-finish' || partType === 'snapshot') {
+    return { ...properties, part: { ...part, snapshot: undefined } };
+  }
+
+  if (partType === 'file') {
+    return { ...properties, part: stripFilePartFields(part) };
+  }
+
+  if (partType === 'tool') {
+    const state = part.state;
+    if (!isRecord(state)) return properties;
+
+    if (state.status === 'completed') {
+      return { ...properties, part: { ...part, state: trimToolCompleted(state) } };
+    }
+    if (state.status === 'pending') {
+      return { ...properties, part: { ...part, state: trimToolPending(state) } };
+    }
+  }
+
+  return properties;
+}
+
+function trimSessionUpdated(properties: Record<string, unknown>): Record<string, unknown> {
+  const info = properties.info;
+  if (!isRecord(info)) return properties;
+
+  const summary = info.summary;
+  if (!isRecord(summary)) return properties;
+
+  return {
+    ...properties,
+    info: {
+      ...info,
+      summary: { ...summary, diffs: undefined },
+    },
+  };
+}
+
+function trimKilocodeData(data: Record<string, unknown>): Record<string, unknown> {
+  const eventName = data.event ?? data.type;
+
+  if (eventName === 'message.part.updated') {
+    const properties = data.properties;
+    if (!isRecord(properties)) return data;
+    return { ...data, properties: trimPartUpdated(properties) };
+  }
+
+  if (eventName === 'session.updated') {
+    const properties = data.properties;
+    if (!isRecord(properties)) return data;
+    return { ...data, properties: trimSessionUpdated(properties) };
+  }
+
+  return data;
+}
+
+function trimOutputData(data: Record<string, unknown>): Record<string, unknown> {
+  const content = data.content;
+  if (typeof content !== 'string') return data;
+  return { ...data, content: truncate(content, MAX_STDOUT_LENGTH) };
+}
+
+export function trimPayload(streamEventType: StreamEventType, data: unknown): unknown {
+  if (!isRecord(data)) return data;
+
+  if (streamEventType === 'kilocode') {
+    return trimKilocodeData(data);
+  }
+
+  if (streamEventType === 'output') {
+    return trimOutputData(data);
+  }
+
+  return data;
+}

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -11,6 +11,7 @@
 
 import type { WrapperState } from './state.js';
 import type { IngestEvent, WrapperCommand } from '../../src/shared/protocol.js';
+import { trimPayload } from '../../src/shared/trim-payload.js';
 import { createSSEConsumer, isTerminalErrorEvent, type SSEConsumer } from './sse-consumer.js';
 import { logToFile } from './utils.js';
 
@@ -217,8 +218,12 @@ export function createConnectionManager(
         state.recordSseEvent();
       },
       onEvent: (event: IngestEvent) => {
-        // Forward to ingest (heartbeats already filtered out)
-        sendToIngest(event);
+        // Trim large payloads before forwarding to reduce DO storage pressure
+        const trimmed: IngestEvent = {
+          ...event,
+          data: trimPayload(event.streamEventType, event.data),
+        };
+        sendToIngest(trimmed);
 
         // Check for terminal errors
         if (event.streamEventType === 'kilocode') {


### PR DESCRIPTION
## Summary

- Add `trimPayload` utility that truncates large event data before forwarding to the ingest WebSocket, reducing Durable Object SQLite storage pressure
- Trims tool outputs, raw inputs, and stdout content to 10KB; strips file attachment blobs, snapshot data, and session diff payloads
- Downstream event processing (terminal error detection, session.idle handling) uses the original untrimmed data and is unaffected
- Includes comprehensive test coverage for all trim paths, edge cases, and immutability guarantees