### PR TITLE
feat(cloud-agent-next): support GitLab URLs in header and detect upstream from git

### DIFF
--- a/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for auto-commit branch protection and upstream branch bypass.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { runAutoCommit, type AutoCommitOptions } from '../../../wrapper/src/auto-commit.js';
+import type { KiloClient } from '../../../wrapper/src/kilo-client.js';
+import type { ExecResult } from '../../../wrapper/src/utils.js';
+
+// ---------------------------------------------------------------------------
+// Mock the utils module (spawns git processes + writes log files)
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../wrapper/src/utils.js', () => ({
+  git: vi.fn(),
+  getCurrentBranch: vi.fn(),
+  hasGitUpstream: vi.fn(),
+  logToFile: vi.fn(),
+}));
+
+// Import mocked functions so we can configure per-test return values
+import { git, getCurrentBranch, hasGitUpstream } from '../../../wrapper/src/utils.js';
+
+const mockGetCurrentBranch = vi.mocked(getCurrentBranch);
+const mockHasGitUpstream = vi.mocked(hasGitUpstream);
+const mockGit = vi.mocked(git);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ok = (stdout = '', stderr = ''): ExecResult => ({ stdout, stderr, exitCode: 0 });
+
+const createMockKiloClient = (): KiloClient => ({
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+  sendPromptAsync: vi.fn(),
+  abortSession: vi.fn(),
+  checkHealth: vi.fn(),
+  sendCommand: vi.fn(),
+  answerPermission: vi.fn(),
+  answerQuestion: vi.fn(),
+  rejectQuestion: vi.fn(),
+  generateCommitMessage: vi.fn().mockResolvedValue({ message: 'test commit' }),
+});
+
+type EmittedEvent = { streamEventType: string; data: Record<string, unknown> };
+
+function createOpts(overrides: Partial<AutoCommitOptions> = {}): {
+  opts: AutoCommitOptions;
+  events: EmittedEvent[];
+} {
+  const events: EmittedEvent[] = [];
+  const opts: AutoCommitOptions = {
+    workspacePath: '/workspace',
+    onEvent: event => events.push(event as unknown as EmittedEvent),
+    kiloClient: createMockKiloClient(),
+    ...overrides,
+  };
+  return { opts, events };
+}
+
+/** Configure mocks for a full happy-path commit+push (from git status onward). */
+function setupHappyPathGit(): void {
+  // git status --porcelain  →  has changes
+  // git add -A              →  ok
+  // git commit -m ...       →  ok
+  // git rev-parse --short HEAD  →  abc1234
+  // git push ...            →  ok
+  mockGit
+    .mockResolvedValueOnce(ok(' M file.ts')) // status
+    .mockResolvedValueOnce(ok()) // add
+    .mockResolvedValueOnce(ok('[main abc1234] test commit')) // commit
+    .mockResolvedValueOnce(ok('abc1234')) // rev-parse
+    .mockResolvedValueOnce(ok()); // push
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runAutoCommit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasGitUpstream.mockResolvedValue(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Detached HEAD
+  // -------------------------------------------------------------------------
+
+  it('skips on detached HEAD', async () => {
+    mockGetCurrentBranch.mockResolvedValue('');
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        streamEventType: 'autocommit_completed',
+        data: expect.objectContaining({ skipped: true, message: 'Skipped: detached HEAD state' }),
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Protected branch — no upstreamBranch
+  // -------------------------------------------------------------------------
+
+  it('skips on main when no upstreamBranch is set', async () => {
+    mockGetCurrentBranch.mockResolvedValue('main');
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        streamEventType: 'autocommit_completed',
+        data: expect.objectContaining({ message: 'Skipped: cannot commit to main' }),
+      })
+    );
+    // Should NOT call git status (bailed before reaching it)
+    expect(mockGit).not.toHaveBeenCalled();
+  });
+
+  it('skips on master when no upstreamBranch is set', async () => {
+    mockGetCurrentBranch.mockResolvedValue('master');
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: 'Skipped: cannot commit to master' }),
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Protected branch — upstreamBranch does NOT match current branch
+  // -------------------------------------------------------------------------
+
+  it('skips on main when upstreamBranch is a different branch', async () => {
+    mockGetCurrentBranch.mockResolvedValue('main');
+
+    const { opts, events } = createOpts({ upstreamBranch: 'feature/test' });
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: 'Skipped: cannot commit to main' }),
+      })
+    );
+    expect(mockGit).not.toHaveBeenCalled();
+  });
+
+  it('skips on master when upstreamBranch is a different branch', async () => {
+    mockGetCurrentBranch.mockResolvedValue('master');
+
+    const { opts, events } = createOpts({ upstreamBranch: 'develop' });
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: 'Skipped: cannot commit to master' }),
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Protected branch — upstreamBranch MATCHES current branch → bypass
+  // -------------------------------------------------------------------------
+
+  it('allows commit to main when upstreamBranch is main', async () => {
+    mockGetCurrentBranch.mockResolvedValue('main');
+    setupHappyPathGit();
+
+    const { opts, events } = createOpts({ upstreamBranch: 'main' });
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true });
+    // Should have emitted autocommit_started and autocommit_completed (success)
+    const completed = events.find(e => e.streamEventType === 'autocommit_completed');
+    expect(completed?.data).toEqual(
+      expect.objectContaining({ success: true, message: 'Changes committed and pushed' })
+    );
+  });
+
+  it('allows commit to master when upstreamBranch is master', async () => {
+    mockGetCurrentBranch.mockResolvedValue('master');
+    setupHappyPathGit();
+
+    const { opts, events } = createOpts({ upstreamBranch: 'master' });
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true });
+    const completed = events.find(e => e.streamEventType === 'autocommit_completed');
+    expect(completed?.data).toEqual(
+      expect.objectContaining({ success: true, message: 'Changes committed and pushed' })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // No uncommitted changes
+  // -------------------------------------------------------------------------
+
+  it('skips when there are no uncommitted changes', async () => {
+    mockGetCurrentBranch.mockResolvedValue('feature/foo');
+    mockGit.mockResolvedValueOnce(ok('')); // git status --porcelain → empty
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: 'No uncommitted changes' }),
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path on a regular feature branch
+  // -------------------------------------------------------------------------
+
+  it('commits and pushes on a feature branch', async () => {
+    mockGetCurrentBranch.mockResolvedValue('feature/cool-stuff');
+    setupHappyPathGit();
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: true });
+    const completed = events.find(e => e.streamEventType === 'autocommit_completed');
+    expect(completed?.data).toEqual(
+      expect.objectContaining({
+        success: true,
+        message: 'Changes committed and pushed',
+        commitHash: 'abc1234',
+        commitMessage: 'test commit',
+      })
+    );
+  });
+});

--- a/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -34,6 +34,7 @@ const createMockKiloClient = (): KiloClient => ({
   answerPermission: vi.fn().mockResolvedValue(true),
   answerQuestion: vi.fn().mockResolvedValue(true),
   rejectQuestion: vi.fn().mockResolvedValue(true),
+  generateCommitMessage: vi.fn().mockResolvedValue({ message: 'test commit' }),
 });
 
 const createMockConnectionManager = (): ConnectionManager => ({

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -60,7 +60,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
 
   try {
     // Check current branch (agent may have switched branches during execution)
-    const branch = await getCurrentBranch(workspacePath);
+    const branch = await getCurrentBranch(workspacePath, GIT_LOCAL_TIMEOUT_MS);
     logToFile(`auto-commit: branch=${branch || '(detached HEAD)'}`);
     if (!branch) {
       logToFile('auto-commit: skipping - detached HEAD state');
@@ -92,7 +92,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     }
 
     // Check actual git upstream (not stale config) to decide push strategy
-    const trackingUpstream = await hasGitUpstream(workspacePath);
+    const trackingUpstream = await hasGitUpstream(workspacePath, GIT_LOCAL_TIMEOUT_MS);
     logToFile(`auto-commit: hasGitUpstream=${trackingUpstream}`);
 
     // Check for uncommitted changes

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -21,6 +21,10 @@ export type AutoCommitOptions = {
   kiloClient: KiloClient;
   /** The assistant message ID this autocommit is associated with (for per-message UI rendering) */
   messageId?: string;
+  /** If the user explicitly provided an upstream branch via API, pass it here to allow
+   *  committing to that branch even if it is main/master. Protection is only bypassed
+   *  when the current branch matches this value exactly. */
+  upstreamBranch?: string;
 };
 
 function emitStarted(
@@ -76,19 +80,25 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       return { success: true, skipped: true };
     }
 
-    // Branch protection: never auto-commit to main/master
+    // Branch protection: block auto-commit to main/master unless the user
+    // explicitly targeted this exact branch via the upstreamBranch API param.
     if (branch === 'main' || branch === 'master') {
-      logToFile(`auto-commit: skipping - protected branch ${branch}`);
-      emitCompleted(
-        onEvent,
-        {
-          success: true,
-          message: `Skipped: cannot commit to ${branch}`,
-          skipped: true,
-        },
-        messageId
+      if (opts.upstreamBranch !== branch) {
+        logToFile(`auto-commit: skipping - protected branch ${branch}`);
+        emitCompleted(
+          onEvent,
+          {
+            success: true,
+            message: `Skipped: cannot commit to ${branch}`,
+            skipped: true,
+          },
+          messageId
+        );
+        return { success: true, skipped: true };
+      }
+      logToFile(
+        `auto-commit: allowing commit to ${branch} (explicit upstreamBranch=${opts.upstreamBranch})`
       );
-      return { success: true, skipped: true };
     }
 
     // Check actual git upstream (not stale config) to decide push strategy

--- a/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -1,6 +1,6 @@
 import type { IngestEvent } from '../../src/shared/protocol.js';
 import type { KiloClient } from './kilo-client.js';
-import { git, getCurrentBranch, logToFile } from './utils.js';
+import { git, getCurrentBranch, hasGitUpstream, logToFile } from './utils.js';
 
 /** Timeout for local git operations (status, add, commit) */
 const GIT_LOCAL_TIMEOUT_MS = 30_000;
@@ -17,7 +17,6 @@ export type AutoCommitResult = {
 
 export type AutoCommitOptions = {
   workspacePath: string;
-  upstreamBranch?: string;
   onEvent: (event: IngestEvent) => void;
   kiloClient: KiloClient;
   /** The assistant message ID this autocommit is associated with (for per-message UI rendering) */
@@ -55,14 +54,12 @@ function emitCompleted(
 }
 
 export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommitResult> {
-  const { workspacePath, upstreamBranch, onEvent, kiloClient, messageId } = opts;
+  const { workspacePath, onEvent, kiloClient, messageId } = opts;
 
-  logToFile(
-    `auto-commit: starting workspacePath=${workspacePath} upstreamBranch=${upstreamBranch ?? '(none)'}`
-  );
+  logToFile(`auto-commit: starting workspacePath=${workspacePath}`);
 
   try {
-    // Check current branch
+    // Check current branch (agent may have switched branches during execution)
     const branch = await getCurrentBranch(workspacePath);
     logToFile(`auto-commit: branch=${branch || '(detached HEAD)'}`);
     if (!branch) {
@@ -79,10 +76,9 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       return { success: true, skipped: true };
     }
 
-    // Branch protection: don't commit to main/master without an explicit upstream
-    const hasUpstream = upstreamBranch !== undefined && upstreamBranch !== '';
-    if (!hasUpstream && (branch === 'main' || branch === 'master')) {
-      logToFile(`auto-commit: skipping - protected branch ${branch} with no upstream`);
+    // Branch protection: never auto-commit to main/master
+    if (branch === 'main' || branch === 'master') {
+      logToFile(`auto-commit: skipping - protected branch ${branch}`);
       emitCompleted(
         onEvent,
         {
@@ -94,6 +90,10 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       );
       return { success: true, skipped: true };
     }
+
+    // Check actual git upstream (not stale config) to decide push strategy
+    const trackingUpstream = await hasGitUpstream(workspacePath);
+    logToFile(`auto-commit: hasGitUpstream=${trackingUpstream}`);
 
     // Check for uncommitted changes
     const status = await git(['status', '--porcelain'], {
@@ -191,7 +191,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     }
 
     // Push
-    const pushArgs = hasUpstream ? ['push'] : ['push', '-u', 'origin', branch];
+    const pushArgs = trackingUpstream ? ['push'] : ['push', '-u', 'origin', branch];
     logToFile(`auto-commit: pushing with args: git ${pushArgs.join(' ')}`);
 
     const pushResult = await git(pushArgs, { cwd: workspacePath, timeoutMs: GIT_PUSH_TIMEOUT_MS });

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -364,8 +364,11 @@ export function createLifecycleManager(
           // BUT only if not aborted - fatal errors already sent their own terminal event
           const job = state.currentJob;
           if (job && !isAborted) {
-            // Capture current branch so the DO can persist it for future warm starts
-            const currentBranch = await getCurrentBranch(config.workspacePath).catch(() => '');
+            // Capture current branch so the DO can persist it for future warm starts.
+            // Use a short timeout — if git hangs here the drain must still proceed.
+            const currentBranch = await getCurrentBranch(config.workspacePath, 10_000).catch(
+              () => ''
+            );
             logToFile(
               `sending complete event for executionId=${job.executionId} branch=${currentBranch || '(none)'}`
             );

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -49,6 +49,8 @@ export type LifecycleConfig = {
   workspacePath: string;
   /** Model for auto-commit/condense */
   model?: string;
+  /** Upstream branch explicitly provided by the user via API */
+  upstreamBranch?: string;
 };
 
 export type LifecycleDependencies = {
@@ -255,6 +257,7 @@ export function createLifecycleManager(
           onEvent: event => state.sendToIngest(event),
           kiloClient,
           messageId: state.lastAssistantMessageId ?? undefined,
+          upstreamBranch: config.upstreamBranch,
         });
         const timeoutPromise = new Promise<'timeout'>(resolve =>
           setTimeout(() => resolve('timeout'), AUTO_COMMIT_TIMEOUT_MS)

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -13,7 +13,7 @@ import type { KiloClient } from './kilo-client.js';
 import type { ConnectionManager } from './connection.js';
 import { runAutoCommit } from './auto-commit.js';
 import { runCondenseOnComplete } from './condense-on-complete.js';
-import { logToFile } from './utils.js';
+import { getCurrentBranch, logToFile } from './utils.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -47,8 +47,6 @@ export type LifecycleConfig = {
   condenseOnComplete: boolean;
   /** Workspace path for auto-commit/condense */
   workspacePath: string;
-  /** Upstream branch for auto-commit */
-  upstreamBranch?: string;
   /** Model for auto-commit/condense */
   model?: string;
 };
@@ -254,7 +252,6 @@ export function createLifecycleManager(
       try {
         const autoCommitPromise = runAutoCommit({
           workspacePath: config.workspacePath,
-          upstreamBranch: config.upstreamBranch,
           onEvent: event => state.sendToIngest(event),
           kiloClient,
           messageId: state.lastAssistantMessageId ?? undefined,
@@ -361,23 +358,32 @@ export function createLifecycleManager(
           uploader.stop();
         }
       })
-      .finally(() => {
-        // Send complete event to ingest so DO can update execution status and trigger callbacks
-        // BUT only if not aborted - fatal errors already sent their own terminal event
-        const job = state.currentJob;
-        if (job && !isAborted) {
-          logToFile(`sending complete event for executionId=${job.executionId}`);
-          state.sendToIngest({
-            streamEventType: 'complete',
-            data: {
-              exitCode: 0,
-              executionId: job.executionId,
-              kiloSessionId: job.kiloSessionId,
-            },
-            timestamp: new Date().toISOString(),
-          });
-        } else if (job && isAborted) {
-          logToFile(`skipping complete event - execution was aborted`);
+      .finally(async () => {
+        try {
+          // Send complete event to ingest so DO can update execution status and trigger callbacks
+          // BUT only if not aborted - fatal errors already sent their own terminal event
+          const job = state.currentJob;
+          if (job && !isAborted) {
+            // Capture current branch so the DO can persist it for future warm starts
+            const currentBranch = await getCurrentBranch(config.workspacePath).catch(() => '');
+            logToFile(
+              `sending complete event for executionId=${job.executionId} branch=${currentBranch || '(none)'}`
+            );
+            state.sendToIngest({
+              streamEventType: 'complete',
+              data: {
+                exitCode: 0,
+                executionId: job.executionId,
+                kiloSessionId: job.kiloSessionId,
+                ...(currentBranch ? { currentBranch } : {}),
+              },
+              timestamp: new Date().toISOString(),
+            });
+          } else if (job && isAborted) {
+            logToFile(`skipping complete event - execution was aborted`);
+          }
+        } catch (err) {
+          logToFile(`drain finally error: ${err instanceof Error ? err.message : String(err)}`);
         }
 
         drainTimeout = setTimeout(() => {

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -85,7 +85,6 @@ async function main() {
 
   const autoCommit = getOptionalEnvBool('AUTO_COMMIT', false);
   const condenseOnComplete = getOptionalEnvBool('CONDENSE_ON_COMPLETE', false);
-  const upstreamBranch = getOptionalEnv('UPSTREAM_BRANCH', '');
   const model = getOptionalEnv('MODEL', '');
 
   const maxRuntimeMs = getOptionalEnvInt('MAX_RUNTIME_MS', DEFAULT_INFLIGHT_TIMEOUT_MS);
@@ -210,7 +209,6 @@ async function main() {
       autoCommit,
       condenseOnComplete,
       workspacePath,
-      upstreamBranch: upstreamBranch || undefined,
       model: model || undefined,
     },
     {

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -86,6 +86,7 @@ async function main() {
   const autoCommit = getOptionalEnvBool('AUTO_COMMIT', false);
   const condenseOnComplete = getOptionalEnvBool('CONDENSE_ON_COMPLETE', false);
   const model = getOptionalEnv('MODEL', '');
+  const upstreamBranch = process.env.UPSTREAM_BRANCH || undefined;
 
   const maxRuntimeMs = getOptionalEnvInt('MAX_RUNTIME_MS', DEFAULT_INFLIGHT_TIMEOUT_MS);
 
@@ -101,7 +102,7 @@ async function main() {
     logToFile(`config: agentSession=${agentSessionId}`);
   }
   logToFile(
-    `config: autoCommit=${autoCommit} condenseOnComplete=${condenseOnComplete} maxRuntimeMs=${maxRuntimeMs}`
+    `config: autoCommit=${autoCommit} condenseOnComplete=${condenseOnComplete} maxRuntimeMs=${maxRuntimeMs} upstreamBranch=${upstreamBranch ?? '(none)'}`
   );
 
   // Create state
@@ -210,6 +211,7 @@ async function main() {
       condenseOnComplete,
       workspacePath,
       model: model || undefined,
+      upstreamBranch,
     },
     {
       state,

--- a/cloud-agent-next/wrapper/src/utils.ts
+++ b/cloud-agent-next/wrapper/src/utils.ts
@@ -60,6 +60,16 @@ export async function getCurrentBranch(workspacePath: string): Promise<string> {
   }
 }
 
+/** Check if the current branch has a remote tracking branch configured in git. */
+export async function hasGitUpstream(workspacePath: string): Promise<boolean> {
+  try {
+    const result = await git(['rev-parse', '--abbrev-ref', '@{upstream}'], { cwd: workspacePath });
+    return result.exitCode === 0 && result.stdout.trim() !== '';
+  } catch {
+    return false;
+  }
+}
+
 export function logToFile(message: string): void {
   const logPath = process.env.WRAPPER_LOG_PATH || '/tmp/kilocode-wrapper.log';
   try {

--- a/cloud-agent-next/wrapper/src/utils.ts
+++ b/cloud-agent-next/wrapper/src/utils.ts
@@ -51,9 +51,9 @@ export function git(
   });
 }
 
-export async function getCurrentBranch(workspacePath: string): Promise<string> {
+export async function getCurrentBranch(workspacePath: string, timeoutMs?: number): Promise<string> {
   try {
-    const result = await git(['branch', '--show-current'], { cwd: workspacePath });
+    const result = await git(['branch', '--show-current'], { cwd: workspacePath, timeoutMs });
     return result.stdout.trim();
   } catch {
     return '';
@@ -61,9 +61,12 @@ export async function getCurrentBranch(workspacePath: string): Promise<string> {
 }
 
 /** Check if the current branch has a remote tracking branch configured in git. */
-export async function hasGitUpstream(workspacePath: string): Promise<boolean> {
+export async function hasGitUpstream(workspacePath: string, timeoutMs?: number): Promise<boolean> {
   try {
-    const result = await git(['rev-parse', '--abbrev-ref', '@{upstream}'], { cwd: workspacePath });
+    const result = await git(['rev-parse', '--abbrev-ref', '@{upstream}'], {
+      cwd: workspacePath,
+      timeoutMs,
+    });
     return result.exitCode === 0 && result.stdout.trim() !== '';
   } catch {
     return false;

--- a/src/components/cloud-agent-next/ChatHeader.tsx
+++ b/src/components/cloud-agent-next/ChatHeader.tsx
@@ -45,10 +45,11 @@ export function ChatHeader({
   const [showActionsDialog, setShowActionsDialog] = useState(false);
 
   const browseUrl = buildRepoBrowseUrl(gitUrl);
+  // Compare URL for GitHub only; GitLab MR links are not yet supported.
   const repoUrl =
     browseUrl && branch && detectGitPlatform(gitUrl) === 'github'
       ? `${browseUrl}/compare/${branch}?expand=1`
-      : (browseUrl ?? (repository ? `https://github.com/${repository}` : undefined));
+      : browseUrl;
 
   return (
     <>

--- a/src/components/cloud-agent-next/ChatHeader.tsx
+++ b/src/components/cloud-agent-next/ChatHeader.tsx
@@ -8,6 +8,7 @@ import { SessionInfoDialog } from './SessionInfoDialog';
 import { SessionActionsDialog } from './SessionActionsDialog';
 import { SoundToggleButton } from '@/components/shared/SoundToggleButton';
 import { FeedbackDialog } from './FeedbackDialog';
+import { buildRepoBrowseUrl, detectGitPlatform } from './utils/git-utils';
 
 type ChatHeaderProps = {
   /** The cloud-agent session ID (e.g., agent_xxx format) */
@@ -16,6 +17,7 @@ type ChatHeaderProps = {
   kiloSessionId?: string;
   repository: string;
   branch?: string;
+  gitUrl?: string | null;
   model?: string;
   isStreaming?: boolean;
   totalCost?: number;
@@ -29,6 +31,7 @@ export function ChatHeader({
   cloudAgentSessionId,
   repository,
   branch,
+  gitUrl,
   model = 'Unknown',
   isStreaming = false,
   totalCost = 0,
@@ -41,9 +44,11 @@ export function ChatHeader({
   const [showInfoDialog, setShowInfoDialog] = useState(false);
   const [showActionsDialog, setShowActionsDialog] = useState(false);
 
-  const githubUrl = branch
-    ? `https://github.com/${repository}/compare/session/${branch}?expand=1`
-    : `https://github.com/${repository}`;
+  const browseUrl = buildRepoBrowseUrl(gitUrl);
+  const repoUrl =
+    browseUrl && branch && detectGitPlatform(gitUrl) === 'github'
+      ? `${browseUrl}/compare/${branch}?expand=1`
+      : (browseUrl ?? (repository ? `https://github.com/${repository}` : undefined));
 
   return (
     <>
@@ -124,15 +129,20 @@ export function ChatHeader({
               {repository && (
                 <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-gray-400 md:text-sm">
                   <GitBranch className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{repository}</span>
-                  <a
-                    href={githubUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="shrink-0 text-blue-400 transition-colors hover:text-blue-300"
-                  >
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
+                  <span className="truncate">
+                    {repository}
+                    {branch && <span className="text-gray-500"> : {branch}</span>}
+                  </span>
+                  {repoUrl && (
+                    <a
+                      href={repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 text-blue-400 transition-colors hover:text-blue-300"
+                    >
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -783,6 +783,9 @@ export function CloudChatContainer({
           const resumeRepo =
             extractRepoFromGitUrl(loadedDbSession?.git_url) || sessionConfig.repository;
           const gitUrl = currentIndexedDbSession?.gitUrl || loadedDbSession?.git_url || null;
+          // Self-hosted git hosts (not github.com or gitlab.com) fall through to 'gitlab'
+          // because the prepare API only supports github/gitlab and GitLab API is closer
+          // to what most self-hosted forges expose. No gitUrl → default to 'github'.
           const repoParams = buildPrepareSessionRepoParams({
             repo: resumeRepo,
             platform: !gitUrl || detectGitPlatform(gitUrl) === 'github' ? 'github' : 'gitlab',

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -53,7 +53,11 @@ import { useResumeConfigModal } from './hooks/useResumeConfigModal';
 import { useSessionConfigCommand } from './hooks/useSessionConfigCommand';
 import { useOrgContextCommand } from './hooks/useOrgContextCommand';
 import { usePreparedSession } from './hooks/usePreparedSession';
-import { buildPrepareSessionRepoParams, extractRepoFromGitUrl } from './utils/git-utils';
+import {
+  buildPrepareSessionRepoParams,
+  detectGitPlatform,
+  extractRepoFromGitUrl,
+} from './utils/git-utils';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
 import { CloudChatPresentation } from './CloudChatPresentation';
 import { QuestionContextProvider } from './QuestionContext';
@@ -301,6 +305,9 @@ export function CloudChatContainer({
     onSessionInitiated: handleSessionInitiated,
     onQuestionAsked: playNotification,
     onSendFailed: handleSendFailed,
+    onBranchChanged: useCallback((branch: string) => {
+      setLoadedDbSession(prev => (prev ? { ...prev, git_branch: branch } : prev));
+    }, []),
   });
 
   // Wrapper for sendMessage that doesn't use sessionIdOverride
@@ -441,7 +448,7 @@ export function CloudChatContainer({
             last_mode: runtimeState?.mode,
             last_model: runtimeState?.model,
             git_url: sessionData.git_url,
-            git_branch: sessionData.git_branch,
+            git_branch: runtimeState?.upstreamBranch ?? sessionData.git_branch,
           };
 
           // Check if session has been initiated - prefer DO state, fallback to message check
@@ -778,7 +785,7 @@ export function CloudChatContainer({
           const gitUrl = currentIndexedDbSession?.gitUrl || loadedDbSession?.git_url || null;
           const repoParams = buildPrepareSessionRepoParams({
             repo: resumeRepo,
-            platform: gitUrl ? 'gitlab' : 'github',
+            platform: !gitUrl || detectGitPlatform(gitUrl) === 'github' ? 'github' : 'gitlab',
           });
           if (!repoParams) {
             setError('Cannot prepare session without a repository.');
@@ -831,7 +838,7 @@ export function CloudChatContainer({
           const gitUrl = currentIndexedDbSession?.gitUrl || loadedDbSession?.git_url || null;
           const repoParams = buildPrepareSessionRepoParams({
             repo: resumeRepo,
-            platform: gitUrl ? 'gitlab' : 'github',
+            platform: !gitUrl || detectGitPlatform(gitUrl) === 'github' ? 'github' : 'gitlab',
           });
           if (!repoParams) {
             setError('Cannot prepare session without a repository.');
@@ -945,6 +952,8 @@ export function CloudChatContainer({
         currentSessionId={currentSessionId}
         currentDbSessionId={currentDbSessionId}
         cloudAgentSessionId={cloudAgentSessionId}
+        gitUrl={currentIndexedDbSession?.gitUrl ?? loadedDbSession?.git_url ?? null}
+        gitBranch={loadedDbSession?.git_branch ?? null}
         sessionConfig={sessionConfig}
         totalCost={totalCost}
         error={error}

--- a/src/components/cloud-agent-next/CloudChatPresentation.tsx
+++ b/src/components/cloud-agent-next/CloudChatPresentation.tsx
@@ -103,6 +103,8 @@ export type CloudChatPresentationProps = {
   currentSessionId: string | null;
   currentDbSessionId: string | null;
   cloudAgentSessionId: string | null;
+  gitUrl?: string | null;
+  gitBranch?: string | null;
   sessionConfig: SessionConfig | null;
   totalCost: number;
   error: string | null;
@@ -198,6 +200,8 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
   currentSessionId,
   currentDbSessionId,
   cloudAgentSessionId,
+  gitUrl,
+  gitBranch,
   sessionConfig,
   totalCost,
   error,
@@ -322,7 +326,8 @@ export const CloudChatPresentation = memo(function CloudChatPresentation({
               cloudAgentSessionId={currentSessionId || 'Starting session...'}
               kiloSessionId={currentDbSessionId || undefined}
               repository={sessionConfig?.repository ?? ''}
-              branch={currentSessionId || undefined}
+              branch={gitBranch || undefined}
+              gitUrl={gitUrl}
               model={sessionConfig?.model}
               isStreaming={isStreaming}
               totalCost={totalCost}

--- a/src/components/cloud-agent-next/store/db-session-atoms.ts
+++ b/src/components/cloud-agent-next/store/db-session-atoms.ts
@@ -598,7 +598,7 @@ export const createNewSessionInIndexedDbAtom = atom(
     const newDbSession: DbSession = {
       session_id: kiloSessionId,
       title,
-      git_url: repository ? `https://github.com/${repository}` : null,
+      git_url: null,
       cloud_agent_session_id: cloudAgentSessionId,
       created_on_platform: 'cloud-agent',
       created_at: nowDate,

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -70,6 +70,8 @@ export type UseCloudAgentStreamOptions = {
   onQuestionAsked?: () => void;
   /** Callback when sendMessage fails — receives the original message text for restoring to input */
   onSendFailed?: (messageText: string) => void;
+  /** Callback when the agent's current branch changes (from complete event) */
+  onBranchChanged?: (branch: string) => void;
 };
 
 export type UseCloudAgentStreamReturn = {
@@ -108,6 +110,7 @@ export function useCloudAgentStream({
   onSessionInitiated,
   onQuestionAsked,
   onSendFailed,
+  onBranchChanged,
 }: UseCloudAgentStreamOptions): UseCloudAgentStreamReturn {
   const trpcClient = useRawTRPCClient();
 
@@ -175,10 +178,15 @@ export function useCloudAgentStream({
   const onSessionInitiatedRef = useRef(onSessionInitiated);
   const onQuestionAskedRef = useRef(onQuestionAsked);
   const onSendFailedRef = useRef(onSendFailed);
+  const onBranchChangedRef = useRef(onBranchChanged);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
   }, [onComplete]);
+
+  useEffect(() => {
+    onBranchChangedRef.current = onBranchChanged;
+  }, [onBranchChanged]);
 
   useEffect(() => {
     onKiloSessionCreatedRef.current = onKiloSessionCreated;
@@ -400,6 +408,10 @@ export function useCloudAgentStream({
           next.set(messageId, status);
           return next;
         });
+      },
+
+      onBranchChanged: branch => {
+        onBranchChangedRef.current?.(branch);
       },
     }),
     [

--- a/src/components/cloud-agent-next/utils/git-utils.test.ts
+++ b/src/components/cloud-agent-next/utils/git-utils.test.ts
@@ -59,6 +59,24 @@ describe('buildRepoBrowseUrl', () => {
     );
   });
 
+  test('ssh:// URI format with .git', () => {
+    expect(buildRepoBrowseUrl('ssh://git@github.com/owner/repo.git')).toBe(
+      'https://github.com/owner/repo'
+    );
+  });
+
+  test('ssh:// URI format without .git', () => {
+    expect(buildRepoBrowseUrl('ssh://git@github.com/owner/repo')).toBe(
+      'https://github.com/owner/repo'
+    );
+  });
+
+  test('ssh:// URI format GitLab nested groups', () => {
+    expect(buildRepoBrowseUrl('ssh://git@gitlab.com/group/subgroup/project.git')).toBe(
+      'https://gitlab.com/group/subgroup/project'
+    );
+  });
+
   test('null returns undefined', () => {
     expect(buildRepoBrowseUrl(null)).toBeUndefined();
   });
@@ -97,6 +115,14 @@ describe('detectGitPlatform', () => {
     expect(detectGitPlatform('git@gitlab.mycompany.com:team/repo.git')).toBeUndefined();
   });
 
+  test('GitHub ssh:// URI format', () => {
+    expect(detectGitPlatform('ssh://git@github.com/owner/repo.git')).toBe('github');
+  });
+
+  test('GitLab ssh:// URI format', () => {
+    expect(detectGitPlatform('ssh://git@gitlab.com/group/project.git')).toBe('gitlab');
+  });
+
   test('Bitbucket returns undefined', () => {
     expect(detectGitPlatform('https://bitbucket.org/owner/repo.git')).toBeUndefined();
   });
@@ -117,6 +143,16 @@ describe('extractRepoFromGitUrl', () => {
 
   test('GitLab SSH nested groups', () => {
     expect(extractRepoFromGitUrl('git@gitlab.com:group/subgroup/project.git')).toBe(
+      'group/subgroup/project'
+    );
+  });
+
+  test('ssh:// URI format', () => {
+    expect(extractRepoFromGitUrl('ssh://git@github.com/owner/repo.git')).toBe('owner/repo');
+  });
+
+  test('ssh:// URI format GitLab nested groups', () => {
+    expect(extractRepoFromGitUrl('ssh://git@gitlab.com/group/subgroup/project.git')).toBe(
       'group/subgroup/project'
     );
   });

--- a/src/components/cloud-agent-next/utils/git-utils.test.ts
+++ b/src/components/cloud-agent-next/utils/git-utils.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  buildRepoBrowseUrl,
+  detectGitPlatform,
+  extractRepoFromGitUrl,
+  buildPrepareSessionRepoParams,
+} from './git-utils';
+
+describe('buildRepoBrowseUrl', () => {
+  test('GitHub HTTPS with .git', () => {
+    expect(buildRepoBrowseUrl('https://github.com/owner/repo.git')).toBe(
+      'https://github.com/owner/repo'
+    );
+  });
+
+  test('GitHub HTTPS without .git', () => {
+    expect(buildRepoBrowseUrl('https://github.com/owner/repo')).toBe(
+      'https://github.com/owner/repo'
+    );
+  });
+
+  test('GitHub SSH', () => {
+    expect(buildRepoBrowseUrl('git@github.com:owner/repo.git')).toBe(
+      'https://github.com/owner/repo'
+    );
+  });
+
+  test('GitHub SSH without .git', () => {
+    expect(buildRepoBrowseUrl('git@github.com:owner/repo')).toBe('https://github.com/owner/repo');
+  });
+
+  test('GitLab HTTPS', () => {
+    expect(buildRepoBrowseUrl('https://gitlab.com/group/project.git')).toBe(
+      'https://gitlab.com/group/project'
+    );
+  });
+
+  test('GitLab nested groups', () => {
+    expect(buildRepoBrowseUrl('https://gitlab.com/group/subgroup/project.git')).toBe(
+      'https://gitlab.com/group/subgroup/project'
+    );
+  });
+
+  test('GitLab SSH', () => {
+    expect(buildRepoBrowseUrl('git@gitlab.com:group/project.git')).toBe(
+      'https://gitlab.com/group/project'
+    );
+  });
+
+  test('self-hosted HTTPS', () => {
+    expect(buildRepoBrowseUrl('https://gitlab.mycompany.com/team/repo.git')).toBe(
+      'https://gitlab.mycompany.com/team/repo'
+    );
+  });
+
+  test('self-hosted SSH', () => {
+    expect(buildRepoBrowseUrl('git@gitlab.mycompany.com:team/repo.git')).toBe(
+      'https://gitlab.mycompany.com/team/repo'
+    );
+  });
+
+  test('null returns undefined', () => {
+    expect(buildRepoBrowseUrl(null)).toBeUndefined();
+  });
+
+  test('undefined returns undefined', () => {
+    expect(buildRepoBrowseUrl(undefined)).toBeUndefined();
+  });
+
+  test('empty string returns undefined', () => {
+    expect(buildRepoBrowseUrl('')).toBeUndefined();
+  });
+});
+
+describe('detectGitPlatform', () => {
+  test('GitHub HTTPS', () => {
+    expect(detectGitPlatform('https://github.com/owner/repo.git')).toBe('github');
+  });
+
+  test('GitHub SSH', () => {
+    expect(detectGitPlatform('git@github.com:owner/repo.git')).toBe('github');
+  });
+
+  test('GitLab HTTPS', () => {
+    expect(detectGitPlatform('https://gitlab.com/group/project.git')).toBe('gitlab');
+  });
+
+  test('GitLab SSH', () => {
+    expect(detectGitPlatform('git@gitlab.com:group/project.git')).toBe('gitlab');
+  });
+
+  test('self-hosted GitLab HTTPS returns undefined', () => {
+    expect(detectGitPlatform('https://gitlab.mycompany.com/team/repo.git')).toBeUndefined();
+  });
+
+  test('self-hosted SSH returns undefined', () => {
+    expect(detectGitPlatform('git@gitlab.mycompany.com:team/repo.git')).toBeUndefined();
+  });
+
+  test('Bitbucket returns undefined', () => {
+    expect(detectGitPlatform('https://bitbucket.org/owner/repo.git')).toBeUndefined();
+  });
+
+  test('null returns undefined', () => {
+    expect(detectGitPlatform(null)).toBeUndefined();
+  });
+
+  test('undefined returns undefined', () => {
+    expect(detectGitPlatform(undefined)).toBeUndefined();
+  });
+});
+
+describe('extractRepoFromGitUrl', () => {
+  test('GitHub HTTPS with .git', () => {
+    expect(extractRepoFromGitUrl('https://github.com/owner/repo.git')).toBe('owner/repo');
+  });
+
+  test('GitLab SSH nested groups', () => {
+    expect(extractRepoFromGitUrl('git@gitlab.com:group/subgroup/project.git')).toBe(
+      'group/subgroup/project'
+    );
+  });
+
+  test('null returns undefined', () => {
+    expect(extractRepoFromGitUrl(null)).toBeUndefined();
+  });
+});
+
+describe('buildPrepareSessionRepoParams', () => {
+  test('github platform with repo', () => {
+    expect(buildPrepareSessionRepoParams({ repo: 'owner/repo', platform: 'github' })).toEqual({
+      githubRepo: 'owner/repo',
+    });
+  });
+
+  test('gitlab platform with repo', () => {
+    expect(buildPrepareSessionRepoParams({ repo: 'group/project', platform: 'gitlab' })).toEqual({
+      gitlabProject: 'group/project',
+    });
+  });
+
+  test('null repo returns null', () => {
+    expect(buildPrepareSessionRepoParams({ repo: null, platform: 'github' })).toBeNull();
+  });
+
+  test('empty string repo returns null', () => {
+    expect(buildPrepareSessionRepoParams({ repo: '', platform: 'github' })).toBeNull();
+  });
+});

--- a/src/components/cloud-agent-next/utils/git-utils.ts
+++ b/src/components/cloud-agent-next/utils/git-utils.ts
@@ -78,11 +78,17 @@ export function buildRepoBrowseUrl(gitUrl: string | null | undefined): string | 
     return `https://${sshMatch[1]}/${sshMatch[2]}`;
   }
 
-  // HTTPS format
+  // Standard URL format (https://, ssh://, etc.)
   try {
     const url = new URL(gitUrl);
     const pathname = url.pathname.replace(/\.git$/, '');
-    return url.origin + pathname;
+    // For non-browseable protocols (e.g. ssh://git@github.com/owner/repo.git),
+    // url.origin is null — force https:// so the result is a clickable URL.
+    const origin =
+      url.protocol === 'http:' || url.protocol === 'https:'
+        ? url.origin
+        : `https://${url.hostname}`;
+    return origin + pathname;
   } catch {
     return undefined;
   }

--- a/src/components/cloud-agent-next/utils/git-utils.ts
+++ b/src/components/cloud-agent-next/utils/git-utils.ts
@@ -68,3 +68,44 @@ export function buildPrepareSessionRepoParams(options: {
 
   return { githubRepo: repo };
 }
+
+export function buildRepoBrowseUrl(gitUrl: string | null | undefined): string | undefined {
+  if (!gitUrl) return undefined;
+
+  // SSH format: git@host:path.git
+  const sshMatch = gitUrl.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return `https://${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  // HTTPS format
+  try {
+    const url = new URL(gitUrl);
+    const pathname = url.pathname.replace(/\.git$/, '');
+    return url.origin + pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+export function detectGitPlatform(gitUrl: string | null | undefined): GitPlatform | undefined {
+  if (!gitUrl) return undefined;
+
+  let hostname: string | undefined;
+
+  // SSH format: git@host:...
+  const sshMatch = gitUrl.match(/^git@([^:]+):/);
+  if (sshMatch) {
+    hostname = sshMatch[1];
+  } else {
+    try {
+      hostname = new URL(gitUrl).hostname;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (hostname === 'github.com') return 'github';
+  if (hostname === 'gitlab.com') return 'gitlab';
+  return undefined;
+}

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -513,10 +513,13 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * Handle the wrapper's "complete" event — the execution is fully done
    * (including autocommit). This is the definitive "safe to send another message" signal.
    */
-  function handleExecutionComplete(): void {
+  function handleExecutionComplete(data: Record<string, unknown>): void {
     if (streaming) {
       streaming = false;
       callbacks.onStreamingChanged?.(false);
+    }
+    if (typeof data.currentBranch === 'string' && data.currentBranch) {
+      callbacks.onBranchChanged?.(data.currentBranch);
     }
   }
 
@@ -649,7 +652,7 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
         break;
 
       case 'complete':
-        handleExecutionComplete();
+        handleExecutionComplete((data ?? {}) as Record<string, unknown>);
         break;
 
       case 'autocommit_started':

--- a/src/lib/cloud-agent-next/processor/types.ts
+++ b/src/lib/cloud-agent-next/processor/types.ts
@@ -107,6 +107,9 @@ export type EventProcessorCallbacks = {
 
   /** Called when an autocommit event (started/completed) is received with a messageId */
   onAutocommitUpdated?: (messageId: string, status: AutocommitStatus) => void;
+
+  /** Called when the current branch changes (from complete event) */
+  onBranchChanged?: (branch: string) => void;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Replace hardcoded GitHub URL construction in the chat header with generic `buildRepoBrowseUrl` and `detectGitPlatform` utilities that support GitHub, GitLab, SSH, HTTPS, and self-hosted git URLs.
- Fix platform detection in session resume/prepare that incorrectly classified every session with a `gitUrl` as GitLab — now inspects the actual hostname.
- Stop fabricating `git_url` from the repository name in `db-session-atoms.ts`; let the real URL flow from the backend instead.
- Remove the stale `UPSTREAM_BRANCH` env-var plumbing from the wrapper. Auto-commit now queries `git rev-parse --abbrev-ref @{upstream}` at push time so the push strategy always reflects the real tracking state (even when the agent switches branches mid-execution).
- Propagate `currentBranch` in the wrapper's `complete` event so the frontend can display the actual branch, and show it in the header next to the repo name.
- Display the actual git branch (not the session ID) in `ChatHeader`, and show the full commit message on hover via Radix Tooltip in `AutocommitStatus`.

## Verification

manual testing with local repos + changing branch via agent

## Visual Changes

| Before | After |
| ------ | ----- |
| Header always shows a GitHub compare link using session ID as branch | Header shows actual branch name next to repo, links to the correct platform (GitHub compare or GitLab browse) |

## Reviewer Notes

-