### PR TITLE
chore(cloud-agent-next): bump Kilo CLI to 7.0.37

### DIFF
--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -118,7 +118,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.0.35",
+        "KILOCODE_CLI_VERSION": "7.0.37",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 120,
@@ -243,7 +243,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.0.35",
+            "KILOCODE_CLI_VERSION": "7.0.37",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,


### PR DESCRIPTION
## Summary

Bump `KILOCODE_CLI_VERSION` from `7.0.35` to `7.0.37` in `cloud-agent-next/wrangler.jsonc` for both production and dev container environments.

## Verification

- [x] Verified both image_vars entries updated in `wrangler.jsonc`

## Visual Changes

N/A

## Reviewer Notes

N/A