### PR TITLE
refactor(bot): use kilo/auto-free as default bot model

### DIFF
--- a/src/lib/bot/constants.ts
+++ b/src/lib/bot/constants.ts
@@ -1,9 +1,6 @@
-import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
-import { minimax_m25_free_model } from '@/lib/providers/minimax';
+import { KILO_AUTO_FREE_MODEL } from '@/lib/kilo-auto-model';
 
 export const BOT_VERSION = '5.1.0';
 export const BOT_USER_AGENT = `Kilo-Code/${BOT_VERSION}`;
-export const DEFAULT_BOT_MODEL = minimax_m25_free_model.is_enabled
-  ? minimax_m25_free_model.public_id
-  : CLAUDE_OPUS_CURRENT_MODEL_ID;
+export const DEFAULT_BOT_MODEL = KILO_AUTO_FREE_MODEL.id;
 export const MAX_ITERATIONS = 5;

--- a/src/lib/integrations/discord-service.ts
+++ b/src/lib/integrations/discord-service.ts
@@ -11,13 +11,10 @@ import { APP_URL } from '@/lib/constants';
 import { getOrganizationById } from '@/lib/organizations/organizations';
 import { getDefaultAllowedModel } from '@/lib/slack-bot/model-allow-list';
 import { createProviderAwareModelAllowPredicate } from '@/lib/model-allow.server';
-import { minimax_m25_free_model } from '@/lib/providers/minimax';
-import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
+import { KILO_AUTO_FREE_MODEL } from '@/lib/kilo-auto-model';
 
 // Default model for Discord integrations - mirrors the Slack default
-const DISCORD_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
-  ? minimax_m25_free_model.public_id
-  : CLAUDE_OPUS_CURRENT_MODEL_ID;
+const DISCORD_DEFAULT_MODEL = KILO_AUTO_FREE_MODEL.id;
 
 // Discord OAuth2 scopes for the bot integration
 // 'bot' scope is needed for the bot to join servers

--- a/src/lib/integrations/slack-service.ts
+++ b/src/lib/integrations/slack-service.ts
@@ -13,13 +13,10 @@ import type { OAuthV2Response } from '@slack/oauth';
 import { getOrganizationById } from '@/lib/organizations/organizations';
 import { getDefaultAllowedModel } from '@/lib/slack-bot/model-allow-list';
 import { createProviderAwareModelAllowPredicate } from '@/lib/model-allow.server';
-import { minimax_m25_free_model } from '@/lib/providers/minimax';
-import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/providers/anthropic';
+import { KILO_AUTO_FREE_MODEL } from '@/lib/kilo-auto-model';
 
 // Default model for Slack integrations - separate from the global platform default
-const SLACK_DEFAULT_MODEL = minimax_m25_free_model.is_enabled
-  ? minimax_m25_free_model.public_id
-  : CLAUDE_OPUS_CURRENT_MODEL_ID;
+const SLACK_DEFAULT_MODEL = KILO_AUTO_FREE_MODEL.id;
 
 // Slack OAuth scopes for the integration
 // These should be kept in sync with the scopes requested in the Slack app configuration


### PR DESCRIPTION
## Summary

- Replace the hardcoded `minimax_m25_free_model.is_enabled ? minimax_m25_free_model.public_id : CLAUDE_OPUS_CURRENT_MODEL_ID` conditional in three files with `KILO_AUTO_FREE_MODEL.id` (`kilo/auto-free`).
- This routes the default bot model through the centralized auto-model resolution layer in `kilo-auto-model.ts`, so future changes to the backing model only need to happen in one place (`resolveAutoModel`).
- Affected files: `src/lib/bot/constants.ts`, `src/lib/integrations/slack-service.ts`, `src/lib/integrations/discord-service.ts`.

## Verification

- [x] `pnpm typecheck` — passes cleanly across all workspace projects

## Visual Changes

N/A

## Reviewer Notes

- At runtime `kilo/auto-free` is resolved by `resolveAutoModel` in the API proxy to `minimax/minimax-m2.5:free`, so the effective model is unchanged.
- Existing integrations that already have `model_slug` stored in their metadata are unaffected — this only changes the default for newly created integrations and the bot's runtime fallback.