### PR TITLE
CloudAgentNext - Fix Wrapper Startup SIGILL With Retry and Diagnostics

### DIFF
--- a/cloud-agent-next/Dockerfile
+++ b/cloud-agent-next/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.7.5
+FROM docker.io/cloudflare/sandbox:0.7.8
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""

--- a/cloud-agent-next/Dockerfile.dev
+++ b/cloud-agent-next/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.7.5
+FROM docker.io/cloudflare/sandbox:0.7.8
 
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""

--- a/cloud-agent-next/README.md
+++ b/cloud-agent-next/README.md
@@ -36,7 +36,7 @@ By default, the script looks for kilo-cli at `$HOME/projects/kilo-cli`. Override
 
 **What's in Dockerfile.dev:**
 
-- Base image: `cloudflare/sandbox:0.7.5`
+- Base image: `cloudflare/sandbox:0.7.8`
 - Pre-built `kilo` binary (from `cloud-agent-build.sh`)
 - GitHub CLI (`gh`) and GitLab CLI (`glab`)
 - Wrapper bundle built inside the container

--- a/cloud-agent-next/package.json
+++ b/cloud-agent-next/package.json
@@ -25,7 +25,7 @@
     "typecheck": "tsgo --noEmit --incremental false && pnpm -C wrapper run typecheck"
   },
   "dependencies": {
-    "@cloudflare/sandbox": "0.7.5",
+    "@cloudflare/sandbox": "0.7.8",
     "@kilocode/db": "workspace:*",
     "@kilocode/encryption": "workspace:*",
     "@kilocode/worker-utils": "workspace:*",

--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -39,11 +39,12 @@ const createMockSession = (
       ? vi.fn().mockImplementation((cmd: string) => Promise.resolve(execResult(cmd)))
       : vi.fn().mockResolvedValue(execResult);
 
-  // Mock startProcess that returns a process with waitForPort
+  // Mock startProcess that returns a process with waitForPort and getLogs
   const startProcessFn = vi.fn().mockImplementation(() =>
     Promise.resolve({
       id: 'mock-process-id',
       waitForPort: vi.fn().mockResolvedValue(undefined),
+      getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
     })
   );
 
@@ -485,6 +486,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: waitForPortMock,
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -506,14 +508,18 @@ describe('WrapperClient', () => {
       });
     });
 
-    it('throws WrapperNotReadyError on timeout', async () => {
+    it('throws WrapperNotReadyError after exhausting all retry attempts', async () => {
       // Health check fails (not running)
       const session = createMockSession(createCurlError(7, 'Connection refused'));
 
+      const getLogsMock = vi
+        .fn()
+        .mockResolvedValue({ stdout: 'some output', stderr: 'some error' });
       // Make startProcess return a process where waitForPort times out
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockRejectedValue(new Error('Port not ready within timeout')),
+        getLogs: getLogsMock,
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -527,6 +533,81 @@ describe('WrapperClient', () => {
           workspacePath: '/workspace/test',
         })
       ).rejects.toThrow(WrapperNotReadyError);
+
+      // Should have retried (2 attempts total)
+      expect(session.startProcess).toHaveBeenCalledTimes(2);
+      // getLogs should be called on each failed attempt
+      expect(getLogsMock).toHaveBeenCalledTimes(2);
+      // pkill should be called between attempts to clean up the failed process
+      const execCalls = (session.exec as ReturnType<typeof vi.fn>).mock.calls;
+      const pkillCalls = execCalls.filter(call => String(call[0]).includes('pkill'));
+      expect(pkillCalls).toHaveLength(1);
+      expect(pkillCalls[0][0]).toContain('--agent-session test-session');
+    });
+
+    it('retries once on failure then succeeds', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+
+      let attempt = 0;
+      (session.startProcess as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        attempt++;
+        const waitForPort =
+          attempt === 1
+            ? vi.fn().mockRejectedValue(new Error('SIGILL'))
+            : vi.fn().mockResolvedValue(undefined);
+        return Promise.resolve({
+          id: `mock-process-${attempt}`,
+          waitForPort,
+          getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+        });
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        maxWaitMs: 5000,
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+      });
+
+      // First attempt fails, second succeeds
+      expect(session.startProcess).toHaveBeenCalledTimes(2);
+
+      // pkill should be called between attempts to clean up the failed process
+      const execCalls = (session.exec as ReturnType<typeof vi.fn>).mock.calls;
+      const pkillCalls = execCalls.filter(call => String(call[0]).includes('pkill'));
+      expect(pkillCalls).toHaveLength(1);
+      expect(pkillCalls[0][0]).toContain('--agent-session test-session');
+    });
+
+    it('calls getLogs on process when startup fails', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+
+      const getLogsMock = vi.fn().mockResolvedValue({
+        stdout: 'wrapper output before crash',
+        stderr: 'illegal instruction',
+      });
+
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockRejectedValue(new Error('Process exited with code 132')),
+        getLogs: getLogsMock,
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await expect(
+        client.ensureRunning({
+          sessionId: 'test-session',
+          maxWaitMs: 100,
+          kiloServerPort: 4600,
+          workspacePath: '/workspace/test',
+        })
+      ).rejects.toThrow(WrapperNotReadyError);
+
+      // getLogs should be called for each failed attempt
+      expect(getLogsMock).toHaveBeenCalledTimes(2);
     });
 
     it('uses default wrapper path and calls startProcess', async () => {
@@ -571,6 +652,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -591,6 +673,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -611,6 +694,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -631,6 +715,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -651,6 +736,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });
@@ -673,6 +759,7 @@ describe('WrapperClient', () => {
       (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'mock-process-id',
         waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       });
 
       const client = new WrapperClient({ session, port: defaultPort });

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -115,6 +115,13 @@ const ERROR_STATUS_CODES: Record<string, number> = {
 };
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max attempts for wrapper startup (1 retry on transient failures like Bun SIGILL) */
+const MAX_WRAPPER_START_ATTEMPTS = 2;
+
+// ---------------------------------------------------------------------------
 // WrapperClient Implementation
 // ---------------------------------------------------------------------------
 
@@ -252,26 +259,85 @@ export class WrapperClient {
 
     const command = `${envParts.join(' ')} bun run ${wrapperPath} ${sessionMarker}`;
 
-    logger.debug('WrapperClient: starting wrapper process', { command, port: this.port });
+    let lastError: Error | undefined;
 
-    try {
-      const proc = await this.session.startProcess(command, {
-        cwd: workspacePath,
+    for (let attempt = 0; attempt < MAX_WRAPPER_START_ATTEMPTS; attempt++) {
+      logger.debug('WrapperClient: starting wrapper process', {
+        command,
+        port: this.port,
+        attempt: attempt + 1,
       });
 
-      // Wait for wrapper to become healthy via port check
-      await proc.waitForPort(this.port, {
-        mode: 'http',
-        path: '/health',
-        timeout: maxWaitMs,
-      });
+      let proc: Awaited<ReturnType<ExecutionSession['startProcess']>> | undefined;
 
-      logger.debug('WrapperClient: wrapper is ready', { port: this.port, processId: proc.id });
-    } catch (error) {
-      throw new WrapperNotReadyError(
-        `Wrapper did not become ready within ${maxWaitMs}ms: ${error instanceof Error ? error.message : String(error)}`
-      );
+      try {
+        proc = await this.session.startProcess(command, {
+          cwd: workspacePath,
+        });
+
+        // Wait for wrapper to become healthy via port check
+        await proc.waitForPort(this.port, {
+          mode: 'http',
+          path: '/health',
+          timeout: maxWaitMs,
+        });
+
+        logger.debug('WrapperClient: wrapper is ready', { port: this.port, processId: proc.id });
+        return;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        // Capture process logs for diagnostics
+        let stdout: string | undefined;
+        let stderr: string | undefined;
+        if (proc) {
+          try {
+            const logs = await proc.getLogs();
+            stdout = logs.stdout;
+            stderr = logs.stderr;
+          } catch (logError) {
+            logger.debug('Failed to read wrapper process logs', {
+              port: this.port,
+              processId: proc.id,
+              error: logError instanceof Error ? logError.message : String(logError),
+            });
+          }
+        }
+
+        if (attempt + 1 < MAX_WRAPPER_START_ATTEMPTS) {
+          // Kill the failed process before retrying (proc.kill() is unreliable
+          // in the sandbox SDK, so use pkill -f against the session marker).
+          try {
+            await this.session.exec(`pkill -f -- '${sessionMarker}'`);
+          } catch {
+            // Process may already be dead — ignore
+          }
+
+          logger.warn('Wrapper startup failed, retrying', {
+            port: this.port,
+            attempt: attempt + 1,
+            error: lastError.message,
+            stdout,
+            stderr,
+          });
+          continue;
+        }
+
+        // Final attempt failed
+        logger.error('Wrapper startup failed after all attempts', {
+          port: this.port,
+          attempt: attempt + 1,
+          error: lastError.message,
+          stdout,
+          stderr,
+        });
+      }
     }
+
+    const logsHint = ' (check logs above for process stdout/stderr)';
+    throw new WrapperNotReadyError(
+      `Wrapper did not become ready within ${maxWaitMs}ms after ${MAX_WRAPPER_START_ATTEMPTS} attempt(s): ${lastError?.message ?? 'unknown error'}${logsHint}`
+    );
   }
 
   /**

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -73,7 +73,7 @@ function getOptionalEnvBool(name: string, defaultValue: boolean): boolean {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  logToFile('wrapper starting (long-running mode)');
+  logToFile(`wrapper starting (long-running mode) bun=${Bun.version}`);
 
   // Parse environment variables
   const wrapperPort = getOptionalEnvInt('WRAPPER_PORT', 5000);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,8 +564,8 @@ importers:
   cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.7.5
-        version: 0.7.5(@xterm/xterm@6.0.0)
+        specifier: 0.7.8
+        version: 0.7.8(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: ^0.4.2
         version: 0.4.2(@trpc/server@11.9.0(typescript@5.9.3))(hono@4.12.2)
@@ -2525,8 +2525,8 @@ packages:
       '@opencode-ai/sdk':
         optional: true
 
-  '@cloudflare/sandbox@0.7.5':
-    resolution: {integrity: sha512-lOegEUL6eDsHrsxEMxqRcftsp46hn+ilQryCLuSDghHvnCdDAenzyN/E3nVjQdYAZnoh5xsLzis/G295LcZr1w==}
+  '@cloudflare/sandbox@0.7.8':
+    resolution: {integrity: sha512-BNiRgHlGWYFYzRDDs+OOy1fEMU+Vr2UsWeTLP1LOQmq1oE2GSc1cWFPOOK4KZXUoxWJurMqZRAG47qa0ipKBCw==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -13339,7 +13339,7 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.0.30
 
-  '@cloudflare/sandbox@0.7.5(@xterm/xterm@6.0.0)':
+  '@cloudflare/sandbox@0.7.8(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.0.30
       aws4fetch: 1.0.20


### PR DESCRIPTION
## Summary

- Add retry loop (2 attempts) to `WrapperClient.ensureRunning()` for transient wrapper startup failures (Bun SIGILL exit code 132)
- Capture `proc.getLogs()` stdout/stderr on each failed attempt for diagnostics
- Kill failed process via `pkill -f` between retry attempts to release the port and prevent zombie processes
- Bump `@cloudflare/sandbox` from 0.7.5 to 0.7.8 (Dockerfiles, package.json, lockfile, README)
- Log `Bun.version` at wrapper startup for runtime diagnostics

## Background

The wrapper process occasionally crashes with exit code 132 (SIGILL) caused by a known Bun JIT compiler bug ([oven-sh/bun#27312](https://github.com/oven-sh/bun/issues/27312)). Since SIGILL is non-deterministic and rare, a single retry is sufficient to recover. The `proc.kill()` sandbox SDK method is unreliable, so `pkill -f` is used instead (consistent with the existing interrupt pattern in `session-service.ts`).

## Testing

- Updated existing tests and added new tests covering retry-then-success, retry exhaustion, getLogs capture, and pkill cleanup between attempts
- All 49 wrapper-client tests pass, typecheck clean