### PR TITLE
fix(gastown): handle Secrets Store fetch failures gracefully

### DIFF
--- a/cloudflare-gastown/src/middleware/auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/auth.middleware.ts
@@ -47,7 +47,7 @@ export const authMiddleware = createMiddleware<GastownEnv>(async (c, next) => {
 
   const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
   if (!secret) {
-    console.error('[auth] GASTOWN_JWT_SECRET not configured');
+    console.error('[auth] failed to resolve GASTOWN_JWT_SECRET from Secrets Store');
     return c.json(resError('Internal server error'), 500);
   }
 

--- a/cloudflare-gastown/src/middleware/kilo-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/kilo-auth.middleware.ts
@@ -23,6 +23,10 @@ export const kiloAuthMiddleware = createMiddleware<GastownEnv>(async (c, next) =
     return c.json(resError('Internal server error'), 500);
   }
   const secret = await resolveSecret(c.env.NEXTAUTH_SECRET);
+  if (!secret) {
+    console.error('[kilo-auth] failed to resolve NEXTAUTH_SECRET from Secrets Store');
+    return c.json(resError('Internal server error'), 500);
+  }
 
   try {
     const payload = await verifyKiloToken(token, secret);

--- a/cloudflare-gastown/src/middleware/mayor-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/mayor-auth.middleware.ts
@@ -22,7 +22,7 @@ export const mayorAuthMiddleware = createMiddleware<GastownEnv>(async (c, next) 
 
   const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
   if (!secret) {
-    console.error('[mayor-auth] GASTOWN_JWT_SECRET not configured');
+    console.error('[mayor-auth] failed to resolve GASTOWN_JWT_SECRET from Secrets Store');
     return c.json(resError('Internal server error'), 500);
   }
 

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -99,16 +99,18 @@ async function verifyRigOwnership(env: Env, userId: string, rigId: string) {
 
 async function mintKilocodeToken(env: Env, user: { id: string; api_token_pepper: string | null }) {
   if (!env.NEXTAUTH_SECRET) {
+    console.error('[mintKilocodeToken] NEXTAUTH_SECRET not configured');
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'NEXTAUTH_SECRET not configured',
+      message: 'Internal server error',
     });
   }
   const secret = await resolveSecret(env.NEXTAUTH_SECRET);
   if (!secret) {
+    console.error('[mintKilocodeToken] failed to resolve NEXTAUTH_SECRET from Secrets Store');
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'Failed to resolve NEXTAUTH_SECRET from Secrets Store',
+      message: 'Internal server error',
     });
   }
   return generateKiloApiToken(user, secret);

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -105,6 +105,12 @@ async function mintKilocodeToken(env: Env, user: { id: string; api_token_pepper:
     });
   }
   const secret = await resolveSecret(env.NEXTAUTH_SECRET);
+  if (!secret) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to resolve NEXTAUTH_SECRET from Secrets Store',
+    });
+  }
   return generateKiloApiToken(user, secret);
 }
 

--- a/cloudflare-gastown/src/util/secret.util.ts
+++ b/cloudflare-gastown/src/util/secret.util.ts
@@ -1,8 +1,20 @@
 /**
  * Resolves a secret value from either a `SecretsStoreSecret` (production, has `.get()`)
  * or a plain string (test env vars set in wrangler.test.jsonc).
+ *
+ * Returns `null` when the Secrets Store fetch fails (transient network error,
+ * misconfigured store, etc.) so callers can return a clean 500 instead of
+ * letting an opaque "Secrets Worker: Failed to fetch secret" bubble up.
  */
-export async function resolveSecret(binding: SecretsStoreSecret | string): Promise<string> {
+export async function resolveSecret(binding: SecretsStoreSecret | string): Promise<string | null> {
   if (typeof binding === 'string') return binding;
-  return binding.get();
+  try {
+    return await binding.get();
+  } catch (err) {
+    console.error(
+      '[resolveSecret] Secrets Store fetch failed:',
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

In production, `SecretsStoreSecret.get()` can fail with an opaque `"Secrets Worker: Failed to fetch secret"` error (transient Secrets Store outage, misconfigured store, etc.). Previously this exception was unhandled in `resolveSecret` and bubbled up through the Hono middleware chain as an unhandled error with an unhelpful stack trace.

This PR:
- Changes `resolveSecret` to catch `.get()` failures, log the original error, and return `null` instead of throwing.
- Adds `null` checks at all 4 call sites (`kilo-auth`, `auth`, `mayor-auth` middlewares and `mintKilocodeToken` in the tRPC router) so they return a clean 500 / `INTERNAL_SERVER_ERROR` with descriptive log messages.
- Fixes misleading "not configured" error messages in existing null guards — the binding exists but the fetch failed, which is a different failure mode.

## Verification

- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm --filter cloudflare-gastown test` — pre-existing failures in `container/plugin/client.test.ts` only (unrelated to these changes)
- [x] Manually confirmed secret was recreated and resolved successfully in production

## Visual Changes

N/A

## Reviewer Notes

The root cause in this instance was a stale/deleted secret in the Cloudflare Secrets Store that needed to be recreated. These changes ensure that if the same situation recurs, the error is caught and logged clearly rather than surfacing as an opaque unhandled exception.