### PR TITLE
chore(cloud-agent-next): add debug logging to alarm handler

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -884,6 +884,10 @@ export class CloudAgentSession extends DurableObject {
   async alarm(): Promise<void> {
     const now = Date.now();
 
+    logger
+      .withFields({ doId: this.ctx.id.toString(), sessionId: this.sessionId })
+      .info('Alarm fired');
+
     try {
       // Check if session should be deleted due to inactivity (90 days)
       const lastActivity = await this.ctx.storage.get<number>(LAST_ACTIVITY_KEY);
@@ -897,18 +901,41 @@ export class CloudAgentSession extends DurableObject {
         return;
       }
 
+      logger
+        .withFields({ sessionId: this.sessionId, lastActivity, elapsedMs: Date.now() - now })
+        .debug('TTL check passed');
+
       // Run cleanup tasks
+      logger
+        .withFields({ sessionId: this.sessionId, elapsedMs: Date.now() - now })
+        .debug('Starting cleanupStaleExecutions');
       await this.cleanupStaleExecutions(now);
+
+      logger
+        .withFields({ sessionId: this.sessionId, elapsedMs: Date.now() - now })
+        .debug('Starting cleanupOldEvents');
       this.cleanupOldEvents(now);
+
+      logger
+        .withFields({ sessionId: this.sessionId, elapsedMs: Date.now() - now })
+        .debug('Starting cleanupExpiredLeases');
       this.cleanupExpiredLeases(now);
 
       // Check if kilo server should be stopped due to inactivity
+      logger
+        .withFields({ sessionId: this.sessionId, elapsedMs: Date.now() - now })
+        .debug('Starting cleanupIdleKiloServer');
       await this.cleanupIdleKiloServer(now);
+
+      logger
+        .withFields({ sessionId: this.sessionId, elapsedMs: Date.now() - now })
+        .debug('All cleanup steps completed');
     } catch (error) {
       logger
         .withFields({
           doId: this.ctx.id.toString(),
           sessionId: this.sessionId,
+          elapsedMs: Date.now() - now,
           error: error instanceof Error ? error.message : String(error),
           stack: error instanceof Error ? error.stack : undefined,
         })
@@ -926,6 +953,9 @@ export class CloudAgentSession extends DurableObject {
     } catch {
       // Fall through with default interval
     }
+    logger
+      .withFields({ sessionId: this.sessionId, nextInterval, elapsedMs: Date.now() - now })
+      .info('Rescheduling alarm');
     await this.ctx.storage.setAlarm(now + nextInterval);
   }
 
@@ -1168,7 +1198,16 @@ export class CloudAgentSession extends DurableObject {
       const sandboxId = await generateSandboxId(metadata.orgId, metadata.userId, metadata.botId);
       const sandbox = getSandbox((this.env as unknown as WorkerEnv).Sandbox, sandboxId);
 
+      const rpcStart = Date.now();
+      logger
+        .withFields({ sessionId: this.sessionId, sandboxId })
+        .debug('Starting stopKiloServer RPC');
+
       await stopKiloServer(sandbox, metadata.sessionId);
+
+      logger
+        .withFields({ sessionId: this.sessionId, sandboxId, rpcElapsedMs: Date.now() - rpcStart })
+        .debug('stopKiloServer RPC completed');
 
       // Clear the activity timestamp since server is stopped
       // Must merge with existing metadata since updateMetadata validates the full schema


### PR DESCRIPTION
## Summary

Add elapsed-time debug logging to `CloudAgentSession.alarm()` and `cleanupIdleKiloServer()` to diagnose which step is consuming the alarm's time budget when timeouts occur.

- Log alarm entry (`info`) with `doId` and `sessionId` so we know the alarm fired and which DO it's on
- Log after the TTL/`lastActivity` storage read with its value, to detect slow reads
- Log before each of the four cleanup steps with `elapsedMs` to pinpoint which step is slow
- Log total elapsed time after all cleanup steps complete
- Log before and after the `stopKiloServer` Sandbox RPC call specifically (the most likely culprit for timeouts)
- Log the chosen `nextInterval` and total elapsed before rescheduling the alarm
- Add `elapsedMs` to the existing catch-block error log

All new per-step logs use `debug` level; entry/exit logs use `info`. No control-flow or logic changes.

## Verification

- [x] `pnpm run typecheck` — passed (tsgo + wrapper)

## Visual Changes

N/A

## Reviewer Notes

- Logging-only change — no behavioral or control-flow modifications
- Uses the existing `logger.withFields(...)` pattern; extra fields like `elapsedMs` and `rpcElapsedMs` are not in the typed `CloudAgentTags` but are accepted by `WorkersLogger`'s `withFields` as arbitrary structured data
- `debug`-level logs can be filtered in production if log volume is a concern