### PR TITLE
CloudAgentNext - Optimistic message display and failed-send text restoration

### DIFF
--- a/src/components/cloud-agent-next/ChatInput.tsx
+++ b/src/components/cloud-agent-next/ChatInput.tsx
@@ -35,6 +35,8 @@ type ChatInputProps = {
   onModelChange?: (model: string) => void;
   /** Whether to show the toolbar (hide when no active session) */
   showToolbar?: boolean;
+  /** Pre-populate the textarea (e.g. to restore text after a failed send) */
+  initialValue?: string;
 };
 
 export function ChatInput({
@@ -51,11 +53,20 @@ export function ChatInput({
   onModeChange,
   onModelChange,
   showToolbar = false,
+  initialValue,
 }: ChatInputProps) {
   const [value, setValue] = useState('');
   const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Restore text into the textarea when initialValue changes (e.g. after a failed send).
+  // Treats undefined as "no opinion" (skip), but empty string actively clears the field.
+  useEffect(() => {
+    if (initialValue !== undefined) {
+      setValue(initialValue);
+    }
+  }, [initialValue]);
 
   // Filter commands based on current input
   const filteredCommands = useMemo(() => {

--- a/src/components/cloud-agent-next/ChatInput.tsx
+++ b/src/components/cloud-agent-next/ChatInput.tsx
@@ -65,6 +65,7 @@ export function ChatInput({
   useEffect(() => {
     if (initialValue !== undefined) {
       setValue(initialValue);
+      textareaRef.current?.focus();
     }
   }, [initialValue]);
 

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -815,6 +815,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
             console.error('Failed to prepare existing session:', err);
             setError('Failed to prepare session. Please try again.');
             toast.error('Failed to prepare session. Please try again.');
+            setFailedMessageText(prompt);
             return;
           }
         }
@@ -849,6 +850,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
             console.error('Failed to prepare session for resume:', err);
             setError('Failed to prepare session. Please try again.');
             toast.error('Failed to prepare session. Please try again.');
+            setFailedMessageText(prompt);
             return;
           }
         }

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -273,6 +273,13 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
     refetchSessions();
   }, [playCelebrationSound, refetchSessions]);
 
+  // Track failed message text to restore into ChatInput on send failure
+  const [failedMessageText, setFailedMessageText] = useState<string | null>(null);
+
+  const handleSendFailed = useCallback((messageText: string) => {
+    setFailedMessageText(messageText);
+  }, []);
+
   // Stream hook (V2 WebSocket-based)
   const {
     sendMessage: sendMessageV2,
@@ -288,6 +295,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
     onKiloSessionCreated: handleKiloSessionCreated,
     onSessionInitiated: handleSessionInitiated,
     onQuestionAsked: playNotification,
+    onSendFailed: handleSendFailed,
   });
 
   // Wrapper for sendMessage that doesn't use sessionIdOverride
@@ -750,6 +758,8 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   // Handle send message
   const handleSendMessage = useCallback(
     async (prompt: string) => {
+      // Clear any previously failed message text so a repeated failure can re-trigger initialValue
+      setFailedMessageText(null);
       // Use cloudAgentSessionId (from IndexedDB for resumed sessions) or
       // currentSessionId (from stream for new sessions)
       let effectiveSessionId = cloudAgentSessionId || currentSessionId || null;
@@ -979,6 +989,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
         autocommitStatus={autocommitStatus}
         getChildMessages={getChildSessionMessages}
         standaloneQuestion={standaloneQuestion}
+        chatInputInitialValue={failedMessageText ?? undefined}
       />
     </QuestionContextProvider>
   );

--- a/src/components/cloud-agent-next/CloudChatPresentation.tsx
+++ b/src/components/cloud-agent-next/CloudChatPresentation.tsx
@@ -178,6 +178,9 @@ export type CloudChatPresentationProps = {
   inputModel?: string;
   onInputModeChange?: (mode: AgentMode) => void;
   onInputModelChange?: (model: string) => void;
+
+  /** Pre-populate the ChatInput textarea (e.g. to restore text after a failed send) */
+  chatInputInitialValue?: string;
 };
 
 /**
@@ -243,6 +246,7 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
   inputModel,
   onInputModeChange,
   onInputModelChange,
+  chatInputInitialValue,
 }: CloudChatPresentationProps) {
   // Show chat interface when we have:
   // 1. An active streaming session (currentSessionId + sessionConfig)
@@ -473,6 +477,7 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
               onModeChange={onInputModeChange}
               onModelChange={onInputModelChange}
               showToolbar={Boolean(currentDbSessionId) && !needsResumeConfig}
+              initialValue={chatInputInitialValue}
             />
 
             {/* Banner for sessions needing configuration */}

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -287,8 +287,8 @@ export const addUserMessageAtom = atom(
     }
   ): string => {
     const { sessionId, content, agent = 'code', model = { providerID: '', modelID: '' } } = payload;
-    const messageId = `optimistic-${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-    const partId = `part_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    const messageId = `optimistic-${crypto.randomUUID()}`;
+    const partId = `part_${crypto.randomUUID()}`;
     const now = Date.now();
 
     const userMessage: StoredMessage = {
@@ -334,8 +334,8 @@ export const addUserMessageAtom = atom(
 /**
  * Remove the optimistic user message (if any) from the store.
  * No-op when no optimistic message exists (avoids unnecessary Map copies / subscriber notifications).
+ * Returns true if an optimistic message was found and removed.
  */
-/** Returns true if an optimistic message was found and removed. */
 export const removeOptimisticMessageAtom = atom(null, (get, set): boolean => {
   const messagesMap = get(messagesMapAtom);
 

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -287,7 +287,7 @@ export const addUserMessageAtom = atom(
     }
   ) => {
     const { sessionId, content, agent = 'code', model = { providerID: '', modelID: '' } } = payload;
-    const messageId = `user_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    const messageId = `optimistic-${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
     const partId = `part_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
     const now = Date.now();
 
@@ -328,6 +328,38 @@ export const addUserMessageAtom = atom(
     set(partsMapAtom, partsMap);
   }
 );
+
+/**
+ * Remove the optimistic user message (if any) from the store.
+ * No-op when no optimistic message exists (avoids unnecessary Map copies / subscriber notifications).
+ */
+export const removeOptimisticMessageAtom = atom(null, (get, set) => {
+  const messagesMap = get(messagesMapAtom);
+
+  // Find the optimistic message without copying first
+  let optimisticId: string | null = null;
+  for (const id of messagesMap.keys()) {
+    if (id.startsWith('optimistic-')) {
+      optimisticId = id;
+      break;
+    }
+  }
+  if (!optimisticId) return;
+
+  const message = messagesMap.get(optimisticId);
+  const newMessagesMap = new Map(messagesMap);
+  const newPartsMap = new Map(get(partsMapAtom));
+
+  if (message) {
+    for (const part of message.parts) {
+      newPartsMap.delete(part.id);
+    }
+  }
+  newMessagesMap.delete(optimisticId);
+
+  set(messagesMapAtom, newMessagesMap);
+  set(partsMapAtom, newPartsMap);
+});
 
 /**
  * Update a message in a child session.

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -285,7 +285,7 @@ export const addUserMessageAtom = atom(
       agent?: string;
       model?: { providerID: string; modelID: string };
     }
-  ) => {
+  ): string => {
     const { sessionId, content, agent = 'code', model = { providerID: '', modelID: '' } } = payload;
     const messageId = `optimistic-${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
     const partId = `part_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
@@ -326,6 +326,8 @@ export const addUserMessageAtom = atom(
     const partsMap = new Map(get(partsMapAtom));
     partsMap.set(partId, { messageId, part: userMessage.parts[0] });
     set(partsMapAtom, partsMap);
+
+    return messageId;
   }
 );
 
@@ -333,7 +335,8 @@ export const addUserMessageAtom = atom(
  * Remove the optimistic user message (if any) from the store.
  * No-op when no optimistic message exists (avoids unnecessary Map copies / subscriber notifications).
  */
-export const removeOptimisticMessageAtom = atom(null, (get, set) => {
+/** Returns true if an optimistic message was found and removed. */
+export const removeOptimisticMessageAtom = atom(null, (get, set): boolean => {
   const messagesMap = get(messagesMapAtom);
 
   // Find the optimistic message without copying first
@@ -344,7 +347,7 @@ export const removeOptimisticMessageAtom = atom(null, (get, set) => {
       break;
     }
   }
-  if (!optimisticId) return;
+  if (!optimisticId) return false;
 
   const message = messagesMap.get(optimisticId);
   const newMessagesMap = new Map(messagesMap);
@@ -359,6 +362,7 @@ export const removeOptimisticMessageAtom = atom(null, (get, set) => {
 
   set(messagesMapAtom, newMessagesMap);
   set(partsMapAtom, newPartsMap);
+  return true;
 });
 
 /**

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -40,6 +40,8 @@ import {
   autocommitStatusAtom,
   standaloneQuestionAtom,
   clearStandaloneQuestionAtom,
+  addUserMessageAtom,
+  removeOptimisticMessageAtom,
 } from './store/atoms';
 import {
   updateHighWaterMarkAtom,
@@ -65,6 +67,8 @@ export type UseCloudAgentStreamOptions = {
   onSessionInitiated?: () => void;
   /** Callback when the agent asks a question */
   onQuestionAsked?: () => void;
+  /** Callback when sendMessage fails — receives the original message text for restoring to input */
+  onSendFailed?: (messageText: string) => void;
 };
 
 export type UseCloudAgentStreamReturn = {
@@ -102,6 +106,7 @@ export function useCloudAgentStream({
   onKiloSessionCreated,
   onSessionInitiated,
   onQuestionAsked,
+  onSendFailed,
 }: UseCloudAgentStreamOptions): UseCloudAgentStreamReturn {
   const trpcClient = useRawTRPCClient();
 
@@ -120,6 +125,10 @@ export function useCloudAgentStream({
   const setQuestionRequestId = useSetAtom(setQuestionRequestIdAtom);
   const setStandaloneQuestion = useSetAtom(standaloneQuestionAtom);
   const clearStandaloneQuestion = useSetAtom(clearStandaloneQuestionAtom);
+
+  // Atoms for optimistic message display
+  const addUserMessage = useSetAtom(addUserMessageAtom);
+  const removeOptimisticMessage = useSetAtom(removeOptimisticMessageAtom);
 
   // Atom for organization ID (used by QuestionToolCard for tRPC calls)
   const setSessionOrganizationId = useSetAtom(sessionOrganizationIdAtom);
@@ -156,6 +165,7 @@ export function useCloudAgentStream({
   const onKiloSessionCreatedRef = useRef(onKiloSessionCreated);
   const onSessionInitiatedRef = useRef(onSessionInitiated);
   const onQuestionAskedRef = useRef(onQuestionAsked);
+  const onSendFailedRef = useRef(onSendFailed);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -172,6 +182,10 @@ export function useCloudAgentStream({
   useEffect(() => {
     onQuestionAskedRef.current = onQuestionAsked;
   }, [onQuestionAsked]);
+
+  useEffect(() => {
+    onSendFailedRef.current = onSendFailed;
+  }, [onSendFailed]);
 
   useEffect(() => {
     cloudAgentSessionIdRef.current = cloudAgentSessionIdProp ?? null;
@@ -191,6 +205,11 @@ export function useCloudAgentStream({
     () => ({
       onMessageUpdated: (sessionId, messageId, message, parentSessionId) => {
         if (parentSessionId === null) {
+          // When the server echoes a user message, remove the optimistic placeholder first
+          if (message.info.role === 'user') {
+            removeOptimisticMessage();
+          }
+
           // Root session message
           updateMessage({ messageId, info: message.info, parts: message.parts });
 
@@ -345,6 +364,7 @@ export function useCloudAgentStream({
       setQuestionRequestId,
       setStandaloneQuestion,
       clearStandaloneQuestion,
+      removeOptimisticMessage,
     ]
   );
 
@@ -706,6 +726,9 @@ export function useCloudAgentStream({
         return;
       }
 
+      // Display the user's message optimistically before the server echoes it back
+      addUserMessage({ sessionId: activeCloudAgentSessionId, content: message, agent: mode });
+
       // Update ref to match the session we're sending to
       cloudAgentSessionIdRef.current = activeCloudAgentSessionId;
 
@@ -743,13 +766,25 @@ export function useCloudAgentStream({
           await connectWebSocket(result.cloudAgentSessionId);
         }
       } catch (err) {
+        // Remove the optimistic message on failure and restore text to input
+        removeOptimisticMessage();
+        onSendFailedRef.current?.(message);
+
         const errorMessage = formatStreamError(err);
         setLocalError(errorMessage);
         setError(errorMessage);
         setIsStreaming(false);
       }
     },
-    [trpcClient, connectWebSocket, formatStreamError, setError, setIsStreaming]
+    [
+      trpcClient,
+      connectWebSocket,
+      formatStreamError,
+      setError,
+      setIsStreaming,
+      addUserMessage,
+      removeOptimisticMessage,
+    ]
   );
 
   return {

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -157,6 +157,7 @@ export function useCloudAgentStream({
   const wsManagerRef = useRef<ReturnType<typeof createWebSocketManager> | null>(null);
   const notifiedKiloSessionIdsRef = useRef<Set<string>>(new Set());
   const sessionInitiatedFiredRef = useRef<Set<string>>(new Set());
+  const optimisticMessageIdRef = useRef<string | null>(null);
   const cloudAgentSessionIdRef = useRef<string | null>(cloudAgentSessionIdProp ?? null);
   const organizationIdRef = useRef<string | undefined>(organizationId);
 
@@ -205,9 +206,10 @@ export function useCloudAgentStream({
     () => ({
       onMessageUpdated: (sessionId, messageId, message, parentSessionId) => {
         if (parentSessionId === null) {
-          // When the server echoes a user message, remove the optimistic placeholder first
-          if (message.info.role === 'user') {
+          // When the server echoes the user message we displayed optimistically, remove the placeholder
+          if (optimisticMessageIdRef.current && message.info.role === 'user') {
             removeOptimisticMessage();
+            optimisticMessageIdRef.current = null;
           }
 
           // Root session message
@@ -727,7 +729,11 @@ export function useCloudAgentStream({
       }
 
       // Display the user's message optimistically before the server echoes it back
-      addUserMessage({ sessionId: activeCloudAgentSessionId, content: message, agent: mode });
+      optimisticMessageIdRef.current = addUserMessage({
+        sessionId: activeCloudAgentSessionId,
+        content: message,
+        agent: mode,
+      });
 
       // Update ref to match the session we're sending to
       cloudAgentSessionIdRef.current = activeCloudAgentSessionId;
@@ -766,9 +772,16 @@ export function useCloudAgentStream({
           await connectWebSocket(result.cloudAgentSessionId);
         }
       } catch (err) {
-        // Remove the optimistic message on failure and restore text to input
-        removeOptimisticMessage();
-        onSendFailedRef.current?.(message);
+        // Remove the optimistic message on failure and restore text to input.
+        // If the server already echoed the real message (race: server succeeded but
+        // client timed out), removeOptimisticMessage returns false and we skip
+        // restoring text to avoid confusing the user with both the chat message
+        // and a pre-filled input.
+        const wasStillOptimistic = removeOptimisticMessage();
+        optimisticMessageIdRef.current = null;
+        if (wasStillOptimistic) {
+          onSendFailedRef.current?.(message);
+        }
 
         const errorMessage = formatStreamError(err);
         setLocalError(errorMessage);


### PR DESCRIPTION
## Summary

- Display the user's message in the chat immediately on send (optimistic UI) instead of waiting for the server echo, making the experience feel instant.
- On send failure, remove the optimistic message and restore the original text back into `ChatInput` so the user can retry without retyping.

## Changes

- **`store/atoms.ts`**: Rename optimistic message ID prefix to `optimistic-` for identification. Add `removeOptimisticMessageAtom` that removes the optimistic message and its parts from the store.
- **`useCloudAgentStream.ts`**: Call `addUserMessage` before the tRPC send to show the message optimistically. Replace the optimistic message when the server echoes the real user message. On failure, remove the optimistic message and invoke `onSendFailed` callback with the original text.
- **`CloudChatContainer.tsx`**: Track `failedMessageText` state, wire `onSendFailed` callback, and pass `chatInputInitialValue` to the presentation layer. Clear the failed text on the next send attempt.
- **`CloudChatPresentation.tsx`**: Thread `chatInputInitialValue` prop down to `ChatInput`.
- **`ChatInput.tsx`**: Accept `initialValue` prop and sync it into the textarea via `useEffect` so failed message text is restored.