### PR TITLE
fix(cloud-agent-next): recover orphaned review sessions

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -983,9 +983,13 @@ export class CloudAgentSession extends DurableObject {
    * Marks them as failed and clears the active execution.
    */
   private async cleanupStaleExecutions(now: number): Promise<void> {
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    let activeExecutionId = await this.executionQueries.getActiveExecutionId();
 
-    if (!activeExecutionId) return;
+    if (!activeExecutionId) {
+      const recoveredExecution = await this.recoverExecutionWithoutActiveMarker();
+      if (!recoveredExecution) return;
+      activeExecutionId = recoveredExecution.executionId;
+    }
 
     // Get the execution metadata
     const execution = await this.executionQueries.get(activeExecutionId);
@@ -1101,6 +1105,47 @@ export class CloudAgentSession extends DurableObject {
         });
       }
     }
+  }
+
+  /**
+   * Recover a non-terminal execution when the active execution marker is missing.
+   *
+   * This keeps the reaper authoritative even if some other code path cleared
+   * active_execution_id before the execution reached a terminal state.
+   */
+  private async recoverExecutionWithoutActiveMarker(): Promise<ExecutionMetadata | null> {
+    const executions = await this.executionQueries.getAll();
+    const candidates = executions
+      .filter(execution => execution.status === 'running' || execution.status === 'pending')
+      .sort((a, b) => b.startedAt - a.startedAt);
+
+    const recoveredExecution = candidates[0] ?? null;
+    if (!recoveredExecution) {
+      return null;
+    }
+
+    logger
+      .withFields({
+        sessionId: this.sessionId,
+        executionId: recoveredExecution.executionId,
+        candidateCount: candidates.length,
+      })
+      .warn('Recovered non-terminal execution without active marker');
+
+    const setActiveResult = await this.executionQueries.setActiveExecution(
+      recoveredExecution.executionId
+    );
+    if (!setActiveResult.ok) {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          executionId: recoveredExecution.executionId,
+          error: setActiveResult.error,
+        })
+        .warn('Failed to restore active execution marker');
+    }
+
+    return recoveredExecution;
   }
 
   /**

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -244,6 +244,63 @@ describe('Disconnect handling & reaper', () => {
     expect(result.activeExecId).toBeNull();
   });
 
+  it('reaper recovers stale running execution when active marker is missing', async () => {
+    const userId = 'user_reaper_5';
+    const sessionId = 'agent_reaper_5';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_missing_active_marker' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Simulate the prod failure mode: the execution remains non-terminal
+      // but active_execution_id has already been cleared.
+      await instance.updateExecutionHeartbeat(excId, now - 11 * 60 * 1000);
+
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorEvents = events.filter(e => e.stream_event_type === 'error');
+
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { execution, errorEvents, activeExecId };
+    });
+
+    expect(result.execution?.status).toBe('failed');
+    expect(result.execution?.error).toContain('no heartbeat');
+    expect(result.activeExecId).toBeNull();
+    expect(result.errorEvents).toHaveLength(1);
+
+    const payload = JSON.parse(result.errorEvents[0].payload);
+    expect(payload.fatal).toBe(true);
+    expect(payload.error).toContain('no heartbeat');
+  });
+
   // ---------------------------------------------------------------------------
   // Fix 5: Dynamic alarm scheduling — 2-min interval when active, 5-min idle
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Recover V2 review sessions when `active_execution_id` disappears so the reaper can still fail the execution and release the review.

This came out of a production check on recent V2 reviews. The recent window reached 5 concurrent runs, so this does not look like a hard one-at-a-time limit. The stuck case was review `42026a6e-776d-4436-b91f-6dd7c25f722e`. Other failed reviews in the same window included `5d51354c-3aa7-4b10-b39c-a37dba694ca9`, `7cf38d28-dde0-4184-b8e7-46ccd944d842`, and `eb0e453c-c12f-48bb-99f9-c683fb59ab24`.

## Verification

- `pnpm --dir cloud-agent-next test:integration test/integration/session/disconnect-and-reaper.test.ts` ✅

## Visual Changes

N/A

## Reviewer Notes

The change is isolated to the reaper path. If a non-terminal execution exists without an active marker, we restore it and reuse the existing stale-execution cleanup flow.
