### PR TITLE
CloudAgentNext - Add self-updating TimeAgo component for live relative timestamps

### DIFF
--- a/src/components/app-builder/AppBuilderChat.tsx
+++ b/src/components/app-builder/AppBuilderChat.tsx
@@ -21,7 +21,8 @@ import React, {
   useSyncExternalStore,
 } from 'react';
 import { User, ArrowDown, ChevronRight, ChevronDown } from 'lucide-react';
-import { formatDistanceToNow, format } from 'date-fns';
+import { format } from 'date-fns';
+import { TimeAgo } from '@/components/shared/TimeAgo';
 import AssistantLogo from '@/components/AssistantLogo';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
@@ -62,14 +63,12 @@ const isDev = process.env.NODE_ENV === 'development';
  * Timestamp display with optional tooltip showing full time in dev mode
  */
 function TimestampDisplay({ ts }: { ts: number }) {
-  const timeAgo = formatDistanceToNow(new Date(ts), { addSuffix: true });
-
   if (isDev) {
     const fullTime = format(new Date(ts), 'yyyy-MM-dd HH:mm:ss.SSS');
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="text-muted-foreground text-xs">{timeAgo}</span>
+          <TimeAgo timestamp={ts} className="text-muted-foreground text-xs" />
         </TooltipTrigger>
         <TooltipContent>
           <span className="font-mono">{fullTime}</span>
@@ -78,7 +77,7 @@ function TimestampDisplay({ ts }: { ts: number }) {
     );
   }
 
-  return <span className="text-muted-foreground text-xs">{timeAgo}</span>;
+  return <TimeAgo timestamp={ts} className="text-muted-foreground text-xs" />;
 }
 
 /**
@@ -239,7 +238,7 @@ function ExpandableSessionBlock({
           {endedDate && (
             <div className="text-muted-foreground mt-0.5 text-xs">
               Chat session ended {format(endedDate, 'MMM d, yyyy')} (
-              {formatDistanceToNow(endedDate, { addSuffix: true })})
+              <TimeAgo timestamp={endedDate.getTime()} />)
             </div>
           )}
         </div>

--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/Button';
 import { Card } from '@/components/ui/card';
 import { Plus, GitBranch, Clock } from 'lucide-react';
 import { InlineDeleteConfirmation } from '@/components/ui/inline-delete-confirmation';
-import { formatDistanceToNow } from 'date-fns';
+import { TimeAgo } from '@/components/shared/TimeAgo';
 import { useRouter } from 'next/navigation';
 import type { StoredSession } from './types';
 import { cn } from '@/lib/utils';
@@ -73,9 +73,6 @@ export function ChatSidebar({
         ) : (
           sessions.map(session => {
             const isActive = session.sessionId === currentSessionId;
-            const timeAgo = formatDistanceToNow(new Date(session.updatedAt), {
-              addSuffix: true,
-            });
 
             return (
               <Card
@@ -112,7 +109,7 @@ export function ChatSidebar({
                   )}
                   <div className="text-muted-foreground flex items-center gap-1 text-xs">
                     <Clock className="h-3 w-3" />
-                    <span>{timeAgo}</span>
+                    <TimeAgo timestamp={session.updatedAt} />
                   </div>
                 </div>
               </Card>

--- a/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/src/components/cloud-agent-next/MessageBubble.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { User, Bot, Scissors, Image, FileText, AlertCircle } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { TimeAgo } from '@/components/shared/TimeAgo';
 import type { AssistantMessage } from '@/types/opencode.gen';
 import type { StoredMessage, Part, CompactionPart } from './types';
 import {
@@ -23,10 +23,10 @@ import { stripImageContext } from '@/lib/app-builder/message-utils';
  */
 function CompactionSeparator({
   compactionPart,
-  timeAgo,
+  timestamp,
 }: {
   compactionPart: CompactionPart;
-  timeAgo: string;
+  timestamp: number | string;
 }) {
   const isAuto = compactionPart.auto;
 
@@ -37,7 +37,7 @@ function CompactionSeparator({
         <Scissors className="h-3 w-3" />
         <span>Context compacted{isAuto ? ' (auto)' : ''}</span>
         <span className="text-muted-foreground/60">·</span>
-        <span className="text-muted-foreground/60">{timeAgo}</span>
+        <TimeAgo timestamp={timestamp} className="text-muted-foreground/60" />
       </div>
       <div className="bg-border h-px flex-1" />
     </div>
@@ -161,7 +161,6 @@ export function MessageBubble({
 }: MessageBubbleProps) {
   const isStreaming = isStreamingProp ?? isMessageStreaming(message);
   const timestamp = message.info.time.created;
-  const timeAgo = formatDistanceToNow(new Date(timestamp), { addSuffix: true });
 
   const getTextForCopy = useCallback(() => getAssistantTextContent(message.parts), [message.parts]);
 
@@ -174,7 +173,7 @@ export function MessageBubble({
 
     // Render compaction separator for compaction-only messages
     if (hasOnlyCompactionParts && compactionPart) {
-      return <CompactionSeparator compactionPart={compactionPart} timeAgo={timeAgo} />;
+      return <CompactionSeparator compactionPart={compactionPart} timestamp={timestamp} />;
     }
 
     const displayName = userName ?? 'You';
@@ -186,7 +185,7 @@ export function MessageBubble({
       <div className="flex items-start justify-end gap-2 py-4 md:gap-3">
         <div className="flex flex-1 flex-col items-end space-y-1">
           <div className="flex items-center gap-2">
-            <span className="text-muted-foreground text-xs">{timeAgo}</span>
+            <TimeAgo timestamp={timestamp} className="text-muted-foreground text-xs" />
             <span className="text-sm font-medium">{displayName}</span>
           </div>
           <div className="bg-primary text-primary-foreground max-w-[95%] rounded-lg p-3 sm:max-w-[85%] md:max-w-[80%] md:p-4">
@@ -235,7 +234,7 @@ export function MessageBubble({
         <div className="min-w-0 flex-1 space-y-3">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-sm font-medium">Kilo Code</span>
-            <span className="text-muted-foreground text-xs">{timeAgo}</span>
+            <TimeAgo timestamp={timestamp} className="text-muted-foreground text-xs" />
             {isStreaming && (
               <span className="text-muted-foreground flex items-center gap-1 text-xs">
                 <span className="relative flex h-2 w-2">

--- a/src/components/cloud-agent-next/SessionsList.tsx
+++ b/src/components/cloud-agent-next/SessionsList.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Bot, Clock, Cloud, GitBranch, Puzzle, Terminal } from 'lucide-react';
 import type { StoredSession } from './types';
-import { formatDistanceToNow } from 'date-fns';
+import { TimeAgo } from '@/components/shared/TimeAgo';
 import Link from 'next/link';
 
 export type SessionsListItem = Pick<
@@ -43,7 +43,6 @@ export function SessionsList({ sessions, organizationId, onSessionClick }: Sessi
     <div className="space-y-3">
       {sessions.map(session => {
         const chatUrl = `${basePath}/chat?sessionId=${session.sessionId}`;
-        const timeAgo = formatDistanceToNow(new Date(session.createdAt), { addSuffix: true });
 
         // Determine badge based on created_on_platform field
         const platform = session.createdOnPlatform;
@@ -112,7 +111,7 @@ export function SessionsList({ sessions, organizationId, onSessionClick }: Sessi
               <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
                 <div className="flex items-center gap-1">
                   <Clock className="h-3 w-3" />
-                  <span>{timeAgo}</span>
+                  <TimeAgo timestamp={session.createdAt} />
                 </div>
                 <div className="font-mono">ID: {truncateId(session.sessionId)}</div>
                 {session.mode && (

--- a/src/components/cloud-agent/MessageBubble.tsx
+++ b/src/components/cloud-agent/MessageBubble.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { User, Bot, Info } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { TimeAgo } from '@/components/shared/TimeAgo';
 import type { Message } from './types';
 import { MessageContent } from './MessageContent';
 import { CopyMessageButton } from '@/components/shared/CopyMessageButton';
@@ -25,7 +25,6 @@ export function MessageBubble({
   userName,
   userAvatarUrl,
 }: MessageBubbleProps) {
-  const timeAgo = formatDistanceToNow(new Date(message.timestamp), { addSuffix: true });
   const getTextForCopy = useCallback(() => message.content, [message.content]);
 
   // User message
@@ -35,7 +34,7 @@ export function MessageBubble({
       <div className="flex items-start justify-end gap-2 py-4 md:gap-3">
         <div className="flex flex-1 flex-col items-end space-y-1">
           <div className="flex items-center gap-2">
-            <span className="text-muted-foreground text-xs">{timeAgo}</span>
+            <TimeAgo timestamp={message.timestamp} className="text-muted-foreground text-xs" />
             <span className="text-sm font-medium">{displayName}</span>
           </div>
           <div className="bg-primary text-primary-foreground max-w-[95%] rounded-lg p-3 sm:max-w-[85%] md:max-w-[80%] md:p-4">
@@ -75,7 +74,7 @@ export function MessageBubble({
           <div className="min-w-0 flex-1 space-y-3">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium">Kilo Code</span>
-              <span className="text-muted-foreground text-xs">{timeAgo}</span>
+              <TimeAgo timestamp={message.timestamp} className="text-muted-foreground text-xs" />
               {isStreaming && (
                 <span className="text-muted-foreground flex items-center gap-1 text-xs">
                   <span className="relative flex h-2 w-2">
@@ -108,7 +107,7 @@ export function MessageBubble({
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground text-sm font-medium">System</span>
-            <span className="text-muted-foreground text-xs">{timeAgo}</span>
+            <TimeAgo timestamp={message.timestamp} className="text-muted-foreground text-xs" />
           </div>
           <div className="text-muted-foreground text-sm">
             <p className="overflow-wrap-anywhere wrap-break-word whitespace-pre-wrap">
@@ -129,7 +128,7 @@ export function MessageBubble({
       <div className="min-w-0 flex-1 space-y-3">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Kilo Code</span>
-          <span className="text-muted-foreground text-xs">{timeAgo}</span>
+          <TimeAgo timestamp={message.timestamp} className="text-muted-foreground text-xs" />
           {isStreaming && (
             <span className="text-muted-foreground flex items-center gap-1 text-xs">
               <span className="relative flex h-2 w-2">

--- a/src/components/shared/TimeAgo.tsx
+++ b/src/components/shared/TimeAgo.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+
+const ONE_MINUTE = 60_000;
+const ONE_HOUR = 60 * ONE_MINUTE;
+const ONE_DAY = 24 * ONE_HOUR;
+
+/**
+ * Choose a refresh interval based on how old the timestamp is:
+ * - < 1 hour:  refresh every 30s  (keeps "X minutes ago" accurate)
+ * - 1–24 hours: refresh every 5 min
+ * - > 24 hours: refresh every 1 hour
+ */
+function refreshInterval(timestampMs: number): number {
+  const age = Date.now() - timestampMs;
+  if (age < ONE_HOUR) return 30_000;
+  if (age < ONE_DAY) return 5 * ONE_MINUTE;
+  return ONE_HOUR;
+}
+
+function useTimeAgo(timestamp: number | string): string {
+  const ms = typeof timestamp === 'string' ? new Date(timestamp).getTime() : timestamp;
+
+  const [text, setText] = useState(() => formatDistanceToNow(new Date(ms), { addSuffix: true }));
+
+  useEffect(() => {
+    // Recompute immediately in case the initial render was cached / stale
+    setText(formatDistanceToNow(new Date(ms), { addSuffix: true }));
+
+    let timer: ReturnType<typeof setTimeout>;
+
+    function tick() {
+      setText(formatDistanceToNow(new Date(ms), { addSuffix: true }));
+      // Schedule next tick with an interval appropriate for the current age
+      timer = setTimeout(tick, refreshInterval(ms));
+    }
+
+    timer = setTimeout(tick, refreshInterval(ms));
+    return () => clearTimeout(timer);
+  }, [ms]);
+
+  return text;
+}
+
+/**
+ * Self-updating relative-time label.
+ * Refreshes on an adaptive schedule so even memoised parents stay accurate.
+ */
+export function TimeAgo({
+  timestamp,
+  className,
+}: {
+  timestamp: number | string;
+  className?: string;
+}) {
+  const text = useTimeAgo(timestamp);
+  // Server and client compute formatDistanceToNow at different wall-clock
+  // times, so a minor mismatch is expected and harmless.
+  return (
+    <span className={className} suppressHydrationWarning>
+      {text}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Introduces a shared `TimeAgo` component (`src/components/shared/TimeAgo.tsx`) that auto-refreshes relative timestamps on an adaptive schedule: every 30s for timestamps < 1 hour old, every 5 min for 1–24 hours, and every hour beyond that.
- Replaces all static `formatDistanceToNow` calls across chat UIs so "X minutes ago" labels stay accurate without a page refresh.
- Affected components: `cloud-agent-next` (MessageBubble, ChatSidebar, SessionsList), `cloud-agent` (MessageBubble), and `app-builder` (AppBuilderChat).