### PR TITLE
feat: add kiloclaw version pin table and admin UI (Phase 1.1)

### DIFF
--- a/packages/db/src/migrations/0037_magical_captain_britain.sql
+++ b/packages/db/src/migrations/0037_magical_captain_britain.sql
@@ -10,4 +10,5 @@ CREATE TABLE "kiloclaw_version_pins" (
 );
 --> statement-breakpoint
 ALTER TABLE "kiloclaw_version_pins" ADD CONSTRAINT "kiloclaw_version_pins_user_id_kilocode_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."kilocode_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "kiloclaw_version_pins" ADD CONSTRAINT "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk" FOREIGN KEY ("image_tag") REFERENCES "public"."kiloclaw_image_catalog"("image_tag") ON DELETE restrict ON UPDATE no action;
+ALTER TABLE "kiloclaw_version_pins" ADD CONSTRAINT "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk" FOREIGN KEY ("image_tag") REFERENCES "public"."kiloclaw_image_catalog"("image_tag") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "kiloclaw_version_pins" ADD CONSTRAINT "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk" FOREIGN KEY ("pinned_by") REFERENCES "public"."kilocode_users"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/db/src/migrations/0037_needy_sunfire.sql
+++ b/packages/db/src/migrations/0037_needy_sunfire.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "kiloclaw_version_pins" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"image_tag" text NOT NULL,
+	"pinned_by" text NOT NULL,
+	"reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "kiloclaw_version_pins_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "kiloclaw_version_pins" ADD CONSTRAINT "kiloclaw_version_pins_user_id_kilocode_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."kilocode_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "kiloclaw_version_pins" ADD CONSTRAINT "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk" FOREIGN KEY ("image_tag") REFERENCES "public"."kiloclaw_image_catalog"("image_tag") ON DELETE restrict ON UPDATE no action;

--- a/packages/db/src/migrations/meta/0037_snapshot.json
+++ b/packages/db/src/migrations/meta/0037_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "38ba9ab0-f42b-4a09-a99b-e7802011f94b",
+  "id": "346c8139-0d84-459f-9080-24f87916a781",
   "prevId": "bec5782c-1827-4b47-b0ce-309628287e4e",
   "version": "7",
   "dialect": "postgresql",
@@ -6830,6 +6830,15 @@
           "columnsFrom": ["image_tag"],
           "columnsTo": ["image_tag"],
           "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk": {
+          "name": "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kilocode_users",
+          "columnsFrom": ["pinned_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
           "onUpdate": "no action"
         }
       },

--- a/packages/db/src/migrations/meta/0037_snapshot.json
+++ b/packages/db/src/migrations/meta/0037_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "ee710077-4ffe-4b56-b079-0aae744efb2a",
-  "prevId": "b51f45f7-a19e-40c2-bf00-72aac398b43c",
+  "id": "38ba9ab0-f42b-4a09-a99b-e7802011f94b",
+  "prevId": "bec5782c-1827-4b47-b0ce-309628287e4e",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -5007,6 +5007,45 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.discord_gateway_listener": {
+      "name": "discord_gateway_listener",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "listener_id": {
+          "name": "listener_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.editor_name": {
       "name": "editor_name",
       "schema": "",
@@ -6723,6 +6762,89 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.kiloclaw_version_pins": {
+      "name": "kiloclaw_version_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_version_pins_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_version_pins_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kilocode_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk": {
+          "name": "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kiloclaw_image_catalog",
+          "columnsFrom": ["image_tag"],
+          "columnsTo": ["image_tag"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_version_pins_user_id_unique": {
+          "name": "kiloclaw_version_pins_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.kilocode_users": {
       "name": "kilocode_users",
       "schema": "",
@@ -6880,9 +7002,32 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
+        },
+        "openrouter_upstream_safety_identifier": {
+          "name": "openrouter_upstream_safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "UQ_kilocode_users_openrouter_upstream_safety_identifier": {
+          "name": "UQ_kilocode_users_openrouter_upstream_safety_identifier",
+          "columns": [
+            {
+              "expression": "openrouter_upstream_safety_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilocode_users\".\"openrouter_upstream_safety_identifier\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -264,8 +264,8 @@
     {
       "idx": 37,
       "version": "7",
-      "when": 1772462713010,
-      "tag": "0037_needy_sunfire",
+      "when": 1772472147057,
+      "tag": "0037_magical_captain_britain",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1772457937366,
       "tag": "0036_early_bastion",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1772462713010,
+      "tag": "0037_needy_sunfire",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3193,7 +3193,9 @@ export const kiloclaw_version_pins = pgTable('kiloclaw_version_pins', {
   image_tag: text()
     .notNull()
     .references(() => kiloclaw_image_catalog.image_tag, { onDelete: 'restrict' }),
-  pinned_by: text().notNull(),
+  pinned_by: text()
+    .notNull()
+    .references(() => kilocode_users.id),
   reason: text(),
   created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   updated_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3145,7 +3145,7 @@ export const kiloclaw_image_catalog = pgTable(
     variant: text().notNull().default('default'),
     image_tag: text().notNull().unique(),
     image_digest: text(),
-    status: text().$type<'available' | 'deprecated' | 'disabled'>().notNull().default('available'),
+    status: text().$type<'available' | 'disabled'>().notNull().default('available'),
     description: text(),
     updated_by: text(),
     published_at: timestamp({ withTimezone: true, mode: 'string' }).notNull(),
@@ -3178,3 +3178,25 @@ export const discord_gateway_listener = pgTable('discord_gateway_listener', {
 });
 
 export type DiscordGatewayListener = typeof discord_gateway_listener.$inferSelect;
+
+// KiloClaw Version Pins — one row per user, tracks who pinned them and why.
+// Both admins and end users can pin (distinguished by pinned_by).
+export const kiloclaw_version_pins = pgTable('kiloclaw_version_pins', {
+  id: uuid()
+    .default(sql`gen_random_uuid()`)
+    .primaryKey()
+    .notNull(),
+  user_id: text()
+    .notNull()
+    .references(() => kilocode_users.id, { onDelete: 'cascade' })
+    .unique(),
+  image_tag: text()
+    .notNull()
+    .references(() => kiloclaw_image_catalog.image_tag, { onDelete: 'restrict' }),
+  pinned_by: text().notNull(),
+  reason: text(),
+  created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  updated_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+});
+
+export type KiloClawVersionPin = typeof kiloclaw_version_pins.$inferSelect;

--- a/src/app/admin/components/AppSidebar.tsx
+++ b/src/app/admin/components/AppSidebar.tsx
@@ -124,8 +124,8 @@ const productEngineeringItems: MenuItem[] = [
     icon: () => <Blocks />,
   },
   {
-    title: () => 'KiloClaw Instances',
-    url: '/admin/kiloclaw-instances',
+    title: () => 'KiloClaw',
+    url: '/admin/kiloclaw',
     icon: () => <Server />,
   },
   {

--- a/src/app/admin/components/KiloclawDashboard.tsx
+++ b/src/app/admin/components/KiloclawDashboard.tsx
@@ -6,8 +6,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { KiloclawInstancesPage } from './KiloclawInstances/KiloclawInstancesPage';
 import { VersionsTab, PinsTab } from './KiloclawVersions/KiloclawVersionsPage';
 
-const VALID_TABS = ['instances', 'versions', 'pins'] as const;
-type Tab = (typeof VALID_TABS)[number];
+const VALID_TABS: readonly string[] = ['instances', 'versions', 'pins'];
+type Tab = 'instances' | 'versions' | 'pins';
+const isValidTab = (value: string | null): value is Tab =>
+  value !== null && VALID_TABS.includes(value);
 
 const tabTriggerClass =
   'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
@@ -18,7 +20,7 @@ export function KiloclawDashboard() {
   const pathname = usePathname();
 
   const tabParam = searchParams.get('tab');
-  const activeTab: Tab = VALID_TABS.includes(tabParam as Tab) ? (tabParam as Tab) : 'instances';
+  const activeTab: Tab = isValidTab(tabParam) ? tabParam : 'instances';
 
   const onTabChange = useCallback(
     (value: string) => {

--- a/src/app/admin/components/KiloclawDashboard.tsx
+++ b/src/app/admin/components/KiloclawDashboard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useCallback } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { KiloclawInstancesPage } from './KiloclawInstances/KiloclawInstancesPage';
+import { VersionsTab, PinsTab } from './KiloclawVersions/KiloclawVersionsPage';
+
+const VALID_TABS = ['instances', 'versions', 'pins'] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
+export function KiloclawDashboard() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const tabParam = searchParams.get('tab');
+  const activeTab: Tab = VALID_TABS.includes(tabParam as Tab) ? (tabParam as Tab) : 'instances';
+
+  const onTabChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === 'instances') {
+        params.delete('tab');
+      } else {
+        params.set('tab', value);
+      }
+      const qs = params.toString();
+      router.replace(`${pathname}${qs ? `?${qs}` : ''}`, { scroll: false });
+    },
+    [searchParams, router, pathname]
+  );
+
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      <Tabs value={activeTab} onValueChange={onTabChange}>
+        <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+          <TabsTrigger value="instances" className={tabTriggerClass}>
+            Instances
+          </TabsTrigger>
+          <TabsTrigger value="versions" className={tabTriggerClass}>
+            Versions
+          </TabsTrigger>
+          <TabsTrigger value="pins" className={tabTriggerClass}>
+            Pins
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="instances" className="mt-4">
+          <KiloclawInstancesPage />
+        </TabsContent>
+        <TabsContent value="versions" className="mt-4">
+          <VersionsTab />
+        </TabsContent>
+        <TabsContent value="pins" className="mt-4">
+          <PinsTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -24,6 +24,14 @@ import {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import {
   User,
   Calendar,
   Loader2,
@@ -39,6 +47,7 @@ import {
   Square,
   RotateCcw,
   RefreshCw,
+  Pin,
 } from 'lucide-react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
@@ -83,7 +92,7 @@ function DetailPageWrapper({ children, subtitle }: DetailPageWrapperProps) {
   const breadcrumbs = (
     <>
       <BreadcrumbItem>
-        <BreadcrumbLink href="/admin/kiloclaw-instances">KiloClaw Instances</BreadcrumbLink>
+        <BreadcrumbLink href="/admin/kiloclaw">KiloClaw</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbSeparator />
       <BreadcrumbItem>
@@ -116,6 +125,170 @@ function DetailField({ label, children }: { label: string; children: React.React
       <div className="text-muted-foreground text-xs">{label}</div>
       <div className="text-sm">{children}</div>
     </div>
+  );
+}
+
+function VersionPinCard({ userId }: { userId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [selectedTag, setSelectedTag] = useState<string>('');
+  const [reason, setReason] = useState('');
+
+  const { data: pinData, isLoading: pinLoading } = useQuery(
+    trpc.admin.kiloclawVersions.getUserPin.queryOptions({ userId })
+  );
+
+  const { data: versionsData } = useQuery(
+    trpc.admin.kiloclawVersions.listVersions.queryOptions({
+      status: 'available',
+      limit: 100,
+    })
+  );
+
+  const { mutateAsync: setPin, isPending: isPinning } = useMutation(
+    trpc.admin.kiloclawVersions.setPin.mutationOptions({
+      onSuccess: () => {
+        toast.success('Version pin set');
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.getUserPin.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.listPins.queryKey(),
+        });
+        setSelectedTag('');
+        setReason('');
+      },
+      onError: err => {
+        toast.error(`Failed to set pin: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: removePin, isPending: isUnpinning } = useMutation(
+    trpc.admin.kiloclawVersions.removePin.mutationOptions({
+      onSuccess: () => {
+        toast.success('Version pin removed');
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.getUserPin.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.listPins.queryKey(),
+        });
+      },
+      onError: err => {
+        toast.error(`Failed to remove pin: ${err.message}`);
+      },
+    })
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Pin className="h-5 w-5" />
+          <CardTitle>Version Pin</CardTitle>
+        </div>
+        <CardDescription>Pin this user to a specific KiloClaw image version</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {pinLoading ? (
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-muted-foreground text-sm">Loading pin status...</span>
+          </div>
+        ) : pinData ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-4">
+              <DetailField label="Status">
+                <Badge className="bg-blue-600">
+                  Pinned to {pinData.openclaw_version ?? pinData.image_tag}
+                </Badge>
+              </DetailField>
+              <DetailField label="Image Tag">
+                <code className="text-xs">{pinData.image_tag}</code>
+              </DetailField>
+              <DetailField label="Variant">{pinData.variant ?? 'default'}</DetailField>
+              <DetailField label="Pinned By">
+                {pinData.pinned_by_email ?? pinData.pinned_by}
+              </DetailField>
+              {pinData.reason && <DetailField label="Reason">{pinData.reason}</DetailField>}
+            </div>
+            <div className="flex items-center gap-2 pt-2">
+              <Select value={selectedTag} onValueChange={setSelectedTag}>
+                <SelectTrigger className="w-[250px]">
+                  <SelectValue placeholder="Change OpenClaw version..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {versionsData?.items.map(v => (
+                    <SelectItem key={v.image_tag} value={v.image_tag}>
+                      {v.openclaw_version} ({v.variant}) - {v.image_tag.slice(0, 16)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                placeholder="Reason (optional)"
+                value={reason}
+                onChange={e => setReason(e.target.value)}
+                className="w-[200px]"
+              />
+              {selectedTag && (
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    void setPin({ userId, imageTag: selectedTag, reason: reason || undefined })
+                  }
+                  disabled={isPinning}
+                >
+                  {isPinning ? 'Updating...' : 'Update Pin'}
+                </Button>
+              )}
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => void removePin({ userId })}
+                disabled={isUnpinning}
+              >
+                {isUnpinning ? 'Unpinning...' : 'Unpin'}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-muted-foreground text-sm">Following latest available version</p>
+            <div className="flex items-center gap-2">
+              <Select value={selectedTag} onValueChange={setSelectedTag}>
+                <SelectTrigger className="w-[250px]">
+                  <SelectValue placeholder="Select OpenClaw version to pin..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {versionsData?.items.map(v => (
+                    <SelectItem key={v.image_tag} value={v.image_tag}>
+                      {v.openclaw_version} ({v.variant}) - {v.image_tag.slice(0, 16)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                placeholder="Reason (optional)"
+                value={reason}
+                onChange={e => setReason(e.target.value)}
+                className="w-[200px]"
+              />
+              <Button
+                size="sm"
+                onClick={() =>
+                  void setPin({ userId, imageTag: selectedTag, reason: reason || undefined })
+                }
+                disabled={!selectedTag || isPinning}
+              >
+                {isPinning ? 'Pinning...' : 'Pin Version'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -692,6 +865,9 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             </CardContent>
           </Card>
         )}
+        {/* Version Pin Card */}
+        {data.user_id && <VersionPinCard userId={data.user_id} />}
+
         {/* Destroy Confirmation Dialog */}
         <Dialog open={destroyDialogOpen} onOpenChange={setDestroyDialogOpen}>
           <DialogContent className="sm:max-w-[425px]">

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -265,7 +265,7 @@ export function KiloclawInstancesPage() {
         ...queryStringState,
         ...overrides,
       });
-      router.push(`/admin/kiloclaw-instances?${queryString.toString()}`);
+      router.push(`/admin/kiloclaw?${queryString.toString()}`);
     },
     [router, queryStringState]
   );
@@ -428,11 +428,11 @@ export function KiloclawInstancesPage() {
                   className="hover:bg-muted/50 cursor-pointer"
                   tabIndex={0}
                   role="link"
-                  onClick={() => router.push(`/admin/kiloclaw-instances/${instance.id}`)}
+                  onClick={() => router.push(`/admin/kiloclaw/${instance.id}`)}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      router.push(`/admin/kiloclaw-instances/${instance.id}`);
+                      router.push(`/admin/kiloclaw/${instance.id}`);
                     }
                   }}
                 >

--- a/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -60,14 +60,14 @@ export function VersionsTab() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(0);
-  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'available' | 'disabled'>('all');
   const limit = 25;
 
   const { data, isLoading } = useQuery(
     trpc.admin.kiloclawVersions.listVersions.queryOptions({
       offset: page * limit,
       limit,
-      status: statusFilter === 'all' ? undefined : (statusFilter as 'available' | 'disabled'),
+      status: statusFilter === 'all' ? undefined : statusFilter,
     })
   );
 
@@ -90,9 +90,11 @@ export function VersionsTab() {
       <div className="flex items-center gap-2">
         <Select
           value={statusFilter}
-          onValueChange={v => {
-            setStatusFilter(v);
-            setPage(0);
+          onValueChange={(v: string) => {
+            if (v === 'all' || v === 'available' || v === 'disabled') {
+              setStatusFilter(v);
+              setPage(0);
+            }
           }}
         >
           <SelectTrigger className="w-[180px]">
@@ -160,12 +162,11 @@ export function VersionsTab() {
                   <TableCell>
                     <Select
                       value={version.status}
-                      onValueChange={newStatus =>
-                        void updateStatus({
-                          imageTag: version.image_tag,
-                          status: newStatus as 'available' | 'disabled',
-                        })
-                      }
+                      onValueChange={newStatus => {
+                        if (newStatus === 'available' || newStatus === 'disabled') {
+                          void updateStatus({ imageTag: version.image_tag, status: newStatus });
+                        }
+                      }}
                     >
                       <SelectTrigger className="w-[130px]">
                         <SelectValue />

--- a/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -1,0 +1,556 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Loader2, AlertTriangle, ChevronsUpDown, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { formatDistanceToNow } from 'date-fns';
+
+function StatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case 'available':
+      return <Badge className="bg-green-600">Available</Badge>;
+    case 'disabled':
+      return <Badge variant="destructive">Disabled</Badge>;
+    default:
+      return <Badge variant="outline">{status}</Badge>;
+  }
+}
+
+export function VersionsTab() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const limit = 25;
+
+  const { data, isLoading } = useQuery(
+    trpc.admin.kiloclawVersions.listVersions.queryOptions({
+      offset: page * limit,
+      limit,
+      status: statusFilter === 'all' ? undefined : (statusFilter as 'available' | 'disabled'),
+    })
+  );
+
+  const { mutateAsync: updateStatus } = useMutation(
+    trpc.admin.kiloclawVersions.updateVersionStatus.mutationOptions({
+      onSuccess: () => {
+        toast.success('Version status updated');
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.listVersions.queryKey(),
+        });
+      },
+      onError: err => {
+        toast.error(`Failed to update status: ${err.message}`);
+      },
+    })
+  );
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-center gap-2">
+        <Select
+          value={statusFilter}
+          onValueChange={v => {
+            setStatusFilter(v);
+            setPage(0);
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Filter by status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="available">Available</SelectItem>
+            <SelectItem value="disabled">Disabled</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>OpenClaw Version</TableHead>
+              <TableHead>Variant</TableHead>
+              <TableHead>Image Tag</TableHead>
+              <TableHead>Digest</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Published</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center">
+                  <Loader2 className="mx-auto h-4 w-4 animate-spin" />
+                </TableCell>
+              </TableRow>
+            ) : data?.items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-muted-foreground text-center">
+                  No versions found
+                </TableCell>
+              </TableRow>
+            ) : (
+              data?.items.map(version => (
+                <TableRow key={version.id}>
+                  <TableCell className="font-medium">{version.openclaw_version}</TableCell>
+                  <TableCell>{version.variant}</TableCell>
+                  <TableCell>
+                    <code className="text-xs">
+                      {version.image_tag.length > 20
+                        ? `${version.image_tag.slice(0, 20)}…`
+                        : version.image_tag}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <code className="text-xs" title={version.image_digest ?? undefined}>
+                      {version.image_digest ? `${version.image_digest.slice(0, 19)}` : '—'}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={version.status} />
+                  </TableCell>
+                  <TableCell>
+                    <span title={new Date(version.published_at).toLocaleString()}>
+                      {formatDistanceToNow(new Date(version.published_at), { addSuffix: true })}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      value={version.status}
+                      onValueChange={newStatus =>
+                        void updateStatus({
+                          imageTag: version.image_tag,
+                          status: newStatus as 'available' | 'disabled',
+                        })
+                      }
+                    >
+                      <SelectTrigger className="w-[130px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="available">Available</SelectItem>
+                        <SelectItem value="disabled">Disabled</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {data && data.pagination.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <div className="text-muted-foreground text-sm">
+            Page {page + 1} of {data.pagination.totalPages}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(p => p - 1)}
+              disabled={page === 0}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(p => p + 1)}
+              disabled={page + 1 >= data.pagination.totalPages}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PinsTab() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null);
+  const limit = 25;
+
+  // Add pin form state
+  const [userSearch, setUserSearch] = useState('');
+  const [userComboboxOpen, setUserComboboxOpen] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [selectedUserEmail, setSelectedUserEmail] = useState<string | null>(null);
+  const [pinImageTag, setPinImageTag] = useState('');
+  const [pinReason, setPinReason] = useState('');
+
+  const { data: userResults } = useQuery({
+    ...trpc.admin.kiloclawVersions.searchUsers.queryOptions({ query: userSearch }),
+    enabled: userSearch.length >= 2 && !selectedUserId,
+  });
+
+  const { data: availableVersions } = useQuery(
+    trpc.admin.kiloclawVersions.listVersions.queryOptions({ status: 'available', limit: 100 })
+  );
+
+  const { data, isLoading } = useQuery(
+    trpc.admin.kiloclawVersions.listPins.queryOptions({
+      offset: page * limit,
+      limit,
+    })
+  );
+
+  const invalidatePinQueries = () => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.admin.kiloclawVersions.listPins.queryKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: trpc.admin.kiloclawVersions.getUserPin.queryKey(),
+    });
+  };
+
+  const { mutateAsync: setPin, isPending: isPinning } = useMutation(
+    trpc.admin.kiloclawVersions.setPin.mutationOptions({
+      onSuccess: () => {
+        toast.success('Pin created');
+        invalidatePinQueries();
+        setSelectedUserId(null);
+        setSelectedUserEmail(null);
+        setUserSearch('');
+        setPinImageTag('');
+        setPinReason('');
+      },
+      onError: err => {
+        toast.error(`Failed to create pin: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: removePin, isPending: isRemoving } = useMutation(
+    trpc.admin.kiloclawVersions.removePin.mutationOptions({
+      onSuccess: () => {
+        toast.success('Pin removed');
+        invalidatePinQueries();
+        setRemovingUserId(null);
+      },
+      onError: err => {
+        toast.error(`Failed to remove pin: ${err.message}`);
+      },
+    })
+  );
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      {/* Add Pin form */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Add Pin</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-end gap-3">
+            <div className="flex-1">
+              <label className="text-muted-foreground mb-1 block text-xs">User</label>
+              {selectedUserId ? (
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-sm">
+                    {selectedUserEmail ?? selectedUserId}
+                  </Badge>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    onClick={() => {
+                      setSelectedUserId(null);
+                      setSelectedUserEmail(null);
+                      setUserSearch('');
+                    }}
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+              ) : (
+                <Popover open={userComboboxOpen} onOpenChange={setUserComboboxOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={userComboboxOpen}
+                      className="w-full justify-between font-normal"
+                    >
+                      <span className="text-muted-foreground">Search by email or user ID...</span>
+                      <ChevronsUpDown className="ml-2 h-4 w-4 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                    <Command shouldFilter={false}>
+                      <CommandInput
+                        placeholder="Search by email or user ID..."
+                        value={userSearch}
+                        onValueChange={setUserSearch}
+                      />
+                      <CommandList>
+                        {userSearch.length < 2 && (
+                          <CommandEmpty>Type at least 2 characters to search...</CommandEmpty>
+                        )}
+                        {userSearch.length >= 2 && !userResults?.length && (
+                          <CommandEmpty>No users found</CommandEmpty>
+                        )}
+                        {userResults && userResults.length > 0 && (
+                          <CommandGroup>
+                            {userResults.map(user => (
+                              <CommandItem
+                                key={user.id}
+                                value={user.id}
+                                onSelect={() => {
+                                  setSelectedUserId(user.id);
+                                  setSelectedUserEmail(user.email);
+                                  setUserSearch('');
+                                  setUserComboboxOpen(false);
+                                }}
+                              >
+                                <span className="font-medium">{user.email}</span>
+                                {user.name && (
+                                  <span className="text-muted-foreground ml-2">{user.name}</span>
+                                )}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        )}
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+              )}
+            </div>
+            <div className="w-[250px]">
+              <label className="text-muted-foreground mb-1 block text-xs">OpenClaw Version</label>
+              <Select value={pinImageTag} onValueChange={setPinImageTag}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select OpenClaw version..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableVersions?.items.map(v => (
+                    <SelectItem key={v.image_tag} value={v.image_tag}>
+                      {v.openclaw_version} ({v.variant})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="w-[200px]">
+              <label className="text-muted-foreground mb-1 block text-xs">Reason</label>
+              <Input
+                placeholder="Why pin this user?"
+                value={pinReason}
+                onChange={e => setPinReason(e.target.value)}
+              />
+            </div>
+            <Button
+              onClick={() =>
+                selectedUserId &&
+                pinImageTag &&
+                void setPin({
+                  userId: selectedUserId,
+                  imageTag: pinImageTag,
+                  reason: pinReason || undefined,
+                })
+              }
+              disabled={!selectedUserId || !pinImageTag || isPinning}
+            >
+              {isPinning ? 'Pinning...' : 'Pin User'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>Image Tag</TableHead>
+              <TableHead>OpenClaw Version</TableHead>
+              <TableHead>Variant</TableHead>
+              <TableHead>Pinned By</TableHead>
+              <TableHead>Reason</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center">
+                  <Loader2 className="mx-auto h-4 w-4 animate-spin" />
+                </TableCell>
+              </TableRow>
+            ) : data?.items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-muted-foreground text-center">
+                  No active pins
+                </TableCell>
+              </TableRow>
+            ) : (
+              data?.items.map(pin => (
+                <TableRow key={pin.id}>
+                  <TableCell className="font-medium">{pin.user_email ?? pin.user_id}</TableCell>
+                  <TableCell>
+                    <code className="text-xs">{pin.image_tag}</code>
+                  </TableCell>
+                  <TableCell>{pin.openclaw_version ?? '—'}</TableCell>
+                  <TableCell>{pin.variant ?? '—'}</TableCell>
+                  <TableCell>{pin.pinned_by_email ?? pin.pinned_by}</TableCell>
+                  <TableCell className="max-w-[200px] truncate text-sm">
+                    {pin.reason ?? '—'}
+                  </TableCell>
+                  <TableCell>
+                    <span title={new Date(pin.created_at).toLocaleString()}>
+                      {formatDistanceToNow(new Date(pin.created_at), { addSuffix: true })}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setRemovingUserId(pin.user_id)}
+                    >
+                      Remove
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {data && data.pagination.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <div className="text-muted-foreground text-sm">
+            Page {page + 1} of {data.pagination.totalPages}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(p => p - 1)}
+              disabled={page === 0}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(p => p + 1)}
+              disabled={page + 1 >= data.pagination.totalPages}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Remove Pin Confirmation Dialog */}
+      <Dialog
+        open={removingUserId !== null}
+        onOpenChange={open => !open && setRemovingUserId(null)}
+      >
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5" />
+              Remove Version Pin
+            </DialogTitle>
+            <DialogDescription className="pt-3">
+              Are you sure you want to remove this version pin? The user will follow the latest
+              available version.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <DialogClose asChild>
+              <Button variant="secondary" disabled={isRemoving}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => removingUserId && void removePin({ userId: removingUserId })}
+              disabled={isRemoving}
+            >
+              {isRemoving ? 'Removing...' : 'Remove Pin'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
+export function KiloclawVersionsPage() {
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      <Tabs defaultValue="versions">
+        <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+          <TabsTrigger value="versions" className={tabTriggerClass}>
+            Versions
+          </TabsTrigger>
+          <TabsTrigger value="pins" className={tabTriggerClass}>
+            Pins
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="versions" className="mt-4">
+          <VersionsTab />
+        </TabsContent>
+        <TabsContent value="pins" className="mt-4">
+          <PinsTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -31,7 +31,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Command,
@@ -526,32 +525,6 @@ export function PinsTab() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  );
-}
-
-const tabTriggerClass =
-  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
-
-export function KiloclawVersionsPage() {
-  return (
-    <div className="flex w-full flex-col gap-y-4">
-      <Tabs defaultValue="versions">
-        <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
-          <TabsTrigger value="versions" className={tabTriggerClass}>
-            Versions
-          </TabsTrigger>
-          <TabsTrigger value="pins" className={tabTriggerClass}>
-            Pins
-          </TabsTrigger>
-        </TabsList>
-        <TabsContent value="versions" className="mt-4">
-          <VersionsTab />
-        </TabsContent>
-        <TabsContent value="pins" className="mt-4">
-          <PinsTab />
-        </TabsContent>
-      </Tabs>
     </div>
   );
 }

--- a/src/app/admin/kiloclaw-instances/[id]/page.tsx
+++ b/src/app/admin/kiloclaw-instances/[id]/page.tsx
@@ -1,24 +1,10 @@
-import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
-import { getUserFromAuth } from '@/lib/user.server';
-import { KiloclawInstanceDetail } from '../../components/KiloclawInstances/KiloclawInstanceDetail';
 
-export default async function KiloclawInstanceDetailPage({
+export default async function KiloclawInstanceDetailRedirect({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
-  if (authFailedResponse) {
-    redirect('/admin/unauthorized');
-  }
-
   const { id } = await params;
-  const instanceId = decodeURIComponent(id);
-
-  return (
-    <Suspense fallback={<div>Loading instance details...</div>}>
-      <KiloclawInstanceDetail instanceId={instanceId} />
-    </Suspense>
-  );
+  redirect(`/admin/kiloclaw/${id}`);
 }

--- a/src/app/admin/kiloclaw-versions/page.tsx
+++ b/src/app/admin/kiloclaw-versions/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
-export default function KiloclawInstancesRedirect() {
+export default function KiloclawVersionsRedirect() {
   redirect('/admin/kiloclaw');
 }

--- a/src/app/admin/kiloclaw/[id]/page.tsx
+++ b/src/app/admin/kiloclaw/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { getUserFromAuth } from '@/lib/user.server';
+import { KiloclawInstanceDetail } from '../../components/KiloclawInstances/KiloclawInstanceDetail';
+
+export default async function KiloclawInstanceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) {
+    redirect('/admin/unauthorized');
+  }
+
+  const { id } = await params;
+  const instanceId = decodeURIComponent(id);
+
+  return (
+    <Suspense fallback={<div>Loading instance details...</div>}>
+      <KiloclawInstanceDetail instanceId={instanceId} />
+    </Suspense>
+  );
+}

--- a/src/app/admin/kiloclaw/page.tsx
+++ b/src/app/admin/kiloclaw/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react';
+import AdminPage from '../components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+import { KiloclawDashboard } from '../components/KiloclawDashboard';
+
+const breadcrumbs = (
+  <>
+    <BreadcrumbItem>
+      <BreadcrumbPage>KiloClaw</BreadcrumbPage>
+    </BreadcrumbItem>
+  </>
+);
+
+export default async function KiloclawAdminPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <Suspense fallback={<div>Loading KiloClaw...</div>}>
+        <KiloclawDashboard />
+      </Suspense>
+    </AdminPage>
+  );
+}

--- a/src/lib/user.test.ts
+++ b/src/lib/user.test.ts
@@ -24,6 +24,8 @@ import {
   user_admin_notes,
   magic_link_tokens,
   stytch_fingerprints,
+  kiloclaw_version_pins,
+  kiloclaw_image_catalog,
 } from '@kilocode/db/schema';
 import { eq, count } from 'drizzle-orm';
 import { softDeleteUser, SoftDeletePreconditionError, findUserById, findUsersByIds } from './user';
@@ -628,6 +630,41 @@ describe('User', () => {
       await softDeleteUser(user.id);
 
       expect((await db.select({ count: count() }).from(magic_link_tokens))[0].count).toBe(0);
+    });
+
+    it('should delete kiloclaw_version_pins for the user', async () => {
+      const user = await insertTestUser();
+      const adminUser = await insertTestUser({ is_admin: true });
+
+      // Create a catalog entry for the FK
+      const testTag = `test-gdpr-${Date.now()}`;
+      await db.insert(kiloclaw_image_catalog).values({
+        openclaw_version: '2026.1.1',
+        variant: 'default',
+        image_tag: testTag,
+        status: 'available',
+        published_at: new Date().toISOString(),
+      });
+
+      await db.insert(kiloclaw_version_pins).values({
+        user_id: user.id,
+        image_tag: testTag,
+        pinned_by: adminUser.id,
+        reason: 'test pin',
+      });
+
+      await softDeleteUser(user.id);
+
+      expect(
+        await db
+          .select({ count: count() })
+          .from(kiloclaw_version_pins)
+          .where(eq(kiloclaw_version_pins.user_id, user.id))
+          .then(r => r[0].count)
+      ).toBe(0);
+
+      // Cleanup catalog entry
+      await db.delete(kiloclaw_image_catalog).where(eq(kiloclaw_image_catalog.image_tag, testTag));
     });
   });
 

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -40,6 +40,7 @@ import {
   cloud_agent_code_reviews,
   kiloclaw_instances,
   kiloclaw_access_codes,
+  kiloclaw_version_pins,
   user_period_cache,
   user_feedback,
   app_builder_feedback,
@@ -512,6 +513,7 @@ export async function softDeleteUser(userId: string) {
     await tx.delete(auto_top_up_configs).where(eq(auto_top_up_configs.owned_by_user_id, userId));
     await tx.delete(kiloclaw_access_codes).where(eq(kiloclaw_access_codes.kilo_user_id, userId));
     await tx.delete(kiloclaw_instances).where(eq(kiloclaw_instances.user_id, userId));
+    await tx.delete(kiloclaw_version_pins).where(eq(kiloclaw_version_pins.user_id, userId));
     await tx.delete(user_period_cache).where(eq(user_period_cache.kilo_user_id, userId));
     await tx
       .delete(kilo_pass_scheduled_changes)

--- a/src/routers/admin-kiloclaw-versions-router.test.ts
+++ b/src/routers/admin-kiloclaw-versions-router.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable drizzle/enforce-delete-with-where */
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';

--- a/src/routers/admin-kiloclaw-versions-router.test.ts
+++ b/src/routers/admin-kiloclaw-versions-router.test.ts
@@ -1,0 +1,292 @@
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import type { User } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { kiloclaw_image_catalog, kiloclaw_version_pins } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+
+let regularUser: User;
+let adminUser: User;
+let targetUser: User;
+
+const catalogEntry = {
+  openclaw_version: '2026.2.9',
+  variant: 'default',
+  image_tag: 'registry.fly.io/kiloclaw:test-v1',
+  image_digest: 'sha256:abc123',
+  status: 'available' as const,
+  published_at: new Date().toISOString(),
+};
+
+const catalogEntry2 = {
+  openclaw_version: '2026.2.10',
+  variant: 'default',
+  image_tag: 'registry.fly.io/kiloclaw:test-v2',
+  image_digest: 'sha256:def456',
+  status: 'available' as const,
+  published_at: new Date().toISOString(),
+};
+
+beforeAll(async () => {
+  regularUser = await insertTestUser({
+    google_user_email: 'regular-kiloclaw-ver@example.com',
+    is_admin: false,
+  });
+  adminUser = await insertTestUser({
+    google_user_email: 'admin-kiloclaw-ver@admin.example.com',
+    is_admin: true,
+  });
+  targetUser = await insertTestUser({
+    google_user_email: 'target-kiloclaw-ver@example.com',
+    is_admin: false,
+  });
+
+  await db.insert(kiloclaw_image_catalog).values([catalogEntry, catalogEntry2]);
+});
+
+afterAll(async () => {
+  try {
+    await db.delete(kiloclaw_version_pins);
+    await db
+      .delete(kiloclaw_image_catalog)
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+    await db
+      .delete(kiloclaw_image_catalog)
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry2.image_tag));
+  } catch {
+    // Test DB may already be torn down by framework
+  }
+});
+
+describe('admin.kiloclawVersions.listVersions', () => {
+  it('throws FORBIDDEN for non-admin users', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+    await expect(caller.admin.kiloclawVersions.listVersions({})).rejects.toThrow(
+      'Admin access required'
+    );
+  });
+
+  it('returns catalog entries with pagination', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.listVersions({});
+
+    expect(result.items.length).toBeGreaterThanOrEqual(2);
+    expect(result.pagination.totalCount).toBeGreaterThanOrEqual(2);
+    expect(result.items[0]).toHaveProperty('image_tag');
+    expect(result.items[0]).toHaveProperty('openclaw_version');
+  });
+
+  it('filters by status', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.listVersions({ status: 'disabled' });
+
+    for (const item of result.items) {
+      expect(item.status).toBe('disabled');
+    }
+  });
+});
+
+describe('admin.kiloclawVersions.updateVersionStatus', () => {
+  it('throws FORBIDDEN for non-admin users', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+    await expect(
+      caller.admin.kiloclawVersions.updateVersionStatus({
+        imageTag: catalogEntry.image_tag,
+        status: 'disabled',
+      })
+    ).rejects.toThrow('Admin access required');
+  });
+
+  it('updates status and records updated_by', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.updateVersionStatus({
+      imageTag: catalogEntry.image_tag,
+      status: 'disabled',
+    });
+
+    expect(result.status).toBe('disabled');
+    expect(result.updated_by).toBe(adminUser.id);
+  });
+
+  it('throws NOT_FOUND for non-existent image tag', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawVersions.updateVersionStatus({
+        imageTag: 'nonexistent-tag',
+        status: 'disabled',
+      })
+    ).rejects.toThrow('Version not found');
+  });
+
+  afterAll(async () => {
+    // Reset status for other tests
+    await db
+      .update(kiloclaw_image_catalog)
+      .set({ status: 'available' })
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+  });
+});
+
+describe('admin.kiloclawVersions pin operations', () => {
+  afterEach(async () => {
+    await db.delete(kiloclaw_version_pins);
+  });
+
+  describe('setPin', () => {
+    it('throws FORBIDDEN for non-admin users', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      await expect(
+        caller.admin.kiloclawVersions.setPin({
+          userId: targetUser.id,
+          imageTag: catalogEntry.image_tag,
+        })
+      ).rejects.toThrow('Admin access required');
+    });
+
+    it('creates a pin for a user', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+      const result = await caller.admin.kiloclawVersions.setPin({
+        userId: targetUser.id,
+        imageTag: catalogEntry.image_tag,
+        reason: 'Testing older version',
+      });
+
+      expect(result.user_id).toBe(targetUser.id);
+      expect(result.image_tag).toBe(catalogEntry.image_tag);
+      expect(result.pinned_by).toBe(adminUser.id);
+      expect(result.reason).toBe('Testing older version');
+    });
+
+    it('upserts pin when user already has one', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+
+      await caller.admin.kiloclawVersions.setPin({
+        userId: targetUser.id,
+        imageTag: catalogEntry.image_tag,
+        reason: 'First pin',
+      });
+
+      const updated = await caller.admin.kiloclawVersions.setPin({
+        userId: targetUser.id,
+        imageTag: catalogEntry2.image_tag,
+        reason: 'Updated pin',
+      });
+
+      expect(updated.image_tag).toBe(catalogEntry2.image_tag);
+      expect(updated.reason).toBe('Updated pin');
+
+      // Verify only one pin exists
+      const pins = await caller.admin.kiloclawVersions.listPins({});
+      expect(pins.pagination.totalCount).toBe(1);
+    });
+
+    it('rejects pin to non-existent image tag (FK constraint)', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+      await expect(
+        caller.admin.kiloclawVersions.setPin({
+          userId: targetUser.id,
+          imageTag: 'nonexistent-tag',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getUserPin', () => {
+    it('returns null when user has no pin', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+      const result = await caller.admin.kiloclawVersions.getUserPin({ userId: targetUser.id });
+      expect(result).toBeNull();
+    });
+
+    it('returns pin with catalog metadata', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+
+      await caller.admin.kiloclawVersions.setPin({
+        userId: targetUser.id,
+        imageTag: catalogEntry.image_tag,
+      });
+
+      const result = await caller.admin.kiloclawVersions.getUserPin({ userId: targetUser.id });
+      expect(result).not.toBeNull();
+      expect(result!.user_id).toBe(targetUser.id);
+      expect(result!.image_tag).toBe(catalogEntry.image_tag);
+      expect(result!.openclaw_version).toBe(catalogEntry.openclaw_version);
+      expect(result!.variant).toBe(catalogEntry.variant);
+      expect(result!.pinned_by_email).toBe(adminUser.google_user_email);
+    });
+  });
+
+  describe('listPins', () => {
+    it('returns pins with joined user and catalog data', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+
+      await caller.admin.kiloclawVersions.setPin({
+        userId: targetUser.id,
+        imageTag: catalogEntry.image_tag,
+        reason: 'Test reason',
+      });
+
+      const result = await caller.admin.kiloclawVersions.listPins({});
+      expect(result.items.length).toBe(1);
+      expect(result.pagination.totalCount).toBe(1);
+
+      const pin = result.items[0];
+      expect(pin.user_email).toBe(targetUser.google_user_email);
+      expect(pin.openclaw_version).toBe(catalogEntry.openclaw_version);
+      expect(pin.pinned_by_email).toBe(adminUser.google_user_email);
+      expect(pin.reason).toBe('Test reason');
+    });
+  });
+
+  describe('removePin', () => {
+    it('removes an existing pin', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+
+      await caller.admin.kiloclawVersions.setPin({
+        userId: targetUser.id,
+        imageTag: catalogEntry.image_tag,
+      });
+
+      const result = await caller.admin.kiloclawVersions.removePin({ userId: targetUser.id });
+      expect(result.success).toBe(true);
+
+      const pin = await caller.admin.kiloclawVersions.getUserPin({ userId: targetUser.id });
+      expect(pin).toBeNull();
+    });
+
+    it('throws NOT_FOUND when no pin exists', async () => {
+      const caller = await createCallerForUser(adminUser.id);
+      await expect(
+        caller.admin.kiloclawVersions.removePin({ userId: targetUser.id })
+      ).rejects.toThrow('No pin found for this user');
+    });
+  });
+});
+
+describe('admin.kiloclawVersions.searchUsers', () => {
+  it('throws FORBIDDEN for non-admin users', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+    await expect(caller.admin.kiloclawVersions.searchUsers({ query: 'target' })).rejects.toThrow(
+      'Admin access required'
+    );
+  });
+
+  it('finds users by email', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.searchUsers({
+      query: 'target-kiloclaw',
+    });
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result.some(u => u.id === targetUser.id)).toBe(true);
+  });
+
+  it('finds users by exact id', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.searchUsers({
+      query: targetUser.id,
+    });
+
+    expect(result.some(u => u.id === targetUser.id)).toBe(true);
+  });
+});

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -201,6 +201,7 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
   searchUsers: adminProcedure
     .input(z.object({ query: z.string().min(1) }))
     .query(async ({ input }) => {
+      const escaped = input.query.replace(/%/g, '\\%').replace(/_/g, '\\_');
       const result = await db
         .select({
           id: kilocode_users.id,
@@ -210,8 +211,8 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
         .from(kilocode_users)
         .where(
           or(
-            ilike(kilocode_users.google_user_email, `%${input.query}%`),
-            ilike(kilocode_users.google_user_name, `%${input.query}%`),
+            ilike(kilocode_users.google_user_email, `%${escaped}%`),
+            ilike(kilocode_users.google_user_name, `%${escaped}%`),
             eq(kilocode_users.id, input.query)
           )
         )

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -182,6 +182,10 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       })
       .returning();
 
+    if (!result) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create pin' });
+    }
+
     return result;
   }),
 

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -1,0 +1,222 @@
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { db } from '@/lib/drizzle';
+import { kiloclaw_image_catalog, kiloclaw_version_pins, kilocode_users } from '@kilocode/db/schema';
+import { eq, desc, sql, or, ilike } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+
+const ListVersionsSchema = z.object({
+  offset: z.number().min(0).default(0),
+  limit: z.number().min(1).max(100).default(25),
+  status: z.enum(['available', 'disabled']).optional(),
+});
+
+const UpdateVersionStatusSchema = z.object({
+  imageTag: z.string().min(1),
+  status: z.enum(['available', 'disabled']),
+});
+
+const ListPinsSchema = z.object({
+  offset: z.number().min(0).default(0),
+  limit: z.number().min(1).max(100).default(25),
+});
+
+const GetUserPinSchema = z.object({
+  userId: z.string().min(1),
+});
+
+const SetPinSchema = z.object({
+  userId: z.string().min(1),
+  imageTag: z.string().min(1),
+  reason: z.string().optional(),
+});
+
+const RemovePinSchema = z.object({
+  userId: z.string().min(1),
+});
+
+export const adminKiloclawVersionsRouter = createTRPCRouter({
+  listVersions: adminProcedure.input(ListVersionsSchema).query(async ({ input }) => {
+    const { offset, limit, status } = input;
+
+    const whereCondition = status ? eq(kiloclaw_image_catalog.status, status) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      db
+        .select()
+        .from(kiloclaw_image_catalog)
+        .where(whereCondition)
+        .orderBy(desc(kiloclaw_image_catalog.published_at))
+        .offset(offset)
+        .limit(limit),
+      db
+        .select({ count: sql<number>`COUNT(*)::int` })
+        .from(kiloclaw_image_catalog)
+        .where(whereCondition),
+    ]);
+
+    const totalCount = countResult[0]?.count ?? 0;
+
+    return {
+      items,
+      pagination: {
+        offset,
+        limit,
+        totalCount,
+        totalPages: Math.ceil(totalCount / limit),
+      },
+    };
+  }),
+
+  updateVersionStatus: adminProcedure
+    .input(UpdateVersionStatusSchema)
+    .mutation(async ({ input, ctx }) => {
+      const [updated] = await db
+        .update(kiloclaw_image_catalog)
+        .set({
+          status: input.status,
+          updated_by: ctx.user.id,
+          updated_at: new Date().toISOString(),
+        })
+        .where(eq(kiloclaw_image_catalog.image_tag, input.imageTag))
+        .returning();
+
+      if (!updated) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Version not found' });
+      }
+
+      return updated;
+    }),
+
+  listPins: adminProcedure.input(ListPinsSchema).query(async ({ input }) => {
+    const { offset, limit } = input;
+    const pinnedByUser = alias(kilocode_users, 'pinned_by_user');
+
+    const [items, countResult] = await Promise.all([
+      db
+        .select({
+          pin: kiloclaw_version_pins,
+          user_email: kilocode_users.google_user_email,
+          openclaw_version: kiloclaw_image_catalog.openclaw_version,
+          variant: kiloclaw_image_catalog.variant,
+          pinned_by_email: pinnedByUser.google_user_email,
+        })
+        .from(kiloclaw_version_pins)
+        .leftJoin(kilocode_users, eq(kiloclaw_version_pins.user_id, kilocode_users.id))
+        .leftJoin(
+          kiloclaw_image_catalog,
+          eq(kiloclaw_version_pins.image_tag, kiloclaw_image_catalog.image_tag)
+        )
+        .leftJoin(pinnedByUser, eq(kiloclaw_version_pins.pinned_by, pinnedByUser.id))
+        .orderBy(desc(kiloclaw_version_pins.created_at))
+        .offset(offset)
+        .limit(limit),
+      db.select({ count: sql<number>`COUNT(*)::int` }).from(kiloclaw_version_pins),
+    ]);
+
+    const totalCount = countResult[0]?.count ?? 0;
+
+    return {
+      items: items.map(row => ({
+        ...row.pin,
+        user_email: row.user_email,
+        openclaw_version: row.openclaw_version,
+        variant: row.variant,
+        pinned_by_email: row.pinned_by_email,
+      })),
+      pagination: {
+        offset,
+        limit,
+        totalCount,
+        totalPages: Math.ceil(totalCount / limit),
+      },
+    };
+  }),
+
+  getUserPin: adminProcedure.input(GetUserPinSchema).query(async ({ input }) => {
+    const pinnedByUser = alias(kilocode_users, 'pinned_by_user');
+    const [result] = await db
+      .select({
+        pin: kiloclaw_version_pins,
+        openclaw_version: kiloclaw_image_catalog.openclaw_version,
+        variant: kiloclaw_image_catalog.variant,
+        pinned_by_email: pinnedByUser.google_user_email,
+      })
+      .from(kiloclaw_version_pins)
+      .leftJoin(
+        kiloclaw_image_catalog,
+        eq(kiloclaw_version_pins.image_tag, kiloclaw_image_catalog.image_tag)
+      )
+      .leftJoin(pinnedByUser, eq(kiloclaw_version_pins.pinned_by, pinnedByUser.id))
+      .where(eq(kiloclaw_version_pins.user_id, input.userId))
+      .limit(1);
+
+    if (!result) return null;
+
+    return {
+      ...result.pin,
+      openclaw_version: result.openclaw_version,
+      variant: result.variant,
+      pinned_by_email: result.pinned_by_email,
+    };
+  }),
+
+  setPin: adminProcedure.input(SetPinSchema).mutation(async ({ input, ctx }) => {
+    const [result] = await db
+      .insert(kiloclaw_version_pins)
+      .values({
+        user_id: input.userId,
+        image_tag: input.imageTag,
+        pinned_by: ctx.user.id,
+        reason: input.reason ?? null,
+      })
+      .onConflictDoUpdate({
+        target: kiloclaw_version_pins.user_id,
+        set: {
+          image_tag: input.imageTag,
+          pinned_by: ctx.user.id,
+          reason: input.reason ?? null,
+          updated_at: new Date().toISOString(),
+        },
+      })
+      .returning();
+
+    return result;
+  }),
+
+  removePin: adminProcedure.input(RemovePinSchema).mutation(async ({ input }) => {
+    const [deleted] = await db
+      .delete(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.user_id, input.userId))
+      .returning();
+
+    if (!deleted) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'No pin found for this user' });
+    }
+
+    return { success: true };
+  }),
+
+  searchUsers: adminProcedure
+    .input(z.object({ query: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const result = await db
+        .select({
+          id: kilocode_users.id,
+          email: kilocode_users.google_user_email,
+          name: kilocode_users.google_user_name,
+        })
+        .from(kilocode_users)
+        .where(
+          or(
+            ilike(kilocode_users.google_user_email, `%${input.query}%`),
+            ilike(kilocode_users.google_user_name, `%${input.query}%`),
+            eq(kilocode_users.id, input.query)
+          )
+        )
+        .limit(20);
+
+      return result;
+    }),
+});

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -17,6 +17,7 @@ import { fetchSessionSnapshot, type SessionMessage } from '@/lib/session-ingest-
 import { adminAppBuilderRouter } from '@/routers/admin-app-builder-router';
 import { adminDeploymentsRouter } from '@/routers/admin-deployments-router';
 import { adminKiloclawInstancesRouter } from '@/routers/admin-kiloclaw-instances-router';
+import { adminKiloclawVersionsRouter } from '@/routers/admin-kiloclaw-versions-router';
 import { adminFeatureInterestRouter } from '@/routers/admin-feature-interest-router';
 import { adminCodeReviewsRouter } from '@/routers/admin-code-reviews-router';
 import { adminAIAttributionRouter } from '@/routers/admin-ai-attribution-router';
@@ -1085,6 +1086,7 @@ export const adminRouter = createTRPCRouter({
   }),
   appBuilder: adminAppBuilderRouter,
   kiloclawInstances: adminKiloclawInstancesRouter,
+  kiloclawVersions: adminKiloclawVersionsRouter,
   aiAttribution: adminAIAttributionRouter,
   ossSponsorship: ossSponsorshipRouter,
   bulkUserCredits: bulkUserCreditsRouter,


### PR DESCRIPTION
- Add kiloclaw_version_pins table with cascade/restrict FKs
- Add tRPC router for catalog + pin CRUD endpoints
- Add admin Versions tab (catalog list, status toggle)
- Add admin Pins tab (pin management with user combobox)
- Add Version Pin card to instance detail page
- Consolidate KiloClaw admin under /admin/kiloclaw with URL-synced tabs
- Simplify version status to available/disabled (remove deprecated)
- Add admin-kiloclaw-versions-router tests (18 tests