### PR TITLE
feat(cloud-agent-next): show full commit message on hover

### DIFF
--- a/src/components/cloud-agent-next/AutocommitStatus.tsx
+++ b/src/components/cloud-agent-next/AutocommitStatus.tsx
@@ -49,7 +49,7 @@ function StatusIndicator({ status }: { status: AutocommitStatusType }) {
         <span className="text-muted-foreground flex items-center gap-2">
           <Check className="h-3 w-3" />
           {status.commitHash ? (
-            <span>
+            <span title={status.commitMessage ?? status.message}>
               <code className="font-mono">{status.commitHash}</code>{' '}
               {truncateCommitMessage(status.commitMessage ?? status.message)}
             </span>

--- a/src/components/cloud-agent-next/AutocommitStatus.tsx
+++ b/src/components/cloud-agent-next/AutocommitStatus.tsx
@@ -1,5 +1,6 @@
 import { useAtomValue } from 'jotai';
 import { Loader2, Check, X } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import type { AutocommitStatus as AutocommitStatusType } from './store/atoms';
 import { autocommitStatusMapAtom } from './store/atoms';
 import { isAssistantMessage } from './types';
@@ -49,10 +50,15 @@ function StatusIndicator({ status }: { status: AutocommitStatusType }) {
         <span className="text-muted-foreground flex items-center gap-2">
           <Check className="h-3 w-3" />
           {status.commitHash ? (
-            <span title={status.commitMessage ?? status.message}>
-              <code className="font-mono">{status.commitHash}</code>{' '}
-              {truncateCommitMessage(status.commitMessage ?? status.message)}
-            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <code className="font-mono">{status.commitHash}</code>{' '}
+                  {truncateCommitMessage(status.commitMessage ?? status.message)}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">{status.commitMessage ?? status.message}</TooltipContent>
+            </Tooltip>
           ) : (
             <span>{status.message}</span>
           )}


### PR DESCRIPTION
## Summary

When the cloud agent auto-commits, the commit message is truncated to 50 characters in the chat UI (e.g. `07b064c chore(config): update tsconfig to use react-jsx an…`). There was no way to see the full message.

This wraps the commit status text in the shadcn/ui `<Tooltip>` component (Radix UI) so hovering reveals the full commit message. The full `commitMessage` was already available in the store — it just wasn't surfaced to the user.

## Verification

- [x] `pnpm typecheck` — passed

## Visual Changes

| Before | After |
| ------ | ----- |
| Truncated commit message with no way to see full text | Hovering over the truncated message shows the full commit message in a Radix tooltip |

 
<img width="563" height="220" alt="Screenshot 2026-03-05 at 11 11 29" src="https://github.com/user-attachments/assets/d3c012ee-8f9e-437d-af50-37462f0f25c6" />



## Reviewer Notes

Small change in `AutocommitStatus.tsx`. Uses the same `Tooltip` / `TooltipTrigger` / `TooltipContent` pattern used across ~34 other files in the codebase, rather than a native `title` attribute.