### PR TITLE
feat(cloud-agent-next): apply session file diffs during cold-start resume

### DIFF
--- a/cloud-agent-next/src/session-ingest-binding.ts
+++ b/cloud-agent-next/src/session-ingest-binding.ts
@@ -29,5 +29,5 @@ export type ExportSessionParams = {
 export type SessionIngestBinding = Fetcher & {
   createSessionForCloudAgent(params: CreateSessionForCloudAgentParams): Promise<void>;
   deleteSessionForCloudAgent(params: DeleteSessionForCloudAgentParams): Promise<void>;
-  exportSession(params: ExportSessionParams): Promise<string | null>;
+  exportSessionWithDiff(params: ExportSessionParams): Promise<string | null>;
 };

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -41,9 +41,9 @@ import type { PersistenceEnv, CloudAgentSessionState } from './persistence/types
 describe('SessionService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockEnv.SESSION_INGEST.exportSession = vi
+    mockEnv.SESSION_INGEST.exportSessionWithDiff = vi
       .fn()
-      .mockResolvedValue(JSON.stringify({ info: {}, messages: [] }));
+      .mockResolvedValue(JSON.stringify({ snapshot: { info: {}, messages: [] }, diff: null }));
   });
 
   const mockedSetupWorkspace = vi.mocked(mockSetupWorkspace);
@@ -68,7 +68,7 @@ describe('SessionService', () => {
     } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
     NEXTAUTH_SECRET: 'mock-secret',
     SESSION_INGEST: {
-      exportSession: vi.fn(),
+      exportSessionWithDiff: vi.fn(),
     } as unknown as PersistenceEnv['SESSION_INGEST'],
   };
 
@@ -166,14 +166,14 @@ describe('SessionService', () => {
       expect(result.context.sessionId).toBe(sessionId);
     });
 
-    it('does not restore session snapshot during initiate (no exportSession call)', async () => {
-      const exportSessionMock = vi
+    it('does not restore session snapshot during initiate (no exportSessionWithDiff call)', async () => {
+      const exportSessionWithDiffMock = vi
         .fn()
-        .mockResolvedValue(JSON.stringify({ info: {}, messages: [] }));
+        .mockResolvedValue(JSON.stringify({ snapshot: { info: {}, messages: [] }, diff: null }));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
         SESSION_INGEST: {
-          exportSession: exportSessionMock,
+          exportSessionWithDiff: exportSessionWithDiffMock,
         } as unknown as PersistenceEnv['SESSION_INGEST'],
       };
 
@@ -209,7 +209,7 @@ describe('SessionService', () => {
         env: envWithIngest,
       });
 
-      expect(exportSessionMock).not.toHaveBeenCalled();
+      expect(exportSessionWithDiffMock).not.toHaveBeenCalled();
       expect(fakeSession.writeFile).not.toHaveBeenCalled();
       expect(fakeSession.exec).not.toHaveBeenCalledWith(
         `kilo import "/tmp/kilo-session-export-${sessionId}.json"`
@@ -574,12 +574,13 @@ describe('SessionService', () => {
 
     it('restores workspace then session snapshot when workspace is missing', async () => {
       const mockDOGetMetadata = vi.fn();
-      const payload = JSON.stringify({ info: {}, messages: [] });
-      const exportSessionMock = vi.fn().mockResolvedValue(payload);
+      const snapshot = { info: {}, messages: [] };
+      const combinedPayload = JSON.stringify({ snapshot, diff: null });
+      const exportSessionWithDiffMock = vi.fn().mockResolvedValue(combinedPayload);
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
         SESSION_INGEST: {
-          exportSession: exportSessionMock,
+          exportSessionWithDiff: exportSessionWithDiffMock,
         } as unknown as PersistenceEnv['SESSION_INGEST'],
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
@@ -632,13 +633,14 @@ describe('SessionService', () => {
         env: envWithIngest,
       });
 
-      expect(exportSessionMock).toHaveBeenCalledWith({
+      expect(exportSessionWithDiffMock).toHaveBeenCalledWith({
         sessionId: kiloSessionId,
         kiloUserId: userId,
       });
+      // Snapshot is re-serialized from the parsed combined payload
       expect(fakeSession.writeFile).toHaveBeenCalledWith(
         `/tmp/kilo-session-export-${sessionId}.json`,
-        payload
+        JSON.stringify(snapshot)
       );
       expect(fakeSession.exec).toHaveBeenCalledWith(
         `kilo import "/tmp/kilo-session-export-${sessionId}.json"`
@@ -665,6 +667,267 @@ describe('SessionService', () => {
       expect(authWriteCallIndex).toBeGreaterThanOrEqual(0);
       const authWriteOrder = sandboxWriteFile.mock.invocationCallOrder[authWriteCallIndex];
       expect(authWriteOrder).toBeLessThan(kiloImportOrder);
+    });
+
+    it('applies session diff after restoring snapshot during cold start', async () => {
+      const mockDOGetMetadata = vi.fn();
+      const diffEntries = [
+        {
+          file: 'src/index.ts',
+          after: 'new content',
+          status: 'modified',
+        },
+        {
+          file: 'src/new-file.ts',
+          after: 'brand new file',
+          status: 'added',
+        },
+        {
+          file: 'src/removed.ts',
+          after: '',
+          status: 'deleted',
+        },
+      ];
+      const combinedPayload = JSON.stringify({
+        snapshot: { info: {}, messages: [] },
+        diff: diffEntries,
+      });
+      const exportSessionWithDiffMock = vi.fn().mockResolvedValue(combinedPayload);
+      const envWithIngest: PersistenceEnv = {
+        ...mockEnv,
+        SESSION_INGEST: {
+          exportSessionWithDiff: exportSessionWithDiffMock,
+        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
+          get: vi.fn(() => ({
+            getMetadata: mockDOGetMetadata,
+            updateMetadata: vi.fn().mockResolvedValue(undefined),
+            deleteSession: vi.fn().mockResolvedValue(undefined),
+          })),
+        } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
+      };
+      const fakeSession = {
+        exec: vi
+          .fn()
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
+          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const kiloSessionId = 'ses_test_kilo_session_id_0001';
+      const metadata = {
+        version: 123456789,
+        sessionId,
+        orgId,
+        userId,
+        timestamp: 123456789,
+        githubRepo: 'facebook/react',
+        githubToken: 'test-token',
+        kiloSessionId,
+      };
+      mockDOGetMetadata.mockResolvedValue(metadata);
+
+      const service = new SessionService();
+      await service.resume({
+        sandbox,
+        sandboxId: `${orgId}__${userId}`,
+        orgId,
+        userId,
+        sessionId,
+        kilocodeToken: 'test-token',
+        kilocodeModel: 'test-model',
+        env: envWithIngest,
+      });
+
+      // Verify exportSessionWithDiff was called (single combined RPC)
+      expect(exportSessionWithDiffMock).toHaveBeenCalledWith({
+        sessionId: kiloSessionId,
+        kiloUserId: userId,
+      });
+
+      // Verify modified file was written
+      expect(fakeSession.writeFile).toHaveBeenCalledWith(
+        `/workspace/${orgId}/${userId}/sessions/${sessionId}/src/index.ts`,
+        'new content'
+      );
+
+      // Verify added file was written
+      expect(fakeSession.writeFile).toHaveBeenCalledWith(
+        `/workspace/${orgId}/${userId}/sessions/${sessionId}/src/new-file.ts`,
+        'brand new file'
+      );
+
+      // Verify deleted file was removed
+      expect(fakeSession.deleteFile).toHaveBeenCalledWith(
+        `/workspace/${orgId}/${userId}/sessions/${sessionId}/src/removed.ts`
+      );
+
+      // Verify mkdir was called for parent directories
+      expect(fakeSession.exec).toHaveBeenCalledWith(
+        `mkdir -p '/workspace/${orgId}/${userId}/sessions/${sessionId}/src'`
+      );
+
+      // Verify session diff was applied AFTER kilo import
+      const kiloImportCallIndex = fakeSession.exec.mock.calls.findIndex(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('kilo import')
+      );
+      expect(kiloImportCallIndex).toBeGreaterThanOrEqual(0);
+      const kiloImportOrder = fakeSession.exec.mock.invocationCallOrder[kiloImportCallIndex];
+
+      const mkdirCallIndex = fakeSession.exec.mock.calls.findIndex(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('mkdir -p') && args[0].includes('/src')
+      );
+      expect(mkdirCallIndex).toBeGreaterThanOrEqual(0);
+      const mkdirOrder = fakeSession.exec.mock.invocationCallOrder[mkdirCallIndex];
+      expect(mkdirOrder).toBeGreaterThan(kiloImportOrder);
+    });
+
+    it('skips session diff gracefully when diff is null in combined response', async () => {
+      const mockDOGetMetadata = vi.fn();
+      const combinedPayload = JSON.stringify({
+        snapshot: { info: {}, messages: [] },
+        diff: null,
+      });
+      const exportSessionWithDiffMock = vi.fn().mockResolvedValue(combinedPayload);
+      const envWithIngest: PersistenceEnv = {
+        ...mockEnv,
+        SESSION_INGEST: {
+          exportSessionWithDiff: exportSessionWithDiffMock,
+        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
+          get: vi.fn(() => ({
+            getMetadata: mockDOGetMetadata,
+            updateMetadata: vi.fn().mockResolvedValue(undefined),
+            deleteSession: vi.fn().mockResolvedValue(undefined),
+          })),
+        } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
+      };
+      const fakeSession = {
+        exec: vi
+          .fn()
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
+          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const kiloSessionId = 'ses_test_kilo_session_id_0001';
+      const metadata = {
+        version: 123456789,
+        sessionId,
+        orgId,
+        userId,
+        timestamp: 123456789,
+        githubRepo: 'facebook/react',
+        githubToken: 'test-token',
+        kiloSessionId,
+      };
+      mockDOGetMetadata.mockResolvedValue(metadata);
+
+      const service = new SessionService();
+      // Should not throw — null diff is gracefully handled
+      await service.resume({
+        sandbox,
+        sandboxId: `${orgId}__${userId}`,
+        orgId,
+        userId,
+        sessionId,
+        kilocodeToken: 'test-token',
+        kilocodeModel: 'test-model',
+        env: envWithIngest,
+      });
+
+      expect(exportSessionWithDiffMock).toHaveBeenCalledWith({
+        sessionId: kiloSessionId,
+        kiloUserId: userId,
+      });
+
+      // No file writes for diff (only the kilo import tmp file)
+      const diffWriteCalls = fakeSession.writeFile.mock.calls.filter(
+        (args: string[]) => !args[0].includes('/tmp/kilo-session-export-')
+      );
+      expect(diffWriteCalls).toHaveLength(0);
+    });
+
+    it('throws when exportSessionWithDiff returns null (session not found)', async () => {
+      const mockDOGetMetadata = vi.fn();
+      const exportSessionWithDiffMock = vi.fn().mockResolvedValue(null);
+      const envWithIngest: PersistenceEnv = {
+        ...mockEnv,
+        SESSION_INGEST: {
+          exportSessionWithDiff: exportSessionWithDiffMock,
+        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
+          get: vi.fn(() => ({
+            getMetadata: mockDOGetMetadata,
+            updateMetadata: vi.fn().mockResolvedValue(undefined),
+            deleteSession: vi.fn().mockResolvedValue(undefined),
+          })),
+        } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
+      };
+      const fakeSession = {
+        exec: vi
+          .fn()
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
+          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const kiloSessionId = 'ses_test_kilo_session_id_0001';
+      const metadata = {
+        version: 123456789,
+        sessionId,
+        orgId,
+        userId,
+        timestamp: 123456789,
+        githubRepo: 'facebook/react',
+        githubToken: 'test-token',
+        kiloSessionId,
+      };
+      mockDOGetMetadata.mockResolvedValue(metadata);
+
+      const service = new SessionService();
+      await expect(
+        service.resume({
+          sandbox,
+          sandboxId: `${orgId}__${userId}`,
+          orgId,
+          userId,
+          sessionId,
+          kilocodeToken: 'test-token',
+          kilocodeModel: 'test-model',
+          env: envWithIngest,
+        })
+      ).rejects.toThrow('session not found');
+
+      expect(exportSessionWithDiffMock).toHaveBeenCalled();
     });
   });
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { z } from 'zod';
 import type {
   ExecutionSession,
   SandboxInstance,
@@ -1411,16 +1412,25 @@ export class SessionService {
       );
     }
 
+    const combinedExportSchema = z.object({
+      snapshot: z.unknown(),
+      diff: z
+        .array(
+          z.object({
+            file: z.string(),
+            after: z.string(),
+            status: z.enum(['added', 'deleted', 'modified']).optional(),
+          })
+        )
+        .nullable(),
+    });
+
     let snapshotJson: string;
-    let diff: Array<{
-      file: string;
-      after: string;
-      status?: 'added' | 'deleted' | 'modified';
-    }> | null;
+    let diff: z.infer<typeof combinedExportSchema>['diff'];
     try {
-      const parsed: { snapshot: unknown; diff: unknown } = JSON.parse(combinedPayload);
+      const parsed = combinedExportSchema.parse(JSON.parse(combinedPayload));
       snapshotJson = JSON.stringify(parsed.snapshot);
-      diff = Array.isArray(parsed.diff) ? parsed.diff : null;
+      diff = parsed.diff;
     } catch (error) {
       throw new Error(
         `Failed to parse combined export payload: ${error instanceof Error ? error.message : String(error)}`

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import type {
   ExecutionSession,
   SandboxInstance,
@@ -901,28 +902,21 @@ export class SessionService {
     };
   }
 
+  /**
+   * Write a snapshot payload to a temp file, run `kilo import`, then clean up.
+   *
+   * @param snapshotPayload - Pre-fetched JSON string of the session snapshot.
+   */
   private async restoreSessionSnapshot(
     session: ExecutionSession,
     sessionId: string,
-    kiloSessionId: string,
-    env: PersistenceEnv,
-    userId: string
+    userId: string,
+    snapshotPayload: string
   ): Promise<void> {
     const tmpPath = `/tmp/kilo-session-export-${sessionId}.json`;
     let wroteSnapshot = false;
     try {
-      const payload = await env.SESSION_INGEST.exportSession({
-        sessionId: kiloSessionId,
-        kiloUserId: userId,
-      });
-
-      if (payload === null) {
-        throw new SessionSnapshotRestoreError(
-          `Session snapshot restore failed: session not found`,
-          404
-        );
-      }
-      await session.writeFile(tmpPath, payload);
+      await session.writeFile(tmpPath, snapshotPayload);
       wroteSnapshot = true;
 
       const importResult = await session.exec(`kilo import "${tmpPath}"`);
@@ -939,17 +933,6 @@ export class SessionService {
         throw new Error(`Session snapshot import failed with exit code ${importResult.exitCode}`);
       }
     } catch (error) {
-      if (error instanceof SessionSnapshotRestoreError) {
-        logger
-          .withFields({
-            sessionId,
-            userId,
-            status: error.status,
-            error: error.message,
-          })
-          .error('Session snapshot restore failed');
-        throw error;
-      }
       logger
         .withFields({
           sessionId,
@@ -973,6 +956,89 @@ export class SessionService {
         }
       }
     }
+  }
+
+  /**
+   * Apply file-level changes from a pre-parsed diff array on top of the freshly
+   * cloned repo.  Called during cold-start resume after `restoreSessionSnapshot`.
+   *
+   * Each diff entry contains the full `after` content, so we simply write (or
+   * delete) files to recreate the workspace state from the previous session.
+   *
+   * @param diffs - Pre-parsed `FileDiff[]` array (or `null` when no diff exists).
+   */
+  private async applySessionDiff(
+    session: ExecutionSession,
+    sessionId: string,
+    userId: string,
+    workspacePath: string,
+    diffs: Array<{
+      file: string;
+      after: string;
+      status?: 'added' | 'deleted' | 'modified';
+    }> | null
+  ): Promise<void> {
+    if (!Array.isArray(diffs) || diffs.length === 0) {
+      return;
+    }
+
+    let applied = 0;
+    let skipped = 0;
+
+    for (const diff of diffs) {
+      if (!diff.file) {
+        skipped++;
+        continue;
+      }
+
+      // Skip binary files — they have empty after content
+      if (diff.status !== 'deleted' && !diff.after) {
+        skipped++;
+        continue;
+      }
+
+      const filePath = resolve(workspacePath, diff.file);
+      if (!filePath.startsWith(workspacePath + '/')) {
+        logger
+          .withFields({ sessionId, userId, file: diff.file })
+          .warn('Skipping diff entry with path outside workspace');
+        skipped++;
+        continue;
+      }
+
+      try {
+        if (diff.status === 'deleted') {
+          await session.deleteFile(filePath);
+          applied++;
+        } else {
+          // Ensure parent directory exists.
+          // Use single-quoted path to prevent shell metacharacter injection.
+          const lastSlash = filePath.lastIndexOf('/');
+          if (lastSlash > 0) {
+            const parentDir = filePath.substring(0, lastSlash);
+            const escaped = parentDir.replaceAll("'", "'\\''");
+            await session.exec(`mkdir -p '${escaped}'`);
+          }
+          await session.writeFile(filePath, diff.after);
+          applied++;
+        }
+      } catch (error) {
+        logger
+          .withFields({
+            sessionId,
+            userId,
+            file: diff.file,
+            status: diff.status,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          .warn('Failed to apply file diff (non-fatal, continuing)');
+        skipped++;
+      }
+    }
+
+    logger
+      .withFields({ sessionId, userId, applied, skipped, total: diffs.length })
+      .info('Applied session diff');
   }
 
   /**
@@ -1332,7 +1398,41 @@ export class SessionService {
     // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
     await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
 
-    await this.restoreSessionSnapshot(session, sessionId, metadata.kiloSessionId, env, userId);
+    // Single combined RPC: fetch snapshot (with diffs stripped) + aggregated diff.
+    const combinedPayload = await env.SESSION_INGEST.exportSessionWithDiff({
+      sessionId: metadata.kiloSessionId,
+      kiloUserId: userId,
+    });
+
+    if (combinedPayload === null) {
+      throw new SessionSnapshotRestoreError(
+        `Session snapshot restore failed: session not found`,
+        404
+      );
+    }
+
+    let snapshotJson: string;
+    let diff: Array<{
+      file: string;
+      after: string;
+      status?: 'added' | 'deleted' | 'modified';
+    }> | null;
+    try {
+      const parsed: { snapshot: unknown; diff: unknown } = JSON.parse(combinedPayload);
+      snapshotJson = JSON.stringify(parsed.snapshot);
+      diff = Array.isArray(parsed.diff) ? parsed.diff : null;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse combined export payload: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    await this.restoreSessionSnapshot(session, sessionId, userId, snapshotJson);
+
+    // Apply file-level changes from the previous session on top of the fresh clone.
+    // This runs after kilo import (conversation restore) since the CLI doesn't need
+    // the file state during import — it only restores its internal session DB.
+    await this.applySessionDiff(session, sessionId, userId, context.workspacePath, diff);
 
     // Re-run setup commands (fresh clone, need to reinstall)
     if (metadata.setupCommands && metadata.setupCommands.length > 0) {

--- a/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
+++ b/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
@@ -23,7 +23,16 @@ import {
   POST_CLOSE_DRAIN_MS,
   type TerminationReason,
 } from './session-metrics';
+import { z } from 'zod';
 import migrations from '../../drizzle/migrations';
+
+const fileDiffSchema = z.object({
+  file: z.string(),
+  after: z.string().default(''),
+  status: z.string().default('modified'),
+});
+
+type FileDiff = z.infer<typeof fileDiffSchema>;
 
 type IngestMetaKey =
   | ExtractableMetaKey
@@ -178,7 +187,8 @@ export class SessionIngestDO extends DurableObject<Env> {
     };
   }
 
-  async getAll(): Promise<string> {
+  /** Read and parse all non-session_diff items from the DB. */
+  private readItems(): IngestBatch {
     const rows = this.db
       .select({
         item_id: ingestItems.item_id,
@@ -205,8 +215,51 @@ export class SessionIngestDO extends DurableObject<Env> {
       }
     }
 
-    const snapshot = buildSharedSessionSnapshot(items);
+    return items;
+  }
+
+  async getAll(): Promise<string> {
+    const snapshot = buildSharedSessionSnapshot(this.readItems());
     return JSON.stringify(snapshot);
+  }
+
+  /**
+   * Aggregate last-write-wins file diffs from the given items' `summary.diffs`.
+   * Returns null when no diffs exist.
+   */
+  private static collectDiffs(items: IngestBatch): FileDiff[] | null {
+    const messageDiffsSchema = z.object({
+      summary: z.object({ diffs: z.array(z.unknown()) }).optional(),
+    });
+
+    const byFile = new Map<string, FileDiff>();
+
+    for (const item of items) {
+      if (item.type !== 'message') continue;
+      const parsed = messageDiffsSchema.safeParse(item.data);
+      const diffs = parsed.data?.summary?.diffs;
+      if (!diffs) continue;
+
+      for (const d of diffs) {
+        const result = fileDiffSchema.safeParse(d);
+        if (!result.success) continue;
+        byFile.set(result.data.file, result.data);
+      }
+    }
+
+    if (byFile.size === 0) return null;
+    return [...byFile.values()];
+  }
+
+  /**
+   * Combined export: returns the session snapshot and aggregated file-level
+   * diff in a single call, reading items from the DB only once.
+   */
+  async getSessionExportWithDiff(): Promise<string> {
+    const items = this.readItems();
+    const snapshot = buildSharedSessionSnapshot(items);
+    const diff = SessionIngestDO.collectDiffs(items);
+    return JSON.stringify({ snapshot, diff });
   }
 
   /**

--- a/cloudflare-session-ingest/src/services/session-export.ts
+++ b/cloudflare-session-ingest/src/services/session-export.ts
@@ -7,6 +7,28 @@ import { getSessionIngestDO } from '../dos/SessionIngestDO';
 import { withDORetry } from '@kilocode/worker-utils';
 
 /**
+ * Verify that the session exists in `cli_sessions_v2` and belongs to the
+ * given user.
+ */
+async function verifySessionOwnership(
+  env: Env,
+  sessionId: string,
+  kiloUserId: string
+): Promise<boolean> {
+  const db = getWorkerDb(env.HYPERDRIVE.connectionString);
+
+  const rows = await db
+    .select({ session_id: cli_sessions_v2.session_id })
+    .from(cli_sessions_v2)
+    .where(
+      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
+    )
+    .limit(1);
+
+  return !!rows[0];
+}
+
+/**
  * Fetch the full session export payload from the SessionIngestDO.
  *
  * Verifies that the session exists in `cli_sessions_v2` and belongs to the
@@ -20,17 +42,8 @@ export async function getSessionExport(
   sessionId: string,
   kiloUserId: string
 ): Promise<string | null> {
-  const db = getWorkerDb(env.HYPERDRIVE.connectionString);
-
-  const rows = await db
-    .select({ session_id: cli_sessions_v2.session_id })
-    .from(cli_sessions_v2)
-    .where(
-      and(eq(cli_sessions_v2.session_id, sessionId), eq(cli_sessions_v2.kilo_user_id, kiloUserId))
-    )
-    .limit(1);
-
-  if (!rows[0]) {
+  const owned = await verifySessionOwnership(env, sessionId, kiloUserId);
+  if (!owned) {
     return null;
   }
 
@@ -38,5 +51,31 @@ export async function getSessionExport(
     () => getSessionIngestDO(env, { kiloUserId, sessionId }),
     stub => stub.getAll(),
     'SessionIngestDO.getAll'
+  );
+}
+
+/**
+ * Fetch the combined session snapshot and aggregated
+ * file-level diff from the SessionIngestDO in a single RPC call.
+ *
+ * Verifies session ownership before reading the DO.
+ *
+ * @returns The raw JSON string of `{ snapshot, diff }`, or `null`
+ *          if the session does not exist or does not belong to the user.
+ */
+export async function getSessionWithDiffExport(
+  env: Env,
+  sessionId: string,
+  kiloUserId: string
+): Promise<string | null> {
+  const owned = await verifySessionOwnership(env, sessionId, kiloUserId);
+  if (!owned) {
+    return null;
+  }
+
+  return withDORetry(
+    () => getSessionIngestDO(env, { kiloUserId, sessionId }),
+    stub => stub.getSessionExportWithDiff(),
+    'SessionIngestDO.getSessionExportWithDiff'
   );
 }

--- a/cloudflare-session-ingest/src/session-ingest-rpc.ts
+++ b/cloudflare-session-ingest/src/session-ingest-rpc.ts
@@ -8,7 +8,7 @@ import type { Env } from './env';
 import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
 import { withDORetry } from '@kilocode/worker-utils';
-import { getSessionExport } from './services/session-export';
+import { getSessionExport, getSessionWithDiffExport } from './services/session-export';
 
 const sessionIdSchema = z.string().startsWith('ses_').length(30);
 
@@ -29,6 +29,28 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> {
       .parse(params);
 
     return getSessionExport(this.env, parsed.sessionId, parsed.kiloUserId);
+  }
+
+  /**
+   * RPC method: export session snapshot with aggregated
+   * file-level diff in a single call. Reduces wire traffic and avoids
+   * double-reading message rows during cold-start resume.
+   *
+   * Returns the raw JSON string of `{ snapshot, diff }`, or null if the session
+   * does not exist, does not belong to the given user, or has no data.
+   */
+  async exportSessionWithDiff(params: {
+    sessionId: string;
+    kiloUserId: string;
+  }): Promise<string | null> {
+    const parsed = z
+      .object({
+        sessionId: sessionIdSchema,
+        kiloUserId: z.string().min(1),
+      })
+      .parse(params);
+
+    return getSessionWithDiffExport(this.env, parsed.sessionId, parsed.kiloUserId);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a combined `exportSessionWithDiff` RPC that fetches the session snapshot and aggregated file-level diffs from `SessionIngestDO` in a single call.

**Key changes:**
- `SessionIngestDO` gains `getSessionExportWithDiff()` which reads items from SQLite once, builds the session snapshot, and aggregates last-write-wins file diffs from message `summary.diffs` fields
- New `exportSessionWithDiff` RPC method in `SessionIngestRPC` with Zod validation
- `SessionService.resume()` now calls the combined RPC, restores the kilo session snapshot via `kilo import`, then applies file-level diffs (writes/deletes) on top of the freshly cloned repo
- `restoreSessionSnapshot` is simplified to accept a pre-fetched payload string instead of fetching internally
- New `applySessionDiff` method handles added/modified/deleted files with path-traversal protection and non-fatal error handling
- `verifySessionOwnership` extracted as a shared helper in `session-export.ts`

## Verification

Verified manually locally
