### PR TITLE
chore(dev): add generic local webhook test flows

### DIFF
--- a/dev/AGENTS.md
+++ b/dev/AGENTS.md
@@ -1,0 +1,51 @@
+# Dev Script Guide For AI Agents
+
+These webhook test scripts intentionally use generic placeholder JSON.
+They are not expected to represent valid production payloads.
+Preferred workflow: capture a real webhook from smee.io, then ask an AI to replace or provide that payload to the script.
+
+## Script Map
+
+- Review flow:
+  - `./dev/review/dev-review.sh`
+  - `./dev/review/test-review-webhook.sh [payload.json]`
+- Auto-fix flow (`@kilo fix it`):
+  - `./dev/auto-fix/dev-auto-fix.sh`
+  - `./dev/auto-fix/test-auto-fix-webhook.sh [payload.json]`
+
+## GitHub App Install Prerequisites
+
+1. Ensure local app secrets are configured, especially `GITHUB_APP_WEBHOOK_SECRET` in `.env.local`.
+2. Install the GitHub App on the repo/org you want to test.
+3. In the GitHub App webhook settings:
+- Set webhook URL to your smee channel URL: `https://smee.io/<channel-id>`.
+- Set webhook secret to match your local webhook secret.
+- Subscribe to required events:
+- Review flow: `pull_request`.
+- Auto-fix flow: `pull_request_review_comment`.
+
+## Forward GitHub Events Locally With smee.io
+
+1. Create a channel at [smee.io](https://smee.io).
+2. Run the relay locally:
+```bash
+npx smee-client \
+  --url https://smee.io/<channel-id> \
+  --target http://127.0.0.1:3000/api/webhooks/github
+```
+3. Keep this process running while testing.
+4. Trigger a real GitHub event and capture the delivered JSON payload from smee.
+
+## How AI Agents Should Use The Test Scripts
+
+1. Start the required local services using the matching `dev` script.
+2. Save the real captured webhook payload to a JSON file.
+3. Run the matching test script with that file path.
+4. If payload is wrapped as `{"event":"...","payload":{...}}`, scripts auto-unwrap `.payload`.
+5. If no file is provided, scripts send embedded generic placeholder JSON.
+
+## Notes
+
+- Generic payload mode is for scaffolding only and may fail validation or integration checks.
+- Real payloads from smee are the source of truth for local webhook debugging.
+- Scripts sign payloads using `WEBHOOK_SECRET` (env override supported).

--- a/dev/auto-fix/dev-auto-fix.sh
+++ b/dev/auto-fix/dev-auto-fix.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ──────────────────────────────────────────────────────────────
+# dev-auto-fix.sh — Start all dev services in parallel with colored logs
+# ──────────────────────────────────────────────────────────────
+#
+# Services:
+#   1. Root (Next.js)           — port 3000
+#   2. Session Worker           — port 8787  (inspector 9230)
+#   3. Auto Fix Worker          — port 8792  (inspector 9231)
+#   4. Agent Next Worker        — port 8794  (inspector 9232)
+#
+# Log files are written to .dev-logs/<service>.log (ANSI stripped)
+# so AI agents and other tools can read them easily.
+#
+# Usage:
+#   ./dev-auto-fix.sh            # start all services
+#   ./dev-auto-fix.sh --no-root  # skip the Next.js root app
+# ──────────────────────────────────────────────────────────────
+
+CLOUD_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$CLOUD_DIR/.dev-logs"
+
+# ANSI colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Strip ANSI escape codes for clean log files
+strip_ansi() {
+  sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'
+}
+
+# Prefixed log helper — adds colored service name to every line
+# Also tees a clean (no ANSI) copy to the per-service log file
+prefix_log() {
+  local color="$1"
+  local label="$2"
+  local logfile="$LOG_DIR/${label}.log"
+  while IFS= read -r line; do
+    printf "${color}[%-14s]${RESET} %s\n" "$label" "$line"
+    printf '%s\n' "$line" | strip_ansi >> "$logfile"
+  done
+}
+
+# Kill the entire process group on exit (all children, pipes, subshells)
+cleanup() {
+  printf "\n${BOLD}${RED}Shutting down all services...${RESET}\n"
+  trap - INT TERM EXIT  # prevent re-entry
+  kill 0 2>/dev/null    # send TERM to every process in this process group
+}
+trap cleanup INT TERM EXIT
+
+# Start a service in the background with prefixed output
+start_service() {
+  local dir="$1"
+  local label="$2"
+  local color="$3"
+  shift 3
+  local cmd=("$@")
+
+  printf "${color}${BOLD}Starting %-14s${RESET} → %s\n" "$label" "$dir"
+  (cd "$dir" && exec "${cmd[@]}") 2>&1 | prefix_log "$color" "$label" &
+}
+
+# Like start_service but takes a shell string (for compound commands)
+start_service_sh() {
+  local dir="$1"
+  local label="$2"
+  local color="$3"
+  local cmd="$4"
+
+  printf "${color}${BOLD}Starting %-14s${RESET} → %s\n" "$label" "$dir"
+  (cd "$dir" && eval "$cmd") 2>&1 | prefix_log "$color" "$label" &
+}
+
+# ── Parse flags ──────────────────────────────────────────────
+SKIP_ROOT=false
+for arg in "$@"; do
+  case "$arg" in
+    --no-root) SKIP_ROOT=true ;;
+  esac
+done
+
+# ── Prepare log directory ────────────────────────────────────
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+# ── Banner ───────────────────────────────────────────────────
+printf "${BOLD}${CYAN}"
+echo "╔══════════════════════════════════════════╗"
+echo "║      Kilo Cloud Auto Fix Services        ║"
+echo "╚══════════════════════════════════════════╝"
+printf "${RESET}\n"
+printf "${CYAN}Logs → %s/${RESET}\n\n" "$LOG_DIR"
+
+# ── Launch services ──────────────────────────────────────────
+# Each wrangler worker gets a unique --inspector-port to avoid all three
+# fighting over the default 9229.
+
+if [ "$SKIP_ROOT" = false ]; then
+  start_service "$CLOUD_DIR" "root" "$GREEN" \
+    pnpm dev
+fi
+
+start_service "$CLOUD_DIR/cloudflare-session-ingest" "session" "$YELLOW" \
+  pnpm exec wrangler dev --inspector-port 9230
+
+start_service "$CLOUD_DIR/cloudflare-auto-fix-infra" "auto-fix" "$BLUE" \
+  pnpm exec wrangler dev --inspector-port 9231
+
+# agent-next needs its predev (build:wrapper) step before starting wrangler
+start_service_sh "$CLOUD_DIR/cloud-agent-next" "agent-next" "$RED" \
+  "pnpm run build:wrapper && exec pnpm exec wrangler dev --env dev --inspector-port 9232"
+
+printf "\n${BOLD}${CYAN}All services launched. Press Ctrl+C to stop.${RESET}\n\n"
+
+# Wait for all background processes
+wait

--- a/dev/auto-fix/test-auto-fix-webhook.sh
+++ b/dev/auto-fix/test-auto-fix-webhook.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Intentionally generic test payload.
+# Ask an AI to replace with a real webhook payload captured from smee.io.
+
+WEBHOOK_URL="${WEBHOOK_URL:-http://127.0.0.1:3000/api/webhooks/github}"
+WEBHOOK_SECRET="${WEBHOOK_SECRET:-dausigdb781g287d9asgd9721dsa}"
+EVENT_TYPE="${EVENT_TYPE:-pull_request_review_comment}"
+DELIVERY_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+# Optional first arg: path to JSON file containing a real GitHub webhook body.
+PAYLOAD_FILE="${1:-}"
+
+GENERIC_BODY='{
+  "action": "created",
+  "comment": {
+    "id": 987654321,
+    "body": "@kilo fix it",
+    "user": {
+      "login": "octocat"
+    },
+    "html_url": "https://github.com/OWNER/REPO/pull/123#discussion_r987654321",
+    "path": "src/example.ts",
+    "line": 42,
+    "diff_hunk": "@@ -1,1 +1,1 @@\\n-const bad = true;\\n+const good = true;",
+    "author_association": "OWNER"
+  },
+  "pull_request": {
+    "number": 123,
+    "title": "PLACEHOLDER: Replace with real PR title",
+    "html_url": "https://github.com/OWNER/REPO/pull/123",
+    "user": {
+      "login": "octocat"
+    },
+    "head": {
+      "sha": "1111111111111111111111111111111111111111",
+      "ref": "feature/placeholder"
+    },
+    "base": {
+      "ref": "main"
+    }
+  },
+  "repository": {
+    "id": 1,
+    "name": "REPO",
+    "full_name": "OWNER/REPO",
+    "private": false,
+    "owner": {
+      "login": "OWNER"
+    }
+  },
+  "installation": {
+    "id": 12345678
+  },
+  "sender": {
+    "login": "octocat"
+  }
+}'
+
+if [ -n "$PAYLOAD_FILE" ]; then
+  RAW_BODY="$(cat "$PAYLOAD_FILE")"
+  PAYLOAD_SOURCE="$PAYLOAD_FILE"
+else
+  RAW_BODY="$GENERIC_BODY"
+  PAYLOAD_SOURCE="embedded generic payload"
+fi
+
+# Support envelope payloads like {"event":"...","payload":{...}}.
+BODY="$(printf '%s' "$RAW_BODY" | jq -c 'if (type == "object" and has("payload")) then .payload else . end')"
+
+SIGNATURE="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $NF}')"
+
+echo "Delivery ID:   $DELIVERY_ID"
+echo "Event:         $EVENT_TYPE"
+echo "URL:           $WEBHOOK_URL"
+echo "Payload source:$PAYLOAD_SOURCE"
+echo "Signature:     $SIGNATURE"
+echo
+echo "Sending webhook..."
+echo
+
+curl -s -w "\nHTTP Status: %{http_code}\n" -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "x-github-event: $EVENT_TYPE" \
+  -H "x-github-delivery: $DELIVERY_ID" \
+  -H "x-hub-signature-256: $SIGNATURE" \
+  -d "$BODY"
+
+echo
+echo "Done."

--- a/dev/review/dev-review.sh
+++ b/dev/review/dev-review.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ──────────────────────────────────────────────────────────────
+# dev.sh — Start all dev services in parallel with colored logs
+# ──────────────────────────────────────────────────────────────
+#
+# Services:
+#   1. Root (Next.js)           — port 3000
+#   2. Session Worker           — port 8787  (inspector 9230)
+#   3. Review Worker            — port 8789  (inspector 9231)
+#   4. Agent Next Worker        — port 8794  (inspector 9232)
+#
+# Log files are written to .dev-logs/<service>.log (ANSI stripped)
+# so AI agents and other tools can read them easily.
+#
+# Usage:
+#   ./dev.sh            # start all services
+#   ./dev.sh --no-root  # skip the Next.js root app
+# ──────────────────────────────────────────────────────────────
+
+CLOUD_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$CLOUD_DIR/.dev-logs"
+
+# ANSI colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Strip ANSI escape codes for clean log files
+strip_ansi() {
+  sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'
+}
+
+# Prefixed log helper — adds colored service name to every line
+# Also tees a clean (no ANSI) copy to the per-service log file
+prefix_log() {
+  local color="$1"
+  local label="$2"
+  local logfile="$LOG_DIR/${label}.log"
+  while IFS= read -r line; do
+    printf "${color}[%-14s]${RESET} %s\n" "$label" "$line"
+    printf '%s\n' "$line" | strip_ansi >> "$logfile"
+  done
+}
+
+# Kill the entire process group on exit (all children, pipes, subshells)
+cleanup() {
+  printf "\n${BOLD}${RED}Shutting down all services...${RESET}\n"
+  trap - INT TERM EXIT  # prevent re-entry
+  kill 0 2>/dev/null     # send TERM to every process in this process group
+}
+trap cleanup INT TERM EXIT
+
+# Start a service in the background with prefixed output
+start_service() {
+  local dir="$1"
+  local label="$2"
+  local color="$3"
+  shift 3
+  local cmd=("$@")
+
+  printf "${color}${BOLD}Starting %-14s${RESET} → %s\n" "$label" "$dir"
+  (cd "$dir" && exec "${cmd[@]}") 2>&1 | prefix_log "$color" "$label" &
+}
+
+# Like start_service but takes a shell string (for compound commands)
+start_service_sh() {
+  local dir="$1"
+  local label="$2"
+  local color="$3"
+  local cmd="$4"
+
+  printf "${color}${BOLD}Starting %-14s${RESET} → %s\n" "$label" "$dir"
+  (cd "$dir" && eval "$cmd") 2>&1 | prefix_log "$color" "$label" &
+}
+
+# ── Parse flags ──────────────────────────────────────────────
+SKIP_ROOT=false
+for arg in "$@"; do
+  case "$arg" in
+    --no-root) SKIP_ROOT=true ;;
+  esac
+done
+
+# ── Prepare log directory ────────────────────────────────────
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+# ── Banner ───────────────────────────────────────────────────
+printf "${BOLD}${CYAN}"
+echo "╔══════════════════════════════════════════╗"
+echo "║         Kilo Cloud Dev Services          ║"
+echo "╚══════════════════════════════════════════╝"
+printf "${RESET}\n"
+printf "${CYAN}Logs → %s/${RESET}\n\n" "$LOG_DIR"
+
+# ── Launch services ──────────────────────────────────────────
+# Each wrangler worker gets a unique --inspector-port to avoid all three
+# fighting over the default 9229.
+
+if [ "$SKIP_ROOT" = false ]; then
+  start_service "$CLOUD_DIR" "root" "$GREEN" \
+    pnpm dev
+fi
+
+start_service "$CLOUD_DIR/cloudflare-session-ingest" "session" "$YELLOW" \
+  pnpm exec wrangler dev --inspector-port 9230
+
+start_service "$CLOUD_DIR/cloudflare-code-review-infra" "review" "$BLUE" \
+  pnpm exec wrangler dev --inspector-port 9231
+
+# agent-next needs its predev (build:wrapper) step before starting wrangler
+start_service_sh "$CLOUD_DIR/cloud-agent-next" "agent-next" "$RED" \
+  "pnpm run build:wrapper && exec pnpm exec wrangler dev --env dev --inspector-port 9232"
+
+printf "\n${BOLD}${CYAN}All services launched. Press Ctrl+C to stop.${RESET}\n\n"
+
+# Wait for all background processes
+wait

--- a/dev/review/test-review-webhook.sh
+++ b/dev/review/test-review-webhook.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Intentionally generic test payload.
+# Ask an AI to replace with a real webhook payload captured from smee.io.
+
+WEBHOOK_URL="${WEBHOOK_URL:-http://127.0.0.1:3000/api/webhooks/github}"
+WEBHOOK_SECRET="${WEBHOOK_SECRET:-dausigdb781g287d9asgd9721dsa}"
+EVENT_TYPE="${EVENT_TYPE:-pull_request}"
+DELIVERY_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+# Optional first arg: path to JSON file containing a real GitHub webhook body.
+PAYLOAD_FILE="${1:-}"
+
+GENERIC_BODY='{
+  "action": "opened",
+  "number": 123,
+  "pull_request": {
+    "number": 123,
+    "title": "PLACEHOLDER: Replace with real PR title",
+    "body": "PLACEHOLDER: Replace with real PR body",
+    "state": "open",
+    "draft": false,
+    "html_url": "https://github.com/OWNER/REPO/pull/123",
+    "user": {
+      "id": 1,
+      "login": "octocat",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif"
+    },
+    "head": {
+      "sha": "1111111111111111111111111111111111111111",
+      "ref": "feature/placeholder",
+      "repo": {
+        "full_name": "OWNER/REPO"
+      }
+    },
+    "base": {
+      "sha": "2222222222222222222222222222222222222222",
+      "ref": "main"
+    }
+  },
+  "repository": {
+    "id": 1,
+    "name": "REPO",
+    "full_name": "OWNER/REPO",
+    "private": false,
+    "owner": {
+      "login": "OWNER"
+    }
+  },
+  "installation": {
+    "id": 12345678
+  },
+  "sender": {
+    "login": "octocat"
+  }
+}'
+
+if [ -n "$PAYLOAD_FILE" ]; then
+  RAW_BODY="$(cat "$PAYLOAD_FILE")"
+  PAYLOAD_SOURCE="$PAYLOAD_FILE"
+else
+  RAW_BODY="$GENERIC_BODY"
+  PAYLOAD_SOURCE="embedded generic payload"
+fi
+
+# Support envelope payloads like {"event":"...","payload":{...}}.
+BODY="$(printf '%s' "$RAW_BODY" | jq -c 'if (type == "object" and has("payload")) then .payload else . end')"
+
+SIGNATURE="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $NF}')"
+
+echo "Delivery ID:   $DELIVERY_ID"
+echo "Event:         $EVENT_TYPE"
+echo "URL:           $WEBHOOK_URL"
+echo "Payload source:$PAYLOAD_SOURCE"
+echo "Signature:     $SIGNATURE"
+echo
+echo "Sending webhook..."
+echo
+
+curl -s -w "\nHTTP Status: %{http_code}\n" -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "x-github-event: $EVENT_TYPE" \
+  -H "x-github-delivery: $DELIVERY_ID" \
+  -H "x-hub-signature-256: $SIGNATURE" \
+  -d "$BODY"
+
+echo
+echo "Done."


### PR DESCRIPTION
## Summary

- Add dedicated local script sets for review and auto-fix webhook testing under `dev/review` and `dev/auto-fix`.
- Make webhook request bodies generic placeholders and allow passing a real payload file (`script.sh payload.json`) for replay.
- Add `dev/AGENTS.md` with GitHub App setup and local webhook forwarding instructions via `smee.io`.
- Use cases:
- Replay real GitHub webhook payloads captured from `smee.io` against local `/api/webhooks/github`.
- Quickly test review (`pull_request`) and auto-fix (`pull_request_review_comment`) flows with separate dev commands.

## Verification

- ✅ `bash -n dev/review/dev-review.sh dev/review/test-review-webhook.sh dev/auto-fix/dev-auto-fix.sh dev/auto-fix/test-auto-fix-webhook.sh`

## Visual Changes

N/A

## Reviewer Notes

- Embedded payloads are intentionally generic scaffolding and may fail real validation/integration checks.
- Expected workflow is to capture real webhook JSON from `smee.io` and pass it to the test scripts.
