### PR TITLE
chore: Adjust anonynmous usage limit to 600 API requests per day

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -54,5 +54,5 @@ export const FREE_MODEL_MAX_REQUESTS_PER_WINDOW = 200;
 // Stripe publishable key (client-side, inlined at build time)
 export const STRIPE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
 
-export const PROMOTION_MAX_REQUESTS = 10000;
+export const PROMOTION_MAX_REQUESTS = 600;
 export const PROMOTION_WINDOW_HOURS = 24;


### PR DESCRIPTION

### Description

Reduce PROMOTION_MAX_REQUESTS limit to 600 API calls/24 hours