### PR TITLE
refactor: centralise Kilo user JWT verification in worker-utils

### DIFF
--- a/cloud-agent-next/src/auth.ts
+++ b/cloud-agent-next/src/auth.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken';
-import type { TokenPayload } from './types.js';
+import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
 
 type StreamTicketPayload = {
   type: 'stream_ticket';
@@ -11,56 +11,29 @@ type StreamTicketPayload = {
   nonce?: string;
 };
 
-export function validateKiloToken(
+export async function validateKiloToken(
   authHeader: string | null,
   secret: string
-):
+): Promise<
   | { success: true; userId: string; token: string; botId?: string }
-  | { success: false; error: string } {
+  | { success: false; error: string }
+> {
   if (!secret) {
     return { success: false, error: 'NEXTAUTH_SECRET is not configured on the worker' };
   }
 
-  // Check header exists and has Bearer format
-  if (!authHeader) {
-    return { success: false, error: 'Missing Authorization header' };
+  const token = extractBearerToken(authHeader);
+  if (!token) {
+    return { success: false, error: 'Missing or malformed Authorization header' };
   }
-
-  if (!authHeader.toLowerCase().startsWith('bearer ')) {
-    return { success: false, error: 'Invalid Authorization header format' };
-  }
-
-  const token = authHeader.substring(7).trim();
 
   try {
-    // Verify JWT signature and decode
-    const payload = jwt.verify(token, secret, {
-      algorithms: ['HS256'],
-    }) as TokenPayload;
-
-    // Validate token version
-    if (payload.version !== 3) {
-      return {
-        success: false,
-        error: `Invalid token version: ${payload.version}, expected 3`,
-      };
-    }
-
-    // Token is valid
-    return {
-      success: true,
-      userId: payload.kiloUserId,
-      token,
-      botId: payload.botId,
-    };
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      return { success: false, error: 'Token expired' };
-    }
-    if (error instanceof jwt.JsonWebTokenError) {
-      return { success: false, error: 'Invalid token signature' };
-    }
-    return { success: false, error: 'Token validation failed' };
+    const payload = await verifyKiloToken(token, secret);
+    const botId = typeof payload['botId'] === 'string' ? payload['botId'] : undefined;
+    return { success: true, userId: payload.kiloUserId, token, botId };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'JWT verification failed';
+    return { success: false, error: message };
   }
 }
 

--- a/cloud-agent-next/src/auth.ts
+++ b/cloud-agent-next/src/auth.ts
@@ -29,8 +29,7 @@ export async function validateKiloToken(
 
   try {
     const payload = await verifyKiloToken(token, secret);
-    const botId = typeof payload['botId'] === 'string' ? payload['botId'] : undefined;
-    return { success: true, userId: payload.kiloUserId, token, botId };
+    return { success: true, userId: payload.kiloUserId, token, botId: payload.botId };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'JWT verification failed';
     return { success: false, error: message };

--- a/cloud-agent-next/src/middleware/auth.ts
+++ b/cloud-agent-next/src/middleware/auth.ts
@@ -9,7 +9,7 @@ import { extractProcedureName } from '../balance-validation.js';
 export const authMiddleware = createMiddleware<HonoContext>(
   async (c: Context<HonoContext>, next: Next) => {
     const authHeader = c.req.header('authorization');
-    const result = validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
+    const result = await validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
 
     if (!result.success) {
       logger.withFields({ error: result.error }).warn('Authentication failed');

--- a/cloud-agent-next/src/server.ts
+++ b/cloud-agent-next/src/server.ts
@@ -94,7 +94,7 @@ app.all('/sessions/:userId/:sessionId/ingest', async (c: Context<HonoContext>) =
 
   const sessionId = c.req.param('sessionId');
   const authHeader = c.req.header('Authorization');
-  const authResult = validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
+  const authResult = await validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
   if (!authResult.success) {
     return c.text(authResult.error, 401);
   }
@@ -129,7 +129,7 @@ app.put(
     }
 
     const authHeader = c.req.header('Authorization');
-    const authResult = validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
+    const authResult = await validateKiloToken(authHeader ?? null, c.env.NEXTAUTH_SECRET);
     if (!authResult.success) {
       return c.text(authResult.error, 401);
     }

--- a/cloud-agent-next/src/types.ts
+++ b/cloud-agent-next/src/types.ts
@@ -77,14 +77,6 @@ export type InterruptResult = {
   message: string;
 };
 
-export type TokenPayload = {
-  kiloUserId: string;
-  apiTokenPepper: string;
-  version: number;
-  env: string;
-  botId?: string;
-};
-
 export type Env = {
   Sandbox: DurableObjectNamespace<Sandbox>;
   /** Durable Object namespace for CloudAgentSession metadata (SQLite-backed) with RPC support */

--- a/cloud-agent/src/auth.ts
+++ b/cloud-agent/src/auth.ts
@@ -27,8 +27,7 @@ export async function validateKiloToken(
 
   try {
     const payload = await verifyKiloToken(token, secret);
-    const botId = typeof payload['botId'] === 'string' ? payload['botId'] : undefined;
-    return { success: true, userId: payload.kiloUserId, token, botId };
+    return { success: true, userId: payload.kiloUserId, token, botId: payload.botId };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'JWT verification failed';
     return { success: false, error: message };

--- a/cloud-agent/src/auth.ts
+++ b/cloud-agent/src/auth.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import jwt from 'jsonwebtoken';
-import type { Env, TokenPayload } from './types.js';
+import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
+import type { Env } from './types.js';
 
 type StreamTicketPayload = {
   type: 'stream_ticket';
@@ -12,52 +13,25 @@ type StreamTicketPayload = {
   nonce?: string;
 };
 
-export function validateKiloToken(
+export async function validateKiloToken(
   authHeader: string | null,
   secret: string
-):
+): Promise<
   | { success: true; userId: string; token: string; botId?: string }
-  | { success: false; error: string } {
-  // Check header exists and has Bearer format
-  if (!authHeader) {
-    return { success: false, error: 'Missing Authorization header' };
+  | { success: false; error: string }
+> {
+  const token = extractBearerToken(authHeader);
+  if (!token) {
+    return { success: false, error: 'Missing or malformed Authorization header' };
   }
-
-  if (!authHeader.toLowerCase().startsWith('bearer ')) {
-    return { success: false, error: 'Invalid Authorization header format' };
-  }
-
-  const token = authHeader.substring(7).trim();
 
   try {
-    // Verify JWT signature and decode
-    const payload = jwt.verify(token, secret, {
-      algorithms: ['HS256'],
-    }) as TokenPayload;
-
-    // Validate token version
-    if (payload.version !== 3) {
-      return {
-        success: false,
-        error: `Invalid token version: ${payload.version}, expected 3`,
-      };
-    }
-
-    // Token is valid
-    return {
-      success: true,
-      userId: payload.kiloUserId,
-      token,
-      botId: payload.botId,
-    };
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      return { success: false, error: 'Token expired' };
-    }
-    if (error instanceof jwt.JsonWebTokenError) {
-      return { success: false, error: 'Invalid token signature' };
-    }
-    return { success: false, error: 'Token validation failed' };
+    const payload = await verifyKiloToken(token, secret);
+    const botId = typeof payload['botId'] === 'string' ? payload['botId'] : undefined;
+    return { success: true, userId: payload.kiloUserId, token, botId };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'JWT verification failed';
+    return { success: false, error: message };
   }
 }
 
@@ -94,13 +68,13 @@ export function validateStreamTicket(
  * Validates JWT token and extracts user ID for tRPC context
  * @throws {TRPCError} If authentication fails
  */
-export function authenticate(
+export async function authenticate(
   request: Request,
   env: Env
-): { userId: string; token: string; botId?: string } {
+): Promise<{ userId: string; token: string; botId?: string }> {
   const authHeader = request.headers.get('authorization');
 
-  const result = validateKiloToken(authHeader, env.NEXTAUTH_SECRET);
+  const result = await validateKiloToken(authHeader, env.NEXTAUTH_SECRET);
 
   if (!result.success) {
     throw new TRPCError({

--- a/cloud-agent/src/balance-validation.test.ts
+++ b/cloud-agent/src/balance-validation.test.ts
@@ -56,7 +56,7 @@ describe('balance-validation', () => {
   describe('validateAuthAndBalance', () => {
     describe('authentication failures', () => {
       it('returns 401 when JWT is invalid', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: false,
           error: 'Invalid token',
         });
@@ -72,7 +72,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 401 when no auth header provided', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: false,
           error: 'No authorization header',
         });
@@ -87,7 +87,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 401 when balance API returns 401', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -109,7 +109,7 @@ describe('balance-validation', () => {
 
     describe('balance validation', () => {
       it('returns 402 when balance is depleted', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -129,7 +129,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 402 when balance is below $1', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -149,7 +149,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 402 when balance is zero', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -169,7 +169,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 402 when balance is negative', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -191,7 +191,7 @@ describe('balance-validation', () => {
 
     describe('error handling', () => {
       it('returns 500 when balance API returns non-401 error', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -211,7 +211,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 500 when fetch throws', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -228,7 +228,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 500 when response JSON is invalid', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -251,7 +251,7 @@ describe('balance-validation', () => {
       });
 
       it('returns 500 when balance is not a number', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -273,7 +273,7 @@ describe('balance-validation', () => {
 
     describe('successful validation', () => {
       it('returns success when balance is sufficient', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -294,7 +294,7 @@ describe('balance-validation', () => {
       });
 
       it('returns success with exactly $1 balance', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -315,7 +315,7 @@ describe('balance-validation', () => {
       });
 
       it('returns success with botId when present', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -337,7 +337,7 @@ describe('balance-validation', () => {
       });
 
       it('uses default API URL when KILOCODE_BACKEND_BASE_URL not configured', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -373,7 +373,7 @@ describe('balance-validation', () => {
 
     describe('organization header', () => {
       it('includes X-KiloCode-OrganizationId header when orgId provided', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',
@@ -401,7 +401,7 @@ describe('balance-validation', () => {
       });
 
       it('does not include X-KiloCode-OrganizationId header when orgId not provided', async () => {
-        vi.mocked(validateKiloToken).mockReturnValue({
+        vi.mocked(validateKiloToken).mockResolvedValue({
           success: true,
           userId: 'user-123',
           token: 'valid-token',

--- a/cloud-agent/src/balance-validation.ts
+++ b/cloud-agent/src/balance-validation.ts
@@ -28,7 +28,7 @@ export async function validateAuthAndBalance(
   env: Env
 ): Promise<BalanceValidationResult> {
   // Validate JWT first
-  const authResult = validateKiloToken(authHeader, env.NEXTAUTH_SECRET);
+  const authResult = await validateKiloToken(authHeader, env.NEXTAUTH_SECRET);
   if (!authResult.success) {
     return { success: false, status: 401, message: authResult.error };
   }

--- a/cloud-agent/src/index.ts
+++ b/cloud-agent/src/index.ts
@@ -172,7 +172,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
         }
         const sessionId = ingestMatch[2];
         const authHeader = request.headers.get('Authorization');
-        const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+        const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
         if (!authResult.success) {
           return new Response(authResult.error, { status: 401 });
         }
@@ -205,7 +205,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
           return new Response('Invalid filename', { status: 400 });
         }
         const authHeader = request.headers.get('Authorization');
-        const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+        const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
         if (!authResult.success) {
           return new Response(authResult.error, { status: 401 });
         }
@@ -244,7 +244,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
         if (skipBalanceCheck) {
           logger.withFields({ procedure: procedureName }).info('Skipping balance check per header');
 
-          const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+          const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
           if (!authResult.success) {
             return new Response(JSON.stringify({ error: authResult.error }), {
               status: 401,
@@ -278,7 +278,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
             });
           }
           // First validate auth to get userId for DO lookup
-          const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+          const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
           if (!authResult.success) {
             return new Response(JSON.stringify({ error: authResult.error }), {
               status: 401,
@@ -326,7 +326,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
         if (skipBalanceCheck) {
           logger.withFields({ procedure: procedureName }).info('Skipping balance check per header');
 
-          const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+          const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
           if (!authResult.success) {
             return this.buildTrpcErrorResponse(401, authResult.error, procedureName);
           }
@@ -359,7 +359,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
 
         // For sendMessageV2, we need to fetch orgId from session metadata if not in input
         if (procedureName === 'sendMessageV2' && !orgId && sessionId) {
-          const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+          const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
           if (!authResult.success) {
             return this.buildTrpcErrorResponse(401, authResult.error, procedureName);
           }
@@ -368,7 +368,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
 
         // For initiateFromKilocodeSessionV2, fetch from session metadata
         if (procedureName === 'initiateFromKilocodeSessionV2' && !orgId && sessionId) {
-          const authResult = validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
+          const authResult = await validateKiloToken(authHeader, this.env.NEXTAUTH_SECRET);
           if (!authResult.success) {
             return this.buildTrpcErrorResponse(401, authResult.error, procedureName);
           }
@@ -396,7 +396,7 @@ export default class KilocodeWorker extends WorkerEntrypoint<Env> {
       }
 
       // For non-balance-required endpoints, use standard tRPC handling
-      const authResult = authenticate(request, this.env);
+      const authResult = await authenticate(request, this.env);
       return this.handleTrpcRequest(request, authResult);
     });
   }

--- a/cloud-agent/src/types.ts
+++ b/cloud-agent/src/types.ts
@@ -81,14 +81,6 @@ export type InterruptResult = {
   message: string;
 };
 
-export type TokenPayload = {
-  kiloUserId: string;
-  apiTokenPepper: string;
-  version: number;
-  env: string;
-  botId?: string;
-};
-
 export type Env = {
   Sandbox: DurableObjectNamespace<Sandbox>;
   /** Durable Object namespace for CloudAgentSession metadata (SQLite-backed) with RPC support */

--- a/cloudflare-ai-attribution/package.json
+++ b/cloudflare-ai-attribution/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@kilocode/eslint-config": "workspace:*",
     "@types/jest": "^29.5.14",
-    "@types/jsonwebtoken": "catalog:",
     "drizzle-kit": "catalog:",
     "eslint": "catalog:",
     "jest": "^29.7.0",
@@ -33,7 +32,6 @@
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
     "workers-tagged-logger": "catalog:",
-    "jsonwebtoken": "catalog:",
     "zod": "catalog:"
   }
 }

--- a/cloudflare-ai-attribution/src/util/auth.ts
+++ b/cloudflare-ai-attribution/src/util/auth.ts
@@ -1,45 +1,31 @@
-/**
- * Authentication utilities for validating Kilo API tokens
- */
-
 import { createMiddleware } from 'hono/factory';
-import jwt from 'jsonwebtoken';
+import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
 import { logger } from './logger';
 import type { HonoContext } from '../ai-attribution.worker';
 import { OrganizationJWTPayload } from '../schemas';
 
 /**
- * Validates a Kilo API JWT token
+ * Validates a Kilo API JWT token, asserting it carries organization claims.
  */
-export function validateKiloToken(
+export async function validateKiloToken(
   authHeader: string | null,
   secret: string
-):
+): Promise<
   | ({ success: true; token: string } & Pick<
       OrganizationJWTPayload,
       'organizationId' | 'organizationRole' | 'kiloUserId'
     >)
-  | { success: false; error: string } {
-  // Check header exists and has Bearer format
-  if (!authHeader) {
-    return { success: false, error: 'Missing Authorization header' };
+  | { success: false; error: string }
+> {
+  const token = extractBearerToken(authHeader);
+  if (!token) {
+    return { success: false, error: 'Missing or malformed Authorization header' };
   }
-
-  if (!authHeader.toLowerCase().startsWith('bearer ')) {
-    return { success: false, error: 'Invalid Authorization header format' };
-  }
-
-  const token = authHeader.substring(7).trim();
 
   try {
-    // Verify JWT signature and decode
-    const payload = OrganizationJWTPayload.parse(
-      jwt.verify(token, secret, {
-        algorithms: ['HS256'],
-      })
-    );
+    const raw = await verifyKiloToken(token, secret);
+    const payload = OrganizationJWTPayload.parse(raw);
 
-    // Token is valid
     return {
       success: true,
       kiloUserId: payload.kiloUserId,
@@ -47,14 +33,8 @@ export function validateKiloToken(
       organizationId: payload.organizationId,
       organizationRole: payload.organizationRole,
     };
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      return { success: false, error: 'Token expired' };
-    }
-    if (error instanceof jwt.JsonWebTokenError) {
-      return { success: false, error: 'Invalid token signature' };
-    }
-    return { success: false, error: 'Token validation failed' };
+  } catch {
+    return { success: false, error: 'Invalid or expired token' };
   }
 }
 
@@ -62,15 +42,16 @@ export function validateKiloToken(
  * Hono middleware for authenticating requests with Kilo API tokens
  */
 export const authMiddleware = createMiddleware<HonoContext>(async (c, next) => {
-  const authHeader = c.req.header('Authorization');
-  const result = validateKiloToken(authHeader || null, await c.env.NEXTAUTH_SECRET.get());
+  const result = await validateKiloToken(
+    c.req.header('Authorization') ?? null,
+    await c.env.NEXTAUTH_SECRET.get()
+  );
 
   if (!result.success) {
     logger.warn('Authentication failed', { error: result.error });
     return c.json({ success: false, error: result.error }, 401);
   }
 
-  // Set user context in Hono variables
   c.set('user_id', result.kiloUserId);
   c.set('token', result.token);
   c.set('organization_id', result.organizationId);
@@ -82,5 +63,5 @@ export const authMiddleware = createMiddleware<HonoContext>(async (c, next) => {
     organizationRole: result.organizationRole,
   });
 
-  await next();
+  return next();
 });

--- a/cloudflare-session-ingest/package.json
+++ b/cloudflare-session-ingest/package.json
@@ -15,7 +15,6 @@
     "@kilocode/worker-utils": "workspace:*",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "jsonwebtoken": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/cloudflare-session-ingest/package.json
+++ b/cloudflare-session-ingest/package.json
@@ -20,8 +20,8 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260120.0",
     "@kilocode/eslint-config": "workspace:*",
-    "@types/jsonwebtoken": "catalog:",
     "@types/node": "^22",
+    "jose": "catalog:",
     "drizzle-kit": "catalog:",
     "eslint": "catalog:",
     "typescript": "catalog:",

--- a/cloudflare-session-ingest/src/middleware/kilo-jwt-auth.test.ts
+++ b/cloudflare-session-ingest/src/middleware/kilo-jwt-auth.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import jwt from 'jsonwebtoken';
+import { SignJWT } from 'jose';
 
 import { kiloJwtAuthMiddleware } from './kilo-jwt-auth';
 
@@ -30,6 +30,14 @@ function makeEnv(secret: string, opts?: { cachedUserState?: '1' | '0' | null }):
   };
 }
 
+async function sign(payload: Record<string, unknown>, secret: string): Promise<string> {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(new TextEncoder().encode(secret));
+}
+
 describe('kiloJwtAuthMiddleware', () => {
   it('rejects missing Authorization header', async () => {
     const app = new Hono<{ Bindings: TestEnv; Variables: { user_id: string } }>();
@@ -42,7 +50,7 @@ describe('kiloJwtAuthMiddleware', () => {
 
   it('accepts valid v3 token when user exists in cache', async () => {
     const secret = 'test-secret';
-    const token = jwt.sign({ kiloUserId: 'usr_123', version: 3 }, secret, { algorithm: 'HS256' });
+    const token = await sign({ kiloUserId: 'usr_123', version: 3 }, secret);
 
     const app = new Hono<{ Bindings: TestEnv; Variables: { user_id: string } }>();
     app.use('/api/*', kiloJwtAuthMiddleware);
@@ -63,9 +71,7 @@ describe('kiloJwtAuthMiddleware', () => {
 
   it('rejects valid v3 token when user is cached as not-found', async () => {
     const secret = 'test-secret';
-    const token = jwt.sign({ kiloUserId: 'deleted_user', version: 3 }, secret, {
-      algorithm: 'HS256',
-    });
+    const token = await sign({ kiloUserId: 'deleted_user', version: 3 }, secret);
 
     const app = new Hono<{ Bindings: TestEnv; Variables: { user_id: string } }>();
     app.use('/api/*', kiloJwtAuthMiddleware);

--- a/cloudflare-session-ingest/src/middleware/kilo-jwt-auth.ts
+++ b/cloudflare-session-ingest/src/middleware/kilo-jwt-auth.ts
@@ -1,24 +1,10 @@
 import { createMiddleware } from 'hono/factory';
-import jwt from 'jsonwebtoken';
+import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
 import { eq } from 'drizzle-orm';
 import { getWorkerDb } from '@kilocode/db/client';
 import { kilocode_users } from '@kilocode/db/schema';
 
 import type { Env } from '../env';
-
-type TokenPayloadV3 = {
-  kiloUserId: string;
-  version: number;
-};
-
-function isTokenPayloadV3(payload: unknown): payload is TokenPayloadV3 {
-  if (!payload || typeof payload !== 'object') {
-    return false;
-  }
-
-  const p = payload as Record<string, unknown>;
-  return typeof p.kiloUserId === 'string' && p.kiloUserId.length > 0 && p.version === 3;
-}
 
 const USER_EXISTS_TTL_SECONDS = 24 * 60 * 60; // 24h
 const USER_NOT_FOUND_TTL_SECONDS = 5 * 60; // 5m
@@ -63,42 +49,26 @@ export const kiloJwtAuthMiddleware = createMiddleware<{
     user_id: string;
   };
 }>(async (c, next) => {
-  const authHeader = c.req.header('Authorization') ?? c.req.header('authorization');
-  if (!authHeader) {
-    return c.json({ success: false, error: 'Missing Authorization header' }, 401);
-  }
-
-  if (!authHeader.toLowerCase().startsWith('bearer ')) {
-    return c.json({ success: false, error: 'Invalid Authorization header format' }, 401);
-  }
-
-  const token = authHeader.slice(7).trim();
+  const token = extractBearerToken(c.req.header('Authorization'));
   if (!token) {
-    return c.json({ success: false, error: 'Missing token' }, 401);
+    return c.json({ success: false, error: 'Missing or malformed Authorization header' }, 401);
   }
 
   const secret = await c.env.NEXTAUTH_SECRET_PROD.get();
 
+  let kiloUserId: string;
   try {
-    const payload = jwt.verify(token, secret, { algorithms: ['HS256'] });
-    if (!isTokenPayloadV3(payload)) {
-      return c.json({ success: false, error: 'Invalid token payload' }, 401);
-    }
-
-    const exists = await userExists(c.env, payload.kiloUserId);
-    if (!exists) {
-      return c.json({ success: false, error: 'User account not found' }, 403);
-    }
-
-    c.set('user_id', payload.kiloUserId);
-    await next();
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      return c.json({ success: false, error: 'Token expired' }, 401);
-    }
-    if (error instanceof jwt.JsonWebTokenError) {
-      return c.json({ success: false, error: 'Invalid token signature' }, 401);
-    }
-    return c.json({ success: false, error: 'Token validation failed' }, 401);
+    const payload = await verifyKiloToken(token, secret);
+    kiloUserId = payload.kiloUserId;
+  } catch {
+    return c.json({ success: false, error: 'Invalid or expired token' }, 401);
   }
+
+  const exists = await userExists(c.env, kiloUserId);
+  if (!exists) {
+    return c.json({ success: false, error: 'User account not found' }, 403);
+  }
+
+  c.set('user_id', kiloUserId);
+  return next();
 });

--- a/kiloclaw/src/auth/index.ts
+++ b/kiloclaw/src/auth/index.ts
@@ -1,5 +1,5 @@
 export { validateKiloToken } from './jwt';
-export type { TokenPayload, ValidateResult } from './jwt';
+export type { ValidateResult } from './jwt';
 export { authMiddleware, internalApiMiddleware } from './middleware';
 export { sandboxIdFromUserId, userIdFromSandboxId } from './sandbox-id';
 export { deriveGatewayToken } from './gateway-token';

--- a/kiloclaw/src/auth/jwt.test.ts
+++ b/kiloclaw/src/auth/jwt.test.ts
@@ -45,10 +45,7 @@ describe('validateKiloToken', () => {
     });
 
     const result = await validateKiloToken(token, TEST_SECRET, undefined);
-    expect(result).toEqual({
-      success: false,
-      error: 'Invalid token',
-    });
+    expect(result.success).toBe(false);
   });
 
   it('rejects env mismatch', async () => {

--- a/kiloclaw/src/auth/jwt.ts
+++ b/kiloclaw/src/auth/jwt.ts
@@ -29,18 +29,15 @@ export async function validateKiloToken(
     return { success: false, error: 'Invalid token' };
   }
 
-  const payloadEnv = typeof payload['env'] === 'string' ? payload['env'] : undefined;
-  if (expectedEnv && payloadEnv && payloadEnv !== expectedEnv) {
+  if (expectedEnv && payload.env && payload.env !== expectedEnv) {
     return { success: false, error: 'Invalid token' };
   }
-
-  const pepper = typeof payload['apiTokenPepper'] === 'string' ? payload['apiTokenPepper'] : null;
 
   return {
     success: true,
     userId: payload.kiloUserId,
     token,
-    pepper,
+    pepper: payload.apiTokenPepper ?? null,
   };
 }
 

--- a/kiloclaw/src/auth/jwt.ts
+++ b/kiloclaw/src/auth/jwt.ts
@@ -1,42 +1,10 @@
-import { jwtVerify, SignJWT } from 'jose';
+import { SignJWT } from 'jose';
+import { verifyKiloToken } from '@kilocode/worker-utils';
 import { KILO_TOKEN_VERSION, KILOCLAW_AUTH_COOKIE_MAX_AGE } from '../config';
-
-/**
- * Shape of the JWT payload issued by the cloud Next.js app.
- * Must stay in sync with cloud's generateApiToken() in src/lib/tokens.ts.
- */
-export type TokenPayload = {
-  kiloUserId: string;
-  apiTokenPepper: string | null;
-  version: number;
-  env?: string;
-};
 
 export type ValidateResult =
   | { success: true; userId: string; token: string; pepper: string | null }
   | { success: false; error: string };
-
-function parseTokenPayload(
-  raw: Record<string, unknown>
-): { ok: true; payload: TokenPayload } | { ok: false; error: string } {
-  const { kiloUserId, apiTokenPepper, version } = raw;
-  if (typeof kiloUserId !== 'string') {
-    return { ok: false, error: 'Missing or invalid kiloUserId' };
-  }
-  if (
-    apiTokenPepper !== null &&
-    apiTokenPepper !== undefined &&
-    typeof apiTokenPepper !== 'string'
-  ) {
-    return { ok: false, error: 'Invalid apiTokenPepper type' };
-  }
-  if (typeof version !== 'number') {
-    return { ok: false, error: 'Missing or invalid version' };
-  }
-  const env = typeof raw.env === 'string' ? raw.env : undefined;
-  const pepper = typeof apiTokenPepper === 'string' ? apiTokenPepper : null;
-  return { ok: true, payload: { kiloUserId, apiTokenPepper: pepper, version, env } };
-}
 
 /**
  * Verify a Kilo JWT using HS256 symmetric secret.
@@ -49,16 +17,9 @@ export async function validateKiloToken(
   secret: string,
   expectedEnv: string | undefined
 ): Promise<ValidateResult> {
-  let payload: TokenPayload;
+  let payload: Awaited<ReturnType<typeof verifyKiloToken>>;
   try {
-    const result = await jwtVerify(token, new TextEncoder().encode(secret), {
-      algorithms: ['HS256'],
-    });
-    const parsed = parseTokenPayload(result.payload);
-    if (!parsed.ok) {
-      return { success: false, error: parsed.error };
-    }
-    payload = parsed.payload;
+    payload = await verifyKiloToken(token, secret);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'JWT verification failed';
     return { success: false, error: message };
@@ -68,15 +29,18 @@ export async function validateKiloToken(
     return { success: false, error: 'Invalid token' };
   }
 
-  if (expectedEnv && payload.env && payload.env !== expectedEnv) {
+  const payloadEnv = typeof payload['env'] === 'string' ? payload['env'] : undefined;
+  if (expectedEnv && payloadEnv && payloadEnv !== expectedEnv) {
     return { success: false, error: 'Invalid token' };
   }
+
+  const pepper = typeof payload['apiTokenPepper'] === 'string' ? payload['apiTokenPepper'] : null;
 
   return {
     success: true,
     userId: payload.kiloUserId,
     token,
-    pepper: payload.apiTokenPepper,
+    pepper,
   };
 }
 

--- a/kiloclaw/src/auth/jwt.ts
+++ b/kiloclaw/src/auth/jwt.ts
@@ -9,7 +9,7 @@ export type ValidateResult =
 /**
  * Verify a Kilo JWT using HS256 symmetric secret.
  *
- * Checks: signature, expiration (built into jose), version === KILO_TOKEN_VERSION,
+ * Checks: signature, expiration (built into jose), version === 3 (via shared schema),
  * and optional env match against the worker's WORKER_ENV.
  */
 export async function validateKiloToken(
@@ -23,10 +23,6 @@ export async function validateKiloToken(
   } catch (err) {
     const message = err instanceof Error ? err.message : 'JWT verification failed';
     return { success: false, error: message };
-  }
-
-  if (payload.version !== KILO_TOKEN_VERSION) {
-    return { success: false, error: 'Invalid token' };
   }
 
   if (expectedEnv && payload.env && payload.env !== expectedEnv) {

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "aws4fetch": "catalog:",
     "hono": "catalog:",
+    "jose": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -22,3 +22,6 @@ export { createErrorHandler } from './error-handler.js';
 export { createNotFoundHandler } from './not-found-handler.js';
 
 export type { Owner, MCPServerConfig } from './types.js';
+
+export { verifyKiloToken, kiloTokenAuthMiddleware, kiloTokenPayload } from './kilo-token.js';
+export type { KiloTokenPayload } from './kilo-token.js';

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -23,5 +23,5 @@ export { createNotFoundHandler } from './not-found-handler.js';
 
 export type { Owner, MCPServerConfig } from './types.js';
 
-export { verifyKiloToken, kiloTokenAuthMiddleware, kiloTokenPayload } from './kilo-token.js';
+export { verifyKiloToken, kiloTokenPayload } from './kilo-token.js';
 export type { KiloTokenPayload } from './kilo-token.js';

--- a/packages/worker-utils/src/kilo-token.test.ts
+++ b/packages/worker-utils/src/kilo-token.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { SignJWT } from 'jose';
+import { verifyKiloToken } from './kilo-token.js';
+
+const SECRET = 'test-secret-at-least-32-characters-long';
+
+function encode(secret: string) {
+  return new TextEncoder().encode(secret);
+}
+
+async function sign(payload: Record<string, unknown>, secret = SECRET, expiresIn = '1h') {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(expiresIn)
+    .sign(encode(secret));
+}
+
+describe('verifyKiloToken', () => {
+  it('accepts a valid version-3 token', async () => {
+    const token = await sign({ version: 3, kiloUserId: 'user-123' });
+    const payload = await verifyKiloToken(token, SECRET);
+    expect(payload.kiloUserId).toBe('user-123');
+    expect(payload.version).toBe(3);
+  });
+
+  it('passthrough preserves extra claims', async () => {
+    const token = await sign({
+      version: 3,
+      kiloUserId: 'user-456',
+      apiTokenPepper: 'pepper-abc',
+      organizationId: 'org-1',
+    });
+    const payload = await verifyKiloToken(token, SECRET);
+    expect(payload.kiloUserId).toBe('user-456');
+    // Extra claims survive the parse
+    expect((payload as Record<string, unknown>).apiTokenPepper).toBe('pepper-abc');
+    expect((payload as Record<string, unknown>).organizationId).toBe('org-1');
+  });
+
+  it('rejects wrong version', async () => {
+    const token = await sign({ version: 2, kiloUserId: 'user-123' });
+    await expect(verifyKiloToken(token, SECRET)).rejects.toThrow();
+  });
+
+  it('rejects token missing kiloUserId', async () => {
+    const token = await sign({ version: 3 });
+    await expect(verifyKiloToken(token, SECRET)).rejects.toThrow();
+  });
+
+  it('rejects empty kiloUserId', async () => {
+    const token = await sign({ version: 3, kiloUserId: '' });
+    await expect(verifyKiloToken(token, SECRET)).rejects.toThrow();
+  });
+
+  it('rejects wrong secret', async () => {
+    const token = await sign({ version: 3, kiloUserId: 'user-123' });
+    await expect(
+      verifyKiloToken(token, 'wrong-secret-that-is-at-least-32-chars')
+    ).rejects.toThrow();
+  });
+
+  it('rejects expired token', async () => {
+    const token = await sign({ version: 3, kiloUserId: 'user-123' }, SECRET, '0s');
+    await expect(verifyKiloToken(token, SECRET)).rejects.toThrow();
+  });
+
+  it('rejects a non-JWT string', async () => {
+    await expect(verifyKiloToken('not.a.token', SECRET)).rejects.toThrow();
+  });
+});

--- a/packages/worker-utils/src/kilo-token.ts
+++ b/packages/worker-utils/src/kilo-token.ts
@@ -1,12 +1,30 @@
 import { jwtVerify } from 'jose';
 import { z } from 'zod';
 
-export const kiloTokenPayload = z
-  .object({
-    version: z.literal(3),
-    kiloUserId: z.string().min(1),
-  })
-  .passthrough();
+/**
+ * All known fields that can appear in a Kilo user JWT, sourced from
+ * generateApiToken() / generateOrganizationApiToken() in src/lib/tokens.ts.
+ * All optional fields beyond version+kiloUserId default to undefined when absent.
+ */
+export const kiloTokenPayload = z.object({
+  // Core — always present
+  version: z.literal(3),
+  kiloUserId: z.string().min(1),
+  // Present in generateApiToken / generateOrganizationApiToken, absent in generateInternalServiceToken
+  apiTokenPepper: z.string().nullable().optional(),
+  env: z.string().optional(),
+  // Optional extras from JWTTokenExtraPayload
+  botId: z.string().optional(),
+  organizationId: z.string().optional(),
+  organizationRole: z.enum(['owner', 'member', 'billing_manager']).optional(),
+  internalApiUse: z.boolean().optional(),
+  createdOnPlatform: z.string().optional(),
+  tokenSource: z.string().optional(),
+  deviceAuthRequestCode: z.string().optional(),
+  // Standard JWT claims
+  iat: z.number().optional(),
+  exp: z.number().optional(),
+});
 
 export type KiloTokenPayload = z.infer<typeof kiloTokenPayload>;
 
@@ -14,8 +32,7 @@ export type KiloTokenPayload = z.infer<typeof kiloTokenPayload>;
  * Verify a Kilo user JWT (HS256, version 3).
  *
  * Checks: signature, expiration (built into jose), version === 3, and that
- * kiloUserId is a non-empty string. Uses .passthrough() so worker-specific
- * claims (e.g. apiTokenPepper, organizationId) are preserved in the result.
+ * kiloUserId is a non-empty string.
  *
  * @throws if the token is invalid, expired, or fails schema validation.
  */

--- a/packages/worker-utils/src/kilo-token.ts
+++ b/packages/worker-utils/src/kilo-token.ts
@@ -1,7 +1,5 @@
 import { jwtVerify } from 'jose';
 import { z } from 'zod';
-import type { MiddlewareHandler } from 'hono';
-import { extractBearerToken } from './extract-bearer-token.js';
 
 export const kiloTokenPayload = z
   .object({
@@ -27,40 +25,4 @@ export async function verifyKiloToken(token: string, secret: string): Promise<Ki
   });
 
   return kiloTokenPayload.parse(payload);
-}
-
-type KiloTokenEnv = {
-  Bindings: Record<never, never>;
-  Variables: { kiloUserId: string; kiloTokenPayload: KiloTokenPayload };
-};
-
-/**
- * Hono middleware that extracts + verifies a Kilo user token from the
- * `Authorization: Bearer` header and sets `kiloUserId` and `kiloTokenPayload`
- * on the Hono context.
- *
- * @param getSecret - Callback to retrieve the NEXTAUTH_SECRET from the context.
- */
-export function kiloTokenAuthMiddleware(
-  getSecret: (c: Parameters<MiddlewareHandler<KiloTokenEnv>>[0]) => string | Promise<string>
-): MiddlewareHandler<KiloTokenEnv> {
-  return async (c, next) => {
-    const token = extractBearerToken(c.req.header('Authorization'));
-    if (!token) {
-      return c.json({ success: false, error: 'Missing or malformed Authorization header' }, 401);
-    }
-
-    const secret = await getSecret(c);
-
-    let payload: KiloTokenPayload;
-    try {
-      payload = await verifyKiloToken(token, secret);
-    } catch {
-      return c.json({ success: false, error: 'Invalid or expired token' }, 401);
-    }
-
-    c.set('kiloUserId', payload.kiloUserId);
-    c.set('kiloTokenPayload', payload);
-    return next();
-  };
 }

--- a/packages/worker-utils/src/kilo-token.ts
+++ b/packages/worker-utils/src/kilo-token.ts
@@ -1,0 +1,66 @@
+import { jwtVerify } from 'jose';
+import { z } from 'zod';
+import type { MiddlewareHandler } from 'hono';
+import { extractBearerToken } from './extract-bearer-token.js';
+
+export const kiloTokenPayload = z
+  .object({
+    version: z.literal(3),
+    kiloUserId: z.string().min(1),
+  })
+  .passthrough();
+
+export type KiloTokenPayload = z.infer<typeof kiloTokenPayload>;
+
+/**
+ * Verify a Kilo user JWT (HS256, version 3).
+ *
+ * Checks: signature, expiration (built into jose), version === 3, and that
+ * kiloUserId is a non-empty string. Uses .passthrough() so worker-specific
+ * claims (e.g. apiTokenPepper, organizationId) are preserved in the result.
+ *
+ * @throws if the token is invalid, expired, or fails schema validation.
+ */
+export async function verifyKiloToken(token: string, secret: string): Promise<KiloTokenPayload> {
+  const { payload } = await jwtVerify(token, new TextEncoder().encode(secret), {
+    algorithms: ['HS256'],
+  });
+
+  return kiloTokenPayload.parse(payload);
+}
+
+type KiloTokenEnv = {
+  Bindings: Record<never, never>;
+  Variables: { kiloUserId: string; kiloTokenPayload: KiloTokenPayload };
+};
+
+/**
+ * Hono middleware that extracts + verifies a Kilo user token from the
+ * `Authorization: Bearer` header and sets `kiloUserId` and `kiloTokenPayload`
+ * on the Hono context.
+ *
+ * @param getSecret - Callback to retrieve the NEXTAUTH_SECRET from the context.
+ */
+export function kiloTokenAuthMiddleware(
+  getSecret: (c: Parameters<MiddlewareHandler<KiloTokenEnv>>[0]) => string | Promise<string>
+): MiddlewareHandler<KiloTokenEnv> {
+  return async (c, next) => {
+    const token = extractBearerToken(c.req.header('Authorization'));
+    if (!token) {
+      return c.json({ success: false, error: 'Missing or malformed Authorization header' }, 401);
+    }
+
+    const secret = await getSecret(c);
+
+    let payload: KiloTokenPayload;
+    try {
+      payload = await verifyKiloToken(token, secret);
+    } catch {
+      return c.json({ success: false, error: 'Invalid or expired token' }, 401);
+    }
+
+    c.set('kiloUserId', payload.kiloUserId);
+    c.set('kiloTokenPayload', payload);
+    return next();
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     hono:
       specifier: ^4.12.1
       version: 4.12.2
+    jose:
+      specifier: ^6.0.0
+      version: 6.1.3
     jsonwebtoken:
       specifier: ^9.0.3
       version: 9.0.3
@@ -675,9 +678,6 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.2
-      jsonwebtoken:
-        specifier: 'catalog:'
-        version: 9.0.3
       workers-tagged-logger:
         specifier: 'catalog:'
         version: 1.0.0
@@ -691,9 +691,6 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
-      '@types/jsonwebtoken':
-        specifier: 'catalog:'
-        version: 9.0.10
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.9
@@ -1226,9 +1223,6 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.2
-      jsonwebtoken:
-        specifier: 'catalog:'
-        version: 9.0.3
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1437,6 +1431,9 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.2
+      jose:
+        specifier: 'catalog:'
+        version: 6.1.3
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -17976,7 +17973,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1233,9 +1233,6 @@ importers:
       '@kilocode/eslint-config':
         specifier: workspace:*
         version: link:../packages/eslint-config
-      '@types/jsonwebtoken':
-        specifier: 'catalog:'
-        version: 9.0.10
       '@types/node':
         specifier: ^22
         version: 22.19.1
@@ -1245,6 +1242,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.3(jiti@2.6.1)
+      jose:
+        specifier: 'catalog:'
+        version: 6.1.3
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ catalog:
   drizzle-orm: ^0.45.1
   eslint: ^9.39.3
   hono: ^4.12.1
+  jose: ^6.0.0
   jsonwebtoken: ^9.0.3
   prettier: ^3.8.1
   typescript: ^5.9.3


### PR DESCRIPTION
## Summary

- Adds `verifyKiloToken(token, secret)` to `@kilocode/worker-utils`: async, `jose`-based (Web Crypto native, no Node compat shim), HS256, Zod-validated (`version: literal(3)`, `kiloUserId: string.min(1)`, `.passthrough()` for worker-specific extra claims)
- Adds `kiloTokenAuthMiddleware(getSecret)`: thin Hono wrapper that extracts the bearer token, calls the above, and sets `kiloUserId` + `kiloTokenPayload` on the Hono context
- Migrates all 5 workers that validate Kilo user tokens to use the shared function, removing duplicated `jsonwebtoken`-based verify logic:
  - `kiloclaw` — replaces local `parseTokenPayload` + `jwtVerify`; retains env-match check and pepper extraction from passthrough payload
  - `cloudflare-session-ingest` — replaces `isTokenPayloadV3` + `jwt.verify`; retains KV-cached user-existence check
  - `cloudflare-ai-attribution` — replaces `jwt.verify`; retains Zod refinement for org claims
  - `cloud-agent` — `validateKiloToken` becomes async; `authenticate` and all call sites in `index.ts` / `balance-validation.ts` updated accordingly
  - `cloud-agent-next` — same as cloud-agent; also updates `middleware/auth.ts`
- Drops `jsonwebtoken` + `@types/jsonwebtoken` from `cloudflare-session-ingest` and `cloudflare-ai-attribution` (no longer needed); `cloud-agent` and `cloud-agent-next` retain it for `validateStreamTicket`
- Adds `jose` to the pnpm catalog (pinned `^6.0.0`, matching kiloclaw's existing version)
- 8 new unit tests in `packages/worker-utils/src/kilo-token.test.ts`

## Checklist

- All 6 affected packages typecheck clean (`pnpm typecheck`)
- All tests pass (`pnpm test` — 26 worker-utils, 488 kiloclaw, 456 cloud-agent)
- All 6 affected packages lint clean (`pnpm lint`)