### PR TITLE
Feat/thinking effort code reviews flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ run-milvus-test.sh
 
 # Git worktrees
 .worktrees/
+
+supabase/.temp

--- a/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/src/components/code-reviews/ReviewConfigForm.tsx
@@ -24,7 +24,7 @@ import { useTRPC, useRawTRPCClient } from '@/lib/trpc/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
+
 import { useRefreshRepositories } from '@/hooks/useRefreshRepositories';
 import { useOrganizationModels } from '@/components/cloud-agent/hooks/useOrganizationModels';
 import { ModelCombobox } from '@/components/shared/ModelCombobox';
@@ -213,10 +213,7 @@ export function ReviewConfigForm({
   const [maxReviewTime, setMaxReviewTime] = useState([10]);
   const [selectedModel, setSelectedModel] = useState(PRIMARY_DEFAULT_MODEL);
   const [thinkingEffort, setThinkingEffort] = useState<string | null>(null);
-  const isCloudAgentNextFlagEnabled = useFeatureFlagEnabled('code-review-cloud-agent-next');
-  const isCloudAgentNextEnabled =
-    // Available only for cloud-agent-next runner
-    isCloudAgentNextFlagEnabled || process.env.NODE_ENV === 'development';
+  const isCloudAgentNextEnabled = configData?.isCloudAgentNextEnabled ?? false;
   const [repositorySelectionMode, setRepositorySelectionMode] = useState<'all' | 'selected'>('all');
   const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
   // Repositories added from search results (for GitLab where pagination limits initial results)

--- a/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -169,10 +169,9 @@ async function dispatchReview(review: CloudAgentCodeReview, owner: Owner): Promi
   }
 
   // 2. Evaluate feature flag: use cloud-agent-next?
-  const useCloudAgentNext = await isFeatureFlagEnabled(
-    'code-review-cloud-agent-next',
-    owner.userId
-  );
+  const useCloudAgentNext =
+    process.env.NODE_ENV === 'development' ||
+    (await isFeatureFlagEnabled('code-review-cloud-agent-next', owner.userId));
 
   logExceptInTest('[dispatchReview] Feature flag evaluated', {
     reviewId: review.id,

--- a/src/routers/code-reviews-router.ts
+++ b/src/routers/code-reviews-router.ts
@@ -24,6 +24,7 @@ import {
 } from '@/lib/integrations/platforms/gitlab/webhook-sync';
 import { getValidGitLabToken } from '@/lib/integrations/gitlab-service';
 import { logExceptInTest } from '@/lib/utils.server';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 
 const PlatformSchema = z.enum(['github', 'gitlab']).default('github');
 
@@ -147,7 +148,12 @@ export const personalReviewAgentRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const owner = { type: 'user' as const, id: ctx.user.id, userId: ctx.user.id };
       const platform = input?.platform ?? 'github';
-      const config = await getAgentConfigForOwner(owner, 'code_review', platform);
+      const [config, isCloudAgentNextFlagEnabled] = await Promise.all([
+        getAgentConfigForOwner(owner, 'code_review', platform),
+        isFeatureFlagEnabled('code-review-cloud-agent-next', ctx.user.id),
+      ]);
+      const isCloudAgentNextEnabled =
+        isCloudAgentNextFlagEnabled || process.env.NODE_ENV === 'development';
 
       if (!config) {
         // Return default configuration
@@ -162,6 +168,7 @@ export const personalReviewAgentRouter = createTRPCRouter({
           repositorySelectionMode: 'all' as const,
           selectedRepositoryIds: [],
           manuallyAddedRepositories: [],
+          isCloudAgentNextEnabled,
         };
       }
 
@@ -177,6 +184,7 @@ export const personalReviewAgentRouter = createTRPCRouter({
         repositorySelectionMode: cfg.repository_selection_mode || 'all',
         selectedRepositoryIds: cfg.selected_repository_ids || [],
         manuallyAddedRepositories: cfg.manually_added_repositories || [],
+        isCloudAgentNextEnabled,
       };
     }),
 

--- a/src/routers/organizations/organization-code-reviews-router.ts
+++ b/src/routers/organizations/organization-code-reviews-router.ts
@@ -32,6 +32,7 @@ import {
 import { getValidGitLabToken } from '@/lib/integrations/gitlab-service';
 import { logExceptInTest } from '@/lib/utils.server';
 import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 
 const PlatformSchema = z.enum(['github', 'gitlab']).default('github');
 
@@ -165,12 +166,15 @@ export const organizationReviewAgentRouter = createTRPCRouter({
     .input(OrganizationIdInputSchema.extend({ platform: PlatformSchema }))
     .query(async ({ input, ctx }) => {
       const platform = input.platform ?? 'github';
-      const [config, isCloudAgentNextFlagEnabled] = await Promise.all([
+      // Resolve bot user for flag evaluation — same identity used at dispatch time
+      const [config, botUserId] = await Promise.all([
         getAgentConfig(input.organizationId, 'code_review', platform),
-        isFeatureFlagEnabled('code-review-cloud-agent-next', ctx.user.id),
+        getBotUserId(input.organizationId, 'code-review'),
       ]);
+      const flagDistinctId = botUserId ?? ctx.user.id;
       const isCloudAgentNextEnabled =
-        isCloudAgentNextFlagEnabled || process.env.NODE_ENV === 'development';
+        process.env.NODE_ENV === 'development' ||
+        (await isFeatureFlagEnabled('code-review-cloud-agent-next', flagDistinctId));
 
       if (!config) {
         // Return default configuration

--- a/src/routers/organizations/organization-code-reviews-router.ts
+++ b/src/routers/organizations/organization-code-reviews-router.ts
@@ -165,10 +165,12 @@ export const organizationReviewAgentRouter = createTRPCRouter({
     .input(OrganizationIdInputSchema.extend({ platform: PlatformSchema }))
     .query(async ({ input, ctx }) => {
       const platform = input.platform ?? 'github';
-      const [config, isCloudAgentNextEnabled] = await Promise.all([
+      const [config, isCloudAgentNextFlagEnabled] = await Promise.all([
         getAgentConfig(input.organizationId, 'code_review', platform),
         isFeatureFlagEnabled('code-review-cloud-agent-next', ctx.user.id),
       ]);
+      const isCloudAgentNextEnabled =
+        isCloudAgentNextFlagEnabled || process.env.NODE_ENV === 'development';
 
       if (!config) {
         // Return default configuration

--- a/src/routers/organizations/organization-code-reviews-router.ts
+++ b/src/routers/organizations/organization-code-reviews-router.ts
@@ -31,6 +31,7 @@ import {
 } from '@/lib/integrations/platforms/gitlab/webhook-sync';
 import { getValidGitLabToken } from '@/lib/integrations/gitlab-service';
 import { logExceptInTest } from '@/lib/utils.server';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 
 const PlatformSchema = z.enum(['github', 'gitlab']).default('github');
 
@@ -162,9 +163,12 @@ export const organizationReviewAgentRouter = createTRPCRouter({
    */
   getReviewConfig: organizationMemberProcedure
     .input(OrganizationIdInputSchema.extend({ platform: PlatformSchema }))
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
       const platform = input.platform ?? 'github';
-      const config = await getAgentConfig(input.organizationId, 'code_review', platform);
+      const [config, isCloudAgentNextEnabled] = await Promise.all([
+        getAgentConfig(input.organizationId, 'code_review', platform),
+        isFeatureFlagEnabled('code-review-cloud-agent-next', ctx.user.id),
+      ]);
 
       if (!config) {
         // Return default configuration
@@ -179,6 +183,7 @@ export const organizationReviewAgentRouter = createTRPCRouter({
           repositorySelectionMode: 'all' as const,
           selectedRepositoryIds: [],
           manuallyAddedRepositories: [],
+          isCloudAgentNextEnabled,
         };
       }
 
@@ -194,6 +199,7 @@ export const organizationReviewAgentRouter = createTRPCRouter({
         repositorySelectionMode: cfg.repository_selection_mode || 'all',
         selectedRepositoryIds: cfg.selected_repository_ids || [],
         manuallyAddedRepositories: cfg.manually_added_repositories || [],
+        isCloudAgentNextEnabled,
       };
     }),
 


### PR DESCRIPTION
Follow up to https://github.com/Kilo-Org/cloud/pull/732

[This flag](https://github.com/Kilo-Org/cloud/pull/732/changes#diff-d8409de2054f653f29b4690316982b8c67942ea060a993e8cda74083fde91901R215-R219) was always `false` because it didn't check for botId / userId

https://github.com/Kilo-Org/cloud/blob/ed10744fe0aacf8f772a7d8a2d3f7fa6a8561038/src/components/code-reviews/ReviewConfigForm.tsx#L216-L219

