### PR TITLE
fix(auto-fix): prevent @kilo fix it from creating new branch

### DIFF
--- a/cloudflare-auto-fix-infra/src/fix-orchestrator.ts
+++ b/cloudflare-auto-fix-infra/src/fix-orchestrator.ts
@@ -78,9 +78,16 @@ export class AutoFixOrchestrator extends DurableObject<Env> {
         }
       }
 
-      await this.updateStatus('failed', {
-        errorMessage: errorMessage,
-      });
+      try {
+        await this.updateStatus('failed', {
+          errorMessage: errorMessage,
+        });
+      } catch (statusError) {
+        console.error('[AutoFixOrchestrator] Failed to update ticket to failed state', {
+          ticketId: this.state.ticketId,
+          error: statusError instanceof Error ? statusError.message : String(statusError),
+        });
+      }
     }
   }
 
@@ -357,16 +364,32 @@ export class AutoFixOrchestrator extends DurableObject<Env> {
     await this.ctx.storage.put('state', this.state);
 
     // Update Next.js database
-    await fetch(`${this.env.API_URL}/api/internal/auto-fix-status/${this.state.ticketId}`, {
-      method: 'POST',
-      headers: {
-        'X-Internal-Secret': this.env.INTERNAL_API_SECRET,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+    const response = await fetch(
+      `${this.env.API_URL}/api/internal/auto-fix-status/${this.state.ticketId}`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Internal-Secret': this.env.INTERNAL_API_SECRET,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          status,
+          ...updates,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'unknown');
+      console.error('[AutoFixOrchestrator] Failed to update status in Next.js database', {
+        ticketId: this.state.ticketId,
         status,
-        ...updates,
-      }),
-    });
+        httpStatus: response.status,
+        errorText,
+      });
+      throw new Error(
+        `Failed to update ticket status in database: ${response.status} ${response.statusText}`
+      );
+    }
   }
 }

--- a/src/app/api/internal/auto-fix/pr-callback/route.ts
+++ b/src/app/api/internal/auto-fix/pr-callback/route.ts
@@ -103,6 +103,34 @@ export async function POST(req: NextRequest) {
     }
 
     const ticketId = ticket.id;
+
+    // Use review_comment_id as the definitive signal for review-comment triggers.
+    // This is more robust than trigger_source alone because review_comment_id is
+    // set immutably at ticket creation and never modified by status updates.
+    const isReviewCommentTrigger = ticket.review_comment_id != null;
+
+    if (isReviewCommentTrigger && ticket.trigger_source !== 'review_comment') {
+      errorExceptInTest(
+        '[auto-fix-pr-callback] trigger_source mismatch: ticket has review_comment_id but trigger_source is not review_comment',
+        {
+          ticketId,
+          sessionId,
+          triggerSource: ticket.trigger_source,
+          reviewCommentId: ticket.review_comment_id,
+        }
+      );
+      captureMessage('auto-fix trigger_source mismatch', {
+        level: 'warning',
+        tags: { source: 'auto-fix-pr-callback' },
+        extra: {
+          ticketId,
+          sessionId,
+          triggerSource: ticket.trigger_source,
+          reviewCommentId: ticket.review_comment_id,
+        },
+      });
+    }
+
     const isTerminalState =
       ticket.status === 'completed' || ticket.status === 'failed' || ticket.status === 'cancelled';
 
@@ -128,7 +156,7 @@ export async function POST(req: NextRequest) {
         errorMessage,
       });
 
-      if (ticket.trigger_source === 'review_comment') {
+      if (isReviewCommentTrigger) {
         const replyResult = await handleCommentReply({
           ticketId,
           sessionId,
@@ -153,7 +181,7 @@ export async function POST(req: NextRequest) {
 
       // Post issue-level failure comment only for issue-triggered tickets.
       // Review-comment-triggered tickets are notified on their original review thread.
-      if (ticket.trigger_source !== 'review_comment') {
+      if (!isReviewCommentTrigger) {
         try {
           if (ticket.platform_integration_id) {
             const integration = await getIntegrationById(ticket.platform_integration_id);
@@ -207,7 +235,7 @@ export async function POST(req: NextRequest) {
       sessionId,
     });
 
-    if (ticket.trigger_source === 'review_comment') {
+    if (isReviewCommentTrigger) {
       const replyResult = await handleCommentReply({
         ticketId,
         sessionId,

--- a/src/lib/auto-fix/github/handle-comment-reply.ts
+++ b/src/lib/auto-fix/github/handle-comment-reply.ts
@@ -141,10 +141,11 @@ export async function handleCommentReply(
     return { ok: false, error: 'Ticket not found', status: 404 };
   }
 
-  if (ticket.trigger_source !== 'review_comment' || !ticket.review_comment_id) {
+  if (!ticket.review_comment_id) {
     logExceptInTest('[auto-fix-comment-reply] Not a review comment ticket', {
       ticketId,
       triggerSource: ticket.trigger_source,
+      reviewCommentId: ticket.review_comment_id,
     });
     return { ok: false, error: 'Ticket is not a review comment trigger', status: 400 };
   }


### PR DESCRIPTION
## Summary

`@kilo fix it` on PR review comments was creating a new branch/PR and posting a top-level summary comment instead of committing to the existing PR branch and replying in-thread. See https://github.com/Kilo-Org/kilocode/pull/6676#issuecomment-4010696474.

The pr-callback handler routed on `ticket.trigger_source`, a mutable text column. If that value was stale or mismatched at callback time, review-comment tickets fell through to the issue-trigger path (create PR + post summary comment).

Fix: route on `ticket.review_comment_id != null` instead — it's set once at ticket creation and never touched by status updates. Also make the orchestrator's status-update fetch fail loudly (`response.ok` check) so DB write failures don't silently go unnoticed.

## Verification

- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm test -- --testPathPattern auto-fix/db/fix-tickets` — 2/2 pass

## Visual Changes

N/A

## Reviewer Notes

The Sentry warning added for `trigger_source` vs `review_comment_id` mismatch will help confirm whether the root cause was a transient DB update failure or something else. If we never see that warning fire, the trigger_source column itself was likely fine and the bug was a deployment timing issue — either way, routing on the immutable column is strictly safer.