### PR TITLE
fix(kiloclaw): recover stuck destroy when machine id is missing

### DIFF
--- a/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -1,0 +1,53 @@
+import { z, type ZodType } from 'zod';
+
+export type GatewayProcessStatus = {
+  state: 'stopped' | 'starting' | 'running' | 'stopping' | 'crashed' | 'shutting_down';
+  pid: number | null;
+  uptime: number;
+  restarts: number;
+  lastExit: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    at: string;
+  } | null;
+};
+
+export const GatewayProcessStatusSchema: ZodType<GatewayProcessStatus> = z.object({
+  state: z.enum(['stopped', 'starting', 'running', 'stopping', 'crashed', 'shutting_down']),
+  pid: z.number().int().nullable(),
+  uptime: z.number(),
+  restarts: z.number().int(),
+  lastExit: z
+    .object({
+      code: z.number().int().nullable(),
+      signal: z
+        .custom<NodeJS.Signals>((value): value is NodeJS.Signals => typeof value === 'string')
+        .nullable(),
+      at: z.string(),
+    })
+    .nullable(),
+});
+
+export const GatewayCommandResponseSchema = z.object({
+  ok: z.boolean(),
+});
+
+export const ConfigRestoreResponseSchema = z.object({
+  ok: z.boolean(),
+  signaled: z.boolean(),
+});
+
+export const ControllerVersionResponseSchema = z.object({
+  version: z.string(),
+  commit: z.string(),
+});
+
+export class GatewayControllerError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'GatewayControllerError';
+    this.status = status;
+  }
+}

--- a/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -20,7 +20,7 @@ import type { KiloClawEnv } from '../types';
 import * as apps from '../fly/apps';
 import { setAppSecret } from '../fly/secrets';
 import { generateEnvKey } from '../utils/env-encryption';
-import { METADATA_KEY_USER_ID } from './kiloclaw-instance';
+import { METADATA_KEY_USER_ID } from './machine-config';
 
 // -- Persisted state schema --
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -346,6 +346,318 @@ describe('two-phase destroy', () => {
   });
 });
 
+describe('destroy: recover bound machine from volume', () => {
+  // Recovery tests use hex machine IDs matching real Fly format (MACHINE_ID_RE = /^[a-z0-9]+$/)
+  const recoveredMachineId = '3d8de100be4289';
+
+  it('recovers bound machine from volume and completes destroy in one alarm', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: recoveredMachineId,
+      state: 'attached',
+    });
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // Recovery populated pendingDestroyMachineId, then both deletes succeeded → finalized
+    expect(storage._store.size).toBe(0);
+    expect(storage._getAlarm()).toBeNull();
+  });
+
+  it('completes destroy over two alarms after machine recovery', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    // Alarm 1: getVolume returns attached machine, destroyMachine succeeds,
+    // but deleteVolume still fails (e.g. Fly needs a moment to unbind)
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: recoveredMachineId,
+      state: 'attached',
+    });
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockRejectedValue(
+      new FlyApiError('failed_precondition: volume is currently bound to machine', 412, '{}')
+    );
+
+    const { instance: inst1 } = createInstance(storage);
+    await inst1.alarm();
+
+    expect(storage._store.get('pendingDestroyMachineId')).toBeNull();
+    expect(storage._store.get('pendingDestroyVolumeId')).toBe('vol-1');
+    expect(storage._store.size).toBeGreaterThan(0);
+
+    // Alarm 2: volume delete succeeds. No recovery needed (machine already cleared).
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    const { instance: inst2 } = createInstance(storage);
+    await inst2.alarm();
+
+    expect(storage._store.size).toBe(0);
+    expect(storage._getAlarm()).toBeNull();
+  });
+
+  it('skips recovery when pendingDestroyMachineId already set', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: 'machine-1',
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: 'machine-1',
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // getVolume should NOT have been called (recovery skipped)
+    expect(flyClient.getVolume).not.toHaveBeenCalled();
+    expect(storage._store.size).toBe(0);
+  });
+
+  it('handles getVolume 404 during destroy recovery', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    // Volume already gone
+    (flyClient.getVolume as Mock).mockRejectedValue(new FlyApiError('not found', 404, '{}'));
+    // deleteVolume will also see 404 → treated as success
+    (flyClient.deleteVolume as Mock).mockRejectedValue(new FlyApiError('not found', 404, '{}'));
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // Both treated as gone → full cleanup
+    expect(storage._store.size).toBe(0);
+  });
+
+  it('handles getVolume transient error during destroy recovery', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    // Recovery fails with transient error
+    (flyClient.getVolume as Mock).mockRejectedValue(new FlyApiError('server error', 500, 'fail'));
+    // Volume delete also fails (machine still bound)
+    (flyClient.deleteVolume as Mock).mockRejectedValue(
+      new FlyApiError('failed_precondition: bound', 412, '{}')
+    );
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // Recovery failed, volume still pending → alarm rescheduled
+    expect(storage._store.get('pendingDestroyVolumeId')).toBe('vol-1');
+    expect(storage._store.get('pendingDestroyMachineId')).toBeNull();
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('ignores null attached_machine_id from getVolume', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    // Volume exists but no machine attached
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: null,
+      state: 'detached',
+    });
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // No machine recovered, but volume delete succeeded → finalized
+    expect(flyClient.destroyMachine).not.toHaveBeenCalled();
+    expect(storage._store.size).toBe(0);
+  });
+
+  it('persists flyMachineId alongside pendingDestroyMachineId on recovery', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: recoveredMachineId,
+      state: 'attached',
+    });
+    // Machine delete fails so we can inspect persisted state before finalization
+    (flyClient.destroyMachine as Mock).mockRejectedValue(
+      new FlyApiError('server error', 500, 'fail')
+    );
+    (flyClient.deleteVolume as Mock).mockRejectedValue(
+      new FlyApiError('failed_precondition', 412, '{}')
+    );
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    expect(flyClient.getVolume).toHaveBeenCalledTimes(1);
+    expect(flyClient.destroyMachine).toHaveBeenCalledTimes(1);
+    expect(storage._store.get('pendingDestroyMachineId')).toBe(recoveredMachineId);
+    expect(storage._store.get('flyMachineId')).toBe(recoveredMachineId);
+  });
+
+  it('respects bound machine recovery cooldown', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+      lastBoundMachineRecoveryAt: Date.now(), // just checked
+    });
+
+    // Volume delete still fails (machine bound)
+    (flyClient.deleteVolume as Mock).mockRejectedValue(
+      new FlyApiError('failed_precondition: bound', 412, '{}')
+    );
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // getVolume should NOT have been called — cooldown active
+    expect(flyClient.getVolume).not.toHaveBeenCalled();
+    expect(storage._store.get('pendingDestroyVolumeId')).toBe('vol-1');
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('retries bound machine recovery after cooldown expires', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+      lastBoundMachineRecoveryAt: Date.now() - 6 * 60 * 1000, // 6 min ago, past 5 min cooldown
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: recoveredMachineId,
+      state: 'attached',
+    });
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // Cooldown expired → getVolume called → recovery → full cleanup
+    expect(flyClient.getVolume).toHaveBeenCalledTimes(1);
+    expect(storage._store.size).toBe(0);
+    expect(storage._getAlarm()).toBeNull();
+  });
+});
+
+describe('destroy error tracking', () => {
+  it('persists structured destroy error on volume delete failure', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: null,
+      state: 'detached',
+    });
+    (flyClient.deleteVolume as Mock).mockRejectedValue(
+      new FlyApiError(
+        'failed_precondition: volume is currently bound to machine: abc123',
+        412,
+        '{}'
+      )
+    );
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    expect(storage._store.get('lastDestroyErrorOp')).toBe('volume');
+    expect(storage._store.get('lastDestroyErrorStatus')).toBe(412);
+    expect(storage._store.get('lastDestroyErrorMessage')).toContain('failed_precondition');
+    expect(storage._store.get('lastDestroyErrorAt')).toBeTypeOf('number');
+  });
+
+  it('clears destroy error on successful delete', async () => {
+    const { storage } = createInstance();
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+      lastDestroyErrorOp: 'volume',
+      lastDestroyErrorStatus: 412,
+      lastDestroyErrorMessage: 'old error',
+      lastDestroyErrorAt: Date.now() - 60_000,
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: null,
+      state: 'detached',
+    });
+    (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
+
+    const { instance } = createInstance(storage);
+    await instance.alarm();
+
+    // Error fields cleared after successful volume delete
+    expect(storage._store.has('lastDestroyErrorOp')).toBe(false);
+  });
+});
+
 describe('reconciliation: machine status sync', () => {
   it('syncs DO status from running to stopped after threshold failures', async () => {
     const { storage } = createInstance();

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1212,12 +1212,8 @@ describe('gateway process control via controller', () => {
 // selectRecoveryCandidate (pure function, no mocks needed)
 // ============================================================================
 
-import {
-  selectRecoveryCandidate,
-  parseRegions,
-  deprioritizeRegion,
-  shuffleRegions,
-} from './kiloclaw-instance';
+import { selectRecoveryCandidate } from './machine-recovery';
+import { parseRegions, deprioritizeRegion, shuffleRegions } from './regions';
 import type { FlyMachine } from '../fly/types';
 
 function fakeMachine(overrides: Partial<FlyMachine>): FlyMachine {

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -294,6 +294,9 @@ export function deprioritizeRegion(regions: string[], failedRegion: string | nul
 /** Cooldown between metadata recovery attempts (1 alarm cycle at idle cadence). */
 const METADATA_RECOVERY_COOLDOWN_MS = ALARM_INTERVAL_IDLE_MS;
 
+/** Cooldown after getVolume finds no attached machine during destroy recovery. */
+const BOUND_MACHINE_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
+
 /** States that indicate the machine is dead and should be ignored for recovery. */
 const DEAD_STATES: ReadonlySet<FlyMachineState> = new Set(['destroyed', 'destroying']);
 
@@ -384,6 +387,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private imageVariant: string | null = null;
   private trackedImageTag: string | null = null;
   private trackedImageDigest: string | null = null;
+  private lastDestroyErrorOp: 'machine' | 'volume' | 'recover' | null = null;
+  private lastDestroyErrorStatus: number | null = null;
+  private lastDestroyErrorMessage: string | null = null;
+  private lastDestroyErrorAt: number | null = null;
+  private lastBoundMachineRecoveryAt: number | null = null;
 
   // In-memory only (not persisted to SQLite) — throttles live Fly checks in getStatus()
   private lastLiveCheckAt: number | null = null;
@@ -425,6 +433,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.imageVariant = s.imageVariant;
       this.trackedImageTag = s.trackedImageTag;
       this.trackedImageDigest = s.trackedImageDigest;
+      this.lastDestroyErrorOp = s.lastDestroyErrorOp;
+      this.lastDestroyErrorStatus = s.lastDestroyErrorStatus;
+      this.lastDestroyErrorMessage = s.lastDestroyErrorMessage;
+      this.lastDestroyErrorAt = s.lastDestroyErrorAt;
+      this.lastBoundMachineRecoveryAt = s.lastBoundMachineRecoveryAt;
     } else {
       const hasAnyData = entries.size > 0;
       if (hasAnyData) {
@@ -1409,6 +1422,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     lastMetadataRecoveryAt: number | null;
     lastLiveCheckAt: number | null;
     alarmScheduledAt: number | null;
+    lastDestroyErrorOp: 'machine' | 'volume' | 'recover' | null;
+    lastDestroyErrorStatus: number | null;
+    lastDestroyErrorMessage: string | null;
+    lastDestroyErrorAt: number | null;
   }> {
     await this.loadState();
     const alarmScheduledAt = await this.ctx.storage.getAlarm();
@@ -1438,6 +1455,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       lastMetadataRecoveryAt: this.lastMetadataRecoveryAt,
       lastLiveCheckAt: this.lastLiveCheckAt,
       alarmScheduledAt,
+      lastDestroyErrorOp: this.lastDestroyErrorOp,
+      lastDestroyErrorStatus: this.lastDestroyErrorStatus,
+      lastDestroyErrorMessage: this.lastDestroyErrorMessage,
+      lastDestroyErrorAt: this.lastDestroyErrorAt,
     };
   }
 
@@ -2113,13 +2134,86 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   // Two-phase destroy helpers
   // ========================================================================
 
+  /** Fly machine IDs are lowercase alphanumeric. */
+  private static MACHINE_ID_RE = /^[a-z0-9]+$/;
+
   /**
    * Retry deleting pending Fly resources. Called from alarm for destroying instances.
    */
   private async retryPendingDestroy(flyConfig: FlyClientConfig, reason: string): Promise<void> {
+    await this.recoverBoundMachineForDestroy(flyConfig, reason);
     await this.tryDeleteMachine(flyConfig, reason);
     await this.tryDeleteVolume(flyConfig, reason);
     await this.finalizeDestroyIfComplete();
+  }
+
+  /**
+   * When a volume has a pending destroy but the machine ID was lost (null),
+   * query the volume to discover the attached machine so we can delete it first.
+   * Without this, volume deletion returns 412 "bound to machine" forever.
+   */
+  private async recoverBoundMachineForDestroy(
+    flyConfig: FlyClientConfig,
+    reason: string
+  ): Promise<void> {
+    if (this.pendingDestroyMachineId) return; // already know the machine
+    if (!this.pendingDestroyVolumeId) return; // nothing to check
+
+    // Cooldown: skip if we recently checked and found no attached machine
+    if (
+      this.lastBoundMachineRecoveryAt &&
+      Date.now() - this.lastBoundMachineRecoveryAt < BOUND_MACHINE_RECOVERY_COOLDOWN_MS
+    ) {
+      return;
+    }
+
+    try {
+      const volume = await fly.getVolume(flyConfig, this.pendingDestroyVolumeId);
+      const machineId = volume.attached_machine_id;
+
+      if (!machineId || !KiloClawInstance.MACHINE_ID_RE.test(machineId)) {
+        if (machineId) {
+          reconcileLog(reason, 'recover_bound_machine_invalid_id', {
+            volume_id: this.pendingDestroyVolumeId,
+            attached_machine_id: machineId,
+          });
+        }
+        // No machine to recover — set cooldown to avoid repeated getVolume calls
+        this.lastBoundMachineRecoveryAt = Date.now();
+        await this.ctx.storage.put(
+          storageUpdate({ lastBoundMachineRecoveryAt: this.lastBoundMachineRecoveryAt })
+        );
+        return;
+      }
+
+      reconcileLog(reason, 'recover_bound_machine_for_destroy', {
+        volume_id: this.pendingDestroyVolumeId,
+        machine_id: machineId,
+      });
+
+      this.pendingDestroyMachineId = machineId;
+      this.flyMachineId = machineId;
+      this.lastBoundMachineRecoveryAt = null;
+      await this.ctx.storage.put(
+        storageUpdate({
+          pendingDestroyMachineId: machineId,
+          flyMachineId: machineId,
+          lastBoundMachineRecoveryAt: null,
+        })
+      );
+    } catch (err) {
+      if (fly.isFlyNotFound(err)) {
+        // Volume already gone — tryDeleteVolume will handle the 404.
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      const status = err instanceof fly.FlyApiError ? err.status : null;
+      reconcileLog(reason, 'recover_bound_machine_failed', {
+        volume_id: this.pendingDestroyVolumeId,
+        error: message,
+      });
+      await this.persistDestroyError('recover', status, message);
+    }
   }
 
   /**
@@ -2139,10 +2233,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           machine_id: this.pendingDestroyMachineId,
         });
       } else {
+        const message = err instanceof Error ? err.message : String(err);
+        const status = err instanceof fly.FlyApiError ? err.status : null;
         reconcileLog(reason, 'destroy_machine_failed', {
           machine_id: this.pendingDestroyMachineId,
-          error: err instanceof Error ? err.message : String(err),
+          error: message,
         });
+        await this.persistDestroyError('machine', status, message);
         return; // Leave pending, retry next alarm
       }
     }
@@ -2153,6 +2250,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     await this.ctx.storage.put(
       storageUpdate({ pendingDestroyMachineId: null, flyMachineId: null })
     );
+    await this.clearDestroyError();
   }
 
   /**
@@ -2172,10 +2270,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           volume_id: this.pendingDestroyVolumeId,
         });
       } else {
+        const message = err instanceof Error ? err.message : String(err);
+        const status = err instanceof fly.FlyApiError ? err.status : null;
         reconcileLog(reason, 'destroy_volume_failed', {
           volume_id: this.pendingDestroyVolumeId,
-          error: err instanceof Error ? err.message : String(err),
+          error: message,
         });
+        await this.persistDestroyError('volume', status, message);
         return; // Leave pending, retry next alarm
       }
     }
@@ -2184,6 +2285,42 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.pendingDestroyVolumeId = null;
     this.flyVolumeId = null;
     await this.ctx.storage.put(storageUpdate({ pendingDestroyVolumeId: null, flyVolumeId: null }));
+    await this.clearDestroyError();
+  }
+
+  private async persistDestroyError(
+    op: 'machine' | 'volume' | 'recover',
+    status: number | null,
+    message: string
+  ): Promise<void> {
+    this.lastDestroyErrorOp = op;
+    this.lastDestroyErrorStatus = status;
+    this.lastDestroyErrorMessage = message;
+    this.lastDestroyErrorAt = Date.now();
+    await this.ctx.storage.put(
+      storageUpdate({
+        lastDestroyErrorOp: op,
+        lastDestroyErrorStatus: status,
+        lastDestroyErrorMessage: message,
+        lastDestroyErrorAt: this.lastDestroyErrorAt,
+      })
+    );
+  }
+
+  private async clearDestroyError(): Promise<void> {
+    if (!this.lastDestroyErrorOp) return; // already clear
+    this.lastDestroyErrorOp = null;
+    this.lastDestroyErrorStatus = null;
+    this.lastDestroyErrorMessage = null;
+    this.lastDestroyErrorAt = null;
+    await this.ctx.storage.put(
+      storageUpdate({
+        lastDestroyErrorOp: null,
+        lastDestroyErrorStatus: null,
+        lastDestroyErrorMessage: null,
+        lastDestroyErrorAt: null,
+      })
+    );
   }
 
   /**
@@ -2267,6 +2404,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.imageVariant = null;
     this.trackedImageTag = null;
     this.trackedImageDigest = null;
+    this.lastDestroyErrorOp = null;
+    this.lastDestroyErrorStatus = null;
+    this.lastDestroyErrorMessage = null;
+    this.lastDestroyErrorAt = null;
+    this.lastBoundMachineRecoveryAt = null;
     this.loaded = false;
   }
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -35,9 +35,7 @@ import {
   type MachineSize,
 } from '../schemas/instance-config';
 import {
-  OPENCLAW_PORT,
   STARTUP_TIMEOUT_SECONDS,
-  DEFAULT_MACHINE_GUEST,
   DEFAULT_VOLUME_SIZE_GB,
   ALARM_INTERVAL_RUNNING_MS,
   ALARM_INTERVAL_DESTROYING_MS,
@@ -52,19 +50,41 @@ import {
   OPENCLAW_BUILTIN_DEFAULT_MODEL,
 } from '../config';
 import type { FlyClientConfig } from '../fly/client';
-import type {
-  FlyMachineConfig,
-  FlyMachine,
-  FlyMachineState,
-  FlyVolumeSnapshot,
-} from '../fly/types';
+import type { FlyMachineConfig, FlyVolumeSnapshot } from '../fly/types';
 import * as fly from '../fly/client';
 import { appNameFromUserId } from '../fly/apps';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../utils/env-encryption';
-import { z, type ZodType } from 'zod';
+import type { ZodType } from 'zod';
 import { resolveLatestVersion, resolveVersionByTag } from '../lib/image-version';
 import { lookupCatalogVersion } from '../lib/catalog-registration';
 import { ImageVariantSchema } from '../schemas/image-version';
+import {
+  type GatewayProcessStatus,
+  GatewayProcessStatusSchema,
+  GatewayCommandResponseSchema,
+  ConfigRestoreResponseSchema,
+  ControllerVersionResponseSchema,
+  GatewayControllerError,
+} from './gateway-controller-types';
+import { parseRegions, shuffleRegions, deprioritizeRegion } from './regions';
+import {
+  METADATA_RECOVERY_COOLDOWN_MS,
+  BOUND_MACHINE_RECOVERY_COOLDOWN_MS,
+  TERMINAL_STOPPED_STATES,
+  selectRecoveryCandidate,
+  volumeIdFromMachine,
+} from './machine-recovery';
+import {
+  METADATA_KEY_USER_ID,
+  buildMachineConfig,
+  guestFromSize,
+  volumeNameFromSandboxId,
+} from './machine-config';
+
+// Re-export extracted helpers so existing consumers don't break.
+export { parseRegions, shuffleRegions, deprioritizeRegion } from './regions';
+export { selectRecoveryCandidate } from './machine-recovery';
+export { METADATA_KEY_USER_ID } from './machine-config';
 
 type InstanceStatus = PersistedState['status'];
 
@@ -73,58 +93,6 @@ type DestroyResult = {
   destroyedUserId: string | null;
   destroyedSandboxId: string | null;
 };
-
-type GatewayProcessStatus = {
-  state: 'stopped' | 'starting' | 'running' | 'stopping' | 'crashed' | 'shutting_down';
-  pid: number | null;
-  uptime: number;
-  restarts: number;
-  lastExit: {
-    code: number | null;
-    signal: NodeJS.Signals | null;
-    at: string;
-  } | null;
-};
-
-const GatewayProcessStatusSchema: ZodType<GatewayProcessStatus> = z.object({
-  state: z.enum(['stopped', 'starting', 'running', 'stopping', 'crashed', 'shutting_down']),
-  pid: z.number().int().nullable(),
-  uptime: z.number(),
-  restarts: z.number().int(),
-  lastExit: z
-    .object({
-      code: z.number().int().nullable(),
-      signal: z
-        .custom<NodeJS.Signals>((value): value is NodeJS.Signals => typeof value === 'string')
-        .nullable(),
-      at: z.string(),
-    })
-    .nullable(),
-});
-
-const GatewayCommandResponseSchema = z.object({
-  ok: z.boolean(),
-});
-
-const ConfigRestoreResponseSchema = z.object({
-  ok: z.boolean(),
-  signaled: z.boolean(),
-});
-
-const ControllerVersionResponseSchema = z.object({
-  version: z.string(),
-  commit: z.string(),
-});
-
-class GatewayControllerError extends Error {
-  readonly status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = 'GatewayControllerError';
-    this.status = status;
-  }
-}
 
 // Derived from PersistedStateSchema -- single source of truth for DO KV keys.
 const STORAGE_KEYS = Object.keys(PersistedStateSchema.shape);
@@ -167,191 +135,6 @@ function alarmIntervalForStatus(status: InstanceStatus): number {
 
 function nextAlarmTime(status: InstanceStatus): number {
   return Date.now() + alarmIntervalForStatus(status) + Math.random() * ALARM_JITTER_MS;
-}
-
-// ============================================================================
-// Metadata keys set on every Fly Machine for recovery/orphan detection.
-// Avoid fly_* keys — those are reserved by Fly.
-// ============================================================================
-
-export const METADATA_KEY_USER_ID = 'kiloclaw_user_id';
-export const METADATA_KEY_SANDBOX_ID = 'kiloclaw_sandbox_id';
-export const METADATA_KEY_OPENCLAW_VERSION = 'kiloclaw_openclaw_version';
-export const METADATA_KEY_IMAGE_VARIANT = 'kiloclaw_image_variant';
-
-// ============================================================================
-// Machine config builder
-// ============================================================================
-
-type MachineIdentity = {
-  userId: string;
-  sandboxId: string;
-  openclawVersion: string | null;
-  imageVariant: string | null;
-};
-
-function buildMachineConfig(
-  registryApp: string,
-  imageTag: string,
-  envVars: Record<string, string>,
-  guest: FlyMachineConfig['guest'],
-  flyVolumeId: string | null,
-  identity: MachineIdentity
-): FlyMachineConfig {
-  return {
-    image: `registry.fly.io/${registryApp}:${imageTag}`,
-    env: envVars,
-    guest,
-    services: [
-      {
-        ports: [{ port: 443, handlers: ['tls', 'http'] }],
-        internal_port: OPENCLAW_PORT,
-        protocol: 'tcp' as const,
-        autostart: false,
-        autostop: 'off',
-      },
-    ],
-    checks: {
-      controller: {
-        type: 'http',
-        port: OPENCLAW_PORT,
-        method: 'GET',
-        path: '/_kilo/health',
-        interval: '30s',
-        timeout: '5s',
-        grace_period: '120s',
-      },
-    },
-    mounts: flyVolumeId ? [{ volume: flyVolumeId, path: '/root' }] : [],
-    metadata: {
-      [METADATA_KEY_USER_ID]: identity.userId,
-      [METADATA_KEY_SANDBOX_ID]: identity.sandboxId,
-      ...(identity.openclawVersion && {
-        [METADATA_KEY_OPENCLAW_VERSION]: identity.openclawVersion,
-      }),
-      ...(identity.imageVariant && { [METADATA_KEY_IMAGE_VARIANT]: identity.imageVariant }),
-    },
-  };
-}
-
-function guestFromSize(machineSize: MachineSize | null): FlyMachineConfig['guest'] {
-  if (!machineSize) return DEFAULT_MACHINE_GUEST;
-  return {
-    cpus: machineSize.cpus,
-    memory_mb: machineSize.memory_mb,
-    cpu_kind: machineSize.cpu_kind ?? 'shared',
-  };
-}
-
-// ============================================================================
-// Volume name helper
-// ============================================================================
-
-function volumeNameFromSandboxId(sandboxId: string): string {
-  return `kiloclaw_${sandboxId}`
-    .toLowerCase()
-    .replace(/[^a-z0-9_]/g, '_')
-    .slice(0, 30);
-}
-
-// ============================================================================
-// Region helpers
-// ============================================================================
-
-/** Split a comma-separated region string into an array. */
-export function parseRegions(regionList: string): string[] {
-  return regionList
-    .split(',')
-    .map(r => r.trim())
-    .filter(Boolean);
-}
-
-/** Fisher-Yates shuffle (in-place). Returns the same array for chaining. */
-export function shuffleRegions(regions: string[]): string[] {
-  for (let i = regions.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = regions[i];
-    regions[i] = regions[j];
-    regions[j] = tmp;
-  }
-  return regions;
-}
-
-/**
- * Move a failed region to the end of the list so we try other regions first.
- * E.g. deprioritizeRegion(['dfw', 'yyz', 'cdg'], 'dfw') → ['yyz', 'cdg', 'dfw']
- */
-export function deprioritizeRegion(regions: string[], failedRegion: string | null): string[] {
-  if (!failedRegion) return regions;
-  const without = regions.filter(r => r !== failedRegion);
-  return without.length < regions.length ? [...without, failedRegion] : regions;
-}
-
-// ============================================================================
-// Machine recovery: deterministic selection from metadata query results
-// ============================================================================
-
-/** Cooldown between metadata recovery attempts (1 alarm cycle at idle cadence). */
-const METADATA_RECOVERY_COOLDOWN_MS = ALARM_INTERVAL_IDLE_MS;
-
-/** Cooldown after getVolume finds no attached machine during destroy recovery. */
-const BOUND_MACHINE_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
-
-/** States that indicate the machine is dead and should be ignored for recovery. */
-const DEAD_STATES: ReadonlySet<FlyMachineState> = new Set(['destroyed', 'destroying']);
-
-/** Terminal non-running states for live check. Transitional states (starting, stopping, replacing)
- *  are intentionally excluded to avoid UI flicker during normal operations. */
-const TERMINAL_STOPPED_STATES: ReadonlySet<FlyMachineState> = new Set([
-  'stopped',
-  'created',
-  'destroyed',
-  'suspended',
-]);
-
-/**
- * Priority order for picking a machine to recover.
- * Lower index = higher preference. `started` is best, then `starting`, etc.
- */
-const STATE_PRIORITY: ReadonlyMap<FlyMachineState, number> = new Map([
-  ['started', 0],
-  ['starting', 1],
-  ['stopped', 2],
-  ['created', 3],
-  ['stopping', 4],
-  ['replacing', 5],
-]);
-
-/**
- * Given a list of machines from Fly's metadata query, pick the best candidate
- * for recovery. Returns null if no live machines found.
- *
- * Selection rules:
- * 1. Ignore destroyed/destroying machines.
- * 2. Prefer started > starting > stopped > created > others.
- * 3. Tie-break by newest updated_at.
- */
-export function selectRecoveryCandidate(machines: FlyMachine[]): FlyMachine | null {
-  const live = machines.filter(m => !DEAD_STATES.has(m.state));
-  if (live.length === 0) return null;
-
-  live.sort((a, b) => {
-    const pa = STATE_PRIORITY.get(a.state) ?? 99;
-    const pb = STATE_PRIORITY.get(b.state) ?? 99;
-    if (pa !== pb) return pa - pb;
-    // Tie-break: newest updated_at first
-    return b.updated_at.localeCompare(a.updated_at);
-  });
-
-  return live[0];
-}
-
-/**
- * Extract the volume ID from a machine's mount config at /root, if present.
- */
-function volumeIdFromMachine(machine: FlyMachine): string | null {
-  const rootMount = (machine.config?.mounts ?? []).find(m => m.path === '/root');
-  return rootMount?.volume ?? null;
 }
 
 // ============================================================================

--- a/kiloclaw/src/durable-objects/machine-config.ts
+++ b/kiloclaw/src/durable-objects/machine-config.ts
@@ -1,0 +1,88 @@
+import type { FlyMachineConfig } from '../fly/types';
+import type { MachineSize } from '../schemas/instance-config';
+import { OPENCLAW_PORT, DEFAULT_MACHINE_GUEST } from '../config';
+
+// ============================================================================
+// Metadata keys set on every Fly Machine for recovery/orphan detection.
+// Avoid fly_* keys — those are reserved by Fly.
+// ============================================================================
+
+export const METADATA_KEY_USER_ID = 'kiloclaw_user_id';
+export const METADATA_KEY_SANDBOX_ID = 'kiloclaw_sandbox_id';
+export const METADATA_KEY_OPENCLAW_VERSION = 'kiloclaw_openclaw_version';
+export const METADATA_KEY_IMAGE_VARIANT = 'kiloclaw_image_variant';
+
+// ============================================================================
+// Machine config builder
+// ============================================================================
+
+export type MachineIdentity = {
+  userId: string;
+  sandboxId: string;
+  openclawVersion: string | null;
+  imageVariant: string | null;
+};
+
+export function buildMachineConfig(
+  registryApp: string,
+  imageTag: string,
+  envVars: Record<string, string>,
+  guest: FlyMachineConfig['guest'],
+  flyVolumeId: string | null,
+  identity: MachineIdentity
+): FlyMachineConfig {
+  return {
+    image: `registry.fly.io/${registryApp}:${imageTag}`,
+    env: envVars,
+    guest,
+    services: [
+      {
+        ports: [{ port: 443, handlers: ['tls', 'http'] }],
+        internal_port: OPENCLAW_PORT,
+        protocol: 'tcp' as const,
+        autostart: false,
+        autostop: 'off',
+      },
+    ],
+    checks: {
+      controller: {
+        type: 'http',
+        port: OPENCLAW_PORT,
+        method: 'GET',
+        path: '/_kilo/health',
+        interval: '30s',
+        timeout: '5s',
+        grace_period: '120s',
+      },
+    },
+    mounts: flyVolumeId ? [{ volume: flyVolumeId, path: '/root' }] : [],
+    metadata: {
+      [METADATA_KEY_USER_ID]: identity.userId,
+      [METADATA_KEY_SANDBOX_ID]: identity.sandboxId,
+      ...(identity.openclawVersion && {
+        [METADATA_KEY_OPENCLAW_VERSION]: identity.openclawVersion,
+      }),
+      ...(identity.imageVariant && { [METADATA_KEY_IMAGE_VARIANT]: identity.imageVariant }),
+    },
+  };
+}
+
+export function guestFromSize(machineSize: MachineSize | null): FlyMachineConfig['guest'] {
+  if (!machineSize) return DEFAULT_MACHINE_GUEST;
+  return {
+    cpus: machineSize.cpus,
+    memory_mb: machineSize.memory_mb,
+    cpu_kind: machineSize.cpu_kind ?? 'shared',
+  };
+}
+
+// ============================================================================
+// Volume name helper
+// ============================================================================
+
+export function volumeNameFromSandboxId(sandboxId: string): string {
+  return `kiloclaw_${sandboxId}`
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '_')
+    .slice(0, 30);
+}

--- a/kiloclaw/src/durable-objects/machine-recovery.ts
+++ b/kiloclaw/src/durable-objects/machine-recovery.ts
@@ -1,0 +1,65 @@
+import type { FlyMachine, FlyMachineState } from '../fly/types';
+import { ALARM_INTERVAL_IDLE_MS } from '../config';
+
+/** Cooldown between metadata recovery attempts (1 alarm cycle at idle cadence). */
+export const METADATA_RECOVERY_COOLDOWN_MS = ALARM_INTERVAL_IDLE_MS;
+
+/** Cooldown after getVolume finds no attached machine during destroy recovery. */
+export const BOUND_MACHINE_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
+
+/** States that indicate the machine is dead and should be ignored for recovery. */
+export const DEAD_STATES: ReadonlySet<FlyMachineState> = new Set(['destroyed', 'destroying']);
+
+/** Terminal non-running states for live check. Transitional states (starting, stopping, replacing)
+ *  are intentionally excluded to avoid UI flicker during normal operations. */
+export const TERMINAL_STOPPED_STATES: ReadonlySet<FlyMachineState> = new Set([
+  'stopped',
+  'created',
+  'destroyed',
+  'suspended',
+]);
+
+/**
+ * Priority order for picking a machine to recover.
+ * Lower index = higher preference. `started` is best, then `starting`, etc.
+ */
+const STATE_PRIORITY: ReadonlyMap<FlyMachineState, number> = new Map([
+  ['started', 0],
+  ['starting', 1],
+  ['stopped', 2],
+  ['created', 3],
+  ['stopping', 4],
+  ['replacing', 5],
+]);
+
+/**
+ * Given a list of machines from Fly's metadata query, pick the best candidate
+ * for recovery. Returns null if no live machines found.
+ *
+ * Selection rules:
+ * 1. Ignore destroyed/destroying machines.
+ * 2. Prefer started > starting > stopped > created > others.
+ * 3. Tie-break by newest updated_at.
+ */
+export function selectRecoveryCandidate(machines: FlyMachine[]): FlyMachine | null {
+  const live = machines.filter(m => !DEAD_STATES.has(m.state));
+  if (live.length === 0) return null;
+
+  live.sort((a, b) => {
+    const pa = STATE_PRIORITY.get(a.state) ?? 99;
+    const pb = STATE_PRIORITY.get(b.state) ?? 99;
+    if (pa !== pb) return pa - pb;
+    // Tie-break: newest updated_at first
+    return b.updated_at.localeCompare(a.updated_at);
+  });
+
+  return live[0];
+}
+
+/**
+ * Extract the volume ID from a machine's mount config at /root, if present.
+ */
+export function volumeIdFromMachine(machine: FlyMachine): string | null {
+  const rootMount = (machine.config?.mounts ?? []).find(m => m.path === '/root');
+  return rootMount?.volume ?? null;
+}

--- a/kiloclaw/src/durable-objects/regions.ts
+++ b/kiloclaw/src/durable-objects/regions.ts
@@ -1,0 +1,28 @@
+/** Split a comma-separated region string into an array. */
+export function parseRegions(regionList: string): string[] {
+  return regionList
+    .split(',')
+    .map(r => r.trim())
+    .filter(Boolean);
+}
+
+/** Fisher-Yates shuffle (in-place). Returns the same array for chaining. */
+export function shuffleRegions(regions: string[]): string[] {
+  for (let i = regions.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = regions[i];
+    regions[i] = regions[j];
+    regions[j] = tmp;
+  }
+  return regions;
+}
+
+/**
+ * Move a failed region to the end of the list so we try other regions first.
+ * E.g. deprioritizeRegion(['dfw', 'yyz', 'cdg'], 'dfw') → ['yyz', 'cdg', 'dfw']
+ */
+export function deprioritizeRegion(regions: string[], failedRegion: string | null): string[] {
+  if (!failedRegion) return regions;
+  const without = regions.filter(r => r !== failedRegion);
+  return without.length < regions.length ? [...without, failedRegion] : regions;
+}

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -135,6 +135,14 @@ export const PersistedStateSchema = z.object({
   imageVariant: z.string().nullable().default(null),
   trackedImageTag: z.string().nullable().default(null),
   trackedImageDigest: z.string().nullable().default(null),
+  // Structured last-error from the destroy retry loop, for admin observability.
+  lastDestroyErrorOp: z.enum(['machine', 'volume', 'recover']).nullable().default(null),
+  lastDestroyErrorStatus: z.number().nullable().default(null),
+  lastDestroyErrorMessage: z.string().nullable().default(null),
+  lastDestroyErrorAt: z.number().nullable().default(null),
+  // Cooldown for bound-machine recovery during destroy: avoids repeated getVolume
+  // calls when the volume consistently reports no attached machine.
+  lastBoundMachineRecoveryAt: z.number().nullable().default(null),
 });
 
 export type PersistedState = z.infer<typeof PersistedStateSchema>;

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -690,6 +690,27 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   {data.workerStatus.pendingPostgresMarkOnFinalize ? 'true' : 'false'}
                 </DetailField>
 
+                <DetailField label="Last Destroy Error">
+                  {data.workerStatus.lastDestroyErrorOp ? (
+                    <span className="text-destructive text-xs">
+                      <code>
+                        {data.workerStatus.lastDestroyErrorOp}
+                        {data.workerStatus.lastDestroyErrorStatus
+                          ? ` ${data.workerStatus.lastDestroyErrorStatus}`
+                          : ''}
+                        {' — '}
+                        {data.workerStatus.lastDestroyErrorMessage ?? 'unknown'}
+                      </code>
+                      <br />
+                      <span className="text-muted-foreground">
+                        {formatEpochTime(data.workerStatus.lastDestroyErrorAt)}
+                      </span>
+                    </span>
+                  ) : (
+                    '—'
+                  )}
+                </DetailField>
+
                 <DetailField label="Last Metadata Recovery Attempt">
                   {formatEpochTime(data.workerStatus.lastMetadataRecoveryAt)}
                 </DetailField>

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -133,6 +133,10 @@ export type PlatformDebugStatusResponse = PlatformStatusResponse & {
   lastMetadataRecoveryAt: number | null;
   lastLiveCheckAt: number | null;
   alarmScheduledAt: number | null;
+  lastDestroyErrorOp: 'machine' | 'volume' | 'recover' | null;
+  lastDestroyErrorStatus: number | null;
+  lastDestroyErrorMessage: string | null;
+  lastDestroyErrorAt: number | null;
 };
 
 /** A Fly volume snapshot. */


### PR DESCRIPTION
## Summary

This fixes a production failure mode where instances got stuck in `destroying` indefinitely. In the cases I found, the Durable Object had pendingDestroyVolumeId but no machine ID, while Fly still had a machine attached to the volume. The alarm retried volume deletion every minute, but Fly correctly returned 412 failed_precondition because the volume was still bound to the machine, so destroy never finalized.  This was a _super_ early user - so hard to say exactly what happened - we had a few bugs early on that could have led to this. 

This change makes destroy retries self-healing by recovering the bound machine ID from the volume, deleting the machine first, and then deleting the volume. It also adds structured lastDestroyError fields in admin debug status so support can immediately see the failing operation and Fly status/message, instead of inferring from sparse state. A small recovery cooldown avoids unnecessary repeated getVolume calls when a volume reports no attached machine.

Also snuck in a tiny refactor to start refactoring some of these larger files. But theres two distinct commits to help figure out whats what. 

- https://github.com/Kilo-Org/cloud/pull/814/commits/91c8233648a956a02cdc05ff2d97375efbd040eb is the fix
- https://github.com/Kilo-Org/cloud/pull/814/commits/ed7214b8d1895e9db1dc8b3f84ae3c4e377979eb the refactor

