### PR TITLE
CloudAgentNext - Bump CLI version to 7.0.35

### DIFF
--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -119,7 +119,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.0.34",
+        "KILOCODE_CLI_VERSION": "7.0.35",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 120,
@@ -245,7 +245,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.0.34",
+            "KILOCODE_CLI_VERSION": "7.0.35",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,


### PR DESCRIPTION
Bumps `@kilocode/cli` from `7.0.34` to `7.0.35` in `wrangler.jsonc` for both the production and dev sandbox container environments.