### PR TITLE
fix(cloud-agent-next): write auth file before kilo import on cold-start resume

### DIFF
--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -599,11 +599,12 @@ describe('SessionService', () => {
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
       };
+      const sandboxWriteFile = vi.fn().mockResolvedValue(undefined);
       const sandbox = {
         createSession: vi.fn().mockResolvedValue(fakeSession),
         mkdir: vi.fn().mockResolvedValue(undefined),
         exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
-        writeFile: vi.fn().mockResolvedValue(undefined),
+        writeFile: sandboxWriteFile,
       } as unknown as SandboxInstance;
 
       const kiloSessionId = 'ses_test_kilo_session_id_0001';
@@ -656,6 +657,14 @@ describe('SessionService', () => {
       const restoreWorkspaceOrder = mockedRestoreWorkspace.mock.invocationCallOrder[0];
       const kiloImportOrder = fakeSession.exec.mock.invocationCallOrder[kiloImportCallIndex];
       expect(restoreWorkspaceOrder).toBeLessThan(kiloImportOrder);
+
+      // Verify writeAuthFile ran before kilo import so KiloSessions.bootstrap() can authenticate
+      const authWriteCallIndex = sandboxWriteFile.mock.calls.findIndex(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('auth.json')
+      );
+      expect(authWriteCallIndex).toBeGreaterThanOrEqual(0);
+      const authWriteOrder = sandboxWriteFile.mock.invocationCallOrder[authWriteCallIndex];
+      expect(authWriteOrder).toBeLessThan(kiloImportOrder);
     });
   });
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1329,6 +1329,9 @@ export class SessionService {
       platform: context.platform,
     });
 
+    // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
+    await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
+
     await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);
 
     // Re-run setup commands (fresh clone, need to reinstall)
@@ -1336,9 +1339,6 @@ export class SessionService {
       logger.info('Re-running setup commands after fresh clone');
       await runSetupCommands(session, context, metadata.setupCommands, false); // lenient
     }
-
-    // Re-write auth file (fresh clone)
-    await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
   }
 
   /**


### PR DESCRIPTION
## Summary

During cold-start resume, `writeAuthFile()` was called **after** `restoreSessionSnapshot()` (which runs `kilo import`). This meant `auth.json` didn't exist when `KiloSessions.bootstrap()` ran inside `kilo import`, causing it to silently skip with "session bootstrap skipped: no client" — the imported session was never registered with the ingest API.

This PR moves the `writeAuthFile()` call to run **before** `restoreSessionSnapshot()`, so `auth.json` is present when `kilo import` invokes `KiloSessions.bootstrap()`.

## Verification

- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 599 tests passed
- [x] *Additional verification by author*

## Visual Changes

N/A

## Reviewer Notes

- The fix is a reordering of two existing calls in `handleColdStartResume()` — no new logic introduced.
- The alternative approach (deferring bootstrap to `kilo serve`) was considered but rejected since `Session.Event.Created` doesn't fire for imported sessions, making it more invasive and cross-repo.
- The test asserts call ordering: `sandbox.writeFile(auth.json)` must happen before `session.exec(kilo import)`.