### PR TITLE
feat(auto-fix): add UI toggle for review comment fixes

### DIFF
--- a/src/components/auto-fix/AutoFixConfigForm.tsx
+++ b/src/components/auto-fix/AutoFixConfigForm.tsx
@@ -68,6 +68,7 @@ export function AutoFixConfigForm({ organizationId }: AutoFixConfigFormProps) {
   const [selectedModel, setSelectedModel] = useState(PRIMARY_DEFAULT_MODEL);
   const [maxPRCreationTime, setMaxPRCreationTime] = useState([15]);
   const [prTitleTemplate, setPrTitleTemplate] = useState('Fix #{issue_number}: {issue_title}');
+  const [enabledForReviewComments, setEnabledForReviewComments] = useState(false);
   const [prBodyTemplate, setPrBodyTemplate] = useState('');
   const [prBaseBranch, setPrBaseBranch] = useState('main');
 
@@ -75,6 +76,7 @@ export function AutoFixConfigForm({ organizationId }: AutoFixConfigFormProps) {
   useEffect(() => {
     if (configData) {
       setIsEnabled(configData.isEnabled);
+      setEnabledForReviewComments(configData.enabled_for_review_comments ?? false);
       setRepositorySelectionMode(configData.repository_selection_mode || 'all');
       setSelectedRepositoryIds(configData.selected_repository_ids || []);
       setSkipLabels((configData.skip_labels || []).join(', '));
@@ -180,6 +182,7 @@ export function AutoFixConfigForm({ organizationId }: AutoFixConfigFormProps) {
       orgSaveMutation.mutate({
         organizationId,
         enabled_for_issues: isEnabled,
+        enabled_for_review_comments: enabledForReviewComments,
         repository_selection_mode: repositorySelectionMode,
         selected_repository_ids: selectedRepositoryIds,
         skip_labels: skipLabelsArray,
@@ -194,6 +197,7 @@ export function AutoFixConfigForm({ organizationId }: AutoFixConfigFormProps) {
     } else {
       personalSaveMutation.mutate({
         enabled_for_issues: isEnabled,
+        enabled_for_review_comments: enabledForReviewComments,
         repository_selection_mode: repositorySelectionMode,
         selected_repository_ids: selectedRepositoryIds,
         skip_labels: skipLabelsArray,
@@ -253,6 +257,29 @@ export function AutoFixConfigForm({ organizationId }: AutoFixConfigFormProps) {
               checked={isEnabled}
               onCheckedChange={handleToggle}
               disabled={orgToggleMutation.isPending || personalToggleMutation.isPending}
+            />
+          </div>
+
+          {/* Review Comments Toggle */}
+          <div
+            className={cn(
+              'flex items-center justify-between rounded-lg border p-4',
+              !isEnabled && 'pointer-events-none opacity-50'
+            )}
+          >
+            <div className="space-y-0.5">
+              <Label htmlFor="enable-review-comments" className="text-base font-semibold">
+                Fix PR Review Comments
+              </Label>
+              <p className="text-muted-foreground text-sm">
+                Respond to <code className="bg-muted rounded px-1 py-0.5">@kilo fix</code> mentions
+                in PR review comments with scoped code changes
+              </p>
+            </div>
+            <Switch
+              id="enable-review-comments"
+              checked={enabledForReviewComments}
+              onCheckedChange={setEnabledForReviewComments}
             />
           </div>
 


### PR DESCRIPTION
## Summary

The `enabled_for_review_comments` config field existed in the backend but had no UI control in `AutoFixConfigForm`. Every save from the UI omitted the field, causing the backend to default it to `false` — silently disabling review comment fixes even if previously enabled via API.

This adds a "Fix PR Review Comments" toggle to the Auto Fix settings page (both personal and org flows) and includes the value in save payloads so it persists correctly.

## Verification

- [x] `pnpm typecheck` — passes across all packages
- [x] Tested auto-fix webhook flow end-to-end locally using `dev/auto-fix/dev-auto-fix.sh` with a real payload

## Visual Changes

New toggle appears below the main "Enable AI Auto Fix" switch, visually disabled when auto-fix is off.

## Reviewer Notes

Backend already accepted `enabled_for_review_comments` — this is purely a frontend fix. The top-level `isEnabled` flag is computed server-side as `enabled_for_issues || enabled_for_review_comments`, so enabling review comments alone will also mark the agent config as enabled.