### PR TITLE
Modify generateOpenRouterUpstreamSafetyIdentifier function

### DIFF
--- a/src/lib/providerHash.ts
+++ b/src/lib/providerHash.ts
@@ -26,7 +26,9 @@ export function generateProviderSpecificHash(payload: string, provider: Provider
 export function generateOpenRouterUpstreamSafetyIdentifier(userId: string): string | null {
   const orgId = getEnvVariable('OPENROUTER_ORG_ID');
   if (!orgId) {
-    console.error('[generateOpenRouterUpstreamSafetyIdentifier] OPENROUTER_ORG_ID is not set, please run vercel env pull');
+    console.error(
+      '[generateOpenRouterUpstreamSafetyIdentifier] OPENROUTER_ORG_ID is not set, please run vercel env pull'
+    );
     return null;
   }
   return crypto

--- a/src/lib/providerHash.ts
+++ b/src/lib/providerHash.ts
@@ -23,10 +23,11 @@ export function generateProviderSpecificHash(payload: string, provider: Provider
     .digest('base64');
 }
 
-export function generateOpenRouterUpstreamSafetyIdentifier(userId: string): string {
+export function generateOpenRouterUpstreamSafetyIdentifier(userId: string): string | null {
   const orgId = getEnvVariable('OPENROUTER_ORG_ID');
   if (!orgId) {
-    throw new Error('OPENROUTER_ORG_ID is not set, please run vercel env pull');
+    console.error('[generateOpenRouterUpstreamSafetyIdentifier] OPENROUTER_ORG_ID is not set, please run vercel env pull');
+    return null;
   }
   return crypto
     .createHash('sha256')


### PR DESCRIPTION
Change return type to string | null and handle missing orgId gracefully.

https://kilo-code.slack.com/archives/C09FDJ2GEF6/p1772469953171979