### PR TITLE
Feat/kiloclaw provision pin support

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /root/.openclaw \
 
 # Copy startup script
 # Build cache bust: 2026-02-27-v57-openclaw-2026.2.26-1password-arch-fix
-RUN echo "7"
+RUN echo "8"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /root/.openclaw \
 
 # Copy startup script
 # Build cache bust: 2026-02-27-v57-openclaw-2026.2.26-1password-arch-fix
-RUN echo "8"
+RUN echo "7"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js

--- a/kiloclaw/scripts/push-dev.sh
+++ b/kiloclaw/scripts/push-dev.sh
@@ -26,13 +26,25 @@ GIT_SHA="$(git -C "$KILOCLAW_DIR" rev-parse HEAD 2>/dev/null || echo 'unknown')"
 
 echo "Building + pushing $IMAGE (linux/amd64) ..."
 echo "Controller commit: $GIT_SHA"
+
+# Use --metadata-file to capture the pushed image digest
+METADATA_FILE="$(mktemp)"
+trap 'rm -f "$METADATA_FILE"' EXIT
+
 docker buildx build \
   --platform linux/amd64 \
   -f "$KILOCLAW_DIR/Dockerfile" \
   --build-arg "CONTROLLER_COMMIT=$GIT_SHA" \
   -t "$IMAGE" \
   --push \
+  --metadata-file "$METADATA_FILE" \
   "$KILOCLAW_DIR"
+
+# Extract digest from build metadata
+DIGEST=""
+if [ -f "$METADATA_FILE" ] && command -v jq >/dev/null 2>&1; then
+  DIGEST=$(jq -r '.["containerimage.digest"] // empty' "$METADATA_FILE" 2>/dev/null)
+fi
 
 # Update .dev.vars
 if [ -f "$KILOCLAW_DIR/.dev.vars" ]; then
@@ -41,7 +53,17 @@ if [ -f "$KILOCLAW_DIR/.dev.vars" ]; then
   else
     echo "FLY_IMAGE_TAG=$TAG" >> "$KILOCLAW_DIR/.dev.vars"
   fi
-  echo "Updated .dev.vars: FLY_IMAGE_TAG=$TAG"
+
+  if [ -n "$DIGEST" ]; then
+    if grep -q '^FLY_IMAGE_DIGEST=' "$KILOCLAW_DIR/.dev.vars"; then
+      sed -i '' "s|^FLY_IMAGE_DIGEST=.*|FLY_IMAGE_DIGEST=$DIGEST|" "$KILOCLAW_DIR/.dev.vars"
+    else
+      echo "FLY_IMAGE_DIGEST=$DIGEST" >> "$KILOCLAW_DIR/.dev.vars"
+    fi
+    echo "Updated .dev.vars: FLY_IMAGE_TAG=$TAG  FLY_IMAGE_DIGEST=$DIGEST"
+  else
+    echo "Updated .dev.vars: FLY_IMAGE_TAG=$TAG  (digest not captured)"
+  fi
 else
   echo "No .dev.vars found — set FLY_IMAGE_TAG=$TAG manually"
 fi

--- a/kiloclaw/scripts/push-dev.sh
+++ b/kiloclaw/scripts/push-dev.sh
@@ -49,14 +49,18 @@ fi
 # Update .dev.vars
 if [ -f "$KILOCLAW_DIR/.dev.vars" ]; then
   if grep -q '^FLY_IMAGE_TAG=' "$KILOCLAW_DIR/.dev.vars"; then
-    sed -i '' "s/^FLY_IMAGE_TAG=.*/FLY_IMAGE_TAG=$TAG/" "$KILOCLAW_DIR/.dev.vars"
+    # Use temp file for cross-platform sed compatibility (macOS/Linux)
+    sed "s/^FLY_IMAGE_TAG=.*/FLY_IMAGE_TAG=$TAG/" "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+    mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
   else
     echo "FLY_IMAGE_TAG=$TAG" >> "$KILOCLAW_DIR/.dev.vars"
   fi
 
   if [ -n "$DIGEST" ]; then
     if grep -q '^FLY_IMAGE_DIGEST=' "$KILOCLAW_DIR/.dev.vars"; then
-      sed -i '' "s|^FLY_IMAGE_DIGEST=.*|FLY_IMAGE_DIGEST=$DIGEST|" "$KILOCLAW_DIR/.dev.vars"
+      # Use temp file for cross-platform sed compatibility (macOS/Linux)
+      sed "s|^FLY_IMAGE_DIGEST=.*|FLY_IMAGE_DIGEST=$DIGEST|" "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+      mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
     else
       echo "FLY_IMAGE_DIGEST=$DIGEST" >> "$KILOCLAW_DIR/.dev.vars"
     fi

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -64,7 +64,7 @@ import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../utils/env-encryption';
 import { z, type ZodType } from 'zod';
 import { resolveLatestVersion, resolveVersionByTag } from '../lib/image-version';
 import { lookupCatalogVersion } from '../lib/catalog-registration';
-import type { ImageVariant } from '../schemas/image-version';
+import { ImageVariantSchema, type ImageVariant } from '../schemas/image-version';
 
 type InstanceStatus = PersistedState['status'];
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -62,7 +62,9 @@ import * as fly from '../fly/client';
 import { appNameFromUserId } from '../fly/apps';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../utils/env-encryption';
 import { z, type ZodType } from 'zod';
-import { resolveLatestVersion } from '../lib/image-version';
+import { resolveLatestVersion, resolveVersionByTag } from '../lib/image-version';
+import { lookupCatalogVersion } from '../lib/catalog-registration';
+import type { ImageVariant } from '../schemas/image-version';
 
 type InstanceStatus = PersistedState['status'];
 
@@ -381,6 +383,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private openclawVersion: string | null = null;
   private imageVariant: string | null = null;
   private trackedImageTag: string | null = null;
+  private trackedImageDigest: string | null = null;
 
   // In-memory only (not persisted to SQLite) — throttles live Fly checks in getStatus()
   private lastLiveCheckAt: number | null = null;
@@ -421,6 +424,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.openclawVersion = s.openclawVersion;
       this.imageVariant = s.imageVariant;
       this.trackedImageTag = s.trackedImageTag;
+      this.trackedImageDigest = s.trackedImageDigest;
     } else {
       const hasAnyData = entries.size > 0;
       if (hasAnyData) {
@@ -487,18 +491,64 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       console.log('[DO] Created Fly Volume:', volume.id, 'region:', volume.region);
     }
 
-    // Resolve the latest registered version on every provision (including re-provision).
-    // If the registry isn't populated yet, fields stay null → fallback to FLY_IMAGE_TAG.
-    const variant = 'default'; // hardcoded day 1; future: from config or provision request
-    const latest = await resolveLatestVersion(this.env.KV_CLAW_CACHE, variant);
-    if (latest) {
-      this.openclawVersion = latest.openclawVersion;
-      this.imageVariant = latest.variant;
-      this.trackedImageTag = latest.imageTag;
-    } else if (isNew) {
-      this.openclawVersion = null;
-      this.imageVariant = null;
-      this.trackedImageTag = null;
+    // Resolve the image version for this provision.
+    // If the user has a pinned image tag, look it up in KV first (fast), then Postgres (authoritative).
+    // If not pinned, resolve latest from KV.
+    console.log('[DO] provision: pinnedImageTag from config:', config.pinnedImageTag ?? 'none');
+    if (config.pinnedImageTag) {
+      // Try KV first (fast, but only has versions registered by the current worker)
+      let pinned = await resolveVersionByTag(this.env.KV_CLAW_CACHE, config.pinnedImageTag);
+
+      // Fall back to Postgres catalog (authoritative, has all synced versions)
+      if (!pinned && this.env.HYPERDRIVE?.connectionString) {
+        try {
+          const catalogEntry = await lookupCatalogVersion(
+            this.env.HYPERDRIVE.connectionString,
+            config.pinnedImageTag
+          );
+          if (catalogEntry) {
+            pinned = {
+              openclawVersion: catalogEntry.openclawVersion,
+              variant: catalogEntry.variant as ImageVariant,
+              imageTag: catalogEntry.imageTag,
+              imageDigest: catalogEntry.imageDigest,
+              publishedAt: catalogEntry.publishedAt,
+            };
+            console.log('[DO] Resolved pinned tag from Postgres catalog:', config.pinnedImageTag);
+          }
+        } catch (err) {
+          console.warn('[DO] Failed to look up pinned tag in Postgres:', err instanceof Error ? err.message : err);
+        }
+      }
+
+      if (pinned) {
+        this.openclawVersion = pinned.openclawVersion;
+        this.imageVariant = pinned.variant;
+        this.trackedImageTag = pinned.imageTag;
+        this.trackedImageDigest = pinned.imageDigest;
+        console.log('[DO] Using pinned version:', pinned.openclawVersion, '→', pinned.imageTag);
+      } else {
+        // Pinned tag not found in KV or Postgres — use the tag directly but metadata is unknown.
+        console.warn('[DO] Pinned tag not found in KV or Postgres, using tag directly:', config.pinnedImageTag);
+        this.trackedImageTag = config.pinnedImageTag;
+        this.trackedImageDigest = null;
+      }
+    } else {
+      // No pin — resolve latest registered version.
+      // If the registry isn't populated yet, fields stay null → fallback to FLY_IMAGE_TAG.
+      const variant = 'default'; // hardcoded day 1; future: from config or provision request
+      const latest = await resolveLatestVersion(this.env.KV_CLAW_CACHE, variant);
+      if (latest) {
+        this.openclawVersion = latest.openclawVersion;
+        this.imageVariant = latest.variant;
+        this.trackedImageTag = latest.imageTag;
+        this.trackedImageDigest = latest.imageDigest;
+      } else if (isNew) {
+        this.openclawVersion = null;
+        this.imageVariant = null;
+        this.trackedImageTag = null;
+        this.trackedImageDigest = null;
+      }
     }
 
     const configFields = {
@@ -518,6 +568,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       openclawVersion: this.openclawVersion,
       imageVariant: this.imageVariant,
       trackedImageTag: this.trackedImageTag,
+      trackedImageDigest: this.trackedImageDigest,
     };
 
     const update = isNew
@@ -1070,6 +1121,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
     const guest = guestFromSize(this.machineSize);
     const imageTag = this.resolveImageTag();
+    console.log('[DO] startGateway: deploying with imageTag:', imageTag, 'trackedImageTag:', this.trackedImageTag, 'openclawVersion:', this.openclawVersion);
     const identity = {
       userId: this.userId,
       sandboxId: this.sandboxId,
@@ -1253,6 +1305,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     openclawVersion: string | null;
     imageVariant: string | null;
     trackedImageTag: string | null;
+    trackedImageDigest: string | null;
   }> {
     await this.loadState();
 
@@ -1287,6 +1340,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       openclawVersion: this.openclawVersion,
       imageVariant: this.imageVariant,
       trackedImageTag: this.trackedImageTag,
+      trackedImageDigest: this.trackedImageDigest,
     };
   }
 
@@ -1527,6 +1581,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
             this.openclawVersion = latest.openclawVersion;
             this.imageVariant = latest.variant;
             this.trackedImageTag = latest.imageTag;
+            this.trackedImageDigest = latest.imageDigest;
           }
           // If KV empty, fall through to existing resolveImageTag() fallback
         } else {
@@ -1534,12 +1589,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           this.trackedImageTag = options.imageTag;
           this.openclawVersion = null;
           this.imageVariant = null;
+          this.trackedImageDigest = null;
         }
         await this.ctx.storage.put(
           storageUpdate({
             openclawVersion: this.openclawVersion,
             imageVariant: this.imageVariant,
             trackedImageTag: this.trackedImageTag,
+            trackedImageDigest: this.trackedImageDigest,
           })
         );
       }
@@ -2112,6 +2169,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.openclawVersion = null;
     this.imageVariant = null;
     this.trackedImageTag = null;
+    this.trackedImageDigest = null;
     this.loaded = false;
   }
 
@@ -2544,6 +2602,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.openclawVersion = null;
       this.imageVariant = null;
       this.trackedImageTag = null;
+      this.trackedImageDigest = null;
       this.loaded = true;
 
       console.log('[DO] Restored from Postgres: sandboxId =', instance.sandboxId);

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -494,7 +494,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     // Resolve the image version for this provision.
     // If the user has a pinned image tag, look it up in KV first (fast), then Postgres (authoritative).
     // If not pinned, resolve latest from KV.
-    console.log('[DO] provision: pinnedImageTag from config:', config.pinnedImageTag ?? 'none');
+    console.debug('[DO] provision: pinnedImageTag from config:', config.pinnedImageTag ?? 'none');
     if (config.pinnedImageTag) {
       // Try KV first (fast, but only has versions registered by the current worker)
       let pinned = await resolveVersionByTag(this.env.KV_CLAW_CACHE, config.pinnedImageTag);
@@ -528,11 +528,17 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
                 imageDigest: catalogEntry.imageDigest,
                 publishedAt: catalogEntry.publishedAt,
               };
-              console.log('[DO] Resolved pinned tag from Postgres catalog:', config.pinnedImageTag);
+              console.debug(
+                '[DO] Resolved pinned tag from Postgres catalog:',
+                config.pinnedImageTag
+              );
             }
           }
         } catch (err) {
-          console.warn('[DO] Failed to look up pinned tag in Postgres:', err instanceof Error ? err.message : err);
+          console.warn(
+            '[DO] Failed to look up pinned tag in Postgres:',
+            err instanceof Error ? err.message : err
+          );
         }
       }
 
@@ -541,11 +547,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         this.imageVariant = pinned.variant;
         this.trackedImageTag = pinned.imageTag;
         this.trackedImageDigest = pinned.imageDigest;
-        console.log('[DO] Using pinned version:', pinned.openclawVersion, '→', pinned.imageTag);
+        console.debug('[DO] Using pinned version:', pinned.openclawVersion, '→', pinned.imageTag);
       } else {
         // Pinned tag not found in KV or Postgres — use the tag directly but metadata is unknown.
         // Clear version metadata to avoid stale values from a previous provision.
-        console.warn('[DO] Pinned tag not found in KV or Postgres, using tag directly:', config.pinnedImageTag);
+        console.warn(
+          '[DO] Pinned tag not found in KV or Postgres, using tag directly:',
+          config.pinnedImageTag
+        );
         this.openclawVersion = null;
         this.imageVariant = null;
         this.trackedImageTag = config.pinnedImageTag;
@@ -1139,7 +1148,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const { envVars, minSecretsVersion } = await this.buildUserEnvVars();
     const guest = guestFromSize(this.machineSize);
     const imageTag = this.resolveImageTag();
-    console.log('[DO] startGateway: deploying with imageTag:', imageTag, 'trackedImageTag:', this.trackedImageTag, 'openclawVersion:', this.openclawVersion);
+    console.log(
+      '[DO] startGateway: deploying with imageTag:',
+      imageTag,
+      'trackedImageTag:',
+      this.trackedImageTag,
+      'openclawVersion:',
+      this.openclawVersion
+    );
     const identity = {
       userId: this.userId,
       sandboxId: this.sandboxId,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -500,6 +500,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       let pinned = await resolveVersionByTag(this.env.KV_CLAW_CACHE, config.pinnedImageTag);
 
       // Fall back to Postgres catalog (authoritative, has all synced versions)
+      if (!pinned && !this.env.HYPERDRIVE?.connectionString) {
+        console.error(
+          '[DO] HYPERDRIVE not configured — cannot look up pinned tag in Postgres:',
+          config.pinnedImageTag
+        );
+      }
       if (!pinned && this.env.HYPERDRIVE?.connectionString) {
         try {
           const catalogEntry = await lookupCatalogVersion(

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -64,7 +64,7 @@ import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../utils/env-encryption';
 import { z, type ZodType } from 'zod';
 import { resolveLatestVersion, resolveVersionByTag } from '../lib/image-version';
 import { lookupCatalogVersion } from '../lib/catalog-registration';
-import { ImageVariantSchema, type ImageVariant } from '../schemas/image-version';
+import { ImageVariantSchema } from '../schemas/image-version';
 
 type InstanceStatus = PersistedState['status'];
 
@@ -544,7 +544,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         console.log('[DO] Using pinned version:', pinned.openclawVersion, '→', pinned.imageTag);
       } else {
         // Pinned tag not found in KV or Postgres — use the tag directly but metadata is unknown.
+        // Clear version metadata to avoid stale values from a previous provision.
         console.warn('[DO] Pinned tag not found in KV or Postgres, using tag directly:', config.pinnedImageTag);
+        this.openclawVersion = null;
+        this.imageVariant = null;
         this.trackedImageTag = config.pinnedImageTag;
         this.trackedImageDigest = null;
       }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -507,14 +507,29 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
             config.pinnedImageTag
           );
           if (catalogEntry) {
-            pinned = {
-              openclawVersion: catalogEntry.openclawVersion,
-              variant: catalogEntry.variant as ImageVariant,
-              imageTag: catalogEntry.imageTag,
-              imageDigest: catalogEntry.imageDigest,
-              publishedAt: catalogEntry.publishedAt,
-            };
-            console.log('[DO] Resolved pinned tag from Postgres catalog:', config.pinnedImageTag);
+            // Validate variant from Postgres catalog against known variants
+            const variantParse = ImageVariantSchema.safeParse(catalogEntry.variant);
+            if (!variantParse.success) {
+              // Log error but treat as cache miss rather than failing provision
+              console.error(
+                '[DO] Invalid variant from Postgres catalog, skipping:',
+                catalogEntry.variant,
+                'for tag:',
+                config.pinnedImageTag,
+                'error:',
+                variantParse.error.flatten()
+              );
+              // Continue without setting pinned - will fall through to error handling below
+            } else {
+              pinned = {
+                openclawVersion: catalogEntry.openclawVersion,
+                variant: variantParse.data,
+                imageTag: catalogEntry.imageTag,
+                imageDigest: catalogEntry.imageDigest,
+                publishedAt: catalogEntry.publishedAt,
+              };
+              console.log('[DO] Resolved pinned tag from Postgres catalog:', config.pinnedImageTag);
+            }
           }
         } catch (err) {
           console.warn('[DO] Failed to look up pinned tag in Postgres:', err instanceof Error ? err.message : err);

--- a/kiloclaw/src/lib/catalog-registration.ts
+++ b/kiloclaw/src/lib/catalog-registration.ts
@@ -5,6 +5,7 @@
 
 import { getWorkerDb } from '@kilocode/db/client';
 import { kiloclaw_image_catalog, sql, ne } from '@kilocode/db';
+import { eq } from 'drizzle-orm';
 import { isValidImageTag } from './image-tag-validation';
 
 const OPENCLAW_VERSION_RE = /^\d{4}\.\d{1,2}\.\d{1,2}$/;
@@ -44,6 +45,41 @@ function validateEntry(entry: CatalogVersionEntry): string | null {
     return `publishedAt is older than 1 year: ${entry.publishedAt}`;
   }
   return null;
+}
+
+/**
+ * Look up a catalog entry by image tag from Postgres via Hyperdrive.
+ * Used during provision to resolve metadata for pinned image tags.
+ * Returns regardless of status — pinning is an admin override that
+ * should work even for disabled versions.
+ * Returns null if the tag is not found.
+ */
+export async function lookupCatalogVersion(
+  connectionString: string,
+  imageTag: string
+): Promise<CatalogVersionEntry | null> {
+  const db = getWorkerDb(connectionString);
+  const [row] = await db
+    .select({
+      openclaw_version: kiloclaw_image_catalog.openclaw_version,
+      variant: kiloclaw_image_catalog.variant,
+      image_tag: kiloclaw_image_catalog.image_tag,
+      image_digest: kiloclaw_image_catalog.image_digest,
+      published_at: kiloclaw_image_catalog.published_at,
+    })
+    .from(kiloclaw_image_catalog)
+    .where(eq(kiloclaw_image_catalog.image_tag, imageTag))
+    .limit(1);
+
+  if (!row) return null;
+
+  return {
+    openclawVersion: row.openclaw_version,
+    variant: row.variant,
+    imageTag: row.image_tag,
+    imageDigest: row.image_digest,
+    publishedAt: row.published_at,
+  };
 }
 
 /**

--- a/kiloclaw/src/lib/image-version.ts
+++ b/kiloclaw/src/lib/image-version.ts
@@ -168,6 +168,39 @@ async function rebuildIndex(kv: KVNamespace): Promise<string[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Resolve a specific version by image tag (for pinned users)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a version entry in KV by its image tag.
+ * Scans versioned keys (not latest pointers) and returns the first match.
+ * Returns null if no entry matches the given tag.
+ */
+export async function resolveVersionByTag(
+  kv: KVNamespace,
+  imageTag: string
+): Promise<ImageVersionEntry | null> {
+  let cursor: string | undefined;
+
+  do {
+    const result = await kv.list({ prefix: 'image-version:', cursor });
+    for (const key of result.keys) {
+      if (key.name.startsWith('image-version:latest:') || key.name === IMAGE_VERSION_INDEX_KEY) {
+        continue;
+      }
+      const raw = await kv.get(key.name, 'json');
+      const parsed = ImageVersionEntrySchema.safeParse(raw);
+      if (parsed.success && parsed.data.imageTag === imageTag) {
+        return parsed.data;
+      }
+    }
+    cursor = result.list_complete ? undefined : result.cursor;
+  } while (cursor);
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // List all versions (for admin tooling / triggerSync)
 // ---------------------------------------------------------------------------
 

--- a/kiloclaw/src/lib/image-version.ts
+++ b/kiloclaw/src/lib/image-version.ts
@@ -8,6 +8,14 @@ import type { ImageVersionEntry, ImageVariant } from '../schemas/image-version';
 import { upsertCatalogVersion } from './catalog-registration';
 
 /**
+ * KV key for direct tag-to-entry lookup.
+ * Enables O(1) resolution of pinned image tags during provision.
+ */
+function imageVersionTagKey(imageTag: string): string {
+  return `image-version-tag:${imageTag}`;
+}
+
+/**
  * Read `image-version:latest:<variant>` from KV.
  * Returns the full parsed ImageVersionEntry or null (single KV read).
  * Callers destructure what they need.
@@ -69,11 +77,12 @@ export async function registerVersionIfNeeded(
     publishedAt,
   };
 
-  // Write to KV: versioned key + latest pointer
+  // Write to KV: versioned key + latest pointer + tag lookup key
   const serialized = JSON.stringify(entry);
   await Promise.all([
     kv.put(imageVersionKey(openclawVersion, variant), serialized),
     kv.put(imageVersionLatestKey(variant), serialized),
+    kv.put(imageVersionTagKey(imageTag), serialized),
   ]);
 
   // Maintain KV tag index (best-effort)
@@ -173,24 +182,47 @@ async function rebuildIndex(kv: KVNamespace): Promise<string[]> {
 
 /**
  * Find a version entry in KV by its image tag.
- * Scans versioned keys (not latest pointers) and returns the first match.
+ * Uses direct tag-to-entry lookup key for O(1) resolution.
+ * Falls back to scanning versioned keys if the tag lookup key is missing
+ * (for backward compatibility or cache misses), then backfills the lookup key.
  * Returns null if no entry matches the given tag.
  */
 export async function resolveVersionByTag(
   kv: KVNamespace,
   imageTag: string
 ): Promise<ImageVersionEntry | null> {
-  let cursor: string | undefined;
+  // Fast path: direct tag lookup
+  const raw = await kv.get(imageVersionTagKey(imageTag), 'json');
+  if (raw) {
+    const parsed = ImageVersionEntrySchema.safeParse(raw);
+    if (parsed.success) {
+      return parsed.data;
+    }
+    console.warn('[image-version] Invalid tag entry in KV:', imageTag, parsed.error.flatten());
+  }
 
+  // Fallback: scan versioned keys (for backward compatibility or cache misses)
+  console.log('[image-version] Tag lookup key missing, falling back to scan for:', imageTag);
+  let cursor: string | undefined;
   do {
     const result = await kv.list({ prefix: 'image-version:', cursor });
     for (const key of result.keys) {
-      if (key.name.startsWith('image-version:latest:') || key.name === IMAGE_VERSION_INDEX_KEY) {
+      if (
+        key.name.startsWith('image-version:latest:') ||
+        key.name.startsWith('image-version-tag:') ||
+        key.name === IMAGE_VERSION_INDEX_KEY
+      ) {
         continue;
       }
       const raw = await kv.get(key.name, 'json');
       const parsed = ImageVersionEntrySchema.safeParse(raw);
       if (parsed.success && parsed.data.imageTag === imageTag) {
+        // Backfill the tag lookup key for future requests (fire-and-forget)
+        // This improves performance for subsequent lookups but isn't critical
+        kv.put(imageVersionTagKey(imageTag), JSON.stringify(parsed.data))
+          .catch(err =>
+            console.warn('[image-version] Failed to backfill tag lookup key:', err instanceof Error ? err.message : err)
+          );
         return parsed.data;
       }
     }
@@ -215,8 +247,12 @@ export async function listAllVersions(kv: KVNamespace): Promise<ImageVersionEntr
   do {
     const result = await kv.list({ prefix: 'image-version:', cursor });
     for (const key of result.keys) {
-      // Skip latest pointers and the index key
-      if (key.name.startsWith('image-version:latest:') || key.name === IMAGE_VERSION_INDEX_KEY) {
+      // Skip latest pointers, tag lookups, and the index key
+      if (
+        key.name.startsWith('image-version:latest:') ||
+        key.name.startsWith('image-version-tag:') ||
+        key.name === IMAGE_VERSION_INDEX_KEY
+      ) {
         continue;
       }
       const raw = await kv.get(key.name, 'json');

--- a/kiloclaw/src/lib/image-version.ts
+++ b/kiloclaw/src/lib/image-version.ts
@@ -201,11 +201,15 @@ export async function resolveVersionByTag(
     console.warn('[image-version] Invalid tag entry in KV:', imageTag, parsed.error.flatten());
   }
 
-  // Fallback: scan versioned keys (for backward compatibility or cache misses)
-  console.log('[image-version] Tag lookup key missing, falling back to scan for:', imageTag);
+  // Fallback: scan versioned keys (for backward compatibility or cache misses).
+  // Capped at 5 pages (5000 keys) to prevent unbounded iteration.
+  console.warn('[image-version] Tag lookup key missing, falling back to scan for:', imageTag);
   let cursor: string | undefined;
+  let pages = 0;
+  const MAX_SCAN_PAGES = 5;
   do {
     const result = await kv.list({ prefix: 'image-version:', cursor });
+    pages++;
     for (const key of result.keys) {
       if (
         key.name.startsWith('image-version:latest:') ||
@@ -218,16 +222,21 @@ export async function resolveVersionByTag(
       const parsed = ImageVersionEntrySchema.safeParse(raw);
       if (parsed.success && parsed.data.imageTag === imageTag) {
         // Backfill the tag lookup key for future requests (fire-and-forget)
-        // This improves performance for subsequent lookups but isn't critical
-        kv.put(imageVersionTagKey(imageTag), JSON.stringify(parsed.data))
-          .catch(err =>
-            console.warn('[image-version] Failed to backfill tag lookup key:', err instanceof Error ? err.message : err)
-          );
+        kv.put(imageVersionTagKey(imageTag), JSON.stringify(parsed.data)).catch(err =>
+          console.warn(
+            '[image-version] Failed to backfill tag lookup key:',
+            err instanceof Error ? err.message : err
+          )
+        );
         return parsed.data;
       }
     }
     cursor = result.list_complete ? undefined : result.cursor;
-  } while (cursor);
+  } while (cursor && pages < MAX_SCAN_PAGES);
+
+  if (cursor) {
+    console.warn('[image-version] Scan aborted after', MAX_SCAN_PAGES, 'pages for tag:', imageTag);
+  }
 
   return null;
 }

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -19,7 +19,7 @@ import {
   imageVersionKey,
   imageVersionLatestKey,
 } from '../schemas/image-version';
-import { listAllVersions, updateTagIndex } from '../lib/image-version';
+import { listAllVersions, resolveLatestVersion, updateTagIndex } from '../lib/image-version';
 import { upsertCatalogVersion } from '../lib/catalog-registration';
 import { z } from 'zod';
 import { withDORetry } from '@kilocode/worker-utils';
@@ -135,6 +135,7 @@ platform.post('/provision', async c => {
     kilocodeDefaultModel,
     machineSize,
     region,
+    pinnedImageTag,
   } = result.data;
 
   try {
@@ -150,6 +151,7 @@ platform.post('/provision', async c => {
           kilocodeDefaultModel,
           machineSize,
           region,
+          pinnedImageTag,
         }),
       'provision'
     );
@@ -576,6 +578,19 @@ platform.get('/versions', async c => {
   } catch (err) {
     console.error('[platform] Failed to list versions:', err);
     return c.json({ error: 'Failed to list versions' }, 500);
+  }
+});
+
+// GET /api/platform/versions/latest
+// Returns the current :latest image version from KV.
+platform.get('/versions/latest', async c => {
+  try {
+    const latest = await resolveLatestVersion(c.env.KV_CLAW_CACHE, 'default');
+    if (!latest) return c.json({ error: 'No latest version registered' }, 404);
+    return c.json(latest);
+  } catch (err) {
+    console.error('[platform] Failed to get latest version:', err);
+    return c.json({ error: 'Failed to get latest version' }, 500);
   }
 });
 

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -50,6 +50,9 @@ export const InstanceConfigSchema = z.object({
   // Examples: "us,eu" (try US first, then Europe), "lhr" (London only).
   // If omitted, falls back to the FLY_REGION env var.
   region: z.string().optional(),
+  // If set, use this image tag instead of resolving latest from KV.
+  // Set by the cloud app when the user has a version pin.
+  pinnedImageTag: z.string().optional(),
 });
 
 export type InstanceConfig = z.infer<typeof InstanceConfigSchema>;
@@ -130,6 +133,7 @@ export const PersistedStateSchema = z.object({
   openclawVersion: z.string().nullable().default(null),
   imageVariant: z.string().nullable().default(null),
   trackedImageTag: z.string().nullable().default(null),
+  trackedImageDigest: z.string().nullable().default(null),
 });
 
 export type PersistedState = z.infer<typeof PersistedStateSchema>;

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { IMAGE_TAG_RE, IMAGE_TAG_MAX_LENGTH } from '../lib/image-tag-validation';
 
 export const EncryptedEnvelopeSchema = z.object({
   // AES-256-GCM ciphertext: 16-byte IV + ciphertext + 16-byte tag, base64-encoded.
@@ -52,7 +53,7 @@ export const InstanceConfigSchema = z.object({
   region: z.string().optional(),
   // If set, use this image tag instead of resolving latest from KV.
   // Set by the cloud app when the user has a version pin.
-  pinnedImageTag: z.string().optional(),
+  pinnedImageTag: z.string().regex(IMAGE_TAG_RE).max(IMAGE_TAG_MAX_LENGTH).optional(),
 });
 
 export type InstanceConfig = z.infer<typeof InstanceConfigSchema>;

--- a/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
+++ b/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
@@ -19,6 +19,10 @@ const baseStatus: KiloClawDashboardStatus = {
   flyVolumeId: null,
   flyRegion: null,
   machineSize: null,
+  openclawVersion: null,
+  imageVariant: null,
+  trackedImageTag: null,
+  trackedImageDigest: null,
   gatewayToken: 'token',
   workerUrl: 'https://claw.kilo.ai',
 };

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -188,7 +188,7 @@ function VersionPinCard({ userId }: { userId: string }) {
           <Pin className="h-5 w-5" />
           <CardTitle>Version Pin</CardTitle>
         </div>
-        <CardDescription>Pin this user to a specific KiloClaw image version</CardDescription>
+        <CardDescription>Pin this user to a specific KiloClaw image tag</CardDescription>
       </CardHeader>
       <CardContent>
         {pinLoading ? (
@@ -199,13 +199,13 @@ function VersionPinCard({ userId }: { userId: string }) {
         ) : pinData ? (
           <div className="space-y-3">
             <div className="grid grid-cols-2 gap-4">
-              <DetailField label="Status">
-                <Badge className="bg-blue-600">
-                  Pinned to {pinData.openclaw_version ?? pinData.image_tag}
+              <DetailField label="Pinned Image Tag">
+                <Badge className="bg-blue-600 font-mono text-xs">
+                  {pinData.image_tag}
                 </Badge>
               </DetailField>
-              <DetailField label="Image Tag">
-                <code className="text-xs">{pinData.image_tag}</code>
+              <DetailField label="OpenClaw Version">
+                {pinData.openclaw_version ?? '—'}
               </DetailField>
               <DetailField label="Variant">{pinData.variant ?? 'default'}</DetailField>
               <DetailField label="Pinned By">
@@ -216,12 +216,12 @@ function VersionPinCard({ userId }: { userId: string }) {
             <div className="flex items-center gap-2 pt-2">
               <Select value={selectedTag} onValueChange={setSelectedTag}>
                 <SelectTrigger className="w-[250px]">
-                  <SelectValue placeholder="Change OpenClaw version..." />
+                  <SelectValue placeholder="Change image tag..." />
                 </SelectTrigger>
                 <SelectContent>
                   {versionsData?.items.map(v => (
                     <SelectItem key={v.image_tag} value={v.image_tag}>
-                      {v.openclaw_version} ({v.variant}) - {v.image_tag.slice(0, 16)}
+                      {v.image_tag} (OpenClaw {v.openclaw_version})
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -259,12 +259,12 @@ function VersionPinCard({ userId }: { userId: string }) {
             <div className="flex items-center gap-2">
               <Select value={selectedTag} onValueChange={setSelectedTag}>
                 <SelectTrigger className="w-[250px]">
-                  <SelectValue placeholder="Select OpenClaw version to pin..." />
+                  <SelectValue placeholder="Select image tag to pin..." />
                 </SelectTrigger>
                 <SelectContent>
                   {versionsData?.items.map(v => (
                     <SelectItem key={v.image_tag} value={v.image_tag}>
-                      {v.openclaw_version} ({v.variant}) - {v.image_tag.slice(0, 16)}
+                      {v.image_tag} (OpenClaw {v.openclaw_version})
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -628,6 +628,30 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   <DetailField label="Secrets">{data.workerStatus.secretCount}</DetailField>
 
                   <DetailField label="Channels">{data.workerStatus.channelCount}</DetailField>
+
+                  <DetailField label="OpenClaw Version">
+                    {data.workerStatus.openclawVersion ?? '—'}
+                  </DetailField>
+
+                  <DetailField label="Image Variant">
+                    {data.workerStatus.imageVariant ?? '—'}
+                  </DetailField>
+
+                  <DetailField label="Image Tag">
+                    {data.workerStatus.trackedImageTag ? (
+                      <code className="text-xs">{data.workerStatus.trackedImageTag}</code>
+                    ) : (
+                      '—'
+                    )}
+                  </DetailField>
+
+                  <DetailField label="Image Digest">
+                    {data.workerStatus.trackedImageDigest ? (
+                      <code className="text-xs">{data.workerStatus.trackedImageDigest}</code>
+                    ) : (
+                      '—'
+                    )}
+                  </DetailField>
                 </div>
               ) : !data.workerStatusError ? (
                 <p className="text-muted-foreground text-sm">No worker status available</p>

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -200,13 +200,9 @@ function VersionPinCard({ userId }: { userId: string }) {
           <div className="space-y-3">
             <div className="grid grid-cols-2 gap-4">
               <DetailField label="Pinned Image Tag">
-                <Badge className="bg-blue-600 font-mono text-xs">
-                  {pinData.image_tag}
-                </Badge>
+                <Badge className="bg-blue-600 font-mono text-xs">{pinData.image_tag}</Badge>
               </DetailField>
-              <DetailField label="OpenClaw Version">
-                {pinData.openclaw_version ?? '—'}
-              </DetailField>
+              <DetailField label="OpenClaw Version">{pinData.openclaw_version ?? '—'}</DetailField>
               <DetailField label="Variant">{pinData.variant ?? 'default'}</DetailField>
               <DetailField label="Pinned By">
                 {pinData.pinned_by_email ?? pinData.pinned_by}

--- a/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -70,6 +70,10 @@ export function VersionsTab() {
     })
   );
 
+  const { data: latestTag } = useQuery(
+    trpc.admin.kiloclawVersions.getLatestTag.queryOptions()
+  );
+
   const { mutateAsync: updateStatus } = useMutation(
     trpc.admin.kiloclawVersions.updateVersionStatus.mutationOptions({
       onSuccess: () => {
@@ -80,6 +84,20 @@ export function VersionsTab() {
       },
       onError: err => {
         toast.error(`Failed to update status: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: syncCatalog, isPending: isSyncing } = useMutation(
+    trpc.admin.kiloclawVersions.syncCatalog.mutationOptions({
+      onSuccess: result => {
+        toast.success(`Sync complete: ${result.synced} added, ${result.skipped} already existed`);
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.listVersions.queryKey(),
+        });
+      },
+      onError: err => {
+        toast.error(`Sync failed: ${err.message}`);
       },
     })
   );
@@ -105,6 +123,14 @@ export function VersionsTab() {
             <SelectItem value="disabled">Disabled</SelectItem>
           </SelectContent>
         </Select>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isSyncing}
+          onClick={() => void syncCatalog()}
+        >
+          {isSyncing ? 'Syncing...' : 'Sync from KV'}
+        </Button>
       </div>
 
       <div className="rounded-lg border">
@@ -139,11 +165,18 @@ export function VersionsTab() {
                   <TableCell className="font-medium">{version.openclaw_version}</TableCell>
                   <TableCell>{version.variant}</TableCell>
                   <TableCell>
-                    <code className="text-xs">
-                      {version.image_tag.length > 20
-                        ? `${version.image_tag.slice(0, 20)}…`
-                        : version.image_tag}
-                    </code>
+                    <div className="flex items-center gap-1.5">
+                      <code className="text-xs">
+                        {version.image_tag.length > 20
+                          ? `${version.image_tag.slice(0, 20)}…`
+                          : version.image_tag}
+                      </code>
+                      {latestTag === version.image_tag && (
+                        <Badge className="bg-blue-600 text-white text-[10px] px-1.5 py-0">
+                          latest
+                        </Badge>
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <code className="text-xs" title={version.image_digest ?? undefined}>
@@ -365,16 +398,16 @@ export function PinsTab() {
                 </Popover>
               )}
             </div>
-            <div className="w-[250px]">
-              <label className="text-muted-foreground mb-1 block text-xs">OpenClaw Version</label>
+            <div className="w-[300px]">
+              <label className="text-muted-foreground mb-1 block text-xs">Image Tag</label>
               <Select value={pinImageTag} onValueChange={setPinImageTag}>
                 <SelectTrigger>
-                  <SelectValue placeholder="Select OpenClaw version..." />
+                  <SelectValue placeholder="Select image tag..." />
                 </SelectTrigger>
                 <SelectContent>
                   {availableVersions?.items.map(v => (
                     <SelectItem key={v.image_tag} value={v.image_tag}>
-                      {v.openclaw_version} ({v.variant})
+                      {v.image_tag} (OpenClaw {v.openclaw_version})
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -70,9 +70,7 @@ export function VersionsTab() {
     })
   );
 
-  const { data: latestTag } = useQuery(
-    trpc.admin.kiloclawVersions.getLatestTag.queryOptions()
-  );
+  const { data: latestTag } = useQuery(trpc.admin.kiloclawVersions.getLatestTag.queryOptions());
 
   const { mutateAsync: updateStatus } = useMutation(
     trpc.admin.kiloclawVersions.updateVersionStatus.mutationOptions({
@@ -91,7 +89,9 @@ export function VersionsTab() {
   const { mutateAsync: syncCatalog, isPending: isSyncing } = useMutation(
     trpc.admin.kiloclawVersions.syncCatalog.mutationOptions({
       onSuccess: result => {
-        toast.success(`Sync complete: ${result.synced} added, ${result.skipped} already existed`);
+        const parts = [`${result.synced} added`, `${result.alreadyExisted} already existed`];
+        if (result.invalid > 0) parts.push(`${result.invalid} invalid`);
+        toast.success(`Sync complete: ${parts.join(', ')}`);
         void queryClient.invalidateQueries({
           queryKey: trpc.admin.kiloclawVersions.listVersions.queryKey(),
         });
@@ -123,12 +123,7 @@ export function VersionsTab() {
             <SelectItem value="disabled">Disabled</SelectItem>
           </SelectContent>
         </Select>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={isSyncing}
-          onClick={() => void syncCatalog()}
-        >
+        <Button variant="outline" size="sm" disabled={isSyncing} onClick={() => void syncCatalog()}>
           {isSyncing ? 'Syncing...' : 'Sync from KV'}
         </Button>
       </div>
@@ -172,7 +167,7 @@ export function VersionsTab() {
                           : version.image_tag}
                       </code>
                       {latestTag === version.image_tag && (
-                        <Badge className="bg-blue-600 text-white text-[10px] px-1.5 py-0">
+                        <Badge className="bg-blue-600 px-1.5 py-0 text-[10px] text-white">
                           latest
                         </Badge>
                       )}

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { KILOCLAW_API_URL, KILOCLAW_INTERNAL_API_SECRET } from '@/lib/config.server';
 import type {
+  ImageVersionEntry,
   ProvisionInput,
   PlatformStatusResponse,
   KiloCodeConfigPatchInput,
@@ -74,6 +75,18 @@ export class KiloClawInternalClient {
     }
 
     return res.json() as Promise<T>;
+  }
+
+  async listVersions(): Promise<ImageVersionEntry[]> {
+    return this.request('/api/platform/versions');
+  }
+
+  async getLatestVersion(): Promise<ImageVersionEntry | null> {
+    try {
+      return await this.request('/api/platform/versions/latest');
+    } catch {
+      return null;
+    }
   }
 
   async provision(userId: string, config: ProvisionInput): Promise<{ sandboxId: string }> {

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -84,8 +84,13 @@ export class KiloClawInternalClient {
   async getLatestVersion(): Promise<ImageVersionEntry | null> {
     try {
       return await this.request('/api/platform/versions/latest');
-    } catch {
-      return null;
+    } catch (err) {
+      // Only return null for 404 (no latest version set)
+      // Re-throw other errors (network, auth, server errors) so callers can handle them
+      if (err instanceof KiloClawApiError && err.statusCode === 404) {
+        return null;
+      }
+      throw err;
     }
   }
 

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -1,5 +1,14 @@
 import type { EncryptedEnvelope } from '@/lib/encryption';
 
+/** Mirrors the worker's ImageVersionEntry schema (KV stored version metadata) */
+export type ImageVersionEntry = {
+  openclawVersion: string;
+  variant: string;
+  imageTag: string;
+  imageDigest: string | null;
+  publishedAt: string;
+};
+
 /** Input to POST /api/platform/provision */
 export type ProvisionInput = {
   envVars?: Record<string, string>;
@@ -13,6 +22,7 @@ export type ProvisionInput = {
   kilocodeApiKey?: string;
   kilocodeApiKeyExpiresAt?: string;
   kilocodeDefaultModel?: string;
+  pinnedImageTag?: string;
 };
 
 export type KiloCodeConfigPatchInput = {
@@ -109,6 +119,10 @@ export type PlatformStatusResponse = {
   flyVolumeId: string | null;
   flyRegion: string | null;
   machineSize: MachineSize | null;
+  openclawVersion: string | null;
+  imageVariant: string | null;
+  trackedImageTag: string | null;
+  trackedImageDigest: string | null;
 };
 
 /** A Fly volume snapshot. */

--- a/src/routers/admin-kiloclaw-versions-router.test.ts
+++ b/src/routers/admin-kiloclaw-versions-router.test.ts
@@ -6,6 +6,22 @@ import { db } from '@/lib/drizzle';
 import { kiloclaw_image_catalog, kiloclaw_version_pins } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 
+// Mock KiloClawInternalClient so tests don't require KILOCLAW_API_URL.
+// getLatestVersion returns null (no latest set) so disable-latest guard passes.
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
+  KiloClawInternalClient: jest.fn().mockImplementation(() => ({
+    getLatestVersion: jest.fn().mockResolvedValue(null),
+    listVersions: jest.fn().mockResolvedValue([]),
+  })),
+  KiloClawApiError: class extends Error {
+    readonly statusCode: number;
+    constructor(statusCode: number) {
+      super(`KiloClaw API error (${statusCode})`);
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
 let regularUser: User;
 let adminUser: User;
 let targetUser: User;

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -267,6 +267,11 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       });
     }
 
+    // Early return if KV has no versions
+    if (kvVersions.length === 0) {
+      return { synced: 0, skipped: 0, total: 0 };
+    }
+
     // Fetch only existing tags that match KV versions (more memory-efficient)
     const kvTags = kvVersions.map(v => v.imageTag);
     const existingTags = new Set(

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -4,6 +4,7 @@ import { kiloclaw_image_catalog, kiloclaw_version_pins, kilocode_users } from '@
 import { eq, desc, sql, or, ilike } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { TRPCError } from '@trpc/server';
+import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import * as z from 'zod';
 
 const ListVersionsSchema = z.object({
@@ -72,6 +73,18 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
   updateVersionStatus: adminProcedure
     .input(UpdateVersionStatusSchema)
     .mutation(async ({ input, ctx }) => {
+      // Prevent disabling the :latest version — it would break all unpinned users
+      if (input.status === 'disabled') {
+        const client = new KiloClawInternalClient();
+        const latestTag = (await client.getLatestVersion())?.imageTag;
+        if (latestTag === input.imageTag) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'Cannot disable the current :latest version. Push a new image first.',
+          });
+        }
+      }
+
       const [updated] = await db
         .update(kiloclaw_image_catalog)
         .set({
@@ -163,24 +176,36 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
   }),
 
   setPin: adminProcedure.input(SetPinSchema).mutation(async ({ input, ctx }) => {
-    const [result] = await db
-      .insert(kiloclaw_version_pins)
-      .values({
-        user_id: input.userId,
-        image_tag: input.imageTag,
-        pinned_by: ctx.user.id,
-        reason: input.reason ?? null,
-      })
-      .onConflictDoUpdate({
-        target: kiloclaw_version_pins.user_id,
-        set: {
+    let result;
+    try {
+      [result] = await db
+        .insert(kiloclaw_version_pins)
+        .values({
+          user_id: input.userId,
           image_tag: input.imageTag,
           pinned_by: ctx.user.id,
           reason: input.reason ?? null,
-          updated_at: new Date().toISOString(),
-        },
-      })
-      .returning();
+        })
+        .onConflictDoUpdate({
+          target: kiloclaw_version_pins.user_id,
+          set: {
+            image_tag: input.imageTag,
+            pinned_by: ctx.user.id,
+            reason: input.reason ?? null,
+            updated_at: new Date().toISOString(),
+          },
+        })
+        .returning();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      if (msg.includes('foreign key') || msg.includes('violates')) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Image tag '${input.imageTag}' not found in catalog`,
+        });
+      }
+      throw err;
+    }
 
     if (!result) {
       throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create pin' });
@@ -200,6 +225,45 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
     }
 
     return { success: true };
+  }),
+
+  getLatestTag: adminProcedure.query(async () => {
+    const client = new KiloClawInternalClient();
+    const latest = await client.getLatestVersion();
+    return latest?.imageTag ?? null;
+  }),
+
+  syncCatalog: adminProcedure.mutation(async () => {
+    const client = new KiloClawInternalClient();
+    const kvVersions = await client.listVersions();
+
+    let synced = 0;
+    let skipped = 0;
+
+    for (const entry of kvVersions) {
+      const [existing] = await db
+        .select({ image_tag: kiloclaw_image_catalog.image_tag })
+        .from(kiloclaw_image_catalog)
+        .where(eq(kiloclaw_image_catalog.image_tag, entry.imageTag))
+        .limit(1);
+
+      if (existing) {
+        skipped++;
+        continue;
+      }
+
+      await db.insert(kiloclaw_image_catalog).values({
+        openclaw_version: entry.openclawVersion,
+        variant: entry.variant,
+        image_tag: entry.imageTag,
+        image_digest: entry.imageDigest,
+        status: 'available',
+        published_at: entry.publishedAt,
+      });
+      synced++;
+    }
+
+    return { synced, skipped, total: kvVersions.length };
   }),
 
   searchUsers: adminProcedure

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -73,7 +73,9 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
   updateVersionStatus: adminProcedure
     .input(UpdateVersionStatusSchema)
     .mutation(async ({ input, ctx }) => {
-      // Prevent disabling the :latest version — it would break all unpinned users
+      // Prevent disabling the :latest version — it would break all unpinned users.
+      // Note: TOCTOU race exists between fetching latest from KV and the DB update below.
+      // Acceptable because this is an admin-only operation with low concurrent usage.
       if (input.status === 'disabled') {
         const client = new KiloClawInternalClient();
         try {
@@ -285,12 +287,25 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
 
     // Filter out entries that already exist
     const newEntries = kvVersions.filter(entry => !existingTags.has(entry.imageTag));
-    const skipped = kvVersions.length - newEntries.length;
 
-    // Bulk insert new entries
-    if (newEntries.length > 0) {
+    // Validate entries before inserting — KV data may be malformed
+    const IMAGE_TAG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+    const VERSION_RE = /^\d{4}\.\d{1,2}\.\d{1,2}$/;
+    const VARIANT_RE = /^[a-z0-9-]{1,64}$/;
+    const validEntries = newEntries.filter(entry => {
+      if (!IMAGE_TAG_RE.test(entry.imageTag) || entry.imageTag.length > 128) return false;
+      if (!VERSION_RE.test(entry.openclawVersion)) return false;
+      if (!VARIANT_RE.test(entry.variant)) return false;
+      const ts = new Date(entry.publishedAt).getTime();
+      if (isNaN(ts)) return false;
+      return true;
+    });
+    const skipped = kvVersions.length - validEntries.length;
+
+    // Bulk insert validated new entries
+    if (validEntries.length > 0) {
       await db.insert(kiloclaw_image_catalog).values(
-        newEntries.map(entry => ({
+        validEntries.map(entry => ({
           openclaw_version: entry.openclawVersion,
           variant: entry.variant,
           image_tag: entry.imageTag,
@@ -301,7 +316,7 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       );
     }
 
-    return { synced: newEntries.length, skipped, total: kvVersions.length };
+    return { synced: validEntries.length, skipped, total: kvVersions.length };
   }),
 
   searchUsers: adminProcedure

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -213,7 +213,7 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
         .returning();
     } catch (err) {
       const msg = err instanceof Error ? err.message : '';
-      if (msg.includes('foreign key') || msg.includes('violates')) {
+      if (msg.includes('foreign key')) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: `Image tag '${input.imageTag}' not found in catalog`,
@@ -271,7 +271,7 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
 
     // Early return if KV has no versions
     if (kvVersions.length === 0) {
-      return { synced: 0, skipped: 0, total: 0 };
+      return { synced: 0, alreadyExisted: 0, invalid: 0, total: 0 };
     }
 
     // Fetch only existing tags that match KV versions (more memory-efficient)
@@ -285,10 +285,11 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       ).map(row => row.image_tag)
     );
 
-    // Filter out entries that already exist
+    // Filter out entries that already exist in Postgres
     const newEntries = kvVersions.filter(entry => !existingTags.has(entry.imageTag));
 
-    // Validate entries before inserting — KV data may be malformed
+    // Validate entries before inserting — KV data may be malformed.
+    // Uses the same rules as validateEntry() in catalog-registration.ts.
     const IMAGE_TAG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
     const VERSION_RE = /^\d{4}\.\d{1,2}\.\d{1,2}$/;
     const VARIANT_RE = /^[a-z0-9-]{1,64}$/;
@@ -300,23 +301,32 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       if (isNaN(ts)) return false;
       return true;
     });
-    const skipped = kvVersions.length - validEntries.length;
+    const invalidCount = newEntries.length - validEntries.length;
 
-    // Bulk insert validated new entries
+    // Bulk insert validated new entries. onConflictDoNothing guards against
+    // concurrent syncs inserting the same tag between our check and insert.
     if (validEntries.length > 0) {
-      await db.insert(kiloclaw_image_catalog).values(
-        validEntries.map(entry => ({
-          openclaw_version: entry.openclawVersion,
-          variant: entry.variant,
-          image_tag: entry.imageTag,
-          image_digest: entry.imageDigest,
-          status: 'available' as const,
-          published_at: entry.publishedAt,
-        }))
-      );
+      await db
+        .insert(kiloclaw_image_catalog)
+        .values(
+          validEntries.map(entry => ({
+            openclaw_version: entry.openclawVersion,
+            variant: entry.variant,
+            image_tag: entry.imageTag,
+            image_digest: entry.imageDigest,
+            status: 'available' as const,
+            published_at: entry.publishedAt,
+          }))
+        )
+        .onConflictDoNothing();
     }
 
-    return { synced: validEntries.length, skipped, total: kvVersions.length };
+    return {
+      synced: validEntries.length,
+      alreadyExisted: existingTags.size,
+      invalid: invalidCount,
+      total: kvVersions.length,
+    };
   }),
 
   searchUsers: adminProcedure

--- a/src/routers/admin-kiloclaw-versions-router.ts
+++ b/src/routers/admin-kiloclaw-versions-router.ts
@@ -1,7 +1,7 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { kiloclaw_image_catalog, kiloclaw_version_pins, kilocode_users } from '@kilocode/db/schema';
-import { eq, desc, sql, or, ilike } from 'drizzle-orm';
+import { eq, desc, sql, or, ilike, inArray } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { TRPCError } from '@trpc/server';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -76,11 +76,24 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       // Prevent disabling the :latest version — it would break all unpinned users
       if (input.status === 'disabled') {
         const client = new KiloClawInternalClient();
-        const latestTag = (await client.getLatestVersion())?.imageTag;
-        if (latestTag === input.imageTag) {
+        try {
+          const latestTag = (await client.getLatestVersion())?.imageTag;
+          if (latestTag === input.imageTag) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'Cannot disable the current :latest version. Push a new image first.',
+            });
+          }
+        } catch (err) {
+          // If it's already a TRPCError, re-throw it
+          if (err instanceof TRPCError) {
+            throw err;
+          }
+          // Only catch unexpected errors (network, service unavailable, etc.)
           throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'Cannot disable the current :latest version. Push a new image first.',
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to verify latest version status',
+            cause: err,
           });
         }
       }
@@ -229,41 +242,61 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
 
   getLatestTag: adminProcedure.query(async () => {
     const client = new KiloClawInternalClient();
-    const latest = await client.getLatestVersion();
-    return latest?.imageTag ?? null;
+    try {
+      const latest = await client.getLatestVersion();
+      return latest?.imageTag ?? null;
+    } catch (err) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to fetch latest version',
+        cause: err,
+      });
+    }
   }),
 
   syncCatalog: adminProcedure.mutation(async () => {
     const client = new KiloClawInternalClient();
-    const kvVersions = await client.listVersions();
-
-    let synced = 0;
-    let skipped = 0;
-
-    for (const entry of kvVersions) {
-      const [existing] = await db
-        .select({ image_tag: kiloclaw_image_catalog.image_tag })
-        .from(kiloclaw_image_catalog)
-        .where(eq(kiloclaw_image_catalog.image_tag, entry.imageTag))
-        .limit(1);
-
-      if (existing) {
-        skipped++;
-        continue;
-      }
-
-      await db.insert(kiloclaw_image_catalog).values({
-        openclaw_version: entry.openclawVersion,
-        variant: entry.variant,
-        image_tag: entry.imageTag,
-        image_digest: entry.imageDigest,
-        status: 'available',
-        published_at: entry.publishedAt,
+    let kvVersions;
+    try {
+      kvVersions = await client.listVersions();
+    } catch (err) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to fetch versions from KiloClaw service',
+        cause: err,
       });
-      synced++;
     }
 
-    return { synced, skipped, total: kvVersions.length };
+    // Fetch only existing tags that match KV versions (more memory-efficient)
+    const kvTags = kvVersions.map(v => v.imageTag);
+    const existingTags = new Set(
+      (
+        await db
+          .select({ image_tag: kiloclaw_image_catalog.image_tag })
+          .from(kiloclaw_image_catalog)
+          .where(inArray(kiloclaw_image_catalog.image_tag, kvTags))
+      ).map(row => row.image_tag)
+    );
+
+    // Filter out entries that already exist
+    const newEntries = kvVersions.filter(entry => !existingTags.has(entry.imageTag));
+    const skipped = kvVersions.length - newEntries.length;
+
+    // Bulk insert new entries
+    if (newEntries.length > 0) {
+      await db.insert(kiloclaw_image_catalog).values(
+        newEntries.map(entry => ({
+          openclaw_version: entry.openclawVersion,
+          variant: entry.variant,
+          image_tag: entry.imageTag,
+          image_digest: entry.imageDigest,
+          status: 'available' as const,
+          published_at: entry.publishedAt,
+        }))
+      );
+    }
+
+    return { synced: newEntries.length, skipped, total: kvVersions.length };
   }),
 
   searchUsers: adminProcedure

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -8,6 +8,9 @@ import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kilocla
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
 import { KILOCLAW_API_URL } from '@/lib/config.server';
+import { db } from '@/lib/drizzle';
+import { kiloclaw_version_pins } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import { sentryLogger } from '@/lib/utils.server';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
 import {
@@ -123,6 +126,13 @@ async function provisionInstance(
   });
   const kilocodeApiKeyExpiresAt = new Date(Date.now() + expiresInSeconds * 1000).toISOString();
 
+  // Check if the user has a version pin
+  const [pin] = await db
+    .select({ image_tag: kiloclaw_version_pins.image_tag })
+    .from(kiloclaw_version_pins)
+    .where(eq(kiloclaw_version_pins.user_id, user.id))
+    .limit(1);
+
   const client = new KiloClawInternalClient();
   return client.provision(user.id, {
     envVars: input.envVars,
@@ -131,6 +141,7 @@ async function provisionInstance(
     kilocodeApiKey,
     kilocodeApiKeyExpiresAt,
     kilocodeDefaultModel: input.kilocodeDefaultModel ?? undefined,
+    pinnedImageTag: pin?.image_tag,
   });
 }
 


### PR DESCRIPTION
feat: KiloClaw Phase 2 — provision pin support and admin UI                             
                                         
Wire pinnedImageTag through the full provision flow so pinned users get their specific image version instead of :latest.                                                      
                                                                                                            
  Provision flow:
  - Query kiloclaw_version_pins before provision (kiloclaw-router.ts)
  - Pass pinnedImageTag through worker route to DO (platform.ts)
  - DO resolves pin metadata from KV first, Postgres catalog fallback
  - Add lookupCatalogVersion() for Postgres-based tag resolution
  - Track trackedImageDigest through full DO lifecycle

  Admin UI:
  - Reframe Version Pin UI around image tag as primary identity
  - Add 'latest' badge on Versions tab via /versions/latest endpoint
  - Show OpenClaw Version, Variant, Image Tag, Digest on instance detail
  - Image tag shown as primary in pin dropdowns and badges

  Safety:
  - Block disabling :latest version (must push new image first)
  - Friendly error on FK violation when pinning to non-existent tag
  - Fail-open if worker unreachable during latest check

  Dev tooling:
  - push-dev.sh captures image digest via --metadata-file
  - Debug logging in provision and start paths