### PR TITLE
feat(kiloclaw): switch tool profile to full and extend safeBins

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -94,7 +94,7 @@ describe('generateBaseConfig', () => {
     expect(config.tools.exec.ask).toBe('on-miss');
 
     // Safe bins
-    expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'node', 'pnpm', 'go']);
+    expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'gh', 'node', 'pnpm', 'go']);
   });
 
   it('always sets tool profile to full on restore', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -97,12 +97,12 @@ describe('generateBaseConfig', () => {
     expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'node', 'pnpm', 'go']);
   });
 
-  it('preserves user-customized tool profile', () => {
+  it('always sets tool profile to full on restore', () => {
     const existing = JSON.stringify({ tools: { profile: 'coding' } });
     const { deps } = fakeDeps(existing);
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
-    expect(config.tools.profile).toBe('coding');
+    expect(config.tools.profile).toBe('full');
   });
 
   it('preserves user-customized safeBins', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -105,7 +105,7 @@ describe('generateBaseConfig', () => {
     expect(config.tools.profile).toBe('full');
   });
 
-  it('preserves user-customized safeBins', () => {
+  it('always resets safeBins to defaults on restore', () => {
     const existing = JSON.stringify({
       tools: {
         exec: { safeBins: ['rg', 'custom_bin'] },
@@ -114,7 +114,7 @@ describe('generateBaseConfig', () => {
     const { deps } = fakeDeps(existing);
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
-    expect(config.tools.exec.safeBins).toEqual(['rg', 'custom_bin']);
+    expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'gh', 'node', 'pnpm', 'go']);
   });
 
   it('preserves existing config keys not touched by the patch', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -105,7 +105,7 @@ describe('generateBaseConfig', () => {
     expect(config.tools.profile).toBe('coding');
   });
 
-  it('merges required safeBins without duplicating existing entries', () => {
+  it('preserves user-customized safeBins', () => {
     const existing = JSON.stringify({
       tools: {
         exec: { safeBins: ['rg', 'custom_bin'] },
@@ -114,7 +114,7 @@ describe('generateBaseConfig', () => {
     const { deps } = fakeDeps(existing);
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
-    expect(config.tools.exec.safeBins).toEqual(['rg', 'custom_bin', 'git', 'node', 'pnpm', 'go']);
+    expect(config.tools.exec.safeBins).toEqual(['rg', 'custom_bin']);
   });
 
   it('preserves existing config keys not touched by the patch', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -85,10 +85,28 @@ describe('generateBaseConfig', () => {
     // No default model override when env var not set
     expect(config.agents).toBeUndefined();
 
+    // Tool profile
+    expect(config.tools.profile).toBe('full');
+
     // Exec
     expect(config.tools.exec.host).toBe('gateway');
     expect(config.tools.exec.security).toBe('allowlist');
     expect(config.tools.exec.ask).toBe('on-miss');
+
+    // Safe bins
+    expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'node', 'pnpm', 'go']);
+  });
+
+  it('does not duplicate safeBins when already present', () => {
+    const existing = JSON.stringify({
+      tools: {
+        exec: { safeBins: ['rg', 'custom_bin'] },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
+
+    expect(config.tools.exec.safeBins).toEqual(['rg', 'custom_bin', 'git', 'node', 'pnpm', 'go']);
   });
 
   it('preserves existing config keys not touched by the patch', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -92,9 +92,6 @@ describe('generateBaseConfig', () => {
     expect(config.tools.exec.host).toBe('gateway');
     expect(config.tools.exec.security).toBe('allowlist');
     expect(config.tools.exec.ask).toBe('on-miss');
-
-    // Safe bins
-    expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'gh', 'node', 'pnpm', 'go']);
   });
 
   it('always sets tool profile to full on restore', () => {
@@ -103,18 +100,6 @@ describe('generateBaseConfig', () => {
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
     expect(config.tools.profile).toBe('full');
-  });
-
-  it('always resets safeBins to defaults on restore', () => {
-    const existing = JSON.stringify({
-      tools: {
-        exec: { safeBins: ['rg', 'custom_bin'] },
-      },
-    });
-    const { deps } = fakeDeps(existing);
-    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
-
-    expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'gh', 'node', 'pnpm', 'go']);
   });
 
   it('preserves existing config keys not touched by the patch', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -97,7 +97,15 @@ describe('generateBaseConfig', () => {
     expect(config.tools.exec.safeBins).toEqual(['rg', 'git', 'node', 'pnpm', 'go']);
   });
 
-  it('does not duplicate safeBins when already present', () => {
+  it('preserves user-customized tool profile', () => {
+    const existing = JSON.stringify({ tools: { profile: 'coding' } });
+    const { deps } = fakeDeps(existing);
+    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
+
+    expect(config.tools.profile).toBe('coding');
+  });
+
+  it('merges required safeBins without duplicating existing entries', () => {
     const existing = JSON.stringify({
       tools: {
         exec: { safeBins: ['rg', 'custom_bin'] },

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -172,8 +172,8 @@ export function generateBaseConfig(
   config.tools.exec.host = 'gateway';
   config.tools.exec.security = 'allowlist';
   config.tools.exec.ask = 'on-miss';
-  // Default safe bins on fresh install only. Users can approve additional
-  // tools via the Control UI; we don't overwrite their choices on restart.
+  // Pre-approved CLIs for allowlist mode. Only set when absent; user
+  // customizations via the Control UI are preserved.
   config.tools.exec.safeBins = config.tools.exec.safeBins ?? ['rg', 'git', 'node', 'pnpm', 'go'];
 
   // Telegram

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -173,7 +173,14 @@ export function generateBaseConfig(
   config.tools.exec.ask = 'on-miss';
   // Pre-approved CLIs for allowlist mode. Only set when absent; user
   // customizations via the Control UI are preserved.
-  config.tools.exec.safeBins = config.tools.exec.safeBins ?? ['rg', 'git', 'node', 'pnpm', 'go'];
+  config.tools.exec.safeBins = config.tools.exec.safeBins ?? [
+    'rg',
+    'git',
+    'gh',
+    'node',
+    'pnpm',
+    'go',
+  ];
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -171,16 +171,8 @@ export function generateBaseConfig(
   config.tools.exec.host = 'gateway';
   config.tools.exec.security = 'allowlist';
   config.tools.exec.ask = 'on-miss';
-  // Pre-approved CLIs for allowlist mode. Only set when absent; user
-  // customizations via the Control UI are preserved.
-  config.tools.exec.safeBins = config.tools.exec.safeBins ?? [
-    'rg',
-    'git',
-    'gh',
-    'node',
-    'pnpm',
-    'go',
-  ];
+  // Pre-approved CLIs for allowlist mode.
+  config.tools.exec.safeBins = ['rg', 'git', 'gh', 'node', 'pnpm', 'go'];
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -158,12 +158,11 @@ export function generateBaseConfig(
     delete config.agents.defaults.models;
   }
 
-  // Tool profile: default to "full" (all tools) on first boot. The onboard
-  // default "messaging" only allows session/message tools, which leaves agents
-  // without file, shell, or web access. Don't overwrite if the user has
-  // customized their profile.
+  // Tool profile: always set to "full" on config restore. The onboard
+  // default "messaging" only allows session/message tools, which leaves
+  // agents without file, shell, or web access.
   config.tools = config.tools ?? {};
-  config.tools.profile = config.tools.profile ?? 'full';
+  config.tools.profile = 'full';
 
   // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
   // gateway host directly. Allowlist mode gates unknown commands via the

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -158,11 +158,12 @@ export function generateBaseConfig(
     delete config.agents.defaults.models;
   }
 
-  // Tool profile: "full" enables all tools without restriction. The default
-  // "messaging" profile from onboard only allows session/message tools, which
-  // leaves agents without file, shell, or web access.
+  // Tool profile: default to "full" (all tools) on first boot. The onboard
+  // default "messaging" only allows session/message tools, which leaves agents
+  // without file, shell, or web access. Don't overwrite if the user has
+  // customized their profile.
   config.tools = config.tools ?? {};
-  config.tools.profile = 'full';
+  config.tools.profile = config.tools.profile ?? 'full';
 
   // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
   // gateway host directly. Allowlist mode gates unknown commands via the

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -158,12 +158,29 @@ export function generateBaseConfig(
     delete config.agents.defaults.models;
   }
 
-  // Exec tool settings
+  // Tool profile: "full" enables all tools without restriction. The default
+  // "messaging" profile from onboard only allows session/message tools, which
+  // leaves agents without file, shell, or web access.
   config.tools = config.tools ?? {};
+  config.tools.profile = 'full';
+
+  // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
+  // gateway host directly. Allowlist mode gates unknown commands via the
+  // Control UI approval dialog; safe bins auto-allow without approval.
   config.tools.exec = config.tools.exec ?? {};
   config.tools.exec.host = 'gateway';
   config.tools.exec.security = 'allowlist';
   config.tools.exec.ask = 'on-miss';
+  // Extend safe bins with tools pre-installed in the Docker image.
+  // The defaults (jq, cut, uniq, head, tail, tr, wc) are inherited;
+  // these additions avoid mandatory approval prompts for common dev CLIs.
+  const existingSafeBins: string[] = Array.isArray(config.tools.exec.safeBins)
+    ? config.tools.exec.safeBins
+    : [];
+  for (const bin of ['rg', 'git', 'node', 'pnpm', 'go']) {
+    if (!existingSafeBins.includes(bin)) existingSafeBins.push(bin);
+  }
+  config.tools.exec.safeBins = existingSafeBins;
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -172,16 +172,9 @@ export function generateBaseConfig(
   config.tools.exec.host = 'gateway';
   config.tools.exec.security = 'allowlist';
   config.tools.exec.ask = 'on-miss';
-  // Extend safe bins with tools pre-installed in the Docker image.
-  // The defaults (jq, cut, uniq, head, tail, tr, wc) are inherited;
-  // these additions avoid mandatory approval prompts for common dev CLIs.
-  const existingSafeBins: string[] = Array.isArray(config.tools.exec.safeBins)
-    ? config.tools.exec.safeBins
-    : [];
-  for (const bin of ['rg', 'git', 'node', 'pnpm', 'go']) {
-    if (!existingSafeBins.includes(bin)) existingSafeBins.push(bin);
-  }
-  config.tools.exec.safeBins = existingSafeBins;
+  // Default safe bins on fresh install only. Users can approve additional
+  // tools via the Control UI; we don't overwrite their choices on restart.
+  config.tools.exec.safeBins = config.tools.exec.safeBins ?? ['rg', 'git', 'node', 'pnpm', 'go'];
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -171,8 +171,6 @@ export function generateBaseConfig(
   config.tools.exec.host = 'gateway';
   config.tools.exec.security = 'allowlist';
   config.tools.exec.ask = 'on-miss';
-  // Pre-approved CLIs for allowlist mode.
-  config.tools.exec.safeBins = ['rg', 'git', 'gh', 'node', 'pnpm', 'go'];
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -118,6 +118,7 @@ if [ -z "$KILOCODE_API_KEY" ]; then
     exit 1
 fi
 
+KILOCLAW_FRESH_INSTALL=false
 if [ ! -f "$CONFIG_FILE" ]; then
     echo "No existing config found, running openclaw onboard..."
 
@@ -130,11 +131,13 @@ if [ ! -f "$CONFIG_FILE" ]; then
         --skip-health \
         --kilocode-api-key "$KILOCODE_API_KEY"
 
+    KILOCLAW_FRESH_INSTALL=true
     echo "Onboard completed"
 else
     echo "Using existing config, running doctor..."
     openclaw doctor --fix --non-interactive
 fi
+export KILOCLAW_FRESH_INSTALL
 
 # ============================================================
 # PATCH CONFIG (channels, gateway auth, exec policy)
@@ -249,12 +252,13 @@ if (config.agents && config.agents.defaults && config.agents.defaults.models) {
     delete config.agents.defaults.models;
 }
 
-// Tool profile: default to "full" (all tools) on first boot. The onboard
-// default "messaging" only allows session/message tools, which leaves agents
-// without file, shell, or web access. Don't overwrite if the user has
-// customized their profile.
+// Tool profile: on fresh install, override the onboard default ("messaging")
+// with "full" so agents have access to all tools. On subsequent boots,
+// leave the user's choice untouched.
 config.tools = config.tools || {};
-config.tools.profile = config.tools.profile || 'full';
+if (process.env.KILOCLAW_FRESH_INSTALL === 'true') {
+    config.tools.profile = 'full';
+}
 
 // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
 // gateway host directly. Allowlist mode gates unknown commands via the

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -270,7 +270,7 @@ config.tools.exec.ask = 'on-miss';
 // Pre-approved CLIs for allowlist mode. Only set when absent; user
 // customizations via the Control UI are preserved.
 if (!config.tools.exec.safeBins) {
-    config.tools.exec.safeBins = ['rg', 'git', 'node', 'pnpm', 'go'];
+    config.tools.exec.safeBins = ['rg', 'git', 'gh', 'node', 'pnpm', 'go'];
 }
 
 // Telegram configuration

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -263,8 +263,8 @@ config.tools.exec = config.tools.exec || {};
 config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
-// Default safe bins on fresh install only. Users can approve additional
-// tools via the Control UI; we don't overwrite their choices on restart.
+// Pre-approved CLIs for allowlist mode. Only set when absent; user
+// customizations via the Control UI are preserved.
 if (!config.tools.exec.safeBins) {
     config.tools.exec.safeBins = ['rg', 'git', 'node', 'pnpm', 'go'];
 }

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -249,11 +249,12 @@ if (config.agents && config.agents.defaults && config.agents.defaults.models) {
     delete config.agents.defaults.models;
 }
 
-// Tool profile: "full" enables all tools without restriction. The default
-// "messaging" profile from onboard only allows session/message tools, which
-// leaves agents without file, shell, or web access.
+// Tool profile: default to "full" (all tools) on first boot. The onboard
+// default "messaging" only allows session/message tools, which leaves agents
+// without file, shell, or web access. Don't overwrite if the user has
+// customized their profile.
 config.tools = config.tools || {};
-config.tools.profile = 'full';
+config.tools.profile = config.tools.profile || 'full';
 
 // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
 // gateway host directly. Allowlist mode gates unknown commands via the
@@ -262,14 +263,16 @@ config.tools.exec = config.tools.exec || {};
 config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
-// Extend safe bins with tools pre-installed in the Docker image.
-// The defaults (jq, cut, uniq, head, tail, tr, wc) are inherited;
-// these additions avoid mandatory approval prompts for common dev CLIs.
-config.tools.exec.safeBins = (config.tools.exec.safeBins || []).concat(
-    ['rg', 'git', 'node', 'pnpm', 'go'].filter(function(bin) {
-        return (config.tools.exec.safeBins || []).indexOf(bin) === -1;
-    })
-);
+// Ensure pre-installed CLIs are in safeBins so they don't require approval.
+// Merges into any existing user-configured list without overwriting.
+var requiredSafeBins = ['rg', 'git', 'node', 'pnpm', 'go'];
+var currentSafeBins = config.tools.exec.safeBins || [];
+requiredSafeBins.forEach(function(bin) {
+    if (currentSafeBins.indexOf(bin) === -1) {
+        currentSafeBins.push(bin);
+    }
+});
+config.tools.exec.safeBins = currentSafeBins;
 
 // Telegram configuration
 // Overwrite entire channel object to drop stale keys that would fail

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -263,16 +263,11 @@ config.tools.exec = config.tools.exec || {};
 config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
-// Ensure pre-installed CLIs are in safeBins so they don't require approval.
-// Merges into any existing user-configured list without overwriting.
-var requiredSafeBins = ['rg', 'git', 'node', 'pnpm', 'go'];
-var currentSafeBins = config.tools.exec.safeBins || [];
-requiredSafeBins.forEach(function(bin) {
-    if (currentSafeBins.indexOf(bin) === -1) {
-        currentSafeBins.push(bin);
-    }
-});
-config.tools.exec.safeBins = currentSafeBins;
+// Default safe bins on fresh install only. Users can approve additional
+// tools via the Control UI; we don't overwrite their choices on restart.
+if (!config.tools.exec.safeBins) {
+    config.tools.exec.safeBins = ['rg', 'git', 'node', 'pnpm', 'go'];
+}
 
 // Telegram configuration
 // Overwrite entire channel object to drop stale keys that would fail

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -267,8 +267,7 @@ config.tools.exec = config.tools.exec || {};
 config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
-// Pre-approved CLIs for allowlist mode. Only set when absent; user
-// customizations via the Control UI are preserved.
+// Pre-approved CLIs for allowlist mode.
 if (!config.tools.exec.safeBins) {
     config.tools.exec.safeBins = ['rg', 'git', 'gh', 'node', 'pnpm', 'go'];
 }

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -249,14 +249,27 @@ if (config.agents && config.agents.defaults && config.agents.defaults.models) {
     delete config.agents.defaults.models;
 }
 
+// Tool profile: "full" enables all tools without restriction. The default
+// "messaging" profile from onboard only allows session/message tools, which
+// leaves agents without file, shell, or web access.
+config.tools = config.tools || {};
+config.tools.profile = 'full';
+
 // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
 // gateway host directly. Allowlist mode gates unknown commands via the
-// Control UI approval dialog; safe bins (jq, head, tail, etc.) auto-allow.
-config.tools = config.tools || {};
+// Control UI approval dialog; safe bins auto-allow without approval.
 config.tools.exec = config.tools.exec || {};
 config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
+// Extend safe bins with tools pre-installed in the Docker image.
+// The defaults (jq, cut, uniq, head, tail, tr, wc) are inherited;
+// these additions avoid mandatory approval prompts for common dev CLIs.
+config.tools.exec.safeBins = (config.tools.exec.safeBins || []).concat(
+    ['rg', 'git', 'node', 'pnpm', 'go'].filter(function(bin) {
+        return (config.tools.exec.safeBins || []).indexOf(bin) === -1;
+    })
+);
 
 // Telegram configuration
 // Overwrite entire channel object to drop stale keys that would fail

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -267,10 +267,6 @@ config.tools.exec = config.tools.exec || {};
 config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
-// Pre-approved CLIs for allowlist mode.
-if (!config.tools.exec.safeBins) {
-    config.tools.exec.safeBins = ['rg', 'git', 'gh', 'node', 'pnpm', 'go'];
-}
 
 // Telegram configuration
 // Overwrite entire channel object to drop stale keys that would fail

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -13,7 +13,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-03-05',
     description:
-      'Switched tool profile from "messaging" to "full". New deploys now have access to all tools including exec, filesystem, web search, and messaging. Existing instances pick up the change on next restart.',
+      'New deploys now default to the "full" tool profile, giving agents access to all tools including exec, filesystem, web search, and messaging. Existing instances can change their profile in the Control UI under Settings > Config > Tools > Tool Profile.',
     category: 'feature',
     deployHint: 'redeploy_suggested',
   },

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -13,6 +13,13 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-03-05',
     description:
+      'Switched tool profile from "messaging" to "full". New deploys now have access to all tools including exec, filesystem, web search, and messaging. Existing instances pick up the change on next restart.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
+    date: '2026-03-05',
+    description:
       'Added Go 1.26, gog (gogcli), goplaces, blogwatcher, xurl, gifgrep, and summarize to the default image. Go is available at runtime for installing additional tools via `go install`.',
     category: 'feature',
     deployHint: 'redeploy_suggested',


### PR DESCRIPTION
## Summary

- OpenClaw's `onboard --non-interactive` defaults to `tools.profile: "messaging"`, which only exposes 5 session/message tools. This left new KiloClaw instances without filesystem access (`read`/`write`/`edit`), shell execution (`exec`), web tools, or the `message` tool — effectively a non-functional coding assistant.
- On fresh install, overrides `tools.profile` to `"full"` (no tool restrictions). The startup script sets a `KILOCLAW_FRESH_INSTALL` flag when onboard runs (no config file existed) and uses it to decide whether to override the profile. On subsequent boots the user's choice is never touched.
- The `exec` tool remains gated by `security: "allowlist"` with `ask: "on-miss"`.
- The config-writer (Restore Default Config path) always sets `tools.profile` to `"full"` since it regenerates a fresh config.
- Adds a changelog entry for the tool profile change.
- Bumps Dockerfile cache bust to v58.

## Verification

- [x] `pnpm typecheck` — passed (tsgo, no errors)
- [x] `pnpm test` — passed (504 tests, 27 test files, 0 failures)
- [x] Manual deploy verification


<img width="1174" height="494" alt="Screenshot 2026-03-05 at 12 47 02 PM" src="https://github.com/user-attachments/assets/c57f84c7-ada3-4534-b97b-10ca59743352" />

<img width="1039" height="731" alt="Screenshot 2026-03-05 at 12 48 33 PM" src="https://github.com/user-attachments/assets/8d316d49-cd77-446f-91a9-e5583501b7ae" />


## Visual Changes

N/A

## Reviewer Notes

- `start-openclaw.sh` and `controller/src/config-writer.ts` must produce equivalent config — both were updated in lockstep. The shell script uses a `KILOCLAW_FRESH_INSTALL` env var to gate the profile override; the config-writer always sets `"full"` because it only runs on explicit config restore.
- `tools.profile` is only set on fresh install. Existing instances keep whatever they have — users can change their profile via the Control UI (Settings > Config > Tools > Tool Profile).
