### PR TITLE
Ignore .worktrees/ in git and jest test discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ run-milvus-test.sh
 .wrangler/
 .env*.local
 /.superset
+
+# Git worktrees
+.worktrees/

--- a/cloudflare-deploy-infra/dispatcher/.gitignore
+++ b/cloudflare-deploy-infra/dispatcher/.gitignore
@@ -1,0 +1,2 @@
+# Environment variables
+.dev.vars

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -44,6 +44,7 @@ const config: Config = {
     '<rootDir>/kiloclaw/',
     '<rootDir>/packages/encryption/',
     '<rootDir>/packages/worker-utils/',
+    '<rootDir>/.worktrees/',
   ],
   transformIgnorePatterns: [
     'node_modules/.pnpm/(?!(@octokit|universal-user-agent|before-after-hook|bottleneck))',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -46,6 +46,7 @@ const config: Config = {
     '<rootDir>/packages/worker-utils/',
     '<rootDir>/.worktrees/',
   ],
+  modulePathIgnorePatterns: ['<rootDir>/.worktrees/'],
   transformIgnorePatterns: [
     'node_modules/.pnpm/(?!(@octokit|universal-user-agent|before-after-hook|bottleneck))',
   ],


### PR DESCRIPTION
## Summary

- Adds `modulePathIgnorePatterns: ['<rootDir>/.worktrees/']` to `jest.config.ts` to prevent Jest from resolving modules inside `.worktrees/` directories, complementing the existing `watchPathIgnorePatterns` entry.