### PR TITLE
CloudAgent - Use oauth2 username for GitLab git authentication

### DIFF
--- a/cloud-agent-next/src/execution/orchestrator.ts
+++ b/cloud-agent-next/src/execution/orchestrator.ts
@@ -406,7 +406,8 @@ export class ExecutionOrchestrator {
           prepared.session,
           prepared.context.workspacePath,
           existingMetadata.gitUrl,
-          resumeContext.gitToken
+          resumeContext.gitToken,
+          prepared.context.platform
         );
       }
     } catch (error) {

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -823,7 +823,10 @@ export class SessionService {
     // Shallow clone (depth: 1) can be enabled for faster checkout and reduced disk usage
     const cloneOptions = shallow ? { shallow: true } : undefined;
     if (gitUrl) {
-      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, cloneOptions);
+      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, {
+        ...cloneOptions,
+        platform: context.platform,
+      });
     } else if (githubRepo) {
       await cloneGitHubRepo(
         session,
@@ -1102,7 +1105,9 @@ export class SessionService {
 
     // Clone repository using appropriate method
     if (gitUrl) {
-      await cloneGitRepo(session, workspacePath, gitUrl, gitToken);
+      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, {
+        platform: context.platform,
+      });
     } else if (githubRepo) {
       await cloneGitHubRepo(
         session,
@@ -1389,6 +1394,7 @@ export class SessionService {
       gitToken: freshGitToken ?? metadata.gitToken,
       gitAuthorEnv: getGitAuthorEnv(env, metadata.githubAppType),
       lastSeenBranch: metadata.upstreamBranch,
+      platform: context.platform,
     });
 
     await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);

--- a/cloud-agent-next/src/workspace.test.ts
+++ b/cloud-agent-next/src/workspace.test.ts
@@ -3,6 +3,7 @@ import {
   manageBranch,
   cloneGitHubRepo,
   cloneGitRepo,
+  updateGitRemoteToken,
   checkDiskSpace,
   createSandboxUsageEvent,
   LOW_DISK_THRESHOLD_MB,
@@ -440,6 +441,121 @@ describe('disk space checking', () => {
         expect.stringContaining('x-access-token:test-token'),
         expect.any(Object)
       );
+    });
+
+    it('should use oauth2 username for gitlab platform', async () => {
+      mockExec
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
+
+      mockGitCheckout.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+      });
+
+      await cloneGitRepo(
+        fakeSession,
+        '/workspace',
+        'https://gitlab.com/repo.git',
+        'test-token',
+        undefined,
+        {
+          platform: 'gitlab',
+        }
+      );
+
+      expect(mockGitCheckout).toHaveBeenCalledWith(
+        expect.stringContaining('oauth2:test-token'),
+        expect.any(Object)
+      );
+    });
+
+    it('should use x-access-token username for github platform', async () => {
+      mockExec
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
+
+      mockGitCheckout.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+      });
+
+      await cloneGitRepo(
+        fakeSession,
+        '/workspace',
+        'https://example.com/repo.git',
+        'test-token',
+        undefined,
+        {
+          platform: 'github',
+        }
+      );
+
+      expect(mockGitCheckout).toHaveBeenCalledWith(
+        expect.stringContaining('x-access-token:test-token'),
+        expect.any(Object)
+      );
+    });
+
+    it('should use x-access-token username when platform is undefined', async () => {
+      mockExec
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
+
+      mockGitCheckout.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+      });
+
+      await cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git', 'test-token');
+
+      expect(mockGitCheckout).toHaveBeenCalledWith(
+        expect.stringContaining('x-access-token:test-token'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('updateGitRemoteToken', () => {
+    it('should use oauth2 username for gitlab platform', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await updateGitRemoteToken(
+        fakeSession,
+        '/workspace',
+        'https://gitlab.com/repo.git',
+        'new-token',
+        'gitlab'
+      );
+
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('oauth2:new-token'));
+    });
+
+    it('should use x-access-token username for github platform', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await updateGitRemoteToken(
+        fakeSession,
+        '/workspace',
+        'https://example.com/repo.git',
+        'new-token',
+        'github'
+      );
+
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('x-access-token:new-token'));
+    });
+
+    it('should use x-access-token username when platform is undefined', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await updateGitRemoteToken(
+        fakeSession,
+        '/workspace',
+        'https://example.com/repo.git',
+        'new-token'
+      );
+
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('x-access-token:new-token'));
     });
   });
 

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -279,14 +279,14 @@ export async function cloneGitRepo(
   gitUrl: string,
   gitToken?: string,
   gitAuthor?: GitAuthorConfig,
-  options?: { shallow?: boolean }
+  options?: { shallow?: boolean; platform?: 'github' | 'gitlab' }
 ): Promise<void> {
   // Build URL with token if available (for private repos)
-  // Use x-access-token format which works across most git providers
+  // GitLab OAuth tokens require username 'oauth2'; all other providers use 'x-access-token'
   let repoUrl = gitUrl;
   if (gitToken) {
     const url = new URL(gitUrl);
-    url.username = 'x-access-token';
+    url.username = options?.platform === 'gitlab' ? 'oauth2' : 'x-access-token';
     url.password = gitToken;
     repoUrl = url.toString();
   }
@@ -338,6 +338,7 @@ export type RestoreWorkspaceOptions = {
   gitToken?: string;
   gitAuthorEnv?: { GITHUB_APP_SLUG?: string; GITHUB_APP_BOT_USER_ID?: string };
   lastSeenBranch?: string;
+  platform?: 'github' | 'gitlab';
 };
 
 export async function restoreWorkspace(
@@ -347,7 +348,9 @@ export async function restoreWorkspace(
   options: RestoreWorkspaceOptions
 ): Promise<void> {
   if (options.gitUrl) {
-    await cloneGitRepo(session, workspacePath, options.gitUrl, options.gitToken);
+    await cloneGitRepo(session, workspacePath, options.gitUrl, options.gitToken, undefined, {
+      platform: options.platform,
+    });
   } else if (options.githubRepo) {
     await cloneGitHubRepo(
       session,
@@ -367,22 +370,23 @@ export async function restoreWorkspace(
 /**
  * Update the git remote origin URL to include a new token.
  * This is needed when the git token changes and we need to push/pull.
- * Uses the same x-access-token format as cloneGitRepo() for consistency.
  *
  * @param session - Execution session
  * @param workspacePath - Path to the git repository
  * @param gitUrl - Full git URL (e.g., https://github.com/org/repo.git)
  * @param gitToken - New git token for authentication
+ * @param platform - Git platform; GitLab requires 'oauth2' as the username
  */
 export async function updateGitRemoteToken(
   session: ExecutionSession,
   workspacePath: string,
   gitUrl: string,
-  gitToken: string
+  gitToken: string,
+  platform?: 'github' | 'gitlab'
 ): Promise<void> {
-  // Build new URL with token embedded (same format as cloneGitRepo)
+  // Build new URL with token embedded (GitLab uses 'oauth2', others use 'x-access-token')
   const newUrl = new URL(gitUrl);
-  newUrl.username = 'x-access-token';
+  newUrl.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
   newUrl.password = gitToken;
 
   const sanitizedGitUrl = sanitizeGitUrlForLogging(gitUrl);

--- a/cloud-agent/src/queue/consumer-core.ts
+++ b/cloud-agent/src/queue/consumer-core.ts
@@ -327,7 +327,8 @@ async function processMessage(msg: ExecutionMessage, env: Env, deps: ConsumerDep
               prepared.session,
               prepared.context.workspacePath,
               planMetadata.gitUrl,
-              resumeTokenOverrides.gitToken
+              resumeTokenOverrides.gitToken,
+              prepared.context.platform
             );
           } else {
             logger.warn('gitToken override provided but session is not gitUrl-based');

--- a/cloud-agent/src/router/handlers/session-messaging.ts
+++ b/cloud-agent/src/router/handlers/session-messaging.ts
@@ -161,7 +161,8 @@ export function createSessionMessagingHandlers() {
                 session,
                 sessionContext.workspacePath,
                 sessionService.metadata.gitUrl,
-                input.gitToken
+                input.gitToken,
+                sessionService.metadata.platform
               );
             }
           }

--- a/cloud-agent/src/session-service.ts
+++ b/cloud-agent/src/session-service.ts
@@ -670,7 +670,10 @@ export class SessionService {
     // Shallow clone (depth: 1) can be enabled for faster checkout and reduced disk usage
     const cloneOptions = shallow ? { shallow: true } : undefined;
     if (gitUrl) {
-      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, cloneOptions);
+      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, {
+        ...cloneOptions,
+        platform: context.platform,
+      });
     } else if (githubRepo) {
       await cloneGitHubRepo(
         session,
@@ -898,7 +901,9 @@ export class SessionService {
 
     // Clone repository using appropriate method
     if (gitUrl) {
-      await cloneGitRepo(session, workspacePath, gitUrl, gitToken);
+      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, {
+        platform: context.platform,
+      });
     } else if (githubRepo) {
       await cloneGitHubRepo(
         session,
@@ -1124,7 +1129,16 @@ export class SessionService {
             .info('Recloning missing repository (generic git)');
 
           // Reclone the repository using generic git
-          await cloneGitRepo(session, workspacePath, metadata.gitUrl, effectiveGitToken);
+          await cloneGitRepo(
+            session,
+            workspacePath,
+            metadata.gitUrl,
+            effectiveGitToken,
+            undefined,
+            {
+              platform: context.platform,
+            }
+          );
         } else if (metadata?.githubRepo) {
           const effectiveGithubToken = freshGithubToken ?? metadata.githubToken;
           logger

--- a/cloud-agent/src/workspace.test.ts
+++ b/cloud-agent/src/workspace.test.ts
@@ -6,6 +6,7 @@ import {
   configureKilocode,
   checkDiskSpace,
   createSandboxUsageEvent,
+  updateGitRemoteToken,
   LOW_DISK_THRESHOLD_MB,
 } from './workspace';
 import type { ExecutionSession } from './types';
@@ -480,6 +481,121 @@ describe('disk space checking', () => {
         expect.stringContaining('x-access-token:test-token'),
         expect.any(Object)
       );
+    });
+
+    it('should use oauth2 username for gitlab platform', async () => {
+      mockExec
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
+
+      mockGitCheckout.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+      });
+
+      await cloneGitRepo(
+        fakeSession,
+        '/workspace',
+        'https://gitlab.com/repo.git',
+        'test-token',
+        undefined,
+        {
+          platform: 'gitlab',
+        }
+      );
+
+      expect(mockGitCheckout).toHaveBeenCalledWith(
+        expect.stringContaining('oauth2:test-token'),
+        expect.any(Object)
+      );
+    });
+
+    it('should use x-access-token username for github platform', async () => {
+      mockExec
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
+
+      mockGitCheckout.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+      });
+
+      await cloneGitRepo(
+        fakeSession,
+        '/workspace',
+        'https://example.com/repo.git',
+        'test-token',
+        undefined,
+        {
+          platform: 'github',
+        }
+      );
+
+      expect(mockGitCheckout).toHaveBeenCalledWith(
+        expect.stringContaining('x-access-token:test-token'),
+        expect.any(Object)
+      );
+    });
+
+    it('should use x-access-token username when platform is undefined', async () => {
+      mockExec
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
+
+      mockGitCheckout.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+      });
+
+      await cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git', 'test-token');
+
+      expect(mockGitCheckout).toHaveBeenCalledWith(
+        expect.stringContaining('x-access-token:test-token'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('updateGitRemoteToken', () => {
+    it('should use oauth2 username for gitlab platform', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await updateGitRemoteToken(
+        fakeSession,
+        '/workspace',
+        'https://gitlab.com/repo.git',
+        'new-token',
+        'gitlab'
+      );
+
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('oauth2:new-token'));
+    });
+
+    it('should use x-access-token username for github platform', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await updateGitRemoteToken(
+        fakeSession,
+        '/workspace',
+        'https://example.com/repo.git',
+        'new-token',
+        'github'
+      );
+
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('x-access-token:new-token'));
+    });
+
+    it('should use x-access-token username when platform is undefined', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await updateGitRemoteToken(
+        fakeSession,
+        '/workspace',
+        'https://example.com/repo.git',
+        'new-token'
+      );
+
+      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('x-access-token:new-token'));
     });
   });
 

--- a/cloud-agent/src/workspace.ts
+++ b/cloud-agent/src/workspace.ts
@@ -512,14 +512,14 @@ export async function cloneGitRepo(
   gitUrl: string,
   gitToken?: string,
   gitAuthor?: GitAuthorConfig,
-  options?: { shallow?: boolean }
+  options?: { shallow?: boolean; platform?: 'github' | 'gitlab' }
 ): Promise<void> {
   // Build URL with token if available (for private repos)
-  // Use x-access-token format which works across most git providers
+  // GitLab OAuth tokens require username 'oauth2'; all other providers use 'x-access-token'
   let repoUrl = gitUrl;
   if (gitToken) {
     const url = new URL(gitUrl);
-    url.username = 'x-access-token';
+    url.username = options?.platform === 'gitlab' ? 'oauth2' : 'x-access-token';
     url.password = gitToken;
     repoUrl = url.toString();
   }
@@ -567,22 +567,23 @@ export async function cloneGitRepo(
 /**
  * Update the git remote origin URL to include a new token.
  * This is needed when the git token changes and we need to push/pull.
- * Uses the same x-access-token format as cloneGitRepo() for consistency.
  *
  * @param session - Execution session
  * @param workspacePath - Path to the git repository
  * @param gitUrl - Full git URL (e.g., https://github.com/org/repo.git)
  * @param gitToken - New git token for authentication
+ * @param platform - Git platform; GitLab requires 'oauth2' as the username
  */
 export async function updateGitRemoteToken(
   session: ExecutionSession,
   workspacePath: string,
   gitUrl: string,
-  gitToken: string
+  gitToken: string,
+  platform?: 'github' | 'gitlab'
 ): Promise<void> {
-  // Build new URL with token embedded (same format as cloneGitRepo)
+  // Build new URL with token embedded (GitLab uses 'oauth2', others use 'x-access-token')
   const newUrl = new URL(gitUrl);
-  newUrl.username = 'x-access-token';
+  newUrl.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
   newUrl.password = gitToken;
 
   const sanitizedGitUrl = sanitizeGitUrlForLogging(gitUrl);


### PR DESCRIPTION
## Summary

- GitLab rejects `x-access-token` as the HTTP username for OAuth tokens — it requires `oauth2` instead. This was causing clone/push/pull failures for GitLab-connected sessions.
- Threads a `platform` parameter (`'github' | 'gitlab'`) through `cloneGitRepo`, `updateGitRemoteToken`, and `restoreWorkspace` in both `cloud-agent` and `cloud-agent-next` workers.
- When `platform === 'gitlab'`, the git credential username is set to `oauth2`; all other platforms (including `undefined`) continue using `x-access-token`.

## Changes

### Core functions (`workspace.ts` in both workers)
- `cloneGitRepo`: `options` parameter extended with `platform`; username selection based on platform.
- `updateGitRemoteToken`: new `platform` parameter; same username logic.
- `RestoreWorkspaceOptions` (cloud-agent-next): added `platform` field, passed through to `cloneGitRepo`.

### Call sites
- `session-service.ts` (both workers): all `cloneGitRepo` and `restoreWorkspace` calls now pass `context.platform`.
- `orchestrator.ts` (cloud-agent-next): `updateGitRemoteToken` call passes `prepared.context.platform`.
- `consumer-core.ts` (cloud-agent): `updateGitRemoteToken` call passes `prepared.context.platform`.
- `session-messaging.ts` (cloud-agent): `updateGitRemoteToken` call passes `sessionService.metadata.platform`.

### Tests (`workspace.test.ts` in both workers)
- Added tests for `cloneGitRepo` with `platform: 'gitlab'`, `platform: 'github'`, and `platform: undefined`.
- Added tests for `updateGitRemoteToken` with all three platform variants.