### PR TITLE
feat(security-agent): add auto_analysis_include_existing config option

### DIFF
--- a/cloudflare-security-auto-analysis/src/consumer.ts
+++ b/cloudflare-security-auto-analysis/src/consumer.ts
@@ -180,7 +180,10 @@ function isEligibleForAutoLaunch(params: {
   if (!params.autoAnalysisEnabledAt) {
     return false;
   }
-  if (Date.parse(params.findingCreatedAt) < Date.parse(params.autoAnalysisEnabledAt)) {
+  if (
+    !params.config.auto_analysis_include_existing &&
+    Date.parse(params.findingCreatedAt) < Date.parse(params.autoAnalysisEnabledAt)
+  ) {
     return false;
   }
 

--- a/cloudflare-security-auto-analysis/src/types.ts
+++ b/cloudflare-security-auto-analysis/src/types.ts
@@ -10,6 +10,7 @@ export const SecurityAgentConfigSchema = z
     analysis_mode: z.enum(['auto', 'shallow', 'deep']).default('auto'),
     auto_analysis_enabled: z.boolean().default(false),
     auto_analysis_min_severity: z.enum(['critical', 'high', 'medium', 'all']).default('high'),
+    auto_analysis_include_existing: z.boolean().default(false),
   })
   .passthrough();
 
@@ -22,6 +23,7 @@ export const DEFAULT_SECURITY_AGENT_CONFIG: SecurityAgentConfig = {
   analysis_mode: 'auto',
   auto_analysis_enabled: false,
   auto_analysis_min_severity: 'high',
+  auto_analysis_include_existing: false,
 };
 
 export const AutoAnalysisFailureCodeSchema = z.enum([

--- a/src/components/security-agent/SecurityAgentPageClient.tsx
+++ b/src/components/security-agent/SecurityAgentPageClient.tsx
@@ -473,6 +473,7 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
         autoDismissConfidenceThreshold: 'high' | 'medium' | 'low';
         autoAnalysisEnabled: boolean;
         autoAnalysisMinSeverity: 'critical' | 'high' | 'medium' | 'all';
+        autoAnalysisIncludeExisting: boolean;
       }
     ) => {
       const modelConfigPayload = {
@@ -495,6 +496,7 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
           autoDismissConfidenceThreshold: config.autoDismissConfidenceThreshold,
           autoAnalysisEnabled: config.autoAnalysisEnabled,
           autoAnalysisMinSeverity: config.autoAnalysisMinSeverity,
+          autoAnalysisIncludeExisting: config.autoAnalysisIncludeExisting,
           ...modelConfigPayload,
         });
       } else if (!isOrg) {
@@ -510,6 +512,7 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
           autoDismissConfidenceThreshold: config.autoDismissConfidenceThreshold,
           autoAnalysisEnabled: config.autoAnalysisEnabled,
           autoAnalysisMinSeverity: config.autoAnalysisMinSeverity,
+          autoAnalysisIncludeExisting: config.autoAnalysisIncludeExisting,
           ...modelConfigPayload,
         });
       }
@@ -880,6 +883,7 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
               autoDismissConfidenceThreshold={configData?.autoDismissConfidenceThreshold ?? 'high'}
               autoAnalysisEnabled={configData?.autoAnalysisEnabled ?? false}
               autoAnalysisMinSeverity={configData?.autoAnalysisMinSeverity ?? 'high'}
+              autoAnalysisIncludeExisting={configData?.autoAnalysisIncludeExisting ?? false}
               repositories={allRepositories}
               onSave={handleSaveConfig}
               onToggleEnabled={handleToggleEnabled}

--- a/src/components/security-agent/SecurityConfigForm.tsx
+++ b/src/components/security-agent/SecurityConfigForm.tsx
@@ -66,6 +66,7 @@ type SecurityConfigFormProps = {
   autoDismissConfidenceThreshold: AutoDismissConfidenceThreshold;
   autoAnalysisEnabled: boolean;
   autoAnalysisMinSeverity: AutoAnalysisMinSeverity;
+  autoAnalysisIncludeExisting: boolean;
   repositories: RepositoryData[];
   repositoriesSyncedAt?: string | null;
   isLoadingRepositories?: boolean;
@@ -81,6 +82,7 @@ type SecurityConfigFormProps = {
       autoDismissConfidenceThreshold: AutoDismissConfidenceThreshold;
       autoAnalysisEnabled: boolean;
       autoAnalysisMinSeverity: AutoAnalysisMinSeverity;
+      autoAnalysisIncludeExisting: boolean;
     }
   ) => void;
   onToggleEnabled: (
@@ -211,6 +213,7 @@ export function SecurityConfigForm({
   autoDismissConfidenceThreshold: initialAutoDismissThreshold,
   autoAnalysisEnabled: initialAutoAnalysisEnabled,
   autoAnalysisMinSeverity: initialAutoAnalysisMinSeverity,
+  autoAnalysisIncludeExisting: initialAutoAnalysisIncludeExisting,
   repositories,
   repositoriesSyncedAt,
   isLoadingRepositories,
@@ -244,6 +247,9 @@ export function SecurityConfigForm({
   const [autoAnalysisMinSeverity, setAutoAnalysisMinSeverity] = useState<AutoAnalysisMinSeverity>(
     initialAutoAnalysisMinSeverity
   );
+  const [autoAnalysisIncludeExisting, setAutoAnalysisIncludeExisting] = useState(
+    initialAutoAnalysisIncludeExisting
+  );
   const [hasChanges, setHasChanges] = useState(false);
 
   useEffect(() => {
@@ -261,6 +267,7 @@ export function SecurityConfigForm({
     setAutoDismissConfidenceThreshold(initialAutoDismissThreshold);
     setAutoAnalysisEnabled(initialAutoAnalysisEnabled);
     setAutoAnalysisMinSeverity(initialAutoAnalysisMinSeverity);
+    setAutoAnalysisIncludeExisting(initialAutoAnalysisIncludeExisting);
     setHasChanges(false);
   }, [
     slaConfig,
@@ -273,52 +280,57 @@ export function SecurityConfigForm({
     initialAutoDismissThreshold,
     initialAutoAnalysisEnabled,
     initialAutoAnalysisMinSeverity,
+    initialAutoAnalysisIncludeExisting,
   ]);
 
+  type FormState = {
+    config: SlaConfig;
+    repositorySelectionMode: 'all' | 'selected';
+    selectedRepositoryIds: number[];
+    triageModel: string;
+    analysisModel: string;
+    analysisMode: AnalysisMode;
+    autoDismissEnabled: boolean;
+    autoDismissConfidenceThreshold: AutoDismissConfidenceThreshold;
+    autoAnalysisEnabled: boolean;
+    autoAnalysisMinSeverity: AutoAnalysisMinSeverity;
+    autoAnalysisIncludeExisting: boolean;
+  };
+
+  const currentFormState = (): FormState => ({
+    config: localConfig,
+    repositorySelectionMode,
+    selectedRepositoryIds,
+    triageModel: selectedTriageModel,
+    analysisModel: selectedAnalysisModel,
+    analysisMode,
+    autoDismissEnabled,
+    autoDismissConfidenceThreshold,
+    autoAnalysisEnabled,
+    autoAnalysisMinSeverity,
+    autoAnalysisIncludeExisting,
+  });
+
   const checkForChanges = useCallback(
-    (
-      newConfig: SlaConfig,
-      newMode: 'all' | 'selected',
-      newSelectedIds: number[],
-      newTriageModel: string,
-      newAnalysisModel: string,
-      newAnalysisMode: AnalysisMode,
-      newAutoDismissEnabled: boolean,
-      newAutoDismissThreshold: AutoDismissConfidenceThreshold,
-      newAutoAnalysisEnabled: boolean,
-      newAutoAnalysisMinSeverity: AutoAnalysisMinSeverity
-    ) => {
-      const configChanged =
-        newConfig.critical !== slaConfig.critical ||
-        newConfig.high !== slaConfig.high ||
-        newConfig.medium !== slaConfig.medium ||
-        newConfig.low !== slaConfig.low;
+    (s: FormState) => {
+      const changed =
+        s.config.critical !== slaConfig.critical ||
+        s.config.high !== slaConfig.high ||
+        s.config.medium !== slaConfig.medium ||
+        s.config.low !== slaConfig.low ||
+        s.repositorySelectionMode !== initialSelectionMode ||
+        JSON.stringify([...s.selectedRepositoryIds].sort()) !==
+          JSON.stringify([...initialSelectedIds].sort()) ||
+        s.triageModel !== initialTriageModel ||
+        s.analysisModel !== initialAnalysisModel ||
+        s.analysisMode !== initialAnalysisMode ||
+        s.autoDismissEnabled !== initialAutoDismissEnabled ||
+        s.autoDismissConfidenceThreshold !== initialAutoDismissThreshold ||
+        s.autoAnalysisEnabled !== initialAutoAnalysisEnabled ||
+        s.autoAnalysisMinSeverity !== initialAutoAnalysisMinSeverity ||
+        s.autoAnalysisIncludeExisting !== initialAutoAnalysisIncludeExisting;
 
-      const modeChanged = newMode !== initialSelectionMode;
-      const idsChanged =
-        JSON.stringify([...newSelectedIds].sort()) !==
-        JSON.stringify([...initialSelectedIds].sort());
-      const triageModelChanged = newTriageModel !== initialTriageModel;
-      const analysisModelChanged = newAnalysisModel !== initialAnalysisModel;
-      const analysisModeChanged = newAnalysisMode !== initialAnalysisMode;
-      const autoDismissEnabledChanged = newAutoDismissEnabled !== initialAutoDismissEnabled;
-      const autoDismissThresholdChanged = newAutoDismissThreshold !== initialAutoDismissThreshold;
-      const autoAnalysisEnabledChanged = newAutoAnalysisEnabled !== initialAutoAnalysisEnabled;
-      const autoAnalysisMinSeverityChanged =
-        newAutoAnalysisMinSeverity !== initialAutoAnalysisMinSeverity;
-
-      setHasChanges(
-        configChanged ||
-          modeChanged ||
-          idsChanged ||
-          triageModelChanged ||
-          analysisModelChanged ||
-          analysisModeChanged ||
-          autoDismissEnabledChanged ||
-          autoDismissThresholdChanged ||
-          autoAnalysisEnabledChanged ||
-          autoAnalysisMinSeverityChanged
-      );
+      setHasChanges(changed);
     },
     [
       slaConfig,
@@ -331,6 +343,7 @@ export function SecurityConfigForm({
       initialAutoDismissThreshold,
       initialAutoAnalysisEnabled,
       initialAutoAnalysisMinSeverity,
+      initialAutoAnalysisIncludeExisting,
     ]
   );
 
@@ -340,162 +353,57 @@ export function SecurityConfigForm({
 
     const newConfig = { ...localConfig, [key]: numValue };
     setLocalConfig(newConfig);
-    checkForChanges(
-      newConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), config: newConfig });
   };
 
   const handleSelectionModeChange = (mode: 'all' | 'selected') => {
     setRepositorySelectionMode(mode);
-    checkForChanges(
-      localConfig,
-      mode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), repositorySelectionMode: mode });
   };
 
   const handleSelectedIdsChange = (ids: number[]) => {
     setSelectedRepositoryIds(ids);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      ids,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), selectedRepositoryIds: ids });
   };
 
   const handleTriageModelChange = (model: string) => {
     setSelectedTriageModel(model);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      model,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), triageModel: model });
   };
 
   const handleAnalysisModelChange = (model: string) => {
     setSelectedAnalysisModel(model);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      model,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), analysisModel: model });
   };
 
   const handleAnalysisModeChange = (mode: AnalysisMode) => {
     setAnalysisMode(mode);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      mode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), analysisMode: mode });
   };
 
   const handleAutoDismissEnabledChange = (newEnabled: boolean) => {
     setAutoDismissEnabled(newEnabled);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      newEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), autoDismissEnabled: newEnabled });
   };
 
   const handleAutoDismissThresholdChange = (threshold: AutoDismissConfidenceThreshold) => {
     setAutoDismissConfidenceThreshold(threshold);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      threshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), autoDismissConfidenceThreshold: threshold });
   };
 
   const handleAutoAnalysisEnabledChange = (newEnabled: boolean) => {
     setAutoAnalysisEnabled(newEnabled);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      newEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), autoAnalysisEnabled: newEnabled });
   };
 
   const handleAutoAnalysisMinSeverityChange = (severity: AutoAnalysisMinSeverity) => {
     setAutoAnalysisMinSeverity(severity);
-    checkForChanges(
-      localConfig,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      severity
-    );
+    checkForChanges({ ...currentFormState(), autoAnalysisMinSeverity: severity });
+  };
+
+  const handleAutoAnalysisIncludeExistingChange = (newIncludeExisting: boolean) => {
+    setAutoAnalysisIncludeExisting(newIncludeExisting);
+    checkForChanges({ ...currentFormState(), autoAnalysisIncludeExisting: newIncludeExisting });
   };
 
   const handleSave = () => {
@@ -511,23 +419,13 @@ export function SecurityConfigForm({
       autoDismissConfidenceThreshold,
       autoAnalysisEnabled,
       autoAnalysisMinSeverity,
+      autoAnalysisIncludeExisting,
     });
   };
 
   const handleReset = () => {
     setLocalConfig(DEFAULT_SLA_CONFIG);
-    checkForChanges(
-      DEFAULT_SLA_CONFIG,
-      repositorySelectionMode,
-      selectedRepositoryIds,
-      selectedTriageModel,
-      selectedAnalysisModel,
-      analysisMode,
-      autoDismissEnabled,
-      autoDismissConfidenceThreshold,
-      autoAnalysisEnabled,
-      autoAnalysisMinSeverity
-    );
+    checkForChanges({ ...currentFormState(), config: DEFAULT_SLA_CONFIG });
   };
 
   // Map repositories to the format expected by RepositoryMultiSelect
@@ -831,6 +729,25 @@ export function SecurityConfigForm({
                     </Label>
                   ))}
                 </RadioGroup>
+              </div>
+            )}
+
+            {autoAnalysisEnabled && (
+              <div className="flex items-center justify-between rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+                <div className="space-y-1">
+                  <Label htmlFor="auto-analysis-include-existing" className="font-medium">
+                    Include Existing Findings
+                  </Label>
+                  <p className="text-muted-foreground text-sm">
+                    Also analyse findings that were synced before auto-analysis was enabled. This
+                    may use additional credits if there are many existing findings.
+                  </p>
+                </div>
+                <Switch
+                  id="auto-analysis-include-existing"
+                  checked={autoAnalysisIncludeExisting}
+                  onCheckedChange={handleAutoAnalysisIncludeExistingChange}
+                />
               </div>
             )}
           </CardContent>

--- a/src/lib/security-agent/core/constants.ts
+++ b/src/lib/security-agent/core/constants.ts
@@ -27,6 +27,7 @@ export const DEFAULT_SECURITY_AGENT_CONFIG: SecurityAgentConfig = {
   auto_dismiss_confidence_threshold: 'high',
   auto_analysis_enabled: false,
   auto_analysis_min_severity: 'high',
+  auto_analysis_include_existing: false,
 };
 
 export const SECURITY_ANALYSIS_OWNER_CAP = 3;

--- a/src/lib/security-agent/core/schemas.ts
+++ b/src/lib/security-agent/core/schemas.ts
@@ -35,6 +35,7 @@ export const SaveSecurityConfigInputSchema = z.object({
   autoDismissConfidenceThreshold: AutoDismissConfidenceThresholdSchema.optional(),
   autoAnalysisEnabled: z.boolean().optional(),
   autoAnalysisMinSeverity: AutoAnalysisMinSeveritySchema.optional(),
+  autoAnalysisIncludeExisting: z.boolean().optional(),
 });
 
 export const ExploitabilityFilterSchema = z.enum(['all', 'exploitable', 'not_exploitable']);

--- a/src/lib/security-agent/core/types.ts
+++ b/src/lib/security-agent/core/types.ts
@@ -65,6 +65,7 @@ export const SecurityAgentConfigSchema = z
     auto_dismiss_confidence_threshold: z.enum(['high', 'medium', 'low']).default('high'),
     auto_analysis_enabled: z.boolean().default(false),
     auto_analysis_min_severity: z.enum(['critical', 'high', 'medium', 'all']).default('high'),
+    auto_analysis_include_existing: z.boolean().default(false),
   })
   .passthrough();
 

--- a/src/lib/security-agent/db/security-analysis.test.ts
+++ b/src/lib/security-agent/db/security-analysis.test.ts
@@ -16,9 +16,11 @@ jest.mock('@/lib/drizzle', () => ({
 jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
 
 let cleanupStaleAnalyses: typeof analysisDbModule.cleanupStaleAnalyses;
+let isFindingEligibleForAutoAnalysis: typeof analysisDbModule.isFindingEligibleForAutoAnalysis;
 
 beforeAll(async () => {
-  ({ cleanupStaleAnalyses } = await import('./security-analysis'));
+  ({ cleanupStaleAnalyses, isFindingEligibleForAutoAnalysis } =
+    await import('./security-analysis'));
 });
 
 beforeEach(() => {
@@ -36,5 +38,66 @@ describe('cleanupStaleAnalyses', () => {
     expect(serialized).toContain('security_analysis_queue');
     expect(serialized).toContain('pending');
     expect(serialized).toContain('running');
+  });
+});
+
+describe('isFindingEligibleForAutoAnalysis', () => {
+  const baseParams = {
+    findingCreatedAt: '2025-06-01T00:00:00Z',
+    findingStatus: 'open',
+    severity: 'high',
+    ownerAutoAnalysisEnabledAt: '2025-07-01T00:00:00Z',
+    isAgentEnabled: true,
+    autoAnalysisEnabled: true,
+    autoAnalysisMinSeverity: 'high' as const,
+  };
+
+  it('rejects findings created before auto_analysis_enabled_at by default', () => {
+    const result = isFindingEligibleForAutoAnalysis(baseParams);
+    expect(result.eligible).toBe(false);
+  });
+
+  it('accepts findings created after auto_analysis_enabled_at', () => {
+    const result = isFindingEligibleForAutoAnalysis({
+      ...baseParams,
+      findingCreatedAt: '2025-08-01T00:00:00Z',
+    });
+    expect(result.eligible).toBe(true);
+  });
+
+  it('accepts pre-existing findings when autoAnalysisIncludeExisting is true', () => {
+    const result = isFindingEligibleForAutoAnalysis({
+      ...baseParams,
+      autoAnalysisIncludeExisting: true,
+    });
+    expect(result.eligible).toBe(true);
+  });
+
+  it('still rejects non-open findings even with autoAnalysisIncludeExisting', () => {
+    const result = isFindingEligibleForAutoAnalysis({
+      ...baseParams,
+      findingStatus: 'fixed',
+      autoAnalysisIncludeExisting: true,
+    });
+    expect(result.eligible).toBe(false);
+  });
+
+  it('still respects severity threshold with autoAnalysisIncludeExisting', () => {
+    const result = isFindingEligibleForAutoAnalysis({
+      ...baseParams,
+      severity: 'low',
+      autoAnalysisMinSeverity: 'high',
+      autoAnalysisIncludeExisting: true,
+    });
+    expect(result.eligible).toBe(false);
+  });
+
+  it('rejects when agent is not enabled even with autoAnalysisIncludeExisting', () => {
+    const result = isFindingEligibleForAutoAnalysis({
+      ...baseParams,
+      isAgentEnabled: false,
+      autoAnalysisIncludeExisting: true,
+    });
+    expect(result.eligible).toBe(false);
   });
 });

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -97,6 +97,7 @@ export function isFindingEligibleForAutoAnalysis(params: {
   isAgentEnabled: boolean;
   autoAnalysisEnabled: boolean;
   autoAnalysisMinSeverity: AutoAnalysisMinSeverity;
+  autoAnalysisIncludeExisting?: boolean;
 }): { eligible: boolean; severityRank: number | null } {
   const severityRank = getSeverityRank(params.severity);
 
@@ -109,7 +110,10 @@ export function isFindingEligibleForAutoAnalysis(params: {
   if (!params.ownerAutoAnalysisEnabledAt) {
     return { eligible: false, severityRank };
   }
-  if (Date.parse(params.findingCreatedAt) < Date.parse(params.ownerAutoAnalysisEnabledAt)) {
+  if (
+    !params.autoAnalysisIncludeExisting &&
+    Date.parse(params.findingCreatedAt) < Date.parse(params.ownerAutoAnalysisEnabledAt)
+  ) {
     return { eligible: false, severityRank };
   }
   if (severityRank == null) {
@@ -408,6 +412,7 @@ export async function syncAutoAnalysisQueueForFinding(params: {
   autoAnalysisEnabled: boolean;
   autoAnalysisMinSeverity: AutoAnalysisMinSeverity;
   ownerAutoAnalysisEnabledAt: string | null;
+  autoAnalysisIncludeExisting?: boolean;
 }): Promise<AutoAnalysisQueueSyncResult> {
   const ownerConverted = toOwner(params.owner);
   const { eligible, severityRank } = isFindingEligibleForAutoAnalysis({
@@ -418,8 +423,10 @@ export async function syncAutoAnalysisQueueForFinding(params: {
     isAgentEnabled: params.isAgentEnabled,
     autoAnalysisEnabled: params.autoAnalysisEnabled,
     autoAnalysisMinSeverity: params.autoAnalysisMinSeverity,
+    autoAnalysisIncludeExisting: params.autoAnalysisIncludeExisting,
   });
   const isBoundarySkip =
+    !params.autoAnalysisIncludeExisting &&
     params.ownerAutoAnalysisEnabledAt != null &&
     Date.parse(params.findingCreatedAt) < Date.parse(params.ownerAutoAnalysisEnabledAt);
   const unknownSeverityCount = severityRank == null ? 1 : 0;

--- a/src/lib/security-agent/services/sync-service.test.ts
+++ b/src/lib/security-agent/services/sync-service.test.ts
@@ -110,6 +110,7 @@ describe('sync-service queue enqueue wiring', () => {
       auto_dismiss_confidence_threshold: 'high',
       auto_analysis_enabled: true,
       auto_analysis_min_severity: 'high',
+      auto_analysis_include_existing: false,
     };
     const configWithStatus: Awaited<ReturnType<typeof mockGetSecurityAgentConfigWithStatus>> = {
       isEnabled: true,

--- a/src/lib/security-agent/services/sync-service.ts
+++ b/src/lib/security-agent/services/sync-service.ts
@@ -121,6 +121,7 @@ export async function syncDependabotAlertsForRepo(params: {
             autoAnalysisEnabled: config.auto_analysis_enabled,
             autoAnalysisMinSeverity: config.auto_analysis_min_severity,
             ownerAutoAnalysisEnabledAt,
+            autoAnalysisIncludeExisting: config.auto_analysis_include_existing,
           });
           queueSyncTotals.enqueueCount += queueSyncResult.enqueueCount;
           queueSyncTotals.eligibleCount += queueSyncResult.eligibleCount;

--- a/src/routers/organizations/organization-security-agent-router.ts
+++ b/src/routers/organizations/organization-security-agent-router.ts
@@ -147,6 +147,7 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
         autoDismissConfidenceThreshold: 'high' as const,
         autoAnalysisEnabled: false,
         autoAnalysisMinSeverity: 'high' as const,
+        autoAnalysisIncludeExisting: false,
       };
     }
 
@@ -178,6 +179,7 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
       autoDismissConfidenceThreshold: result.config.auto_dismiss_confidence_threshold ?? 'high',
       autoAnalysisEnabled: result.config.auto_analysis_enabled ?? false,
       autoAnalysisMinSeverity: result.config.auto_analysis_min_severity ?? 'high',
+      autoAnalysisIncludeExisting: result.config.auto_analysis_include_existing ?? false,
     };
   }),
 
@@ -208,6 +210,7 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
             autoDismissConfidenceThreshold: existingConfig.config.auto_dismiss_confidence_threshold,
             autoAnalysisEnabled: existingConfig.config.auto_analysis_enabled,
             autoAnalysisMinSeverity: existingConfig.config.auto_analysis_min_severity,
+            autoAnalysisIncludeExisting: existingConfig.config.auto_analysis_include_existing,
             modelSlug: existingConfig.config.model_slug,
             triageModelSlug: existingTriageModelSlug,
             analysisModelSlug: existingAnalysisModelSlug,
@@ -252,6 +255,7 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           auto_dismiss_confidence_threshold: input.autoDismissConfidenceThreshold,
           auto_analysis_enabled: input.autoAnalysisEnabled,
           auto_analysis_min_severity: input.autoAnalysisMinSeverity,
+          auto_analysis_include_existing: input.autoAnalysisIncludeExisting,
         },
         ctx.user.id
       );
@@ -287,6 +291,7 @@ export const organizationSecurityAgentRouter = createTRPCRouter({
           autoDismissConfidenceThreshold: input.autoDismissConfidenceThreshold,
           autoAnalysisEnabled: input.autoAnalysisEnabled,
           autoAnalysisMinSeverity: input.autoAnalysisMinSeverity,
+          autoAnalysisIncludeExisting: input.autoAnalysisIncludeExisting,
           modelSlug,
           triageModelSlug,
           analysisModelSlug,

--- a/src/routers/security-agent-router.ts
+++ b/src/routers/security-agent-router.ts
@@ -128,6 +128,7 @@ export const securityAgentRouter = createTRPCRouter({
         autoDismissConfidenceThreshold: 'high' as const,
         autoAnalysisEnabled: false,
         autoAnalysisMinSeverity: 'high' as const,
+        autoAnalysisIncludeExisting: false,
       };
     }
 
@@ -159,6 +160,7 @@ export const securityAgentRouter = createTRPCRouter({
       autoDismissConfidenceThreshold: result.config.auto_dismiss_confidence_threshold ?? 'high',
       autoAnalysisEnabled: result.config.auto_analysis_enabled ?? false,
       autoAnalysisMinSeverity: result.config.auto_analysis_min_severity ?? 'high',
+      autoAnalysisIncludeExisting: result.config.auto_analysis_include_existing ?? false,
     };
   }),
 
@@ -189,6 +191,7 @@ export const securityAgentRouter = createTRPCRouter({
             autoDismissConfidenceThreshold: existingConfig.config.auto_dismiss_confidence_threshold,
             autoAnalysisEnabled: existingConfig.config.auto_analysis_enabled,
             autoAnalysisMinSeverity: existingConfig.config.auto_analysis_min_severity,
+            autoAnalysisIncludeExisting: existingConfig.config.auto_analysis_include_existing,
             modelSlug: existingConfig.config.model_slug,
             triageModelSlug: existingTriageModelSlug,
             analysisModelSlug: existingAnalysisModelSlug,
@@ -233,6 +236,7 @@ export const securityAgentRouter = createTRPCRouter({
           auto_dismiss_confidence_threshold: input.autoDismissConfidenceThreshold,
           auto_analysis_enabled: input.autoAnalysisEnabled,
           auto_analysis_min_severity: input.autoAnalysisMinSeverity,
+          auto_analysis_include_existing: input.autoAnalysisIncludeExisting,
         },
         ctx.user.id
       );
@@ -267,6 +271,7 @@ export const securityAgentRouter = createTRPCRouter({
           autoDismissConfidenceThreshold: input.autoDismissConfidenceThreshold,
           autoAnalysisEnabled: input.autoAnalysisEnabled,
           autoAnalysisMinSeverity: input.autoAnalysisMinSeverity,
+          autoAnalysisIncludeExisting: input.autoAnalysisIncludeExisting,
           modelSlug,
           triageModelSlug,
           analysisModelSlug,


### PR DESCRIPTION
## Summary

- Adds a new `auto_analysis_include_existing` boolean config option (default `false`) that allows users to opt-in to analysing findings synced before auto-analysis was enabled
- When disabled (default), the existing date-gating behaviour is preserved; when enabled, the created-before check is skipped so pre-existing findings enter the auto-analysis queue
- Adds a UI toggle ("Include Existing Findings") under the auto-analysis settings with a warning about potential credit usage
- Refactors `SecurityConfigForm`'s `checkForChanges` to accept a single `FormState` object instead of a growing list of positional parameters
- Adds unit tests for `isFindingEligibleForAutoAnalysis` covering the new flag's interaction with severity, status, and agent-enabled checks

| New setting |
|--------|
| <img width="2268" height="882" alt="CleanShot 2026-03-04 at 10 54 32@2x" src="https://github.com/user-attachments/assets/7f8ae6f4-82d4-476e-b026-8cae25b8fe96" /> | 