### PR TITLE
fix(gastown): block downstream beads until upstream reviews are merged, require depends_on

### DIFF
--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -290,6 +290,7 @@ export class MayorGastownClient {
     convoy_title: string;
     tasks: Array<{ title: string; body?: string; depends_on?: number[] }>;
     merge_mode?: 'review-then-land' | 'review-and-merge';
+    parallel?: boolean;
   }): Promise<SlingBatchResult> {
     return this.request<SlingBatchResult>(this.mayorPath('/sling-batch'), {
       method: 'POST',

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -160,6 +160,15 @@ export function createMayorTools(client: MayorGastownClient) {
               'Best for loosely coupled tasks where each bead stands on its own and you want incremental merges.'
           )
           .optional(),
+        parallel: tool.schema
+          .boolean()
+          .describe(
+            'Set to true ONLY when ALL tasks are genuinely independent — they touch completely ' +
+              'different files with no shared state. Without this flag, the system REQUIRES at least ' +
+              'one task to declare depends_on. This prevents accidental parallel execution of tasks ' +
+              'that need ordering, which causes merge conflicts and failures.'
+          )
+          .optional(),
       },
       async execute(args) {
         const result = await client.slingBatch({
@@ -167,6 +176,7 @@ export function createMayorTools(client: MayorGastownClient) {
           convoy_title: args.convoy_title,
           tasks: args.tasks,
           merge_mode: args.merge_mode,
+          parallel: args.parallel,
         });
 
         const beadLines = result.beads.map(

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -527,7 +527,21 @@ export class TownDO extends DurableObject<Env> {
     commit_sha?: string;
   }): Promise<void> {
     await this.ensureInitialized();
+
+    // Resolve the source bead ID before completing the review, so we can
+    // trigger dispatchUnblockedBeads for it after the MR closes.
+    const mrBead = beadOps.getBead(this.sql, input.entry_id);
+    const sourceBeadId =
+      typeof mrBead?.metadata?.source_bead_id === 'string' ? mrBead.metadata.source_bead_id : null;
+
     reviewQueue.completeReviewWithResult(this.sql, input);
+
+    // When a review is merged, the source bead's pending MR is now resolved.
+    // Downstream beads that were blocked (because hasUnresolvedBlockers saw
+    // the open MR) should now be dispatched.
+    if (input.status === 'merged' && sourceBeadId) {
+      this.dispatchUnblockedBeads(sourceBeadId);
+    }
   }
 
   async agentDone(agentId: string, input: AgentDoneInput): Promise<void> {
@@ -1515,6 +1529,19 @@ export class TownDO extends DurableObject<Env> {
       }
     }
 
+    // Process reviews FIRST so the refinery gets assigned before the
+    // scheduler dispatches new polecats. This prevents downstream beads
+    // from starting before upstream reviews are merged.
+    try {
+      await this.processReviewQueue();
+    } catch (err) {
+      console.error(`${TOWN_LOG} alarm: processReviewQueue failed`, err);
+    }
+    try {
+      await this.processConvoyLandings();
+    } catch (err) {
+      console.error(`${TOWN_LOG} alarm: processConvoyLandings failed`, err);
+    }
     try {
       await this.schedulePendingWork();
     } catch (err) {
@@ -1529,16 +1556,6 @@ export class TownDO extends DurableObject<Env> {
       await this.deliverPendingMail();
     } catch (err) {
       console.warn(`${TOWN_LOG} alarm: deliverPendingMail failed`, err);
-    }
-    try {
-      await this.processReviewQueue();
-    } catch (err) {
-      console.error(`${TOWN_LOG} alarm: processReviewQueue failed`, err);
-    }
-    try {
-      await this.processConvoyLandings();
-    } catch (err) {
-      console.error(`${TOWN_LOG} alarm: processConvoyLandings failed`, err);
     }
     try {
       await this.reEscalateStaleEscalations();

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -369,8 +369,15 @@ function updateConvoyProgress(sql: SqlStorage, beadId: string, timestamp: string
 }
 
 /**
- * Check if a bead has unresolved 'blocks' dependencies — i.e. beads
- * that must close before this bead can be dispatched.
+ * Check if a bead has unresolved 'blocks' dependencies.
+ *
+ * A blocker is resolved only when:
+ * 1. The blocker bead itself is closed or failed, AND
+ * 2. The blocker has no pending merge_request child beads (open/in_progress).
+ *
+ * Condition (2) prevents dispatching downstream beads before the refinery
+ * has reviewed and merged the upstream bead's work. Without this, the
+ * downstream polecat would start on a codebase missing the upstream changes.
  */
 export function hasUnresolvedBlockers(sql: SqlStorage, beadId: string): boolean {
   const rows = [
@@ -378,11 +385,23 @@ export function hasUnresolvedBlockers(sql: SqlStorage, beadId: string): boolean 
       sql,
       /* sql */ `
         SELECT COUNT(1) AS count
-        FROM ${bead_dependencies}
-        INNER JOIN ${beads} ON ${bead_dependencies.depends_on_bead_id} = ${beads.bead_id}
-        WHERE ${bead_dependencies.bead_id} = ?
-          AND ${bead_dependencies.dependency_type} = 'blocks'
-          AND ${beads.status} NOT IN ('closed', 'failed')
+        FROM ${bead_dependencies} AS dep
+        INNER JOIN ${beads} AS blocker
+          ON dep.${bead_dependencies.columns.depends_on_bead_id} = blocker.${beads.columns.bead_id}
+        WHERE dep.${bead_dependencies.columns.bead_id} = ?
+          AND dep.${bead_dependencies.columns.dependency_type} = 'blocks'
+          AND (
+            blocker.${beads.columns.status} NOT IN ('closed', 'failed')
+            OR EXISTS (
+              SELECT 1 FROM ${bead_dependencies} AS mr_dep
+              INNER JOIN ${beads} AS mr_bead
+                ON mr_dep.${bead_dependencies.columns.bead_id} = mr_bead.${beads.columns.bead_id}
+              WHERE mr_dep.${bead_dependencies.columns.depends_on_bead_id} = blocker.${beads.columns.bead_id}
+                AND mr_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+                AND mr_bead.${beads.columns.type} = 'merge_request'
+                AND mr_bead.${beads.columns.status} IN ('open', 'in_progress')
+            )
+          )
       `,
       [beadId]
     ),

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -18,21 +18,43 @@ const MayorSlingBody = z.object({
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
-const MayorSlingBatchBody = z.object({
-  rig_id: z.string().min(1),
-  convoy_title: z.string().min(1),
-  tasks: z
-    .array(
-      z.object({
-        title: z.string().min(1),
-        body: z.string().optional(),
-        depends_on: z.array(z.number().int().min(0)).optional(),
-      })
-    )
-    .min(1)
-    .max(50),
-  merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
-});
+const MayorSlingBatchBody = z
+  .object({
+    rig_id: z.string().min(1),
+    convoy_title: z.string().min(1),
+    tasks: z
+      .array(
+        z.object({
+          title: z.string().min(1),
+          body: z.string().optional(),
+          depends_on: z.array(z.number().int().min(0)).optional(),
+        })
+      )
+      .min(1)
+      .max(50),
+    merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
+    /** Set to true only when ALL tasks are genuinely independent (no shared files, no shared state). */
+    parallel: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Require dependency graph unless explicitly opted out with parallel: true.
+    // Without depends_on, all polecats start simultaneously on the same codebase
+    // and produce merge conflicts.
+    if (data.parallel) return;
+    if (data.tasks.length <= 1) return;
+    const hasDeps = data.tasks.some(t => t.depends_on && t.depends_on.length > 0);
+    if (!hasDeps) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Convoy has multiple tasks but none declare depends_on. ' +
+          'Without dependencies, all polecats start at the same time on the same codebase and will produce merge conflicts. ' +
+          'Add depends_on to express task ordering, or set parallel: true if ALL tasks are genuinely independent ' +
+          '(they touch completely different files with no shared state).',
+        path: ['tasks'],
+      });
+    }
+  });
 
 const MayorMailBody = z.object({
   rig_id: z.string().min(1),

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -56,16 +56,18 @@ This is critical. A single polecat works on a single bead. Large, vague tasks wi
 
 ## depends_on — THE MOST IMPORTANT PART OF CONVOY PLANNING
 
-**YOU MUST express dependencies between beads using depends_on.** This is not optional. A convoy without depends_on is almost always wrong. Without depends_on, ALL beads dispatch simultaneously — polecats step on each other's work, write conflicting code, and produce merge conflicts.
+**The system ENFORCES dependency declarations.** If you call gt_sling_batch with 2+ tasks and none of them have depends_on, **the call will fail with an error.** This is intentional — without depends_on, all polecats start simultaneously on the same codebase, produce merge conflicts, and fail.
+
+To express that tasks are genuinely independent, you must pass \`parallel: true\`. But this should be RARE — only when tasks touch completely different files with zero shared state.
 
 **The system uses depends_on to:**
-- Hold back blocked beads until their dependencies complete
+- Hold back blocked beads until their dependencies' reviews are merged
 - Dispatch beads in the correct order
-- Ensure each polecat builds on top of the previous polecat's work
+- Ensure each polecat builds on top of the previous polecat's merged work
 
-**Default assumption: most beads need depends_on.** Only omit depends_on when tasks are truly independent — they touch completely different files, have no shared state, and their output doesn't affect each other. This is RARE for feature work.
+**Default assumption: most beads need depends_on.** Only use \`parallel: true\` when tasks touch completely different files, have no shared state, and their output doesn't affect each other. This is RARE for feature work.
 
-**How to think about it:** Before slinging, ask yourself: "If this bead's polecat starts before bead X finishes, will it have the files/code/context it needs?" If the answer is no, add depends_on.
+**How to think about it:** Before slinging, ask yourself for EACH bead: "If this bead's polecat starts before bead X finishes AND its review is merged, will it have the files/code/context it needs?" If the answer is no, add depends_on.
 
 **Common patterns:**
 - **Foundation first:** Scaffolding, schemas, config → everything else depends on these
@@ -104,13 +106,13 @@ Tasks 1 and 2 both depend on 0 (the scaffold) but NOT on each other — they run
 
 User says: "Add formatCurrency, debounce, and throttle utility functions with tests"
 
-GOOD (no dependencies needed — all are genuinely independent):
-→ gt_sling_batch with convoy_title "Utility Functions" and tasks:
+GOOD (genuinely independent — uses parallel flag):
+→ gt_sling_batch with convoy_title "Utility Functions", parallel: true, and tasks:
   0. "Add formatCurrency(amount, locale) utility with tests"
   1. "Add debounce(fn, wait) utility with tests"
   2. "Add throttle(fn, limit) utility with tests"
 
-No depends_on needed — all three touch separate files with no shared state. This is the EXCEPTION, not the rule.
+parallel: true is required here because no task has depends_on. All three touch separate files with no shared state. This is the EXCEPTION, not the rule. Without parallel: true, this call would fail.
 
 **Example — serial feature work (common):**
 


### PR DESCRIPTION
## Summary

Two related fixes for convoy bead scheduling:

### 1. Block downstream beads until upstream reviews are merged

Fixes an off-by-one scheduling issue where convoy beads were dispatched before the refinery had reviewed and merged upstream work. The sequence was:

1. Polecat finishes bead A → `agentDone` closes bead A + creates MR bead
2. `dispatchUnblockedBeads` fires for bead B (depends on A) — A is closed, so B looks unblocked
3. Bead B dispatches immediately, but the refinery hasn't reviewed/merged A's work yet
4. Bead B's polecat starts on a codebase missing bead A's changes

Three fixes:
- **`hasUnresolvedBlockers` now checks for pending MR reviews.** A blocker bead is only "resolved" when it's closed AND has no open/in_progress `merge_request` child beads.
- **Alarm reordered: reviews before scheduling.** `processReviewQueue` and `processConvoyLandings` now run before `schedulePendingWork`.
- **`completeReviewWithResult` triggers dispatch.** When a review is merged, `dispatchUnblockedBeads` fires for the source bead so downstream beads dispatch immediately.

### 2. Require `depends_on` in convoys

The mayor kept dispatching convoys without dependency graphs. Added hard validation:
- `MayorSlingBatchBody` rejects multi-task convoys where no task declares `depends_on`
- New `parallel: true` flag opts out for genuinely independent tasks
- Mayor prompt updated to document the enforcement and the opt-out

## Verification

- [x] `pnpm typecheck` — passes
- [x] Integration tests (20/20 convoy-dag) — pass
- [x] Unit tests (55/55) — pass
- [x] ESLint on changed files — clean

## Visual Changes

N/A

## Reviewer Notes

The core insight for fix 1: "bead closed" previously meant "dependency resolved," but with the refinery review step, "bead closed" only means "polecat is done." The work isn't on the branch until the refinery merges it. `hasUnresolvedBlockers` now captures this distinction.

For fix 2: the `parallel` flag is deliberately opt-in (default false) to force the mayor to think about dependencies. The validation error message is actionable and explains both how to add dependencies and how to opt out.