### PR TITLE
fix: Fix code reviewer running out of space

### DIFF
--- a/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -22,7 +22,7 @@ import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { codeReviewWorkerClient } from '../client/code-review-worker-client';
 import type { CodeReviewPlatform } from '../core/schemas';
 
-const MAX_CONCURRENT_REVIEWS_PER_OWNER = 20;
+const MAX_CONCURRENT_REVIEWS_PER_OWNER = 10;
 
 export interface DispatchResult {
   dispatched: number;


### PR DESCRIPTION
## Architecture for the PR review flow

There are **no BullMQ, Inngest, SQS, Cloudflare Queues, or any external message queue** in this flow. The "queue" is the `cloud_agent_code_reviews` Postgres table with a `status` column:

### Flow

```
GitHub webhook → Next.js API route (sync)
  → Creates DB row: status='pending'
  → tryDispatchPendingReviews(owner)
      → Counts active reviews (status 'queued' or 'running') in Postgres
      → Picks up to (20 - activeCount) pending reviews (FIFO by created_at)
      → For each: HTTP POST to Cloudflare Worker → Durable Object
          → DO.runReview() → fetch cloud-agent-next/trpc/prepareSession
```

### Concurrency Control

- **`MAX_CONCURRENT_REVIEWS_PER_OWNER = 20`** — enforced by counting `queued` + `running` rows per owner in Postgres
- Dispatch within a single call is **sequential** (`for...await` loop), but execution is **parallel** — each review runs in its own Cloudflare Durable Object (`CodeReviewOrchestrator`)
- When a review completes, its status callback endpoint (`/api/internal/code-review-status/{reviewId}`) calls `tryDispatchPendingReviews()` again to drain the next pending item

With up to **20 concurrent reviews** per owner, and all bot reviews for org `....` funneling into a **single sandbox container** (because they share the same `bot-code-review-{orgId}` userId + `"reviewer"` botId → same deterministic sandbox hash), you can have 20 simultaneous git clones of potentially large repos on the same ~4GB disk. That's why the disk fills up and you see cascading failures.

## Workspace directories are never cleaned up after a review ends.

| Event | Workspace dirs cleaned? |
|---|---|
| Execution completes (success or failure) | ❌ No |
| Execution times out / stale heartbeat | ❌ No |
| Code review DO 7-day cleanup alarm | ❌ No (only deletes DO storage, not filesystem) |
| 90-day session inactivity alarm | ❌ No (only deletes DO storage, not filesystem) |
| User explicitly calls `deleteSession` API | ✅ Yes |
| Sandbox retry between failed attempts | ✅ Yes |
| Cloudflare evicts the container | ✅ Implicitly (ephemeral filesystem gone) |

A `cleanupWorkspace` function exists in `cloud-agent-next/src/workspace.ts` that does `rm -rf` on the workspace and home dirs, but it's only wired up for explicit `deleteSession` calls and sandbox retry cleanup — never called after an execution finishes.

This is the root cause of the disk exhaustion. Sessions accumulate directories like `/workspace/{orgId}/{userId}/sessions/{sessionId}/` with full repo clones, and they're never removed. With all bot reviews for one org sharing a single container, the disk fills up after a few reviews of large repos.
