### PR TITLE
Webhooks - Migrate agent ingest to cloud-agent-next with v2 session support

### DIFF
--- a/cloudflare-app-builder/start-dev.sh
+++ b/cloudflare-app-builder/start-dev.sh
@@ -11,6 +11,7 @@
 #   - cloudflare-git-token-service (port 8795)
 #   - cloudflare-app-builder (port 8790)
 #   - cloudflare-images-mcp (port 8796)
+#   - cloudflare-webhook-agent-ingest (port 8793)
 #   - ngrok (forwarding to port 8790)
 #
 # Requirements:
@@ -79,17 +80,18 @@ fi
 # Create new tmux session with first window for db-proxy
 tmux new-session -d -s "$SESSION_NAME" -n "services" -c "$PROJECT_ROOT"
 
-# Split into grid for 8 services
+# Split into grid for 9 services + ngrok
 # First split horizontally (top/bottom)
 tmux split-window -v -t "$SESSION_NAME:services" -c "$PROJECT_ROOT"
-# Split top pane vertically into 4
+# Split top pane vertically into 5
+tmux split-window -h -t "$SESSION_NAME:services.0" -c "$PROJECT_ROOT"
 tmux split-window -h -t "$SESSION_NAME:services.0" -c "$PROJECT_ROOT"
 tmux split-window -h -t "$SESSION_NAME:services.0" -c "$PROJECT_ROOT"
 tmux split-window -h -t "$SESSION_NAME:services.0" -c "$PROJECT_ROOT"
 # Split bottom pane vertically into 4
-tmux split-window -h -t "$SESSION_NAME:services.4" -c "$PROJECT_ROOT"
-tmux split-window -h -t "$SESSION_NAME:services.4" -c "$PROJECT_ROOT"
-tmux split-window -h -t "$SESSION_NAME:services.4" -c "$PROJECT_ROOT"
+tmux split-window -h -t "$SESSION_NAME:services.5" -c "$PROJECT_ROOT"
+tmux split-window -h -t "$SESSION_NAME:services.5" -c "$PROJECT_ROOT"
+tmux split-window -h -t "$SESSION_NAME:services.5" -c "$PROJECT_ROOT"
 
 # Arrange panes in a tiled layout
 tmux select-layout -t "$SESSION_NAME:services" tiled
@@ -112,28 +114,32 @@ tmux send-keys -t "$SESSION_NAME:services.1" "cd $PROJECT_ROOT/cloudflare-sessio
 tmux select-pane -t "$SESSION_NAME:services.2" -T "cloud-agent (8788)"
 tmux send-keys -t "$SESSION_NAME:services.2" "cd $PROJECT_ROOT/cloud-agent && echo '🤖 Starting cloud-agent (port 8788)...' && pnpm exec wrangler dev --inspector-port 9231" C-m
 
-# Pane 3 (top-right): cloudflare-images-mcp
+# Pane 3: cloudflare-images-mcp
 tmux select-pane -t "$SESSION_NAME:services.3" -T "images-mcp (8796)"
 tmux send-keys -t "$SESSION_NAME:services.3" "cd $PROJECT_ROOT/cloudflare-images-mcp && echo '🖼️  Starting cloudflare-images-mcp (port 8796)...' && pnpm exec wrangler dev --env dev --inspector-port 9236" C-m
 
-# Pane 4 (bottom-left): cloudflare-git-token-service
-tmux select-pane -t "$SESSION_NAME:services.4" -T "git-token-service (8795)"
-tmux send-keys -t "$SESSION_NAME:services.4" "cd $PROJECT_ROOT/cloudflare-git-token-service && echo '🔑 Starting cloudflare-git-token-service (port 8795)...' && pnpm exec wrangler dev --inspector-port 9235" C-m
+# Pane 4: cloudflare-webhook-agent-ingest
+tmux select-pane -t "$SESSION_NAME:services.4" -T "webhook-ingest (8793)"
+tmux send-keys -t "$SESSION_NAME:services.4" "cd $PROJECT_ROOT/cloudflare-webhook-agent-ingest && echo '🪝 Starting cloudflare-webhook-agent-ingest (port 8793)...' && pnpm exec wrangler dev --env dev --inspector-port 9237" C-m
 
-# Pane 5: cloudflare-app-builder
-tmux select-pane -t "$SESSION_NAME:services.5" -T "app-builder (8790)"
-tmux send-keys -t "$SESSION_NAME:services.5" "cd $PROJECT_ROOT/cloudflare-app-builder && echo '🏗️  Starting cloudflare-app-builder (port 8790)...' && pnpm exec wrangler dev --inspector-port 9232" C-m
+# Pane 5: cloudflare-git-token-service
+tmux select-pane -t "$SESSION_NAME:services.5" -T "git-token-service (8795)"
+tmux send-keys -t "$SESSION_NAME:services.5" "cd $PROJECT_ROOT/cloudflare-git-token-service && echo '🔑 Starting cloudflare-git-token-service (port 8795)...' && pnpm exec wrangler dev --inspector-port 9235" C-m
 
-# Pane 6: ngrok
-tmux select-pane -t "$SESSION_NAME:services.6" -T "ngrok → 8790"
-tmux send-keys -t "$SESSION_NAME:services.6" "echo '🌐 Starting ngrok (forwarding to port 8790)...' && ngrok http 8790" C-m
+# Pane 6: cloudflare-app-builder
+tmux select-pane -t "$SESSION_NAME:services.6" -T "app-builder (8790)"
+tmux send-keys -t "$SESSION_NAME:services.6" "cd $PROJECT_ROOT/cloudflare-app-builder && echo '🏗️  Starting cloudflare-app-builder (port 8790)...' && pnpm exec wrangler dev --inspector-port 9232" C-m
 
-# Pane 7 (bottom-right): cloud-agent-next
-tmux select-pane -t "$SESSION_NAME:services.7" -T "cloud-agent-next (8794)"
-tmux send-keys -t "$SESSION_NAME:services.7" "cd $PROJECT_ROOT/cloud-agent-next && echo '☁️  Starting cloud-agent-next (port 8794)...' && pnpm run dev" C-m
+# Pane 7: ngrok
+tmux select-pane -t "$SESSION_NAME:services.7" -T "ngrok → 8790"
+tmux send-keys -t "$SESSION_NAME:services.7" "echo '🌐 Starting ngrok (forwarding to port 8790)...' && ngrok http 8790" C-m
+
+# Pane 8: cloud-agent-next
+tmux select-pane -t "$SESSION_NAME:services.8" -T "cloud-agent-next (8794)"
+tmux send-keys -t "$SESSION_NAME:services.8" "cd $PROJECT_ROOT/cloud-agent-next && echo '☁️  Starting cloud-agent-next (port 8794)...' && pnpm run dev" C-m
 
 # Select the ngrok pane by default
-tmux select-pane -t "$SESSION_NAME:services.6"
+tmux select-pane -t "$SESSION_NAME:services.7"
 
 echo ""
 echo "╔══════════════════════════════════════════════════════════════════╗"
@@ -147,6 +153,7 @@ echo "║    • cloud-agent-next          → http://localhost:8794          �
 echo "║    • git-token-service         → http://localhost:8795          ║"
 echo "║    • cloudflare-app-builder    → http://localhost:8790          ║"
 echo "║    • cloudflare-images-mcp     → http://localhost:8796          ║"
+echo "║    • webhook-agent-ingest     → http://localhost:8793          ║"
 echo "║    • ngrok                     → forwarding to :8790            ║"
 echo "╠══════════════════════════════════════════════════════════════════╣"
 echo "║  tmux Navigation:                                                ║"

--- a/cloudflare-webhook-agent-ingest/README.md
+++ b/cloudflare-webhook-agent-ingest/README.md
@@ -6,14 +6,14 @@ A webhook trigger service for Kilo Code that allows users to create named endpoi
 
 - Create named webhook endpoints per user/org
 - Capture and store last 50 requests per ingest endpoint
-- Queue-based delivery to cloud-agent
+- Queue-based delivery to cloud-agent-next
 - Internal API key authentication for CRUD routes (backend-to-backend)
 
 ## Architecture
 
 - **Durable Objects**: TriggerDO for per-trigger request storage with SQLite
-- **Queue**: WEBHOOK_DELIVERY_QUEUE for reliable delivery to cloud-agent
-- **Service Binding**: Direct connection to cloud-agent worker
+- **Queue**: WEBHOOK_DELIVERY_QUEUE for reliable delivery to cloud-agent-next
+- **Service Binding**: Direct connection to cloud-agent-next worker
 
 > **Note**: KV registry for abuse prevention is planned for future implementation.
 > See [plans/webhook-catcher-design.md](plans/webhook-catcher-design.md#future-work-kv-registry-for-abuse-prevention).
@@ -218,12 +218,12 @@ curl -X DELETE "https://localhost:8793/api/triggers/org/org_xyz789/my-github-web
 
 Captured requests go through the following status lifecycle:
 
-| Status       | Description                    |
-| ------------ | ------------------------------ |
-| `captured`   | Request received and stored    |
-| `inprogress` | Being processed by cloud-agent |
-| `success`    | Successfully processed         |
-| `failed`     | Processing failed              |
+| Status       | Description                         |
+| ------------ | ----------------------------------- |
+| `captured`   | Request received and stored         |
+| `inprogress` | Being processed by cloud-agent-next |
+| `success`    | Successfully processed              |
+| `failed`     | Processing failed                   |
 
 ## Environment Variables
 
@@ -266,10 +266,10 @@ The following resources are already configured:
 
 ### Service Bindings
 
-| Binding       | Target Worker     | Environment |
-| ------------- | ----------------- | ----------- |
-| `CLOUD_AGENT` | `cloud-agent`     | Production  |
-| `CLOUD_AGENT` | `cloud-agent-dev` | Development |
+| Binding       | Target Worker          | Environment |
+| ------------- | ---------------------- | ----------- |
+| `CLOUD_AGENT` | `cloud-agent-next`     | Production  |
+| `CLOUD_AGENT` | `cloud-agent-next-dev` | Development |
 
 ### KV Namespaces
 
@@ -326,8 +326,8 @@ The worker includes a queue consumer that processes webhook delivery messages fr
 2. Checks idempotency (only processes requests in `captured` status)
 3. Gets or mints an API token (cached in KV for 30 minutes)
 4. Renders the prompt from the trigger's template
-5. Calls cloud-agent's `prepareSession` to create a session
-6. Calls cloud-agent's `initiateFromKilocodeSessionV2` to start processing
+5. Calls cloud-agent-next's `prepareSession` to create a session
+6. Calls cloud-agent-next's `initiateFromKilocodeSessionV2` to start processing
 7. Updates request status through the lifecycle
 
 ### Queue Configuration

--- a/cloudflare-webhook-agent-ingest/src/initiate-response.test.ts
+++ b/cloudflare-webhook-agent-ingest/src/initiate-response.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { classifyInitiateResponse } from './initiate-response';
+
+function makeResponse(status: number, body = ''): Response {
+  return new Response(body, { status });
+}
+
+describe('classifyInitiateResponse', () => {
+  it('returns ack for 200 OK', async () => {
+    const result = await classifyInitiateResponse(makeResponse(200, '{}'));
+    expect(result).toEqual({ action: 'ack' });
+  });
+
+  it('returns ack for 409 (execution already in progress)', async () => {
+    const result = await classifyInitiateResponse(
+      makeResponse(409, 'Execution already in progress')
+    );
+    expect(result).toEqual({ action: 'ack' });
+  });
+
+  it('returns ack for 409 with empty body', async () => {
+    const result = await classifyInitiateResponse(makeResponse(409));
+    expect(result).toEqual({ action: 'ack' });
+  });
+
+  it('returns ack for 400 "Session has already been initiated"', async () => {
+    const result = await classifyInitiateResponse(
+      makeResponse(400, 'Session has already been initiated')
+    );
+    expect(result).toEqual({ action: 'ack' });
+  });
+
+  it('returns retry for 503 (retryable sandbox failure)', async () => {
+    const result = await classifyInitiateResponse(makeResponse(503, 'sandbox startup failed'));
+    expect(result).toEqual({
+      action: 'retry',
+      errorMessage: 'initiateFromKilocodeSessionV2 returned retryable 503: sandbox startup failed',
+    });
+  });
+
+  it('returns retry for 503 with empty body', async () => {
+    const result = await classifyInitiateResponse(makeResponse(503));
+    expect(result).toEqual({
+      action: 'retry',
+      errorMessage: 'initiateFromKilocodeSessionV2 returned retryable 503: ',
+    });
+  });
+
+  it('returns throw for generic 500', async () => {
+    const result = await classifyInitiateResponse(makeResponse(500, 'Internal server error'));
+    expect(result).toEqual({
+      action: 'throw',
+      errorMessage: 'initiateFromKilocodeSessionV2 failed: 500 - Internal server error',
+    });
+  });
+
+  it('returns throw for 502', async () => {
+    const result = await classifyInitiateResponse(makeResponse(502, 'Bad gateway'));
+    expect(result).toEqual({
+      action: 'throw',
+      errorMessage: 'initiateFromKilocodeSessionV2 failed: 502 - Bad gateway',
+    });
+  });
+
+  it('returns fail for 402 (insufficient balance)', async () => {
+    const result = await classifyInitiateResponse(makeResponse(402, 'Insufficient credits'));
+    expect(result).toEqual({
+      action: 'fail',
+      errorMessage: 'Insufficient credits',
+    });
+  });
+
+  it('returns fail for 402 with empty body, using default message', async () => {
+    const result = await classifyInitiateResponse(makeResponse(402));
+    expect(result).toEqual({
+      action: 'fail',
+      errorMessage: 'Insufficient balance',
+    });
+  });
+
+  it('returns fail for other 4xx errors', async () => {
+    const result = await classifyInitiateResponse(makeResponse(422, 'Validation failed'));
+    expect(result).toEqual({
+      action: 'fail',
+      errorMessage: 'Validation failed',
+    });
+  });
+
+  it('returns fail for 400 without "Session has already been initiated"', async () => {
+    const result = await classifyInitiateResponse(makeResponse(400, 'Bad request'));
+    expect(result).toEqual({
+      action: 'fail',
+      errorMessage: 'Bad request',
+    });
+  });
+
+  // 503 is classified distinctly from other 5xx — verify ordering
+  it('classifies 503 as retry, not generic throw', async () => {
+    const result = await classifyInitiateResponse(makeResponse(503, 'workspace error'));
+    expect(result.action).toBe('retry');
+  });
+
+  it('classifies 500 as throw, not retry', async () => {
+    const result = await classifyInitiateResponse(makeResponse(500, 'crash'));
+    expect(result.action).toBe('throw');
+  });
+});

--- a/cloudflare-webhook-agent-ingest/src/initiate-response.ts
+++ b/cloudflare-webhook-agent-ingest/src/initiate-response.ts
@@ -1,0 +1,60 @@
+// Ack the message — the operation succeeded or is idempotently done
+export type AckAction = { action: 'ack' };
+
+// Fail the request and ack the message — non-retriable error
+export type FailAction = { action: 'fail'; errorMessage: string };
+
+// Throw to trigger queue retry (canRetryInitiate = true)
+export type RetryAction = { action: 'retry'; errorMessage: string };
+
+// Throw to trigger queue retry (canRetryInitiate = false, generic 5xx)
+export type ThrowAction = { action: 'throw'; errorMessage: string };
+
+export type InitiateResponseAction = AckAction | FailAction | RetryAction | ThrowAction;
+
+/**
+ * Classify the response from initiateFromKilocodeSessionV2 into an action.
+ *
+ * Pure-ish function (only reads the response body) — no env, DO, or message side effects.
+ * The caller is responsible for executing the returned action.
+ */
+export async function classifyInitiateResponse(
+  response: Response
+): Promise<InitiateResponseAction> {
+  if (response.ok) {
+    return { action: 'ack' };
+  }
+
+  const errorBody = await response.text();
+
+  if (response.status === 400 && errorBody.includes('Session has already been initiated')) {
+    return { action: 'ack' };
+  }
+
+  if (response.status === 409) {
+    // cloud-agent-next returns 409 when execution is already in progress — treat as idempotent success
+    return { action: 'ack' };
+  }
+
+  if (response.status === 402) {
+    return { action: 'fail', errorMessage: errorBody || 'Insufficient balance' };
+  }
+
+  if (response.status === 503) {
+    // cloud-agent-next returns 503 for retryable sandbox/workspace startup failures — trigger queue retry
+    return {
+      action: 'retry',
+      errorMessage: `initiateFromKilocodeSessionV2 returned retryable 503: ${errorBody}`,
+    };
+  }
+
+  if (response.status >= 500) {
+    return {
+      action: 'throw',
+      errorMessage: `initiateFromKilocodeSessionV2 failed: ${response.status} - ${errorBody}`,
+    };
+  }
+
+  // Other 4xx — non-retriable
+  return { action: 'fail', errorMessage: errorBody };
+}

--- a/cloudflare-webhook-agent-ingest/src/queue-consumer.ts
+++ b/cloudflare-webhook-agent-ingest/src/queue-consumer.ts
@@ -5,6 +5,7 @@ import { logger } from './util/logger';
 import { withDORetry } from './util/do-retry';
 import { getTokenMintingService } from './services/token-minting-service.js';
 import { getProfileResolutionService } from './services/profile-resolution-service.js';
+import { classifyInitiateResponse } from './initiate-response';
 import { z } from 'zod';
 
 // Token cache TTL: 30 minutes. Token validity is 1 hour, so 30 min gives safety margin.
@@ -250,12 +251,14 @@ async function processWebhookMessage(
         setupCommands?: string[];
         autoCommit?: boolean;
         condenseOnComplete?: boolean;
+        createdOnPlatform: string;
       } = {
         prompt: renderedPrompt,
         mode: triggerConfig.mode,
         model: triggerConfig.model,
         githubRepo: triggerConfig.githubRepo,
         callbackTarget,
+        createdOnPlatform: 'webhook',
       };
 
       if (triggerConfig.orgId) {
@@ -402,25 +405,31 @@ async function processWebhookMessage(
       throw error;
     }
 
-    if (!initiateResponse.ok) {
-      const errorBody = await initiateResponse.text();
-      if (
-        initiateResponse.status === 400 &&
-        errorBody.includes('Session has already been initiated')
-      ) {
-        logger.info('Session already initiated, acknowledging', {
-          requestId: webhook.requestId,
-          cloudAgentSessionId,
-        });
+    const initiateAction = await classifyInitiateResponse(initiateResponse);
+
+    switch (initiateAction.action) {
+      case 'ack':
+        if (initiateResponse.ok) {
+          logger.info('Session initiated successfully', {
+            requestId: webhook.requestId,
+            cloudAgentSessionId: cloudAgentSessionId ?? 'unknown',
+          });
+        } else {
+          logger.info('Initiate response treated as idempotent success', {
+            requestId: webhook.requestId,
+            cloudAgentSessionId,
+            status: initiateResponse.status,
+          });
+        }
         message.ack();
         return;
-      }
-      if (initiateResponse.status === 402) {
-        logger.warn('Insufficient balance for initiateFromKilocodeSessionV2', {
+
+      case 'fail':
+        logger.error('initiateFromKilocodeSessionV2 failed', {
           requestId: webhook.requestId,
           cloudAgentSessionId,
           status: initiateResponse.status,
-          error: errorBody,
+          error: initiateAction.errorMessage,
         });
         await withDORetry(
           () => stub,
@@ -428,44 +437,20 @@ async function processWebhookMessage(
             doStub.updateRequest(webhook.requestId, {
               process_status: 'failed',
               completed_at: new Date().toISOString(),
-              error_message: errorBody || 'Insufficient balance',
+              error_message: initiateAction.errorMessage,
             }),
           'updateRequest'
         );
         message.ack();
         return;
-      }
-      if (initiateResponse.status >= 500) {
-        throw new Error(
-          `initiateFromKilocodeSessionV2 failed: ${initiateResponse.status} - ${errorBody}`
-        );
-      }
-      logger.error('initiateFromKilocodeSessionV2 failed', {
-        requestId: webhook.requestId,
-        cloudAgentSessionId,
-        status: initiateResponse.status,
-        error: errorBody,
-      });
-      await withDORetry(
-        () => stub,
-        doStub =>
-          doStub.updateRequest(webhook.requestId, {
-            process_status: 'failed',
-            completed_at: new Date().toISOString(),
-            error_message: errorBody,
-          }),
-        'updateRequest'
-      );
-      message.ack();
-      return;
+
+      case 'retry':
+        canRetryInitiate = true;
+        throw new Error(initiateAction.errorMessage);
+
+      case 'throw':
+        throw new Error(initiateAction.errorMessage);
     }
-
-    logger.info('Session initiated successfully', {
-      requestId: webhook.requestId,
-      cloudAgentSessionId: cloudAgentSessionId ?? 'unknown',
-    });
-
-    message.ack();
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error('Failed to process webhook', {

--- a/cloudflare-webhook-agent-ingest/wrangler.jsonc
+++ b/cloudflare-webhook-agent-ingest/wrangler.jsonc
@@ -37,7 +37,7 @@
   "services": [
     {
       "binding": "CLOUD_AGENT",
-      "service": "cloud-agent",
+      "service": "cloud-agent-next",
     },
   ],
   // PRODUCTION Queue for webhook delivery
@@ -125,7 +125,7 @@
       "services": [
         {
           "binding": "CLOUD_AGENT",
-          "service": "cloud-agent-dev",
+          "service": "cloud-agent-next-dev",
         },
       ],
       // DEV Queue (separate from production)

--- a/src/app/(app)/cloud/webhooks/[triggerId]/requests/WebhookRequestsContent.tsx
+++ b/src/app/(app)/cloud/webhooks/[triggerId]/requests/WebhookRequestsContent.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { format, formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
 import { getWebhookRoutes } from '@/lib/webhook-routes';
+import { isNewSession } from '@/lib/cloud-agent/session-type';
 
 import { Button } from '@/components/ui/button';
 import { CopyTextButton } from '@/components/admin/CopyEmailButton';
@@ -240,13 +241,27 @@ export function WebhookRequestsContent({
     [organizationId]
   );
 
-  // State and mutation for sharing sessions (org context only)
+  // State and mutations for sharing sessions (org context only)
   const [sharingSessionId, setSharingSessionId] = useState<string | null>(null);
 
-  const { mutate: shareSession } = useMutation(
+  const { mutate: shareV1Session } = useMutation(
     trpc.cliSessions.shareForWebhookTrigger.mutationOptions({
       onSuccess: data => {
         const shareUrl = `${window.location.origin}/share/${data.share_id}`;
+        window.open(shareUrl, '_blank');
+        toast.success('Session shared successfully');
+        setSharingSessionId(null);
+      },
+      onError: err => {
+        toast.error(`Failed to share session: ${err.message}`);
+        setSharingSessionId(null);
+      },
+    })
+  );
+  const { mutate: shareV2Session } = useMutation(
+    trpc.cliSessionsV2.shareForWebhookTrigger.mutationOptions({
+      onSuccess: data => {
+        const shareUrl = `${window.location.origin}/s/${data.share_id}`;
         window.open(shareUrl, '_blank');
         toast.success('Session shared successfully');
         setSharingSessionId(null);
@@ -261,13 +276,18 @@ export function WebhookRequestsContent({
   const handleShareSession = useCallback(
     (kiloSessionId: string) => {
       setSharingSessionId(kiloSessionId);
-      shareSession({
+      const params = {
         kilo_session_id: kiloSessionId,
         trigger_id: triggerId,
         organization_id: organizationId,
-      });
+      };
+      if (isNewSession(kiloSessionId)) {
+        shareV2Session(params);
+      } else {
+        shareV1Session(params);
+      }
     },
-    [shareSession, triggerId, organizationId]
+    [shareV1Session, shareV2Session, triggerId, organizationId]
   );
 
   // Loading state

--- a/src/lib/webhook-session-resolution.test.ts
+++ b/src/lib/webhook-session-resolution.test.ts
@@ -1,0 +1,121 @@
+import { db } from '@/lib/drizzle';
+import { cliSessions, cli_sessions_v2 } from '@kilocode/db/schema';
+import { inArray } from 'drizzle-orm';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { resolveCloudAgentSessionIds } from './webhook-session-resolution';
+
+describe('resolveCloudAgentSessionIds', () => {
+  const testUserId = `test-user-webhook-res-${crypto.randomUUID()}`;
+  const v1SessionIds: string[] = [];
+  const v2SessionIds: string[] = [];
+
+  beforeAll(async () => {
+    await insertTestUser({ id: testUserId });
+  });
+
+  afterAll(async () => {
+    if (v2SessionIds.length > 0) {
+      await db.delete(cli_sessions_v2).where(inArray(cli_sessions_v2.session_id, v2SessionIds));
+    }
+    if (v1SessionIds.length > 0) {
+      await db.delete(cliSessions).where(inArray(cliSessions.session_id, v1SessionIds));
+    }
+  });
+
+  it('returns empty map for empty input', async () => {
+    const result = await resolveCloudAgentSessionIds([]);
+    expect(result).toEqual(new Map());
+  });
+
+  it('resolves all IDs from v1 without querying v2', async () => {
+    const cloudId1 = crypto.randomUUID();
+    const cloudId2 = crypto.randomUUID();
+
+    const [s1] = await db
+      .insert(cliSessions)
+      .values({
+        kilo_user_id: testUserId,
+        title: 'v1 session 1',
+        cloud_agent_session_id: cloudId1,
+      })
+      .returning({ session_id: cliSessions.session_id });
+
+    const [s2] = await db
+      .insert(cliSessions)
+      .values({
+        kilo_user_id: testUserId,
+        title: 'v1 session 2',
+        cloud_agent_session_id: cloudId2,
+      })
+      .returning({ session_id: cliSessions.session_id });
+
+    v1SessionIds.push(s1.session_id, s2.session_id);
+
+    const result = await resolveCloudAgentSessionIds([cloudId1, cloudId2]);
+
+    expect(result.size).toBe(2);
+    expect(result.get(cloudId1)).toBe(s1.session_id);
+    expect(result.get(cloudId2)).toBe(s2.session_id);
+  });
+
+  it('resolves some IDs from v1 and remainder from v2', async () => {
+    const cloudIdV1 = crypto.randomUUID();
+    const cloudIdV2 = crypto.randomUUID();
+
+    const [s1] = await db
+      .insert(cliSessions)
+      .values({
+        kilo_user_id: testUserId,
+        title: 'v1 session mixed',
+        cloud_agent_session_id: cloudIdV1,
+      })
+      .returning({ session_id: cliSessions.session_id });
+    v1SessionIds.push(s1.session_id);
+
+    const v2SessionId = `ses_${crypto.randomUUID()}`;
+    await db.insert(cli_sessions_v2).values({
+      session_id: v2SessionId,
+      kilo_user_id: testUserId,
+      cloud_agent_session_id: cloudIdV2,
+    });
+    v2SessionIds.push(v2SessionId);
+
+    const result = await resolveCloudAgentSessionIds([cloudIdV1, cloudIdV2]);
+
+    expect(result.size).toBe(2);
+    expect(result.get(cloudIdV1)).toBe(s1.session_id);
+    expect(result.get(cloudIdV2)).toBe(v2SessionId);
+  });
+
+  it('returns empty map when IDs are not found in either table', async () => {
+    const result = await resolveCloudAgentSessionIds([crypto.randomUUID(), crypto.randomUUID()]);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns the v1 session_id when same cloud_agent_session_id exists in both tables', async () => {
+    const sharedCloudId = crypto.randomUUID();
+
+    const [v1Session] = await db
+      .insert(cliSessions)
+      .values({
+        kilo_user_id: testUserId,
+        title: 'v1 priority session',
+        cloud_agent_session_id: sharedCloudId,
+      })
+      .returning({ session_id: cliSessions.session_id });
+    v1SessionIds.push(v1Session.session_id);
+
+    const v2SessionId = `ses_${crypto.randomUUID()}`;
+    await db.insert(cli_sessions_v2).values({
+      session_id: v2SessionId,
+      kilo_user_id: testUserId,
+      cloud_agent_session_id: sharedCloudId,
+    });
+    v2SessionIds.push(v2SessionId);
+
+    const result = await resolveCloudAgentSessionIds([sharedCloudId]);
+
+    expect(result.size).toBe(1);
+    expect(result.get(sharedCloudId)).toBe(v1Session.session_id);
+  });
+});

--- a/src/lib/webhook-session-resolution.ts
+++ b/src/lib/webhook-session-resolution.ts
@@ -1,0 +1,49 @@
+import { inArray } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import { cliSessions, cli_sessions_v2 } from '@kilocode/db/schema';
+
+/**
+ * Resolve cloudAgentSessionIds to kiloSessionIds by looking up
+ * first in cliSessions (v1), then falling back to cli_sessions_v2.
+ */
+export async function resolveCloudAgentSessionIds(
+  cloudAgentSessionIds: string[]
+): Promise<Map<string, string>> {
+  if (cloudAgentSessionIds.length === 0) return new Map();
+
+  const v1Sessions = await db
+    .select({
+      cloudAgentSessionId: cliSessions.cloud_agent_session_id,
+      sessionId: cliSessions.session_id,
+    })
+    .from(cliSessions)
+    .where(inArray(cliSessions.cloud_agent_session_id, cloudAgentSessionIds));
+
+  const sessionIdMap = new Map(
+    v1Sessions
+      .filter(
+        (s): s is { cloudAgentSessionId: string; sessionId: string } =>
+          s.cloudAgentSessionId !== null
+      )
+      .map(s => [s.cloudAgentSessionId, s.sessionId])
+  );
+
+  const unresolvedIds = cloudAgentSessionIds.filter(id => !sessionIdMap.has(id));
+  if (unresolvedIds.length > 0) {
+    const v2Sessions = await db
+      .select({
+        cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id,
+        sessionId: cli_sessions_v2.session_id,
+      })
+      .from(cli_sessions_v2)
+      .where(inArray(cli_sessions_v2.cloud_agent_session_id, unresolvedIds));
+
+    for (const s of v2Sessions) {
+      if (s.cloudAgentSessionId !== null) {
+        sessionIdMap.set(s.cloudAgentSessionId, s.sessionId);
+      }
+    }
+  }
+
+  return sessionIdMap;
+}

--- a/src/lib/webhook-trigger-ownership.ts
+++ b/src/lib/webhook-trigger-ownership.ts
@@ -1,0 +1,46 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { TRPCError } from '@trpc/server';
+import { db } from '@/lib/drizzle';
+import { cloud_agent_webhook_triggers } from '@kilocode/db/schema';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import type { TRPCContext } from '@/lib/trpc/init';
+
+/**
+ * Verify the caller has access to the given webhook trigger.
+ *
+ * For org triggers: checks the trigger exists for the org, then verifies org membership.
+ * For personal triggers: checks the trigger exists and belongs to the user.
+ *
+ * Throws NOT_FOUND if the trigger doesn't exist or the caller lacks access.
+ */
+export async function verifyWebhookTriggerAccess(
+  ctx: TRPCContext,
+  triggerId: string,
+  organizationId: string | undefined
+) {
+  const triggerWhereClause = organizationId
+    ? and(
+        eq(cloud_agent_webhook_triggers.trigger_id, triggerId),
+        eq(cloud_agent_webhook_triggers.organization_id, organizationId)
+      )
+    : and(
+        eq(cloud_agent_webhook_triggers.trigger_id, triggerId),
+        eq(cloud_agent_webhook_triggers.user_id, ctx.user.id),
+        isNull(cloud_agent_webhook_triggers.organization_id)
+      );
+
+  const [trigger] = await db.select().from(cloud_agent_webhook_triggers).where(triggerWhereClause);
+
+  if (!trigger) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Trigger not found',
+    });
+  }
+
+  if (organizationId) {
+    await ensureOrganizationAccess(ctx, organizationId);
+  }
+
+  return trigger;
+}

--- a/src/routers/admin-webhook-triggers-router.ts
+++ b/src/routers/admin-webhook-triggers-router.ts
@@ -1,9 +1,10 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { TRPCError } from '@trpc/server';
-import { and, eq, isNull, inArray, desc } from 'drizzle-orm';
+import { and, eq, isNull, desc } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '@/lib/drizzle';
-import { cloud_agent_webhook_triggers, cliSessions } from '@kilocode/db/schema';
+import { cloud_agent_webhook_triggers } from '@kilocode/db/schema';
+import { resolveCloudAgentSessionIds } from '@/lib/webhook-session-resolution';
 import { triggerIdSchema } from '@/lib/webhook-trigger-validation';
 import {
   getWorkerTrigger,
@@ -181,25 +182,7 @@ export const adminWebhookTriggersRouter = createTRPCRouter({
         .map(request => request.cloudAgentSessionId)
         .filter((sessionId): sessionId is string => sessionId !== null);
 
-      const sessionIdMap =
-        cloudAgentSessionIds.length > 0
-          ? new Map(
-              (
-                await db
-                  .select({
-                    cloudAgentSessionId: cliSessions.cloud_agent_session_id,
-                    sessionId: cliSessions.session_id,
-                  })
-                  .from(cliSessions)
-                  .where(inArray(cliSessions.cloud_agent_session_id, cloudAgentSessionIds))
-              )
-                .filter(
-                  (session): session is { cloudAgentSessionId: string; sessionId: string } =>
-                    session.cloudAgentSessionId !== null
-                )
-                .map(session => [session.cloudAgentSessionId, session.sessionId])
-            )
-          : new Map<string, string>();
+      const sessionIdMap = await resolveCloudAgentSessionIds(cloudAgentSessionIds);
 
       return result.requests.map(request => ({
         ...request,

--- a/src/routers/cli-sessions-router.test.ts
+++ b/src/routers/cli-sessions-router.test.ts
@@ -6,6 +6,8 @@ import {
   sharedCliSessions,
   organizations,
   organization_memberships,
+  cloud_agent_webhook_triggers,
+  agent_environment_profiles,
 } from '@kilocode/db/schema';
 import { CliSessionSharedState } from '@/types/cli-session-shared-state';
 import { eq, and } from 'drizzle-orm';
@@ -40,6 +42,14 @@ jest.mock('@/lib/cloud-agent/cloud-agent-client', () => ({
     deleteSession: deleteCloudAgentSessionMock,
   })),
 }));
+
+jest.mock('@/lib/config.server', () => {
+  const actual: Record<string, unknown> = jest.requireActual('@/lib/config.server');
+  return {
+    ...actual,
+    SESSION_INGEST_WORKER_URL: 'https://test-ingest.example.com',
+  };
+});
 
 let regularUser: User;
 let otherUser: User;
@@ -1832,6 +1842,112 @@ describe('cli-sessions-router', () => {
           cloud_agent_session_id: testCloudAgentSessionId,
         })
       ).rejects.toThrow('No kilo session found for this cloud-agent session');
+    });
+  });
+
+  describe('shareForWebhookTrigger', () => {
+    let triggerId: string;
+    let profileId: string;
+    const testTriggerId = 'test-trigger-share';
+
+    beforeAll(async () => {
+      // Create an environment profile (required FK for triggers)
+      const [profile] = await db
+        .insert(agent_environment_profiles)
+        .values({
+          owned_by_user_id: regularUser.id,
+          name: 'share-test-profile',
+        })
+        .returning({ id: agent_environment_profiles.id });
+      profileId = profile.id;
+
+      // Create a personal webhook trigger owned by regularUser
+      const [trigger] = await db
+        .insert(cloud_agent_webhook_triggers)
+        .values({
+          trigger_id: testTriggerId,
+          user_id: regularUser.id,
+          github_repo: 'test/repo',
+          profile_id: profileId,
+        })
+        .returning({ id: cloud_agent_webhook_triggers.id });
+      triggerId = trigger.id;
+    });
+
+    afterAll(async () => {
+      await db
+        .delete(cloud_agent_webhook_triggers)
+        .where(eq(cloud_agent_webhook_triggers.id, triggerId));
+      await db
+        .delete(agent_environment_profiles)
+        .where(eq(agent_environment_profiles.id, profileId));
+    });
+
+    describe('v1 path (UUID sessions)', () => {
+      let v1SessionId: string;
+
+      beforeEach(async () => {
+        const [session] = await db
+          .insert(cliSessions)
+          .values({
+            kilo_user_id: regularUser.id,
+            title: 'V1 Share Test Session',
+            created_on_platform: 'vscode',
+          })
+          .returning({ session_id: cliSessions.session_id });
+        v1SessionId = session.session_id;
+      });
+
+      afterEach(async () => {
+        await db.delete(sharedCliSessions).where(eq(sharedCliSessions.session_id, v1SessionId));
+        await db.delete(cliSessions).where(eq(cliSessions.session_id, v1SessionId));
+      });
+
+      it('should share a v1 session by copying blobs and creating a shared record', async () => {
+        const caller = await createCallerForUser(regularUser.id);
+
+        const result = await caller.cliSessions.shareForWebhookTrigger({
+          kilo_session_id: v1SessionId,
+          trigger_id: testTriggerId,
+        });
+
+        expect(result.session_id).toBe(v1SessionId);
+        expect(result.share_id).toBeDefined();
+
+        // Verify shared session was created in the database
+        const [shared] = await db
+          .select()
+          .from(sharedCliSessions)
+          .where(eq(sharedCliSessions.share_id, result.share_id));
+
+        expect(shared).toBeDefined();
+        expect(shared.session_id).toBe(v1SessionId);
+        expect(shared.shared_state).toBe(CliSessionSharedState.Public);
+      });
+
+      it('should throw NOT_FOUND for non-existent v1 session', async () => {
+        const caller = await createCallerForUser(regularUser.id);
+        const fakeUuid = '00000000-0000-0000-0000-000000000000';
+
+        await expect(
+          caller.cliSessions.shareForWebhookTrigger({
+            kilo_session_id: fakeUuid,
+            trigger_id: testTriggerId,
+          })
+        ).rejects.toThrow('Session not found');
+      });
+    });
+
+    it('should throw NOT_FOUND for non-existent trigger', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      const fakeUuid = '10000000-0000-1000-8000-000000000001';
+
+      await expect(
+        caller.cliSessions.shareForWebhookTrigger({
+          kilo_session_id: fakeUuid,
+          trigger_id: 'non-existent-trigger',
+        })
+      ).rejects.toThrow('Trigger not found');
     });
   });
 });

--- a/src/routers/cli-sessions-router.test.ts
+++ b/src/routers/cli-sessions-router.test.ts
@@ -1936,6 +1936,122 @@ describe('cli-sessions-router', () => {
           })
         ).rejects.toThrow('Session not found');
       });
+
+      it('should throw NOT_FOUND when session belongs to a different user (personal trigger)', async () => {
+        // Session is created by regularUser (via beforeEach), but otherUser tries to share it
+        // otherUser needs their own trigger to pass verifyWebhookTriggerAccess
+        const [otherProfile] = await db
+          .insert(agent_environment_profiles)
+          .values({
+            owned_by_user_id: otherUser.id,
+            name: 'other-user-share-profile',
+          })
+          .returning({ id: agent_environment_profiles.id });
+
+        const otherTriggerId = 'test-trigger-share-other-user';
+        const [otherTrigger] = await db
+          .insert(cloud_agent_webhook_triggers)
+          .values({
+            trigger_id: otherTriggerId,
+            user_id: otherUser.id,
+            github_repo: 'test/other-repo',
+            profile_id: otherProfile.id,
+          })
+          .returning({ id: cloud_agent_webhook_triggers.id });
+
+        try {
+          const caller = await createCallerForUser(otherUser.id);
+          await expect(
+            caller.cliSessions.shareForWebhookTrigger({
+              kilo_session_id: v1SessionId,
+              trigger_id: otherTriggerId,
+            })
+          ).rejects.toThrow('Session not found');
+        } finally {
+          await db
+            .delete(cloud_agent_webhook_triggers)
+            .where(eq(cloud_agent_webhook_triggers.id, otherTrigger.id));
+          await db
+            .delete(agent_environment_profiles)
+            .where(eq(agent_environment_profiles.id, otherProfile.id));
+        }
+      });
+
+      it('should throw NOT_FOUND when session belongs to a different org (org trigger)', async () => {
+        // Create a session belonging to testOrganization
+        const [orgSession] = await db
+          .insert(cliSessions)
+          .values({
+            kilo_user_id: regularUser.id,
+            title: 'Org Session',
+            created_on_platform: 'vscode',
+            organization_id: testOrganization.id,
+          })
+          .returning({ session_id: cliSessions.session_id });
+
+        // Create a second org and an org trigger for it
+        const [otherOrg] = await db
+          .insert(organizations)
+          .values({
+            name: 'Other Org for Share Test',
+            created_by_kilo_user_id: regularUser.id,
+          })
+          .returning();
+
+        await db.insert(organization_memberships).values({
+          organization_id: otherOrg.id,
+          kilo_user_id: regularUser.id,
+          role: 'owner',
+        });
+
+        const [otherProfile] = await db
+          .insert(agent_environment_profiles)
+          .values({
+            name: 'other-org-share-profile',
+            owned_by_organization_id: otherOrg.id,
+          })
+          .returning({ id: agent_environment_profiles.id });
+
+        const otherOrgTriggerId = 'test-trigger-share-other-org';
+        const [otherOrgTrigger] = await db
+          .insert(cloud_agent_webhook_triggers)
+          .values({
+            trigger_id: otherOrgTriggerId,
+            organization_id: otherOrg.id,
+            github_repo: 'test/other-org-repo',
+            profile_id: otherProfile.id,
+          })
+          .returning({ id: cloud_agent_webhook_triggers.id });
+
+        try {
+          const caller = await createCallerForUser(regularUser.id);
+          // Try to share orgSession (belongs to testOrganization) via otherOrg's trigger
+          await expect(
+            caller.cliSessions.shareForWebhookTrigger({
+              kilo_session_id: orgSession.session_id,
+              trigger_id: otherOrgTriggerId,
+              organization_id: otherOrg.id,
+            })
+          ).rejects.toThrow('Session not found');
+        } finally {
+          await db
+            .delete(cloud_agent_webhook_triggers)
+            .where(eq(cloud_agent_webhook_triggers.id, otherOrgTrigger.id));
+          await db
+            .delete(agent_environment_profiles)
+            .where(eq(agent_environment_profiles.id, otherProfile.id));
+          await db
+            .delete(organization_memberships)
+            .where(
+              and(
+                eq(organization_memberships.organization_id, otherOrg.id),
+                eq(organization_memberships.kilo_user_id, regularUser.id)
+              )
+            );
+          await db.delete(cliSessions).where(eq(cliSessions.session_id, orgSession.session_id));
+          await db.delete(organizations).where(eq(organizations.id, otherOrg.id));
+        }
+      });
     });
 
     it('should throw NOT_FOUND for non-existent trigger', async () => {

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -783,10 +783,16 @@ export const cliSessionsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await verifyWebhookTriggerAccess(ctx, input.trigger_id, input.organization_id);
 
+      // For org triggers, verify the session belongs to the same org.
+      // For personal triggers, verify the session belongs to the requesting user.
+      const ownerCondition = input.organization_id
+        ? eq(cliSessions.organization_id, input.organization_id)
+        : eq(cliSessions.kilo_user_id, ctx.user.id);
+
       const [session] = await db
-        .select()
+        .select({ session_id: cliSessions.session_id })
         .from(cliSessions)
-        .where(eq(cliSessions.session_id, input.kilo_session_id))
+        .where(and(eq(cliSessions.session_id, input.kilo_session_id), ownerCondition))
         .limit(1);
 
       if (!session) {

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { db } from '@/lib/drizzle';
 import { eq, and, desc, lt, or, ilike, sql, isNull, notInArray, type SQL } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
-import { cliSessions, sharedCliSessions, cloud_agent_webhook_triggers } from '@kilocode/db/schema';
+import { cliSessions, sharedCliSessions } from '@kilocode/db/schema';
 import { CliSessionSharedState } from '@/types/cli-session-shared-state';
 import {
   generateSignedUrls,
@@ -18,6 +18,7 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { getCodeReviewById } from '@/lib/code-reviews/db/code-reviews';
 import { createCloudAgentClient } from '@/lib/cloud-agent/cloud-agent-client';
 import { generateApiToken } from '@/lib/tokens';
+import { verifyWebhookTriggerAccess } from '@/lib/webhook-trigger-ownership';
 
 export const BLOB_TYPES = [
   'api_conversation_history',
@@ -768,45 +769,19 @@ export const cliSessionsRouter = createTRPCRouter({
     }),
 
   /**
-   * Share a CLI session from a webhook trigger request.
-   * This allows any org member to share the session associated with an org webhook trigger,
-   * or the owner to share their personal webhook trigger session.
+   * Share a legacy v1 CLI session (UUID) from a webhook trigger request.
+   * For v2 sessions (ses_*), use cliSessionsV2.shareForWebhookTrigger instead.
    */
   shareForWebhookTrigger: baseProcedure
     .input(
       z.object({
-        kilo_session_id: sessionIdField,
+        kilo_session_id: z.string().uuid(),
         trigger_id: z.string().min(1),
         organization_id: z.string().uuid().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const triggerWhereClause = input.organization_id
-        ? and(
-            eq(cloud_agent_webhook_triggers.trigger_id, input.trigger_id),
-            eq(cloud_agent_webhook_triggers.organization_id, input.organization_id)
-          )
-        : and(
-            eq(cloud_agent_webhook_triggers.trigger_id, input.trigger_id),
-            eq(cloud_agent_webhook_triggers.user_id, ctx.user.id),
-            isNull(cloud_agent_webhook_triggers.organization_id)
-          );
-
-      const [trigger] = await db
-        .select()
-        .from(cloud_agent_webhook_triggers)
-        .where(triggerWhereClause);
-
-      if (!trigger) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Trigger not found',
-        });
-      }
-
-      if (input.organization_id) {
-        await ensureOrganizationAccess(ctx, input.organization_id);
-      }
+      await verifyWebhookTriggerAccess(ctx, input.trigger_id, input.organization_id);
 
       const [session] = await db
         .select()

--- a/src/routers/cli-sessions-v2-router.test.ts
+++ b/src/routers/cli-sessions-v2-router.test.ts
@@ -5,9 +5,11 @@ import {
   cloud_agent_webhook_triggers,
   cli_sessions_v2,
   agent_environment_profiles,
+  organizations,
+  organization_memberships,
 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
-import type { User } from '@kilocode/db/schema';
+import { eq, and } from 'drizzle-orm';
+import type { User, Organization } from '@kilocode/db/schema';
 
 jest.mock('@/lib/config.server', () => {
   const actual: Record<string, unknown> = jest.requireActual('@/lib/config.server');
@@ -18,6 +20,8 @@ jest.mock('@/lib/config.server', () => {
 });
 
 let regularUser: User;
+let otherUser: User;
+let testOrganization: Organization;
 
 describe('cli-sessions-v2-router', () => {
   beforeAll(async () => {
@@ -26,6 +30,21 @@ describe('cli-sessions-v2-router', () => {
       google_user_name: 'CLI Sessions V2 User',
       is_admin: false,
     });
+
+    otherUser = await insertTestUser({
+      google_user_email: 'cli-sessions-v2-other@example.com',
+      google_user_name: 'CLI Sessions V2 Other User',
+      is_admin: false,
+    });
+
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        name: 'CLI Sessions V2 Test Org',
+        created_by_kilo_user_id: regularUser.id,
+      })
+      .returning();
+    testOrganization = org;
   });
 
   describe('shareForWebhookTrigger', () => {
@@ -138,6 +157,120 @@ describe('cli-sessions-v2-router', () => {
           trigger_id: testTriggerId,
         })
       ).rejects.toThrow('Session share failed: 500 Internal Server Error');
+    });
+
+    it('should throw NOT_FOUND when session belongs to a different user (personal trigger)', async () => {
+      // Session is created by regularUser (via beforeEach), but otherUser tries to share it
+      // otherUser needs their own trigger to pass verifyWebhookTriggerAccess
+      const [otherProfile] = await db
+        .insert(agent_environment_profiles)
+        .values({
+          owned_by_user_id: otherUser.id,
+          name: 'other-user-share-profile-v2',
+        })
+        .returning({ id: agent_environment_profiles.id });
+
+      const otherTriggerId = 'test-trigger-share-other-user-v2';
+      const [otherTrigger] = await db
+        .insert(cloud_agent_webhook_triggers)
+        .values({
+          trigger_id: otherTriggerId,
+          user_id: otherUser.id,
+          github_repo: 'test/other-repo',
+          profile_id: otherProfile.id,
+        })
+        .returning({ id: cloud_agent_webhook_triggers.id });
+
+      try {
+        const caller = await createCallerForUser(otherUser.id);
+        await expect(
+          caller.cliSessionsV2.shareForWebhookTrigger({
+            kilo_session_id: v2SessionId,
+            trigger_id: otherTriggerId,
+          })
+        ).rejects.toThrow('Session not found');
+      } finally {
+        await db
+          .delete(cloud_agent_webhook_triggers)
+          .where(eq(cloud_agent_webhook_triggers.id, otherTrigger.id));
+        await db
+          .delete(agent_environment_profiles)
+          .where(eq(agent_environment_profiles.id, otherProfile.id));
+      }
+    });
+
+    it('should throw NOT_FOUND when session belongs to a different org (org trigger)', async () => {
+      // Create a session belonging to testOrganization
+      const orgSessionId = 'ses_test_share_v2_org_session_1234';
+      await db.insert(cli_sessions_v2).values({
+        session_id: orgSessionId,
+        kilo_user_id: regularUser.id,
+        created_on_platform: 'webhook',
+        organization_id: testOrganization.id,
+      });
+
+      // Create a second org and an org trigger for it
+      const [otherOrg] = await db
+        .insert(organizations)
+        .values({
+          name: 'Other Org for Share Test V2',
+          created_by_kilo_user_id: regularUser.id,
+        })
+        .returning();
+
+      await db.insert(organization_memberships).values({
+        organization_id: otherOrg.id,
+        kilo_user_id: regularUser.id,
+        role: 'owner',
+      });
+
+      const [otherProfile] = await db
+        .insert(agent_environment_profiles)
+        .values({
+          name: 'other-org-share-profile-v2',
+          owned_by_organization_id: otherOrg.id,
+        })
+        .returning({ id: agent_environment_profiles.id });
+
+      const otherOrgTriggerId = 'test-trigger-share-other-org-v2';
+      const [otherOrgTrigger] = await db
+        .insert(cloud_agent_webhook_triggers)
+        .values({
+          trigger_id: otherOrgTriggerId,
+          organization_id: otherOrg.id,
+          github_repo: 'test/other-org-repo',
+          profile_id: otherProfile.id,
+        })
+        .returning({ id: cloud_agent_webhook_triggers.id });
+
+      try {
+        const caller = await createCallerForUser(regularUser.id);
+        // Try to share orgSession (belongs to testOrganization) via otherOrg's trigger
+        await expect(
+          caller.cliSessionsV2.shareForWebhookTrigger({
+            kilo_session_id: orgSessionId,
+            trigger_id: otherOrgTriggerId,
+            organization_id: otherOrg.id,
+          })
+        ).rejects.toThrow('Session not found');
+      } finally {
+        await db
+          .delete(cloud_agent_webhook_triggers)
+          .where(eq(cloud_agent_webhook_triggers.id, otherOrgTrigger.id));
+        await db
+          .delete(agent_environment_profiles)
+          .where(eq(agent_environment_profiles.id, otherProfile.id));
+        await db
+          .delete(organization_memberships)
+          .where(
+            and(
+              eq(organization_memberships.organization_id, otherOrg.id),
+              eq(organization_memberships.kilo_user_id, regularUser.id)
+            )
+          );
+        await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, orgSessionId));
+        await db.delete(organizations).where(eq(organizations.id, otherOrg.id));
+      }
     });
 
     it('should throw NOT_FOUND for non-existent trigger', async () => {

--- a/src/routers/cli-sessions-v2-router.test.ts
+++ b/src/routers/cli-sessions-v2-router.test.ts
@@ -1,0 +1,154 @@
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { db } from '@/lib/drizzle';
+import {
+  cloud_agent_webhook_triggers,
+  cli_sessions_v2,
+  agent_environment_profiles,
+} from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import type { User } from '@kilocode/db/schema';
+
+jest.mock('@/lib/config.server', () => {
+  const actual: Record<string, unknown> = jest.requireActual('@/lib/config.server');
+  return {
+    ...actual,
+    SESSION_INGEST_WORKER_URL: 'https://test-ingest.example.com',
+  };
+});
+
+let regularUser: User;
+
+describe('cli-sessions-v2-router', () => {
+  beforeAll(async () => {
+    regularUser = await insertTestUser({
+      google_user_email: 'cli-sessions-v2-user@example.com',
+      google_user_name: 'CLI Sessions V2 User',
+      is_admin: false,
+    });
+  });
+
+  describe('shareForWebhookTrigger', () => {
+    let triggerId: string;
+    let profileId: string;
+    const testTriggerId = 'test-trigger-share-v2';
+
+    beforeAll(async () => {
+      const [profile] = await db
+        .insert(agent_environment_profiles)
+        .values({
+          owned_by_user_id: regularUser.id,
+          name: 'share-test-profile-v2',
+        })
+        .returning({ id: agent_environment_profiles.id });
+      profileId = profile.id;
+
+      const [trigger] = await db
+        .insert(cloud_agent_webhook_triggers)
+        .values({
+          trigger_id: testTriggerId,
+          user_id: regularUser.id,
+          github_repo: 'test/repo',
+          profile_id: profileId,
+        })
+        .returning({ id: cloud_agent_webhook_triggers.id });
+      triggerId = trigger.id;
+    });
+
+    afterAll(async () => {
+      await db
+        .delete(cloud_agent_webhook_triggers)
+        .where(eq(cloud_agent_webhook_triggers.id, triggerId));
+      await db
+        .delete(agent_environment_profiles)
+        .where(eq(agent_environment_profiles.id, profileId));
+    });
+
+    const v2SessionId = 'ses_test_share_v2_session_1234';
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      await db.insert(cli_sessions_v2).values({
+        session_id: v2SessionId,
+        kilo_user_id: regularUser.id,
+        created_on_platform: 'webhook',
+      });
+
+      fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ success: true, public_id: 'test-public-uuid' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+
+    afterEach(async () => {
+      fetchSpy.mockRestore();
+      await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, v2SessionId));
+    });
+
+    it('should share a v2 session via the session-ingest worker', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+
+      const result = await caller.cliSessionsV2.shareForWebhookTrigger({
+        kilo_session_id: v2SessionId,
+        trigger_id: testTriggerId,
+      });
+
+      expect(result).toEqual({
+        share_id: 'test-public-uuid',
+        session_id: v2SessionId,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [fetchUrl, fetchOpts] = fetchSpy.mock.calls[0];
+      expect(fetchUrl).toBe(
+        `https://test-ingest.example.com/api/session/${encodeURIComponent(v2SessionId)}/share`
+      );
+      expect(fetchOpts.method).toBe('POST');
+      expect(fetchOpts.headers.Authorization).toMatch(/^Bearer .+/);
+    });
+
+    it('should throw NOT_FOUND for non-existent v2 session', async () => {
+      await db.delete(cli_sessions_v2).where(eq(cli_sessions_v2.session_id, v2SessionId));
+
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.cliSessionsV2.shareForWebhookTrigger({
+          kilo_session_id: 'ses_nonexistent_session_12345',
+          trigger_id: testTriggerId,
+        })
+      ).rejects.toThrow('Session not found');
+    });
+
+    it('should throw INTERNAL_SERVER_ERROR when session-ingest returns an error', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        })
+      );
+
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.cliSessionsV2.shareForWebhookTrigger({
+          kilo_session_id: v2SessionId,
+          trigger_id: testTriggerId,
+        })
+      ).rejects.toThrow('Session share failed: 500 Internal Server Error');
+    });
+
+    it('should throw NOT_FOUND for non-existent trigger', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.cliSessionsV2.shareForWebhookTrigger({
+          kilo_session_id: v2SessionId,
+          trigger_id: 'non-existent-trigger',
+        })
+      ).rejects.toThrow('Trigger not found');
+    });
+  });
+});

--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -8,14 +8,16 @@ import { captureException } from '@sentry/nextjs';
 import { TRPCClientError } from '@trpc/client';
 import { cli_sessions_v2 } from '@kilocode/db/schema';
 import { createCloudAgentNextClient } from '@/lib/cloud-agent-next/cloud-agent-client';
-import { generateApiToken } from '@/lib/tokens';
+import { generateApiToken, generateInternalServiceToken } from '@/lib/tokens';
 import {
   fetchSessionMessages,
   deleteSession as deleteSessionIngest,
   shareSession as shareSessionIngest,
 } from '@/lib/session-ingest-client';
+import { SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
 import { baseGetSessionNextOutputSchema } from './cloud-agent-next-schemas';
 import { sanitizeGitUrl } from '@/routers/cli-sessions-router';
+import { verifyWebhookTriggerAccess } from '@/lib/webhook-trigger-ownership';
 
 /**
  * Check if an error indicates the session was not found in the cloud-agent DO.
@@ -399,4 +401,92 @@ export const cliSessionsV2Router = createTRPCRouter({
       });
     }
   }),
+
+  /**
+   * Share a v2 CLI session from a webhook trigger request.
+   * Creates a read-only public snapshot via the session-ingest worker.
+   *
+   * For org triggers, any org member can share; for personal triggers, only the owner.
+   */
+  shareForWebhookTrigger: baseProcedure
+    .input(
+      z.object({
+        kilo_session_id: z.string().startsWith('ses_'),
+        trigger_id: z.string().min(1),
+        organization_id: z.string().uuid().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await verifyWebhookTriggerAccess(ctx, input.trigger_id, input.organization_id);
+
+      const [session] = await db
+        .select({
+          kilo_user_id: cli_sessions_v2.kilo_user_id,
+          organization_id: cli_sessions_v2.organization_id,
+        })
+        .from(cli_sessions_v2)
+        .where(eq(cli_sessions_v2.session_id, input.kilo_session_id))
+        .limit(1);
+
+      if (!session) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Session not found',
+        });
+      }
+
+      // For org triggers, verify the session belongs to the same org.
+      // For personal triggers, verify the session belongs to the requesting user.
+      if (input.organization_id) {
+        if (session.organization_id !== input.organization_id) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Session not found',
+          });
+        }
+      } else {
+        if (session.kilo_user_id !== ctx.user.id) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Session not found',
+          });
+        }
+      }
+
+      if (!SESSION_INGEST_WORKER_URL) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'SESSION_INGEST_WORKER_URL is not configured',
+        });
+      }
+
+      const token = generateInternalServiceToken(session.kilo_user_id);
+      const url = `${SESSION_INGEST_WORKER_URL}/api/session/${encodeURIComponent(input.kilo_session_id)}/share`;
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Session share failed: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`,
+        });
+      }
+
+      const shareResponseSchema = z.object({ public_id: z.string() });
+      let body: z.infer<typeof shareResponseSchema>;
+      try {
+        body = shareResponseSchema.parse(await response.json());
+      } catch {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Session share succeeded but response was malformed',
+        });
+      }
+
+      return { share_id: body.public_id, session_id: input.kilo_session_id };
+    }),
 });

--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -419,13 +419,16 @@ export const cliSessionsV2Router = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await verifyWebhookTriggerAccess(ctx, input.trigger_id, input.organization_id);
 
+      // For org triggers, verify the session belongs to the same org.
+      // For personal triggers, verify the session belongs to the requesting user.
+      const ownerCondition = input.organization_id
+        ? eq(cli_sessions_v2.organization_id, input.organization_id)
+        : eq(cli_sessions_v2.kilo_user_id, ctx.user.id);
+
       const [session] = await db
-        .select({
-          kilo_user_id: cli_sessions_v2.kilo_user_id,
-          organization_id: cli_sessions_v2.organization_id,
-        })
+        .select({ kilo_user_id: cli_sessions_v2.kilo_user_id })
         .from(cli_sessions_v2)
-        .where(eq(cli_sessions_v2.session_id, input.kilo_session_id))
+        .where(and(eq(cli_sessions_v2.session_id, input.kilo_session_id), ownerCondition))
         .limit(1);
 
       if (!session) {
@@ -433,24 +436,6 @@ export const cliSessionsV2Router = createTRPCRouter({
           code: 'NOT_FOUND',
           message: 'Session not found',
         });
-      }
-
-      // For org triggers, verify the session belongs to the same org.
-      // For personal triggers, verify the session belongs to the requesting user.
-      if (input.organization_id) {
-        if (session.organization_id !== input.organization_id) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Session not found',
-          });
-        }
-      } else {
-        if (session.kilo_user_id !== ctx.user.id) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Session not found',
-          });
-        }
       }
 
       if (!SESSION_INGEST_WORKER_URL) {

--- a/src/routers/webhook-triggers-router.ts
+++ b/src/routers/webhook-triggers-router.ts
@@ -1,14 +1,11 @@
 import { createTRPCRouter, baseProcedure } from '@/lib/trpc/init';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { TRPCError } from '@trpc/server';
-import { and, eq, isNull, inArray } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import * as z from 'zod';
 import { db } from '@/lib/drizzle';
-import {
-  cloud_agent_webhook_triggers,
-  agent_environment_profiles,
-  cliSessions,
-} from '@kilocode/db/schema';
+import { cloud_agent_webhook_triggers, agent_environment_profiles } from '@kilocode/db/schema';
+import { resolveCloudAgentSessionIds } from '@/lib/webhook-session-resolution';
 import { triggerIdSchema } from '@/lib/webhook-trigger-validation';
 import {
   createWorkerTrigger,
@@ -562,26 +559,7 @@ export const webhookTriggersRouter = createTRPCRouter({
         .map(r => r.cloudAgentSessionId)
         .filter((id): id is string => id !== null);
 
-      let sessionIdMap = new Map<string, string>();
-
-      if (cloudAgentSessionIds.length > 0) {
-        const sessions = await db
-          .select({
-            cloudAgentSessionId: cliSessions.cloud_agent_session_id,
-            sessionId: cliSessions.session_id,
-          })
-          .from(cliSessions)
-          .where(inArray(cliSessions.cloud_agent_session_id, cloudAgentSessionIds));
-
-        sessionIdMap = new Map(
-          sessions
-            .filter(
-              (s): s is { cloudAgentSessionId: string; sessionId: string } =>
-                s.cloudAgentSessionId !== null
-            )
-            .map(s => [s.cloudAgentSessionId, s.sessionId])
-        );
-      }
+      const sessionIdMap = await resolveCloudAgentSessionIds(cloudAgentSessionIds);
 
       return result.requests.map(request => ({
         ...request,


### PR DESCRIPTION
## Summary

Migrates the webhook agent ingest worker from `cloud-agent` to `cloud-agent-next` and adds full v2 session (`ses_*`) support across webhook-related routers and UI.

## Changes

### Webhook Agent Ingest Worker
- Update service bindings from `cloud-agent` to `cloud-agent-next` (prod and dev)
- Extract initiate response handling into `classifyInitiateResponse` — a pure function returning a discriminated union (`ack`/`fail`/`retry`/`throw`), with new handling for 409 (idempotent success) and 503 (retryable) responses
- Add `createdOnPlatform: 'webhook'` to the `prepareSession` payload
- 14 unit tests for `classifyInitiateResponse`

### v2 Session Sharing (`shareForWebhookTrigger`)
- Route `ses_*` sessions through the session-ingest worker instead of R2 blob copy
- Validate the upstream response with a zod schema instead of a bare type annotation
- Add ownership checks: org triggers require matching `organization_id`, personal triggers require matching `kilo_user_id`
- 6 integration tests covering v1/v2 happy paths, not-found, and error cases

### Session ID Resolution
- Extract duplicated v1→v2 `cloudAgentSessionId` → `kiloSessionId` lookup into a shared `resolveCloudAgentSessionIds` utility (`src/lib/webhook-session-resolution.ts`), used by both `admin-webhook-triggers-router` and `webhook-triggers-router`

### UI
- Use `/s/` share URL path for v2 sessions, `/share/` for v1 sessions