### PR TITLE
Bring workaround for duplicate reasoning over

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextResponse as NextResponseType } from 'next/server';
 import { type NextRequest } from 'next/server';
-import { stripRequiredPrefix } from '@/lib/utils';
+import { isOpenCodeBasedClient, isRooCodeBasedClient, stripRequiredPrefix } from '@/lib/utils';
 import { generateProviderSpecificHash } from '@/lib/providerHash';
 import { extractPromptInfo, type MicrodollarUsageContext } from '@/lib/processUsage';
 import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
@@ -61,6 +61,7 @@ import { isRateLimitedToDeath } from '@/lib/rate-limited-models';
 import { isActiveReviewPromo } from '@/lib/code-reviews/core/constants';
 import { isActiveCloudAgentPromo } from '@/lib/promotions/cloud-agent-promo';
 import { isKiloAutoModel, resolveAutoModel } from '@/lib/kilo-auto-model';
+import { fixOpenCodeDuplicateReasoning } from '@/lib/providers/fixOpenCodeDuplicateReasoning';
 
 export const maxDuration = 800;
 
@@ -360,6 +361,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     repairTools(requestBodyParsed);
   }
 
+  if (isOpenCodeBasedClient(fraudHeaders)) {
+    fixOpenCodeDuplicateReasoning(originalModelIdLowerCased, requestBodyParsed, taskId);
+  }
+
   const toolsAvailable = getToolsAvailable(requestBodyParsed.tools);
   const toolsUsed = getToolsUsed(requestBodyParsed.messages);
 
@@ -378,7 +383,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         requestBodyParsed,
         user.id,
         taskId,
-        !!fraudHeaders.http_user_agent?.startsWith('Kilo-Code/')
+        isRooCodeBasedClient(fraudHeaders)
       )
     : await openRouterRequest({
         path,

--- a/src/lib/providers/fixOpenCodeDuplicateReasoning.ts
+++ b/src/lib/providers/fixOpenCodeDuplicateReasoning.ts
@@ -1,0 +1,55 @@
+import { ReasoningDetailType } from '@/lib/custom-llm/reasoning-details';
+import { isAnthropicModel } from '@/lib/providers/anthropic';
+import type {
+  MessageWithReasoning,
+  OpenRouterChatCompletionRequest,
+} from '@/lib/providers/openrouter/types';
+
+export function fixOpenCodeDuplicateReasoning(
+  requestedModel: string,
+  request: OpenRouterChatCompletionRequest,
+  sessionId: string | undefined
+) {
+  // workaround for @openrouter/ai-sdk-provider v1 duplicating reasoning
+  // possibly fixed in https://github.com/OpenRouterTeam/ai-sdk-provider/pull/344/
+  console.debug(
+    `[fixOpenCodeDuplicateReasoning] start, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
+  );
+  for (const msg of request.messages) {
+    const msgWithReasoning = msg as MessageWithReasoning;
+    if (!msgWithReasoning.reasoning_details) {
+      continue;
+    }
+    const encryptedDataSet = new Set<string>();
+    const textSet = new Set<string>();
+    msgWithReasoning.reasoning_details = msgWithReasoning.reasoning_details.filter(rd => {
+      if (rd.type === ReasoningDetailType.Encrypted && rd.data) {
+        if (!encryptedDataSet.has(rd.data)) {
+          encryptedDataSet.add(rd.data);
+          return true;
+        }
+        console.debug(
+          `[fixOpenCodeDuplicateReasoning] removing duplicated encrypted reasoning, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
+        );
+        return false;
+      }
+      if (rd.type === ReasoningDetailType.Text && rd.text) {
+        if (isAnthropicModel(requestedModel) && !rd.signature) {
+          console.debug(
+            `[fixOpenCodeDuplicateReasoning] removing reasoning text without signature, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
+          );
+          return false;
+        }
+        if (!textSet.has(rd.text)) {
+          textSet.add(rd.text);
+          return true;
+        }
+        console.debug(
+          `[fixOpenCodeDuplicateReasoning] removing duplicated reasoning text, model: ${requestedModel}, session: ${sessionId || 'unknown'}`
+        );
+        return false;
+      }
+      return true;
+    });
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,14 @@ export function getFraudDetectionHeaders(headers: Headers) {
   };
 }
 
+export function isRooCodeBasedClient(headers: FraudDetectionHeaders) {
+  return !!headers.http_user_agent?.startsWith('Kilo-Code/');
+}
+
+export function isOpenCodeBasedClient(headers: FraudDetectionHeaders) {
+  return !!headers.http_user_agent?.startsWith('opencode-kilo-provider');
+}
+
 export function getInitials(user: User) {
   if (!user) {
     return '';


### PR DESCRIPTION
Ideally we would fix the client, but since this is several levels deep in the dependency stack this cannot be done in short order.

Tested locally in conjunction with https://github.com/Kilo-Org/kilocode/pull/6629 by verifying there are no errors and logged requests look at expected.