### PR TITLE
Cloud Agent Next - Delegate V2 Session Deletion to Session-Ingest Worker

### DIFF
--- a/src/lib/session-ingest-client.test.ts
+++ b/src/lib/session-ingest-client.test.ts
@@ -1,7 +1,7 @@
 import { captureException } from '@sentry/nextjs';
 import { generateInternalServiceToken } from '@/lib/tokens';
 import type { SessionSnapshot } from './session-ingest-client';
-import { fetchSessionSnapshot, fetchSessionMessages } from './session-ingest-client';
+import { fetchSessionSnapshot, fetchSessionMessages, deleteSession } from './session-ingest-client';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -165,6 +165,98 @@ describe('fetchSessionSnapshot', () => {
       expect.objectContaining({
         headers: { Authorization: 'Bearer custom-test-token' },
       })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSession
+// ---------------------------------------------------------------------------
+
+describe('deleteSession', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockCaptureException.mockReset();
+    mockGenerateInternalServiceToken.mockReset().mockReturnValue('mock-jwt-token');
+  });
+
+  it('resolves successfully on 200', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await expect(deleteSession('ses_abc123', 'user_123')).resolves.toBeUndefined();
+  });
+
+  it('calls DELETE on the correct URL', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deleteSession('ses_abc123', 'user_123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ingest.test.example.com/api/session/ses_abc123',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('sends correct Authorization header', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deleteSession('ses_abc123', 'user_123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: { Authorization: 'Bearer mock-jwt-token' } })
+    );
+  });
+
+  it('generates token for the given userId', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deleteSession('ses_abc123', 'user_test_456');
+
+    expect(mockGenerateInternalServiceToken).toHaveBeenCalledWith('user_test_456');
+  });
+
+  it('throws and calls captureException on 500', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve('something broke'),
+    });
+
+    await expect(deleteSession('ses_abc123', 'user_123')).rejects.toThrow(
+      'Session ingest delete failed: 500 Internal Server Error - something broke'
+    );
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { source: 'session-ingest-client', endpoint: 'delete' },
+        extra: { sessionId: 'ses_abc123', status: 500 },
+      })
+    );
+  });
+
+  it('resolves successfully on 404 (idempotent delete)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: () => Promise.resolve(''),
+    });
+
+    await expect(deleteSession('ses_nonexistent', 'user_123')).resolves.toBeUndefined();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('encodes session ID in URL', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await deleteSession('ses_with spaces&special', 'user_123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ingest.test.example.com/api/session/ses_with%20spaces%26special',
+      expect.any(Object)
     );
   });
 });

--- a/src/lib/session-ingest-client.ts
+++ b/src/lib/session-ingest-client.ts
@@ -96,3 +96,40 @@ export async function fetchSessionMessages(
   const snapshot = await fetchSessionSnapshot(sessionId, user.id);
   return snapshot?.messages ?? null;
 }
+
+/**
+ * Delete a session via the session-ingest worker.
+ *
+ * The ingest worker owns all DB deletion (recursive child sessions) and
+ * ingest DO / cache cleanup. Returns void on success.
+ */
+export async function deleteSession(sessionId: string, userId: string): Promise<void> {
+  if (!SESSION_INGEST_WORKER_URL) {
+    throw new Error('SESSION_INGEST_WORKER_URL is not configured');
+  }
+
+  const token = generateInternalServiceToken(userId);
+  const url = `${SESSION_INGEST_WORKER_URL}/api/session/${encodeURIComponent(sessionId)}`;
+
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (response.status === 404) {
+    // Session already deleted or was never ingested — treat as success (idempotent delete).
+    return;
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    const error = new Error(
+      `Session ingest delete failed: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`
+    );
+    captureException(error, {
+      tags: { source: 'session-ingest-client', endpoint: 'delete' },
+      extra: { sessionId, status: response.status },
+    });
+    throw error;
+  }
+}

--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -4,11 +4,15 @@ import * as z from 'zod';
 import { db } from '@/lib/drizzle';
 import { eq, and, desc, lt, isNull } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
+import { captureException } from '@sentry/nextjs';
 import { TRPCClientError } from '@trpc/client';
 import { cli_sessions_v2 } from '@kilocode/db/schema';
 import { createCloudAgentNextClient } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { generateApiToken } from '@/lib/tokens';
-import { fetchSessionMessages } from '@/lib/session-ingest-client';
+import {
+  fetchSessionMessages,
+  deleteSession as deleteSessionIngest,
+} from '@/lib/session-ingest-client';
 import { baseGetSessionNextOutputSchema } from './cloud-agent-next-schemas';
 import { sanitizeGitUrl } from '@/routers/cli-sessions-router';
 
@@ -329,7 +333,9 @@ export const cliSessionsV2Router = createTRPCRouter({
 
   /**
    * Delete a V2 session.
-   * Cleans up the cloud-agent-next DO/sandbox if applicable, then deletes the DB row.
+   *
+   * Cleans up the cloud-agent-next DO/sandbox if applicable, then delegates
+   * all DB deletion and ingest DO/cache cleanup to the session-ingest worker.
    */
   delete: baseProcedure.input(DeleteSessionInputSchema).mutation(async ({ ctx, input }) => {
     const { session_id } = input;
@@ -338,22 +344,27 @@ export const cliSessionsV2Router = createTRPCRouter({
     if (session.cloud_agent_session_id) {
       const authToken = generateApiToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
-      await client.deleteSession(session.cloud_agent_session_id);
+      try {
+        await client.deleteSession(session.cloud_agent_session_id);
+      } catch (err) {
+        if (!isSessionNotFoundError(err)) {
+          captureException(err, {
+            tags: { source: 'cli-sessions-v2-router', endpoint: 'delete' },
+            extra: { session_id, cloud_agent_session_id: session.cloud_agent_session_id },
+          });
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to clean up cloud-agent session',
+            cause: err,
+          });
+        }
+        // Session not found in cloud-agent DO — already gone, continue with DB cleanup.
+      }
     }
 
-    const [deletedSession] = await db
-      .delete(cli_sessions_v2)
-      .where(
-        and(
-          eq(cli_sessions_v2.session_id, session_id),
-          eq(cli_sessions_v2.kilo_user_id, ctx.user.id)
-        )
-      )
-      .returning({ session_id: cli_sessions_v2.session_id });
-
-    if (!deletedSession) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
-    }
+    // Delegate DB deletion (including child sessions) and ingest DO/cache cleanup
+    // to the session-ingest worker.
+    await deleteSessionIngest(session_id, ctx.user.id);
 
     return { success: true, session_id };
   }),


### PR DESCRIPTION
## Summary

- Replaces the direct Postgres `DELETE` in the V2 session delete endpoint with a call to the session-ingest worker, which owns all DB deletion (including recursive child sessions) and ingest DO/cache cleanup.
- Adds `deleteSession` to `session-ingest-client.ts`, following the same auth and error-reporting pattern as `fetchSessionSnapshot`. 404 responses are treated as a success (idempotent delete semantics — mirrors the cloud-agent DO "not found" handling already in the router).
- Wraps the cloud-agent DO cleanup in a try/catch that swallows `NOT_FOUND` errors, so legacy or partially-created sessions can still be deleted cleanly.
- Adds full unit test coverage for `deleteSession` in the existing test file.