### PR TITLE
CloudAgentNext - Improve interrupted session UI and error handling

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -402,27 +402,28 @@ export class CloudAgentSession extends DurableObject {
               logger
                 .withFields({ executionId: activeExecutionId, error: statusResult.error })
                 .info('Skipping disconnect cleanup - status transition failed');
-            } else {
-              // Clear active execution (updateStatus should do this, but ensure it)
-              await this.executionQueries.clearActiveExecution();
-
-              // Clear interrupt flag if set
-              await this.executionQueries.clearInterrupt();
-
-              // Insert a synthetic wrapper_disconnected event so /stream clients are notified
-              const sessionId = await this.requireSessionId();
-              this.insertAndBroadcastEvent({
-                executionId: activeExecutionId,
-                sessionId,
-                streamEventType: 'wrapper_disconnected',
-                payload: JSON.stringify({
-                  reason: 'Wrapper disconnected',
-                  wsCloseCode: code,
-                  wsCloseReason: reason,
-                }),
-                timestamp: now,
-              });
+              return;
             }
+
+            // Clear active execution (updateStatus should do this, but ensure it)
+            await this.executionQueries.clearActiveExecution();
+
+            // Clear interrupt flag if set
+            await this.executionQueries.clearInterrupt();
+
+            // Insert a synthetic wrapper_disconnected event so /stream clients are notified
+            const sessionId = await this.requireSessionId();
+            this.insertAndBroadcastEvent({
+              executionId: activeExecutionId,
+              sessionId,
+              streamEventType: 'wrapper_disconnected',
+              payload: JSON.stringify({
+                reason: 'Wrapper disconnected',
+                wsCloseCode: code,
+                wsCloseReason: reason,
+              }),
+              timestamp: now,
+            });
           }
         }
       }

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -284,12 +284,6 @@ export function createSessionManagementHandlers() {
 
                 await withDORetry(
                   getStub,
-                  stub => stub.clearInterruptRequest(),
-                  'clearInterruptRequest'
-                );
-
-                await withDORetry(
-                  getStub,
                   stub =>
                     stub.emitExecutionError(
                       activeExecutionId,

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -85,12 +85,10 @@ export const SendMessageV2Input = z
     autoCommit: z
       .boolean()
       .optional()
-      .default(false)
       .describe('Automatically commit and push changes after execution'),
     condenseOnComplete: z
       .boolean()
       .optional()
-      .default(false)
       .describe('Automatically condense context after execution completes'),
     githubToken: z
       .string()

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -62,6 +62,7 @@ export type KilocodeEventData = {
  */
 export type AutocommitStartedData = {
   message: string;
+  messageId?: string;
 };
 
 /**
@@ -70,7 +71,10 @@ export type AutocommitStartedData = {
 export type AutocommitCompletedData = {
   success: boolean;
   message: string;
+  messageId?: string;
   skipped?: boolean;
+  commitHash?: string;
+  commitMessage?: string;
 };
 
 /**

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -13,6 +13,7 @@
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { ExecutionId } from '../../../src/types/ids.js';
 
@@ -70,7 +71,8 @@ describe('Disconnect handling & reaper', () => {
       const execution = await instance.getExecution(excId);
 
       // Check events for synthetic error event
-      const eventQueries = createEventQueries(state.storage.sql);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 
@@ -138,7 +140,8 @@ describe('Disconnect handling & reaper', () => {
 
       const execution = await instance.getExecution(excId);
 
-      const eventQueries = createEventQueries(state.storage.sql);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 
@@ -195,7 +198,8 @@ describe('Disconnect handling & reaper', () => {
 
       const execution = await instance.getExecution(excId);
 
-      const eventQueries = createEventQueries(state.storage.sql);
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -12,7 +12,6 @@
  */
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
-import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { ExecutionId } from '../../../src/types/ids.js';
@@ -71,8 +70,7 @@ describe('Disconnect handling & reaper', () => {
       const execution = await instance.getExecution(excId);
 
       // Check events for synthetic error event
-      const db = drizzle(state.storage, { logger: false });
-      const eventQueries = createEventQueries(db, state.storage.sql);
+      const eventQueries = createEventQueries(state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 
@@ -140,8 +138,7 @@ describe('Disconnect handling & reaper', () => {
 
       const execution = await instance.getExecution(excId);
 
-      const db = drizzle(state.storage, { logger: false });
-      const eventQueries = createEventQueries(db, state.storage.sql);
+      const eventQueries = createEventQueries(state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 
@@ -198,8 +195,7 @@ describe('Disconnect handling & reaper', () => {
 
       const execution = await instance.getExecution(excId);
 
-      const db = drizzle(state.storage, { logger: false });
-      const eventQueries = createEventQueries(db, state.storage.sql);
+      const eventQueries = createEventQueries(state.storage.sql);
       const events = eventQueries.findByFilters({ executionIds: [excId] });
       const errorEvents = events.filter(e => e.stream_event_type === 'error');
 

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -7,7 +7,7 @@ const GIT_LOCAL_TIMEOUT_MS = 30_000;
 /** Timeout for git push (network-bound) */
 const GIT_PUSH_TIMEOUT_MS = 60_000;
 /** Timeout for commit message generation API call */
-const COMMIT_MESSAGE_TIMEOUT_MS = 60_000;
+const COMMIT_MESSAGE_TIMEOUT_MS = 30_000;
 
 export type AutoCommitResult = {
   success: boolean;
@@ -20,29 +20,42 @@ export type AutoCommitOptions = {
   upstreamBranch?: string;
   onEvent: (event: IngestEvent) => void;
   kiloClient: KiloClient;
+  /** The assistant message ID this autocommit is associated with (for per-message UI rendering) */
+  messageId?: string;
 };
 
-function emitStarted(onEvent: AutoCommitOptions['onEvent'], message: string): void {
+function emitStarted(
+  onEvent: AutoCommitOptions['onEvent'],
+  message: string,
+  messageId?: string
+): void {
   onEvent({
     streamEventType: 'autocommit_started',
-    data: { message },
+    data: { message, messageId },
     timestamp: new Date().toISOString(),
   });
 }
 
 function emitCompleted(
   onEvent: AutoCommitOptions['onEvent'],
-  result: { success: boolean; message: string; skipped?: boolean }
+  result: {
+    success: boolean;
+    message: string;
+    skipped?: boolean;
+    commitHash?: string;
+    commitMessage?: string;
+  },
+  messageId?: string
 ): void {
   onEvent({
     streamEventType: 'autocommit_completed',
-    data: result,
+    data: { ...result, messageId },
     timestamp: new Date().toISOString(),
   });
 }
 
 export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommitResult> {
-  const { workspacePath, upstreamBranch, onEvent, kiloClient } = opts;
+  const { workspacePath, upstreamBranch, onEvent, kiloClient, messageId } = opts;
 
   logToFile(
     `auto-commit: starting workspacePath=${workspacePath} upstreamBranch=${upstreamBranch ?? '(none)'}`
@@ -54,11 +67,15 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     logToFile(`auto-commit: branch=${branch || '(detached HEAD)'}`);
     if (!branch) {
       logToFile('auto-commit: skipping - detached HEAD state');
-      emitCompleted(onEvent, {
-        success: true,
-        message: 'Skipped: detached HEAD state',
-        skipped: true,
-      });
+      emitCompleted(
+        onEvent,
+        {
+          success: true,
+          message: 'Skipped: detached HEAD state',
+          skipped: true,
+        },
+        messageId
+      );
       return { success: true, skipped: true };
     }
 
@@ -66,11 +83,15 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     const hasUpstream = upstreamBranch !== undefined && upstreamBranch !== '';
     if (!hasUpstream && (branch === 'main' || branch === 'master')) {
       logToFile(`auto-commit: skipping - protected branch ${branch} with no upstream`);
-      emitCompleted(onEvent, {
-        success: true,
-        message: `Skipped: cannot commit to ${branch}`,
-        skipped: true,
-      });
+      emitCompleted(
+        onEvent,
+        {
+          success: true,
+          message: `Skipped: cannot commit to ${branch}`,
+          skipped: true,
+        },
+        messageId
+      );
       return { success: true, skipped: true };
     }
 
@@ -82,19 +103,23 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     if (status.exitCode === 124) {
       const msg = 'git status timed out';
       logToFile(`auto-commit: ${msg} (exit 124)`);
-      emitCompleted(onEvent, { success: false, message: msg });
+      emitCompleted(onEvent, { success: false, message: msg }, messageId);
       return { success: false, error: msg };
     }
     logToFile(`auto-commit: git status exitCode=${status.exitCode}`);
     if (!status.stdout.trim()) {
       logToFile('auto-commit: skipping - no uncommitted changes');
-      emitCompleted(onEvent, { success: true, message: 'No uncommitted changes', skipped: true });
+      emitCompleted(
+        onEvent,
+        { success: true, message: 'No uncommitted changes', skipped: true },
+        messageId
+      );
       return { success: true, skipped: true };
     }
 
-    emitStarted(onEvent, 'Committing changes...');
+    emitStarted(onEvent, 'Generating commit message...', messageId);
 
-    // Generate commit message via kilo server API
+    // Generate commit message via kilo server API, falling back to a generic message on failure
     logToFile('auto-commit: generating commit message');
     let commitMessage: string;
     try {
@@ -110,13 +135,11 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       logToFile(`auto-commit: generated commit message: ${commitMessage}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      logToFile(`auto-commit: commit message generation failed: ${msg}`);
-      emitCompleted(onEvent, {
-        success: false,
-        message: `Failed to generate commit message: ${msg}`,
-      });
-      return { success: false, error: msg };
+      logToFile(`auto-commit: commit message generation failed, using fallback: ${msg}`);
+      commitMessage = 'wip';
     }
+
+    emitStarted(onEvent, 'Committing changes...', messageId);
 
     // Stage all changes
     logToFile('auto-commit: staging changes');
@@ -127,7 +150,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     if (addResult.exitCode !== 0) {
       const msg = `git add failed: ${addResult.stderr.trim()}`;
       logToFile(`auto-commit: ${msg}`);
-      emitCompleted(onEvent, { success: false, message: msg });
+      emitCompleted(onEvent, { success: false, message: msg }, messageId);
       return { success: false, error: msg };
     }
 
@@ -146,11 +169,26 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       if (commitResult.exitCode !== 0) {
         const msg = `git commit failed: ${commitResult.stderr.trim()}`;
         logToFile(`auto-commit: ${msg}`);
-        emitCompleted(onEvent, { success: false, message: msg });
+        emitCompleted(onEvent, { success: false, message: msg }, messageId);
         return { success: false, error: msg };
       }
     }
     logToFile(`auto-commit: commit succeeded: ${commitResult.stdout.trim()}`);
+
+    // Get commit hash for UI display
+    let commitHash: string | undefined;
+    try {
+      const hashResult = await git(['rev-parse', '--short', 'HEAD'], {
+        cwd: workspacePath,
+        timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+      });
+      if (hashResult.exitCode === 0 && hashResult.stdout.trim()) {
+        commitHash = hashResult.stdout.trim();
+        logToFile(`auto-commit: commit hash=${commitHash}`);
+      }
+    } catch {
+      logToFile('auto-commit: failed to get commit hash, continuing without it');
+    }
 
     // Push
     const pushArgs = hasUpstream ? ['push'] : ['push', '-u', 'origin', branch];
@@ -161,21 +199,40 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       // Push failure is non-fatal — changes are committed locally
       const msg = `git push failed: ${pushResult.stderr.trim()}`;
       logToFile(`auto-commit: ${msg}`);
-      emitCompleted(onEvent, {
-        success: true,
-        message: `Changes committed (push failed: ${pushResult.stderr.trim()})`,
-      });
+      emitCompleted(
+        onEvent,
+        {
+          success: true,
+          message: `Changes committed (push failed: ${pushResult.stderr.trim()})`,
+          commitHash,
+          commitMessage,
+        },
+        messageId
+      );
       return { success: true };
     }
 
     logToFile('auto-commit: push succeeded');
     logToFile('auto-commit: completed successfully');
-    emitCompleted(onEvent, { success: true, message: 'Changes committed and pushed' });
+    emitCompleted(
+      onEvent,
+      {
+        success: true,
+        message: 'Changes committed and pushed',
+        commitHash,
+        commitMessage,
+      },
+      messageId
+    );
     return { success: true };
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     logToFile(`auto-commit: error - ${errorMsg}`);
-    emitCompleted(onEvent, { success: false, message: `Auto-commit failed: ${errorMsg}` });
+    emitCompleted(
+      onEvent,
+      { success: false, message: `Auto-commit failed: ${errorMsg}` },
+      messageId
+    );
     return { success: false, error: errorMsg };
   }
 }

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -231,6 +231,23 @@ export function createConnectionManager(
         if (event.streamEventType === 'kilocode') {
           const data = event.data as Record<string, unknown>;
           const eventName = typeof data.event === 'string' ? data.event : '';
+
+          // Track the last root-session assistant message ID for autocommit association.
+          // message.updated events carry { event, properties: { info: { id, role, sessionID } } }
+          if (eventName === 'message.updated') {
+            const props = data.properties;
+            if (isRecord(props)) {
+              const info = props.info;
+              if (isRecord(info) && info.role === 'assistant' && typeof info.id === 'string') {
+                const msgSessionId = info.sessionID;
+                const currentSessionId = state.currentJob?.kiloSessionId;
+                if (!currentSessionId || msgSessionId === currentSessionId) {
+                  state.setLastAssistantMessageId(info.id);
+                }
+              }
+            }
+          }
+
           const terminal = isTerminalErrorEvent({ event: eventName, data });
           if (terminal.isTerminal) {
             callbacks.onTerminalError(terminal.reason ?? 'terminal error');

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -102,10 +102,6 @@ export function createLifecycleManager(
   let isDraining = false;
   let isAborted = false;
 
-  // Incremented on reset() so in-flight triggerDrainAndClose chains from
-  // a previous execution can detect they are stale and bail out.
-  let generation = 0;
-
   // Completion waiter for post-processing tasks (auto-commit, condense)
   let postProcessingResolve: (() => void) | null = null;
   let postProcessingCompleted = false;
@@ -303,6 +299,7 @@ export function createLifecycleManager(
           upstreamBranch: config.upstreamBranch,
           onEvent: event => state.sendToIngest(event),
           kiloClient,
+          messageId: state.lastAssistantMessageId ?? undefined,
         });
         const timeoutPromise = new Promise<'timeout'>(resolve =>
           setTimeout(() => resolve('timeout'), AUTO_COMMIT_TIMEOUT_MS)
@@ -381,10 +378,6 @@ export function createLifecycleManager(
     if (isDraining) return;
     isDraining = true;
 
-    // Capture generation so the async chain can detect if reset() was called
-    // (which starts a new execution) before it reaches the finally block.
-    const drainGeneration = generation;
-
     logToFile(`starting drain period (isAborted=${isAborted})`);
 
     // Run post-completion tasks first (auto-commit, condense), THEN send the complete event.
@@ -411,14 +404,6 @@ export function createLifecycleManager(
         }
       })
       .finally(() => {
-        // If reset() was called while post-completion tasks were running,
-        // a new execution has started — bail out to avoid sending a spurious
-        // complete event or tearing down the new execution's connection.
-        if (drainGeneration !== generation) {
-          logToFile('drain chain cancelled - lifecycle was reset');
-          return;
-        }
-
         // Send complete event to ingest so DO can update execution status and trigger callbacks
         // BUT only if not aborted - fatal errors already sent their own terminal event
         const job = state.currentJob;
@@ -508,7 +493,6 @@ export function createLifecycleManager(
     getMaxRuntimeMs: () => config.maxRuntimeMs,
 
     reset: () => {
-      generation++;
       isAborted = false;
       isDraining = false;
       postProcessingCompleted = false;

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -169,7 +169,7 @@ async function main() {
           // Send interrupted event before aborting
           state.sendToIngest({
             streamEventType: 'interrupted',
-            data: { reason: 'User killed execution' },
+            data: { reason: 'Session stopped' },
             timestamp: new Date().toISOString(),
           });
           // Abort the kilo session

--- a/cloud-agent-next/wrapper/src/state.ts
+++ b/cloud-agent-next/wrapper/src/state.ts
@@ -75,6 +75,9 @@ export class WrapperState {
   // Message counter for ID generation
   private messageCounter = 0;
 
+  // Last root-session assistant message ID (tracked from message.updated kilocode events)
+  private _lastAssistantMessageId: string | null = null;
+
   // Callbacks for sending events to ingest
   private _sendToIngestFn: ((event: IngestEvent) => void) | null = null;
 
@@ -146,6 +149,7 @@ export class WrapperState {
     this.job = null;
     this.inflight.clear();
     this.messageCounter = 0;
+    this._lastAssistantMessageId = null;
   }
 
   // ---------------------------------------------------------------------------
@@ -345,6 +349,26 @@ export class WrapperState {
    */
   clearLastError(): void {
     this._lastError = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assistant Message ID Tracking
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get the last root-session assistant message ID.
+   * Tracked from message.updated kilocode events for autocommit association.
+   */
+  get lastAssistantMessageId(): string | null {
+    return this._lastAssistantMessageId;
+  }
+
+  /**
+   * Update the last assistant message ID.
+   * Called by connection.ts when a message.updated event with role=assistant is seen.
+   */
+  setLastAssistantMessageId(messageId: string): void {
+    this._lastAssistantMessageId = messageId;
   }
 
   // ---------------------------------------------------------------------------

--- a/cloudflare-app-builder/start-dev.sh
+++ b/cloudflare-app-builder/start-dev.sh
@@ -130,7 +130,7 @@ tmux send-keys -t "$SESSION_NAME:services.6" "echo '🌐 Starting ngrok (forward
 
 # Pane 7 (bottom-right): cloud-agent-next
 tmux select-pane -t "$SESSION_NAME:services.7" -T "cloud-agent-next (8794)"
-tmux send-keys -t "$SESSION_NAME:services.7" "cd $PROJECT_ROOT/cloud-agent-next && echo '☁️  Starting cloud-agent-next (port 8794)...' && pnpm exec wrangler dev --env dev --inspector-port 9234" C-m
+tmux send-keys -t "$SESSION_NAME:services.7" "cd $PROJECT_ROOT/cloud-agent-next && echo '☁️  Starting cloud-agent-next (port 8794)...' && pnpm run dev" C-m
 
 # Select the ngrok pane by default
 tmux select-pane -t "$SESSION_NAME:services.6"

--- a/src/components/cloud-agent-next/AutocommitStatus.tsx
+++ b/src/components/cloud-agent-next/AutocommitStatus.tsx
@@ -1,5 +1,21 @@
+import { useAtomValue } from 'jotai';
 import { Loader2, Check, X } from 'lucide-react';
 import type { AutocommitStatus as AutocommitStatusType } from './store/atoms';
+import { autocommitStatusMapAtom } from './store/atoms';
+import { isAssistantMessage } from './types';
+import type { StoredMessage } from './types';
+
+/**
+ * Renders autocommit status for an assistant message, if any.
+ * Subscribes directly to the autocommit atom so it re-renders independently
+ * of memo'd parent components (e.g. StaticMessages).
+ */
+export function MaybeAutocommitStatus({ msg }: { msg: StoredMessage }) {
+  const statusMap = useAtomValue(autocommitStatusMapAtom);
+  if (!isAssistantMessage(msg.info)) return null;
+  const status = statusMap.get(msg.info.id);
+  return status ? <AutocommitStatus status={status} /> : null;
+}
 
 export function AutocommitStatus({ status }: { status: AutocommitStatusType }) {
   return (
@@ -11,6 +27,12 @@ export function AutocommitStatus({ status }: { status: AutocommitStatusType }) {
       <div className="bg-border h-px flex-1" />
     </div>
   );
+}
+
+function truncateCommitMessage(message: string, maxLength = 50): string {
+  const firstLine = message.split('\n')[0];
+  if (firstLine.length <= maxLength) return firstLine;
+  return firstLine.slice(0, maxLength) + '…';
 }
 
 function StatusIndicator({ status }: { status: AutocommitStatusType }) {
@@ -26,7 +48,14 @@ function StatusIndicator({ status }: { status: AutocommitStatusType }) {
       return (
         <span className="text-muted-foreground flex items-center gap-2">
           <Check className="h-3 w-3" />
-          <span>{status.message}</span>
+          {status.commitHash ? (
+            <span>
+              <code className="font-mono">{status.commitHash}</code>{' '}
+              {truncateCommitMessage(status.commitMessage ?? status.message)}
+            </span>
+          ) : (
+            <span>{status.message}</span>
+          )}
         </span>
       );
     case 'failed':

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -24,7 +24,8 @@ import {
   getChildSessionMessagesAtom,
   questionRequestIdsAtom,
   sessionOrganizationIdAtom,
-  autocommitStatusAtom,
+  autocommitStatusMapAtom,
+  sessionStatusIndicatorAtom,
   standaloneQuestionAtom,
 } from './store/atoms';
 import { buildSessionConfig, needsResumeConfiguration } from './session-config';
@@ -85,7 +86,8 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   const currentSessionId = useAtomValue(currentSessionIdAtom);
   const sessionConfig = useAtomValue(sessionConfigAtom);
   const totalCost = useAtomValue(totalCostAtom);
-  const autocommitStatus = useAtomValue(autocommitStatusAtom);
+  const autocommitStatusMap = useAtomValue(autocommitStatusMapAtom);
+  const sessionStatusIndicator = useAtomValue(sessionStatusIndicatorAtom);
   const questionRequestIds = useAtomValue(questionRequestIdsAtom);
   const questionOrganizationId = useAtomValue(sessionOrganizationIdAtom);
   const standaloneQuestion = useAtomValue(standaloneQuestionAtom);
@@ -218,9 +220,13 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
   const [inputMode, setInputMode] = useState<AgentMode>('code');
   const [inputModel, setInputModel] = useState<string>('');
 
-  // Auto-scroll behavior
+  // Auto-scroll behavior — also scroll when autocommit/status/question content changes
   const { messagesEndRef, scrollContainerRef, showScrollButton, handleScroll, scrollToBottom } =
-    useAutoScroll(dynamicMessages);
+    useAutoScroll(dynamicMessages, [
+      autocommitStatusMap,
+      sessionStatusIndicator,
+      standaloneQuestion,
+    ]);
 
   // Slash commands
   const { availableCommands } = useSlashCommandSets();
@@ -988,7 +994,7 @@ export function CloudChatContainer({ organizationId }: CloudChatContainerProps) 
         onInputModeChange={handleInputModeChange}
         onInputModelChange={handleInputModelChange}
         isOldSession={isOldSession}
-        autocommitStatus={autocommitStatus}
+        sessionStatusIndicator={sessionStatusIndicator}
         getChildMessages={getChildSessionMessages}
         standaloneQuestion={standaloneQuestion}
         chatInputInitialValue={failedMessageText ?? undefined}

--- a/src/components/cloud-agent-next/CloudChatPresentation.tsx
+++ b/src/components/cloud-agent-next/CloudChatPresentation.tsx
@@ -16,8 +16,9 @@ import { ChatInput } from './ChatInput';
 import { ErrorBanner } from './ErrorBanner';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
 import { MessageBubble } from './MessageBubble';
-import { AutocommitStatus } from './AutocommitStatus';
-import type { AutocommitStatus as AutocommitStatusType } from './store/atoms';
+import { MaybeAutocommitStatus } from './AutocommitStatus';
+import { SessionStatusIndicator } from './SessionStatusIndicator';
+import type { SessionStatusIndicator as SessionStatusIndicatorType } from './store/atoms';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ArrowDown, RefreshCw } from 'lucide-react';
@@ -48,6 +49,7 @@ const StaticMessages = memo(
         {messages.map(msg => (
           <MessageErrorBoundary key={msg.info.id}>
             <MessageBubble message={msg} getChildMessages={getChildMessages} />
+            <MaybeAutocommitStatus msg={msg} />
           </MessageErrorBoundary>
         ))}
       </>
@@ -79,6 +81,7 @@ function DynamicMessages({
               isStreaming={streaming}
               getChildMessages={getChildMessages}
             />
+            <MaybeAutocommitStatus msg={msg} />
           </MessageErrorBoundary>
         );
       })}
@@ -164,8 +167,8 @@ export type CloudChatPresentationProps = {
   onMenuClick: () => void;
   onMobileSheetOpenChange: (open: boolean) => void;
 
-  /** Autocommit status to display after messages */
-  autocommitStatus?: AutocommitStatusType | null;
+  /** Session status indicator for recoverable errors, reconnections, interrupts */
+  sessionStatusIndicator?: SessionStatusIndicatorType | null;
 
   // Old session handling
   isOldSession?: boolean;
@@ -238,7 +241,7 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
   onToggleSound,
   onMenuClick,
   onMobileSheetOpenChange,
-  autocommitStatus,
+  sessionStatusIndicator,
   isOldSession = false,
   getChildMessages,
   standaloneQuestion,
@@ -404,9 +407,6 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
                 {/* Dynamic messages - re-render during streaming */}
                 <DynamicMessages messages={dynamicMessages} getChildMessages={getChildMessages} />
 
-                {/* Auto-commit status indicator */}
-                {autocommitStatus && <AutocommitStatus status={autocommitStatus} />}
-
                 {/* Standalone question (not attached to a tool call) */}
                 {standaloneQuestion && (
                   <div className="my-4 ml-12">
@@ -417,6 +417,11 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
                       status="running"
                     />
                   </div>
+                )}
+
+                {/* Session status indicator (recoverable errors, reconnection, interrupts) */}
+                {sessionStatusIndicator && (
+                  <SessionStatusIndicator indicator={sessionStatusIndicator} />
                 )}
 
                 {/* Invisible anchor for auto-scroll */}
@@ -467,7 +472,9 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
                         ? 'Configure session to continue...'
                         : isStreaming
                           ? 'Streaming...'
-                          : 'Type your message... (/ for commands)'
+                          : sessionStatusIndicator?.type === 'error'
+                            ? 'Send a message to continue...'
+                            : 'Type your message... (/ for commands)'
               }
               slashCommands={availableCommands}
               mode={inputMode}

--- a/src/components/cloud-agent-next/SessionStatusIndicator.tsx
+++ b/src/components/cloud-agent-next/SessionStatusIndicator.tsx
@@ -1,0 +1,40 @@
+import { AlertCircle, Loader2, Check } from 'lucide-react';
+import type { SessionStatusIndicator as SessionStatusIndicatorType } from './store/atoms';
+
+export function SessionStatusIndicator({ indicator }: { indicator: SessionStatusIndicatorType }) {
+  return (
+    <div className="flex items-center gap-3 py-4">
+      <div className="bg-border h-px flex-1" />
+      <div className="flex items-center gap-2 text-xs">
+        <IndicatorContent indicator={indicator} />
+      </div>
+      <div className="bg-border h-px flex-1" />
+    </div>
+  );
+}
+
+function IndicatorContent({ indicator }: { indicator: SessionStatusIndicatorType }) {
+  switch (indicator.type) {
+    case 'error':
+      return (
+        <span className="text-destructive flex items-center gap-2">
+          <AlertCircle className="h-3 w-3" />
+          <span>{indicator.message}</span>
+        </span>
+      );
+    case 'warning':
+      return (
+        <span className="flex items-center gap-2 text-amber-500">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span>{indicator.message}</span>
+        </span>
+      );
+    case 'info':
+      return (
+        <span className="text-muted-foreground flex items-center gap-2">
+          <Check className="h-3 w-3" />
+          <span>{indicator.message}</span>
+        </span>
+      );
+  }
+}

--- a/src/components/cloud-agent-next/hooks/useAutoScroll.ts
+++ b/src/components/cloud-agent-next/hooks/useAutoScroll.ts
@@ -12,7 +12,7 @@
  * - Provides manual scroll-to-bottom function
  */
 
-import { useRef, useState, useEffect, useCallback } from 'react';
+import { useRef, useState, useEffect, useCallback, useMemo } from 'react';
 import { useAtom } from 'jotai';
 import { chatUIAtom } from '../store/atoms';
 
@@ -33,13 +33,29 @@ type UseAutoScrollReturn = {
  * Hook for managing auto-scroll behavior in the chat message container.
  *
  * @param dynamicMessages - The dynamic messages array (triggers auto-scroll effect)
+ * @param extraScrollTriggers - Additional values that should trigger auto-scroll when changed
+ *   (e.g. autocommit status map, session status indicator, standalone question)
  * @returns Refs, state, and handlers for auto-scroll behavior
  */
-export function useAutoScroll(dynamicMessages: unknown[]): UseAutoScrollReturn {
+export function useAutoScroll(
+  dynamicMessages: unknown[],
+  extraScrollTriggers: unknown[] = []
+): UseAutoScrollReturn {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [chatUI, setChatUI] = useAtom(chatUIAtom);
   const [showScrollButton, setShowScrollButton] = useState(false);
+
+  // Serialize extra triggers into a single stable dependency so the useEffect
+  // dependency count stays constant regardless of array length.
+  // Custom replacer handles Map (JSON.stringify produces "{}" for Map by default).
+  const extraTriggersKey = useMemo(
+    () =>
+      JSON.stringify(extraScrollTriggers, (_key, value) =>
+        value instanceof Map ? [...value] : value
+      ),
+    [extraScrollTriggers]
+  );
 
   // Auto-scroll effect - only scroll when dynamic messages change AND user is near bottom
   // Note: staticMessages intentionally excluded - they never change once rendered
@@ -54,7 +70,7 @@ export function useAutoScroll(dynamicMessages: unknown[]): UseAutoScrollReturn {
         });
       }
     }
-  }, [dynamicMessages, chatUI.shouldAutoScroll]);
+  }, [dynamicMessages, extraTriggersKey, chatUI.shouldAutoScroll]);
 
   // Handle scroll events to detect if user scrolled up
   const handleScroll = useCallback(() => {

--- a/src/components/cloud-agent-next/hooks/useAutoScroll.ts
+++ b/src/components/cloud-agent-next/hooks/useAutoScroll.ts
@@ -51,7 +51,7 @@ export function useAutoScroll(
   // Custom replacer handles Map (JSON.stringify produces "{}" for Map by default).
   const extraTriggersKey = useMemo(
     () =>
-      JSON.stringify(extraScrollTriggers, (_key, value) =>
+      JSON.stringify(extraScrollTriggers, (_key, value: unknown) =>
         value instanceof Map ? [...value] : value
       ),
     [extraScrollTriggers]

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -10,6 +10,8 @@ import type { SessionConfig, StoredMessage, Part } from '../types';
 import { isMessageStreaming, isAssistantMessage } from '../types';
 import type { QuestionInfo } from '@/types/opencode.gen';
 import { splitByContiguousPrefix } from '@/lib/utils/splitByContiguousPrefix';
+import type { AutocommitStatus } from '@/lib/cloud-agent-next/processor/types';
+export type { AutocommitStatus };
 
 // ============================================================================
 // Primary State - StoredMessage format
@@ -84,16 +86,24 @@ export const sessionStatusAtom = atom<
 >({ type: 'idle' });
 
 /**
- * Autocommit status — one per execution, transitions in-place.
- * Reset to null when a new execution starts.
+ * Per-message autocommit status map.
+ * Key is the assistant message ID; value is the status for that turn's autocommit.
+ * Replaces the old single-value `autocommitStatusAtom` to survive multi-turn replays.
  */
-export type AutocommitStatus = {
-  status: 'in_progress' | 'completed' | 'failed';
+export const autocommitStatusMapAtom = atom<Map<string, AutocommitStatus>>(new Map());
+
+/**
+ * Inline session status indicator — shown in the chat feed for recoverable
+ * session errors, reconnection states, and interrupts.
+ * Non-recoverable errors still go through `errorAtom` → `ErrorBanner`.
+ */
+export type SessionStatusIndicator = {
+  type: 'error' | 'warning' | 'info';
   message: string;
-  timestamp: string;
+  timestamp: number;
 };
 
-export const autocommitStatusAtom = atom<AutocommitStatus | null>(null);
+export const sessionStatusIndicatorAtom = atom<SessionStatusIndicator | null>(null);
 
 // ============================================================================
 // Common State
@@ -161,7 +171,8 @@ export const clearMessagesAtom = atom(null, (_get, set) => {
   set(messagesMapAtom, new Map());
   set(partsMapAtom, new Map());
   set(questionRequestIdsAtom, new Map());
-  set(autocommitStatusAtom, null);
+  set(autocommitStatusMapAtom, new Map());
+  set(sessionStatusIndicatorAtom, null);
   set(standaloneQuestionAtom, null);
 });
 

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -839,6 +839,7 @@ export function useCloudAgentStream({
               prompt: message,
               mode: mode as 'code' | 'plan' | 'debug' | 'orchestrator' | 'ask',
               model,
+              autoCommit: true,
               organizationId: organizationIdRef.current,
             },
             { context: { skipBatch: true } }
@@ -850,6 +851,7 @@ export function useCloudAgentStream({
               prompt: message,
               mode: mode as 'code' | 'plan' | 'debug' | 'orchestrator' | 'ask',
               model,
+              autoCommit: true,
             },
             { context: { skipBatch: true } }
           );

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -37,7 +37,8 @@ import {
   removeChildSessionPartAtom,
   setQuestionRequestIdAtom,
   sessionOrganizationIdAtom,
-  autocommitStatusAtom,
+  autocommitStatusMapAtom,
+  sessionStatusIndicatorAtom,
   standaloneQuestionAtom,
   clearStandaloneQuestionAtom,
   addUserMessageAtom,
@@ -133,8 +134,11 @@ export function useCloudAgentStream({
   // Atom for organization ID (used by QuestionToolCard for tRPC calls)
   const setSessionOrganizationId = useSetAtom(sessionOrganizationIdAtom);
 
-  // Atom for autocommit status
-  const setAutocommitStatus = useSetAtom(autocommitStatusAtom);
+  // Atom for per-message autocommit status
+  const setAutocommitStatusMap = useSetAtom(autocommitStatusMapAtom);
+
+  // Atom for session status indicator (inline chat feed indicators)
+  const setSessionStatusIndicator = useSetAtom(sessionStatusIndicatorAtom);
 
   // Common atoms
   const setCurrentSessionId = useSetAtom(currentSessionIdAtom);
@@ -152,12 +156,16 @@ export function useCloudAgentStream({
   const [connectionState, setConnectionState] = useState<ConnectionState>({
     status: 'disconnected',
   });
+  const connectionStateRef = useRef<ConnectionState>(connectionState);
   const [localError, setLocalError] = useState<string | null>(null);
 
   const wsManagerRef = useRef<ReturnType<typeof createWebSocketManager> | null>(null);
   const notifiedKiloSessionIdsRef = useRef<Set<string>>(new Set());
   const sessionInitiatedFiredRef = useRef<Set<string>>(new Set());
   const optimisticMessageIdRef = useRef<string | null>(null);
+
+  // Timer for auto-clearing info-type indicators
+  const infoClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cloudAgentSessionIdRef = useRef<string | null>(cloudAgentSessionIdProp ?? null);
   const organizationIdRef = useRef<string | undefined>(organizationId);
 
@@ -196,6 +204,37 @@ export function useCloudAgentStream({
     organizationIdRef.current = organizationId;
     setSessionOrganizationId(organizationId ?? null);
   }, [organizationId, setSessionOrganizationId]);
+
+  /**
+   * Set the session status indicator. Auto-clears `info` type indicators after 3 seconds.
+   */
+  const setIndicator = useCallback(
+    (
+      indicator: { type: 'error' | 'warning' | 'info'; message: string; timestamp: number } | null
+    ) => {
+      if (infoClearTimerRef.current) {
+        clearTimeout(infoClearTimerRef.current);
+        infoClearTimerRef.current = null;
+      }
+      setSessionStatusIndicator(indicator);
+      if (indicator?.type === 'info') {
+        infoClearTimerRef.current = setTimeout(() => {
+          setSessionStatusIndicator(null);
+          infoClearTimerRef.current = null;
+        }, 3000);
+      }
+    },
+    [setSessionStatusIndicator]
+  );
+
+  // Clean up info clear timer on unmount
+  useEffect(() => {
+    return () => {
+      if (infoClearTimerRef.current) {
+        clearTimeout(infoClearTimerRef.current);
+      }
+    };
+  }, []);
 
   /**
    * Create the event processor with callbacks wired to Jotai atoms and IndexedDB.
@@ -277,8 +316,16 @@ export function useCloudAgentStream({
           onCompleteRef.current?.();
         } else if (status.type === 'busy') {
           setIsStreaming(true);
+          // Clear any previous indicator when session resumes
+          setIndicator(null);
+        } else if (status.type === 'retry') {
+          // Show retry indicator in chat feed
+          setIndicator({
+            type: 'warning',
+            message: `Retrying... ${status.message}`,
+            timestamp: Date.now(),
+          });
         }
-        // 'retry' status keeps streaming active
       },
 
       onSessionCreated: async sessionInfo => {
@@ -347,6 +394,14 @@ export function useCloudAgentStream({
       onQuestionResolved: requestId => {
         clearStandaloneQuestion(requestId);
       },
+
+      onAutocommitUpdated: (messageId, status) => {
+        setAutocommitStatusMap(prev => {
+          const next = new Map(prev);
+          next.set(messageId, status);
+          return next;
+        });
+      },
     }),
     [
       updateMessage,
@@ -367,6 +422,8 @@ export function useCloudAgentStream({
       setStandaloneQuestion,
       clearStandaloneQuestion,
       removeOptimisticMessage,
+      setIndicator,
+      setAutocommitStatusMap,
     ]
   );
 
@@ -381,30 +438,28 @@ export function useCloudAgentStream({
 
   const handleEvent = useCallback(
     (event: CloudAgentEvent) => {
-      // Intercept autocommit events — update atom directly, don't pass to EventProcessor
-      if (event.streamEventType === 'autocommit_started') {
-        const data = event.data as { message?: string } | undefined;
-        setAutocommitStatus({
-          status: 'in_progress',
-          message: data?.message ?? 'Committing changes...',
-          timestamp: event.timestamp,
+      // Set inline indicator for session-level events (no ErrorBanner).
+      // The event processor handles streaming state and message completion.
+      if (event.streamEventType === 'wrapper_disconnected') {
+        setIndicator({
+          type: 'error',
+          message: 'Agent connection lost',
+          timestamp: Date.now(),
         });
-        return;
-      }
-      if (event.streamEventType === 'autocommit_completed') {
-        const data = event.data as
-          | { success?: boolean; message?: string; skipped?: boolean }
-          | undefined;
-        if (data?.skipped) {
-          setAutocommitStatus(null);
-        } else {
-          setAutocommitStatus({
-            status: data?.success ? 'completed' : 'failed',
-            message: data?.message ?? (data?.success ? 'Changes committed' : 'Commit failed'),
-            timestamp: event.timestamp,
-          });
-        }
-        return;
+      } else if (event.streamEventType === 'error') {
+        const data = event.data as { error?: string } | undefined;
+        setIndicator({
+          type: 'error',
+          message: typeof data?.error === 'string' ? data.error : 'Unknown error',
+          timestamp: Date.now(),
+        });
+      } else if (event.streamEventType === 'interrupted') {
+        const data = event.data as { reason?: string } | undefined;
+        setIndicator({
+          type: 'info',
+          message: data?.reason || 'Session stopped',
+          timestamp: Date.now(),
+        });
       }
 
       if (!processorRef.current) {
@@ -412,7 +467,7 @@ export function useCloudAgentStream({
       }
       processorRef.current?.processEvent(event);
     },
-    [getProcessor, setAutocommitStatus]
+    [getProcessor, setIndicator]
   );
 
   // Cleanup processor on unmount
@@ -548,13 +603,39 @@ export function useCloudAgentStream({
         onEvent: handleEvent,
         onError: handleWsError,
         onStateChange: state => {
+          // Check transition from reconnecting→connected before updating state
+          const prev = connectionStateRef.current;
+          connectionStateRef.current = state;
           setConnectionState(state);
 
-          if (state.status === 'error') {
-            setLocalError(state.error);
-            setError(state.error);
+          if (
+            (prev.status === 'reconnecting' || prev.status === 'refreshing_ticket') &&
+            state.status === 'connected'
+          ) {
+            setIndicator({
+              type: 'info',
+              message: 'Reconnected',
+              timestamp: Date.now(),
+            });
+          } else if (state.status === 'reconnecting') {
+            setIndicator({
+              type: 'warning',
+              message: `Reconnecting... (attempt ${state.attempt})`,
+              timestamp: Date.now(),
+            });
+          } else if (state.status === 'error') {
             if (!state.retryable) {
+              // Non-retryable errors (auth failure, max retries) → ErrorBanner
+              setLocalError(state.error);
+              setError(state.error);
               setIsStreaming(false);
+            } else {
+              // Retryable errors → inline indicator only
+              setIndicator({
+                type: 'warning',
+                message: state.error,
+                timestamp: Date.now(),
+              });
             }
           }
         },
@@ -567,7 +648,7 @@ export function useCloudAgentStream({
       wsManagerRef.current = createWebSocketManager(config);
       wsManagerRef.current.connect();
     },
-    [getTicket, buildWsUrl, handleEvent, handleWsError, setError, setIsStreaming]
+    [getTicket, buildWsUrl, handleEvent, handleWsError, setError, setIsStreaming, setIndicator]
   );
 
   /**
@@ -585,7 +666,8 @@ export function useCloudAgentStream({
 
     setLocalError(null);
     setError(null);
-    setAutocommitStatus(null);
+    setAutocommitStatusMap(new Map());
+    setIndicator(null);
     setIsStreaming(true);
 
     try {
@@ -625,6 +707,8 @@ export function useCloudAgentStream({
     setError,
     setIsStreaming,
     setCurrentSessionId,
+    setAutocommitStatusMap,
+    setIndicator,
   ]);
 
   /**
@@ -658,7 +742,9 @@ export function useCloudAgentStream({
       wsManagerRef.current = null;
     }
     setIsStreaming(false);
-    setConnectionState({ status: 'disconnected' });
+    const disconnected: ConnectionState = { status: 'disconnected' };
+    connectionStateRef.current = disconnected;
+    setConnectionState(disconnected);
   }, [setIsStreaming]);
 
   /**
@@ -696,14 +782,18 @@ export function useCloudAgentStream({
         // Clean up WebSocket connection
         stopStream();
 
-        // Session status will be updated via session.status event
-        // No need to manually add a system message - UI handles interrupted state
+        // Show inline indicator confirming the interrupt
+        setIndicator({
+          type: 'info',
+          message: 'Session stopped',
+          timestamp: Date.now(),
+        });
       } catch (error) {
         console.error('Failed to interrupt session:', error);
         setError('Failed to stop execution');
       }
     },
-    [trpcClient, stopStream, setError]
+    [trpcClient, stopStream, setError, setIndicator]
   );
 
   /**
@@ -715,7 +805,7 @@ export function useCloudAgentStream({
     async (message: string, cloudAgentSessionId: string, mode: string, model: string) => {
       setLocalError(null);
       setError(null);
-      setAutocommitStatus(null);
+      setIndicator(null);
       setIsStreaming(true);
 
       // Use provided cloudAgentSessionId, falling back to ref for backward compatibility
@@ -797,6 +887,7 @@ export function useCloudAgentStream({
       setIsStreaming,
       addUserMessage,
       removeOptimisticMessage,
+      setIndicator,
     ]
   );
 

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -310,11 +310,10 @@ export function useCloudAgentStream({
       onSessionStatusChanged: status => {
         setSessionStatus(status);
 
-        // Handle streaming state based on status
-        if (status.type === 'idle') {
-          setIsStreaming(false);
-          onCompleteRef.current?.();
-        } else if (status.type === 'busy') {
+        // Streaming is NOT stopped on idle — the wrapper's `complete` event
+        // (handled by onStreamingChanged) is the definitive signal, firing
+        // after autocommit finishes.
+        if (status.type === 'busy') {
           setIsStreaming(true);
           // Clear any previous indicator when session resumes
           setIndicator(null);
@@ -501,6 +500,9 @@ export function useCloudAgentStream({
       }
       if (code === 'NOT_FOUND') {
         return 'Cloud Agent service is unavailable right now. Please try again.';
+      }
+      if (code === 'CONFLICT' || httpStatus === 409) {
+        return 'Previous task is still finishing up. Please wait a moment.';
       }
       return 'Cloud Agent encountered an error. Please retry in a moment.';
     }

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -786,11 +786,8 @@ describe('createEventProcessor', () => {
 
       // Message should be force-completed
       expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
-      // onError should fire
-      expect(callbacks.onError).toHaveBeenCalledWith(
-        'The model failed to generate a response',
-        'child-1'
-      );
+      // No ErrorBanner — the session is still alive
+      expect(callbacks.onError).not.toHaveBeenCalled();
       // streaming should still be true (only 1 call: the busy=true)
       expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
     });
@@ -990,12 +987,8 @@ describe('createEventProcessor', () => {
         null
       );
 
-      // Should stop streaming and fire error
-      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
-      expect(callbacks.onError).toHaveBeenCalledWith(
-        'The model failed to generate a response',
-        'session-123'
-      );
+      // No ErrorBanner — the session is still alive, user can retry
+      expect(callbacks.onError).not.toHaveBeenCalled();
     });
 
     it('should not force-complete messages when reason is not error', () => {
@@ -1278,6 +1271,196 @@ describe('createEventProcessor', () => {
 
       expect(callbacks.onQuestionAsked).not.toHaveBeenCalled();
       expect(callbacks.onStandaloneQuestionAsked).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('termination events (interrupted, wrapper_disconnected, error)', () => {
+    it('interrupted should stop streaming and force-complete messages without calling onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Create an in-flight assistant message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', {
+          info: createAssistantInfo('msg-1'),
+        })
+      );
+
+      // Interrupted event (top-level streamEventType, not kilocode-wrapped)
+      processor.processEvent(createEvent('interrupted', { reason: 'Session stopped' }));
+
+      expect(callbacks.onError).not.toHaveBeenCalled();
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('wrapper_disconnected should stop streaming and force-complete messages without calling onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Create an in-flight assistant message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', {
+          info: createAssistantInfo('msg-1'),
+        })
+      );
+
+      // Wrapper disconnected event
+      processor.processEvent(createEvent('wrapper_disconnected', { reason: 'container died' }));
+
+      expect(callbacks.onError).not.toHaveBeenCalled();
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('bare error (fatal) should stop streaming and force-complete messages without calling onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onMessageCompleted: jest.fn(),
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Create an in-flight assistant message
+      processor.processEvent(
+        createKilocodeEvent('message.updated', {
+          info: createAssistantInfo('msg-1'),
+        })
+      );
+
+      // Fatal error event
+      processor.processEvent(createEvent('error', { error: 'Process killed', fatal: true }));
+
+      expect(callbacks.onError).not.toHaveBeenCalled();
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('session.error after interrupted should be silently dropped', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Interrupted event
+      processor.processEvent(createEvent('interrupted', { reason: 'Session stopped' }));
+
+      // session.error arrives as an aftershock (CLI dying)
+      processor.processEvent(
+        createKilocodeEvent('session.error', {
+          sessionID: 'session-123',
+          error: 'MessageAbortedError',
+        })
+      );
+
+      // onError should NOT have been called — the session.error is an aftershock
+      expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+
+    it('session.error without prior termination should still call onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // session.error without any prior termination event
+      processor.processEvent(
+        createKilocodeEvent('session.error', {
+          sessionID: 'session-123',
+          error: 'Something went wrong',
+        })
+      );
+
+      expect(callbacks.onError).toHaveBeenCalledWith('Something went wrong', 'session-123');
+    });
+
+    it('clear() should reset terminated state', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming, then interrupt
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+      processor.processEvent(createEvent('interrupted', { reason: 'Session stopped' }));
+
+      // Clear and start fresh
+      processor.clear();
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // session.error should now trigger onError again (terminated was reset)
+      processor.processEvent(
+        createKilocodeEvent('session.error', {
+          sessionID: 'session-123',
+          error: 'Real error',
+        })
+      );
+
+      expect(callbacks.onError).toHaveBeenCalledWith('Real error', 'session-123');
     });
   });
 

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -1462,6 +1462,44 @@ describe('createEventProcessor', () => {
 
       expect(callbacks.onError).toHaveBeenCalledWith('Real error', 'session-123');
     });
+
+    it('session.error after interrupted + new busy status should call onError', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onError: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // First execution: start streaming, then interrupt
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+      processor.processEvent(createEvent('interrupted', { reason: 'Session stopped' }));
+
+      // Second execution: new busy status (user sent another message)
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // session.error from the NEW execution should NOT be suppressed
+      processor.processEvent(
+        createKilocodeEvent('session.error', {
+          sessionID: 'session-123',
+          error: 'Real error from new execution',
+        })
+      );
+
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        'Real error from new execution',
+        'session-123'
+      );
+    });
   });
 
   describe('invalid events', () => {

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -445,7 +445,7 @@ describe('createEventProcessor', () => {
       expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
     });
 
-    it('should update session status to idle and set streaming false', () => {
+    it('should update session status to idle without stopping streaming (complete event does that)', () => {
       const callbacks: EventProcessorCallbacks = {
         onSessionStatusChanged: jest.fn(),
         onStreamingChanged: jest.fn(),
@@ -460,7 +460,7 @@ describe('createEventProcessor', () => {
         })
       );
 
-      // Then set to idle
+      // Then set to idle — streaming should NOT stop yet
       processor.processEvent(
         createKilocodeEvent('session.status', {
           sessionID: 'session-123',
@@ -469,7 +469,9 @@ describe('createEventProcessor', () => {
       );
 
       expect(callbacks.onSessionStatusChanged).toHaveBeenLastCalledWith({ type: 'idle' });
-      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+      // onStreamingChanged should only have been called once (busy=true)
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
     });
 
     it('should handle retry status without changing streaming state', () => {
@@ -676,6 +678,7 @@ describe('createEventProcessor', () => {
       expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
 
       // Child session emits idle — should NOT set streaming false
+      // (neither root nor child idle stops streaming; only `complete` does)
       processor.processEvent(createKilocodeEvent('session.idle', { sessionID: 'child-1' }));
 
       // onStreamingChanged should only have been called once (the busy=true)
@@ -1498,6 +1501,298 @@ describe('createEventProcessor', () => {
       expect(callbacks.onError).toHaveBeenCalledWith(
         'Real error from new execution',
         'session-123'
+      );
+    });
+  });
+
+  describe('complete event (execution fully done)', () => {
+    it('should stop streaming when complete event arrives', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
+
+      // Complete event arrives (wrapper finished including autocommit)
+      processor.processEvent(createEvent('complete', {}));
+
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should stop streaming only on complete, not on session.idle', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onSessionStatusChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Start streaming
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      // Session goes idle (CLI finished, autocommit about to start)
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'idle' },
+        })
+      );
+
+      // Streaming should still be true (only busy=true call so far)
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledWith(true);
+
+      // Complete event arrives after autocommit
+      processor.processEvent(createEvent('complete', {}));
+
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(2);
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should be a no-op when not streaming', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Complete without ever starting streaming
+      processor.processEvent(createEvent('complete', {}));
+
+      expect(callbacks.onStreamingChanged).not.toHaveBeenCalled();
+    });
+
+    it('full lifecycle: busy → idle → autocommit → complete', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onStreamingChanged: jest.fn(),
+        onSessionStatusChanged: jest.fn(),
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // 1. Session starts
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(true);
+
+      // 2. CLI finishes, session goes idle
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'idle' },
+        })
+      );
+      // Still streaming
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+
+      // 3. Autocommit starts
+      processor.processEvent(
+        createEvent('autocommit_started', { message: 'Committing...', messageId: 'msg-1' })
+      );
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledTimes(1);
+      // Still streaming
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+
+      // 4. Autocommit completes
+      processor.processEvent(
+        createEvent('autocommit_completed', {
+          success: true,
+          message: 'Done',
+          messageId: 'msg-1',
+          commitHash: 'abc123',
+        })
+      );
+      // Still streaming (complete hasn't fired yet)
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(1);
+
+      // 5. Wrapper sends complete
+      processor.processEvent(createEvent('complete', {}));
+      expect(callbacks.onStreamingChanged).toHaveBeenCalledTimes(2);
+      expect(callbacks.onStreamingChanged).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  describe('autocommit events', () => {
+    it('autocommit_started with messageId should fire onAutocommitUpdated with in_progress', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createEvent('autocommit_started', {
+          message: 'Generating commit message...',
+          messageId: 'msg-42',
+        })
+      );
+
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledWith(
+        'msg-42',
+        expect.objectContaining({
+          status: 'in_progress',
+          message: 'Generating commit message...',
+          timestamp: expect.any(String),
+        })
+      );
+    });
+
+    it('autocommit_started without messageId should not fire callback', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createEvent('autocommit_started', { message: 'Generating commit message...' })
+      );
+
+      expect(callbacks.onAutocommitUpdated).not.toHaveBeenCalled();
+    });
+
+    it('autocommit_started should use default message when none provided', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(createEvent('autocommit_started', { messageId: 'msg-42' }));
+
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledWith(
+        'msg-42',
+        expect.objectContaining({
+          status: 'in_progress',
+          message: 'Committing changes...',
+        })
+      );
+    });
+
+    it('autocommit_completed with success should fire onAutocommitUpdated with completed', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createEvent('autocommit_completed', {
+          success: true,
+          message: 'Committed abc123',
+          commitHash: 'abc123',
+          commitMessage: 'fix: resolve race condition',
+          messageId: 'msg-42',
+        })
+      );
+
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledWith(
+        'msg-42',
+        expect.objectContaining({
+          status: 'completed',
+          message: 'Committed abc123',
+          commitHash: 'abc123',
+          commitMessage: 'fix: resolve race condition',
+          timestamp: expect.any(String),
+        })
+      );
+    });
+
+    it('autocommit_completed with success: false should fire onAutocommitUpdated with failed', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createEvent('autocommit_completed', {
+          success: false,
+          message: 'git push rejected',
+          messageId: 'msg-42',
+        })
+      );
+
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledWith(
+        'msg-42',
+        expect.objectContaining({
+          status: 'failed',
+          message: 'git push rejected',
+        })
+      );
+    });
+
+    it('autocommit_completed with skipped: true should not fire callback', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createEvent('autocommit_completed', {
+          success: true,
+          skipped: true,
+          messageId: 'msg-42',
+        })
+      );
+
+      expect(callbacks.onAutocommitUpdated).not.toHaveBeenCalled();
+    });
+
+    it('autocommit_completed without messageId should not fire callback', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createEvent('autocommit_completed', {
+          success: true,
+          message: 'Committed',
+        })
+      );
+
+      expect(callbacks.onAutocommitUpdated).not.toHaveBeenCalled();
+    });
+
+    it('autocommit_completed should use default messages when none provided', () => {
+      const callbacks: EventProcessorCallbacks = {
+        onAutocommitUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Success without message
+      processor.processEvent(
+        createEvent('autocommit_completed', { success: true, messageId: 'msg-1' })
+      );
+
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledWith(
+        'msg-1',
+        expect.objectContaining({ status: 'completed', message: 'Changes committed' })
+      );
+
+      // Failure without message
+      processor.processEvent(
+        createEvent('autocommit_completed', { success: false, messageId: 'msg-2' })
+      );
+
+      expect(callbacks.onAutocommitUpdated).toHaveBeenCalledWith(
+        'msg-2',
+        expect.objectContaining({ status: 'failed', message: 'Commit failed' })
       );
     });
   });

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -18,7 +18,7 @@
 import type { CloudAgentEvent } from '../event-types';
 import { isValidCloudAgentEvent } from '../event-types';
 import type { Part, QuestionInfo } from '@/types/opencode.gen';
-import type { ProcessedMessage, EventProcessorConfig } from './types';
+import type { ProcessedMessage, EventProcessorConfig, AutocommitStatus } from './types';
 import {
   stripPartContentIfFile,
   isUserMessage,
@@ -48,6 +48,11 @@ const HANDLED_EVENT_TYPES = new Set([
   'question.asked',
   'question.replied',
   'question.rejected',
+  'wrapper_disconnected',
+  'error',
+  'interrupted',
+  'autocommit_started',
+  'autocommit_completed',
 ]);
 
 function isHandledEventType(type: string): boolean {
@@ -131,6 +136,9 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   const completedMessages = new Set<string>();
 
   let streaming = false;
+  // Set when an interrupted/wrapper_disconnected/error event arrives.
+  // Suppresses subsequent session.error events (aftershocks from the CLI dying).
+  let terminated = false;
 
   /**
    * Get parent session ID for a session.
@@ -372,8 +380,13 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * Handle session.error events.
    * onError fires for all sessions (root and child).
    * Streaming toggle only fires for root sessions.
+   *
+   * When `terminated` is true, the session was already interrupted/disconnected
+   * and this is just an aftershock from the CLI dying — skip the error banner.
    */
   function handleSessionError(data: { sessionID?: string; error?: unknown }): void {
+    if (terminated) return;
+
     const errorMessage = typeof data.error === 'string' ? data.error : 'Session error occurred';
     const fromChild = isChildSession(data.sessionID);
 
@@ -457,8 +470,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * Handle session.turn.close events.
    * When reason is "error", force-complete all in-flight assistant messages
    * that never received time.completed from the server.
-   * Child session turn close events still complete messages and fire onError,
-   * but skip the streaming toggle.
+   * No ErrorBanner — the session is still alive; the user can retry.
    */
   function handleSessionTurnClose(data: { sessionID?: string; reason?: string }): void {
     if (data.reason !== 'error') {
@@ -467,8 +479,79 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
     const fromChild = isChildSession(data.sessionID);
     forceCompleteAllMessages(fromChild);
+  }
 
-    callbacks.onError?.('The model failed to generate a response', data.sessionID);
+  /**
+   * Handle wrapper_disconnected events — the container WebSocket died.
+   * Sets inline indicator via handleEvent in the consumer; no ErrorBanner.
+   */
+  function handleWrapperDisconnected(): void {
+    terminated = true;
+    forceCompleteAllMessages();
+  }
+
+  /**
+   * Handle bare "error" events from the reaper or interrupt flow.
+   * These are NOT session.error — they come with { error, fatal } payloads.
+   * Sets inline indicator via handleEvent in the consumer; no ErrorBanner.
+   */
+  function handleBareError(data: { fatal?: boolean }): void {
+    terminated = true;
+    if (data.fatal) {
+      forceCompleteAllMessages();
+    }
+    if (streaming) {
+      streaming = false;
+      callbacks.onStreamingChanged?.(false);
+    }
+  }
+
+  /**
+   * Handle "interrupted" events — the execution was interrupted.
+   * Sets inline indicator via handleEvent in the consumer; no ErrorBanner.
+   */
+  function handleInterrupted(): void {
+    terminated = true;
+    forceCompleteAllMessages();
+  }
+
+  /**
+   * Handle autocommit_started events.
+   * Only fires callback if the event includes a messageId.
+   */
+  function handleAutocommitStarted(data: { message?: string; messageId?: string }): void {
+    if (!data.messageId) return;
+    const status: AutocommitStatus = {
+      status: 'in_progress',
+      message: data.message ?? 'Committing changes...',
+      timestamp: new Date().toISOString(),
+    };
+    callbacks.onAutocommitUpdated?.(data.messageId, status);
+  }
+
+  /**
+   * Handle autocommit_completed events.
+   * Only fires callback if the event includes a messageId.
+   * Skipped autocommits are silently dropped (no map entry).
+   */
+  function handleAutocommitCompleted(data: {
+    success?: boolean;
+    message?: string;
+    skipped?: boolean;
+    commitHash?: string;
+    commitMessage?: string;
+    messageId?: string;
+  }): void {
+    if (!data.messageId) return;
+    if (data.skipped) return;
+    const status: AutocommitStatus = {
+      status: data.success ? 'completed' : 'failed',
+      message: data.message ?? (data.success ? 'Changes committed' : 'Commit failed'),
+      timestamp: new Date().toISOString(),
+      commitHash: data.commitHash,
+      commitMessage: data.commitMessage,
+    };
+    callbacks.onAutocommitUpdated?.(data.messageId, status);
   }
 
   /**
@@ -547,6 +630,35 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
         }
         break;
       }
+
+      case 'wrapper_disconnected':
+        handleWrapperDisconnected();
+        break;
+
+      case 'error':
+        handleBareError(data as { fatal?: boolean });
+        break;
+
+      case 'interrupted':
+        handleInterrupted();
+        break;
+
+      case 'autocommit_started':
+        handleAutocommitStarted(data as { message?: string; messageId?: string });
+        break;
+
+      case 'autocommit_completed':
+        handleAutocommitCompleted(
+          data as {
+            success?: boolean;
+            message?: string;
+            skipped?: boolean;
+            commitHash?: string;
+            commitMessage?: string;
+            messageId?: string;
+          }
+        );
+        break;
     }
   }
 
@@ -559,6 +671,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
     sessionParents.clear();
     completedMessages.clear();
     streaming = false;
+    terminated = false;
   }
 
   return {

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -423,7 +423,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * Child session idle events still trigger user message completion
    * but do NOT toggle the streaming flag or fire onStreamingChanged.
    */
-  function handleSessionIdle(data: { sessionID: string }): void {
+  function handleSessionIdle(_data: { sessionID: string }): void {
     // Complete user messages for both root and child sessions.
     // Streaming is NOT stopped here — the wrapper's `complete` event handles that.
     completeUserMessages();

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -348,6 +348,8 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
         callbacks.onStreamingChanged?.(false);
       }
     } else if (status.type === 'busy') {
+      // New execution started — prior termination state is stale
+      terminated = false;
       if (!fromChild && !streaming) {
         streaming = true;
         callbacks.onStreamingChanged?.(true);

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -53,6 +53,7 @@ const HANDLED_EVENT_TYPES = new Set([
   'interrupted',
   'autocommit_started',
   'autocommit_completed',
+  'complete',
 ]);
 
 function isHandledEventType(type: string): boolean {
@@ -340,13 +341,10 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
     // Update streaming state based on status
     if (status.type === 'idle') {
-      // Complete user messages when session becomes idle (for both root and child)
+      // Complete user messages when session becomes idle (for both root and child).
+      // Streaming is NOT stopped here — the wrapper's `complete` event is the
+      // definitive signal (fires after autocommit finishes).
       completeUserMessages();
-
-      if (!fromChild && streaming) {
-        streaming = false;
-        callbacks.onStreamingChanged?.(false);
-      }
     } else if (status.type === 'busy') {
       // New execution started — prior termination state is stale
       terminated = false;
@@ -426,15 +424,9 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * but do NOT toggle the streaming flag or fire onStreamingChanged.
    */
   function handleSessionIdle(data: { sessionID: string }): void {
-    const fromChild = isChildSession(data.sessionID);
-
-    // Complete user messages for both root and child sessions
+    // Complete user messages for both root and child sessions.
+    // Streaming is NOT stopped here — the wrapper's `complete` event handles that.
     completeUserMessages();
-
-    if (!fromChild && streaming) {
-      streaming = false;
-      callbacks.onStreamingChanged?.(false);
-    }
   }
 
   /**
@@ -515,6 +507,17 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   function handleInterrupted(): void {
     terminated = true;
     forceCompleteAllMessages();
+  }
+
+  /**
+   * Handle the wrapper's "complete" event — the execution is fully done
+   * (including autocommit). This is the definitive "safe to send another message" signal.
+   */
+  function handleExecutionComplete(): void {
+    if (streaming) {
+      streaming = false;
+      callbacks.onStreamingChanged?.(false);
+    }
   }
 
   /**
@@ -643,6 +646,10 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
       case 'interrupted':
         handleInterrupted();
+        break;
+
+      case 'complete':
+        handleExecutionComplete();
         break;
 
       case 'autocommit_started':

--- a/src/lib/cloud-agent-next/processor/index.ts
+++ b/src/lib/cloud-agent-next/processor/index.ts
@@ -9,4 +9,9 @@
  */
 
 export { createEventProcessor, type EventProcessor } from './event-processor';
-export type { ProcessedMessage, EventProcessorCallbacks, EventProcessorConfig } from './types';
+export type {
+  ProcessedMessage,
+  EventProcessorCallbacks,
+  EventProcessorConfig,
+  AutocommitStatus,
+} from './types';

--- a/src/lib/cloud-agent-next/processor/types.ts
+++ b/src/lib/cloud-agent-next/processor/types.ts
@@ -25,6 +25,17 @@ export type ProcessedMessage = {
 };
 
 /**
+ * Autocommit status for a single turn, keyed by assistant message ID.
+ */
+export type AutocommitStatus = {
+  status: 'in_progress' | 'completed' | 'failed';
+  message: string;
+  timestamp: string;
+  commitHash?: string;
+  commitMessage?: string;
+};
+
+/**
  * Callbacks for state change notifications.
  * All callbacks are optional - only subscribe to what you need.
  *
@@ -93,6 +104,9 @@ export type EventProcessorCallbacks = {
 
   /** Called when a question is answered or rejected (question.replied / question.rejected) */
   onQuestionResolved?: (requestId: string) => void;
+
+  /** Called when an autocommit event (started/completed) is received with a messageId */
+  onAutocommitUpdated?: (messageId: string, status: AutocommitStatus) => void;
 };
 
 /**

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -82,7 +82,7 @@ export const basePrepareSessionNextSchema = z
     setupCommands: z.array(z.string().max(500)).max(20).optional(),
     mcpServers: z.record(z.string(), mcpServerConfigNextSchema).optional(),
     upstreamBranch: z.string().optional(),
-    autoCommit: z.boolean().optional(),
+    autoCommit: z.boolean().optional().default(false),
   })
   .refine(
     data => (data.githubRepo || data.gitlabProject) && !(data.githubRepo && data.gitlabProject),

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -82,7 +82,7 @@ export const basePrepareSessionNextSchema = z
     setupCommands: z.array(z.string().max(500)).max(20).optional(),
     mcpServers: z.record(z.string(), mcpServerConfigNextSchema).optional(),
     upstreamBranch: z.string().optional(),
-    autoCommit: z.boolean().optional().default(false),
+    autoCommit: z.boolean().optional(),
   })
   .refine(
     data => (data.githubRepo || data.gitlabProject) && !(data.githubRepo && data.gitlabProject),
@@ -114,7 +114,7 @@ export const baseSendMessageNextSchema = z.object({
   mode: agentModeSendMessageSchema,
   model: z.string().min(1),
   variant: z.string().max(50).optional(),
-  autoCommit: z.boolean().optional().default(false),
+  autoCommit: z.boolean().optional(),
 });
 
 // Schema for interrupting a session


### PR DESCRIPTION
## Summary

- **Inline session indicators**: Replace `ErrorBanner` for recoverable session events (interrupted, wrapper_disconnected, error) with inline `SessionStatusIndicator` components. The "interrupted" indicator uses info-type with "Session stopped" label instead of error-type.
- **Termination handling in event processor**: The event processor now owns termination state via a `terminated` flag — it stops streaming, force-completes in-flight messages, and suppresses aftershock `session.error` events from the dying CLI. Removes the `suppressErrorBannerRef` workaround from `useCloudAgentStream`.
- **Per-message autocommit status**: Show autocommit progress inline per-message instead of globally, truncate long autocommit commit messages.
- **Auto-scroll fix**: Auto-scroll now triggers for non-message content like session indicators.
- **Wrapper auto-commit improvements**: Reworked auto-commit flow to report status per-message via stream events, and emit interrupted events with "Session stopped" reason.