### PR TITLE
refactor(bot): extract session URL helpers and add ephemeral session link

### DIFF
--- a/src/app/slack/webhook/route.ts
+++ b/src/app/slack/webhook/route.ts
@@ -20,13 +20,12 @@ import {
   isExternalWorkspaceEvent,
 } from '@/lib/slack-bot/slack-utils';
 import { getDevUserSuffix } from '@/lib/slack-bot/dev-user-info';
-import { APP_URL } from '@/lib/constants';
+import {
+  buildSessionUrl,
+  getDbSessionIdFromCloudAgentId,
+} from '@/lib/cloud-agent-next/session-url';
 import { verifySlackRequest } from '@/lib/slack/verify-request';
-import { db } from '@/lib/drizzle';
-import { cli_sessions_v2 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
 
-import type { Owner } from '@/lib/integrations/core/types';
 import type { PlatformIntegration } from '@kilocode/db/schema';
 
 export const maxDuration = 800;
@@ -36,31 +35,6 @@ export const maxDuration = 800;
  */
 const PROCESSING_REACTION = 'hourglass_flowing_sand';
 const COMPLETE_REACTION = 'white_check_mark';
-
-/**
- * Build the session URL for a cloud agent session based on the owner type
- * @param dbSessionId - The database UUID (session_id from cli_sessions table)
- * @param owner - The owner of the installation (user or org)
- */
-function buildSessionUrl(dbSessionId: string, owner: Owner): string {
-  const basePath = owner.type === 'org' ? `/organizations/${owner.id}/cloud` : '/cloud';
-  return `${APP_URL}${basePath}/chat?sessionId=${dbSessionId}`;
-}
-
-/**
- * Look up the database session UUID from the cloud agent session ID
- * @param cloudAgentSessionId - The agent_xxx format ID from cloud agent
- * @returns The database UUID (session_id) or null if not found
- */
-async function getDbSessionIdFromCloudAgentId(cloudAgentSessionId: string): Promise<string | null> {
-  const [session] = await db
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .where(eq(cli_sessions_v2.cloud_agent_session_id, cloudAgentSessionId))
-    .limit(1);
-
-  return session?.session_id ?? null;
-}
 
 /**
  * Post an ephemeral message to the user with a button to view the cloud agent session

--- a/src/lib/bot/run.ts
+++ b/src/lib/bot/run.ts
@@ -7,6 +7,7 @@ import {
 import spawnCloudAgentSession, {
   spawnCloudAgentInputSchema,
 } from '@/lib/bot/tools/spawn-cloud-agent-session';
+import { buildSessionUrl } from '@/lib/cloud-agent-next/session-url';
 import { APP_URL } from '@/lib/constants';
 import { FEATURE_HEADER } from '@/lib/feature-detection';
 import type { Owner } from '@/lib/integrations/core/types';
@@ -22,6 +23,7 @@ import { generateApiToken } from '@/lib/tokens';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { PlatformIntegration, User } from '@kilocode/db';
 import { ToolLoopAgent, stepCountIs, tool } from 'ai';
+import { Actions, Card, CardText, LinkButton, Section } from 'chat';
 import type { Thread, Message } from 'chat';
 
 function ownerFromIntegration(pi: PlatformIntegration): Owner {
@@ -96,6 +98,8 @@ export async function processMessage({
 
   const modelSlug =
     (platformIntegration.metadata as { model_slug?: string }).model_slug ?? DEFAULT_BOT_MODEL;
+  const owner = ownerFromIntegration(platformIntegration);
+
   const agent = new ToolLoopAgent({
     model: provider.chatModel(modelSlug),
     instructions: await buildSystemPrompt(platformIntegration),
@@ -106,7 +110,17 @@ export async function processMessage({
           'Spawn a Cloud Agent session to perform coding tasks on a GitHub repository. The agent can make code changes, fix bugs, implement features, and more.',
         inputSchema: spawnCloudAgentInputSchema,
         execute: async args =>
-          await spawnCloudAgentSession(args, modelSlug, platformIntegration, authToken, user.id),
+          await spawnCloudAgentSession(
+            args,
+            modelSlug,
+            platformIntegration,
+            authToken,
+            user.id,
+            ({ kiloSessionId }) => {
+              const sessionUrl = buildSessionUrl(kiloSessionId, owner);
+              postSessionLinkEphemeral(thread, message, sessionUrl);
+            }
+          ),
       }),
     },
   });
@@ -122,4 +136,21 @@ export async function processMessage({
 
     await thread.post(`Sorry, there was an error calling the AI service: ${errMsg.slice(0, 200)}`);
   }
+}
+
+function postSessionLinkEphemeral(thread: Thread, message: Message, sessionUrl: string): void {
+  thread
+    .postEphemeral(
+      message.author,
+      Card({
+        children: [
+          Section([CardText('A Cloud Agent session has been started for this task.')]),
+          Actions([LinkButton({ label: 'View Session', url: sessionUrl, style: 'primary' })]),
+        ],
+      }),
+      { fallbackToDM: true }
+    )
+    .catch(error => {
+      console.error('[KiloBot] Failed to post session link ephemeral:', error);
+    });
 }

--- a/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -3,7 +3,7 @@ import {
   type AgentMode,
   type PrepareSessionInput,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
-import { runSessionToCompletion } from '@/lib/cloud-agent-next/run-session';
+import { runSessionToCompletion, type RunSessionInput } from '@/lib/cloud-agent-next/run-session';
 import {
   getGitHubTokenForOrganization,
   getGitHubTokenForUser,
@@ -72,7 +72,8 @@ export default async function spawnCloudAgentSession(
   model: string,
   platformIntegration: PlatformIntegration,
   authToken: string,
-  ticketUserId: string
+  ticketUserId: string,
+  onSessionReady?: RunSessionInput['onSessionReady']
 ): Promise<SpawnCloudAgentResult> {
   console.log('[SlackBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
 
@@ -157,6 +158,7 @@ export default async function spawnCloudAgentSession(
       organizationId: kilocodeOrganizationId,
     },
     logPrefix: '[KiloBot]',
+    onSessionReady,
   });
 
   return { response: result.response, sessionId: result.sessionId };

--- a/src/lib/cloud-agent-next/run-session.ts
+++ b/src/lib/cloud-agent-next/run-session.ts
@@ -104,6 +104,14 @@ export type RunSessionInput = {
   streamTimeoutMs?: number;
   /** Optional log prefix for console messages (e.g. '[SlackBot]'). */
   logPrefix?: string;
+  /**
+   * Called once, right after the session has been prepared and initiated
+   * (i.e. the cloud agent is running). Useful for posting early user
+   * feedback such as an ephemeral "View Session" link before the session
+   * completes. Errors thrown by this callback are logged but do not abort
+   * the session.
+   */
+  onSessionReady?: (info: { cloudAgentSessionId: string; kiloSessionId: string }) => void;
 };
 
 /** Result from runSessionToCompletion */
@@ -140,6 +148,7 @@ export async function runSessionToCompletion(input: RunSessionInput): Promise<Ru
     initiateInput,
     ticketPayload,
     logPrefix = '[CloudAgentNext]',
+    onSessionReady,
   } = input;
   const streamTimeoutMs = input.streamTimeoutMs ?? DEFAULT_STREAM_TIMEOUT_MS;
 
@@ -189,6 +198,13 @@ export async function runSessionToCompletion(input: RunSessionInput): Promise<Ru
       hasError: true,
       statusMessages,
     };
+  }
+
+  // Notify caller that the session is live (fire-and-forget)
+  try {
+    onSessionReady?.({ cloudAgentSessionId: sessionId, kiloSessionId });
+  } catch (error) {
+    console.error(`${logPrefix} onSessionReady callback error:`, error);
   }
 
   // 3. Resolve URL

--- a/src/lib/cloud-agent-next/session-url.ts
+++ b/src/lib/cloud-agent-next/session-url.ts
@@ -1,0 +1,32 @@
+import { APP_URL } from '@/lib/constants';
+import { db } from '@/lib/drizzle';
+import type { Owner } from '@/lib/integrations/core/types';
+import { cli_sessions_v2 } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Build the browser URL for a cloud agent session based on the owner type.
+ * @param dbSessionId - The database UUID (session_id from cli_sessions table)
+ * @param owner - The owner of the installation (user or org)
+ */
+export function buildSessionUrl(dbSessionId: string, owner: Owner): string {
+  const basePath = owner.type === 'org' ? `/organizations/${owner.id}/cloud` : '/cloud';
+  return `${APP_URL}${basePath}/chat?sessionId=${dbSessionId}`;
+}
+
+/**
+ * Look up the database session UUID from the cloud agent session ID.
+ * @param cloudAgentSessionId - The agent_xxx format ID from cloud agent
+ * @returns The database UUID (session_id) or null if not found
+ */
+export async function getDbSessionIdFromCloudAgentId(
+  cloudAgentSessionId: string
+): Promise<string | null> {
+  const [session] = await db
+    .select({ session_id: cli_sessions_v2.session_id })
+    .from(cli_sessions_v2)
+    .where(eq(cli_sessions_v2.cloud_agent_session_id, cloudAgentSessionId))
+    .limit(1);
+
+  return session?.session_id ?? null;
+}


### PR DESCRIPTION
## Summary

- Extract `buildSessionUrl` and `getDbSessionIdFromCloudAgentId` from the Slack webhook route into a shared `session-url.ts` module so they can be reused across platforms.
- Add an `onSessionReady` callback to `runSessionToCompletion` that fires as soon as the cloud agent session is live (fire-and-forget, errors are logged but don't abort the session).
- Use the callback in the bot engine to post an ephemeral "View Session" card with a link button to the user immediately after the session starts, rather than waiting for completion.

## Verification

- [x] `pnpm typecheck` — passes

## Visual Changes

<img width="812" height="716" alt="CleanShot 2026-03-05 at 16 33 44@2x" src="https://github.com/user-attachments/assets/12c07880-c47c-42eb-8526-e27fd6829452" />

## Reviewer Notes

- `onSessionReady` is intentionally fire-and-forget: errors are caught and logged but don't propagate to avoid disrupting the session lifecycle.
- `postSessionLinkEphemeral` uses `fallbackToDM: true` so the link still reaches the user on platforms where ephemeral messages aren't supported.