### PR TITLE
feat: Trust internatl bot for code reviews

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -238,12 +238,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   console.debug(`Routing request to ${provider.id}`);
 
   // Start abuse classification early (non-blocking) - we'll await it before creating usage context
+  // Bot users (code-review, auto-fix, etc.) are exempt — classifyAbuse short-circuits to null.
   const classifyPromise = classifyAbuse(request, requestBodyParsed, {
     kiloUserId: user.id,
     organizationId,
     projectId,
     provider: provider.id,
     isByok: !!userByok,
+    botId,
   });
 
   // large responses may run longer than the 800s serverless function timeout, usually this value is set to 8192 tokens

--- a/src/lib/abuse-service.ts
+++ b/src/lib/abuse-service.ts
@@ -332,7 +332,16 @@ export type AbuseClassificationContext = {
   projectId?: string | null;
   provider?: string | null;
   isByok?: boolean | null;
+  /** When set, the request originates from an internal bot (e.g. 'reviewer', 'auto-fix'). */
+  botId?: string | null;
 };
+
+const ABUSE_EXEMPT_BOT_IDS = new Set(['reviewer']);
+
+/** Internal bots in this set are exempt from abuse classification. */
+function isAbuseExemptBot(botId: string | null | undefined): boolean {
+  return !!botId && ABUSE_EXEMPT_BOT_IDS.has(botId);
+}
 
 /**
  * High-level function to classify a request for abuse.
@@ -348,6 +357,10 @@ export async function classifyAbuse(
   body: OpenRouterChatCompletionRequest,
   context?: AbuseClassificationContext
 ): Promise<AbuseClassificationResponse | null> {
+  if (isAbuseExemptBot(context?.botId)) {
+    return null;
+  }
+
   const fraudHeaders = getFraudDetectionHeaders(request.headers);
   const { systemPrompt, userPrompt } = extractFullPrompts(body);
 


### PR DESCRIPTION
Whitelist/exclude the code review bot user (`review-*`) from abuse detection.

## Context

The code review bot `bot-code-review-9d278969-5453-4ae3-a51f-a8d2274a7b56` is being **SOFT_BLOCKED** by the abuse detection system on **every single LLM request**. The abuse classification consistently returns:

```
verdict: 'SOFT_BLOCK'
risk_score: 0.5
signals: ['high_velocity', 'jailbreak_pattern']
rps: 0.37-0.55
```

This is a flood of SOFT_BLOCK verdicts hitting the code review bot at high frequency (~0.5 rps). The requests are coming from IP `.....` (Cloudflare) for `anthropic/claude-opus-4.6`. The requests are retrying rapidly.

Here is the diagnosis and root cause:

**Root cause: The code reviews are failing because of a cascading SOFT_BLOCK from the abuse detection system, NOT because of a bug in the thinking effort/variant code itself.**

The sequence is:
1. PR #798 enabled thinking effort (`variant: 'high'`) for org `Kilo`
2. Reviews are dispatched via cloud-agent-next (v2 path) with `variant: 'high'`
3. When the Kilo CLI inside the sandbox makes its first LLM request to `api.kilo.ai/api/openrouter/chat/completions`, the abuse detection classifies the bot user as `SOFT_BLOCK` with signals `high_velocity` and `jailbreak_pattern`
4. The SOFT_BLOCK causes the LLM request to fail (or return an error response)
5. The Kilo CLI interprets this as a fatal error and the execution fails after ~15 seconds
6. The failure triggers a re-dispatch, which creates a new session and tries again
7. The new attempt also gets SOFT_BLOCKED, creating a vicious cycle of rapid re-dispatches that INCREASES the `rps` (requests per second) metric, further cementing the SOFT_BLOCK verdict
8. The `high_velocity` signal is self-reinforcing: each failed retry increases the rate, keeping the bot permanently blocked

**Why did the earlier v2 reviews (without variant) succeed?** They were dispatched and completed BEFORE the failure cascade started. The request IDs in the SOFT_BLOCK logs start from `97408` at 13:06:40 and climb rapidly (to `97448+`), suggesting the bot was being rate-limited due to too many concurrent active sessions. The "jailbreak_pattern" signal likely comes from the code review system prompt which uses terms like "READ-ONLY mode" and "RESTRICTIONS" that pattern-match as jailbreak attempts.

**The thinking effort feature is a contributing factor** because it increases the number of LLM API calls per review (extended thinking generates multiple streaming requests) and the review prompts with thinking effort may be longer, further triggering the `jailbreak_pattern` signal. This pushes the bot over the abuse threshold.
