### PR TITLE
fix(cloud-agent-next): recover orphaned review sessions

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -995,7 +995,8 @@ export class CloudAgentSession extends DurableObject {
 
       if (execution.status === 'running') {
         const staleThresholdMs = this.getStaleThresholdMs();
-        const isStale = !execution.lastHeartbeat || now - execution.lastHeartbeat > staleThresholdMs;
+        const isStale =
+          !execution.lastHeartbeat || now - execution.lastHeartbeat > staleThresholdMs;
 
         if (!isStale) {
           continue;
@@ -1076,7 +1077,8 @@ export class CloudAgentSession extends DurableObject {
 
     if (activeExecutionId) {
       const activeExecution =
-        nonTerminalExecutions.find(execution => execution.executionId === activeExecutionId) ?? null;
+        nonTerminalExecutions.find(execution => execution.executionId === activeExecutionId) ??
+        null;
       if (activeExecution) {
         return activeExecution;
       }
@@ -1091,7 +1093,9 @@ export class CloudAgentSession extends DurableObject {
       return null;
     }
 
-    const setActiveResult = await this.executionQueries.setActiveExecution(canonicalExecution.executionId);
+    const setActiveResult = await this.executionQueries.setActiveExecution(
+      canonicalExecution.executionId
+    );
     if (!setActiveResult.ok) {
       logger
         .withFields({

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -983,169 +983,165 @@ export class CloudAgentSession extends DurableObject {
    * Marks them as failed and clears the active execution.
    */
   private async cleanupStaleExecutions(now: number): Promise<void> {
-    let activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const executions = await this.executionQueries.getAll();
+    const activeExecution =
+      activeExecutionId === null
+        ? null
+        : executions.find(execution => execution.executionId === activeExecutionId) ?? null;
 
-    if (!activeExecutionId) {
-      const recoveredExecution = await this.recoverExecutionWithoutActiveMarker();
-      if (!recoveredExecution) return;
-      activeExecutionId = recoveredExecution.executionId;
-    }
-
-    // Get the execution metadata
-    const execution = await this.executionQueries.get(activeExecutionId);
-
-    if (!execution) {
-      // Orphaned active execution ID - clear it
+    if (activeExecutionId && (!activeExecution || !this.isNonTerminalExecution(activeExecution))) {
       logger
-        .withFields({ sessionId: this.sessionId, executionId: activeExecutionId })
-        .warn('Clearing orphaned active execution ID');
+        .withFields({
+          sessionId: this.sessionId,
+          executionId: activeExecutionId,
+          reason: activeExecution ? activeExecution.status : 'missing',
+        })
+        .warn('Clearing invalid active execution ID');
       await this.executionQueries.clearActiveExecution();
-      return;
     }
 
-    // Check if execution is stale (no heartbeat for STALE_THRESHOLD_MS)
-    if (execution.status === 'running') {
-      const staleThresholdMs = this.getStaleThresholdMs();
-      const isStale = !execution.lastHeartbeat || now - execution.lastHeartbeat > staleThresholdMs;
+    const nonTerminalExecutions = executions
+      .filter(execution => this.isNonTerminalExecution(execution))
+      .sort((a, b) => a.startedAt - b.startedAt);
 
-      if (isStale) {
+    for (const execution of nonTerminalExecutions) {
+      const wasActiveExecution = execution.executionId === activeExecution?.executionId;
+
+      if (execution.status === 'running') {
+        const staleThresholdMs = this.getStaleThresholdMs();
+        const isStale = !execution.lastHeartbeat || now - execution.lastHeartbeat > staleThresholdMs;
+
+        if (!isStale) {
+          continue;
+        }
+
         logger
           .withFields({
             sessionId: this.sessionId,
-            executionId: activeExecutionId,
+            executionId: execution.executionId,
             lastHeartbeat: execution.lastHeartbeat,
             staleDurationMs: execution.lastHeartbeat ? now - execution.lastHeartbeat : 'never',
             staleThresholdMs,
+            wasActiveExecution,
           })
           .info('Marking stale execution as failed');
 
-        // Mark as failed — if another codepath already moved it to a terminal
-        // state (e.g. webSocketClose), skip cleanup and broadcast.
-        const statusResult = await this.updateExecutionStatus({
-          executionId: activeExecutionId,
-          status: 'failed',
-          error: 'Execution timeout - no heartbeat received',
-          completedAt: now,
+        await this.failExecutionFromReaper({
+          executionId: execution.executionId,
+          now,
+          errorMessage: 'Execution timeout - no heartbeat received',
+          wasActiveExecution,
+          skipLogMessage: 'Skipping stale cleanup - status transition failed',
         });
-
-        if (!statusResult.ok) {
-          logger
-            .withFields({ executionId: activeExecutionId, error: statusResult.error })
-            .info('Skipping reaper cleanup - status transition failed');
-          return;
-        }
-
-        // Clear active execution (updateStatus should do this, but ensure it)
-        await this.executionQueries.clearActiveExecution();
-
-        // Clear interrupt flag if set
-        await this.executionQueries.clearInterrupt();
-
-        // Notify /stream clients that the execution was reaped
-        const sessionId = await this.requireSessionId();
-        const errorPayload = JSON.stringify({
-          error: 'Execution timeout - no heartbeat received',
-          fatal: true,
-        });
-        this.insertAndBroadcastEvent({
-          executionId: activeExecutionId,
-          sessionId,
-          streamEventType: 'error',
-          payload: errorPayload,
-          timestamp: now,
-        });
+        continue;
       }
-    }
 
-    if (execution.status === 'pending') {
       const pendingTimeoutMs = this.getPendingStartTimeoutMs();
       const isPendingTooLong = now - execution.startedAt > pendingTimeoutMs;
 
-      if (isPendingTooLong) {
-        logger
-          .withFields({
-            sessionId: this.sessionId,
-            executionId: activeExecutionId,
-            startedAt: execution.startedAt,
-            pendingTimeoutMs,
-          })
-          .info('Marking stuck pending execution as failed');
-
-        // Mark as failed — if another codepath already moved it to a terminal
-        // state, skip cleanup and broadcast.
-        const statusResult = await this.updateExecutionStatus({
-          executionId: activeExecutionId,
-          status: 'failed',
-          error: 'Execution timeout - wrapper never connected',
-          completedAt: now,
-        });
-
-        if (!statusResult.ok) {
-          logger
-            .withFields({ executionId: activeExecutionId, error: statusResult.error })
-            .info('Skipping pending timeout cleanup - status transition failed');
-          return;
-        }
-
-        await this.executionQueries.clearActiveExecution();
-        await this.executionQueries.clearInterrupt();
-
-        // Notify /stream clients that the pending execution timed out
-        const sessionId = await this.requireSessionId();
-        const errorPayload = JSON.stringify({
-          error: 'Execution timeout - wrapper never connected',
-          fatal: true,
-        });
-        this.insertAndBroadcastEvent({
-          executionId: activeExecutionId,
-          sessionId,
-          streamEventType: 'error',
-          payload: errorPayload,
-          timestamp: now,
-        });
+      if (!isPendingTooLong) {
+        continue;
       }
+
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          executionId: execution.executionId,
+          startedAt: execution.startedAt,
+          pendingTimeoutMs,
+          wasActiveExecution,
+        })
+        .info('Marking stuck pending execution as failed');
+
+      await this.failExecutionFromReaper({
+        executionId: execution.executionId,
+        now,
+        errorMessage: 'Execution timeout - wrapper never connected',
+        wasActiveExecution,
+        skipLogMessage: 'Skipping pending timeout cleanup - status transition failed',
+      });
     }
   }
 
   /**
-   * Recover a non-terminal execution when the active execution marker is missing.
-   *
-   * This keeps the reaper authoritative even if some other code path cleared
-   * active_execution_id before the execution reached a terminal state.
+   * Get non-terminal executions in deterministic order.
    */
-  private async recoverExecutionWithoutActiveMarker(): Promise<ExecutionMetadata | null> {
-    const executions = await this.executionQueries.getAll();
-    const candidates = executions
-      .filter(execution => execution.status === 'running' || execution.status === 'pending')
-      .sort((a, b) => b.startedAt - a.startedAt);
+  private async getNonTerminalExecutions(): Promise<ExecutionMetadata[]> {
+    return (await this.executionQueries.getAll())
+      .filter(execution => this.isNonTerminalExecution(execution))
+      .sort((a, b) => a.startedAt - b.startedAt);
+  }
 
-    const recoveredExecution = candidates[0] ?? null;
-    if (!recoveredExecution) {
-      return null;
-    }
+  private isNonTerminalExecution(
+    execution: ExecutionMetadata
+  ): execution is ExecutionMetadata & { status: 'running' | 'pending' } {
+    return execution.status === 'running' || execution.status === 'pending';
+  }
 
-    logger
-      .withFields({
-        sessionId: this.sessionId,
-        executionId: recoveredExecution.executionId,
-        candidateCount: candidates.length,
-      })
-      .warn('Recovered non-terminal execution without active marker');
+  /**
+   * Returns the execution that should block a new start, even if the active marker
+   * has been lost. Clears invalid active markers so new executions can start again
+   * once all real non-terminal work is gone.
+   */
+  private async getExecutionInProgress(): Promise<ExecutionMetadata | null> {
+    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const nonTerminalExecutions = await this.getNonTerminalExecutions();
 
-    const setActiveResult = await this.executionQueries.setActiveExecution(
-      recoveredExecution.executionId
-    );
-    if (!setActiveResult.ok) {
+    if (activeExecutionId) {
+      const activeExecution =
+        nonTerminalExecutions.find(execution => execution.executionId === activeExecutionId) ?? null;
+      if (activeExecution) {
+        return activeExecution;
+      }
+
       logger
-        .withFields({
-          sessionId: this.sessionId,
-          executionId: recoveredExecution.executionId,
-          error: setActiveResult.error,
-        })
-        .warn('Failed to restore active execution marker');
+        .withFields({ sessionId: this.sessionId, executionId: activeExecutionId })
+        .warn('Clearing invalid active execution ID during start check');
+      await this.executionQueries.clearActiveExecution();
     }
 
-    return recoveredExecution;
+    return nonTerminalExecutions[0] ?? null;
+  }
+
+  private async failExecutionFromReaper(params: {
+    executionId: ExecutionId;
+    now: number;
+    errorMessage: string;
+    wasActiveExecution: boolean;
+    skipLogMessage: string;
+  }): Promise<void> {
+    const statusResult = await this.updateExecutionStatus({
+      executionId: params.executionId,
+      status: 'failed',
+      error: params.errorMessage,
+      completedAt: params.now,
+    });
+
+    if (!statusResult.ok) {
+      logger
+        .withFields({ executionId: params.executionId, error: statusResult.error })
+        .info(params.skipLogMessage);
+      return;
+    }
+
+    if (params.wasActiveExecution) {
+      await this.executionQueries.clearActiveExecution();
+      await this.executionQueries.clearInterrupt();
+    }
+
+    const sessionId = await this.requireSessionId();
+    const errorPayload = JSON.stringify({
+      error: params.errorMessage,
+      fatal: true,
+    });
+    this.insertAndBroadcastEvent({
+      executionId: params.executionId,
+      sessionId,
+      streamEventType: 'error',
+      payload: errorPayload,
+      timestamp: params.now,
+    });
   }
 
   /**
@@ -1590,9 +1586,10 @@ export class CloudAgentSession extends DurableObject {
 
   /**
    * Start a V2 execution using direct execution (no queue).
-   * This method performs validation, checks for active execution, and executes directly.
+   * This method performs validation, checks for non-terminal execution state,
+   * and executes directly.
    *
-   * Returns 409 Conflict (EXECUTION_IN_PROGRESS) if an execution is already active.
+   * Returns 409 Conflict (EXECUTION_IN_PROGRESS) if an execution is already in progress.
    */
   async startExecutionV2(request: StartExecutionV2Request): Promise<StartExecutionV2Result> {
     const sessionId = await this.requireSessionId();
@@ -1613,13 +1610,13 @@ export class CloudAgentSession extends DurableObject {
     };
 
     try {
-      // Check if there's already an active execution - return 409 if so
-      const activeExecutionId = await this.executionQueries.getActiveExecutionId();
-      if (activeExecutionId) {
+      // Check if any execution is still pending/running - return 409 if so.
+      const executionInProgress = await this.getExecutionInProgress();
+      if (executionInProgress) {
         return this.buildStartError(
           'EXECUTION_IN_PROGRESS',
-          `Execution ${activeExecutionId} is in progress`,
-          activeExecutionId
+          `Execution ${executionInProgress.executionId} is in progress`,
+          executionInProgress.executionId
         );
       }
 

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -983,9 +983,13 @@ export class CloudAgentSession extends DurableObject {
    * Marks them as failed and clears the active execution.
    */
   private async cleanupStaleExecutions(now: number): Promise<void> {
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    let activeExecutionId = await this.executionQueries.getActiveExecutionId();
 
-    if (!activeExecutionId) return;
+    if (!activeExecutionId) {
+      const recoveredExecution = await this.recoverExecutionWithoutActiveMarker();
+      if (!recoveredExecution) return;
+      activeExecutionId = recoveredExecution.executionId;
+    }
 
     // Get the execution metadata
     const execution = await this.executionQueries.get(activeExecutionId);
@@ -1101,6 +1105,47 @@ export class CloudAgentSession extends DurableObject {
         });
       }
     }
+  }
+
+  /**
+   * Recover a non-terminal execution when the active execution marker is missing.
+   *
+   * This keeps the reaper authoritative even if some other code path cleared
+   * active_execution_id before the execution reached a terminal state.
+   */
+  private async recoverExecutionWithoutActiveMarker(): Promise<ExecutionMetadata | null> {
+    const executions = await this.executionQueries.getAll();
+    const candidates = executions
+      .filter(execution => execution.status === 'running' || execution.status === 'pending')
+      .sort((a, b) => b.startedAt - a.startedAt);
+
+    const recoveredExecution = candidates[0] ?? null;
+    if (!recoveredExecution) {
+      return null;
+    }
+
+    logger
+      .withFields({
+        sessionId: this.sessionId,
+        executionId: recoveredExecution.executionId,
+        candidateCount: candidates.length,
+      })
+      .warn('Recovered non-terminal execution without active marker');
+
+    const setActiveResult = await this.executionQueries.setActiveExecution(
+      recoveredExecution.executionId
+    );
+    if (!setActiveResult.ok) {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          executionId: recoveredExecution.executionId,
+          error: setActiveResult.error,
+        })
+        .warn('Failed to restore active execution marker');
+    }
+
+    return recoveredExecution;
   }
 
   /**

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -681,7 +681,7 @@ export class CloudAgentSession extends DurableObject {
    * @returns Result indicating if the interrupt was initiated
    */
   async interruptExecution(): Promise<{ success: boolean; message?: string }> {
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const activeExecutionId = (await this.getExecutionInProgress())?.executionId ?? null;
 
     if (!activeExecutionId) {
       return { success: false, message: 'No active execution' };
@@ -946,8 +946,8 @@ export class CloudAgentSession extends DurableObject {
     // Wrapped in try/catch so a failure here never prevents rescheduling the alarm.
     let nextInterval = this.getReaperIntervalMs();
     try {
-      const activeExecutionId = await this.executionQueries.getActiveExecutionId();
-      if (activeExecutionId) {
+      const executionInProgress = await this.getExecutionInProgress();
+      if (executionInProgress) {
         nextInterval = REAPER_ACTIVE_INTERVAL_MS;
       }
     } catch {
@@ -983,23 +983,8 @@ export class CloudAgentSession extends DurableObject {
    * Marks them as failed and clears the active execution.
    */
   private async cleanupStaleExecutions(now: number): Promise<void> {
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const activeExecution = await this.getExecutionInProgress();
     const executions = await this.executionQueries.getAll();
-    const activeExecution =
-      activeExecutionId === null
-        ? null
-        : executions.find(execution => execution.executionId === activeExecutionId) ?? null;
-
-    if (activeExecutionId && (!activeExecution || !this.isNonTerminalExecution(activeExecution))) {
-      logger
-        .withFields({
-          sessionId: this.sessionId,
-          executionId: activeExecutionId,
-          reason: activeExecution ? activeExecution.status : 'missing',
-        })
-        .warn('Clearing invalid active execution ID');
-      await this.executionQueries.clearActiveExecution();
-    }
 
     const nonTerminalExecutions = executions
       .filter(execution => this.isNonTerminalExecution(execution))
@@ -1087,6 +1072,7 @@ export class CloudAgentSession extends DurableObject {
   private async getExecutionInProgress(): Promise<ExecutionMetadata | null> {
     const activeExecutionId = await this.executionQueries.getActiveExecutionId();
     const nonTerminalExecutions = await this.getNonTerminalExecutions();
+    const canonicalExecution = nonTerminalExecutions[nonTerminalExecutions.length - 1] ?? null;
 
     if (activeExecutionId) {
       const activeExecution =
@@ -1101,7 +1087,30 @@ export class CloudAgentSession extends DurableObject {
       await this.executionQueries.clearActiveExecution();
     }
 
-    return nonTerminalExecutions[0] ?? null;
+    if (!canonicalExecution) {
+      return null;
+    }
+
+    const setActiveResult = await this.executionQueries.setActiveExecution(canonicalExecution.executionId);
+    if (!setActiveResult.ok) {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          executionId: canonicalExecution.executionId,
+          error: setActiveResult.error,
+        })
+        .warn('Failed to restore active execution ID');
+    } else {
+      logger
+        .withFields({
+          sessionId: this.sessionId,
+          executionId: canonicalExecution.executionId,
+          candidateCount: nonTerminalExecutions.length,
+        })
+        .warn('Restored active execution ID from non-terminal execution');
+    }
+
+    return canonicalExecution;
   }
 
   private async failExecutionFromReaper(params: {
@@ -1214,7 +1223,7 @@ export class CloudAgentSession extends DurableObject {
     }
 
     // Check if there's an active execution - don't stop the server mid-run
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    const activeExecutionId = (await this.getExecutionInProgress())?.executionId ?? null;
     if (activeExecutionId !== null) {
       logger
         .withFields({
@@ -1367,7 +1376,7 @@ export class CloudAgentSession extends DurableObject {
    * Get the currently active execution ID.
    */
   async getActiveExecutionId(): Promise<ExecutionId | null> {
-    return this.executionQueries.getActiveExecutionId();
+    return (await this.getExecutionInProgress())?.executionId ?? null;
   }
 
   /**

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -301,6 +301,100 @@ describe('Disconnect handling & reaper', () => {
     expect(payload.error).toContain('no heartbeat');
   });
 
+  it('reaper scans all non-terminal executions when active marker is missing', async () => {
+    const userId = 'user_reaper_6';
+    const sessionId = 'agent_reaper_6';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const staleId = 'exc_orphan_stale' as ExecutionId;
+      const freshId = 'exc_orphan_fresh' as ExecutionId;
+
+      await instance.addExecution({
+        executionId: staleId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: staleId,
+      });
+      await instance.addExecution({
+        executionId: freshId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: freshId,
+      });
+
+      await instance.updateExecutionStatus({
+        executionId: staleId,
+        status: 'running',
+      });
+      await instance.updateExecutionStatus({
+        executionId: freshId,
+        status: 'running',
+      });
+
+      const executions =
+        await state.storage.get<
+          Array<{ executionId: string; startedAt: number; [k: string]: unknown }>
+        >('executions');
+      if (executions) {
+        const staleIndex = executions.findIndex(execution => execution.executionId === staleId);
+        const freshIndex = executions.findIndex(execution => execution.executionId === freshId);
+        if (staleIndex !== -1) {
+          executions[staleIndex].startedAt = now - 20_000;
+        }
+        if (freshIndex !== -1) {
+          executions[freshIndex].startedAt = now - 10_000;
+        }
+        await state.storage.put('executions', executions);
+      }
+
+      await instance.updateExecutionHeartbeat(staleId, now - 11 * 60 * 1000);
+      await instance.updateExecutionHeartbeat(freshId, now - 5_000);
+
+      await instance.alarm();
+
+      const staleExecution = await instance.getExecution(staleId);
+      const freshExecution = await instance.getExecution(freshId);
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [staleId, freshId] });
+      const staleErrorEvents = events.filter(
+        event => event.execution_id === staleId && event.stream_event_type === 'error'
+      );
+      const freshErrorEvents = events.filter(
+        event => event.execution_id === freshId && event.stream_event_type === 'error'
+      );
+
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return {
+        staleExecution,
+        freshExecution,
+        staleErrorEvents,
+        freshErrorEvents,
+        activeExecId,
+      };
+    });
+
+    expect(result.staleExecution?.status).toBe('failed');
+    expect(result.staleExecution?.error).toContain('no heartbeat');
+    expect(result.freshExecution?.status).toBe('running');
+    expect(result.activeExecId).toBeNull();
+    expect(result.staleErrorEvents).toHaveLength(1);
+    expect(result.freshErrorEvents).toHaveLength(0);
+  });
+
   // ---------------------------------------------------------------------------
   // Fix 5: Dynamic alarm scheduling — 2-min interval when active, 5-min idle
   // ---------------------------------------------------------------------------

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -244,6 +244,63 @@ describe('Disconnect handling & reaper', () => {
     expect(result.activeExecId).toBeNull();
   });
 
+  it('reaper recovers stale running execution when active marker is missing', async () => {
+    const userId = 'user_reaper_5';
+    const sessionId = 'agent_reaper_5';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_missing_active_marker' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Simulate the prod failure mode: the execution remains non-terminal
+      // but active_execution_id has already been cleared.
+      await instance.updateExecutionHeartbeat(excId, now - 11 * 60 * 1000);
+
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorEvents = events.filter(e => e.stream_event_type === 'error');
+
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { execution, errorEvents, activeExecId };
+    });
+
+    expect(result.execution?.status).toBe('failed');
+    expect(result.execution?.error).toContain('no heartbeat');
+    expect(result.activeExecId).toBeNull();
+    expect(result.errorEvents).toHaveLength(1);
+
+    const payload = JSON.parse(result.errorEvents[0].payload);
+    expect(payload.fatal).toBe(true);
+    expect(payload.error).toContain('no heartbeat');
+  });
+
   // ---------------------------------------------------------------------------
   // Fix 5: Dynamic alarm scheduling — 2-min interval when active, 5-min idle
   // ---------------------------------------------------------------------------

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -390,7 +390,7 @@ describe('Disconnect handling & reaper', () => {
     expect(result.staleExecution?.status).toBe('failed');
     expect(result.staleExecution?.error).toContain('no heartbeat');
     expect(result.freshExecution?.status).toBe('running');
-    expect(result.activeExecId).toBeNull();
+    expect(result.activeExecId).toBe('exc_orphan_fresh');
     expect(result.staleErrorEvents).toHaveLength(1);
     expect(result.freshErrorEvents).toHaveLength(0);
   });
@@ -445,6 +445,52 @@ describe('Disconnect handling & reaper', () => {
     expect(result.nextAlarm).toBeDefined();
     const delta = (result.nextAlarm as number) - result.now;
     // Allow ± 5s for clock drift inside the DO
+    expect(delta).toBeGreaterThanOrEqual(115_000);
+    expect(delta).toBeLessThanOrEqual(125_000);
+  });
+
+  it('alarm restores the active marker for a hidden running execution', async () => {
+    const userId = 'user_alarm_3';
+    const sessionId = 'agent_alarm_3';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_hidden_alarm' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      await instance.updateExecutionHeartbeat(excId, now - 5_000);
+
+      await instance.alarm();
+
+      const nextAlarm = await state.storage.getAlarm();
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { nextAlarm, activeExecId, now };
+    });
+
+    expect(result.activeExecId).toBe('exc_hidden_alarm');
+    expect(result.nextAlarm).toBeDefined();
+    const delta = (result.nextAlarm as number) - result.now;
     expect(delta).toBeGreaterThanOrEqual(115_000);
     expect(delta).toBeLessThanOrEqual(125_000);
   });

--- a/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -149,8 +149,7 @@ describe('CloudAgentSession.startExecutionV2', () => {
       });
 
       const activeExecutionId = await instance.getActiveExecutionId();
-      const storedActiveExecutionId =
-        await state.storage.get<string>('active_execution_id');
+      const storedActiveExecutionId = await state.storage.get<string>('active_execution_id');
 
       return { activeExecutionId, storedActiveExecutionId };
     });

--- a/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -63,6 +63,113 @@ describe('CloudAgentSession.startExecutionV2', () => {
     expect(result.plan).toBeNull();
   });
 
+  it('returns EXECUTION_IN_PROGRESS when a non-terminal execution exists without an active marker', async () => {
+    const userId = 'user_exec_hidden' as const;
+    const sessionId = 'agent_exec_hidden' as const;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async instance => {
+      let capturedPlan: any = null;
+      (instance as any).orchestrator = {
+        execute: async (plan: any) => {
+          capturedPlan = plan;
+          return { messageId: plan.executionId, kiloSessionId: 'kilo_test' };
+        },
+      };
+
+      const now = Date.now();
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const hiddenId = 'exc_hidden' as ExecutionId;
+      await instance.addExecution({
+        executionId: hiddenId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: hiddenId,
+      });
+      await instance.updateExecutionStatus({
+        executionId: hiddenId,
+        status: 'running',
+      });
+
+      const request: StartExecutionV2Request = {
+        kind: 'initiate',
+        userId,
+        authToken: 'token-init',
+        prompt: 'do the thing',
+        mode: 'code',
+        model: 'test-model',
+        gitUrl: 'https://example.com/repo.git',
+        gitToken: 'git-token',
+      };
+
+      const startResult = await instance.startExecutionV2(request);
+      return { startResult, plan: capturedPlan };
+    });
+
+    expect(result.startResult.success).toBe(false);
+    if (result.startResult.success) return;
+
+    expect(result.startResult.code).toBe('EXECUTION_IN_PROGRESS');
+    expect(result.startResult.activeExecutionId).toBe('exc_hidden');
+    expect(result.plan).toBeNull();
+  });
+
+  it('clears an invalid active marker before starting a new execution', async () => {
+    const userId = 'user_exec_invalid_marker' as const;
+    const sessionId = 'agent_exec_invalid_marker' as const;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      let capturedPlan: any = null;
+      (instance as any).orchestrator = {
+        execute: async (plan: any) => {
+          capturedPlan = plan;
+          return { messageId: plan.executionId, kiloSessionId: 'kilo_test' };
+        },
+      };
+
+      const now = Date.now();
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      await state.storage.put('active_execution_id', 'exc_missing');
+
+      const request: StartExecutionV2Request = {
+        kind: 'initiate',
+        userId,
+        authToken: 'token-init',
+        prompt: 'do the thing',
+        mode: 'code',
+        model: 'test-model',
+        gitUrl: 'https://example.com/repo.git',
+        gitToken: 'git-token',
+      };
+
+      const startResult = await instance.startExecutionV2(request);
+      const activeExecutionId = await instance.getActiveExecutionId();
+      return { startResult, activeExecutionId, plan: capturedPlan };
+    });
+
+    expect(result.startResult.success).toBe(true);
+    if (!result.startResult.success) return;
+
+    expect(result.startResult.status).toBe('started');
+    expect(result.activeExecutionId).toBe(result.startResult.executionId);
+    expect(result.plan).toBeTruthy();
+  });
+
   it('builds a launch plan for follow-up and applies token overrides', async () => {
     const userId = 'user_exec_followup' as const;
     const sessionId = 'agent_exec_followup' as const;

--- a/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -121,6 +121,44 @@ describe('CloudAgentSession.startExecutionV2', () => {
     expect(result.plan).toBeNull();
   });
 
+  it('repairs the active execution ID when a hidden execution is still running', async () => {
+    const userId = 'user_exec_repair' as const;
+    const sessionId = 'agent_exec_repair' as const;
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const hiddenId = 'exc_hidden_repair' as ExecutionId;
+      await instance.addExecution({
+        executionId: hiddenId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: hiddenId,
+      });
+      await instance.updateExecutionStatus({
+        executionId: hiddenId,
+        status: 'running',
+      });
+
+      const activeExecutionId = await instance.getActiveExecutionId();
+      const storedActiveExecutionId =
+        await state.storage.get<string>('active_execution_id');
+
+      return { activeExecutionId, storedActiveExecutionId };
+    });
+
+    expect(result.activeExecutionId).toBe('exc_hidden_repair');
+    expect(result.storedActiveExecutionId).toBe('exc_hidden_repair');
+  });
+
   it('clears an invalid active marker before starting a new execution', async () => {
     const userId = 'user_exec_invalid_marker' as const;
     const sessionId = 'agent_exec_invalid_marker' as const;


### PR DESCRIPTION
## Summary

Recover V2 review sessions when a running execution loses `active_execution_id`.

The production case here looks like a single hidden execution, not intended parallel work in one session. Once the marker was lost, stale reaping, interrupts, alarm cadence, idle Kilo cleanup, and the terminal callback path could all treat the session as idle. This change repairs the active marker from non-terminal execution state and makes those lifecycle checks use the repaired view. The broader scan of non-terminal executions is defensive hardening if marker loss ever lets session state drift.

## Verification

- `pnpm --dir cloud-agent-next exec tsc -p tsconfig.json --noEmit` ✅
- `pnpm --dir cloud-agent-next test:integration test/integration/session/disconnect-and-reaper.test.ts test/integration/session/start-execution-v2.test.ts` ✅

## Visual Changes

N/A

## Reviewer Notes

The observed incident is explained by one running execution with a missing marker. Handling multiple non-terminal records here is secondary hardening, not an assumption that parallel executions in one session are expected.
