### PR TITLE
feat(bot): Introduce Bot v2, powered by Chat SDK

### DIFF
--- a/.agents/skills/chat-sdk/SKILL.md
+++ b/.agents/skills/chat-sdk/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: chat-sdk
+description: >
+  Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to
+  (1) Build a Slack, Teams, Google Chat, Discord, GitHub, or Linear bot,
+  (2) Use the Chat SDK to handle mentions, messages, reactions, slash commands, cards, modals, or streaming,
+  (3) Set up webhook handlers for chat platforms,
+  (4) Send interactive cards or stream AI responses to chat platforms.
+  Triggers on "chat sdk", "chat bot", "slack bot", "teams bot", "discord bot", "@chat-adapter",
+  building bots that work across multiple chat platforms.
+---
+
+# Chat SDK
+
+Unified TypeScript SDK for building chat bots across Slack, Teams, Google Chat, Discord, GitHub, and Linear. Write bot logic once, deploy everywhere.
+
+## Critical: Read the bundled docs
+
+The `chat` package ships with full documentation in `node_modules/chat/docs/` and TypeScript source types. **Always read these before writing code:**
+
+```
+node_modules/chat/docs/           # Full documentation (MDX files)
+node_modules/chat/dist/           # Built types (.d.ts files)
+```
+
+Key docs to read based on task:
+- `docs/getting-started.mdx` — setup guides
+- `docs/usage.mdx` — event handlers, threads, messages, channels
+- `docs/streaming.mdx` — AI streaming with AI SDK
+- `docs/cards.mdx` — JSX interactive cards
+- `docs/actions.mdx` — button/dropdown handlers
+- `docs/modals.mdx` — form dialogs (Slack only)
+- `docs/adapters/*.mdx` — platform-specific adapter setup
+- `docs/state/*.mdx` — state adapter config (Redis, ioredis, memory)
+
+Also read the TypeScript types from `node_modules/chat/dist/` to understand the full API surface.
+
+## Quick start
+
+```typescript
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createRedisState } from "@chat-adapter/state-redis";
+
+const bot = new Chat({
+  userName: "mybot",
+  adapters: {
+    slack: createSlackAdapter({
+      botToken: process.env.SLACK_BOT_TOKEN!,
+      signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    }),
+  },
+  state: createRedisState({ url: process.env.REDIS_URL! }),
+});
+
+bot.onNewMention(async (thread) => {
+  await thread.subscribe();
+  await thread.post("Hello! I'm listening to this thread.");
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await thread.post(`You said: ${message.text}`);
+});
+```
+
+## Core concepts
+
+- **Chat** — main entry point, coordinates adapters and routes events
+- **Adapters** — platform-specific (Slack, Teams, GChat, Discord, GitHub, Linear)
+- **State** — pluggable persistence (Redis for prod, memory for dev)
+- **Thread** — conversation thread with `post()`, `subscribe()`, `startTyping()`
+- **Message** — normalized format with `text`, `formatted` (mdast AST), `raw`
+- **Channel** — container for threads, supports listing and posting
+
+## Event handlers
+
+| Handler | Trigger |
+|---------|---------|
+| `onNewMention` | Bot @-mentioned in unsubscribed thread |
+| `onSubscribedMessage` | Any message in subscribed thread |
+| `onNewMessage(regex)` | Messages matching pattern in unsubscribed threads |
+| `onSlashCommand("/cmd")` | Slash command invocations |
+| `onReaction(emojis)` | Emoji reactions added/removed |
+| `onAction(actionId)` | Button clicks and dropdown selections |
+| `onAssistantThreadStarted` | Slack Assistants API thread opened |
+| `onAppHomeOpened` | Slack App Home tab opened |
+
+## Streaming
+
+Pass any `AsyncIterable<string>` to `thread.post()`. Works with AI SDK's `textStream`:
+
+```typescript
+import { ToolLoopAgent } from "ai";
+const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
+
+bot.onNewMention(async (thread, message) => {
+  const result = await agent.stream({ prompt: message.text });
+  await thread.post(result.textStream);
+});
+```
+
+## Cards (JSX)
+
+Set `jsxImportSource: "chat"` in tsconfig. Components: `Card`, `CardText`, `Button`, `Actions`, `Fields`, `Field`, `Select`, `SelectOption`, `Image`, `Divider`, `LinkButton`, `Section`, `RadioSelect`.
+
+```tsx
+await thread.post(
+  <Card title="Order #1234">
+    <CardText>Your order has been received!</CardText>
+    <Actions>
+      <Button id="approve" style="primary">Approve</Button>
+      <Button id="reject" style="danger">Reject</Button>
+    </Actions>
+  </Card>
+);
+```
+
+## Packages
+
+| Package | Purpose |
+|---------|---------|
+| `chat` | Core SDK |
+| `@chat-adapter/slack` | Slack |
+| `@chat-adapter/teams` | Microsoft Teams |
+| `@chat-adapter/gchat` | Google Chat |
+| `@chat-adapter/discord` | Discord |
+| `@chat-adapter/github` | GitHub Issues |
+| `@chat-adapter/linear` | Linear Issues |
+| `@chat-adapter/state-redis` | Redis state (production) |
+| `@chat-adapter/state-ioredis` | ioredis state (alternative) |
+| `@chat-adapter/state-memory` | In-memory state (development) |
+
+## Changesets (Release Flow)
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) for versioning and changelogs. Every PR that changes a package's behavior must include a changeset.
+
+```bash
+pnpm changeset
+# → select affected package(s) (e.g. @chat-adapter/slack, chat)
+# → choose bump type: patch (fixes), minor (features), major (breaking)
+# → write a short summary for the CHANGELOG
+```
+
+This creates a file in `.changeset/` — commit it with the PR. When merged to `main`, the Changesets GitHub Action opens a "Version Packages" PR to bump versions and update CHANGELOGs. Merging that PR publishes to npm.
+
+## Webhook setup
+
+Each adapter exposes a webhook handler via `bot.webhooks.{platform}`. Wire these to your HTTP framework's routes (e.g. Next.js API routes, Hono, Express).

--- a/.agents/skills/chat-sdk/SKILL.md
+++ b/.agents/skills/chat-sdk/SKILL.md
@@ -24,6 +24,7 @@ node_modules/chat/dist/           # Built types (.d.ts files)
 ```
 
 Key docs to read based on task:
+
 - `docs/getting-started.mdx` — setup guides
 - `docs/usage.mdx` — event handlers, threads, messages, channels
 - `docs/streaming.mdx` — AI streaming with AI SDK
@@ -38,12 +39,12 @@ Also read the TypeScript types from `node_modules/chat/dist/` to understand the 
 ## Quick start
 
 ```typescript
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createRedisState } from "@chat-adapter/state-redis";
+import { Chat } from 'chat';
+import { createSlackAdapter } from '@chat-adapter/slack';
+import { createRedisState } from '@chat-adapter/state-redis';
 
 const bot = new Chat({
-  userName: "mybot",
+  userName: 'mybot',
   adapters: {
     slack: createSlackAdapter({
       botToken: process.env.SLACK_BOT_TOKEN!,
@@ -53,7 +54,7 @@ const bot = new Chat({
   state: createRedisState({ url: process.env.REDIS_URL! }),
 });
 
-bot.onNewMention(async (thread) => {
+bot.onNewMention(async thread => {
   await thread.subscribe();
   await thread.post("Hello! I'm listening to this thread.");
 });
@@ -74,24 +75,24 @@ bot.onSubscribedMessage(async (thread, message) => {
 
 ## Event handlers
 
-| Handler | Trigger |
-|---------|---------|
-| `onNewMention` | Bot @-mentioned in unsubscribed thread |
-| `onSubscribedMessage` | Any message in subscribed thread |
-| `onNewMessage(regex)` | Messages matching pattern in unsubscribed threads |
-| `onSlashCommand("/cmd")` | Slash command invocations |
-| `onReaction(emojis)` | Emoji reactions added/removed |
-| `onAction(actionId)` | Button clicks and dropdown selections |
-| `onAssistantThreadStarted` | Slack Assistants API thread opened |
-| `onAppHomeOpened` | Slack App Home tab opened |
+| Handler                    | Trigger                                           |
+| -------------------------- | ------------------------------------------------- |
+| `onNewMention`             | Bot @-mentioned in unsubscribed thread            |
+| `onSubscribedMessage`      | Any message in subscribed thread                  |
+| `onNewMessage(regex)`      | Messages matching pattern in unsubscribed threads |
+| `onSlashCommand("/cmd")`   | Slash command invocations                         |
+| `onReaction(emojis)`       | Emoji reactions added/removed                     |
+| `onAction(actionId)`       | Button clicks and dropdown selections             |
+| `onAssistantThreadStarted` | Slack Assistants API thread opened                |
+| `onAppHomeOpened`          | Slack App Home tab opened                         |
 
 ## Streaming
 
 Pass any `AsyncIterable<string>` to `thread.post()`. Works with AI SDK's `textStream`:
 
 ```typescript
-import { ToolLoopAgent } from "ai";
-const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
+import { ToolLoopAgent } from 'ai';
+const agent = new ToolLoopAgent({ model: 'anthropic/claude-4.5-sonnet' });
 
 bot.onNewMention(async (thread, message) => {
   const result = await agent.stream({ prompt: message.text });
@@ -108,8 +109,12 @@ await thread.post(
   <Card title="Order #1234">
     <CardText>Your order has been received!</CardText>
     <Actions>
-      <Button id="approve" style="primary">Approve</Button>
-      <Button id="reject" style="danger">Reject</Button>
+      <Button id="approve" style="primary">
+        Approve
+      </Button>
+      <Button id="reject" style="danger">
+        Reject
+      </Button>
     </Actions>
   </Card>
 );
@@ -117,18 +122,18 @@ await thread.post(
 
 ## Packages
 
-| Package | Purpose |
-|---------|---------|
-| `chat` | Core SDK |
-| `@chat-adapter/slack` | Slack |
-| `@chat-adapter/teams` | Microsoft Teams |
-| `@chat-adapter/gchat` | Google Chat |
-| `@chat-adapter/discord` | Discord |
-| `@chat-adapter/github` | GitHub Issues |
-| `@chat-adapter/linear` | Linear Issues |
-| `@chat-adapter/state-redis` | Redis state (production) |
-| `@chat-adapter/state-ioredis` | ioredis state (alternative) |
-| `@chat-adapter/state-memory` | In-memory state (development) |
+| Package                       | Purpose                       |
+| ----------------------------- | ----------------------------- |
+| `chat`                        | Core SDK                      |
+| `@chat-adapter/slack`         | Slack                         |
+| `@chat-adapter/teams`         | Microsoft Teams               |
+| `@chat-adapter/gchat`         | Google Chat                   |
+| `@chat-adapter/discord`       | Discord                       |
+| `@chat-adapter/github`        | GitHub Issues                 |
+| `@chat-adapter/linear`        | Linear Issues                 |
+| `@chat-adapter/state-redis`   | Redis state (production)      |
+| `@chat-adapter/state-ioredis` | ioredis state (alternative)   |
+| `@chat-adapter/state-memory`  | In-memory state (development) |
 
 ## Changesets (Release Flow)
 

--- a/.kilocode/skills/chat-sdk
+++ b/.kilocode/skills/chat-sdk
@@ -1,0 +1,1 @@
+../../.agents/skills/chat-sdk

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -11,5 +11,14 @@ services:
       - postgres_data:/var/lib/postgresql
     restart: unless-stopped
 
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
 volumes:
   postgres_data:
+  redis_data:

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/client-s3": "^3.980.0",
     "@aws-sdk/s3-request-presigner": "^3.980.0",
     "@chat-adapter/slack": "^4.15.0",
+    "@chat-adapter/state-memory": "^4.15.0",
     "@chat-adapter/state-redis": "^4.15.0",
     "@kilocode/db": "workspace:*",
     "@kilocode/encryption": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "@ai-sdk/openai-compatible": "^2.0.31",
     "@aws-sdk/client-s3": "^3.980.0",
     "@aws-sdk/s3-request-presigner": "^3.980.0",
+    "@chat-adapter/slack": "^4.15.0",
+    "@chat-adapter/state-redis": "^4.15.0",
     "@kilocode/db": "workspace:*",
     "@kilocode/encryption": "workspace:*",
     "@kilocode/worker-utils": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.105",
+    "chat": "^4.15.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,17 +76,17 @@ importers:
   .:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.41
-        version: 3.0.41(zod@4.3.6)
+        specifier: ^3.0.50
+        version: 3.0.50(zod@4.3.6)
       '@ai-sdk/gateway':
-        specifier: ^3.0.16
-        version: 3.0.16(zod@4.3.6)
+        specifier: ^3.0.59
+        version: 3.0.59(zod@4.3.6)
       '@ai-sdk/mistral':
-        specifier: ^3.0.19
-        version: 3.0.19(zod@4.3.6)
+        specifier: ^3.0.21
+        version: 3.0.21(zod@4.3.6)
       '@ai-sdk/openai':
-        specifier: ^3.0.27
-        version: 3.0.27(zod@4.3.6)
+        specifier: ^3.0.37
+        version: 3.0.37(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.31
         version: 2.0.31(zod@4.3.6)
@@ -256,8 +256,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       ai:
-        specifier: ^6.0.78
-        version: 6.0.78(zod@4.3.6)
+        specifier: ^6.0.105
+        version: 6.0.105(zod@4.3.6)
       chat:
         specifier: ^4.15.0
         version: 4.15.0
@@ -328,8 +328,8 @@ importers:
         specifier: ^4.24.13
         version: 4.24.13(next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       openai:
-        specifier: ^6.22.0
-        version: 6.22.0(ws@8.18.2)(zod@4.3.6)
+        specifier: ^6.25.0
+        version: 6.25.0(ws@8.18.2)(zod@4.3.6)
       posthog-js:
         specifier: ^1.275.1
         version: 1.275.1
@@ -576,8 +576,8 @@ importers:
   cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.7.5
-        version: 0.7.5(@xterm/xterm@6.0.0)
+        specifier: 0.7.8
+        version: 0.7.8(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: ^0.4.2
         version: 0.4.2(@trpc/server@11.9.0(typescript@5.9.3))(hono@4.12.2)
@@ -1590,26 +1590,20 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/anthropic@3.0.41':
-    resolution: {integrity: sha512-Wk/YHKyP/MmvQ63MFGRwmm3URM3ey7Tg62y0a7MT+7/8kMVZ40pUYidYO0hB9YB+dHe4z1ks006mNfGYy+wzkA==}
+  '@ai-sdk/anthropic@3.0.50':
+    resolution: {integrity: sha512-BkCUgGTp/iZJuuFBF1wv7GGnrEJg7X7hqbaa+/t4HTBt9dZn3e6NFn5NhPUvo2p5SreUeHEl0As0r2uaVn3K9Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.16':
-    resolution: {integrity: sha512-OOY5CfRJiHvh/8np2vs1RQaCZ5hWv2qOeEmmeiABXK3gLQHUVnCO+1hhoLsZdHM5iElu6M407dAOfyvTsKJqcQ==}
+  '@ai-sdk/gateway@3.0.59':
+    resolution: {integrity: sha512-MbtheWHgEFV/8HL1Z6E3hOAsmP73zZlNFg0F0nJAD0Adnjp4J/plqNK00Y896d+dWTw+r0OXzyov9/2wCFjH0Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.39':
-    resolution: {integrity: sha512-SeCZBAdDNbWpVUXiYgOAqis22p5MEYfrjRw0hiBa5hM+7sDGYQpMinUjkM8kbPXMkY+AhKLrHleBl+SuqpzlgA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/mistral@3.0.19':
-    resolution: {integrity: sha512-yd0OJ3fm2YKdwxh1pd9m720sENVVcylAD+Bki8C80QqVpUxGNL1/C4N4JJGb56eCCWr6VU/3gHFe9PKui9n/Hg==}
+  '@ai-sdk/mistral@3.0.21':
+    resolution: {integrity: sha512-GhLRyfXghnKpt51t8ELU3cXwbCUcGOxZFUQFUZvNBt+y298PlOhaAK6pQtihfpNRGUycrdNotKwVajJm0a6uwg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1620,14 +1614,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.27':
-    resolution: {integrity: sha512-pLMxWOypwroXiK9dxNpn60/HGhWWWDEOJ3lo9vZLoxvpJNtKnLKojwVIvlW3yEjlD7ll1+jUO2uzsABNTaP5Yg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.14':
-    resolution: {integrity: sha512-7bzKd9lgiDeXM7O4U4nQ8iTxguAOkg8LZGD9AfDVZYjO5cKYRwBPwVjboFcVrxncRHu0tYxZtXZtiLKpG4pEng==}
+  '@ai-sdk/openai@3.0.37':
+    resolution: {integrity: sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1637,16 +1625,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.8':
-    resolution: {integrity: sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@3.0.4':
-    resolution: {integrity: sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==}
-    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -2558,8 +2536,8 @@ packages:
       '@opencode-ai/sdk':
         optional: true
 
-  '@cloudflare/sandbox@0.7.5':
-    resolution: {integrity: sha512-lOegEUL6eDsHrsxEMxqRcftsp46hn+ilQryCLuSDghHvnCdDAenzyN/E3nVjQdYAZnoh5xsLzis/G295LcZr1w==}
+  '@cloudflare/sandbox@0.7.8':
+    resolution: {integrity: sha512-BNiRgHlGWYFYzRDDs+OOy1fEMU+Vr2UsWeTLP1LOQmq1oE2GSc1cWFPOOK4KZXUoxWJurMqZRAG47qa0ipKBCw==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -6399,8 +6377,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@6.0.78:
-    resolution: {integrity: sha512-eriIX/NLWfWNDeE/OJy8wmIp9fyaH7gnxTOCPT5bp0MNkvORstp1TwRUql9au8XjXzH7o2WApqbwgxJDDV0Rbw==}
+  ai@6.0.105:
+    resolution: {integrity: sha512-rp+exWtZS3J0DDvZIfetpKCIg7D3cCsvBPoFN3I67IDTs9aoBZDbpecoIkmNLT+U9RBkoEial3OGHRvme23HCw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9754,8 +9732,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openai@6.22.0:
-    resolution: {integrity: sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==}
+  openai@6.25.0:
+    resolution: {integrity: sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -11883,30 +11861,23 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/anthropic@3.0.41(zod@4.3.6)':
+  '@ai-sdk/anthropic@3.0.50(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.16(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.59(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.4
-      '@ai-sdk/provider-utils': 4.0.8(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.39(zod@4.3.6)':
+  '@ai-sdk/mistral@3.0.21(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
-      zod: 4.3.6
-
-  '@ai-sdk/mistral@3.0.19(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai-compatible@2.0.31(zod@4.3.6)':
@@ -11915,17 +11886,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.27(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.37(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
-      zod: 4.3.6
-
-  '@ai-sdk/provider-utils@4.0.14(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.16(zod@4.3.6)':
@@ -11934,17 +11898,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
-
-  '@ai-sdk/provider-utils@4.0.8(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.4
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.6
-
-  '@ai-sdk/provider@3.0.4':
-    dependencies:
-      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -13353,7 +13306,7 @@ snapshots:
   '@chat-adapter/slack@4.15.0':
     dependencies:
       '@chat-adapter/shared': 4.15.0
-      '@slack/web-api': 7.13.0
+      '@slack/web-api': 7.14.1
       chat: 4.15.0
     transitivePeerDependencies:
       - debug
@@ -13453,7 +13406,7 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.0.30
 
-  '@cloudflare/sandbox@0.7.5(@xterm/xterm@6.0.0)':
+  '@cloudflare/sandbox@0.7.8(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.0.30
       aws4fetch: 1.0.20
@@ -17727,7 +17680,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -17926,11 +17879,11 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@6.0.78(zod@4.3.6):
+  ai@6.0.105(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.39(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.59(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
@@ -22188,7 +22141,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.22.0(ws@8.18.2)(zod@4.3.6):
+  openai@6.25.0(ws@8.18.2)(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.2
       zod: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@chat-adapter/slack':
         specifier: ^4.15.0
         version: 4.15.0
+      '@chat-adapter/state-memory':
+        specifier: ^4.15.0
+        version: 4.15.0
       '@chat-adapter/state-redis':
         specifier: ^4.15.0
         version: 4.15.0
@@ -2485,6 +2488,9 @@ packages:
 
   '@chat-adapter/slack@4.15.0':
     resolution: {integrity: sha512-DE2puxMXitt2AVLBvMAldZ4KKUKpKWxSd62nWLDX6xXtOo6z9uXAggZD3FnMOGITqw+oQypdFopvm/Wu6OxeFg==}
+
+  '@chat-adapter/state-memory@4.15.0':
+    resolution: {integrity: sha512-I/p6dA8fl8peZH9utKOsO8raFttUSyIQwyhB/uP6cR9d07hZVcG/SF30t4RjKDgegnq8+euqPFj3lCssIaYhoA==}
 
   '@chat-adapter/state-redis@4.15.0':
     resolution: {integrity: sha512-156CGZCkMXzsnMC20nIpNkAGScbasOHxR9YcPMuLm2IwSC1L/Kyea7o9TEv2ldvk63q/e+AaU+98T7T5/2+mvg==}
@@ -13312,6 +13318,12 @@ snapshots:
       - debug
       - supports-color
 
+  '@chat-adapter/state-memory@4.15.0':
+    dependencies:
+      chat: 4.15.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@chat-adapter/state-redis@4.15.0':
     dependencies:
       chat: 4.15.0
@@ -17680,7 +17692,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.980.0
         version: 3.980.0
+      '@chat-adapter/slack':
+        specifier: ^4.15.0
+        version: 4.15.0
+      '@chat-adapter/state-redis':
+        specifier: ^4.15.0
+        version: 4.15.0
       '@kilocode/db':
         specifier: workspace:*
         version: link:packages/db
@@ -2481,6 +2487,15 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@chat-adapter/shared@4.15.0':
+    resolution: {integrity: sha512-otIS9zf0wY3DMc5WGK1sOJiASSeMHcdEqmuxDWW/6tK7gdRE7FOVE+dfo/74ykj9QZwv+a9cByh1cimaeHbiAw==}
+
+  '@chat-adapter/slack@4.15.0':
+    resolution: {integrity: sha512-DE2puxMXitt2AVLBvMAldZ4KKUKpKWxSd62nWLDX6xXtOo6z9uXAggZD3FnMOGITqw+oQypdFopvm/Wu6OxeFg==}
+
+  '@chat-adapter/state-redis@4.15.0':
+    resolution: {integrity: sha512-156CGZCkMXzsnMC20nIpNkAGScbasOHxR9YcPMuLm2IwSC1L/Kyea7o9TEv2ldvk63q/e+AaU+98T7T5/2+mvg==}
+
   '@chromatic-com/playwright@0.12.8':
     resolution: {integrity: sha512-2oi8ghd+2N+hDI0Y65Ac/aYfsvDTyDHvEZMNS4Ln7VzyZ6SdGLoQLOvP80IGJlekTI68K8gQpzXewRV2chUaZQ==}
     hasBin: true
@@ -4551,6 +4566,35 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
 
   '@reduxjs/toolkit@2.9.1':
     resolution: {integrity: sha512-sETJ3qO72y7L7WiR5K54UFLT3jRzAtqeBPVO15xC3bGA6kDqCH8m/v7BKCPH4czydXzz/1lPEGLvew7GjOO3Qw==}
@@ -6866,6 +6910,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
@@ -8037,6 +8085,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -10379,6 +10431,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
@@ -13261,6 +13316,28 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@chat-adapter/shared@4.15.0':
+    dependencies:
+      chat: 4.15.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@chat-adapter/slack@4.15.0':
+    dependencies:
+      '@chat-adapter/shared': 4.15.0
+      '@slack/web-api': 7.13.0
+      chat: 4.15.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@chat-adapter/state-redis@4.15.0':
+    dependencies:
+      chat: 4.15.0
+      redis: 4.7.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@chromatic-com/playwright@0.12.8(@playwright/test@1.57.0)(@swc/core@1.12.5)(@types/react@19.2.2)(esbuild@0.27.0)(prettier@3.8.1)(typescript@5.9.3)':
     dependencies:
       '@chromaui/rrweb-snapshot': 2.0.0-alpha.18-noAbsolute
@@ -15412,6 +15489,32 @@ snapshots:
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
 
   '@reduxjs/toolkit@2.9.1(react-redux@9.2.0(@types/react@19.2.2)(react@19.2.0)(redux@5.0.1))(react@19.2.0)':
     dependencies:
@@ -18377,6 +18480,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.1.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
@@ -19644,6 +19749,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   generator-function@2.0.1: {}
+
+  generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -22771,6 +22878,15 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,20 +76,17 @@ importers:
   .:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.50
-        version: 3.0.50(zod@4.3.6)
+        specifier: ^3.0.41
+        version: 3.0.41(zod@4.3.6)
       '@ai-sdk/gateway':
-        specifier: ^3.0.59
-        version: 3.0.59(zod@4.3.6)
+        specifier: ^3.0.16
+        version: 3.0.16(zod@4.3.6)
       '@ai-sdk/mistral':
-        specifier: ^3.0.21
-        version: 3.0.21(zod@4.3.6)
+        specifier: ^3.0.19
+        version: 3.0.19(zod@4.3.6)
       '@ai-sdk/openai':
-        specifier: ^3.0.37
-        version: 3.0.37(zod@4.3.6)
-      '@ai-sdk/openai-compatible':
-        specifier: ^2.0.31
-        version: 2.0.31(zod@4.3.6)
+        specifier: ^3.0.27
+        version: 3.0.27(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.980.0
         version: 3.980.0
@@ -250,8 +247,11 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       ai:
-        specifier: ^6.0.105
-        version: 6.0.105(zod@4.3.6)
+        specifier: ^6.0.78
+        version: 6.0.78(zod@4.3.6)
+      chat:
+        specifier: ^4.15.0
+        version: 4.15.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -319,8 +319,8 @@ importers:
         specifier: ^4.24.13
         version: 4.24.13(next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       openai:
-        specifier: ^6.25.0
-        version: 6.25.0(ws@8.18.2)(zod@4.3.6)
+        specifier: ^6.22.0
+        version: 6.22.0(ws@8.18.2)(zod@4.3.6)
       posthog-js:
         specifier: ^1.275.1
         version: 1.275.1
@@ -567,8 +567,8 @@ importers:
   cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.7.8
-        version: 0.7.8(@xterm/xterm@6.0.0)
+        specifier: 0.7.5
+        version: 0.7.5(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: ^0.4.2
         version: 0.4.2(@trpc/server@11.9.0(typescript@5.9.3))(hono@4.12.2)
@@ -1581,41 +1581,51 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/anthropic@3.0.50':
-    resolution: {integrity: sha512-BkCUgGTp/iZJuuFBF1wv7GGnrEJg7X7hqbaa+/t4HTBt9dZn3e6NFn5NhPUvo2p5SreUeHEl0As0r2uaVn3K9Q==}
+  '@ai-sdk/anthropic@3.0.41':
+    resolution: {integrity: sha512-Wk/YHKyP/MmvQ63MFGRwmm3URM3ey7Tg62y0a7MT+7/8kMVZ40pUYidYO0hB9YB+dHe4z1ks006mNfGYy+wzkA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.59':
-    resolution: {integrity: sha512-MbtheWHgEFV/8HL1Z6E3hOAsmP73zZlNFg0F0nJAD0Adnjp4J/plqNK00Y896d+dWTw+r0OXzyov9/2wCFjH0Q==}
+  '@ai-sdk/gateway@3.0.16':
+    resolution: {integrity: sha512-OOY5CfRJiHvh/8np2vs1RQaCZ5hWv2qOeEmmeiABXK3gLQHUVnCO+1hhoLsZdHM5iElu6M407dAOfyvTsKJqcQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mistral@3.0.21':
-    resolution: {integrity: sha512-GhLRyfXghnKpt51t8ELU3cXwbCUcGOxZFUQFUZvNBt+y298PlOhaAK6pQtihfpNRGUycrdNotKwVajJm0a6uwg==}
+  '@ai-sdk/gateway@3.0.39':
+    resolution: {integrity: sha512-SeCZBAdDNbWpVUXiYgOAqis22p5MEYfrjRw0hiBa5hM+7sDGYQpMinUjkM8kbPXMkY+AhKLrHleBl+SuqpzlgA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.31':
-    resolution: {integrity: sha512-e78xiImcTe2aCMQoFbVJluQmUV4XgahOmmehAuRPlcwzRv2KtkvuLCXPC9Xcy2u83e8SimVva9k9G8SvZcnaBA==}
+  '@ai-sdk/mistral@3.0.19':
+    resolution: {integrity: sha512-yd0OJ3fm2YKdwxh1pd9m720sENVVcylAD+Bki8C80QqVpUxGNL1/C4N4JJGb56eCCWr6VU/3gHFe9PKui9n/Hg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.37':
-    resolution: {integrity: sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow==}
+  '@ai-sdk/openai@3.0.27':
+    resolution: {integrity: sha512-pLMxWOypwroXiK9dxNpn60/HGhWWWDEOJ3lo9vZLoxvpJNtKnLKojwVIvlW3yEjlD7ll1+jUO2uzsABNTaP5Yg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.16':
-    resolution: {integrity: sha512-kBvDqNkt5EwlzF9FujmNhhtl8FYg3e8FO8P5uneKliqfRThWemzBj+wfYr7ZCymAQhTRnwSSz1/SOqhOAwmx9g==}
+  '@ai-sdk/provider-utils@4.0.14':
+    resolution: {integrity: sha512-7bzKd9lgiDeXM7O4U4nQ8iTxguAOkg8LZGD9AfDVZYjO5cKYRwBPwVjboFcVrxncRHu0tYxZtXZtiLKpG4pEng==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.8':
+    resolution: {integrity: sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.4':
+    resolution: {integrity: sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -2518,8 +2528,8 @@ packages:
       '@opencode-ai/sdk':
         optional: true
 
-  '@cloudflare/sandbox@0.7.8':
-    resolution: {integrity: sha512-BNiRgHlGWYFYzRDDs+OOy1fEMU+Vr2UsWeTLP1LOQmq1oE2GSc1cWFPOOK4KZXUoxWJurMqZRAG47qa0ipKBCw==}
+  '@cloudflare/sandbox@0.7.5':
+    resolution: {integrity: sha512-lOegEUL6eDsHrsxEMxqRcftsp46hn+ilQryCLuSDghHvnCdDAenzyN/E3nVjQdYAZnoh5xsLzis/G295LcZr1w==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -6247,6 +6257,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   '@workos-inc/node@8.2.0':
     resolution: {integrity: sha512-aAY2k7X09lQ4TaVe7Kjm3gjb+EsGRoncbwJCOou9mCmunQoEYO1lsNrJTRIMM+jKCPBQDcmMF1O3Bv8IQwQKtg==}
     engines: {node: '>=20.15.0'}
@@ -6327,8 +6340,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@6.0.105:
-    resolution: {integrity: sha512-rp+exWtZS3J0DDvZIfetpKCIg7D3cCsvBPoFN3I67IDTs9aoBZDbpecoIkmNLT+U9RBkoEial3OGHRvme23HCw==}
+  ai@6.0.78:
+    resolution: {integrity: sha512-eriIX/NLWfWNDeE/OJy8wmIp9fyaH7gnxTOCPT5bp0MNkvORstp1TwRUql9au8XjXzH7o2WApqbwgxJDDV0Rbw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6767,6 +6780,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chat@4.15.0:
+    resolution: {integrity: sha512-fE1m3UEiKQoiYkhXWT0rpH1+ZhKqJGZYkS+1gNCZWNkLv0QWTZhzdzBM5qYWe5A/Y0wJ8yLVjaqvGO4zZFxZqg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -9671,8 +9687,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openai@6.25.0:
-    resolution: {integrity: sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww==}
+  openai@6.22.0:
+    resolution: {integrity: sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -11797,43 +11813,55 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/anthropic@3.0.50(zod@4.3.6)':
+  '@ai-sdk/anthropic@3.0.41(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.59(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.16(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.4
+      '@ai-sdk/provider-utils': 4.0.8(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/mistral@3.0.21(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.39(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/openai-compatible@2.0.31(zod@4.3.6)':
+  '@ai-sdk/mistral@3.0.19(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.37(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.27(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.16(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.14(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.8(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.4
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.4':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -13320,7 +13348,7 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.0.30
 
-  '@cloudflare/sandbox@0.7.8(@xterm/xterm@6.0.0)':
+  '@cloudflare/sandbox@0.7.5(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.0.30
       aws4fetch: 1.0.20
@@ -17691,6 +17719,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   '@workos-inc/node@8.2.0':
     dependencies:
       iron-webcrypto: 2.0.0
@@ -17765,11 +17795,11 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@6.0.105(zod@4.3.6):
+  ai@6.0.78(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.59(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.39(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
@@ -18265,6 +18295,17 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  chat@4.15.0:
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   check-error@2.1.1: {}
 
@@ -22012,7 +22053,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.25.0(ws@8.18.2)(zod@4.3.6):
+  openai@6.22.0(ws@8.18.2)(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.2
       zod: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.27
         version: 3.0.27(zod@4.3.6)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.31
+        version: 2.0.31(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.980.0
         version: 3.980.0
@@ -1611,6 +1614,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.31':
+    resolution: {integrity: sha512-e78xiImcTe2aCMQoFbVJluQmUV4XgahOmmehAuRPlcwzRv2KtkvuLCXPC9Xcy2u83e8SimVva9k9G8SvZcnaBA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.27':
     resolution: {integrity: sha512-pLMxWOypwroXiK9dxNpn60/HGhWWWDEOJ3lo9vZLoxvpJNtKnLKojwVIvlW3yEjlD7ll1+jUO2uzsABNTaP5Yg==}
     engines: {node: '>=18'}
@@ -1619,6 +1628,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.14':
     resolution: {integrity: sha512-7bzKd9lgiDeXM7O4U4nQ8iTxguAOkg8LZGD9AfDVZYjO5cKYRwBPwVjboFcVrxncRHu0tYxZtXZtiLKpG4pEng==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.16':
+    resolution: {integrity: sha512-kBvDqNkt5EwlzF9FujmNhhtl8FYg3e8FO8P5uneKliqfRThWemzBj+wfYr7ZCymAQhTRnwSSz1/SOqhOAwmx9g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -11894,6 +11909,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/openai-compatible@2.0.31(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/openai@3.0.27(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -11901,6 +11922,13 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.14(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.16(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "chat-sdk": {
+      "source": "vercel/chat",
+      "sourceType": "github",
+      "computedHash": "dd43b1cf55f7a481732655011e121140143db3c1280b7ed502fa6be8180fb057"
+    },
     "sentry-cli": {
       "source": "cli.sentry.dev",
       "sourceType": "well-known",

--- a/src/app/api/chat/link-account/route.ts
+++ b/src/app/api/chat/link-account/route.ts
@@ -1,7 +1,11 @@
 import { bot } from '@/lib/bot';
 import { APP_URL } from '@/lib/constants';
 import { linkKiloUser, verifyLinkToken } from '@/lib/bot-identity';
+import { db } from '@/lib/drizzle';
+import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { getUserFromAuth } from '@/lib/user.server';
+import { platform_integrations } from '@kilocode/db';
+import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 function escapeHtml(s: string): string {
@@ -13,17 +17,62 @@ function escapeHtml(s: string): string {
 }
 
 /**
+ * Verify that the authenticated user is allowed to link to this
+ * platform installation. For org-owned integrations the user must be
+ * an org member; for user-owned integrations only the owner may link.
+ */
+async function verifyIntegrationAccess(
+  platform: string,
+  teamId: string,
+  kiloUserId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.platform, platform),
+        eq(platform_integrations.platform_installation_id, teamId)
+      )
+    )
+    .limit(1);
+
+  if (!integration) {
+    return { ok: false, error: 'No matching integration found for this workspace.' };
+  }
+
+  if (integration.owned_by_organization_id) {
+    const isMember = await isOrganizationMember(integration.owned_by_organization_id, kiloUserId);
+    if (!isMember) {
+      return {
+        ok: false,
+        error: 'You are not a member of the organization that owns this workspace integration.',
+      };
+    }
+  } else if (integration.owned_by_user_id) {
+    if (integration.owned_by_user_id !== kiloUserId) {
+      return { ok: false, error: 'You are not the owner of this workspace integration.' };
+    }
+  } else {
+    return { ok: false, error: 'This integration has invalid ownership data.' };
+  }
+
+  return { ok: true };
+}
+
+/**
  * GET /api/chat/link-account?token=<signed-token>
  *
  * Opened in the browser when a chat user clicks "Link Account".
- * The token is HMAC-signed and time-limited (10 min) so that a third
- * party cannot forge a link for an arbitrary platform identity.
+ * The token is HMAC-signed and time-limited so that a third party
+ * cannot forge a link for an arbitrary platform identity.
  *
  * Flow:
  *  1. Verify the signed token (reject expired / tampered tokens).
  *  2. Authenticate the user via NextAuth session (redirect to sign-in if needed).
- *  3. Write the platform identity → Kilo user mapping into Redis.
- *  4. Show a success page.
+ *  3. Verify the user belongs to the org that owns the integration.
+ *  4. Write the platform identity → Kilo user mapping into Redis.
+ *  5. Show a success page.
  */
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -48,6 +97,12 @@ export async function GET(request: Request) {
     const signInUrl = new URL('/users/sign_in', APP_URL);
     signInUrl.searchParams.set('callbackPath', url.pathname + url.search);
     return NextResponse.redirect(signInUrl);
+  }
+
+  // Verify the user is allowed to link to this integration
+  const access = await verifyIntegrationAccess(identity.platform, identity.teamId, user.id);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: 403 });
   }
 
   await bot.initialize();

--- a/src/app/api/chat/link-account/route.ts
+++ b/src/app/api/chat/link-account/route.ts
@@ -6,14 +6,19 @@ import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { getUserFromAuth } from '@/lib/user.server';
 import { platform_integrations } from '@kilocode/db';
 import { and, eq } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+function errorPage(title: string, message: string, status: number): Response {
+  return new Response(
+    `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${title}</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+  <h1>${title}</h1>
+  <p>${message}</p>
+</div>
+</body></html>`,
+    { status, headers: { 'content-type': 'text/html; charset=utf-8' } }
+  );
 }
 
 /**
@@ -79,15 +84,16 @@ export async function GET(request: Request) {
   const token = url.searchParams.get('token');
 
   if (!token) {
-    return NextResponse.json({ error: 'Missing token parameter' }, { status: 400 });
+    return errorPage('Bad Request', 'Missing token parameter.', 400);
   }
 
   const identity = verifyLinkToken(token);
 
   if (!identity) {
-    return NextResponse.json(
-      { error: 'Invalid or expired link. Please go back to your chat and try again.' },
-      { status: 400 }
+    return errorPage(
+      'Link Expired',
+      'Invalid or expired link. Please go back to your chat and try again.',
+      400
     );
   }
 
@@ -96,20 +102,18 @@ export async function GET(request: Request) {
   if (authFailedResponse) {
     const signInUrl = new URL('/users/sign_in', APP_URL);
     signInUrl.searchParams.set('callbackPath', url.pathname + url.search);
-    return NextResponse.redirect(signInUrl);
+    return Response.redirect(signInUrl.toString());
   }
 
   // Verify the user is allowed to link to this integration
   const access = await verifyIntegrationAccess(identity.platform, identity.teamId, user.id);
   if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: 403 });
+    return errorPage('Access Denied', access.error, 403);
   }
 
   await bot.initialize();
 
   await linkKiloUser(bot.getState(), identity, user.id);
-
-  const platformLabel = escapeHtml(identity.platform);
 
   return new Response(
     `<!DOCTYPE html>
@@ -117,7 +121,7 @@ export async function GET(request: Request) {
 <body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
 <div style="text-align:center">
   <h1>Account linked</h1>
-  <p>Your ${platformLabel} account has been linked to your Kilo account.<br>
+  <p>Your ${identity.platform} account has been linked to your Kilo account.<br>
      You can close this tab and @mention Kilo again in your chat.</p>
 </div>
 </body></html>`,

--- a/src/app/api/chat/link-account/route.ts
+++ b/src/app/api/chat/link-account/route.ts
@@ -97,6 +97,10 @@ export async function GET(request: Request) {
     );
   }
 
+  // TODO(remon): Remove this hack once we've replaced the old slack integration
+  let platform = identity.platform;
+  if (identity.platform === 'slack') platform = 'slack-next';
+
   // Authenticate — redirect to sign-in if no session, then back here
   const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) {
@@ -106,7 +110,7 @@ export async function GET(request: Request) {
   }
 
   // Verify the user is allowed to link to this integration
-  const access = await verifyIntegrationAccess(identity.platform, identity.teamId, user.id);
+  const access = await verifyIntegrationAccess(platform, identity.teamId, user.id);
   if (!access.ok) {
     return errorPage('Access Denied', access.error, 403);
   }

--- a/src/app/api/chat/link-account/route.ts
+++ b/src/app/api/chat/link-account/route.ts
@@ -1,0 +1,71 @@
+import { bot } from '@/lib/bot';
+import { APP_URL } from '@/lib/constants';
+import { linkKiloUser, verifyLinkToken } from '@/lib/bot-identity';
+import { getUserFromAuth } from '@/lib/user.server';
+import { NextResponse } from 'next/server';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * GET /api/chat/link-account?token=<signed-token>
+ *
+ * Opened in the browser when a chat user clicks "Link Account".
+ * The token is HMAC-signed and time-limited (10 min) so that a third
+ * party cannot forge a link for an arbitrary platform identity.
+ *
+ * Flow:
+ *  1. Verify the signed token (reject expired / tampered tokens).
+ *  2. Authenticate the user via NextAuth session (redirect to sign-in if needed).
+ *  3. Write the platform identity → Kilo user mapping into Redis.
+ *  4. Show a success page.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get('token');
+
+  if (!token) {
+    return NextResponse.json({ error: 'Missing token parameter' }, { status: 400 });
+  }
+
+  const identity = verifyLinkToken(token);
+
+  if (!identity) {
+    return NextResponse.json(
+      { error: 'Invalid or expired link. Please go back to your chat and try again.' },
+      { status: 400 }
+    );
+  }
+
+  // Authenticate — redirect to sign-in if no session, then back here
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+  if (authFailedResponse) {
+    const signInUrl = new URL('/users/sign_in', APP_URL);
+    signInUrl.searchParams.set('callbackPath', url.pathname + url.search);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  await bot.initialize();
+
+  await linkKiloUser(bot.getState(), identity, user.id);
+
+  const platformLabel = escapeHtml(identity.platform);
+
+  return new Response(
+    `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Account Linked</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+  <h1>Account linked</h1>
+  <p>Your ${platformLabel} account has been linked to your Kilo account.<br>
+     You can close this tab and @mention Kilo again in your chat.</p>
+</div>
+</body></html>`,
+    { headers: { 'content-type': 'text/html; charset=utf-8' } }
+  );
+}

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -79,5 +79,15 @@ export async function GET(request: Request) {
     });
   }
 
-  return new Response(`Installed for team ${teamId} and ${state}!`);
+  return new Response(
+    `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Slack Installed</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+  <h1>Slack app installed</h1>
+  <p>Kilo has been installed to your workspace. You can close this tab.</p>
+</div>
+</body></html>`,
+    { headers: { 'content-type': 'text/html; charset=utf-8' } }
+  );
 }

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -1,7 +1,20 @@
 import { bot } from '@/lib/bot';
+import { APP_URL } from '@/lib/constants';
+import { db } from '@/lib/drizzle';
+import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
 import { SLACK_REDIRECT_URI } from '@/lib/integrations/slack-service';
+import { getUserFromAuth } from '@/lib/user.server';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import { platform_integrations } from '@kilocode/db';
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+  if (authFailedResponse) {
+    return NextResponse.redirect(new URL('/users/sign_in', APP_URL));
+  }
+
   await bot.initialize();
   const slackAdapter = bot.getAdapter('slack');
 
@@ -11,6 +24,60 @@ export async function GET(request: Request) {
   url.searchParams.set('redirect_uri', SLACK_REDIRECT_URI);
   const patchedRequest = new Request(url, request);
 
-  const { teamId } = await slackAdapter.handleOAuthCallback(patchedRequest);
-  return new Response(`Installed for team ${teamId}!`);
+  const { teamId, installation } = await slackAdapter.handleOAuthCallback(patchedRequest);
+
+  const state = url?.searchParams.get('state');
+
+  if (state?.startsWith('org_')) {
+    const orgId = state.split('_')[1];
+    await ensureOrganizationAccess({ user }, orgId);
+
+    await db.transaction(async tx => {
+      await tx
+        .delete(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.owned_by_organization_id, orgId),
+            eq(platform_integrations.platform, PLATFORM.SLACK)
+          )
+        );
+
+      await tx.insert(platform_integrations).values({
+        owned_by_organization_id: orgId,
+        platform: PLATFORM.SLACK,
+        integration_type: 'oauth',
+        platform_installation_id: teamId,
+        platform_account_id: teamId,
+        platform_account_login: installation.teamName,
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: {},
+        installed_at: new Date().toISOString(),
+      });
+    });
+  } else {
+    await db.transaction(async tx => {
+      await tx
+        .delete(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.owned_by_user_id, user.id),
+            eq(platform_integrations.platform, PLATFORM.SLACK)
+          )
+        );
+
+      await tx.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        platform: PLATFORM.SLACK,
+        integration_type: 'oauth',
+        platform_installation_id: teamId,
+        platform_account_id: teamId,
+        platform_account_login: installation.teamName,
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: {},
+        installed_at: new Date().toISOString(),
+      });
+    });
+  }
+
+  return new Response(`Installed for team ${teamId} and ${state}!`);
 }

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -26,12 +26,17 @@ export async function GET(request: Request) {
 
   const { teamId, installation } = await slackAdapter.handleOAuthCallback(patchedRequest);
 
+  // TODO: HMAC-sign the state parameter when generating the install URL
+  // and verify the signature here to prevent CSRF / tampering.
   const state = url?.searchParams.get('state');
 
   if (state?.startsWith('org_')) {
     const orgId = state.split('_')[1];
     await ensureOrganizationAccess({ user }, orgId);
 
+    // TODO: Reconsider blindly deleting the existing integration on re-install.
+    // We also need to handle the case where a teamId was previously installed
+    // for a personal account and is now being re-installed for an org (or vice versa).
     await db.transaction(async tx => {
       await tx
         .delete(platform_integrations)

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -5,8 +5,18 @@ import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants'
 import { getUserFromAuth } from '@/lib/user.server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { platform_integrations } from '@kilocode/db';
+import { captureException } from '@sentry/nextjs';
 import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
+
+async function hasPlatformIntegrationForAccountId(platformAccountId: string) {
+  return !!(await db.query.platform_integrations.findFirst({
+    where: and(
+      eq(platform_integrations.platform, 'slack-next'),
+      eq(platform_integrations.platform_account_id, platformAccountId)
+    ),
+  }));
+}
 
 export async function GET(request: Request) {
   const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
@@ -25,6 +35,27 @@ export async function GET(request: Request) {
 
   const { teamId, installation } = await slackAdapter.handleOAuthCallback(patchedRequest);
 
+  if (await hasPlatformIntegrationForAccountId(teamId)) {
+    captureException(new Error('Slack already installed for other kilo organization/user'), {
+      extra: { teamId, userId: user.id },
+    });
+
+    await slackAdapter.deleteInstallation(teamId);
+
+    return new Response(
+      `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Slack Already Installed</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<div style="text-align:center">
+  <h1>Slack workspace already connected</h1>
+  <p>This Slack workspace is already installed for another entity in Kilo.</p>
+  <p>Please reach out to <a href="mailto:hi@kilocode.ai">hi@kilocode.ai</a> for support.</p>
+</div>
+</body></html>`,
+      { headers: { 'content-type': 'text/html; charset=utf-8' } }
+    );
+  }
+
   // TODO: HMAC-sign the state parameter when generating the install URL
   // and verify the signature here to prevent CSRF / tampering.
   const state = url?.searchParams.get('state');
@@ -33,9 +64,6 @@ export async function GET(request: Request) {
     const orgId = state.replace('org_', '');
     await ensureOrganizationAccess({ user }, orgId);
 
-    // TODO: Reconsider blindly deleting the existing integration on re-install.
-    // We also need to handle the case where a teamId was previously installed
-    // for a personal account and is now being re-installed for an org (or vice versa).
     await db.transaction(async tx => {
       await tx
         .delete(platform_integrations)

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request) {
   // TODO(remon): Not completely sure why this is needed, but handleOAuthCallback
   //   requires a redirect_uri in the URL, and we don't have it (because we are the redirect_uri)
   const url = new URL(request.url);
-  url.searchParams.set('redirect_uri', SLACK_REDIRECT_URI);
+  url.searchParams.set('redirect_uri', `${APP_URL}/api/chat/slack/install/callback`);
   const patchedRequest = new Request(url, request);
 
   const { teamId, installation } = await slackAdapter.handleOAuthCallback(patchedRequest);
@@ -43,13 +43,13 @@ export async function GET(request: Request) {
         .where(
           and(
             eq(platform_integrations.owned_by_organization_id, orgId),
-            eq(platform_integrations.platform, PLATFORM.SLACK)
+            eq(platform_integrations.platform, PLATFORM.SLACK_NEXT)
           )
         );
 
       await tx.insert(platform_integrations).values({
         owned_by_organization_id: orgId,
-        platform: PLATFORM.SLACK,
+        platform: PLATFORM.SLACK_NEXT,
         integration_type: 'oauth',
         platform_installation_id: teamId,
         platform_account_id: teamId,
@@ -66,13 +66,13 @@ export async function GET(request: Request) {
         .where(
           and(
             eq(platform_integrations.owned_by_user_id, user.id),
-            eq(platform_integrations.platform, PLATFORM.SLACK)
+            eq(platform_integrations.platform, PLATFORM.SLACK_NEXT)
           )
         );
 
       await tx.insert(platform_integrations).values({
         owned_by_user_id: user.id,
-        platform: PLATFORM.SLACK,
+        platform: PLATFORM.SLACK_NEXT,
         integration_type: 'oauth',
         platform_installation_id: teamId,
         platform_account_id: teamId,

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
   const state = url?.searchParams.get('state');
 
   if (state?.startsWith('org_')) {
-    const orgId = state.split('_')[1];
+    const orgId = state.replace('org_', '');
     await ensureOrganizationAccess({ user }, orgId);
 
     // TODO: Reconsider blindly deleting the existing integration on re-install.

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -5,18 +5,8 @@ import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants'
 import { getUserFromAuth } from '@/lib/user.server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { platform_integrations } from '@kilocode/db';
-import { captureException } from '@sentry/nextjs';
 import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
-
-async function hasPlatformIntegrationForAccountId(platformAccountId: string) {
-  return !!(await db.query.platform_integrations.findFirst({
-    where: and(
-      eq(platform_integrations.platform, 'slack-next'),
-      eq(platform_integrations.platform_account_id, platformAccountId)
-    ),
-  }));
-}
 
 export async function GET(request: Request) {
   const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
@@ -34,27 +24,6 @@ export async function GET(request: Request) {
   const patchedRequest = new Request(url, request);
 
   const { teamId, installation } = await slackAdapter.handleOAuthCallback(patchedRequest);
-
-  if (await hasPlatformIntegrationForAccountId(teamId)) {
-    captureException(new Error('Slack already installed for other kilo organization/user'), {
-      extra: { teamId, userId: user.id },
-    });
-
-    await slackAdapter.deleteInstallation(teamId);
-
-    return new Response(
-      `<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>Slack Already Installed</title></head>
-<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
-<div style="text-align:center">
-  <h1>Slack workspace already connected</h1>
-  <p>This Slack workspace is already installed for another entity in Kilo.</p>
-  <p>Please reach out to <a href="mailto:hi@kilocode.ai">hi@kilocode.ai</a> for support.</p>
-</div>
-</body></html>`,
-      { headers: { 'content-type': 'text/html; charset=utf-8' } }
-    );
-  }
 
   // TODO: HMAC-sign the state parameter when generating the install URL
   // and verify the signature here to prevent CSRF / tampering.

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -2,7 +2,6 @@ import { bot } from '@/lib/bot';
 import { APP_URL } from '@/lib/constants';
 import { db } from '@/lib/drizzle';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
-import { SLACK_REDIRECT_URI } from '@/lib/integrations/slack-service';
 import { getUserFromAuth } from '@/lib/user.server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { platform_integrations } from '@kilocode/db';

--- a/src/app/api/chat/slack/install/callback/route.ts
+++ b/src/app/api/chat/slack/install/callback/route.ts
@@ -1,0 +1,16 @@
+import { bot } from '@/lib/bot';
+import { SLACK_REDIRECT_URI } from '@/lib/integrations/slack-service';
+
+export async function GET(request: Request) {
+  await bot.initialize();
+  const slackAdapter = bot.getAdapter('slack');
+
+  // TODO(remon): Not completely sure why this is needed, but handleOAuthCallback
+  //   requires a redirect_uri in the URL, and we don't have it (because we are the redirect_uri)
+  const url = new URL(request.url);
+  url.searchParams.set('redirect_uri', SLACK_REDIRECT_URI);
+  const patchedRequest = new Request(url, request);
+
+  const { teamId } = await slackAdapter.handleOAuthCallback(patchedRequest);
+  return new Response(`Installed for team ${teamId}!`);
+}

--- a/src/app/api/chat/slack/install/route.ts
+++ b/src/app/api/chat/slack/install/route.ts
@@ -1,13 +1,16 @@
 import { APP_URL } from '@/lib/constants';
 import { SLACK_SCOPES } from '@/lib/integrations/slack-service';
 import { getUserFromAuth } from '@/lib/user.server';
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 /**
  * Temporary admin-only route that redirects to the Slack OAuth flow
  * for the chat-adapter Slack app (SLACK_NEXT_*).
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+
   const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
   if (authFailedResponse) return authFailedResponse;
 
@@ -20,6 +23,7 @@ export async function GET() {
     client_id: clientId,
     redirect_uri: `${APP_URL}/api/chat/slack/install/callback`,
     scope: SLACK_SCOPES.join(','),
+    state: requestUrl.searchParams.get('state') || '',
   });
 
   return NextResponse.redirect(`https://slack.com/oauth/v2/authorize?${params.toString()}`);

--- a/src/app/api/chat/slack/install/route.ts
+++ b/src/app/api/chat/slack/install/route.ts
@@ -1,0 +1,26 @@
+import { APP_URL } from '@/lib/constants';
+import { SLACK_SCOPES } from '@/lib/integrations/slack-service';
+import { getUserFromAuth } from '@/lib/user.server';
+import { NextResponse } from 'next/server';
+
+/**
+ * Temporary admin-only route that redirects to the Slack OAuth flow
+ * for the chat-adapter Slack app (SLACK_NEXT_*).
+ */
+export async function GET() {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  const clientId = process.env.SLACK_NEXT_CLIENT_ID;
+  if (!clientId) {
+    return NextResponse.json({ error: 'SLACK_NEXT_CLIENT_ID is not configured' }, { status: 500 });
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${APP_URL}/api/chat/slack/install/callback`,
+    scope: SLACK_SCOPES.join(','),
+  });
+
+  return NextResponse.redirect(`https://slack.com/oauth/v2/authorize?${params.toString()}`);
+}

--- a/src/app/api/chat/webhooks/[platform]/route.ts
+++ b/src/app/api/chat/webhooks/[platform]/route.ts
@@ -1,0 +1,16 @@
+import { after } from 'next/server';
+import { bot } from '@/lib/bot';
+type Platform = keyof typeof bot.webhooks;
+type RouteContext = {
+  params: Promise<{ platform: string }>;
+};
+export async function POST(request: Request, context: RouteContext) {
+  const { platform } = await context.params;
+  const handler = bot.webhooks[platform as Platform];
+  if (!handler) {
+    return new Response(`Unknown platform: ${platform}`, { status: 404 });
+  }
+  return handler(request, {
+    waitUntil: task => after(() => task),
+  });
+}

--- a/src/app/api/chat/webhooks/[platform]/route.ts
+++ b/src/app/api/chat/webhooks/[platform]/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request, context: RouteContext) {
   const { platform } = await context.params;
   const handler = bot.webhooks[platform as Platform];
   if (!handler) {
-    return new Response(`Unknown platform: ${platform}`, { status: 404 });
+    return new Response('Unknown platform', { status: 404 });
   }
   return handler(request, {
     waitUntil: task => after(() => task),

--- a/src/app/api/chat/webhooks/[platform]/route.ts
+++ b/src/app/api/chat/webhooks/[platform]/route.ts
@@ -1,5 +1,8 @@
 import { after } from 'next/server';
 import { bot } from '@/lib/bot';
+
+export const maxDuration = 800;
+
 type Platform = keyof typeof bot.webhooks;
 type RouteContext = {
   params: Promise<{ platform: string }>;

--- a/src/lib/bot-identity.ts
+++ b/src/lib/bot-identity.ts
@@ -1,0 +1,128 @@
+import 'server-only';
+import crypto from 'node:crypto';
+import type { StateAdapter } from 'chat';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
+
+/**
+ * Platform identity coordinates — the minimum info needed to identify
+ * a user on any chat platform (Slack, Discord, Teams, Google Chat, etc.).
+ */
+export type PlatformIdentity = {
+  /** e.g. "slack", "discord", "teams", "gchat" */
+  platform: string;
+  /** Workspace / team / guild / tenant ID */
+  teamId: string;
+  /** Platform-specific user ID (e.g. Slack's "U123ABC") */
+  userId: string;
+};
+
+// -- Redis key helpers --------------------------------------------------------
+
+function redisKey({ platform, teamId, userId }: PlatformIdentity): string {
+  return `identity:${platform}:${teamId}:${userId}`;
+}
+
+/**
+ * Look up the Kilo user ID linked to a chat-platform user.
+ * Returns `null` when no mapping exists yet.
+ */
+export async function resolveKiloUserId(
+  state: StateAdapter,
+  identity: PlatformIdentity
+): Promise<string | null> {
+  return state.get<string>(redisKey(identity));
+}
+
+/**
+ * Persist a platform-user → Kilo-user link.
+ */
+export async function linkKiloUser(
+  state: StateAdapter,
+  identity: PlatformIdentity,
+  kiloUserId: string
+): Promise<void> {
+  await state.set(redisKey(identity), kiloUserId);
+}
+
+/**
+ * Remove a previously stored link.
+ */
+export async function unlinkKiloUser(
+  state: StateAdapter,
+  identity: PlatformIdentity
+): Promise<void> {
+  await state.delete(redisKey(identity));
+}
+
+// -- HMAC-signed link tokens --------------------------------------------------
+//
+// The link-account URL carries a single `token` query parameter rather than
+// plain-text platform/teamId/userId.  The token is HMAC-signed and time-limited
+// so a third party cannot forge a link for a team they don't belong to.
+//
+// Format:  base64url({ platform, teamId, userId, iat, nonce }) . HMAC-SHA256
+//
+// Follows the same pattern as src/lib/integrations/oauth-state.ts.
+
+const HMAC_ALGORITHM = 'sha256';
+
+const TOKEN_TTL_SECONDS = 30 * 60;
+
+const NONCE_BYTES = 16;
+
+function hmacSign(data: string): string {
+  return crypto.createHmac(HMAC_ALGORITHM, NEXTAUTH_SECRET).update(data).digest('base64url');
+}
+
+/** Create a signed, time-limited token encoding a PlatformIdentity. */
+export function createLinkToken(identity: PlatformIdentity): string {
+  const iat = Math.floor(Date.now() / 1000);
+  const nonce = crypto.randomBytes(NONCE_BYTES).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ ...identity, iat, nonce })).toString('base64url');
+  return `${payload}.${hmacSign(payload)}`;
+}
+
+/** Verify and decode a link token. Returns the identity or `null` on failure. */
+export function verifyLinkToken(token: string): PlatformIdentity | null {
+  const dotIndex = token.indexOf('.');
+  if (dotIndex === -1) return null;
+
+  const payload = token.slice(0, dotIndex);
+  const providedSig = token.slice(dotIndex + 1);
+
+  const expectedSig = hmacSign(payload);
+  if (
+    providedSig.length !== expectedSig.length ||
+    !crypto.timingSafeEqual(Buffer.from(providedSig), Buffer.from(expectedSig))
+  ) {
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
+      platform?: string;
+      teamId?: string;
+      userId?: string;
+      iat?: number;
+      nonce?: string;
+    };
+
+    if (
+      typeof data.platform !== 'string' ||
+      typeof data.teamId !== 'string' ||
+      typeof data.userId !== 'string'
+    ) {
+      return null;
+    }
+
+    if (typeof data.iat !== 'number') return null;
+    const age = Math.floor(Date.now() / 1000) - data.iat;
+    if (age < 0 || age > TOKEN_TTL_SECONDS) return null;
+
+    if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
+
+    return { platform: data.platform, teamId: data.teamId, userId: data.userId };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -15,7 +15,8 @@ const slackAdapter = createSlackAdapter({
 });
 
 export const bot = new Chat({
-  userName: process.env.NODE_ENV === 'production' ? 'Kilo' : 'Henk Bot',
+  // TODO(remon): Update names before going live
+  userName: process.env.NODE_ENV === 'production' ? 'Pound' : 'Sjors Bot',
   adapters: {
     slack: slackAdapter,
   },

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -6,6 +6,7 @@ import {
   LinkButton,
   Section,
   CardText,
+  type ActionEvent,
   type Message,
   type Thread,
 } from 'chat';
@@ -54,8 +55,13 @@ async function getPlatformIntegration(thread: Thread, message: Message) {
 
 // -- Link-account prompt ------------------------------------------------------
 
+const LINK_ACCOUNT_PATH = '/api/chat/link-account';
+
+/** Prefix that the Slack adapter auto-generates for LinkButton action_ids. */
+const LINK_ACCOUNT_ACTION_PREFIX = `link-${APP_URL}${LINK_ACCOUNT_PATH}`;
+
 function buildLinkAccountUrl(identity: PlatformIdentity): string {
-  const url = new URL('/api/chat/link-account', APP_URL);
+  const url = new URL(LINK_ACCOUNT_PATH, APP_URL);
   url.searchParams.set('token', createLinkToken(identity));
   return url.toString();
 }
@@ -142,5 +148,21 @@ bot.onNewMention(async function handleIncomingMessage(
     await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
   } finally {
     await Promise.all([received.removeReaction(emoji.eyes), received.addReaction(emoji.check)]);
+  }
+});
+
+// When the user clicks the "Link Account" LinkButton, Slack fires a
+// block_actions event *in addition to* opening the URL in the browser.
+// For ephemeral messages the adapter encodes the response_url into the
+// messageId, so deleteMessage sends `{ delete_original: true }` — removing
+// the ephemeral card from the user's view.
+bot.onAction(async function handleLinkAccountClick(event: ActionEvent): Promise<void> {
+  if (!event.actionId.startsWith(LINK_ACCOUNT_ACTION_PREFIX)) return;
+
+  try {
+    await event.adapter.deleteMessage(event.threadId, event.messageId);
+  } catch (error) {
+    // Not critical — the ephemeral message will disappear on its own eventually
+    console.warn('[Bot] Failed to delete link-account ephemeral:', error);
   }
 });

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,6 +1,7 @@
 import { Chat, emoji, type ActionEvent, type Message, type Thread } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
+import { createMemoryState } from '@chat-adapter/state-memory';
 import { captureException } from '@sentry/nextjs';
 import { resolveKiloUserId, unlinkKiloUser } from '@/lib/bot-identity';
 import { getPlatformIdentity, getPlatformIntegration } from '@/lib/bot/platform-helpers';
@@ -20,7 +21,7 @@ export const bot = new Chat({
   adapters: {
     slack: slackAdapter,
   },
-  state: createRedisState(),
+  state: process.env.REDIS_URL ? createRedisState() : createMemoryState(),
 });
 
 bot.onNewMention(async function handleIncomingMessage(

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,6 +1,38 @@
-import { Chat, emoji } from 'chat';
-import { createSlackAdapter } from '@chat-adapter/slack';
+import { Chat, emoji, type Message, type Thread } from 'chat';
+import { createSlackAdapter, type SlackEvent } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
+import { getInstallationByTeamId } from '@/lib/integrations/slack-service';
+import type { PlatformIntegration } from '@kilocode/db';
+
+async function getSlackPlatformIntegration(message: Message<SlackEvent>) {
+  const teamId = message.raw.team_id ?? message.raw.team;
+
+  if (!teamId) throw new Error('Expected a teamId in message.raw');
+
+  return await getInstallationByTeamId(teamId);
+}
+
+async function getPlatformIntegration(thread: Thread, message: Message) {
+  const parts = thread.id.split(':');
+  const platform = parts[0]; // "slack", "discord", "gchat", "teams", "github"
+
+  switch (platform) {
+    case 'slack':
+      return await getSlackPlatformIntegration(message as Message<SlackEvent>);
+    default:
+      throw new Error('PlatformNotSupported');
+  }
+}
+
+async function processMessage(
+  thread: Thread,
+  _message: Message,
+  _platformIntegration: PlatformIntegration
+) {
+  await thread.post('TODO');
+}
+
+// -- Bot instance -------------------------------------------------------------
 
 const slackAdapter = createSlackAdapter({
   clientId: process.env.SLACK_CLIENT_ID,
@@ -15,10 +47,25 @@ export const bot = new Chat({
   state: createRedisState(),
 });
 
-// Respond when someone @mentions the bot, or talks in a DM
-bot.onNewMention(async (thread, message) => {
+bot.onNewMention(async function handleIncomingMessage(
+  thread: Thread,
+  message: Message
+): Promise<void> {
+  const platformIntegration = await getPlatformIntegration(thread, message);
+
+  if (!platformIntegration) {
+    throw new Error('No Active Platform Integration Found');
+  }
+
   const received = thread.createSentMessageFromMessage(message);
   await received.addReaction(emoji.eyes);
-  await thread.post('Hello!');
-  await Promise.all([received.removeReaction(emoji.eyes), received.addReaction(emoji.check)]);
+
+  try {
+    await processMessage(thread, message, platformIntegration);
+  } catch (error) {
+    console.error('[Bot] Unhandled error in message handler:', error);
+    await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
+  } finally {
+    await Promise.all([received.removeReaction(emoji.eyes), received.addReaction(emoji.check)]);
+  }
 });

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -81,16 +81,32 @@ function linkAccountCard(linkUrl: string) {
   });
 }
 
+/** True when the message is a top-level channel post (not a threaded reply). */
+function isChannelLevelMessage(thread: Thread, message: Message): boolean {
+  const platform = thread.id.split(':')[0];
+
+  switch (platform) {
+    case 'slack': {
+      const raw = (message as Message<SlackEvent>).raw;
+      return !raw.thread_ts || raw.thread_ts === raw.ts;
+    }
+    default:
+      return false;
+  }
+}
+
 async function promptLinkAccount(
   thread: Thread,
   message: Message,
   identity: PlatformIdentity
 ): Promise<void> {
   const linkUrl = buildLinkAccountUrl(identity);
+  const card = linkAccountCard(linkUrl);
+  const opts = { fallbackToDM: true } as const;
 
-  await thread.postEphemeral(message.author, linkAccountCard(linkUrl), {
-    fallbackToDM: true,
-  });
+  // Post to the channel when the @mention is top-level, otherwise into the thread.
+  const target = isChannelLevelMessage(thread, message) ? thread.channel : thread;
+  await target.postEphemeral(message.author, card, opts);
 }
 
 // -- Message processing -------------------------------------------------------

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,7 +1,8 @@
 import { Chat, emoji, type ActionEvent, type Message, type Thread } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
-import { resolveKiloUserId } from '@/lib/bot-identity';
+import { captureException } from '@sentry/nextjs';
+import { resolveKiloUserId, unlinkKiloUser } from '@/lib/bot-identity';
 import { getPlatformIdentity, getPlatformIntegration } from '@/lib/bot/platform-helpers';
 import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
 import { findUserById } from '@/lib/user';
@@ -31,7 +32,10 @@ bot.onNewMention(async function handleIncomingMessage(
   ]);
 
   if (!platformIntegration) {
-    throw new Error('No Active Platform Integration Found');
+    captureException(new Error('No active platform integration found'), {
+      extra: { platform: identity.platform, teamId: identity.teamId },
+    });
+    return;
   }
 
   if (!kiloUserId) {

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -46,7 +46,9 @@ bot.onNewMention(async function handleIncomingMessage(
   const user = await findUserById(kiloUserId);
 
   if (!user) {
-    throw new Error('User not found');
+    await unlinkKiloUser(bot.getState(), identity);
+    await promptLinkAccount(thread, message, identity);
+    return;
   }
 
   const received = thread.createSentMessageFromMessage(message);

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,4 +1,4 @@
-import { Chat } from 'chat';
+import { Chat, emoji } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
 
@@ -16,6 +16,9 @@ export const bot = new Chat({
 });
 
 // Respond when someone @mentions the bot, or talks in a DM
-bot.onNewMention(async thread => {
+bot.onNewMention(async (thread, message) => {
+  const received = thread.createSentMessageFromMessage(message);
+  await received.addReaction(emoji.eyes);
   await thread.post('Hello!');
+  await Promise.all([received.removeReaction(emoji.eyes), received.addReaction(emoji.check)]);
 });

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,115 +1,10 @@
-import {
-  Actions,
-  Card,
-  Chat,
-  emoji,
-  LinkButton,
-  Section,
-  CardText,
-  type ActionEvent,
-  type Message,
-  type Thread,
-} from 'chat';
-import { createSlackAdapter, type SlackEvent } from '@chat-adapter/slack';
+import { Chat, emoji, type ActionEvent, type Message, type Thread } from 'chat';
+import { createSlackAdapter } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
-import { getInstallationByTeamId } from '@/lib/integrations/slack-service';
-import { createLinkToken, resolveKiloUserId, type PlatformIdentity } from '@/lib/bot-identity';
-import { APP_URL } from '@/lib/constants';
+import { resolveKiloUserId } from '@/lib/bot-identity';
 import type { PlatformIntegration } from '@kilocode/db';
-
-// -- Platform helpers ---------------------------------------------------------
-
-function getSlackTeamId(message: Message<SlackEvent>): string {
-  const teamId = message.raw.team_id ?? message.raw.team;
-  if (!teamId) throw new Error('Expected a teamId in message.raw');
-  return teamId;
-}
-
-/**
- * Extract platform identity coordinates from any adapter's message.
- * Extend the switch for Discord / Teams / Google Chat / etc.
- */
-function getPlatformIdentity(thread: Thread, message: Message): PlatformIdentity {
-  const platform = thread.id.split(':')[0]; // "slack", "discord", "gchat", "teams", …
-
-  switch (platform) {
-    case 'slack': {
-      const teamId = getSlackTeamId(message as Message<SlackEvent>);
-      return { platform: 'slack', teamId, userId: message.author.userId };
-    }
-    default:
-      throw new Error(`PlatformNotSupported: ${platform}`);
-  }
-}
-
-async function getPlatformIntegration(thread: Thread, message: Message) {
-  const platform = thread.id.split(':')[0];
-
-  switch (platform) {
-    case 'slack':
-      return await getInstallationByTeamId(getSlackTeamId(message as Message<SlackEvent>));
-    default:
-      throw new Error(`PlatformNotSupported: ${platform}`);
-  }
-}
-
-// -- Link-account prompt ------------------------------------------------------
-
-const LINK_ACCOUNT_PATH = '/api/chat/link-account';
-
-/** Prefix that the Slack adapter auto-generates for LinkButton action_ids. */
-const LINK_ACCOUNT_ACTION_PREFIX = `link-${APP_URL}${LINK_ACCOUNT_PATH}`;
-
-function buildLinkAccountUrl(identity: PlatformIdentity): string {
-  const url = new URL(LINK_ACCOUNT_PATH, APP_URL);
-  url.searchParams.set('token', createLinkToken(identity));
-  return url.toString();
-}
-
-function linkAccountCard(linkUrl: string) {
-  return Card({
-    title: 'Link your Kilo account',
-    children: [
-      Section([
-        CardText(
-          'To use Kilo from this workspace you first need to link your chat account. ' +
-            'Click the button below to sign in and link your account.'
-        ),
-      ]),
-      Actions([LinkButton({ label: 'Link Account', url: linkUrl, style: 'primary' })]),
-    ],
-  });
-}
-
-/** True when the message is a top-level channel post (not a threaded reply). */
-function isChannelLevelMessage(thread: Thread, message: Message): boolean {
-  const platform = thread.id.split(':')[0];
-
-  switch (platform) {
-    case 'slack': {
-      const raw = (message as Message<SlackEvent>).raw;
-      return !raw.thread_ts || raw.thread_ts === raw.ts;
-    }
-    default:
-      return false;
-  }
-}
-
-async function promptLinkAccount(
-  thread: Thread,
-  message: Message,
-  identity: PlatformIdentity
-): Promise<void> {
-  const linkUrl = buildLinkAccountUrl(identity);
-  const card = linkAccountCard(linkUrl);
-  const opts = { fallbackToDM: true } as const;
-
-  // Post to the channel when the @mention is top-level, otherwise into the thread.
-  const target = isChannelLevelMessage(thread, message) ? thread.channel : thread;
-  await target.postEphemeral(message.author, card, opts);
-}
-
-// -- Message processing -------------------------------------------------------
+import { getPlatformIdentity, getPlatformIntegration } from '@/lib/bot/platform-helpers';
+import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
 
 async function processMessage(
   thread: Thread,
@@ -119,8 +14,6 @@ async function processMessage(
 ) {
   await thread.post('TODO');
 }
-
-// -- Bot instance -------------------------------------------------------------
 
 const slackAdapter = createSlackAdapter({
   clientId: process.env.SLACK_CLIENT_ID,

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -2,18 +2,10 @@ import { Chat, emoji, type ActionEvent, type Message, type Thread } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
 import { resolveKiloUserId } from '@/lib/bot-identity';
-import type { PlatformIntegration } from '@kilocode/db';
 import { getPlatformIdentity, getPlatformIntegration } from '@/lib/bot/platform-helpers';
 import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
-
-async function processMessage(
-  thread: Thread,
-  _message: Message,
-  _platformIntegration: PlatformIntegration,
-  _kiloUserId: string
-) {
-  await thread.post('TODO');
-}
+import { findUserById } from '@/lib/user';
+import { processMessage } from '@/lib/bot/run';
 
 const slackAdapter = createSlackAdapter({
   clientId: process.env.SLACK_CLIENT_ID,
@@ -47,11 +39,17 @@ bot.onNewMention(async function handleIncomingMessage(
     return;
   }
 
+  const user = await findUserById(kiloUserId);
+
+  if (!user) {
+    throw new Error('User not found');
+  }
+
   const received = thread.createSentMessageFromMessage(message);
   await received.addReaction(emoji.eyes);
 
   try {
-    await processMessage(thread, message, platformIntegration, kiloUserId);
+    await processMessage({ thread, message, platformIntegration, user });
   } catch (error) {
     console.error('[Bot] Unhandled error in message handler:', error);
     await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,0 +1,21 @@
+import { Chat } from 'chat';
+import { createSlackAdapter } from '@chat-adapter/slack';
+import { createRedisState } from '@chat-adapter/state-redis';
+
+const slackAdapter = createSlackAdapter({
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+});
+
+export const bot = new Chat({
+  userName: process.env.NODE_ENV === 'production' ? 'Kilo' : 'Henk Bot',
+  adapters: {
+    slack: slackAdapter,
+  },
+  state: createRedisState(),
+});
+
+// Respond when someone @mentions the bot, or talks in a DM
+bot.onNewMention(async thread => {
+  await thread.post('Hello!');
+});

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -9,8 +9,9 @@ import { findUserById } from '@/lib/user';
 import { processMessage } from '@/lib/bot/run';
 
 const slackAdapter = createSlackAdapter({
-  clientId: process.env.SLACK_CLIENT_ID,
-  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  clientId: process.env.SLACK_NEXT_CLIENT_ID,
+  clientSecret: process.env.SLACK_NEXT_CLIENT_SECRET,
+  signingSecret: process.env.SLACK_NEXT_SIGNING_SECRET,
 });
 
 export const bot = new Chat({

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,33 +1,99 @@
-import { Chat, emoji, type Message, type Thread } from 'chat';
+import {
+  Actions,
+  Card,
+  Chat,
+  emoji,
+  LinkButton,
+  Section,
+  CardText,
+  type Message,
+  type Thread,
+} from 'chat';
 import { createSlackAdapter, type SlackEvent } from '@chat-adapter/slack';
 import { createRedisState } from '@chat-adapter/state-redis';
 import { getInstallationByTeamId } from '@/lib/integrations/slack-service';
+import { createLinkToken, resolveKiloUserId, type PlatformIdentity } from '@/lib/bot-identity';
+import { APP_URL } from '@/lib/constants';
 import type { PlatformIntegration } from '@kilocode/db';
 
-async function getSlackPlatformIntegration(message: Message<SlackEvent>) {
+// -- Platform helpers ---------------------------------------------------------
+
+function getSlackTeamId(message: Message<SlackEvent>): string {
   const teamId = message.raw.team_id ?? message.raw.team;
-
   if (!teamId) throw new Error('Expected a teamId in message.raw');
+  return teamId;
+}
 
-  return await getInstallationByTeamId(teamId);
+/**
+ * Extract platform identity coordinates from any adapter's message.
+ * Extend the switch for Discord / Teams / Google Chat / etc.
+ */
+function getPlatformIdentity(thread: Thread, message: Message): PlatformIdentity {
+  const platform = thread.id.split(':')[0]; // "slack", "discord", "gchat", "teams", …
+
+  switch (platform) {
+    case 'slack': {
+      const teamId = getSlackTeamId(message as Message<SlackEvent>);
+      return { platform: 'slack', teamId, userId: message.author.userId };
+    }
+    default:
+      throw new Error(`PlatformNotSupported: ${platform}`);
+  }
 }
 
 async function getPlatformIntegration(thread: Thread, message: Message) {
-  const parts = thread.id.split(':');
-  const platform = parts[0]; // "slack", "discord", "gchat", "teams", "github"
+  const platform = thread.id.split(':')[0];
 
   switch (platform) {
     case 'slack':
-      return await getSlackPlatformIntegration(message as Message<SlackEvent>);
+      return await getInstallationByTeamId(getSlackTeamId(message as Message<SlackEvent>));
     default:
-      throw new Error('PlatformNotSupported');
+      throw new Error(`PlatformNotSupported: ${platform}`);
   }
 }
+
+// -- Link-account prompt ------------------------------------------------------
+
+function buildLinkAccountUrl(identity: PlatformIdentity): string {
+  const url = new URL('/api/chat/link-account', APP_URL);
+  url.searchParams.set('token', createLinkToken(identity));
+  return url.toString();
+}
+
+function linkAccountCard(linkUrl: string) {
+  return Card({
+    title: 'Link your Kilo account',
+    children: [
+      Section([
+        CardText(
+          'To use Kilo from this workspace you first need to link your chat account. ' +
+            'Click the button below to sign in and link your account.'
+        ),
+      ]),
+      Actions([LinkButton({ label: 'Link Account', url: linkUrl, style: 'primary' })]),
+    ],
+  });
+}
+
+async function promptLinkAccount(
+  thread: Thread,
+  message: Message,
+  identity: PlatformIdentity
+): Promise<void> {
+  const linkUrl = buildLinkAccountUrl(identity);
+
+  await thread.postEphemeral(message.author, linkAccountCard(linkUrl), {
+    fallbackToDM: true,
+  });
+}
+
+// -- Message processing -------------------------------------------------------
 
 async function processMessage(
   thread: Thread,
   _message: Message,
-  _platformIntegration: PlatformIntegration
+  _platformIntegration: PlatformIntegration,
+  _kiloUserId: string
 ) {
   await thread.post('TODO');
 }
@@ -51,17 +117,26 @@ bot.onNewMention(async function handleIncomingMessage(
   thread: Thread,
   message: Message
 ): Promise<void> {
-  const platformIntegration = await getPlatformIntegration(thread, message);
+  const identity = getPlatformIdentity(thread, message);
+  const [platformIntegration, kiloUserId] = await Promise.all([
+    getPlatformIntegration(thread, message),
+    resolveKiloUserId(bot.getState(), identity),
+  ]);
 
   if (!platformIntegration) {
     throw new Error('No Active Platform Integration Found');
+  }
+
+  if (!kiloUserId) {
+    await promptLinkAccount(thread, message, identity);
+    return;
   }
 
   const received = thread.createSentMessageFromMessage(message);
   await received.addReaction(emoji.eyes);
 
   try {
-    await processMessage(thread, message, platformIntegration);
+    await processMessage(thread, message, platformIntegration, kiloUserId);
   } catch (error) {
     console.error('[Bot] Unhandled error in message handler:', error);
     await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });

--- a/src/lib/bot/constants.ts
+++ b/src/lib/bot/constants.ts
@@ -1,0 +1,32 @@
+import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
+import { minimax_m25_free_model } from '@/lib/providers/minimax';
+
+export const BOT_VERSION = '5.1.0';
+export const BOT_USER_AGENT = `Kilo-Code/${BOT_VERSION}`;
+export const DEFAULT_BOT_MODEL = minimax_m25_free_model.is_enabled
+  ? minimax_m25_free_model.public_id
+  : CLAUDE_OPUS_CURRENT_MODEL_ID;
+export const MAX_ITERATIONS = 5;
+export const BOT_SYSTEM_PROMPT = `You are Kilo Bot, a helpful AI assistant.
+
+## Core behavior
+- Be concise and direct. Prefer short messages over long explanations.
+- Don't add filler. Start with the answer or the next action.
+- If the user's request is ambiguous, ask 1-2 clarifying questions instead of guessing.
+
+## Answering questions about Kilo Bot
+- When users ask what you can do, how you work, or for general help, include a link to the Bot documentation: https://kilo.ai/docs/advanced-usage/slackbot
+- Provide the docs link along with your answer so users can learn more.
+
+## Context you may receive
+Additional context may be appended to this prompt:
+- Conversation context (recent messages, thread context)
+- Available GitHub repositories for this integration
+- Available GitLab projects for this integration
+
+Treat this context as authoritative. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo (or group/project for GitLab) and ensure it's accessible to the integration. Never invent repository names.
+
+## Accuracy & safety
+- Don't claim you ran tools, changed code, or created a PR/MR unless the tool results confirm it.
+- Don't fabricate links (including PR/MR URLs).
+- If you can't proceed (missing repo, missing details, permissions), say what's missing and what you need next.`;

--- a/src/lib/bot/constants.ts
+++ b/src/lib/bot/constants.ts
@@ -7,26 +7,3 @@ export const DEFAULT_BOT_MODEL = minimax_m25_free_model.is_enabled
   ? minimax_m25_free_model.public_id
   : CLAUDE_OPUS_CURRENT_MODEL_ID;
 export const MAX_ITERATIONS = 5;
-export const BOT_SYSTEM_PROMPT = `You are Kilo Bot, a helpful AI assistant.
-
-## Core behavior
-- Be concise and direct. Prefer short messages over long explanations.
-- Don't add filler. Start with the answer or the next action.
-- If the user's request is ambiguous, ask 1-2 clarifying questions instead of guessing.
-
-## Answering questions about Kilo Bot
-- When users ask what you can do, how you work, or for general help, include a link to the Bot documentation: https://kilo.ai/docs/advanced-usage/slackbot
-- Provide the docs link along with your answer so users can learn more.
-
-## Context you may receive
-Additional context may be appended to this prompt:
-- Conversation context (recent messages, thread context)
-- Available GitHub repositories for this integration
-- Available GitLab projects for this integration
-
-Treat this context as authoritative. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo (or group/project for GitLab) and ensure it's accessible to the integration. Never invent repository names.
-
-## Accuracy & safety
-- Don't claim you ran tools, changed code, or created a PR/MR unless the tool results confirm it.
-- Don't fabricate links (including PR/MR URLs).
-- If you can't proceed (missing repo, missing details, permissions), say what's missing and what you need next.`;

--- a/src/lib/bot/helpers.ts
+++ b/src/lib/bot/helpers.ts
@@ -1,0 +1,15 @@
+import type { SlackEvent } from '@chat-adapter/slack';
+import type { Thread, Message } from 'chat';
+
+export function isChannelLevelMessage(thread: Thread, message: Message): boolean {
+  const platform = thread.id.split(':')[0];
+
+  switch (platform) {
+    case 'slack': {
+      const raw = (message as Message<SlackEvent>).raw;
+      return !raw.thread_ts || raw.thread_ts === raw.ts;
+    }
+    default:
+      return false;
+  }
+}

--- a/src/lib/bot/link-account.ts
+++ b/src/lib/bot/link-account.ts
@@ -33,11 +33,10 @@ export async function promptLinkAccount(
   message: Message,
   identity: PlatformIdentity
 ): Promise<void> {
-  const linkUrl = buildLinkAccountUrl(identity);
-  const card = linkAccountCard(linkUrl);
-  const opts = { fallbackToDM: true } as const;
-
   // Post to the channel when the @mention is top-level, otherwise into the thread.
   const target = isChannelLevelMessage(thread, message) ? thread.channel : thread;
-  await target.postEphemeral(message.author, card, opts);
+
+  await target.postEphemeral(message.author, linkAccountCard(buildLinkAccountUrl(identity)), {
+    fallbackToDM: true,
+  });
 }

--- a/src/lib/bot/link-account.ts
+++ b/src/lib/bot/link-account.ts
@@ -5,7 +5,6 @@ import { isChannelLevelMessage } from '@/lib/bot/helpers';
 
 const LINK_ACCOUNT_PATH = '/api/chat/link-account';
 
-/** Prefix that the Slack adapter auto-generates for LinkButton action_ids. */
 export const LINK_ACCOUNT_ACTION_PREFIX = `link-${APP_URL}${LINK_ACCOUNT_PATH}`;
 
 function buildLinkAccountUrl(identity: PlatformIdentity): string {

--- a/src/lib/bot/link-account.ts
+++ b/src/lib/bot/link-account.ts
@@ -1,0 +1,44 @@
+import { Actions, Card, LinkButton, Section, CardText, type Message, type Thread } from 'chat';
+import { createLinkToken, type PlatformIdentity } from '@/lib/bot-identity';
+import { APP_URL } from '@/lib/constants';
+import { isChannelLevelMessage } from '@/lib/bot/helpers';
+
+const LINK_ACCOUNT_PATH = '/api/chat/link-account';
+
+/** Prefix that the Slack adapter auto-generates for LinkButton action_ids. */
+export const LINK_ACCOUNT_ACTION_PREFIX = `link-${APP_URL}${LINK_ACCOUNT_PATH}`;
+
+function buildLinkAccountUrl(identity: PlatformIdentity): string {
+  const url = new URL(LINK_ACCOUNT_PATH, APP_URL);
+  url.searchParams.set('token', createLinkToken(identity));
+  return url.toString();
+}
+
+function linkAccountCard(linkUrl: string) {
+  return Card({
+    title: 'Link your Kilo account',
+    children: [
+      Section([
+        CardText(
+          'To use Kilo from this workspace you first need to link your chat account. ' +
+            'Click the button below to sign in and link your account.'
+        ),
+      ]),
+      Actions([LinkButton({ label: 'Link Account', url: linkUrl, style: 'primary' })]),
+    ],
+  });
+}
+
+export async function promptLinkAccount(
+  thread: Thread,
+  message: Message,
+  identity: PlatformIdentity
+): Promise<void> {
+  const linkUrl = buildLinkAccountUrl(identity);
+  const card = linkAccountCard(linkUrl);
+  const opts = { fallbackToDM: true } as const;
+
+  // Post to the channel when the @mention is top-level, otherwise into the thread.
+  const target = isChannelLevelMessage(thread, message) ? thread.channel : thread;
+  await target.postEphemeral(message.author, card, opts);
+}

--- a/src/lib/bot/platform-helpers.ts
+++ b/src/lib/bot/platform-helpers.ts
@@ -1,0 +1,38 @@
+import type { PlatformIdentity } from '@/lib/bot-identity';
+import { getInstallationByTeamId } from '@/lib/integrations/slack-service';
+import { type SlackEvent } from '@chat-adapter/slack';
+import type { Message, Thread } from 'chat';
+
+export function getSlackTeamId(message: Message<SlackEvent>): string {
+  const teamId = message.raw.team_id ?? message.raw.team;
+  if (!teamId) throw new Error('Expected a teamId in message.raw');
+  return teamId;
+}
+
+/**
+ * Extract platform identity coordinates from any adapter's message.
+ * Extend the switch for Discord / Teams / Google Chat / etc.
+ */
+export function getPlatformIdentity(thread: Thread, message: Message): PlatformIdentity {
+  const platform = thread.id.split(':')[0]; // "slack", "discord", "gchat", "teams", …
+
+  switch (platform) {
+    case 'slack': {
+      const teamId = getSlackTeamId(message as Message<SlackEvent>);
+      return { platform: 'slack', teamId, userId: message.author.userId };
+    }
+    default:
+      throw new Error(`PlatformNotSupported: ${platform}`);
+  }
+}
+
+export async function getPlatformIntegration(thread: Thread, message: Message) {
+  const platform = thread.id.split(':')[0];
+
+  switch (platform) {
+    case 'slack':
+      return await getInstallationByTeamId(getSlackTeamId(message as Message<SlackEvent>));
+    default:
+      throw new Error(`PlatformNotSupported: ${platform}`);
+  }
+}

--- a/src/lib/bot/platform-helpers.ts
+++ b/src/lib/bot/platform-helpers.ts
@@ -1,6 +1,9 @@
 import type { PlatformIdentity } from '@/lib/bot-identity';
-import { getInstallationByTeamId } from '@/lib/integrations/slack-service';
+import { db } from '@/lib/drizzle';
+import { eq, and } from 'drizzle-orm';
+import { PLATFORM } from '@/lib/integrations/core/constants';
 import { type SlackEvent } from '@chat-adapter/slack';
+import { platform_integrations } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
 
 export function getSlackTeamId(message: Message<SlackEvent>): string {
@@ -26,12 +29,27 @@ export function getPlatformIdentity(thread: Thread, message: Message): PlatformI
   }
 }
 
+async function getSlackNextInstallation(teamId: string) {
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.platform, PLATFORM.SLACK_NEXT),
+        eq(platform_integrations.platform_installation_id, teamId)
+      )
+    )
+    .limit(1);
+
+  return integration;
+}
+
 export async function getPlatformIntegration(thread: Thread, message: Message) {
   const platform = thread.id.split(':')[0];
 
   switch (platform) {
     case 'slack':
-      return await getInstallationByTeamId(getSlackTeamId(message as Message<SlackEvent>));
+      return await getSlackNextInstallation(getSlackTeamId(message as Message<SlackEvent>));
     default:
       throw new Error(`PlatformNotSupported: ${platform}`);
   }

--- a/src/lib/bot/run.ts
+++ b/src/lib/bot/run.ts
@@ -5,12 +5,15 @@ import {
   DEFAULT_BOT_MODEL,
 } from '@/lib/bot/constants';
 import { MAX_ITERATIONS } from '@/lib/bot/constants';
+import spawnCloudAgentSession, {
+  spawnCloudAgentInputSchema,
+} from '@/lib/bot/tools/spawn-cloud-agent-session';
 import { APP_URL } from '@/lib/constants';
 import { FEATURE_HEADER } from '@/lib/feature-detection';
 import { generateApiToken } from '@/lib/tokens';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { PlatformIntegration, User } from '@kilocode/db';
-import { ToolLoopAgent, stepCountIs } from 'ai';
+import { ToolLoopAgent, stepCountIs, tool } from 'ai';
 import type { Thread, Message } from 'chat';
 
 export async function processMessage({
@@ -34,25 +37,35 @@ export async function processMessage({
     headers['X-KiloCode-OrganizationId'] = platformIntegration.owned_by_organization_id;
   }
 
+  const authToken = generateApiToken(user, { internalApiUse: true });
   const provider = createOpenAICompatible({
-    name: 'kilo-proxy',
+    name: 'kilo-gateway',
     baseURL: `${APP_URL}/api/openrouter`,
-    apiKey: generateApiToken(user, { internalApiUse: true }),
+    apiKey: authToken,
     headers,
   });
 
+  const modelSlug =
+    (platformIntegration.metadata as { model_slug?: string }).model_slug ?? DEFAULT_BOT_MODEL;
   const agent = new ToolLoopAgent({
-    model: provider.chatModel(
-      (platformIntegration.metadata as { model_slug?: string }).model_slug ?? DEFAULT_BOT_MODEL
-    ),
+    model: provider.chatModel(modelSlug),
     instructions: BOT_SYSTEM_PROMPT,
     stopWhen: stepCountIs(MAX_ITERATIONS),
+    tools: {
+      spawnCloudAgentSession: tool({
+        description:
+          'Spawn a Cloud Agent session to perform coding tasks on a GitHub repository. The agent can make code changes, fix bugs, implement features, and more.',
+        inputSchema: spawnCloudAgentInputSchema,
+        execute: async args =>
+          await spawnCloudAgentSession(args, modelSlug, platformIntegration, authToken, user.id),
+      }),
+    },
   });
 
   try {
     const result = await agent.generate({ prompt: message.text });
 
-    await thread.post(result.text);
+    await thread.post({ markdown: result.text });
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
 

--- a/src/lib/bot/run.ts
+++ b/src/lib/bot/run.ts
@@ -1,20 +1,69 @@
 import {
-  BOT_SYSTEM_PROMPT,
   BOT_USER_AGENT,
   BOT_VERSION,
   DEFAULT_BOT_MODEL,
+  MAX_ITERATIONS,
 } from '@/lib/bot/constants';
-import { MAX_ITERATIONS } from '@/lib/bot/constants';
 import spawnCloudAgentSession, {
   spawnCloudAgentInputSchema,
 } from '@/lib/bot/tools/spawn-cloud-agent-session';
 import { APP_URL } from '@/lib/constants';
 import { FEATURE_HEADER } from '@/lib/feature-detection';
+import type { Owner } from '@/lib/integrations/core/types';
+import {
+  formatGitHubRepositoriesForPrompt,
+  getGitHubRepositoryContext,
+} from '@/lib/slack-bot/github-repository-context';
+import {
+  formatGitLabRepositoriesForPrompt,
+  getGitLabRepositoryContext,
+} from '@/lib/slack-bot/gitlab-repository-context';
 import { generateApiToken } from '@/lib/tokens';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { PlatformIntegration, User } from '@kilocode/db';
 import { ToolLoopAgent, stepCountIs, tool } from 'ai';
 import type { Thread, Message } from 'chat';
+
+function ownerFromIntegration(pi: PlatformIntegration): Owner {
+  if (pi.owned_by_organization_id) return { type: 'org', id: pi.owned_by_organization_id };
+  else return { type: 'user', id: pi.owned_by_user_id as string };
+}
+
+async function buildSystemPrompt(platformIntegration: PlatformIntegration) {
+  const owner = ownerFromIntegration(platformIntegration);
+
+  const [githubContext, gitlabContext] = await Promise.all([
+    getGitHubRepositoryContext(owner),
+    getGitLabRepositoryContext(owner),
+  ]);
+
+  return `You are Kilo Bot, a helpful AI assistant.
+
+## Core behavior
+- Be concise and direct. Prefer short messages over long explanations.
+- Don't add filler. Start with the answer or the next action.
+- If the user's request is ambiguous, ask 1-2 clarifying questions instead of guessing.
+
+## Answering questions about Kilo Bot
+- When users ask what you can do, how you work, or for general help, include a link to the Bot documentation: https://kilo.ai/docs/advanced-usage/slackbot
+- Provide the docs link along with your answer so users can learn more.
+
+## Context you may receive
+Additional context may be appended to this prompt:
+- Conversation context (recent messages, thread context)
+${githubContext.repositories && '- Available GitHub repositories for this integration'}
+${gitlabContext.repositories && '- Available GitLab projects for this integration'}
+
+${formatGitHubRepositoriesForPrompt(githubContext)}
+${formatGitLabRepositoriesForPrompt(gitlabContext)}
+
+Treat this context as authoritative. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo (or group/project for GitLab) and ensure it's accessible to the integration. Never invent repository names.
+
+## Accuracy & safety
+- Don't claim you ran tools, changed code, or created a PR/MR unless the tool results confirm it.
+- Don't fabricate links (including PR/MR URLs).
+- If you can't proceed (missing repo, missing details, permissions), say what's missing and what you need next.`;
+}
 
 export async function processMessage({
   thread,
@@ -49,7 +98,7 @@ export async function processMessage({
     (platformIntegration.metadata as { model_slug?: string }).model_slug ?? DEFAULT_BOT_MODEL;
   const agent = new ToolLoopAgent({
     model: provider.chatModel(modelSlug),
-    instructions: BOT_SYSTEM_PROMPT,
+    instructions: await buildSystemPrompt(platformIntegration),
     stopWhen: stepCountIs(MAX_ITERATIONS),
     tools: {
       spawnCloudAgentSession: tool({

--- a/src/lib/bot/run.ts
+++ b/src/lib/bot/run.ts
@@ -1,0 +1,63 @@
+import {
+  BOT_SYSTEM_PROMPT,
+  BOT_USER_AGENT,
+  BOT_VERSION,
+  DEFAULT_BOT_MODEL,
+} from '@/lib/bot/constants';
+import { MAX_ITERATIONS } from '@/lib/bot/constants';
+import { APP_URL } from '@/lib/constants';
+import { FEATURE_HEADER } from '@/lib/feature-detection';
+import { generateApiToken } from '@/lib/tokens';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { PlatformIntegration, User } from '@kilocode/db';
+import { ToolLoopAgent, stepCountIs } from 'ai';
+import type { Thread, Message } from 'chat';
+
+export async function processMessage({
+  thread,
+  message,
+  platformIntegration,
+  user,
+}: {
+  thread: Thread;
+  message: Message;
+  platformIntegration: PlatformIntegration;
+  user: User;
+}) {
+  const headers: Record<string, string> = {
+    'X-KiloCode-Version': BOT_VERSION,
+    'User-Agent': BOT_USER_AGENT,
+    [FEATURE_HEADER]: 'bot',
+  };
+
+  if (platformIntegration.owned_by_organization_id) {
+    headers['X-KiloCode-OrganizationId'] = platformIntegration.owned_by_organization_id;
+  }
+
+  const provider = createOpenAICompatible({
+    name: 'kilo-proxy',
+    baseURL: `${APP_URL}/api/openrouter`,
+    apiKey: generateApiToken(user, { internalApiUse: true }),
+    headers,
+  });
+
+  const agent = new ToolLoopAgent({
+    model: provider.chatModel(
+      (platformIntegration.metadata as { model_slug?: string }).model_slug ?? DEFAULT_BOT_MODEL
+    ),
+    instructions: BOT_SYSTEM_PROMPT,
+    stopWhen: stepCountIs(MAX_ITERATIONS),
+  });
+
+  try {
+    const result = await agent.generate({ prompt: message.text });
+
+    await thread.post(result.text);
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+
+    console.error(`[KiloBot] Error during bot run:`, errMsg, error);
+
+    await thread.post(`Sorry, there was an error calling the AI service: ${errMsg.slice(0, 200)}`);
+  }
+}

--- a/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -1,0 +1,176 @@
+import {
+  createCloudAgentNextClient,
+  type PrepareSessionInput,
+} from '@/lib/cloud-agent-next/cloud-agent-client';
+import { runSessionToCompletion } from '@/lib/cloud-agent-next/run-session';
+import {
+  getGitHubTokenForOrganization,
+  getGitHubTokenForUser,
+} from '@/lib/cloud-agent/github-integration-helpers';
+import {
+  getGitLabTokenForOrganization,
+  getGitLabTokenForUser,
+  getGitLabInstanceUrlForOrganization,
+  getGitLabInstanceUrlForUser,
+  buildGitLabCloneUrl,
+} from '@/lib/cloud-agent/gitlab-integration-helpers';
+import type { PlatformIntegration } from '@kilocode/db';
+import z from 'zod';
+
+/**
+ * Result from spawning a Cloud Agent session
+ */
+type SpawnCloudAgentResult = {
+  response: string;
+  sessionId?: string;
+};
+
+export const spawnCloudAgentInputSchema = z.object({
+  githubRepo: z
+    .string()
+    .regex(/^[-a-zA-Z0-9_.]+\/[-a-zA-Z0-9_.]+$/)
+    .describe('The GitHub repository in owner/repo format (e.g., "facebook/react")')
+    .optional(),
+  gitlabProject: z
+    .string()
+    .regex(/^[-a-zA-Z0-9_.]+(?:\/[-a-zA-Z0-9_.]+)+$/)
+    .describe(
+      'The GitLab project path in group/project format (e.g., "mygroup/myproject"). May include nested groups (e.g., "group/subgroup/project").'
+    )
+    .optional(),
+  prompt: z
+    .string()
+    .describe(
+      'The task description for the Cloud Agent. Be specific about what changes or analysis you want.'
+    ),
+  mode: z
+    .enum(['architect', 'code', 'ask', 'debug', 'orchestrator'])
+    .default('code')
+    .describe(
+      'The agent mode: "code" for making changes, "architect" for design tasks, "ask" for questions, "debug" for troubleshooting, "orchestrator" for complex multi-step tasks'
+    ),
+});
+
+/**
+ * Spawn a Cloud Agent session and collect the results.
+ * Supports both GitHub (githubRepo) and GitLab (gitlabProject) repositories.
+ * Delegates to the shared runSessionToCompletion helper.
+ */
+export default async function spawnCloudAgentSession(
+  args: {
+    githubRepo?: string;
+    gitlabProject?: string;
+    prompt: string;
+    mode?: string;
+  },
+  model: string,
+  platformIntegration: PlatformIntegration,
+  authToken: string,
+  ticketUserId: string
+): Promise<SpawnCloudAgentResult> {
+  console.log('[SlackBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
+
+  if (args.githubRepo && args.gitlabProject) {
+    return {
+      response: 'Error: Both githubRepo and gitlabProject were specified. Provide exactly one.',
+    };
+  }
+
+  if (!args.githubRepo && !args.gitlabProject) {
+    return {
+      response: 'Error: No repository specified. Provide either githubRepo or gitlabProject.',
+    };
+  }
+
+  // Validate the repo identifier has at least "owner/repo" shape (non-empty segments around a slash)
+  const repoIdentifier = args.githubRepo ?? args.gitlabProject;
+  if (!repoIdentifier || !/\/./.test(repoIdentifier)) {
+    return {
+      response: `Error: Invalid repository identifier "${repoIdentifier ?? ''}". Expected format like "owner/repo".`,
+    };
+  }
+
+  // Build platform-specific prepareInput and initiateInput
+  const kilocodeOrganizationId = platformIntegration.owned_by_organization_id || undefined;
+  let prepareInput: PrepareSessionInput;
+  let initiateInput: { githubToken?: string; kilocodeOrganizationId?: string };
+
+  if (args.gitlabProject) {
+    // GitLab path: get token + instance URL, build clone URL, use gitUrl/gitToken
+    const gitlabToken =
+      typeof platformIntegration.owned_by_organization_id === 'string'
+        ? await getGitLabTokenForOrganization(platformIntegration.owned_by_organization_id)
+        : await getGitLabTokenForUser(platformIntegration.owned_by_user_id as string);
+
+    if (!gitlabToken) {
+      return {
+        response:
+          'Error: No GitLab token available. Please ensure a GitLab integration is connected in your Kilo Code settings.',
+      };
+    }
+
+    const instanceUrl =
+      typeof platformIntegration.owned_by_organization_id === 'string'
+        ? await getGitLabInstanceUrlForOrganization(platformIntegration.owned_by_organization_id)
+        : await getGitLabInstanceUrlForUser(platformIntegration.owned_by_user_id as string);
+
+    const gitUrl = buildGitLabCloneUrl(args.gitlabProject, instanceUrl);
+
+    const isSelfHosted = !/^https?:\/\/(www\.)?gitlab\.com(\/|$)/i.test(instanceUrl);
+    console.log(
+      '[SlackBot] GitLab session - project:',
+      args.gitlabProject,
+      'instance:',
+      isSelfHosted ? 'self-hosted' : 'gitlab.com'
+    );
+
+    prepareInput = {
+      prompt: args.prompt,
+      mode: (args.mode as PrepareSessionInput['mode']) || 'code',
+      model,
+      gitUrl,
+      gitToken: gitlabToken,
+      platform: 'gitlab',
+      kilocodeOrganizationId,
+      createdOnPlatform: 'slack',
+    };
+    initiateInput = { kilocodeOrganizationId };
+  } else {
+    // GitHub path: get token, use githubRepo/githubToken
+    const githubToken =
+      typeof platformIntegration.owned_by_organization_id === 'string'
+        ? await getGitHubTokenForOrganization(platformIntegration.owned_by_organization_id)
+        : await getGitHubTokenForUser(platformIntegration.owned_by_user_id as string);
+
+    if (!githubToken) {
+      return {
+        response:
+          'Error: No GitHub token available. Please ensure a GitHub integration is connected in your Kilo Code settings.',
+      };
+    }
+
+    prepareInput = {
+      githubRepo: args.githubRepo,
+      prompt: args.prompt,
+      mode: (args.mode as PrepareSessionInput['mode']) || 'code',
+      model,
+      githubToken,
+      kilocodeOrganizationId,
+      createdOnPlatform: 'slack',
+    };
+    initiateInput = { githubToken, kilocodeOrganizationId };
+  }
+
+  const result = await runSessionToCompletion({
+    client: createCloudAgentNextClient(authToken, { skipBalanceCheck: true }),
+    prepareInput,
+    initiateInput,
+    ticketPayload: {
+      userId: ticketUserId,
+      organizationId: kilocodeOrganizationId,
+    },
+    logPrefix: '[KiloBot]',
+  });
+
+  return { response: result.response, sessionId: result.sessionId };
+}

--- a/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -1,5 +1,6 @@
 import {
   createCloudAgentNextClient,
+  type AgentMode,
   type PrepareSessionInput,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { runSessionToCompletion } from '@/lib/cloud-agent-next/run-session';
@@ -25,31 +26,41 @@ type SpawnCloudAgentResult = {
   sessionId?: string;
 };
 
-export const spawnCloudAgentInputSchema = z.object({
-  githubRepo: z
-    .string()
-    .regex(/^[-a-zA-Z0-9_.]+\/[-a-zA-Z0-9_.]+$/)
-    .describe('The GitHub repository in owner/repo format (e.g., "facebook/react")')
-    .optional(),
-  gitlabProject: z
-    .string()
-    .regex(/^[-a-zA-Z0-9_.]+(?:\/[-a-zA-Z0-9_.]+)+$/)
-    .describe(
-      'The GitLab project path in group/project format (e.g., "mygroup/myproject"). May include nested groups (e.g., "group/subgroup/project").'
-    )
-    .optional(),
+const sharedFields = {
   prompt: z
     .string()
     .describe(
       'The task description for the Cloud Agent. Be specific about what changes or analysis you want.'
     ),
   mode: z
-    .enum(['architect', 'code', 'ask', 'debug', 'orchestrator'])
+    .enum(['code', 'plan', 'debug', 'orchestrator', 'ask', 'build', 'architect', 'custom'])
     .default('code')
     .describe(
-      'The agent mode: "code" for making changes, "architect" for design tasks, "ask" for questions, "debug" for troubleshooting, "orchestrator" for complex multi-step tasks'
+      'The agent mode: "code" for making changes, "plan" for design tasks, "ask" for questions, "debug" for troubleshooting, "orchestrator" for complex multi-step tasks. "build" and "architect" are backward-compatible aliases for "code" and "plan".'
     ),
+};
+
+const githubSchema = z.object({
+  githubRepo: z
+    .string()
+    .regex(/^[-a-zA-Z0-9_.]+\/[-a-zA-Z0-9_.]+$/)
+    .describe('The GitHub repository in owner/repo format (e.g., "facebook/react")'),
+  ...sharedFields,
 });
+
+const gitlabSchema = z.object({
+  gitlabProject: z
+    .string()
+    .regex(/^[-a-zA-Z0-9_.]+(?:\/[-a-zA-Z0-9_.]+)+$/)
+    .describe(
+      'The GitLab project path in group/project format (e.g., "mygroup/myproject"). May include nested groups (e.g., "group/subgroup/project").'
+    ),
+  ...sharedFields,
+});
+
+export const spawnCloudAgentInputSchema = z.union([githubSchema, gitlabSchema]);
+
+type SpawnCloudAgentInput = z.infer<typeof spawnCloudAgentInputSchema>;
 
 /**
  * Spawn a Cloud Agent session and collect the results.
@@ -57,12 +68,7 @@ export const spawnCloudAgentInputSchema = z.object({
  * Delegates to the shared runSessionToCompletion helper.
  */
 export default async function spawnCloudAgentSession(
-  args: {
-    githubRepo?: string;
-    gitlabProject?: string;
-    prompt: string;
-    mode?: string;
-  },
+  args: SpawnCloudAgentInput,
   model: string,
   platformIntegration: PlatformIntegration,
   authToken: string,
@@ -70,32 +76,13 @@ export default async function spawnCloudAgentSession(
 ): Promise<SpawnCloudAgentResult> {
   console.log('[SlackBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
 
-  if (args.githubRepo && args.gitlabProject) {
-    return {
-      response: 'Error: Both githubRepo and gitlabProject were specified. Provide exactly one.',
-    };
-  }
-
-  if (!args.githubRepo && !args.gitlabProject) {
-    return {
-      response: 'Error: No repository specified. Provide either githubRepo or gitlabProject.',
-    };
-  }
-
-  // Validate the repo identifier has at least "owner/repo" shape (non-empty segments around a slash)
-  const repoIdentifier = args.githubRepo ?? args.gitlabProject;
-  if (!repoIdentifier || !/\/./.test(repoIdentifier)) {
-    return {
-      response: `Error: Invalid repository identifier "${repoIdentifier ?? ''}". Expected format like "owner/repo".`,
-    };
-  }
-
   // Build platform-specific prepareInput and initiateInput
   const kilocodeOrganizationId = platformIntegration.owned_by_organization_id || undefined;
   let prepareInput: PrepareSessionInput;
   let initiateInput: { githubToken?: string; kilocodeOrganizationId?: string };
+  const mode: AgentMode = args.mode ?? 'code';
 
-  if (args.gitlabProject) {
+  if ('gitlabProject' in args) {
     // GitLab path: get token + instance URL, build clone URL, use gitUrl/gitToken
     const gitlabToken =
       typeof platformIntegration.owned_by_organization_id === 'string'
@@ -126,7 +113,7 @@ export default async function spawnCloudAgentSession(
 
     prepareInput = {
       prompt: args.prompt,
-      mode: (args.mode as PrepareSessionInput['mode']) || 'code',
+      mode,
       model,
       gitUrl,
       gitToken: gitlabToken,
@@ -152,7 +139,7 @@ export default async function spawnCloudAgentSession(
     prepareInput = {
       githubRepo: args.githubRepo,
       prompt: args.prompt,
-      mode: (args.mode as PrepareSessionInput['mode']) || 'code',
+      mode,
       model,
       githubToken,
       kilocodeOrganizationId,

--- a/src/lib/feature-detection.ts
+++ b/src/lib/feature-detection.ts
@@ -26,6 +26,7 @@ export const FEATURE_VALUES = [
   'security-agent',
   'slack',
   'discord',
+  'bot',
   'webhook',
   'kiloclaw',
   'openclaw',

--- a/src/lib/integrations/core/constants.ts
+++ b/src/lib/integrations/core/constants.ts
@@ -147,6 +147,7 @@ export const PLATFORM = {
   GITLAB: 'gitlab',
   SLACK: 'slack',
   DISCORD: 'discord',
+  SLACK_NEXT: 'slack-next',
 } as const;
 
 /**

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -17,7 +17,7 @@ import { minimax_m25_free_model } from '@/lib/providers/minimax';
 import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
 
 // Default model for Slack integrations - separate from the global platform default
-const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
+export const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
   ? minimax_m25_free_model.public_id
   : CLAUDE_OPUS_CURRENT_MODEL_ID;
 

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -17,7 +17,7 @@ import { minimax_m25_free_model } from '@/lib/providers/minimax';
 import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
 
 // Default model for Slack integrations - separate from the global platform default
-export const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
+const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
   ? minimax_m25_free_model.public_id
   : CLAUDE_OPUS_CURRENT_MODEL_ID;
 

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -44,7 +44,7 @@ export const SLACK_SCOPES = [
   'users:read.email',
 ];
 
-export const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
+const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
 
 function getOwnershipConditions(owner: Owner) {
   return owner.type === 'user'

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -23,7 +23,7 @@ const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
 
 // Slack OAuth scopes for the integration
 // These should be kept in sync with the scopes requested in the Slack app configuration
-const SLACK_SCOPES = [
+export const SLACK_SCOPES = [
   'app_mentions:read',
   'channels:history',
   'channels:read',
@@ -44,7 +44,7 @@ const SLACK_SCOPES = [
   'users:read.email',
 ];
 
-export const SLACK_REDIRECT_URI = `${APP_URL}/api/chat/slack/install/callback`;
+export const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
 
 function getOwnershipConditions(owner: Owner) {
   return owner.type === 'user'

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -44,7 +44,7 @@ const SLACK_SCOPES = [
   'users:read.email',
 ];
 
-const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
+export const SLACK_REDIRECT_URI = `${APP_URL}/api/chat/slack/install/callback`;
 
 function getOwnershipConditions(owner: Owner) {
   return owner.type === 'user'


### PR DESCRIPTION
## Summary

Vercel recently launched the Chat SDK, a helpful abstraction that makes it easier to build chatbots that work across platforms (Slack, Discord, Teams, Linear, etc.). In this PR, I introduce a completely new infrastructure for the Kilo Bot, powered by the Chat SDK. 

Chat SDK uses Redis for state management and data storage, so we'll have to figure out how to transfer existing users from the old bot to the new bot, but that's out of scope for this PR.

I've also opted to move the AI loop to use the AI SDK. This really cleans up the code, in my opinion.

## Verification

I've been running the `Henk Bot` in Slack, testing its various behaviors. There seems to be some subtle differences in how the bot responds after spawning a Cloud Agent. I'll try to figure out where that's coming from.

- [x] Make sure that this doesn't hurt existing integrations with Kilo for Slack
- [x] Tell `Henk Bot` hi, verify that you're asked to link your account
- [x] Verify that account linking only works if you're part of the organization
- [x] After linking the account, ask `Henk Bot` what the first line is of the README of the cloud repo
- [x] Verify that Sessions are shared in an ephemeral message (fallback to DM in Discord)

## Visual Changes

The big change is that Kilo will now ask you to link your account:

<img width="1318" height="500" alt="CleanShot 2026-03-05 at 09 38 49@2x" src="https://github.com/user-attachments/assets/4ad26fb5-91b5-47e2-857c-c6bf1d2f2e3e" />

## Reviewer Notes

The new code should be factored much more cleanly, so I hope this is an easy review. My main goal is to enable this new bot only for the Kilo org, so we can test it internally.
