### PR TITLE
fix(code-reviews): fix retrigger routing and add error logging

### DIFF
--- a/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -148,6 +148,7 @@ export async function POST(
       cliSessionId,
       status,
       hasError: !!errorMessage,
+      ...(errorMessage ? { errorMessage } : {}),
     });
 
     // Get current review to check if update is needed

--- a/src/routers/code-reviews/code-reviews-router.ts
+++ b/src/routers/code-reviews/code-reviews-router.ts
@@ -32,6 +32,7 @@ import {
 import { DEFAULT_LIST_LIMIT } from '@/lib/code-reviews/core/constants';
 import { codeReviewWorkerClient } from '@/lib/code-reviews/client/code-review-worker-client';
 import { tryDispatchPendingReviews } from '@/lib/code-reviews/dispatch/dispatch-pending-reviews';
+import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 
 export const codeReviewRouter = createTRPCRouter({
   /**
@@ -297,10 +298,20 @@ export const codeReviewRouter = createTRPCRouter({
         // Reset the review for retry
         await resetCodeReviewForRetry(input.reviewId);
 
-        // Build owner object for dispatch
-        const owner: Owner = review.owned_by_organization_id
-          ? { type: 'org', id: review.owned_by_organization_id, userId: ctx.user.id }
-          : { type: 'user', id: review.owned_by_user_id as string, userId: ctx.user.id };
+        // Build owner object for dispatch.
+        // For org reviews, use the bot user ID so feature flags (e.g. code-review-cloud-agent-next)
+        // evaluate consistently regardless of which human triggers the retrigger.
+        let owner: Owner;
+        if (review.owned_by_organization_id) {
+          const botUserId = await getBotUserId(review.owned_by_organization_id, 'code-review');
+          owner = {
+            type: 'org',
+            id: review.owned_by_organization_id,
+            userId: botUserId ?? ctx.user.id,
+          };
+        } else {
+          owner = { type: 'user', id: review.owned_by_user_id as string, userId: ctx.user.id };
+        }
 
         // Try to dispatch the review
         await tryDispatchPendingReviews(owner);


### PR DESCRIPTION
## Summary

Two fixes for code review debugging:

1. **Retrigger feature flag routing bug**: Manual retriggers from the UI evaluated the `code-review-cloud-agent-next` feature flag using the human user's ID instead of the org's bot user ID. This caused retriggered reviews to route to cloud-agent v1 even when the org has the v2 flag enabled. Now uses `getBotUserId()` to match the webhook and status callback handlers.

2. **Missing error message in logs**: The `/api/internal/code-review-status/[reviewId]` endpoint logged `hasError: true/false` but not the actual `errorMessage` string, making it impossible to diagnose CLI failures from Axiom without cross-referencing Cloudflare worker logs.

## Verification

- [x] `pnpm typecheck` passes

## Visual Changes

N/A

## Reviewer Notes

Bug (1) was discovered debugging why review `bd487cd6` ran on cloud-agent v1 after a manual retrigger despite the org having `code-review-cloud-agent-next` enabled. The first webhook-triggered dispatch correctly evaluated the flag as `true`, but the retrigger at 20:04 evaluated it against the human user (`839bdee0`) and got `false`.

The underlying "CLI exited with code 1" failures (~0.8s after prompt execution) are a separate systemic issue not addressed here — the error logging in commit 2 will help diagnose those going forward.