### PR TITLE
Stop honoring obsolete reasoning_effort and verbosity columns on custom_llm

### DIFF
--- a/src/lib/custom-llm/customLlmRequest.ts
+++ b/src/lib/custom-llm/customLlmRequest.ts
@@ -566,10 +566,8 @@ function buildCommonParams(
   request: OpenRouterChatCompletionRequest,
   isLegacyExtension: boolean
 ) {
-  const verbosity = VerbositySchema.safeParse(request.verbosity ?? customLlm.verbosity).data;
-  const reasoningEffort = ReasoningEffortSchema.safeParse(
-    request.reasoning?.effort ?? customLlm.reasoning_effort
-  ).data;
+  const verbosity = VerbositySchema.safeParse(request.verbosity).data;
+  const reasoningEffort = ReasoningEffortSchema.safeParse(request.reasoning?.effort).data;
   return {
     messages,
     tools: convertTools(request.tools),


### PR DESCRIPTION
So that we can remove them in the future.

Low risk change since this code is only used internally.