### PR TITLE
chore: default PRs to ready-for-review instead of draft

### DIFF
--- a/.kilocode/workflows/prepare-pr.md
+++ b/.kilocode/workflows/prepare-pr.md
@@ -2,6 +2,10 @@
 
 Prepare a pull request description using this repository's PR template and then create or update the PR.
 
+Arguments:
+
+- `--draft` — Create the PR as a draft instead of ready for review.
+
 ## Required source of truth
 
 - Read and use `/.github/pull_request_template.md` from this repository.
@@ -50,5 +54,7 @@ Prepare a pull request description using this repository's PR template and then 
 
 1. Check whether a PR already exists for the current branch.
 2. If a PR exists, update the PR body using `gh pr edit --body`.
-3. If a PR does not exist, create it as a **draft** using `gh pr create --draft` with the generated title and body.
+3. If a PR does not exist:
+   - If `--draft` was passed as an argument, create it as a draft using `gh pr create --draft`.
+   - Otherwise, create it as ready for review using `gh pr create`.
 4. Return the PR URL.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Draft PRs
 
-When creating a pull request, **always create it as a draft** (`gh pr create --draft`). Let the author mark it ready for review.
+When creating a pull request, create it as **ready for review** by default. Only create it as a draft (`gh pr create --draft`) if the user explicitly requests a draft PR. Look for phrases like "draft", "WIP", or "not ready for review" in the user's prompt.
 
 ## Pull Request Descriptions
 


### PR DESCRIPTION
## Summary

- Changed default PR creation behavior from draft to ready-for-review in both `AGENTS.md` and the `.kilocode/workflows/prepare-pr.md` workflow.
- Added a `--draft` argument to the `prepare-pr` workflow so users can explicitly opt into draft PRs when needed.
- Draft PRs are now only created when the user explicitly requests it (e.g., via `--draft` flag or keywords like "draft", "WIP", "not ready for review").

## Verification

- Reviewed the diff to confirm both files are consistent in their new default behavior.
- No code logic to test — changes are documentation/workflow instructions only.

## Visual Changes

N/A

## Reviewer Notes

This is a policy change: PRs will now be created as ready-for-review by default, reducing friction for authors who previously had to manually mark drafts as ready. Authors who want draft PRs can still get them by passing `--draft` or using draft-related keywords.