### PR TITLE
Send feature details to abuse classifier

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -234,6 +234,11 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   console.debug(`Routing request to ${provider.id}`);
 
+  const isLegacyOpenRouterPath = url.pathname.includes('/openrouter');
+  const feature = validateFeatureHeader(
+    request.headers.get(FEATURE_HEADER) || (isLegacyOpenRouterPath ? '' : 'direct-gateway')
+  );
+
   // Start abuse classification early (non-blocking) - we'll await it before creating usage context
   const classifyPromise = classifyAbuse(request, requestBodyParsed, {
     kiloUserId: user.id,
@@ -241,6 +246,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     projectId,
     provider: provider.id,
     isByok: !!userByok,
+    feature,
   });
 
   // large responses may run longer than the 800s serverless function timeout, usually this value is set to 8192 tokens
@@ -264,7 +270,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // Extract properties for usage context
   const tokenEstimates = estimateChatTokens_ignoringToolDefinitions(requestBodyParsed);
   const promptInfo = extractPromptInfo(requestBodyParsed);
-  const isLegacyOpenRouterPath = url.pathname.includes('/openrouter');
 
   const usageContext: MicrodollarUsageContext = {
     kiloUserId: user.id,
@@ -288,9 +293,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     has_tools: (requestBodyParsed.tools?.length ?? 0) > 0,
     botId,
     tokenSource,
-    feature: validateFeatureHeader(
-      request.headers.get(FEATURE_HEADER) || (isLegacyOpenRouterPath ? '' : 'direct-gateway')
-    ),
+    feature,
     session_id: taskId ?? null,
     mode: modeHeader,
     auto_model: autoModel,

--- a/src/lib/abuse-service.ts
+++ b/src/lib/abuse-service.ts
@@ -11,6 +11,7 @@ import {
 import { getFraudDetectionHeaders } from '@/lib/utils';
 import type { OpenRouterChatCompletionRequest } from '@/lib/providers/openrouter/types';
 import type { AuthProviderId } from '@/lib/auth/provider-metadata';
+import type { FeatureValue } from '@/lib/feature-detection';
 import 'server-only';
 
 /**
@@ -183,6 +184,7 @@ export type UsagePayload = {
   is_byok?: boolean | null;
   is_user_byok?: boolean | null;
   editor_name?: string | null;
+  feature?: string | null;
 
   // Existing classification (if any)
   abuse_classification?: number | null;
@@ -332,6 +334,7 @@ export type AbuseClassificationContext = {
   projectId?: string | null;
   provider?: string | null;
   isByok?: boolean | null;
+  feature?: FeatureValue | null;
 };
 
 /**
@@ -372,6 +375,7 @@ export async function classifyAbuse(
     streamed: body.stream === true,
     is_user_byok: context?.isByok ?? null,
     editor_name: request.headers.get('x-kilocode-editorname') ?? null,
+    feature: context?.feature ?? null,
   };
 
   return classifyRequest(payload);


### PR DESCRIPTION
## Summary

In support of my RFC around making a public profile page (https://github.com/Kilo-Org/cloud/pull/899), this will send feature information to the abuse service at abuse.kiloapps.io so that we can collect data about a user's feature usage and report that out in a public profile optionally.

This pairs with this PR to the abuse service to store this information: https://github.com/Kilo-Org/abuse/pull/36