### PR TITLE
Integrate abuse service auth event tracking

### DIFF
--- a/src/lib/abuse-service.ts
+++ b/src/lib/abuse-service.ts
@@ -189,6 +189,48 @@ export type UsagePayload = {
 };
 
 /**
+ * Shared fetch helper for all abuse service endpoints.
+ * Handles URL check, CF Access auth headers, and fail-open error handling.
+ * Returns the parsed JSON response, or null if the service is unavailable or errored.
+ */
+async function fetchAbuseService<T>(
+  path: string,
+  payload: unknown,
+  label: string
+): Promise<T | null> {
+  if (!ABUSE_SERVICE_URL) {
+    return null;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
+      headers['CF-Access-Client-Id'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
+      headers['CF-Access-Client-Secret'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
+    }
+
+    const response = await fetch(`${ABUSE_SERVICE_URL}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error(`[Abuse] ${label} failed (${response.status}): ${await response.text()}`);
+      return null;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    console.error(`[Abuse] ${label} error:`, error);
+    return null;
+  }
+}
+
+/**
  * Classify a request for potential abuse.
  * This is called before proxying requests to detect fraudulent activity.
  *
@@ -200,38 +242,7 @@ export type UsagePayload = {
 export async function classifyRequest(
   payload: UsagePayload
 ): Promise<AbuseClassificationResponse | null> {
-  if (!ABUSE_SERVICE_URL) {
-    return null;
-  }
-
-  try {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    // Add Cloudflare Access headers for authentication
-    if (ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
-      headers['CF-Access-Client-Id'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
-      headers['CF-Access-Client-Secret'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
-    }
-
-    const response = await fetch(`${ABUSE_SERVICE_URL}/api/classify`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      console.error(`Abuse service error (${response.status}): ${await response.text()}`);
-      return null;
-    }
-
-    return (await response.json()) as AbuseClassificationResponse;
-  } catch (error) {
-    // Fail-open: don't block requests if abuse service is down
-    console.error('Abuse classification failed:', error);
-    return null;
-  }
+  return fetchAbuseService<AbuseClassificationResponse>('/api/classify', payload, 'classify');
 }
 
 /**
@@ -281,38 +292,7 @@ export type CostUpdateResponse = {
  * @returns Response or null if service unavailable/failed
  */
 export async function reportCost(payload: CostUpdatePayload): Promise<CostUpdateResponse | null> {
-  if (!ABUSE_SERVICE_URL) {
-    return null;
-  }
-
-  try {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    // Add Cloudflare Access headers in production
-    if (ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
-      headers['CF-Access-Client-Id'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
-      headers['CF-Access-Client-Secret'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
-    }
-
-    const response = await fetch(`${ABUSE_SERVICE_URL}/api/usage/cost`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      console.error(`[Abuse] Cost update failed (${response.status}): ${await response.text()}`);
-      return null;
-    }
-
-    return (await response.json()) as CostUpdateResponse;
-  } catch (error) {
-    // Log but don't throw - this shouldn't affect user experience
-    console.error('[Abuse] Failed to report cost:', error);
-    return null;
-  }
+  return fetchAbuseService<CostUpdateResponse>('/api/usage/cost', payload, 'cost update');
 }
 
 /**
@@ -330,6 +310,7 @@ export type AuthEventPayload = {
   ja4_digest?: string | null;
   user_agent?: string | null;
   auth_method: AuthProviderId;
+  /** Reserved for future Stytch integration — not populated yet */
   stytch_session_id?: string | null;
 };
 
@@ -338,32 +319,7 @@ export type AuthEventPayload = {
  * Fire-and-forget: catches all errors, never throws, never blocks auth.
  */
 export async function reportAuthEvent(payload: AuthEventPayload): Promise<void> {
-  if (!ABUSE_SERVICE_URL) {
-    return;
-  }
-
-  try {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    if (ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
-      headers['CF-Access-Client-Id'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
-      headers['CF-Access-Client-Secret'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
-    }
-
-    const response = await fetch(`${ABUSE_SERVICE_URL}/api/auth-event`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      console.error(`[Abuse] Auth event failed (${response.status}): ${await response.text()}`);
-    }
-  } catch (error) {
-    console.error('[Abuse] Failed to report auth event:', error);
-  }
+  await fetchAbuseService('/api/auth-event', payload, 'auth event');
 }
 
 /**

--- a/src/lib/abuse-service.ts
+++ b/src/lib/abuse-service.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/config.server';
 import { getFraudDetectionHeaders } from '@/lib/utils';
 import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter/types';
+import type { AuthProviderId } from '@/lib/auth/provider-metadata';
 import 'server-only';
 
 /**
@@ -311,6 +312,57 @@ export async function reportCost(payload: CostUpdatePayload): Promise<CostUpdate
     // Log but don't throw - this shouldn't affect user experience
     console.error('[Abuse] Failed to report cost:', error);
     return null;
+  }
+}
+
+/**
+ * Payload for the auth event tracking endpoint.
+ * Tracks signup/signin patterns for abuse detection.
+ */
+export type AuthEventPayload = {
+  kilo_user_id: string;
+  event_type: 'signup' | 'signin';
+  email: string;
+  account_created_at: string; // ISO 8601
+  ip_address?: string | null;
+  geo_city?: string | null;
+  geo_country?: string | null;
+  ja4_digest?: string | null;
+  user_agent?: string | null;
+  auth_method: AuthProviderId;
+  stytch_session_id?: string | null;
+};
+
+/**
+ * Report an auth event (signup or signin) to the abuse service.
+ * Fire-and-forget: catches all errors, never throws, never blocks auth.
+ */
+export async function reportAuthEvent(payload: AuthEventPayload): Promise<void> {
+  if (!ABUSE_SERVICE_URL) {
+    return;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (ABUSE_SERVICE_CF_ACCESS_CLIENT_ID && ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET) {
+      headers['CF-Access-Client-Id'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_ID;
+      headers['CF-Access-Client-Secret'] = ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET;
+    }
+
+    const response = await fetch(`${ABUSE_SERVICE_URL}/api/auth-event`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error(`[Abuse] Auth event failed (${response.status}): ${await response.text()}`);
+    }
+  } catch (error) {
+    console.error('[Abuse] Failed to report auth event:', error);
   }
 }
 

--- a/src/lib/sso-user.ts
+++ b/src/lib/sso-user.ts
@@ -15,7 +15,10 @@ import { SSO_SIGNIN_PATH } from '@/lib/auth/constants';
 
 const workos = new WorkOS(WORKOS_API_KEY);
 
-async function processSSOInternal(args: CreateOrUpdateUserArgs): Promise<boolean> {
+async function processSSOInternal(
+  args: CreateOrUpdateUserArgs,
+  requestHeaders?: Headers
+): Promise<boolean> {
   if (args.provider !== 'workos') {
     throw new Error('Only SSO logins supported');
   }
@@ -48,7 +51,7 @@ async function processSSOInternal(args: CreateOrUpdateUserArgs): Promise<boolean
     );
   }
 
-  const res = await createOrUpdateUser(args, undefined, true);
+  const res = await createOrUpdateUser(args, undefined, true, requestHeaders);
   if (!res.success) {
     throw new Error(res.error);
   }
@@ -96,9 +99,9 @@ async function processSSOInternal(args: CreateOrUpdateUserArgs): Promise<boolean
   return true;
 }
 
-export async function processSSOUserLogin(args: CreateOrUpdateUserArgs) {
+export async function processSSOUserLogin(args: CreateOrUpdateUserArgs, requestHeaders?: Headers) {
   try {
-    return await processSSOInternal(args);
+    return await processSSOInternal(args, requestHeaders);
   } catch (error) {
     console.error('Error processing SSO login:', error);
     captureException(error, {

--- a/src/lib/user.server.ts
+++ b/src/lib/user.server.ts
@@ -462,8 +462,10 @@ const authOptions: NextAuthOptions = {
           }
         }
 
+        const requestHeaders = await headers();
+
         if (accountInfo.provider === 'workos') {
-          return processSSOUserLogin(accountInfo);
+          return processSSOUserLogin(accountInfo, requestHeaders);
         }
 
         // Validate Turnstile JWT for real OAuth logins (not fake logins or email auth)
@@ -491,7 +493,7 @@ const authOptions: NextAuthOptions = {
             return redirectUrlForCode('INVALID_VERIFICATION');
           }
 
-          const currentIP = (await headers()).get('x-forwarded-for');
+          const currentIP = requestHeaders.get('x-forwarded-for');
           if (verifiedToken.ip !== currentIP) {
             sentryLogger('turnstile-auth')(
               `SECURITY: IP mismatch - JWT: ${verifiedToken.ip}, Current: ${currentIP}`,
@@ -513,7 +515,12 @@ const authOptions: NextAuthOptions = {
                 await linkAccountToExistingUser(linkingSession.existingUserId, accountInfo),
                 v => ({ ...v, isNew: false })
               )
-            : await createOrUpdateUser(accountInfo, verifiedToken?.guid, autoLinkToExistingUser);
+            : await createOrUpdateUser(
+                accountInfo,
+                verifiedToken?.guid,
+                autoLinkToExistingUser,
+                requestHeaders
+              );
 
         if (result.success === false) {
           // Expected user errors that shouldn't be logged to Sentry

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -225,6 +225,21 @@ export async function createOrUpdateUser(
       if (!linkResult.success) {
         return { success: false, error: linkResult.error };
       }
+      // Fire-and-forget auth event for auto-linked signin
+      if (requestHeaders) {
+        void reportAuthEvent({
+          kilo_user_id: userByEmail.id,
+          event_type: 'signin',
+          email: userByEmail.google_user_email,
+          account_created_at: userByEmail.created_at,
+          ip_address: requestHeaders.get('x-forwarded-for'),
+          geo_city: requestHeaders.get('x-vercel-ip-city'),
+          geo_country: requestHeaders.get('x-vercel-ip-country'),
+          ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
+          user_agent: requestHeaders.get('user-agent'),
+          auth_method: args.provider,
+        });
+      }
       // Successfully linked account, return the existing user
       posthogClient.capture({
         distinctId: userByEmail.google_user_email,

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -156,6 +156,26 @@ export async function findUserByEmail(email: string): Promise<User | undefined> 
   });
 }
 
+function fireAuthEvent(
+  user: Pick<User, 'id' | 'google_user_email' | 'created_at'>,
+  eventType: 'signup' | 'signin',
+  provider: AuthProviderId,
+  requestHeaders: Headers
+) {
+  void reportAuthEvent({
+    kilo_user_id: user.id,
+    event_type: eventType,
+    email: user.google_user_email,
+    account_created_at: user.created_at,
+    ip_address: requestHeaders.get('x-forwarded-for'),
+    geo_city: requestHeaders.get('x-vercel-ip-city'),
+    geo_country: requestHeaders.get('x-vercel-ip-country'),
+    ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
+    user_agent: requestHeaders.get('user-agent'),
+    auth_method: provider,
+  });
+}
+
 export async function createOrUpdateUser(
   args: CreateOrUpdateUserArgs,
   turnstile_guid: UUID | undefined,
@@ -164,20 +184,8 @@ export async function createOrUpdateUser(
 ): Promise<Result<{ user: User; isNew: boolean }, AuthErrorType>> {
   const existingUser = await findAndSyncExistingUser(args);
   if (existingUser) {
-    // Fire-and-forget auth event for signin
     if (requestHeaders) {
-      void reportAuthEvent({
-        kilo_user_id: existingUser.id,
-        event_type: 'signin',
-        email: existingUser.google_user_email,
-        account_created_at: existingUser.created_at,
-        ip_address: requestHeaders.get('x-forwarded-for'),
-        geo_city: requestHeaders.get('x-vercel-ip-city'),
-        geo_country: requestHeaders.get('x-vercel-ip-country'),
-        ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
-        user_agent: requestHeaders.get('user-agent'),
-        auth_method: args.provider,
-      });
+      fireAuthEvent(existingUser, 'signin', args.provider, requestHeaders);
     }
 
     // User signed in or is being updated
@@ -225,20 +233,8 @@ export async function createOrUpdateUser(
       if (!linkResult.success) {
         return { success: false, error: linkResult.error };
       }
-      // Fire-and-forget auth event for auto-linked signin
       if (requestHeaders) {
-        void reportAuthEvent({
-          kilo_user_id: userByEmail.id,
-          event_type: 'signin',
-          email: userByEmail.google_user_email,
-          account_created_at: userByEmail.created_at,
-          ip_address: requestHeaders.get('x-forwarded-for'),
-          geo_city: requestHeaders.get('x-vercel-ip-city'),
-          geo_country: requestHeaders.get('x-vercel-ip-country'),
-          ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
-          user_agent: requestHeaders.get('user-agent'),
-          auth_method: args.provider,
-        });
+        fireAuthEvent(userByEmail, 'signin', args.provider, requestHeaders);
       }
       // Successfully linked account, return the existing user
       posthogClient.capture({
@@ -317,20 +313,8 @@ export async function createOrUpdateUser(
     return savedUser;
   });
 
-  // Fire-and-forget auth event for signup
   if (requestHeaders) {
-    void reportAuthEvent({
-      kilo_user_id: savedUser.id,
-      event_type: 'signup',
-      email: savedUser.google_user_email,
-      account_created_at: savedUser.created_at,
-      ip_address: requestHeaders.get('x-forwarded-for'),
-      geo_city: requestHeaders.get('x-vercel-ip-city'),
-      geo_country: requestHeaders.get('x-vercel-ip-country'),
-      ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
-      user_agent: requestHeaders.get('user-agent'),
-      auth_method: args.provider,
-    });
+    fireAuthEvent(savedUser, 'signup', args.provider, requestHeaders);
   }
 
   // User created event in PostHog

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/drizzle';
 import { WORKOS_API_KEY } from '@/lib/config.server';
 import { WorkOS } from '@workos-inc/node';
 import type { User } from '@kilocode/db/schema';
+import { reportAuthEvent } from '@/lib/abuse-service';
 import {
   payment_methods,
   kilocode_users,
@@ -158,10 +159,27 @@ export async function findUserByEmail(email: string): Promise<User | undefined> 
 export async function createOrUpdateUser(
   args: CreateOrUpdateUserArgs,
   turnstile_guid: UUID | undefined,
-  autoLinkToExistingUser: boolean = false
+  autoLinkToExistingUser: boolean = false,
+  requestHeaders?: Headers
 ): Promise<Result<{ user: User; isNew: boolean }, AuthErrorType>> {
   const existingUser = await findAndSyncExistingUser(args);
   if (existingUser) {
+    // Fire-and-forget auth event for signin
+    if (requestHeaders) {
+      void reportAuthEvent({
+        kilo_user_id: existingUser.id,
+        event_type: 'signin',
+        email: existingUser.google_user_email,
+        account_created_at: existingUser.created_at,
+        ip_address: requestHeaders.get('x-forwarded-for'),
+        geo_city: requestHeaders.get('x-vercel-ip-city'),
+        geo_country: requestHeaders.get('x-vercel-ip-country'),
+        ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
+        user_agent: requestHeaders.get('user-agent'),
+        auth_method: args.provider,
+      });
+    }
+
     // User signed in or is being updated
     posthogClient.capture({
       distinctId: existingUser.google_user_email,
@@ -283,6 +301,22 @@ export async function createOrUpdateUser(
 
     return savedUser;
   });
+
+  // Fire-and-forget auth event for signup
+  if (requestHeaders) {
+    void reportAuthEvent({
+      kilo_user_id: savedUser.id,
+      event_type: 'signup',
+      email: savedUser.google_user_email,
+      account_created_at: savedUser.created_at,
+      ip_address: requestHeaders.get('x-forwarded-for'),
+      geo_city: requestHeaders.get('x-vercel-ip-city'),
+      geo_country: requestHeaders.get('x-vercel-ip-country'),
+      ja4_digest: requestHeaders.get('x-vercel-ja4-digest'),
+      user_agent: requestHeaders.get('user-agent'),
+      auth_method: args.provider,
+    });
+  }
 
   // User created event in PostHog
   posthogClient.capture({

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -160,8 +160,9 @@ function fireAuthEvent(
   user: Pick<User, 'id' | 'google_user_email' | 'created_at'>,
   eventType: 'signup' | 'signin',
   provider: AuthProviderId,
-  requestHeaders: Headers
+  requestHeaders?: Headers
 ) {
+  if (!requestHeaders) return;
   void reportAuthEvent({
     kilo_user_id: user.id,
     event_type: eventType,
@@ -184,9 +185,7 @@ export async function createOrUpdateUser(
 ): Promise<Result<{ user: User; isNew: boolean }, AuthErrorType>> {
   const existingUser = await findAndSyncExistingUser(args);
   if (existingUser) {
-    if (requestHeaders) {
-      fireAuthEvent(existingUser, 'signin', args.provider, requestHeaders);
-    }
+    fireAuthEvent(existingUser, 'signin', args.provider, requestHeaders);
 
     // User signed in or is being updated
     posthogClient.capture({
@@ -233,9 +232,7 @@ export async function createOrUpdateUser(
       if (!linkResult.success) {
         return { success: false, error: linkResult.error };
       }
-      if (requestHeaders) {
-        fireAuthEvent(userByEmail, 'signin', args.provider, requestHeaders);
-      }
+      fireAuthEvent(userByEmail, 'signin', args.provider, requestHeaders);
       // Successfully linked account, return the existing user
       posthogClient.capture({
         distinctId: userByEmail.google_user_email,
@@ -313,9 +310,7 @@ export async function createOrUpdateUser(
     return savedUser;
   });
 
-  if (requestHeaders) {
-    fireAuthEvent(savedUser, 'signup', args.provider, requestHeaders);
-  }
+  fireAuthEvent(savedUser, 'signup', args.provider, requestHeaders);
 
   // User created event in PostHog
   posthogClient.capture({


### PR DESCRIPTION
## Summary

- Adds `reportAuthEvent()` to `src/lib/abuse-service.ts` — POSTs signup/signin events to `POST /api/auth-event` on the abuse service, following the same fail-open pattern as `classifyRequest()` and `reportCost()`.
- Calls `reportAuthEvent()` from `createOrUpdateUser()` in `src/lib/user.ts` for both signin (existing user found) and signup (after DB transaction) paths.
- Threads `requestHeaders` through `createOrUpdateUser()` and the SSO path (`processSSOUserLogin` → `processSSOInternal`) so IP, geo, JA4, and user-agent are available for the payload.
- Reuses the existing `requestHeaders` variable in the Turnstile IP check instead of calling `await headers()` a second time.

### Constraints met
- **Fire-and-forget**: Uses `void reportAuthEvent(...)` — never awaited, never blocks auth.
- **Fail-open**: All errors are caught and logged, never thrown.
- **No new env vars**: Uses existing `ABUSE_SERVICE_URL`, `ABUSE_SERVICE_CF_ACCESS_CLIENT_ID`, `ABUSE_SERVICE_CF_ACCESS_CLIENT_SECRET`.
- **No changes to after-sign-in route or Stytch flow**.