### PR TITLE
Feature/display openclaw version

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -57,6 +57,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
 ENV PATH="/root/.bun/bin:$PATH"
 
 ARG CONTROLLER_COMMIT=unknown
+ARG CONTROLLER_CACHE_BUST=1
 COPY controller/ /tmp/controller-build/
 RUN cd /tmp/controller-build \
     && bun install --frozen-lockfile \

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -57,6 +57,8 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
 ENV PATH="/root/.bun/bin:$PATH"
 
 ARG CONTROLLER_COMMIT=unknown
+# Changing this ARG value invalidates the COPY + RUN layers below it,
+# forcing a controller rebuild even when Docker thinks the source is unchanged.
 ARG CONTROLLER_CACHE_BUST=1
 COPY controller/ /tmp/controller-build/
 RUN cd /tmp/controller-build \

--- a/kiloclaw/controller/src/routes/health.ts
+++ b/kiloclaw/controller/src/routes/health.ts
@@ -12,20 +12,21 @@ import { getBearerToken } from './gateway';
  * This is acceptable: the UI shows a "Modified" badge by comparing image vs running
  * version, and spawning a subprocess on every request is not worth the cost.
  */
-let cachedOpenclawVersion: string | null | undefined;
+let openclawVersionPromise: Promise<string | null> | undefined;
 function getOpenclawVersion(): Promise<string | null> {
-  if (cachedOpenclawVersion !== undefined) return Promise.resolve(cachedOpenclawVersion);
-  return new Promise(resolve => {
-    execFile(
-      '/usr/bin/env',
-      ['HOME=/root', 'openclaw', '--version'],
-      { timeout: 5000 },
-      (err, stdout) => {
-        cachedOpenclawVersion = err ? null : stdout.toString().trim();
-        resolve(cachedOpenclawVersion);
-      }
-    );
-  });
+  if (!openclawVersionPromise) {
+    openclawVersionPromise = new Promise(resolve => {
+      execFile(
+        '/usr/bin/env',
+        ['HOME=/root', 'openclaw', '--version'],
+        { timeout: 5000 },
+        (err, stdout) => {
+          resolve(err ? null : stdout.toString().trim());
+        }
+      );
+    });
+  }
+  return openclawVersionPromise;
 }
 
 export function registerHealthRoute(
@@ -33,6 +34,9 @@ export function registerHealthRoute(
   supervisor: Supervisor,
   expectedToken?: string
 ): void {
+  // Eagerly resolve so the first /_kilo/version request doesn't wait on the subprocess.
+  getOpenclawVersion();
+
   const handler = (c: Context) => c.json({ status: 'ok' });
 
   // Public Fly health probe endpoint. Keep response intentionally minimal.

--- a/kiloclaw/controller/src/routes/health.ts
+++ b/kiloclaw/controller/src/routes/health.ts
@@ -1,8 +1,25 @@
+import { execFileSync } from 'node:child_process';
 import type { Context, Hono } from 'hono';
 import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from '../version';
 import { getBearerToken } from './gateway';
+
+/** Resolve the installed openclaw version once and cache it for the process lifetime. */
+let cachedOpenclawVersion: string | null | undefined;
+function getOpenclawVersion(): string | null {
+  if (cachedOpenclawVersion !== undefined) return cachedOpenclawVersion;
+  try {
+    cachedOpenclawVersion = execFileSync('/usr/bin/env', ['HOME=/root', 'openclaw', '--version'], {
+      timeout: 5000,
+    })
+      .toString()
+      .trim();
+  } catch {
+    cachedOpenclawVersion = null;
+  }
+  return cachedOpenclawVersion;
+}
 
 export function registerHealthRoute(
   app: Hono,
@@ -28,6 +45,7 @@ export function registerHealthRoute(
     return c.json({
       version: CONTROLLER_VERSION,
       commit: CONTROLLER_COMMIT,
+      openclawVersion: getOpenclawVersion(),
       gateway: supervisor.getStats(),
     });
   });

--- a/kiloclaw/controller/src/routes/health.ts
+++ b/kiloclaw/controller/src/routes/health.ts
@@ -1,24 +1,31 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import type { Context, Hono } from 'hono';
 import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from '../version';
 import { getBearerToken } from './gateway';
 
-/** Resolve the installed openclaw version once and cache it for the process lifetime. */
+/**
+ * Resolve the installed openclaw version once and cache it for the process lifetime.
+ * If the user upgrades openclaw while the controller is running, the cached value
+ * becomes stale until the next redeploy (which restarts the controller process).
+ * This is acceptable: the UI shows a "Modified" badge by comparing image vs running
+ * version, and spawning a subprocess on every request is not worth the cost.
+ */
 let cachedOpenclawVersion: string | null | undefined;
-function getOpenclawVersion(): string | null {
-  if (cachedOpenclawVersion !== undefined) return cachedOpenclawVersion;
-  try {
-    cachedOpenclawVersion = execFileSync('/usr/bin/env', ['HOME=/root', 'openclaw', '--version'], {
-      timeout: 5000,
-    })
-      .toString()
-      .trim();
-  } catch {
-    cachedOpenclawVersion = null;
-  }
-  return cachedOpenclawVersion;
+function getOpenclawVersion(): Promise<string | null> {
+  if (cachedOpenclawVersion !== undefined) return Promise.resolve(cachedOpenclawVersion);
+  return new Promise(resolve => {
+    execFile(
+      '/usr/bin/env',
+      ['HOME=/root', 'openclaw', '--version'],
+      { timeout: 5000 },
+      (err, stdout) => {
+        cachedOpenclawVersion = err ? null : stdout.toString().trim();
+        resolve(cachedOpenclawVersion);
+      }
+    );
+  });
 }
 
 export function registerHealthRoute(
@@ -34,7 +41,7 @@ export function registerHealthRoute(
   app.get('/health', handler);
 
   // Authenticated version/diagnostics endpoint.
-  app.get('/_kilo/version', c => {
+  app.get('/_kilo/version', async c => {
     if (expectedToken) {
       const token = getBearerToken(c.req.header('authorization'));
       if (!timingSafeTokenEqual(token, expectedToken)) {
@@ -45,7 +52,7 @@ export function registerHealthRoute(
     return c.json({
       version: CONTROLLER_VERSION,
       commit: CONTROLLER_COMMIT,
-      openclawVersion: getOpenclawVersion(),
+      openclawVersion: await getOpenclawVersion(),
       gateway: supervisor.getStats(),
     });
   });

--- a/kiloclaw/scripts/push-dev.sh
+++ b/kiloclaw/scripts/push-dev.sh
@@ -38,6 +38,7 @@ docker buildx build \
   --platform linux/amd64 \
   -f "$KILOCLAW_DIR/Dockerfile" \
   --build-arg "CONTROLLER_COMMIT=$GIT_SHA" \
+  --build-arg "CONTROLLER_CACHE_BUST=$(date +%s)" \
   -t "$IMAGE" \
   --push \
   --metadata-file "$METADATA_FILE" \

--- a/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -40,6 +40,7 @@ export const ConfigRestoreResponseSchema = z.object({
 export const ControllerVersionResponseSchema = z.object({
   version: z.string(),
   commit: z.string(),
+  // optional() for backward compat with older controllers that don't include this field
   openclawVersion: z.string().nullable().optional(),
 });
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -114,6 +114,7 @@ const ConfigRestoreResponseSchema = z.object({
 const ControllerVersionResponseSchema = z.object({
   version: z.string(),
   commit: z.string(),
+  openclawVersion: z.string().nullable().optional(),
 });
 
 class GatewayControllerError extends Error {
@@ -1601,7 +1602,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   }
 
   /** Returns null if the controller is too old to have the /_kilo/version endpoint. */
-  async getControllerVersion(): Promise<{ version: string; commit: string } | null> {
+  async getControllerVersion(): Promise<{ version: string; commit: string; openclawVersion?: string | null } | null> {
     await this.loadState();
     try {
       return await this.callGatewayController(

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { AlertCircle, AlertTriangle, Hash, Package, RotateCcw, Save, Square, X } from 'lucide-react';
+import {
+  AlertCircle,
+  AlertTriangle,
+  Hash,
+  Package,
+  RotateCcw,
+  Save,
+  Square,
+  X,
+} from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
@@ -8,7 +17,7 @@ import { useOpenRouterModels } from '@/app/api/openrouter/hooks';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { useControllerVersion, useKiloClawConfig } from '@/hooks/useKiloClaw';
+import { useControllerVersion, useKiloClawConfig, useKiloClawMyPin } from '@/hooks/useKiloClaw';
 import { useDefaultModelSelection } from '../hooks/useDefaultModelSelection';
 
 import { Badge } from '@/components/ui/badge';
@@ -41,6 +50,11 @@ export const KILOCODE_CATALOG_IDS = new Set([
   'x-ai/grok-code-fast-1',
   'moonshotai/kimi-k2.5',
 ]);
+
+/** Strip surrounding quotes if the API returns them in version strings. */
+function cleanVersion(v: string | null | undefined): string | null {
+  return v?.replace(/^["']|["']$/g, '') || null;
+}
 
 /** Returns true if calver `version` is >= `minVersion` (e.g. "2026.2.26"). Fails closed on malformed input. */
 function calverAtLeast(version: string | null | undefined, minVersion: string): boolean {
@@ -236,6 +250,7 @@ export function SettingsTab({
   const isDestroying = status.status === 'destroying';
   const isRunning = status.status === 'running';
   const { data: controllerVersion } = useControllerVersion(isRunning);
+  const { data: myPin } = useKiloClawMyPin();
   const supportsConfigRestore = calverAtLeast(controllerVersion?.version, '2026.2.26');
 
   const channelStatus = config?.channels ?? {
@@ -268,13 +283,14 @@ export function SettingsTab({
   }
 
   // Determine if running version differs from tracked version
-  // Strip quotes if the API returns them in the string
-  const cleanVersion = (v: string | null | undefined) => v?.replace(/^["']|["']$/g, '') || null;
   const trackedVersion = cleanVersion(status.openclawVersion);
-  const runningVersion = cleanVersion(controllerVersion?.version);
+  const runningVersion = cleanVersion(controllerVersion?.openclawVersion);
+  // Old image: controller has no /_kilo/version endpoint → returns { version: null }
+  const needsImageUpgrade = isRunning && controllerVersion && !controllerVersion.version;
   const versionMismatch = trackedVersion && runningVersion && trackedVersion !== runningVersion;
-  
-  // Only show version info if we have meaningful data (not just ":latest" or empty)
+  const isPinned = !!myPin;
+
+  // Show version section when running with a tracked version — even if running version is unknown yet
   const hasVersionInfo = isRunning && trackedVersion && trackedVersion !== ':latest';
 
   return (
@@ -291,52 +307,75 @@ export function SettingsTab({
       {hasVersionInfo && (
         <>
           <div>
-        <h3 className="text-foreground mb-3 flex items-center gap-2 text-sm font-medium">
-          <Package className="h-4 w-4" />
-          OpenClaw Version
-        </h3>
-        <div className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-3">
-          <div>
-            <p className="text-muted-foreground mb-1.5 text-xs">Running Version</p>
-            <div className="flex items-center gap-2">
-              <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
-                {runningVersion || '—'}
-              </code>
-              {versionMismatch && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Badge variant="outline" className="border-amber-500/30 bg-amber-500/15 text-amber-400">
-                      Upgraded
-                    </Badge>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Running version differs from image version</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
+            <h3 className="text-foreground mb-3 flex items-center gap-2 text-sm font-medium">
+              <Package className="h-4 w-4" />
+              OpenClaw Version
+            </h3>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-3">
+              <div>
+                <p className="text-muted-foreground mb-1.5 text-xs">Running Version</p>
+                <div className="flex items-center gap-2">
+                  <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+                    {runningVersion ?? '—'}
+                  </code>
+                  {needsImageUpgrade && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant="outline"
+                          className="border-blue-500/30 bg-blue-500/15 text-blue-400"
+                        >
+                          Upgrade required
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Upgrade your image to report the running OpenClaw version</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {versionMismatch && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant="outline"
+                          className="border-amber-500/30 bg-amber-500/15 text-amber-400"
+                        >
+                          Modified
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          OpenClaw was updated on this machine independently of the image —
+                          redeploying will revert to the image version ({trackedVersion})
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              </div>
+              <div>
+                <p className="text-muted-foreground mb-1.5 text-xs">Image Version</p>
+                <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+                  {trackedVersion}
+                </code>
+              </div>
+              <div>
+                <p className="text-muted-foreground mb-1.5 text-xs">Variant</p>
+                <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+                  {status.imageVariant || '—'}
+                </code>
+              </div>
             </div>
+            {versionMismatch && (
+              <p className="text-muted-foreground mt-2 text-xs">
+                {isPinned
+                  ? `Redeploying will replace the running version with your pinned image version (${trackedVersion}).`
+                  : `Redeploying will replace the running version with the image version (${trackedVersion}).`}
+              </p>
+            )}
           </div>
-          <div>
-            <p className="text-muted-foreground mb-1.5 text-xs">Image Version</p>
-            <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
-              {trackedVersion || '—'}
-            </code>
-          </div>
-          <div>
-            <p className="text-muted-foreground mb-1.5 text-xs">Variant</p>
-            <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
-              {status.imageVariant || '—'}
-            </code>
-          </div>
-        </div>
-        {versionMismatch && (
-          <p className="text-muted-foreground mt-2 text-xs">
-            The running version has been upgraded independently. Redeploy to sync with the image version.
-          </p>
-        )}
-      </div>
 
-      <Separator />
+          <Separator />
         </>
       )}
 

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -51,7 +51,7 @@ export const KILOCODE_CATALOG_IDS = new Set([
   'moonshotai/kimi-k2.5',
 ]);
 
-/** Strip surrounding quotes if the API returns them in version strings. */
+/** Strip surrounding quotes — bun build --define wraps values in extra quotes. */
 function cleanVersion(v: string | null | undefined): string | null {
   return v?.replace(/^["']|["']$/g, '') || null;
 }
@@ -285,7 +285,8 @@ export function SettingsTab({
   // Determine if running version differs from tracked version
   const trackedVersion = cleanVersion(status.openclawVersion);
   const runningVersion = cleanVersion(controllerVersion?.openclawVersion);
-  // Old image: controller has no /_kilo/version endpoint → returns { version: null }
+  // Old image: the DO returns null when the controller lacks /_kilo/version,
+  // and the platform route converts that to { version: null, commit: null }.
   const needsImageUpgrade = isRunning && controllerVersion && !controllerVersion.version;
   const versionMismatch = trackedVersion && runningVersion && trackedVersion !== runningVersion;
   const isPinned = !!myPin;

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -268,8 +268,10 @@ export function SettingsTab({
   }
 
   // Determine if running version differs from tracked version
-  const trackedVersion = status.openclawVersion;
-  const runningVersion = controllerVersion?.version;
+  // Strip quotes if the API returns them in the string
+  const cleanVersion = (v: string | null | undefined) => v?.replace(/^["']|["']$/g, '') || null;
+  const trackedVersion = cleanVersion(status.openclawVersion);
+  const runningVersion = cleanVersion(controllerVersion?.version);
   const versionMismatch = trackedVersion && runningVersion && trackedVersion !== runningVersion;
 
   return (

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -273,6 +273,9 @@ export function SettingsTab({
   const trackedVersion = cleanVersion(status.openclawVersion);
   const runningVersion = cleanVersion(controllerVersion?.version);
   const versionMismatch = trackedVersion && runningVersion && trackedVersion !== runningVersion;
+  
+  // Only show version info if we have meaningful data (not just ":latest" or empty)
+  const hasVersionInfo = isRunning && trackedVersion && trackedVersion !== ':latest';
 
   return (
     <div className="flex flex-col gap-6">
@@ -284,8 +287,10 @@ export function SettingsTab({
 
       <Separator />
 
-      {/* OpenClaw Version Information */}
-      <div>
+      {/* OpenClaw Version Information - only show when instance is running with real version data */}
+      {hasVersionInfo && (
+        <>
+          <div>
         <h3 className="text-foreground mb-3 flex items-center gap-2 text-sm font-medium">
           <Package className="h-4 w-4" />
           OpenClaw Version
@@ -332,6 +337,8 @@ export function SettingsTab({
       </div>
 
       <Separator />
+        </>
+      )}
 
       <div>
         <h2 className="text-foreground mb-4 text-lg font-semibold">KiloCode Configuration</h2>

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AlertCircle, AlertTriangle, Hash, RotateCcw, Save, Square, X } from 'lucide-react';
+import { AlertCircle, AlertTriangle, Hash, Package, RotateCcw, Save, Square, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
@@ -11,6 +11,7 @@ import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useControllerVersion, useKiloClawConfig } from '@/hooks/useKiloClaw';
 import { useDefaultModelSelection } from '../hooks/useDefaultModelSelection';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
@@ -266,12 +267,66 @@ export function SettingsTab({
     );
   }
 
+  // Determine if running version differs from tracked version
+  const trackedVersion = status.openclawVersion;
+  const runningVersion = controllerVersion?.version;
+  const versionMismatch = trackedVersion && runningVersion && trackedVersion !== runningVersion;
+
   return (
     <div className="flex flex-col gap-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <DetailTile label="Env Vars" value={String(status.envVarCount)} icon={Hash} />
         <DetailTile label="Secrets" value={String(status.secretCount)} icon={Hash} />
         <DetailTile label="Channels" value={String(status.channelCount)} icon={Hash} />
+      </div>
+
+      <Separator />
+
+      {/* OpenClaw Version Information */}
+      <div>
+        <h3 className="text-foreground mb-3 flex items-center gap-2 text-sm font-medium">
+          <Package className="h-4 w-4" />
+          OpenClaw Version
+        </h3>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-3">
+          <div>
+            <p className="text-muted-foreground mb-1.5 text-xs">Running Version</p>
+            <div className="flex items-center gap-2">
+              <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+                {runningVersion || '—'}
+              </code>
+              {versionMismatch && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="outline" className="border-amber-500/30 bg-amber-500/15 text-amber-400">
+                      Upgraded
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Running version differs from image version</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+          <div>
+            <p className="text-muted-foreground mb-1.5 text-xs">Image Version</p>
+            <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+              {trackedVersion || '—'}
+            </code>
+          </div>
+          <div>
+            <p className="text-muted-foreground mb-1.5 text-xs">Variant</p>
+            <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+              {status.imageVariant || '—'}
+            </code>
+          </div>
+        </div>
+        {versionMismatch && (
+          <p className="text-muted-foreground mt-2 text-xs">
+            The running version has been upgraded independently. Redeploy to sync with the image version.
+          </p>
+        )}
       </div>
 
       <Separator />

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -76,7 +76,7 @@ export function useControllerVersion(enabled: boolean) {
   return useQuery(
     trpc.kiloclaw.controllerVersion.queryOptions(undefined, {
       enabled,
-      staleTime: 5 * 60_000, // version doesn't change without a redeploy
+      staleTime: 5 * 60_000, // version changes infrequently; acceptable staleness window
     })
   );
 }

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -207,6 +207,7 @@ export type ConfigRestoreResponse = {
 export type ControllerVersionResponse = {
   version: string | null;
   commit: string | null;
+  openclawVersion?: string | null;
 };
 
 /** Combined status + gateway token returned by tRPC getStatus */


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->
Display the OpenClaw running version, image from the original image and variant in the Settings tab
## Summary
The controller's /_kilo/version endpoint now reports the installed OpenClaw  version by shelling out to openclaw --version. The frontend version card uses this to show the running version alongside the image version, with contextual badges when they differ or when the image predates this feature. 
<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification

<!-- List the checks you ran and what passed. Add command output notes when useful. -->
- prettier and tsc --noEmit pass
- Deployed to dev, confirmed version displays correctly in the Settings tab
- Ran manual version updates, re deploys, upgrades scenarios

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

- "Running Version" field now shows the actual openclaw version reported by the controller
- Blue "Upgrade required" badge when the deployed image is too old to report the running version
- Amber "Modified" badge when the running version differs from the image version (e.g. user upgraded openclaw independently), with tooltip warning that redeploying will revert
<img width="1125" height="166" alt="Screenshot 2026-03-04 at 2 18 19 PM" src="https://github.com/user-attachments/assets/d9f5c359-5fe5-43bc-af7b-d5df249ba7d3" />


## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
- Also added CONTROLLER_CACHE_BUST build-arg to push-dev.sh to ensure controller code changes invalidate Docker layer cache