### PR TITLE
feat: gate org auto top-up UI behind posthog feature flag

### DIFF
--- a/src/app/(app)/organizations/[id]/page.tsx
+++ b/src/app/(app)/organizations/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { OrganizationDashboard } from '@/components/organizations/OrganizationDashboard';
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
 import { TOPUP_AMOUNT_QUERY_STRING_KEY } from '@/lib/organizations/constants';
+import { isOrgAutoTopUpFeatureEnabled } from '@/lib/organizations/organization-auto-top-up';
 
 export default async function OrganizationByIdPage({
   params,
@@ -9,8 +10,11 @@ export default async function OrganizationByIdPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<Record<string, string>>;
 }) {
+  const { id: organizationId } = await params;
   const search = new URLSearchParams(await searchParams);
   const topupAmount = Number.parseFloat(search.get(TOPUP_AMOUNT_QUERY_STRING_KEY) || '0') || 0;
+  const isAutoTopUpEnabled = await isOrgAutoTopUpFeatureEnabled(organizationId);
+
   return (
     <OrganizationByPageLayout
       params={params}
@@ -19,6 +23,7 @@ export default async function OrganizationByIdPage({
           organizationId={organization.id}
           role={role}
           topupAmount={topupAmount}
+          isAutoTopUpEnabled={isAutoTopUpEnabled}
         />
       )}
     />

--- a/src/app/(app)/organizations/[id]/payment-details/page.tsx
+++ b/src/app/(app)/organizations/[id]/payment-details/page.tsx
@@ -1,16 +1,24 @@
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
 import { OrganizationPaymentDetails } from '@/components/organizations/OrganizationPaymentDetails';
+import { isOrgAutoTopUpFeatureEnabled } from '@/lib/organizations/organization-auto-top-up';
 
 export default async function OrganizationPaymentDetailsPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const { id: organizationId } = await params;
+  const isAutoTopUpEnabled = await isOrgAutoTopUpFeatureEnabled(organizationId);
+
   return (
     <OrganizationByPageLayout
       params={params}
       render={({ role, organization }) => (
-        <OrganizationPaymentDetails organizationId={organization.id} role={role} />
+        <OrganizationPaymentDetails
+          organizationId={organization.id}
+          role={role}
+          isAutoTopUpEnabled={isAutoTopUpEnabled}
+        />
       )}
     />
   );

--- a/src/components/organizations/OrganizationContext.tsx
+++ b/src/components/organizations/OrganizationContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext } from 'react';
 type OrganizationContextType = {
   userRole: OrganizationRole;
   isKiloAdmin?: boolean; // Optional, can be used to indicate if the user is a Kilo admin
+  isAutoTopUpEnabled?: boolean;
 };
 
 const OrganizationContext = createContext<OrganizationContextType>({
@@ -21,4 +22,9 @@ export const useUserOrganizationRole = (): OrganizationRole => {
 export const useIsKiloAdmin = (): boolean => {
   const context = useContext(OrganizationContext);
   return context?.isKiloAdmin || false; // Fallback to false if context is not available
+};
+
+export const useIsAutoTopUpEnabled = (): boolean => {
+  const context = useContext(OrganizationContext);
+  return context?.isAutoTopUpEnabled || false;
 };

--- a/src/components/organizations/OrganizationContextWrapper.tsx
+++ b/src/components/organizations/OrganizationContextWrapper.tsx
@@ -10,11 +10,13 @@ import type { OrganizationMember } from '@/lib/organizations/organization-types'
 type OrganizationContextWrapperProps = {
   organizationId: string;
   children: ReactNode;
+  isAutoTopUpEnabled?: boolean;
 };
 
 export function OrganizationAdminContextProvider({
   organizationId,
   children,
+  isAutoTopUpEnabled,
 }: OrganizationContextWrapperProps) {
   const { data: organizationData } = useOrganizationWithMembers(organizationId);
   const { assumedRole } = useRoleTesting();
@@ -32,7 +34,7 @@ export function OrganizationAdminContextProvider({
   const isKiloAdmin = assumedRole === 'KILO ADMIN' || session?.data?.isAdmin || false;
 
   return (
-    <OrganizationContextProvider value={{ userRole: currentRole, isKiloAdmin }}>
+    <OrganizationContextProvider value={{ userRole: currentRole, isKiloAdmin, isAutoTopUpEnabled }}>
       {children}
     </OrganizationContextProvider>
   );

--- a/src/components/organizations/OrganizationDashboard.tsx
+++ b/src/components/organizations/OrganizationDashboard.tsx
@@ -51,9 +51,15 @@ type Props = {
   organizationId: string;
   role: OrganizationRole;
   topupAmount: number;
+  isAutoTopUpEnabled: boolean;
 };
 
-export function OrganizationDashboard({ organizationId, role, topupAmount }: Props) {
+export function OrganizationDashboard({
+  organizationId,
+  role,
+  topupAmount,
+  isAutoTopUpEnabled,
+}: Props) {
   const [showWelcomeMessage, setShowWelcomeMessage] = useState(false);
   const [showNewOrgWelcome, setShowNewOrgWelcome] = useState(false);
   const [showTopupSuccess, setShowTopupSuccess] = useState(topupAmount !== 0);
@@ -98,7 +104,10 @@ export function OrganizationDashboard({ organizationId, role, topupAmount }: Pro
   };
 
   return (
-    <OrganizationAdminContextProvider organizationId={organizationId}>
+    <OrganizationAdminContextProvider
+      organizationId={organizationId}
+      isAutoTopUpEnabled={isAutoTopUpEnabled}
+    >
       <div className="flex w-full flex-col gap-y-6">
         <OrganizationPageHeader
           organizationId={organizationId}

--- a/src/components/organizations/OrganizationInfoCard.tsx
+++ b/src/components/organizations/OrganizationInfoCard.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import {
   useIsKiloAdmin,
+  useIsAutoTopUpEnabled,
   useUserOrganizationRole,
 } from '@/components/organizations/OrganizationContext';
 import BuyOrganizationCreditsDialog from '@/components/payment/BuyOrganizationCreditsDialog';
@@ -178,6 +179,7 @@ function Inner(props: InnerProps) {
   };
 
   const isKiloAdmin = useIsKiloAdmin();
+  const isAutoTopUpEnabled = useIsAutoTopUpEnabled();
   const isInAdminDashboard = isKiloAdmin && showAdminControls;
   const isOrgOwner = useCanManagePaymentInfo();
 
@@ -354,7 +356,7 @@ function Inner(props: InnerProps) {
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-              {auto_top_up_enabled && isKiloAdmin && (
+              {auto_top_up_enabled && isAutoTopUpEnabled && (
                 <Link
                   href={`/organizations/${id}/payment-details`}
                   className="text-muted-foreground hover:text-foreground text-sm hover:underline"

--- a/src/components/organizations/OrganizationPaymentDetails.tsx
+++ b/src/components/organizations/OrganizationPaymentDetails.tsx
@@ -22,9 +22,10 @@ import { useExpiringCredits } from './useExpiringCredits';
 type Props = {
   organizationId: string;
   role: OrganizationRole;
+  isAutoTopUpEnabled: boolean;
 };
 
-export function OrganizationPaymentDetails({ organizationId, role }: Props) {
+export function OrganizationPaymentDetails({ organizationId, role, isAutoTopUpEnabled }: Props) {
   const [timePeriod, setTimePeriod] = useState<TimePeriod>('year');
   const [isSpendingAlertsModalOpen, setIsSpendingAlertsModalOpen] = useState(false);
   const userRole = role;
@@ -34,7 +35,7 @@ export function OrganizationPaymentDetails({ organizationId, role }: Props) {
   const { expiringBlocks, expiring_mUsd, earliestExpiry } = useExpiringCredits(organizationId);
 
   return (
-    <OrganizationContextProvider value={{ userRole, isKiloAdmin }}>
+    <OrganizationContextProvider value={{ userRole, isKiloAdmin, isAutoTopUpEnabled }}>
       <div className="flex w-full flex-col gap-y-8">
         <OrganizationPageHeader
           organizationId={organizationId}
@@ -54,7 +55,7 @@ export function OrganizationPaymentDetails({ organizationId, role }: Props) {
         />
 
         {/* Buy Credits and Auto Top-Up Section */}
-        {isKiloAdmin && (
+        {isAutoTopUpEnabled && (
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {/* Buy Credits Card */}
             <Card>

--- a/src/components/organizations/OrganizationPaymentDetails.tsx
+++ b/src/components/organizations/OrganizationPaymentDetails.tsx
@@ -55,51 +55,49 @@ export function OrganizationPaymentDetails({ organizationId, role, isAutoTopUpEn
         />
 
         {/* Buy Credits and Auto Top-Up Section */}
-        {isAutoTopUpEnabled && (
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {/* Buy Credits Card */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <PiggyBank className="h-5 w-5" />
-                  Balance & Credits
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div>
-                  <span className="text-muted-foreground text-sm font-medium">
-                    Current Balance{' '}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <AnimatedDollars
-                      dollars={fromMicrodollars(
-                        (organizationData?.total_microdollars_acquired ?? 0) -
-                          (organizationData?.microdollars_used ?? 0)
-                      )}
-                      className="text-2xl font-semibold"
-                    />
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            onClick={() => setIsSpendingAlertsModalOpen(true)}
-                            className="hover:bg-muted inline-flex cursor-pointer items-center gap-1 rounded p-1 transition-all duration-200 focus:outline-none"
-                          >
-                            <Bell className="text-muted-foreground hover:text-foreground h-4 w-4" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Configure Low Balance Alert</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {/* Balance & Credits Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <PiggyBank className="h-5 w-5" />
+                Balance & Credits
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <span className="text-muted-foreground text-sm font-medium">Current Balance </span>
+                <div className="flex items-center gap-2">
+                  <AnimatedDollars
+                    dollars={fromMicrodollars(
+                      (organizationData?.total_microdollars_acquired ?? 0) -
+                        (organizationData?.microdollars_used ?? 0)
+                    )}
+                    className="text-2xl font-semibold"
+                  />
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={() => setIsSpendingAlertsModalOpen(true)}
+                          className="hover:bg-muted inline-flex cursor-pointer items-center gap-1 rounded p-1 transition-all duration-200 focus:outline-none"
+                        >
+                          <Bell className="text-muted-foreground hover:text-foreground h-4 w-4" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Configure Low Balance Alert</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
-                <CreditPurchaseOptions amounts={[100, 500, 1000]} organizationId={organizationId} />
-              </CardContent>
-            </Card>
+              </div>
+              <CreditPurchaseOptions amounts={[100, 500, 1000]} organizationId={organizationId} />
+            </CardContent>
+          </Card>
 
-            {/* Auto Top-Up Card */}
+          {/* Auto Top-Up Card */}
+          {isAutoTopUpEnabled && (
             <Card>
               <CardHeader>
                 <CardTitle>Automatic Top-Up</CardTitle>
@@ -108,8 +106,8 @@ export function OrganizationPaymentDetails({ organizationId, role, isAutoTopUpEn
                 <OrganizationAutoTopUpToggle organizationId={organizationId} />
               </CardContent>
             </Card>
-          </div>
-        )}
+          )}
+        </div>
 
         {expiringBlocks.length > 0 && earliestExpiry && (
           <Card>

--- a/src/components/payment/BuyOrganizationCreditsDialog.tsx
+++ b/src/components/payment/BuyOrganizationCreditsDialog.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import CreditPurchaseOptions from './CreditPurchaseOptions';
 import { OrganizationAutoTopUpToggle } from '@/components/organizations/OrganizationAutoTopUpToggle';
 import { RefreshCw } from 'lucide-react';
-import { useIsKiloAdmin } from '@/components/organizations/OrganizationContext';
+import { useIsAutoTopUpEnabled } from '@/components/organizations/OrganizationContext';
 
 type BuyOrganizationCreditsDialogProps = {
   organizationId: string;
@@ -23,7 +23,7 @@ export default function BuyOrganizationCreditsDialog({
   amounts = DEFAULT_ORG_AMOUNTS,
 }: BuyOrganizationCreditsDialogProps) {
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false);
-  const isKiloAdmin = useIsKiloAdmin();
+  const isAutoTopUpEnabled = useIsAutoTopUpEnabled();
 
   return (
     <>
@@ -39,7 +39,7 @@ export default function BuyOrganizationCreditsDialog({
           </DialogHeader>
           <div className="space-y-4">
             <CreditPurchaseOptions amounts={amounts} organizationId={organizationId} />
-            {isKiloAdmin && (
+            {isAutoTopUpEnabled && (
               <Card>
                 <CardHeader className="pb-3">
                   <CardTitle className="flex items-center gap-2 text-base font-semibold">

--- a/src/lib/organizations/organization-auto-top-up.ts
+++ b/src/lib/organizations/organization-auto-top-up.ts
@@ -5,6 +5,14 @@ import {
   ORG_AUTO_TOP_UP_THRESHOLD_DOLLARS,
   DEFAULT_ORG_AUTO_TOP_UP_AMOUNT_CENTS,
 } from '@/lib/autoTopUpConstants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+
+export async function isOrgAutoTopUpFeatureEnabled(organizationId: string): Promise<boolean> {
+  return (
+    process.env.NODE_ENV === 'development' ||
+    (await isFeatureFlagEnabled('org-auto-topup', organizationId))
+  );
+}
 
 /**
  * Creates a Stripe checkout session for organization auto-top-up setup.


### PR DESCRIPTION
## Summary

Replace the `isKiloAdmin` gate on organization auto top-up UI with a PostHog feature flag (`org-auto-topup`), evaluated server-side per organization ID. This allows controlled rollout to specific organizations rather than restricting the feature to Kilo admins only.

- Add `isOrgAutoTopUpFeatureEnabled(organizationId)` helper in `organization-auto-top-up.ts` that checks the flag (always enabled in dev)
- Thread the flag result from server pages through `OrganizationContext` via a new `useIsAutoTopUpEnabled` hook
- Replace `isKiloAdmin` guards with the feature flag in: org dashboard page, payment details page, buy credits dialog, and org info card
- No backend changes — `organizationOwnerProcedure` already provides correct authorization for org owners/billing managers

## Visual Changes

N/A — no visual changes; the same UI elements are shown/hidden, just controlled by a feature flag instead of admin status.

## Reviewer Notes

- The flag is evaluated using `organizationId` as the PostHog `distinctId`, following the existing `auto-triage-feature` pattern. To enable for a specific org, target its UUID in PostHog's flag rules.
- The admin dashboard (`OrganizationAdminDashboard`) does not pass `isAutoTopUpEnabled` into context, so the auto-topup badge won't appear there. This is intentional — that dashboard has its own richer admin controls via `showAdminControls`.
- Kilo admins no longer bypass the gate — if you want an admin to see auto top-up for an org, enable the flag for that org in PostHog.