### PR TITLE
CloudAgentNext - Clean Up Stale Workspaces When Disk Space Is Low

### DIFF
--- a/cloud-agent-next/src/kilo/wrapper-manager.ts
+++ b/cloud-agent-next/src/kilo/wrapper-manager.ts
@@ -73,18 +73,14 @@ export function extractWrapperSessionIdFromCommand(command: string): string | nu
 }
 
 /**
- * Find an existing wrapper for the given session.
- * Scans listProcesses() for a command containing "--agent-session {sessionId}".
- *
- * @param sandbox - The sandbox instance to search in
- * @param sessionId - The cloud-agent session ID to find
- * @returns Wrapper info if found, null otherwise
+ * Find a wrapper for the given session in a pre-fetched process list.
+ * Useful when the caller already has the process list (e.g. to avoid
+ * repeated listProcesses() calls in a loop).
  */
-export async function findWrapperForSession(
-  sandbox: SandboxInstance,
+export function findWrapperForSessionInProcesses(
+  processes: Process[],
   sessionId: string
-): Promise<WrapperInfo | null> {
-  const processes = await sandbox.listProcesses();
+): WrapperInfo | null {
   const marker = `${KILO_WRAPPER_SESSION_FLAG} ${sessionId}`;
 
   for (const proc of processes) {
@@ -103,6 +99,22 @@ export async function findWrapperForSession(
   }
 
   return null;
+}
+
+/**
+ * Find an existing wrapper for the given session.
+ * Scans listProcesses() for a command containing "--agent-session {sessionId}".
+ *
+ * @param sandbox - The sandbox instance to search in
+ * @param sessionId - The cloud-agent session ID to find
+ * @returns Wrapper info if found, null otherwise
+ */
+export async function findWrapperForSession(
+  sandbox: SandboxInstance,
+  sessionId: string
+): Promise<WrapperInfo | null> {
+  const processes = await sandbox.listProcesses();
+  return findWrapperForSessionInProcesses(processes, sessionId);
 }
 
 /**

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -10,9 +10,11 @@ import type { ExecutionParams as _ExecutionParams } from './schema.js';
 import { generateSandboxId } from './sandbox-id.js';
 import {
   checkDiskSpace,
+  cleanupStaleWorkspaces,
   cloneGitHubRepo,
   cloneGitRepo,
   cleanupWorkspace,
+  getBaseWorkspacePath,
   getSessionHomePath,
   getSessionWorkspacePath,
   manageBranch,
@@ -827,8 +829,16 @@ export class SessionService {
       mcpServers
     );
 
-    // Check disk space before clone for observability (logs warning if low)
-    await checkDiskSpace(session);
+    // Check disk space before clone; clean up stale workspaces if low
+    const diskSpace = await checkDiskSpace(session);
+    if (diskSpace.isLow) {
+      await cleanupStaleWorkspaces(
+        session,
+        sandbox,
+        getBaseWorkspacePath(orgId, userId),
+        sessionId
+      );
+    }
 
     // Clone repository using appropriate method
     // Shallow clone (depth: 1) can be enabled for faster checkout and reduced disk usage
@@ -1070,8 +1080,16 @@ export class SessionService {
       mcpServers
     );
 
-    // Check disk space before clone for observability (logs warning if low)
-    await checkDiskSpace(session);
+    // Check disk space before clone; clean up stale workspaces if low
+    const diskSpace = await checkDiskSpace(session);
+    if (diskSpace.isLow) {
+      await cleanupStaleWorkspaces(
+        session,
+        sandbox,
+        getBaseWorkspacePath(orgId, userId),
+        sessionId
+      );
+    }
 
     // Clone repository using appropriate method
     if (gitUrl) {
@@ -1254,8 +1272,16 @@ export class SessionService {
     const repoExists = repoCheck.stdout?.includes('exists') ?? false;
     const isColdStart = !repoExists;
 
-    // Check disk space for observability (logs warning if low)
-    await checkDiskSpace(session);
+    // Check disk space; clean up stale workspaces if low
+    const diskSpace = await checkDiskSpace(session);
+    if (diskSpace.isLow) {
+      await cleanupStaleWorkspaces(
+        session,
+        sandbox,
+        getBaseWorkspacePath(orgId, userId),
+        sessionId
+      );
+    }
 
     // Only re-run setup if we had to reclone (cold start)
     if (isColdStart) {

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -830,15 +830,7 @@ export class SessionService {
     );
 
     // Check disk space before clone; clean up stale workspaces if low
-    const diskSpace = await checkDiskSpace(session);
-    if (diskSpace.isLow) {
-      await cleanupStaleWorkspaces(
-        session,
-        sandbox,
-        getBaseWorkspacePath(orgId, userId),
-        sessionId
-      );
-    }
+    await SessionService.checkDiskAndCleanIfLow(session, sandbox, orgId, userId, sessionId);
 
     // Clone repository using appropriate method
     // Shallow clone (depth: 1) can be enabled for faster checkout and reduced disk usage
@@ -1081,15 +1073,7 @@ export class SessionService {
     );
 
     // Check disk space before clone; clean up stale workspaces if low
-    const diskSpace = await checkDiskSpace(session);
-    if (diskSpace.isLow) {
-      await cleanupStaleWorkspaces(
-        session,
-        sandbox,
-        getBaseWorkspacePath(orgId, userId),
-        sessionId
-      );
-    }
+    await SessionService.checkDiskAndCleanIfLow(session, sandbox, orgId, userId, sessionId);
 
     // Clone repository using appropriate method
     if (gitUrl) {
@@ -1273,15 +1257,7 @@ export class SessionService {
     const isColdStart = !repoExists;
 
     // Check disk space; clean up stale workspaces if low
-    const diskSpace = await checkDiskSpace(session);
-    if (diskSpace.isLow) {
-      await cleanupStaleWorkspaces(
-        session,
-        sandbox,
-        getBaseWorkspacePath(orgId, userId),
-        sessionId
-      );
-    }
+    await SessionService.checkDiskAndCleanIfLow(session, sandbox, orgId, userId, sessionId);
 
     // Only re-run setup if we had to reclone (cold start)
     if (isColdStart) {
@@ -1383,6 +1359,24 @@ export class SessionService {
       return SessionService.interruptWithPkill(session, sessionContext, executionId);
     }
     return SessionService.interruptWithSandboxApi(sandbox, session, sessionContext);
+  }
+
+  private static async checkDiskAndCleanIfLow(
+    session: ExecutionSession,
+    sandbox: SandboxInstance,
+    orgId: string | undefined,
+    userId: string,
+    sessionId: string
+  ): Promise<void> {
+    const diskSpace = await checkDiskSpace(session);
+    if (diskSpace.isLow) {
+      await cleanupStaleWorkspaces(
+        session,
+        sandbox,
+        getBaseWorkspacePath(orgId, userId),
+        sessionId
+      );
+    }
   }
 
   /**

--- a/cloud-agent-next/src/workspace.test.ts
+++ b/cloud-agent-next/src/workspace.test.ts
@@ -5,10 +5,11 @@ import {
   cloneGitRepo,
   updateGitRemoteToken,
   checkDiskSpace,
+  cleanupStaleWorkspaces,
   createSandboxUsageEvent,
   LOW_DISK_THRESHOLD_MB,
 } from './workspace';
-import type { ExecutionSession } from './types';
+import type { ExecutionSession, SandboxInstance } from './types';
 
 describe('manageBranch', () => {
   let fakeSession: ExecutionSession;
@@ -302,6 +303,7 @@ describe('disk space checking', () => {
       expect(result).toBeDefined();
       expect(result.availableMB).toBe(1024);
       expect(result.totalMB).toBe(10000);
+      expect(result.isLow).toBe(true);
     });
 
     it('should return DiskSpaceResult with adequate disk space', async () => {
@@ -317,6 +319,7 @@ describe('disk space checking', () => {
       expect(result).toBeDefined();
       expect(result.availableMB).toBe(5000);
       expect(result.totalMB).toBe(10000);
+      expect(result.isLow).toBe(false);
     });
 
     it('should throw when df command fails', async () => {
@@ -562,6 +565,204 @@ describe('disk space checking', () => {
   describe('LOW_DISK_THRESHOLD_MB export', () => {
     it('should export threshold constant as 2048 (2GB)', () => {
       expect(LOW_DISK_THRESHOLD_MB).toBe(2048);
+    });
+  });
+
+  describe('cleanupStaleWorkspaces', () => {
+    let fakeSandbox: SandboxInstance;
+    let mockListProcesses: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockListProcesses = vi.fn();
+      fakeSandbox = {
+        listProcesses: mockListProcesses,
+      } as unknown as SandboxInstance;
+    });
+
+    it('cleans up sessions with no running wrapper', async () => {
+      mockExec
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'agent_stale-1111\nagent_current-aaaa\n',
+          stderr: '',
+        }) // ls sessions/
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm -rf workspace for stale session
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // rm -rf home for stale session
+
+      mockListProcesses.mockResolvedValue([]);
+
+      await cleanupStaleWorkspaces(
+        fakeSession,
+        fakeSandbox,
+        '/workspace/org/user',
+        'agent_current-aaaa'
+      );
+
+      const execCalls = mockExec.mock.calls.map(c => c[0] as string);
+      expect(execCalls[1]).toContain("rm -rf '/workspace/org/user/sessions/agent_stale-1111'");
+      expect(execCalls[2]).toContain("rm -rf '/home/agent_stale-1111'");
+    });
+
+    it('skips the current session directory', async () => {
+      mockExec.mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'agent_current-aaaa\n',
+        stderr: '',
+      });
+
+      mockListProcesses.mockResolvedValue([]);
+
+      await cleanupStaleWorkspaces(
+        fakeSession,
+        fakeSandbox,
+        '/workspace/org/user',
+        'agent_current-aaaa'
+      );
+
+      // Only the ls call — no rm calls
+      expect(mockExec).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips sessions that have a running wrapper', async () => {
+      mockExec.mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'agent_active-bbbb\n',
+        stderr: '',
+      });
+
+      mockListProcesses.mockResolvedValue([
+        {
+          id: 1,
+          command: 'kilocode-wrapper --agent-session agent_active-bbbb WRAPPER_PORT=5001',
+          status: 'running',
+        },
+      ]);
+
+      await cleanupStaleWorkspaces(
+        fakeSession,
+        fakeSandbox,
+        '/workspace/org/user',
+        'agent_current-aaaa'
+      );
+
+      // Only the ls call — no rm calls
+      expect(mockExec).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns early when sessions directory does not exist', async () => {
+      mockExec.mockResolvedValueOnce({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'No such file or directory',
+      });
+
+      await cleanupStaleWorkspaces(
+        fakeSession,
+        fakeSandbox,
+        '/workspace/org/user',
+        'agent_current-aaaa'
+      );
+
+      expect(mockExec).toHaveBeenCalledTimes(1);
+      expect(mockListProcesses).not.toHaveBeenCalled();
+    });
+
+    it('returns early when sessions directory is empty', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+      await cleanupStaleWorkspaces(
+        fakeSession,
+        fakeSandbox,
+        '/workspace/org/user',
+        'agent_current-aaaa'
+      );
+
+      expect(mockExec).toHaveBeenCalledTimes(1);
+      expect(mockListProcesses).not.toHaveBeenCalled();
+    });
+
+    it('continues cleaning remaining sessions when one throws', async () => {
+      mockExec
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'agent_stale-aaaa\nagent_stale-bbbb\n',
+          stderr: '',
+        }) // ls
+        .mockRejectedValueOnce(new Error('exec threw during agent_stale-aaaa cleanup')) // throws during first session
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm workspace agent_stale-bbbb
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // rm home agent_stale-bbbb
+
+      mockListProcesses.mockResolvedValue([]);
+
+      // Should not throw
+      await expect(
+        cleanupStaleWorkspaces(
+          fakeSession,
+          fakeSandbox,
+          '/workspace/org/user',
+          'agent_current-aaaa'
+        )
+      ).resolves.toBeUndefined();
+
+      // second session was still attempted despite first throwing
+      const execCalls = mockExec.mock.calls.map(c => c[0] as string);
+      expect(execCalls.some(c => c.includes('agent_stale-bbbb'))).toBe(true);
+    });
+
+    it('does not throw when listProcesses rejects', async () => {
+      mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: 'agent_stale-1111\n', stderr: '' });
+      mockListProcesses.mockRejectedValue(new Error('sandbox unavailable'));
+
+      // Should not throw
+      await expect(
+        cleanupStaleWorkspaces(
+          fakeSession,
+          fakeSandbox,
+          '/workspace/org/user',
+          'agent_current-aaaa'
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not throw when ls throws', async () => {
+      mockExec.mockRejectedValueOnce(new Error('exec error'));
+
+      await expect(
+        cleanupStaleWorkspaces(
+          fakeSession,
+          fakeSandbox,
+          '/workspace/org/user',
+          'agent_current-aaaa'
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('skips directory entries that do not match the agent_ session ID format', async () => {
+      mockExec
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'unexpected-dir\n.hidden\nlost+found\nagent_valid-1234\n',
+          stderr: '',
+        }) // ls
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // rm workspace agent_valid-1234
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // rm home agent_valid-1234
+
+      mockListProcesses.mockResolvedValue([]);
+
+      await cleanupStaleWorkspaces(
+        fakeSession,
+        fakeSandbox,
+        '/workspace/org/user',
+        'agent_current-aaaa'
+      );
+
+      const execCalls = mockExec.mock.calls.map(c => c[0] as string);
+      // Non-matching entries never appear in any exec call after the ls
+      expect(execCalls.every(c => !c.includes('unexpected-dir'))).toBe(true);
+      expect(execCalls.every(c => !c.includes('.hidden'))).toBe(true);
+      expect(execCalls.every(c => !c.includes('lost+found'))).toBe(true);
+      // The valid session was cleaned up
+      expect(execCalls.some(c => c.includes('agent_valid-1234'))).toBe(true);
     });
   });
 });

--- a/cloud-agent-next/src/workspace.test.ts
+++ b/cloud-agent-next/src/workspace.test.ts
@@ -598,6 +598,9 @@ describe('disk space checking', () => {
         'agent_current-aaaa'
       );
 
+      // listProcesses is called exactly once (not per session)
+      expect(mockListProcesses).toHaveBeenCalledTimes(1);
+
       const execCalls = mockExec.mock.calls.map(c => c[0] as string);
       expect(execCalls[1]).toContain("rm -rf '/workspace/org/user/sessions/agent_stale-1111'");
       expect(execCalls[2]).toContain("rm -rf '/home/agent_stale-1111'");
@@ -704,6 +707,9 @@ describe('disk space checking', () => {
         )
       ).resolves.toBeUndefined();
 
+      // listProcesses is called exactly once (not per session)
+      expect(mockListProcesses).toHaveBeenCalledTimes(1);
+
       // second session was still attempted despite first throwing
       const execCalls = mockExec.mock.calls.map(c => c[0] as string);
       expect(execCalls.some(c => c.includes('agent_stale-bbbb'))).toBe(true);
@@ -713,7 +719,7 @@ describe('disk space checking', () => {
       mockExec.mockResolvedValueOnce({ exitCode: 0, stdout: 'agent_stale-1111\n', stderr: '' });
       mockListProcesses.mockRejectedValue(new Error('sandbox unavailable'));
 
-      // Should not throw
+      // Should not throw — returns early without cleaning any sessions
       await expect(
         cleanupStaleWorkspaces(
           fakeSession,
@@ -722,6 +728,9 @@ describe('disk space checking', () => {
           'agent_current-aaaa'
         )
       ).resolves.toBeUndefined();
+
+      // Only the ls call — no rm calls since listProcesses failed
+      expect(mockExec).toHaveBeenCalledTimes(1);
     });
 
     it('does not throw when ls throws', async () => {

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -1,5 +1,6 @@
 import type { SandboxInstance, ExecutionSession, SystemSandboxUsageEvent } from './types.js';
 import { logger } from './logger.js';
+import { findWrapperForSession } from './kilo/wrapper-manager.js';
 import { withTimeout } from '@kilocode/worker-utils';
 
 /**
@@ -157,6 +158,92 @@ export async function cleanupWorkspace(
   }
 }
 
+/**
+ * Clean up workspace directories for sessions that no longer have a running wrapper.
+ * Called when disk space is low to reclaim space from abandoned sessions.
+ * Errors are caught and logged — never rethrown — so cleanup failure never blocks setup.
+ */
+export async function cleanupStaleWorkspaces(
+  session: ExecutionSession,
+  sandbox: SandboxInstance,
+  baseWorkspacePath: string,
+  currentSessionId: string
+): Promise<void> {
+  logger
+    .withFields({ baseWorkspacePath, currentSessionId })
+    .info('Starting stale workspace cleanup');
+
+  let sessionDirs: string[];
+  try {
+    const lsResult = await session.exec(`ls -1 '${baseWorkspacePath}/sessions/'`);
+    if (lsResult.exitCode !== 0 || !lsResult.stdout) {
+      logger
+        .withFields({ stderr: lsResult.stderr })
+        .info('No sessions directory or listing failed, skipping cleanup');
+      return;
+    }
+    sessionDirs = lsResult.stdout
+      .trim()
+      .split('\n')
+      .map(d => d.trim())
+      .filter(Boolean);
+  } catch (error) {
+    logger
+      .withFields({ error: error instanceof Error ? error.message : String(error) })
+      .warn('Failed to list sessions directory, skipping cleanup');
+    return;
+  }
+
+  logger.withFields({ found: sessionDirs.length }).info('Found session directories');
+
+  let cleaned = 0;
+  let skipped = 0;
+
+  for (const candidateSessionId of sessionDirs) {
+    if (candidateSessionId === currentSessionId) {
+      skipped++;
+      continue;
+    }
+
+    // Only process entries that look like session IDs (agent_<uuid>) to guard
+    // against unexpected directory names breaking the rm -rf shell commands.
+    if (!/^agent_[\w-]+$/.test(candidateSessionId)) {
+      logger
+        .withFields({ candidateSessionId })
+        .warn('Skipping unexpected sessions directory entry');
+      skipped++;
+      continue;
+    }
+
+    try {
+      const wrapperInfo = await findWrapperForSession(sandbox, candidateSessionId);
+      if (wrapperInfo !== null) {
+        logger.withFields({ candidateSessionId }).info('Skipping session: wrapper is running');
+        skipped++;
+        continue;
+      }
+
+      const workspacePath = `${baseWorkspacePath}/sessions/${candidateSessionId}`;
+      const sessionHome = getSessionHomePath(candidateSessionId);
+      logger
+        .withFields({ candidateSessionId, workspacePath, sessionHome })
+        .info('Removing stale session directories');
+
+      await cleanupWorkspace(session, workspacePath, sessionHome);
+      cleaned++;
+    } catch (error) {
+      logger
+        .withFields({
+          candidateSessionId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .warn('Error while cleaning up stale session, continuing');
+    }
+  }
+
+  logger.withFields({ cleaned, skipped }).info('Stale workspace cleanup complete');
+}
+
 export type GitAuthorConfig = {
   name: string;
   email: string;
@@ -170,6 +257,7 @@ export const LOW_DISK_THRESHOLD_MB = 2048; // 2GB
 export type DiskSpaceResult = {
   availableMB: number;
   totalMB: number;
+  isLow: boolean;
 };
 
 /**
@@ -222,6 +310,7 @@ export async function checkDiskSpace(session: ExecutionSession): Promise<DiskSpa
   return {
     availableMB,
     totalMB,
+    isLow,
   };
 }
 

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -1,6 +1,6 @@
 import type { SandboxInstance, ExecutionSession, SystemSandboxUsageEvent } from './types.js';
 import { logger } from './logger.js';
-import { findWrapperForSession } from './kilo/wrapper-manager.js';
+import { findWrapperForSessionInProcesses } from './kilo/wrapper-manager.js';
 import { withTimeout } from '@kilocode/worker-utils';
 
 /**
@@ -196,6 +196,17 @@ export async function cleanupStaleWorkspaces(
 
   logger.withFields({ found: sessionDirs.length }).info('Found session directories');
 
+  // Fetch the process list once so we don't call listProcesses() per session
+  let processes: Awaited<ReturnType<SandboxInstance['listProcesses']>>;
+  try {
+    processes = await sandbox.listProcesses();
+  } catch (error) {
+    logger
+      .withFields({ error: error instanceof Error ? error.message : String(error) })
+      .warn('Failed to list processes, skipping cleanup');
+    return;
+  }
+
   let cleaned = 0;
   let skipped = 0;
 
@@ -206,7 +217,7 @@ export async function cleanupStaleWorkspaces(
     }
 
     try {
-      const wrapperInfo = await findWrapperForSession(sandbox, candidateSessionId);
+      const wrapperInfo = findWrapperForSessionInProcesses(processes, candidateSessionId);
       if (wrapperInfo !== null) {
         logger.withFields({ candidateSessionId }).info('Skipping session: wrapper is running');
         skipped++;

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -186,7 +186,7 @@ export async function cleanupStaleWorkspaces(
       .trim()
       .split('\n')
       .map(d => d.trim())
-      .filter(Boolean);
+      .filter(d => /^agent_[\w-]+$/.test(d));
   } catch (error) {
     logger
       .withFields({ error: error instanceof Error ? error.message : String(error) })
@@ -201,16 +201,6 @@ export async function cleanupStaleWorkspaces(
 
   for (const candidateSessionId of sessionDirs) {
     if (candidateSessionId === currentSessionId) {
-      skipped++;
-      continue;
-    }
-
-    // Only process entries that look like session IDs (agent_<uuid>) to guard
-    // against unexpected directory names breaking the rm -rf shell commands.
-    if (!/^agent_[\w-]+$/.test(candidateSessionId)) {
-      logger
-        .withFields({ candidateSessionId })
-        .warn('Skipping unexpected sessions directory entry');
       skipped++;
       continue;
     }


### PR DESCRIPTION
## Summary

When a sandbox container reports low disk space during `initiate`, `initiateFromKiloSession`, or `resume`, scan the sibling session directories and delete any whose wrapper process is no longer running.

- Added `cleanupStaleWorkspaces()` to `workspace.ts`: lists `sessions/` directories, skips the current session and any with a running wrapper (via `findWrapperForSession`), and calls `cleanupWorkspace()` on the rest. Errors per session are caught and logged — never rethrown — so cleanup never blocks setup.
- Only directory entries matching `^agent_[\w-]+$` are processed, guarding against unexpected names that could break the `rm -rf '...'` shell commands.
- `DiskSpaceResult` now includes `isLow` so callers don't need to re-derive the threshold.
- All three call sites in `session-service.ts` (`initiate`, `initiateFromKiloSession`, `resume`) updated to trigger cleanup when `diskSpace.isLow`.
- Full unit test coverage: happy path, current-session skip, active-wrapper skip, empty/missing directory, per-session error resilience, format guard, and `ls`/`listProcesses` failure cases.