### PR TITLE
fix(cloud-agent-next): refresh GitLab token on sendMessage

### DIFF
--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -411,6 +411,7 @@ export function createSessionManagementHandlers() {
 
             githubRepo: metadata.githubRepo,
             gitUrl: metadata.gitUrl,
+            platform: metadata.platform,
             // githubToken: OMITTED
             // gitToken: OMITTED
 

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -353,6 +353,7 @@ export const GetSessionOutput = z.object({
   // Repository info (no tokens)
   githubRepo: z.string().optional().describe('GitHub repository in org/repo format'),
   gitUrl: z.string().optional().describe('Generic git URL'),
+  platform: z.enum(['github', 'gitlab']).optional().describe('Git platform type'),
 
   // Execution params
   prompt: z.string().optional().describe('Task prompt'),

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -25,6 +25,12 @@ function sanitizeGitUrlForLogging(gitUrl: string): string {
   }
 }
 
+// Mask authentication tokens in git stderr output to prevent leaking secrets in logs/errors.
+// Handles patterns like `oauth2:TOKEN@`, `x-access-token:TOKEN@`, and `x-token-auth:TOKEN@`.
+function sanitizeGitStderr(stderr: string): string {
+  return stderr.replace(/(oauth2|x-access-token|x-token-auth):([^@]+)@/gi, '$1:***@');
+}
+
 const SESSION_HOME_ROOT = `/home`;
 const KILOCODE_DIR = `.kilocode`;
 const CLI_DIR = `${KILOCODE_DIR}/cli`;
@@ -502,7 +508,7 @@ export async function updateGitRemoteToken(
 async function gitFetch(session: ExecutionSession, workspacePath: string): Promise<void> {
   const result = await session.exec(`cd ${workspacePath} && git fetch origin`);
   if (result.exitCode !== 0) {
-    logger.withFields({ stderr: result.stderr }).warn('Git fetch failed');
+    logger.withFields({ stderr: sanitizeGitStderr(result.stderr) }).warn('Git fetch failed');
   }
 }
 
@@ -535,7 +541,9 @@ async function checkoutExistingBranch(
 ): Promise<void> {
   const result = await session.exec(`cd ${workspacePath} && git checkout '${branchName}'`);
   if (result.exitCode !== 0) {
-    throw new Error(`Failed to checkout branch ${branchName}: ${result.stderr || result.stdout}`);
+    throw new Error(
+      `Failed to checkout branch ${branchName}: ${sanitizeGitStderr(result.stderr || result.stdout)}`
+    );
   }
 }
 
@@ -548,7 +556,7 @@ async function pullLatestChangesLenient(
   if (result.exitCode !== 0) {
     // Session branches might have unpushed work or conflicts, just warn
     logger
-      .withFields({ branchName, stderr: result.stderr })
+      .withFields({ branchName, stderr: sanitizeGitStderr(result.stderr) })
       .warn('Could not pull branch, continuing with local version');
   }
 }
@@ -563,7 +571,7 @@ async function createTrackingBranch(
   );
   if (result.exitCode !== 0) {
     throw new Error(
-      `Failed to create tracking branch ${branchName}: ${result.stderr || result.stdout}`
+      `Failed to create tracking branch ${branchName}: ${sanitizeGitStderr(result.stderr || result.stdout)}`
     );
   }
 }
@@ -575,7 +583,9 @@ async function createNewBranch(
 ): Promise<void> {
   const result = await session.exec(`cd ${workspacePath} && git checkout -b '${branchName}'`);
   if (result.exitCode !== 0) {
-    throw new Error(`Failed to create branch ${branchName}: ${result.stderr || result.stdout}`);
+    throw new Error(
+      `Failed to create branch ${branchName}: ${sanitizeGitStderr(result.stderr || result.stdout)}`
+    );
   }
 }
 
@@ -593,7 +603,7 @@ async function fetchPullRefAndCheckout(
   const fetchResult = await session.exec(`cd ${workspacePath} && git fetch origin '${pullRef}'`);
   if (fetchResult.exitCode !== 0) {
     throw new Error(
-      `Failed to fetch pull ref ${pullRef}: ${fetchResult.stderr || fetchResult.stdout}`
+      `Failed to fetch pull ref ${pullRef}: ${sanitizeGitStderr(fetchResult.stderr || fetchResult.stdout)}`
     );
   }
 
@@ -602,7 +612,7 @@ async function fetchPullRefAndCheckout(
   );
   if (checkoutResult.exitCode !== 0) {
     throw new Error(
-      `Failed to checkout pull ref ${pullRef}: ${checkoutResult.stderr || checkoutResult.stdout}`
+      `Failed to checkout pull ref ${pullRef}: ${sanitizeGitStderr(checkoutResult.stderr || checkoutResult.stdout)}`
     );
   }
 }

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -25,10 +25,10 @@ function sanitizeGitUrlForLogging(gitUrl: string): string {
   }
 }
 
-// Mask authentication tokens in git stderr output to prevent leaking secrets in logs/errors.
+// Mask authentication tokens in git output to prevent leaking secrets in logs/errors.
 // Handles patterns like `oauth2:TOKEN@`, `x-access-token:TOKEN@`, and `x-token-auth:TOKEN@`.
-function sanitizeGitStderr(stderr: string): string {
-  return stderr.replace(/(oauth2|x-access-token|x-token-auth):([^@]+)@/gi, '$1:***@');
+function sanitizeGitOutput(output: string): string {
+  return output.replace(/(oauth2|x-access-token|x-token-auth):([^@]+)@/gi, '$1:***@');
 }
 
 const SESSION_HOME_ROOT = `/home`;
@@ -508,7 +508,7 @@ export async function updateGitRemoteToken(
 async function gitFetch(session: ExecutionSession, workspacePath: string): Promise<void> {
   const result = await session.exec(`cd ${workspacePath} && git fetch origin`);
   if (result.exitCode !== 0) {
-    logger.withFields({ stderr: sanitizeGitStderr(result.stderr) }).warn('Git fetch failed');
+    logger.withFields({ stderr: sanitizeGitOutput(result.stderr) }).warn('Git fetch failed');
   }
 }
 
@@ -542,7 +542,7 @@ async function checkoutExistingBranch(
   const result = await session.exec(`cd ${workspacePath} && git checkout '${branchName}'`);
   if (result.exitCode !== 0) {
     throw new Error(
-      `Failed to checkout branch ${branchName}: ${sanitizeGitStderr(result.stderr || result.stdout)}`
+      `Failed to checkout branch ${branchName}: ${sanitizeGitOutput(result.stderr || result.stdout)}`
     );
   }
 }
@@ -556,7 +556,7 @@ async function pullLatestChangesLenient(
   if (result.exitCode !== 0) {
     // Session branches might have unpushed work or conflicts, just warn
     logger
-      .withFields({ branchName, stderr: sanitizeGitStderr(result.stderr) })
+      .withFields({ branchName, stderr: sanitizeGitOutput(result.stderr) })
       .warn('Could not pull branch, continuing with local version');
   }
 }
@@ -571,7 +571,7 @@ async function createTrackingBranch(
   );
   if (result.exitCode !== 0) {
     throw new Error(
-      `Failed to create tracking branch ${branchName}: ${sanitizeGitStderr(result.stderr || result.stdout)}`
+      `Failed to create tracking branch ${branchName}: ${sanitizeGitOutput(result.stderr || result.stdout)}`
     );
   }
 }
@@ -584,7 +584,7 @@ async function createNewBranch(
   const result = await session.exec(`cd ${workspacePath} && git checkout -b '${branchName}'`);
   if (result.exitCode !== 0) {
     throw new Error(
-      `Failed to create branch ${branchName}: ${sanitizeGitStderr(result.stderr || result.stdout)}`
+      `Failed to create branch ${branchName}: ${sanitizeGitOutput(result.stderr || result.stdout)}`
     );
   }
 }
@@ -603,7 +603,7 @@ async function fetchPullRefAndCheckout(
   const fetchResult = await session.exec(`cd ${workspacePath} && git fetch origin '${pullRef}'`);
   if (fetchResult.exitCode !== 0) {
     throw new Error(
-      `Failed to fetch pull ref ${pullRef}: ${sanitizeGitStderr(fetchResult.stderr || fetchResult.stdout)}`
+      `Failed to fetch pull ref ${pullRef}: ${sanitizeGitOutput(fetchResult.stderr || fetchResult.stdout)}`
     );
   }
 
@@ -612,7 +612,7 @@ async function fetchPullRefAndCheckout(
   );
   if (checkoutResult.exitCode !== 0) {
     throw new Error(
-      `Failed to checkout pull ref ${pullRef}: ${sanitizeGitStderr(checkoutResult.stderr || checkoutResult.stdout)}`
+      `Failed to checkout pull ref ${pullRef}: ${sanitizeGitOutput(checkoutResult.stderr || checkoutResult.stdout)}`
     );
   }
 }

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -172,6 +172,7 @@ export type GetSessionOutput = {
   // Repository info (no tokens)
   githubRepo?: string;
   gitUrl?: string;
+  platform?: 'github' | 'gitlab';
 
   // Execution params
   prompt?: string;

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -108,7 +108,6 @@ export type PrepareSessionOutput = {
 export type InitiateFromPreparedSessionInput = {
   cloudAgentSessionId: string;
   kilocodeOrganizationId?: string;
-  githubToken?: string;
 };
 
 /** Input for sendMessage procedure (V2 - uses cloudAgentSessionId) */

--- a/src/lib/cloud-agent-next/run-session.ts
+++ b/src/lib/cloud-agent-next/run-session.ts
@@ -96,7 +96,7 @@ export type RunSessionInput = {
   client: CloudAgentNextClient;
   /** Fields forwarded to prepareSession. */
   prepareInput: PrepareSessionInput;
-  /** Partial override for initiateFromPreparedSession (e.g. githubToken). */
+  /** Partial override for initiateFromPreparedSession (e.g. kilocodeOrganizationId). */
   initiateInput?: Omit<InitiateFromPreparedSessionInput, 'cloudAgentSessionId'>;
   /** Payload fields for signing the WebSocket stream ticket. */
   ticketPayload: Pick<StreamTicketPayload, 'userId' | 'organizationId'>;

--- a/src/lib/discord-bot.ts
+++ b/src/lib/discord-bot.ts
@@ -194,7 +194,6 @@ async function spawnCloudAgentSession(
       createdOnPlatform: 'discord',
     },
     initiateInput: {
-      githubToken,
       kilocodeOrganizationId,
     },
     ticketPayload: {

--- a/src/lib/slack-bot.ts
+++ b/src/lib/slack-bot.ts
@@ -288,7 +288,7 @@ async function spawnCloudAgentSession(
 
   // Build platform-specific prepareInput and initiateInput
   let prepareInput: PrepareSessionInput;
-  let initiateInput: { githubToken?: string; kilocodeOrganizationId?: string };
+  let initiateInput: { kilocodeOrganizationId?: string };
 
   if (args.gitlabProject) {
     // GitLab path: get token + instance URL, build clone URL, use gitUrl/gitToken
@@ -353,7 +353,7 @@ async function spawnCloudAgentSession(
       kilocodeOrganizationId,
       createdOnPlatform: 'slack',
     };
-    initiateInput = { githubToken, kilocodeOrganizationId };
+    initiateInput = { kilocodeOrganizationId };
   }
 
   const result = await runSessionToCompletion({

--- a/src/routers/cloud-agent-next-router.ts
+++ b/src/routers/cloud-agent-next-router.ts
@@ -126,8 +126,15 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
       const authToken = generateCloudAgentToken(ctx.user);
-      const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudAgentNextClient(authToken);
+
+      // Determine platform to fetch the correct token
+      const session = await client.getSession(input.cloudAgentSessionId);
+      let githubToken: string | undefined;
+
+      if (session.platform !== 'gitlab') {
+        githubToken = await getGitHubTokenForUser(ctx.user.id);
+      }
 
       try {
         return await client.initiateFromPreparedSession({
@@ -151,13 +158,30 @@ export const cloudAgentNextRouter = createTRPCRouter({
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
       const authToken = generateCloudAgentToken(ctx.user);
-      const githubToken = await getGitHubTokenForUser(ctx.user.id);
       const client = createCloudAgentNextClient(authToken);
+
+      // Determine platform to fetch the correct token
+      const session = await client.getSession(input.cloudAgentSessionId);
+      let githubToken: string | undefined;
+      let gitToken: string | undefined;
+
+      if (session.platform === 'gitlab') {
+        gitToken = await getGitLabTokenForUser(ctx.user.id);
+        if (!gitToken) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'No GitLab integration found. Please connect your GitLab account first.',
+          });
+        }
+      } else {
+        githubToken = await getGitHubTokenForUser(ctx.user.id);
+      }
 
       try {
         return await client.sendMessage({
           ...input,
           githubToken,
+          gitToken,
         });
       } catch (error) {
         rethrowAsPaymentRequired(error);

--- a/src/routers/cloud-agent-next-router.ts
+++ b/src/routers/cloud-agent-next-router.ts
@@ -128,18 +128,12 @@ export const cloudAgentNextRouter = createTRPCRouter({
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
-      // Determine platform to fetch the correct token
-      const session = await client.getSession(input.cloudAgentSessionId);
-      let githubToken: string | undefined;
-
-      if (session.platform !== 'gitlab') {
-        githubToken = await getGitHubTokenForUser(ctx.user.id);
-      }
-
+      // No token fetch needed: prepare and initiate happen back-to-back,
+      // so tokens stored during prepareSession are still fresh.
+      // The DO refreshes GitHub App installation tokens internally.
       try {
         return await client.initiateFromPreparedSession({
           cloudAgentSessionId: input.cloudAgentSessionId,
-          githubToken,
         });
       } catch (error) {
         rethrowAsPaymentRequired(error);

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -166,6 +166,7 @@ export const baseGetSessionNextOutputSchema = z.object({
   // Repository info (no tokens)
   githubRepo: z.string().optional(),
   gitUrl: z.string().optional(),
+  platform: z.enum(['github', 'gitlab']).optional(),
 
   // Execution params
   prompt: z.string().optional(),

--- a/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -176,8 +176,15 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
       const authToken = generateCloudAgentToken(ctx.user);
-      const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudAgentNextClient(authToken);
+
+      // Determine platform to fetch the correct token
+      const session = await client.getSession(input.cloudAgentSessionId);
+      let githubToken: string | undefined;
+
+      if (session.platform !== 'gitlab') {
+        githubToken = await getGitHubTokenForOrganization(input.organizationId);
+      }
 
       try {
         return await client.initiateFromPreparedSession({
@@ -202,15 +209,32 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
     .output(baseInitiateSessionNextOutputSchema)
     .mutation(async ({ ctx, input }) => {
       const authToken = generateCloudAgentToken(ctx.user);
-      const githubToken = await getGitHubTokenForOrganization(input.organizationId);
       const client = createCloudAgentNextClient(authToken);
 
-      const { organizationId: _organizationId, ...messageInput } = input;
+      const { organizationId, ...messageInput } = input;
+
+      // Determine platform to fetch the correct token
+      const session = await client.getSession(messageInput.cloudAgentSessionId);
+      let githubToken: string | undefined;
+      let gitToken: string | undefined;
+
+      if (session.platform === 'gitlab') {
+        gitToken = await getGitLabTokenForOrganization(organizationId);
+        if (!gitToken) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'No GitLab integration found. Please connect your GitLab account first.',
+          });
+        }
+      } else {
+        githubToken = await getGitHubTokenForOrganization(organizationId);
+      }
 
       try {
         return await client.sendMessage({
           ...messageInput,
           githubToken,
+          gitToken,
         });
       } catch (error) {
         rethrowAsPaymentRequired(error);

--- a/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -178,19 +178,13 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       const authToken = generateCloudAgentToken(ctx.user);
       const client = createCloudAgentNextClient(authToken);
 
-      // Determine platform to fetch the correct token
-      const session = await client.getSession(input.cloudAgentSessionId);
-      let githubToken: string | undefined;
-
-      if (session.platform !== 'gitlab') {
-        githubToken = await getGitHubTokenForOrganization(input.organizationId);
-      }
-
+      // No token fetch needed: prepare and initiate happen back-to-back,
+      // so tokens stored during prepareSession are still fresh.
+      // The DO refreshes GitHub App installation tokens internally.
       try {
         return await client.initiateFromPreparedSession({
           cloudAgentSessionId: input.cloudAgentSessionId,
           kilocodeOrganizationId: input.organizationId,
-          githubToken,
         });
       } catch (error) {
         rethrowAsPaymentRequired(error);


### PR DESCRIPTION
## Summary

- Fix expired GitLab OAuth tokens causing authentication failures when `sendMessage` triggers a re-clone. `prepareSession` fetches a fresh token, but `sendMessage` was reusing the stale token stored in DO metadata at prepare time. Now `sendMessage` calls `getSession()` to check the platform and fetches a fresh GitLab token via `getGitLabTokenForUser` / `getGitLabTokenForOrganization` when needed.
- Expose `platform` field (`github` | `gitlab`) from the `getSession` worker response so `sendMessage` can determine whether to fetch a GitLab token.
- Add `sanitizeGitStderr()` helper in `workspace.ts` to mask `oauth2:TOKEN@`, `x-access-token:TOKEN@`, and `x-token-auth:TOKEN@` patterns in git stderr output, preventing token leaks in logs and error messages. Applied to all 7 stderr logging/throw sites.

## Verification

- [x] `pnpm typecheck` — passed

## Visual Changes

N/A

## Reviewer Notes

- The downstream plumbing already exists: the worker schema defines optional `gitToken` on `SendMessageV2Input`, the DO's `startExecutionV2` handles `tokenOverrides.gitToken`, and the orchestrator calls `updateGitRemoteToken()`.
- `sendMessage` now makes one extra network call to the CF DO (via `getSession()`) to check the platform before deciding which token to fetch.
- `initiateFromPreparedSession` also updated to skip fetching GitHub tokens for GitLab repos.
- The old cloud-agent stack has the same bug but is out of scope for this branch.