### PR TITLE
feat(bot): auto-append PR/MR instruction to cloud agent prompt and simplify mode enum

### DIFF
--- a/src/lib/bot/run.ts
+++ b/src/lib/bot/run.ts
@@ -108,7 +108,7 @@ export async function processMessage({
       spawnCloudAgentSession: tool({
         description: `Spawn a Cloud Agent session to perform coding tasks on a GitHub repository or GitLab project. The agent can make code changes, fix bugs, implement features, review/analyze code, run tests, or open PRs/MRs. Do NOT use it for questions you can answer directly.
 
-After the tool returns, check the result for a PR/MR URL and share it with the user — this is the most important output.`,
+After the tool returns, if mode was "code", check the result for a PR/MR URL and share it with the user — this is the most important output.`,
         inputSchema: spawnCloudAgentInputSchema,
         execute: async args =>
           await spawnCloudAgentSession(

--- a/src/lib/bot/run.ts
+++ b/src/lib/bot/run.ts
@@ -106,8 +106,9 @@ export async function processMessage({
     stopWhen: stepCountIs(MAX_ITERATIONS),
     tools: {
       spawnCloudAgentSession: tool({
-        description:
-          'Spawn a Cloud Agent session to perform coding tasks on a GitHub repository. The agent can make code changes, fix bugs, implement features, and more.',
+        description: `Spawn a Cloud Agent session to perform coding tasks on a GitHub repository or GitLab project. The agent can make code changes, fix bugs, implement features, review/analyze code, run tests, or open PRs/MRs. Do NOT use it for questions you can answer directly.
+
+After the tool returns, check the result for a PR/MR URL and share it with the user — this is the most important output.`,
         inputSchema: spawnCloudAgentInputSchema,
         execute: async args =>
           await spawnCloudAgentSession(

--- a/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -33,10 +33,10 @@ const sharedFields = {
       'The task description for the Cloud Agent. Be specific about what changes or analysis you want.'
     ),
   mode: z
-    .enum(['code', 'plan', 'debug', 'orchestrator', 'ask', 'build', 'architect', 'custom'])
+    .enum(['code', 'ask'])
     .default('code')
     .describe(
-      'The agent mode: "code" for making changes, "plan" for design tasks, "ask" for questions, "debug" for troubleshooting, "orchestrator" for complex multi-step tasks. "build" and "architect" are backward-compatible aliases for "code" and "plan".'
+      'The agent mode: "code" for making changes (creates a PR/MR), "ask" for questions and explanations about existing code.'
     ),
 };
 
@@ -83,6 +83,15 @@ export default async function spawnCloudAgentSession(
   let initiateInput: { githubToken?: string; kilocodeOrganizationId?: string };
   const mode: AgentMode = args.mode ?? 'code';
 
+  const isGitLab = 'gitlabProject' in args;
+  const prompt =
+    mode === 'code'
+      ? args.prompt +
+        (isGitLab
+          ? '\n\nOpen a merge request with your changes and return the MR URL.'
+          : '\n\nOpen a pull request with your changes and return the PR URL.')
+      : args.prompt;
+
   if ('gitlabProject' in args) {
     // GitLab path: get token + instance URL, build clone URL, use gitUrl/gitToken
     const gitlabToken =
@@ -113,7 +122,7 @@ export default async function spawnCloudAgentSession(
     );
 
     prepareInput = {
-      prompt: args.prompt,
+      prompt,
       mode,
       model,
       gitUrl,
@@ -139,7 +148,7 @@ export default async function spawnCloudAgentSession(
 
     prepareInput = {
       githubRepo: args.githubRepo,
-      prompt: args.prompt,
+      prompt,
       mode,
       model,
       githubToken,


### PR DESCRIPTION
## Summary

The bot's `spawn_cloud_agent` tool was not reliably instructing the cloud agent to create a PR/MR because the LLM composing the prompt would omit it. This change moves the PR/MR creation instruction out of the LLM's hands and appends it server-side when mode is `code` — GitHub repos get "Open a pull request…", GitLab projects get "Open a merge request…". The mode enum is also narrowed from 8 options (`code`, `plan`, `debug`, `orchestrator`, `ask`, `build`, `architect`, `custom`) to just `code`/`ask` since the other modes weren't performing well.

## Verification

- [x] `pnpm typecheck` — passes

## Visual Changes

N/A

## Reviewer Notes

The tool description in `run.ts` still tells the bot LLM to surface the PR/MR URL from the tool result back to the user — this is complementary to the server-side prompt append (one ensures the cloud agent creates a PR, the other ensures the bot relays the URL).