### PR TITLE
feat(gastown): replace binary is_admin gate with PostHog feature flags

### DIFF
--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -174,6 +174,21 @@ export class GastownClient {
       body: JSON.stringify({ summary }),
     });
   }
+
+  /**
+   * Resolve a triage_request bead with the chosen action and notes.
+   * The TownDO closes the triage request and executes any side effects.
+   */
+  async resolveTriage(input: {
+    triage_request_bead_id: string;
+    action: string;
+    resolution_notes: string;
+  }): Promise<Bead> {
+    return this.request<Bead>(this.rigPath('/triage/resolve'), {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
 }
 
 /**

--- a/cloudflare-gastown/container/plugin/tools.ts
+++ b/cloudflare-gastown/container/plugin/tools.ts
@@ -184,5 +184,32 @@ export function createTools(client: GastownClient) {
         return `Advanced to step ${result.currentStep + 1} of ${result.totalSteps}.`;
       },
     }),
+
+    gt_triage_resolve: tool({
+      description:
+        'Resolve a triage request with your chosen action. The TownDO will execute ' +
+        'the action (restart agent, close bead, escalate, etc.) and close the triage request.',
+      args: {
+        triage_request_bead_id: tool.schema
+          .string()
+          .describe('The UUID of the triage_request bead to resolve'),
+        action: tool.schema
+          .string()
+          .describe(
+            'The chosen action from the available options (e.g. RESTART, ESCALATE_TO_MAYOR, CLOSE_BEAD)'
+          ),
+        resolution_notes: tool.schema
+          .string()
+          .describe('Brief explanation of your reasoning for choosing this action'),
+      },
+      async execute(args) {
+        const bead = await client.resolveTriage({
+          triage_request_bead_id: args.triage_request_bead_id,
+          action: args.action,
+          resolution_notes: args.resolution_notes,
+        });
+        return `Triage request ${args.triage_request_bead_id} resolved with action: ${args.action}`;
+      },
+    }),
   };
 }

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -30,7 +30,7 @@ export type Bead = {
   closed_at: string | null;
 };
 
-export type AgentRole = 'polecat' | 'refinery' | 'mayor' | 'witness';
+export type AgentRole = 'polecat' | 'refinery' | 'mayor';
 export type AgentStatus = 'idle' | 'working' | 'stalled' | 'dead';
 
 export type Agent = {

--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -1,7 +1,7 @@
 import type { Config } from '@kilocode/sdk';
 import { z } from 'zod';
 import { writeFile } from 'node:fs/promises';
-import { cloneRepo, createWorktree } from './git-manager';
+import { cloneRepo, createWorktree, setupRigBrowseWorktree } from './git-manager';
 import { startAgent } from './process-manager';
 import { getCurrentTownConfig } from './control-server';
 import type { ManagedAgent, StartAgentRequest } from './types';
@@ -210,15 +210,16 @@ async function configureGitCredentials(
  * is available, call the Next.js server to resolve fresh credentials.
  * Returns the (potentially enriched) envVars.
  */
-async function resolveGitCredentialsIfMissing(
-  request: StartAgentRequest
-): Promise<Record<string, string>> {
-  const envVars = { ...(request.envVars ?? {}) };
+export async function resolveGitCredentials(params: {
+  envVars?: Record<string, string>;
+  platformIntegrationId?: string;
+}): Promise<Record<string, string>> {
+  const envVars = { ...(params.envVars ?? {}) };
   const hasToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
 
   if (hasToken) return envVars;
 
-  const integrationId = request.platformIntegrationId;
+  const integrationId = params.platformIntegrationId;
   const kiloToken = envVars.KILOCODE_TOKEN;
   // The Next.js server URL — in dev it's localhost:3000, in prod it's the main app URL.
   // We derive it from KILO_API_URL (the gateway URL) or fall back to localhost.
@@ -361,6 +362,58 @@ async function createMayorWorkspace(rigId: string): Promise<string> {
 }
 
 /**
+ * Write the mayor's system prompt to AGENTS.md in the workspace.
+ *
+ * kilo/opencode reads AGENTS.md from the project root for ALL sessions,
+ * including built-in sub-agents (explore, general). By writing the full
+ * system prompt here instead of passing it via the session.prompt API,
+ * the mayor and all its sub-agents share the exact same instructions.
+ *
+ * The system prompt comes from the TownDO (buildMayorSystemPrompt) and
+ * is the single source of truth. When it changes (gastown updates,
+ * user customization), the TownDO sends the updated prompt and we
+ * rewrite this file.
+ */
+async function writeMayorSystemPromptToAgentsMd(
+  workspaceDir: string,
+  systemPrompt: string
+): Promise<void> {
+  const { writeFile, readdir, stat } = await import('node:fs/promises');
+  const path = await import('node:path');
+
+  // Append a dynamic section listing discovered browse worktrees so
+  // sub-agents know where to find rig codebases.
+  const rigsRoot = '/workspace/rigs';
+  let rigDirs: string[] = [];
+  try {
+    rigDirs = await readdir(rigsRoot);
+  } catch {
+    // No rigs directory yet
+  }
+
+  const browseEntries: string[] = [];
+  for (const entry of rigDirs) {
+    if (entry.startsWith('mayor-')) continue;
+    const browseDir = path.join(rigsRoot, entry, 'browse');
+    try {
+      const s = await stat(browseDir);
+      if (s.isDirectory()) {
+        browseEntries.push(`- **${entry}**: \`${browseDir}\``);
+      }
+    } catch {
+      // No browse worktree yet
+    }
+  }
+
+  const browseSuffix =
+    browseEntries.length > 0
+      ? `\n\n## Discovered Browse Worktrees\n\n${browseEntries.join('\n')}`
+      : '';
+
+  await writeFile(path.join(workspaceDir, 'AGENTS.md'), systemPrompt + browseSuffix);
+}
+
+/**
  * Run the full agent startup sequence:
  * 1. Clone/fetch the rig's git repo (or create minimal workspace for mayor)
  * 2. Create an isolated worktree for the agent's branch
@@ -368,17 +421,54 @@ async function createMayorWorkspace(rigId: string): Promise<string> {
  * 4. Start a kilo serve instance for the worktree (or reuse existing)
  * 5. Create a session and send the initial prompt via HTTP API
  */
-export async function runAgent(request: StartAgentRequest): Promise<ManagedAgent> {
+export async function runAgent(originalRequest: StartAgentRequest): Promise<ManagedAgent> {
+  let request = originalRequest;
   let workdir: string;
 
   if (request.role === 'mayor') {
     // Mayor doesn't need a repo clone — just a git-initialized directory
     workdir = await createMayorWorkspace(request.rigId);
+
+    // On fresh containers the browse worktrees won't exist yet. Set them
+    // up for all known rigs before writing AGENTS.md so the mayor (and its
+    // sub-agents) can immediately browse codebases.
+    if (request.rigs?.length) {
+      const envVars = await resolveGitCredentials(request);
+      await Promise.allSettled(
+        request.rigs.map(async rig => {
+          try {
+            await setupRigBrowseWorktree({
+              rigId: rig.rigId,
+              gitUrl: rig.gitUrl,
+              defaultBranch: rig.defaultBranch,
+              envVars,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+            console.warn(`[runAgent] browse worktree setup failed for rig=${rig.rigId}: ${msg}`);
+          }
+        })
+      );
+    }
+
+    // Write the system prompt to AGENTS.md so the mayor AND its built-in
+    // sub-agents (explore, general) all share the same instructions.
+    // The system prompt is NOT passed via the session.prompt API — AGENTS.md
+    // is the sole source of truth for the mayor's instructions.
+    if (request.systemPrompt) {
+      await writeMayorSystemPromptToAgentsMd(workdir, request.systemPrompt);
+    }
   } else {
     // Resolve git credentials if missing. When the town config doesn't have
     // a token (common on first dispatch after rig creation), fetch one from
     // the Next.js server using the platform_integration_id.
-    const envVars = await resolveGitCredentialsIfMissing(request);
+    const envVars = await resolveGitCredentials(request);
+
+    // Merge resolved credentials back into the request so buildAgentEnv
+    // can propagate GIT_TOKEN/GH_TOKEN to the spawned kilo serve process.
+    // Without this, rigs using platformIntegrationId would clone successfully
+    // but the agent session itself would lack git push / gh credentials.
+    request = { ...request, envVars };
 
     await cloneRepo({
       rigId: request.rigId,
@@ -390,6 +480,8 @@ export async function runAgent(request: StartAgentRequest): Promise<ManagedAgent
     workdir = await createWorktree({
       rigId: request.rigId,
       branch: request.branch,
+      startPoint: request.startPoint,
+      defaultBranch: request.defaultBranch,
     });
 
     // Set up git credentials so the agent can push
@@ -401,5 +493,13 @@ export async function runAgent(request: StartAgentRequest): Promise<ManagedAgent
 
   const env = buildAgentEnv(request);
 
-  return startAgent(request, workdir, env);
+  // For the mayor, the system prompt lives in AGENTS.md (written above)
+  // so all sessions — including sub-agents — share it. Don't also pass
+  // it via the session.prompt API to avoid duplication. Setting to
+  // undefined (not '') so the SDK omits it entirely and kilo serve
+  // uses its default system prompt + AGENTS.md, rather than treating
+  // an empty string as an explicit override.
+  const startRequest = request.role === 'mayor' ? { ...request, systemPrompt: undefined } : request;
+
+  return startAgent(startRequest, workdir, env);
 }

--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -433,10 +433,16 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
     // up for all known rigs before writing AGENTS.md so the mayor (and its
     // sub-agents) can immediately browse codebases.
     if (request.rigs?.length) {
-      const envVars = await resolveGitCredentials(request);
+      // Resolve credentials per-rig since each may use a different
+      // GitHub App installation (platformIntegrationId).
+      const baseEnvVars = request.envVars ?? {};
       await Promise.allSettled(
         request.rigs.map(async rig => {
           try {
+            const envVars = await resolveGitCredentials({
+              envVars: baseEnvVars,
+              platformIntegrationId: rig.platformIntegrationId,
+            });
             await setupRigBrowseWorktree({
               rigId: rig.rigId,
               gitUrl: rig.gitUrl,

--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { runAgent } from './agent-runner';
+import { runAgent, resolveGitCredentials } from './agent-runner';
 import {
   stopAgent,
   sendMessage,
@@ -13,8 +13,8 @@ import {
   registerEventSink,
 } from './process-manager';
 import { startHeartbeat, stopHeartbeat } from './heartbeat';
-import { mergeBranch } from './git-manager';
-import { StartAgentRequest, SendMessageRequest, MergeRequest } from './types';
+import { mergeBranch, setupRigBrowseWorktree } from './git-manager';
+import { StartAgentRequest, SendMessageRequest, MergeRequest, SetupRepoRequest } from './types';
 import type {
   AgentStatusResponse,
   HealthResponse,
@@ -105,7 +105,7 @@ app.post('/agents/start', async c => {
   console.log(
     `[control-server] /agents/start: role=${parsed.data.role} name=${parsed.data.name} rigId=${parsed.data.rigId} agentId=${parsed.data.agentId}`
   );
-  console.log(`[control-server] system prompt length: ${parsed.data.systemPrompt.length}`);
+  console.log(`[control-server] system prompt length: ${parsed.data.systemPrompt?.length ?? 0}`);
 
   try {
     const agent = await runAgent(parsed.data);
@@ -227,6 +227,53 @@ export function consumeStreamTicket(ticket: string): string | null {
   if (entry.expiresAt < Date.now()) return null;
   return entry.agentId;
 }
+
+// POST /repos/setup
+// Proactively clone a rig's repo and create a browse worktree so the
+// mayor (and future agents) have immediate access to the codebase.
+// Called by the TownDO when a new rig is added.
+app.post('/repos/setup', async c => {
+  const body: unknown = await c.req.json().catch(() => null);
+  const parsed = SetupRepoRequest.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request body', issues: parsed.error.issues }, 400);
+  }
+
+  const req = parsed.data;
+  console.log(`[control-server] /repos/setup: rigId=${req.rigId} gitUrl=${req.gitUrl}`);
+
+  // Run in background so we return 202 immediately.
+  // Errors are caught and logged — never propagated as unhandled rejections.
+  const doSetup = async () => {
+    try {
+      // Resolve git credentials from platformIntegrationId if no token
+      // is present in envVars (e.g. rigs using GitHub App installations).
+      const envVars = await resolveGitCredentials({
+        envVars: req.envVars,
+        platformIntegrationId: req.platformIntegrationId,
+      });
+
+      const browseDir = await setupRigBrowseWorktree({
+        rigId: req.rigId,
+        gitUrl: req.gitUrl,
+        defaultBranch: req.defaultBranch,
+        envVars,
+      });
+      console.log(`[control-server] /repos/setup: done rigId=${req.rigId} browse=${browseDir}`);
+    } catch (err) {
+      // Log as a warning, not an error — this is a best-effort background
+      // operation. The mayor and agents can still function without the
+      // browse worktree; it will be retried on the next agent dispatch.
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[control-server] /repos/setup: FAILED for rigId=${req.rigId}: ${message.split('\n')[0]}`
+      );
+    }
+  };
+  doSetup().catch(() => {});
+
+  return c.json({ status: 'accepted', message: 'Repo setup started' }, 202);
+});
 
 // POST /git/merge
 // Deterministic merge of a polecat branch into the target branch.

--- a/cloudflare-gastown/container/src/git-manager.ts
+++ b/cloudflare-gastown/container/src/git-manager.ts
@@ -142,6 +142,13 @@ async function exec(cmd: string, args: string[], cwd?: string): Promise<string> 
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
+    env: {
+      ...process.env,
+      // Prevent git from prompting for credentials in the container.
+      // Public repos clone without auth; private repos fail fast with
+      // a clear error instead of hanging on a username prompt.
+      GIT_TERMINAL_PROMPT: '0',
+    },
   });
 
   const exitCode = await proc.exited;
@@ -246,10 +253,27 @@ async function createWorktreeInner(options: WorktreeOptions): Promise<string> {
     return dir;
   }
 
+  // When a startPoint is provided (e.g. a convoy feature branch), create
+  // the new branch from that ref so the agent begins with the latest
+  // merged work from upstream. Without a startPoint, try to track the
+  // remote branch or fall back to the repo's current HEAD.
+  const startPoint = options.startPoint;
   try {
-    await exec('git', ['branch', '--track', options.branch, `origin/${options.branch}`], repo);
+    if (startPoint) {
+      await exec('git', ['branch', options.branch, startPoint], repo);
+    } else {
+      await exec('git', ['branch', '--track', options.branch, `origin/${options.branch}`], repo);
+    }
   } catch {
-    await exec('git', ['branch', options.branch], repo);
+    // Fall back to origin/<defaultBranch> so we always branch from the
+    // latest remote tip rather than the repo's local HEAD (which may be
+    // stale in a --no-checkout bare clone).
+    const fallback = options.defaultBranch ? `origin/${options.defaultBranch}` : undefined;
+    if (fallback) {
+      await exec('git', ['branch', options.branch, fallback], repo);
+    } else {
+      await exec('git', ['branch', options.branch], repo);
+    }
   }
 
   await exec('git', ['worktree', 'add', dir, options.branch], repo);
@@ -284,6 +308,64 @@ export async function listWorktrees(rigId: string): Promise<string[]> {
     .split('\n')
     .filter(line => line.startsWith('worktree '))
     .map(line => line.replace('worktree ', ''));
+}
+
+/**
+ * Create (or update) a read-only browse worktree for a rig on its default branch.
+ * This gives the mayor agent a checked-out view of the codebase at
+ * `/workspace/rigs/<rigId>/browse/` that it can navigate into via external_directory.
+ *
+ * If the browse worktree already exists, pulls latest from the remote.
+ */
+export function setupRigBrowseWorktree(
+  options: CloneOptions & { envVars?: Record<string, string> }
+): Promise<string> {
+  return withRigLock(options.rigId, async () => {
+    // Ensure the repo is cloned/up-to-date first
+    await cloneRepoInner(options);
+    return setupBrowseWorktreeInner(options.rigId, options.defaultBranch);
+  });
+}
+
+async function setupBrowseWorktreeInner(rigId: string, defaultBranch: string): Promise<string> {
+  validatePathSegment(rigId, 'rigId');
+  const repo = await repoDir(rigId);
+  const browseDir = resolve(WORKSPACE_ROOT, rigId, 'browse');
+  await assertInsideWorkspace(browseDir);
+
+  if (await pathExists(browseDir)) {
+    // Already exists — pull latest. Log failures so callers know the
+    // browse worktree may contain stale code.
+    try {
+      await exec('git', ['checkout', defaultBranch], browseDir);
+      await exec('git', ['pull', '--rebase', '--autostash'], browseDir);
+      console.log(`Updated browse worktree for rig ${rigId} at ${browseDir}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+      console.warn(`Browse worktree refresh failed for rig ${rigId} (may be stale): ${msg}`);
+    }
+    return browseDir;
+  }
+
+  // Create a worktree on the default branch for browsing.
+  // Force-create (or reset) the tracking branch to origin/<defaultBranch>
+  // so a recreated browse worktree always starts from the latest remote
+  // tip rather than a stale local ref.
+  const trackingBranch = `browse-${rigId.slice(0, 8)}`;
+  try {
+    await exec(
+      'git',
+      ['branch', '--force', '--track', trackingBranch, `origin/${defaultBranch}`],
+      repo
+    );
+  } catch {
+    // --force --track may fail on very old git; fall back to create-or-reset
+    await exec('git', ['branch', '-f', trackingBranch, `origin/${defaultBranch}`], repo);
+  }
+
+  await exec('git', ['worktree', 'add', browseDir, trackingBranch], repo);
+  console.log(`Created browse worktree for rig ${rigId} at ${browseDir}`);
+  return browseDir;
 }
 
 export type MergeOutcome = {

--- a/cloudflare-gastown/container/src/git-manager.ts
+++ b/cloudflare-gastown/container/src/git-manager.ts
@@ -334,11 +334,12 @@ async function setupBrowseWorktreeInner(rigId: string, defaultBranch: string): P
   await assertInsideWorkspace(browseDir);
 
   if (await pathExists(browseDir)) {
-    // Already exists — pull latest. Log failures so callers know the
-    // browse worktree may contain stale code.
+    // Already exists — fetch latest and reset the tracking branch to
+    // origin/<defaultBranch>. The worktree lives on the synthetic
+    // browse-<rigId> branch, not on <defaultBranch> directly.
     try {
-      await exec('git', ['checkout', defaultBranch], browseDir);
-      await exec('git', ['pull', '--rebase', '--autostash'], browseDir);
+      await exec('git', ['fetch', 'origin', defaultBranch], browseDir);
+      await exec('git', ['reset', '--hard', `origin/${defaultBranch}`], browseDir);
       console.log(`Updated browse worktree for rig ${rigId} at ${browseDir}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -34,6 +34,7 @@ export const StartAgentRequest = z.object({
         rigId: z.string(),
         gitUrl: z.string(),
         defaultBranch: z.string(),
+        platformIntegrationId: z.string().optional(),
       })
     )
     .optional(),

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // ── Agent roles (mirrors worker types) ──────────────────────────────────
 
-export const AgentRole = z.enum(['mayor', 'polecat', 'refinery', 'witness']);
+export const AgentRole = z.enum(['mayor', 'polecat', 'refinery']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 // ── Control server request/response schemas ─────────────────────────────
@@ -18,13 +18,25 @@ export const StartAgentRequest = z.object({
   model: z.string(),
   /** Lightweight model for title generation, explore subagent, etc. */
   smallModel: z.string().optional(),
-  systemPrompt: z.string(),
+  systemPrompt: z.string().optional(),
   gitUrl: z.string(),
   branch: z.string(),
   defaultBranch: z.string(),
   envVars: z.record(z.string(), z.string()).optional(),
   /** Platform integration ID for resolving fresh git credentials at startup */
   platformIntegrationId: z.string().optional(),
+  /** Git ref to branch from (e.g. convoy feature branch). Falls back to HEAD if absent. */
+  startPoint: z.string().optional(),
+  /** Rig list for mayor agents — used to set up browse worktrees on fresh containers. */
+  rigs: z
+    .array(
+      z.object({
+        rigId: z.string(),
+        gitUrl: z.string(),
+        defaultBranch: z.string(),
+      })
+    )
+    .optional(),
 });
 export type StartAgentRequest = z.infer<typeof StartAgentRequest>;
 
@@ -254,7 +266,23 @@ export type CloneOptions = {
 export type WorktreeOptions = {
   rigId: string;
   branch: string;
+  /** Optional start point for the new branch (e.g. 'origin/main' or a feature branch ref). */
+  startPoint?: string;
+  /** Default branch name, used as fallback start point (e.g. 'main'). */
+  defaultBranch?: string;
 };
+
+// ── Repo setup (proactive clone + browse worktree) ──────────────────────
+
+export const SetupRepoRequest = z.object({
+  rigId: z.string().min(1),
+  gitUrl: z.string().min(1),
+  defaultBranch: z.string().min(1),
+  envVars: z.record(z.string(), z.string()).optional(),
+  /** Platform integration ID for resolving git credentials when no token is in envVars */
+  platformIntegrationId: z.string().optional(),
+});
+export type SetupRepoRequest = z.infer<typeof SetupRepoRequest>;
 
 // ── Heartbeat ───────────────────────────────────────────────────────────
 

--- a/cloudflare-gastown/src/db/tables/agent-metadata.table.ts
+++ b/cloudflare-gastown/src/db/tables/agent-metadata.table.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
 
-const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness']);
-const AgentProcessStatus = z.enum(['idle', 'working', 'stalled', 'dead']);
+// Accept legacy role values (e.g. 'witness' from pre-#442 towns) so that
+// queries parsing through AgentMetadataRecord don't throw on old rows.
+// Application code should only create the known roles below.
+const AgentRole = z.enum(['polecat', 'refinery', 'mayor']).or(z.string());
+const AgentProcessStatus = z.enum(['idle', 'working', 'stalled', 'dead']).or(z.string());
 
 export const AgentMetadataRecord = z.object({
   bead_id: z.string(),
@@ -32,13 +35,16 @@ export type AgentMetadataRecord = z.output<typeof AgentMetadataRecord>;
 
 export const agent_metadata = getTableFromZodSchema('agent_metadata', AgentMetadataRecord);
 
+// CHECK constraints are intentionally omitted — Cloudflare DO SQLite
+// provides no way to alter CHECK constraints on existing tables, and
+// Zod validates all values at the application layer. See #442.
 export function createTableAgentMetadata(): string {
   return getCreateTableQueryFromTable(agent_metadata, {
     bead_id: `text primary key references beads(bead_id)`,
-    role: `text not null check(role in ('polecat', 'refinery', 'mayor', 'witness'))`,
+    role: `text not null`,
     identity: `text not null unique`,
     container_process_id: `text`,
-    status: `text not null default 'idle' check(status in ('idle', 'working', 'stalled', 'dead'))`,
+    status: `text not null default 'idle'`,
     current_hook_bead_id: `text references beads(bead_id)`,
     dispatch_attempts: `integer not null default 0`,
     checkpoint: `text`,

--- a/cloudflare-gastown/src/db/tables/beads.table.ts
+++ b/cloudflare-gastown/src/db/tables/beads.table.ts
@@ -110,17 +110,20 @@ export type BeadRecordWithMetadata = z.output<typeof BeadRecordWithMetadata>;
 
 export const beads = getTableFromZodSchema('beads', BeadRecord);
 
+// CHECK constraints are intentionally omitted — Cloudflare DO SQLite
+// provides no way to alter CHECK constraints on existing tables, and
+// Zod validates all values at the application layer. See #442.
 export function createTableBeads(): string {
   return getCreateTableQueryFromTable(beads, {
     bead_id: `text primary key`,
-    type: `text not null check(type in ('issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'))`,
-    status: `text not null default 'open' check(status in ('open', 'in_progress', 'closed', 'failed'))`,
+    type: `text not null`,
+    status: `text not null default 'open'`,
     title: `text not null`,
     body: `text`,
     rig_id: `text`,
     parent_bead_id: `text references beads(bead_id)`,
     assignee_agent_bead_id: `text`,
-    priority: `text default 'medium' check(priority in ('low', 'medium', 'high', 'critical'))`,
+    priority: `text default 'medium'`,
     labels: `text default '[]'`,
     metadata: `text default '{}'`,
     created_by: `text`,

--- a/cloudflare-gastown/src/db/tables/rig-agents.table.ts
+++ b/cloudflare-gastown/src/db/tables/rig-agents.table.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
 
-const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness']);
+const AgentRole = z.enum(['polecat', 'refinery', 'mayor']);
 const AgentStatus = z.enum(['idle', 'working', 'blocked', 'dead']);
 
 export const RigAgentRecord = z.object({
@@ -31,10 +31,10 @@ export function createTableRigAgents(): string {
   return getCreateTableQueryFromTable(rig_agents, {
     id: `text primary key`,
     rig_id: `text`,
-    role: `text not null check(role in ('polecat', 'refinery', 'mayor', 'witness'))`,
+    role: `text not null`,
     name: `text not null`,
     identity: `text not null unique`,
-    status: `text not null default 'idle' check(status in ('idle', 'working', 'blocked', 'dead'))`,
+    status: `text not null default 'idle'`,
     current_hook_bead_id: `text references rig_beads(id)`,
     dispatch_attempts: `integer not null default 0`,
     last_activity_at: `text`,

--- a/cloudflare-gastown/src/dos/GastownUser.do.ts
+++ b/cloudflare-gastown/src/dos/GastownUser.do.ts
@@ -2,8 +2,12 @@ import { DurableObject } from 'cloudflare:workers';
 import { createTableUserTowns, user_towns, UserTownRecord } from '../db/tables/user-towns.table';
 import { createTableUserRigs, user_rigs, UserRigRecord } from '../db/tables/user-rigs.table';
 import { query } from '../util/query.util';
+import { getTownDOStub } from './Town.do';
 
 const USER_LOG = '[GastownUser.do]';
+
+/** Health watchdog interval — check town alarms every 5 minutes */
+const WATCHDOG_INTERVAL_MS = 5 * 60_000;
 
 function generateId(): string {
   return crypto.randomUUID();
@@ -49,6 +53,9 @@ export class GastownUserDO extends DurableObject<Env> {
   private async initializeDatabase(): Promise<void> {
     query(this.sql, createTableUserTowns(), []);
     query(this.sql, createTableUserRigs(), []);
+    // Arm the watchdog on every initialization so existing users (who
+    // created towns before the watchdog was added) get health checks.
+    await this.armWatchdogIfNeeded();
   }
 
   // ── Towns ─────────────────────────────────────────────────────────────
@@ -78,6 +85,9 @@ export class GastownUserDO extends DurableObject<Env> {
     console.log(`${USER_LOG} createTown: created town id=${town.id}`);
     // TODO: Should create the Town DO now, call setTownId, and then some function like ensureContainer
     // In the background, this way the town will likely be ready to go when the user gets to the UI
+
+    // Arm the health watchdog so it starts checking this town's alarm
+    await this.armWatchdogIfNeeded();
 
     return town;
   }
@@ -222,6 +232,57 @@ export class GastownUserDO extends DurableObject<Env> {
 
   async ping(): Promise<string> {
     return 'pong';
+  }
+
+  // ── Health Watchdog ───────────────────────────────────────────────────
+
+  /**
+   * Arm the watchdog alarm if this user has any towns. Called after
+   * creating a town to ensure the watchdog runs.
+   */
+  private async armWatchdogIfNeeded(): Promise<void> {
+    const currentAlarm = await this.ctx.storage.getAlarm();
+    if (!currentAlarm || currentAlarm < Date.now()) {
+      const towns = UserTownRecord.array().parse([
+        ...query(this.sql, /* sql */ `SELECT * FROM ${user_towns} LIMIT 1`, []),
+      ]);
+      if (towns.length > 0) {
+        await this.ctx.storage.setAlarm(Date.now() + WATCHDOG_INTERVAL_MS);
+      }
+    }
+  }
+
+  /**
+   * Watchdog alarm: periodically ping each town's TownDO to verify its
+   * alarm is firing and re-arm it if not. This is the external observer
+   * that catches a silently broken alarm handler.
+   *
+   * See #442 — replaces the Boot agent's role from local Gastown.
+   */
+  async alarm(): Promise<void> {
+    await this.ensureInitialized();
+    const towns = UserTownRecord.array().parse([
+      ...query(this.sql, /* sql */ `SELECT * FROM ${user_towns}`, []),
+    ]);
+
+    if (towns.length === 0) return;
+
+    console.log(`${USER_LOG} watchdog: checking ${towns.length} town(s)`);
+
+    for (const town of towns) {
+      try {
+        const townStub = getTownDOStub(this.env, town.id);
+        const health = await townStub.healthCheck();
+        if (!health.alarmSet) {
+          console.warn(`${USER_LOG} watchdog: re-armed alarm for town=${town.id} (was missing)`);
+        }
+      } catch (err) {
+        console.error(`${USER_LOG} watchdog: healthCheck failed for town=${town.id}:`, err);
+      }
+    }
+
+    // Re-arm the watchdog
+    await this.ctx.storage.setAlarm(Date.now() + WATCHDOG_INTERVAL_MS);
   }
 }
 

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -70,11 +70,12 @@ const TOWN_LOG = '[Town.do]';
 
 /** Format a bead_events row into a human-readable message for the status feed. */
 function formatEventMessage(row: Record<string, unknown>): string {
-  const eventType = String(row.event_type ?? '');
-  const beadTitle = row.bead_title ? String(row.bead_title) : null;
-  const newValue = row.new_value ? String(row.new_value) : null;
-  const agentId = row.agent_id ? String(row.agent_id).slice(0, 8) : null;
-  const beadId = row.bead_id ? String(row.bead_id).slice(0, 8) : null;
+  const s = (v: unknown) => (v == null ? '' : `${v as string}`);
+  const eventType = s(row.event_type);
+  const beadTitle = row.bead_title ? s(row.bead_title) : null;
+  const newValue = row.new_value ? s(row.new_value) : null;
+  const agentId = row.agent_id ? s(row.agent_id).slice(0, 8) : null;
+  const beadId = row.bead_id ? s(row.bead_id).slice(0, 8) : null;
 
   const target = beadTitle ? `"${beadTitle}"` : beadId ? `bead ${beadId}…` : 'unknown';
   const actor = agentId ? `agent ${agentId}…` : 'system';
@@ -3138,7 +3139,7 @@ export class TownDO extends DurableObject<Env> {
     ];
     const agentCounts = { working: 0, idle: 0, stalled: 0, dead: 0, total: 0 };
     for (const row of agentRows) {
-      const s = String(row.status);
+      const s = `${row.status as string}`;
       const c = Number(row.cnt);
       if (s in agentCounts) (agentCounts as Record<string, number>)[s] = c;
       agentCounts.total += c;
@@ -3159,7 +3160,7 @@ export class TownDO extends DurableObject<Env> {
     ];
     const beadCounts = { open: 0, inProgress: 0, failed: 0, triageRequests: 0 };
     for (const row of beadRows) {
-      const s = String(row.status);
+      const s = `${row.status as string}`;
       const c = Number(row.cnt);
       if (s === 'open') beadCounts.open = c;
       else if (s === 'in_progress') beadCounts.inProgress = c;
@@ -3241,8 +3242,8 @@ export class TownDO extends DurableObject<Env> {
     ];
 
     const recentEvents = recentRows.map(row => ({
-      time: String(row.created_at),
-      type: String(row.event_type),
+      time: `${row.created_at as string}`,
+      type: `${row.event_type as string}`,
       message: formatEventMessage(row),
     }));
 

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2570,9 +2570,17 @@ export class TownDO extends DurableObject<Env> {
         `convoyMode=${convoyMergeMode ?? 'standalone'} gates=${gates.length}`
     );
 
-    // Always spawn a refinery agent — it handles quality gates (if any),
-    // code review, and the merge/PR creation step via CLI tools.
+    // Get or create the per-rig refinery. If it already exists and is busy
+    // (processing another review), put the entry back to 'open' so it gets
+    // retried on the next alarm cycle.
     const refineryAgent = agents.getOrCreateAgent(this.sql, 'refinery', rigId, this.townId);
+    if (refineryAgent.status !== 'idle') {
+      console.log(
+        `${TOWN_LOG} processReviewQueue: refinery for rig=${rigId} is ${refineryAgent.status}, re-queuing entry=${entry.id}`
+      );
+      beadOps.updateBeadStatus(this.sql, entry.id, 'open', 'system');
+      return;
+    }
 
     const { buildRefinerySystemPrompt } = await import('../prompts/refinery-system.prompt');
     const systemPrompt = buildRefinerySystemPrompt({

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -920,10 +920,14 @@ export class TownDO extends DurableObject<Env> {
 
     // If this triage request was created for an escalation, close the
     // linked escalation bead too so it doesn't sit open indefinitely.
-    const escalationBeadId =
-      typeof triageBead.metadata?.escalation_bead_id === 'string'
-        ? triageBead.metadata.escalation_bead_id
+    // The escalation_bead_id is nested under metadata.context (set by
+    // createTriageRequest's TriageRequestMetadata structure).
+    const ctx =
+      typeof triageBead.metadata?.context === 'object' && triageBead.metadata.context !== null
+        ? (triageBead.metadata.context as Record<string, unknown>)
         : null;
+    const escalationBeadId =
+      typeof ctx?.escalation_bead_id === 'string' ? ctx.escalation_bead_id : null;
     if (escalationBeadId) {
       beadOps.updateBeadStatus(this.sql, escalationBeadId, 'closed', input.agent_id);
     }
@@ -2694,6 +2698,7 @@ export class TownDO extends DurableObject<Env> {
 
     if (!started) {
       agents.unhookBead(this.sql, refineryAgent.id);
+      agents.updateAgentStatus(this.sql, refineryAgent.id, 'idle');
       console.error(
         `${TOWN_LOG} processReviewQueue: refinery agent failed to start for entry=${entry.id}`
       );

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -24,6 +24,7 @@ import * as reviewQueue from './town/review-queue';
 import * as config from './town/config';
 import * as rigs from './town/rigs';
 import * as dispatch from './town/container-dispatch';
+import * as patrol from './town/patrol';
 import { GitHubPRStatusSchema, GitLabMRStatusSchema } from '../util/platform-pr.util';
 
 // Table imports for beads-centric operations
@@ -67,11 +68,39 @@ import type {
 
 const TOWN_LOG = '[Town.do]';
 
+/** Format a bead_events row into a human-readable message for the status feed. */
+function formatEventMessage(row: Record<string, unknown>): string {
+  const eventType = String(row.event_type ?? '');
+  const beadTitle = row.bead_title ? String(row.bead_title) : null;
+  const newValue = row.new_value ? String(row.new_value) : null;
+  const agentId = row.agent_id ? String(row.agent_id).slice(0, 8) : null;
+  const beadId = row.bead_id ? String(row.bead_id).slice(0, 8) : null;
+
+  const target = beadTitle ? `"${beadTitle}"` : beadId ? `bead ${beadId}…` : 'unknown';
+  const actor = agentId ? `agent ${agentId}…` : 'system';
+
+  switch (eventType) {
+    case 'status_changed':
+      return `${target} → ${newValue ?? '?'} (by ${actor})`;
+    case 'assigned':
+      return `${target} assigned to ${actor}`;
+    case 'pr_created':
+      return `PR created for ${target}`;
+    case 'pr_merged':
+      return `PR merged for ${target}`;
+    case 'pr_creation_failed':
+      return `PR creation failed for ${target}`;
+    case 'escalation_created':
+      return `Escalation created: ${target}`;
+    default:
+      return `${eventType}: ${target}`;
+  }
+}
+
 // Alarm intervals
 const ACTIVE_ALARM_INTERVAL_MS = 5_000; // 5s when agents are active
 const IDLE_ALARM_INTERVAL_MS = 1 * 60_000; // 1m when idle
 const DISPATCH_COOLDOWN_MS = 2 * 60_000; // 2 min — skip agents with recent dispatch activity
-const GUPP_THRESHOLD_MS = 30 * 60_000; // 30 min
 const MAX_DISPATCH_ATTEMPTS = 5;
 
 // Escalation constants
@@ -188,6 +217,86 @@ export class TownDO extends DurableObject<Env> {
       await this.ensureInitialized();
     });
   }
+
+  // ── WebSocket: status broadcast ──────────────────────────────────────
+
+  /**
+   * Handle HTTP requests to the DO. Only used for the /status/ws
+   * WebSocket upgrade — all other requests use RPC methods.
+   */
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (
+      url.pathname.endsWith('/status/ws') &&
+      request.headers.get('Upgrade')?.toLowerCase() === 'websocket'
+    ) {
+      await this.ensureInitialized();
+      const pair = new WebSocketPair();
+      const [client, server] = [pair[0], pair[1]];
+      this.ctx.acceptWebSocket(server, ['status']);
+
+      // Send an initial snapshot immediately so the client doesn't
+      // wait for the next alarm tick.
+      try {
+        const snapshot = await this.getAlarmStatus();
+        server.send(JSON.stringify(snapshot));
+      } catch {
+        // Best-effort — snapshot will come on next tick
+      }
+
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  /** Called by the runtime when a hibernated WebSocket receives a message. */
+  async webSocketMessage(_ws: WebSocket, _message: string | ArrayBuffer): Promise<void> {
+    // Status WebSocket is server-push only — ignore client messages.
+  }
+
+  /** Called by the runtime when a hibernated WebSocket is closed. */
+  async webSocketClose(
+    ws: WebSocket,
+    _code: number,
+    _reason: string,
+    _wasClean: boolean
+  ): Promise<void> {
+    try {
+      ws.close();
+    } catch {
+      // Already closed
+    }
+  }
+
+  /** Called by the runtime when a hibernated WebSocket errors. */
+  async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
+    try {
+      ws.close(1011, 'WebSocket error');
+    } catch {
+      // Already closed
+    }
+  }
+
+  /**
+   * Broadcast the alarm status snapshot to all connected status WebSocket
+   * clients. Called at the end of each alarm tick.
+   */
+  private broadcastAlarmStatus(snapshot: Awaited<ReturnType<TownDO['getAlarmStatus']>>): void {
+    const sockets = this.ctx.getWebSockets('status');
+    if (sockets.length === 0) return;
+
+    const payload = JSON.stringify(snapshot);
+    for (const ws of sockets) {
+      try {
+        ws.send(payload);
+      } catch {
+        // Client disconnected — will be cleaned up by webSocketClose
+      }
+    }
+  }
+
+  // ── Initialization ──────────────────────────────────────────────────
 
   private async ensureInitialized(): Promise<void> {
     if (!this.initPromise) {
@@ -330,6 +439,63 @@ export class TownDO extends DurableObject<Env> {
       await container.fetch('http://container/health');
     } catch {
       // Container may take a moment to start — the alarm will retry
+    }
+
+    // Proactively clone the rig's repo and create a browse worktree so
+    // the mayor has immediate access to the codebase without waiting for
+    // the first agent dispatch.
+    this.setupRigRepoInContainer(rigConfig).catch(err =>
+      console.warn(`${TOWN_LOG} configureRig: background repo setup failed:`, err)
+    );
+  }
+
+  /**
+   * Tell the container to clone a rig's repo and create a browse worktree.
+   * Fire-and-forget — failures are logged but don't block the caller.
+   */
+  private async setupRigRepoInContainer(rigConfig: RigConfig): Promise<void> {
+    const townConfig = await this.getTownConfig();
+    const envVars: Record<string, string> = {};
+    if (townConfig.git_auth?.github_token) {
+      envVars.GIT_TOKEN = townConfig.git_auth.github_token;
+    }
+    if (townConfig.git_auth?.gitlab_token) {
+      envVars.GITLAB_TOKEN = townConfig.git_auth.gitlab_token;
+    }
+    if (townConfig.git_auth?.gitlab_instance_url) {
+      envVars.GITLAB_INSTANCE_URL = townConfig.git_auth.gitlab_instance_url;
+    }
+    // resolveGitCredentials in the container needs KILOCODE_TOKEN to
+    // authenticate against the credential API for platform integrations.
+    const kilocodeToken = rigConfig.kilocodeToken ?? townConfig.kilocode_token;
+    if (kilocodeToken) {
+      envVars.KILOCODE_TOKEN = kilocodeToken;
+    }
+
+    const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
+    const container = getTownContainerStub(this.env, this.townId);
+    const response = await container.fetch('http://container/repos/setup', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Town-Config': JSON.stringify(containerConfig),
+      },
+      body: JSON.stringify({
+        rigId: rigConfig.rigId,
+        gitUrl: rigConfig.gitUrl,
+        defaultBranch: rigConfig.defaultBranch,
+        envVars: Object.keys(envVars).length > 0 ? envVars : undefined,
+        platformIntegrationId: rigConfig.platformIntegrationId,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '(unreadable)');
+      console.warn(
+        `${TOWN_LOG} setupRigRepoInContainer: failed for rig=${rigConfig.rigId}: ${response.status} ${text.slice(0, 200)}`
+      );
+    } else {
+      console.log(`${TOWN_LOG} setupRigRepoInContainer: accepted for rig=${rigConfig.rigId}`);
     }
   }
 
@@ -565,6 +731,199 @@ export class TownDO extends DurableObject<Env> {
     }
   }
 
+  /**
+   * Resolve a triage_request bead. Called by the triage agent via the
+   * gt_triage_resolve tool. Applies the chosen action, closes the
+   * triage request, and logs the resolution.
+   */
+  async resolveTriage(input: {
+    agent_id: string;
+    triage_request_bead_id: string;
+    action: string;
+    resolution_notes: string;
+  }): Promise<Bead> {
+    await this.ensureInitialized();
+    const triageBead = beadOps.getBead(this.sql, input.triage_request_bead_id);
+    if (!triageBead)
+      throw new Error(`Triage request bead ${input.triage_request_bead_id} not found`);
+    if (!triageBead.labels.includes(patrol.TRIAGE_REQUEST_LABEL)) {
+      throw new Error(`Bead ${input.triage_request_bead_id} is not a triage request`);
+    }
+    if (triageBead.status !== 'open') {
+      throw new Error(
+        `Triage request ${input.triage_request_bead_id} is already ${triageBead.status} — cannot resolve again`
+      );
+    }
+
+    // ── Apply the chosen action ────────────────────────────────────
+    const targetAgentId =
+      typeof triageBead.metadata?.agent_bead_id === 'string'
+        ? triageBead.metadata.agent_bead_id
+        : null;
+    // Use the hooked bead ID captured when the triage request was created,
+    // not the agent's current hook (which may have changed since then).
+    const snapshotHookedBeadId =
+      typeof triageBead.metadata?.hooked_bead_id === 'string'
+        ? triageBead.metadata.hooked_bead_id
+        : null;
+    const action = input.action.toUpperCase();
+
+    if (targetAgentId) {
+      const targetAgent = agents.getAgent(this.sql, targetAgentId);
+
+      switch (action) {
+        case 'RESTART':
+        case 'RESTART_WITH_BACKOFF': {
+          // Stop the agent in the container, reset to idle so the
+          // scheduler picks it up again on the next alarm cycle.
+          if (targetAgent?.status === 'working' || targetAgent?.status === 'stalled') {
+            dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
+          }
+          if (targetAgent) {
+            // RESTART clears last_activity_at so the scheduler picks it
+            // up immediately. RESTART_WITH_BACKOFF sets it to now() so
+            // the dispatch cooldown (DISPATCH_COOLDOWN_MS) delays the
+            // next attempt, preventing immediate restart of crash loops.
+            const activityAt = action === 'RESTART_WITH_BACKOFF' ? now() : null;
+            query(
+              this.sql,
+              /* sql */ `
+                UPDATE ${agent_metadata}
+                SET ${agent_metadata.columns.status} = 'idle',
+                    ${agent_metadata.columns.last_activity_at} = ?
+                WHERE ${agent_metadata.bead_id} = ?
+              `,
+              [activityAt, targetAgentId]
+            );
+          }
+          break;
+        }
+        case 'CLOSE_BEAD': {
+          // Stop the agent in the container first so it can't push stale
+          // changes after the bead is marked failed.
+          if (targetAgent?.status === 'working' || targetAgent?.status === 'stalled') {
+            dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
+          }
+          // Fail the bead that was hooked when the triage request was
+          // created (not the agent's current hook, which may differ).
+          const beadToClose = snapshotHookedBeadId ?? targetAgent?.current_hook_bead_id;
+          if (beadToClose) {
+            beadOps.updateBeadStatus(this.sql, beadToClose, 'failed', input.agent_id);
+            // Only unhook if the agent is still hooked to this bead
+            if (targetAgent?.current_hook_bead_id === beadToClose) {
+              agents.unhookBead(this.sql, targetAgentId);
+            }
+          }
+          break;
+        }
+        case 'ESCALATE_TO_MAYOR':
+        case 'ESCALATE': {
+          const message = input.resolution_notes || triageBead.title || 'Triage escalation';
+          this.sendMayorMessage(`[Triage Escalation] ${message}`).catch(err =>
+            console.warn(`${TOWN_LOG} resolveTriage: mayor notification failed:`, err)
+          );
+          break;
+        }
+        case 'NUDGE': {
+          // Send a nudge message to the stuck agent
+          if (targetAgent) {
+            mail.sendMail(this.sql, {
+              from_agent_id: 'patrol',
+              to_agent_id: targetAgentId,
+              subject: 'TRIAGE_NUDGE',
+              body:
+                input.resolution_notes ||
+                'The triage system has flagged you as potentially stuck. Please report your status.',
+            });
+          }
+          break;
+        }
+        case 'REASSIGN_BEAD': {
+          // Stop the agent in the container before reassigning so the old
+          // polecat can't push changes for work being handed off.
+          if (targetAgent?.status === 'working' || targetAgent?.status === 'stalled') {
+            dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
+          }
+          // Target the bead from the triage snapshot, not the agent's current hook.
+          const beadToReassign = snapshotHookedBeadId ?? targetAgent?.current_hook_bead_id;
+          if (beadToReassign) {
+            // Only unhook if the agent is still hooked to this bead
+            if (targetAgent?.current_hook_bead_id === beadToReassign) {
+              agents.unhookBead(this.sql, targetAgentId);
+            }
+            // Reset the bead to open so the scheduler can re-assign it
+            query(
+              this.sql,
+              /* sql */ `
+                UPDATE ${beads}
+                SET ${beads.columns.assignee_agent_bead_id} = NULL,
+                    ${beads.columns.status} = 'open',
+                    ${beads.columns.updated_at} = ?
+                WHERE ${beads.bead_id} = ?
+                  AND ${beads.status} != 'closed'
+                  AND ${beads.status} != 'failed'
+              `,
+              [now(), beadToReassign]
+            );
+          }
+          break;
+        }
+        // DISCARD, PROVIDE_GUIDANCE, and other informational actions
+        // are handled by the triage agent itself via gt_mail_send
+        // before calling gt_triage_resolve — no server-side effect needed.
+        default:
+          break;
+      }
+    }
+
+    // ── Close the triage request bead with resolution metadata ──────
+    const timestamp = now();
+    query(
+      this.sql,
+      /* sql */ `
+        UPDATE ${beads}
+        SET ${beads.columns.status} = 'closed',
+            ${beads.columns.closed_at} = ?,
+            ${beads.columns.updated_at} = ?,
+            ${beads.columns.metadata} = json_set(
+              COALESCE(${beads.metadata}, '{}'),
+              '$.resolution_action', ?,
+              '$.resolution_notes', ?,
+              '$.resolved_by', ?
+            )
+        WHERE ${beads.bead_id} = ?
+      `,
+      [
+        timestamp,
+        timestamp,
+        input.action,
+        input.resolution_notes,
+        input.agent_id,
+        input.triage_request_bead_id,
+      ]
+    );
+
+    beadOps.logBeadEvent(this.sql, {
+      beadId: input.triage_request_bead_id,
+      agentId: input.agent_id,
+      eventType: 'status_changed',
+      oldValue: triageBead.status,
+      newValue: 'closed',
+      metadata: {
+        action: input.action,
+        resolution_notes: input.resolution_notes,
+      },
+    });
+
+    console.log(
+      `${TOWN_LOG} resolveTriage: bead=${input.triage_request_bead_id} action=${input.action}`
+    );
+
+    const updated = beadOps.getBead(this.sql, input.triage_request_bead_id);
+    if (!updated) throw new Error('Triage bead not found after update');
+    return updated;
+  }
+
   async createMolecule(beadId: string, formula: unknown): Promise<Molecule> {
     await this.ensureInitialized();
     return reviewQueue.createMolecule(this.sql, beadId, formula);
@@ -618,6 +977,15 @@ export class TownDO extends DurableObject<Env> {
     );
     await this.armAlarmIfNeeded();
     return { bead, agent: hookedAgent };
+  }
+
+  /** Build the rig list for mayor agent startup (browse worktree setup on fresh containers). */
+  private rigListForMayor(): Array<{ rigId: string; gitUrl: string; defaultBranch: string }> {
+    return rigs.listRigs(this.sql).map(r => ({
+      rigId: r.id,
+      gitUrl: r.git_url,
+      defaultBranch: r.default_branch,
+    }));
   }
 
   // ══════════════════════════════════════════════════════════════════
@@ -687,6 +1055,7 @@ export class TownDO extends DurableObject<Env> {
         defaultBranch: rigConfig?.defaultBranch ?? 'main',
         kilocodeToken,
         townConfig,
+        rigs: this.rigListForMayor(),
       });
 
       if (started) {
@@ -769,6 +1138,7 @@ export class TownDO extends DurableObject<Env> {
       defaultBranch: rigConfig?.defaultBranch ?? 'main',
       kilocodeToken,
       townConfig,
+      rigs: this.rigListForMayor(),
     });
 
     if (started) {
@@ -1553,6 +1923,11 @@ export class TownDO extends DurableObject<Env> {
       console.error(`${TOWN_LOG} alarm: witnessPatrol failed`, err);
     }
     try {
+      this.deaconPatrol();
+    } catch (err) {
+      console.error(`${TOWN_LOG} alarm: deaconPatrol failed`, err);
+    }
+    try {
       await this.deliverPendingMail();
     } catch (err) {
       console.warn(`${TOWN_LOG} alarm: deliverPendingMail failed`, err);
@@ -1562,11 +1937,24 @@ export class TownDO extends DurableObject<Env> {
     } catch (err) {
       console.warn(`${TOWN_LOG} alarm: reEscalation failed`, err);
     }
+    try {
+      await this.maybeDispatchTriageAgent();
+    } catch (err) {
+      console.warn(`${TOWN_LOG} alarm: maybeDispatchTriageAgent failed`, err);
+    }
 
     // Re-arm: fast when active, slow when idle
     const active = this.hasActiveWork();
     const interval = active ? ACTIVE_ALARM_INTERVAL_MS : IDLE_ALARM_INTERVAL_MS;
     await this.ctx.storage.setAlarm(Date.now() + interval);
+
+    // Broadcast status snapshot to connected WebSocket clients
+    try {
+      const snapshot = await this.getAlarmStatus();
+      this.broadcastAlarmStatus(snapshot);
+    } catch (err) {
+      console.warn(`${TOWN_LOG} alarm: status broadcast failed`, err);
+    }
   }
 
   private hasActiveWork(): boolean {
@@ -1591,10 +1979,18 @@ export class TownDO extends DurableObject<Env> {
         []
       ),
     ];
+    const pendingTriageRows = [
+      ...query(
+        this.sql,
+        /* sql */ `SELECT COUNT(*) as cnt FROM ${beads} WHERE ${beads.type} = 'issue' AND ${beads.labels} LIKE ? AND ${beads.status} = 'open'`,
+        [patrol.TRIAGE_LABEL_LIKE]
+      ),
+    ];
     return (
       Number(activeAgentRows[0]?.cnt ?? 0) > 0 ||
       Number(pendingBeadRows[0]?.cnt ?? 0) > 0 ||
-      Number(pendingReviewRows[0]?.cnt ?? 0) > 0
+      Number(pendingReviewRows[0]?.cnt ?? 0) > 0 ||
+      Number(pendingTriageRows[0]?.cnt ?? 0) > 0
     );
   }
 
@@ -1637,18 +2033,24 @@ export class TownDO extends DurableObject<Env> {
         beadOps.updateBeadStatus(this.sql, bead.bead_id, 'in_progress', agent.id);
       }
 
-      // Mark dispatch in progress: set last_activity_at so schedulePendingWork
-      // skips this agent while the container start is in flight, and bump
-      // dispatch_attempts for the retry budget.
+      // Set status to 'working' BEFORE the async container start. This
+      // must happen synchronously so the SQL write executes while the I/O
+      // gate is still open. When dispatchAgent is called fire-and-forget
+      // (from slingBead, slingConvoy, dispatchUnblockedBeads), any SQL
+      // writes after the first `await` may be silently dropped because
+      // the DO's RPC response closes the I/O gate. If the container fails
+      // to start, we roll back to 'idle'.
+      const timestamp = now();
       query(
         this.sql,
         /* sql */ `
           UPDATE ${agent_metadata}
-          SET ${agent_metadata.columns.dispatch_attempts} = ${agent_metadata.columns.dispatch_attempts} + 1,
+          SET ${agent_metadata.columns.status} = 'working',
+              ${agent_metadata.columns.dispatch_attempts} = ${agent_metadata.columns.dispatch_attempts} + 1,
               ${agent_metadata.columns.last_activity_at} = ?
           WHERE ${agent_metadata.bead_id} = ?
         `,
-        [now(), agent.id]
+        [timestamp, agent.id]
       );
 
       const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
@@ -1672,23 +2074,52 @@ export class TownDO extends DurableObject<Env> {
       });
 
       if (started) {
-        const timestamp = now();
+        // Reset dispatch_attempts on success (best-effort — may be
+        // dropped if the I/O gate is already closed, but that's fine
+        // because the agent is already 'working').
         query(
           this.sql,
           /* sql */ `
             UPDATE ${agent_metadata}
-            SET ${agent_metadata.columns.status} = 'working',
-                ${agent_metadata.columns.dispatch_attempts} = 0,
-                ${agent_metadata.columns.last_activity_at} = ?
+            SET ${agent_metadata.columns.dispatch_attempts} = 0
             WHERE ${agent_metadata.bead_id} = ?
           `,
-          [timestamp, agent.id]
+          [agent.id]
         );
         console.log(`${TOWN_LOG} dispatchAgent: started agent=${agent.name}(${agent.id})`);
+      } else {
+        // Container failed to start — roll back to idle
+        query(
+          this.sql,
+          /* sql */ `
+            UPDATE ${agent_metadata}
+            SET ${agent_metadata.columns.status} = 'idle'
+            WHERE ${agent_metadata.bead_id} = ?
+          `,
+          [agent.id]
+        );
       }
       return started;
     } catch (err) {
       console.error(`${TOWN_LOG} dispatchAgent: failed for agent=${agent.id}:`, err);
+      // Roll back agent and bead to prevent them from being stuck in
+      // working/in_progress state when the container call throws.
+      try {
+        query(
+          this.sql,
+          /* sql */ `
+            UPDATE ${agent_metadata}
+            SET ${agent_metadata.columns.status} = 'idle'
+            WHERE ${agent_metadata.bead_id} = ?
+          `,
+          [agent.id]
+        );
+        if (agent.current_hook_bead_id) {
+          beadOps.updateBeadStatus(this.sql, agent.current_hook_bead_id, 'open', agent.id);
+        }
+      } catch (rollbackErr) {
+        console.error(`${TOWN_LOG} dispatchAgent: rollback also failed:`, rollbackErr);
+      }
       return false;
     }
   }
@@ -1802,12 +2233,17 @@ export class TownDO extends DurableObject<Env> {
   }
 
   /**
-   * Witness patrol: detect dead/stale agents, orphaned beads.
+   * Witness patrol: detect dead/stale agents, GUPP violations with
+   * tiered escalation, orphaned work, agent GC, per-bead timeouts.
+   *
+   * Mechanical checks run as deterministic code. Ambiguous situations
+   * produce triage_request beads for the on-demand triage agent.
+   * See #442.
    */
   private async witnessPatrol(): Promise<void> {
     const townId = this.townId;
-    const guppThreshold = new Date(Date.now() - GUPP_THRESHOLD_MS).toISOString();
 
+    // ── Zombie detection (container status reconciliation) ──────────
     const WorkingAgentRow = AgentMetadataRecord.pick({
       bead_id: true,
       current_hook_bead_id: true,
@@ -1827,7 +2263,6 @@ export class TownDO extends DurableObject<Env> {
 
     for (const working of workingAgents) {
       const agentId = working.bead_id;
-      const lastActivity = working.last_activity_at;
 
       const containerInfo = await dispatch.checkAgentContainerStatus(this.env, townId, agentId);
 
@@ -1838,38 +2273,190 @@ export class TownDO extends DurableObject<Env> {
         }
         query(
           this.sql,
-          /* sql */ `UPDATE ${agent_metadata} SET ${agent_metadata.columns.status} = 'idle', ${agent_metadata.columns.last_activity_at} = ? WHERE ${agent_metadata.bead_id} = ?`,
+          /* sql */ `
+            UPDATE ${agent_metadata}
+            SET ${agent_metadata.columns.status} = 'idle',
+                ${agent_metadata.columns.last_activity_at} = ?
+            WHERE ${agent_metadata.bead_id} = ?
+          `,
           [now(), agentId]
         );
         continue;
       }
+    }
 
-      // GUPP violation check
-      if (lastActivity && lastActivity < guppThreshold) {
-        // Check for existing GUPP mail
-        const existingGupp = [
-          ...query(
-            this.sql,
-            /* sql */ `
-              SELECT ${beads.bead_id} FROM ${beads}
-              WHERE ${beads.type} = 'message'
-                AND ${beads.assignee_agent_bead_id} = ?
-                AND ${beads.title} = 'GUPP_CHECK'
-                AND ${beads.status} = 'open'
-              LIMIT 1
-            `,
-            [agentId]
-          ),
-        ];
-        if (existingGupp.length === 0) {
-          mail.sendMail(this.sql, {
-            from_agent_id: 'witness',
-            to_agent_id: agentId,
-            subject: 'GUPP_CHECK',
-            body: 'You have had work hooked for 30+ minutes with no activity. Are you stuck? If so, call gt_escalate.',
-          });
-        }
+    // ── Tiered GUPP violation handling ──────────────────────────────
+    // Re-query to get the current set of working agents (some may have
+    // been reset to idle by zombie detection above).
+    const currentWorking = WorkingAgentRow.array().parse([
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id}, ${agent_metadata.current_hook_bead_id}, ${agent_metadata.last_activity_at}
+          FROM ${agent_metadata}
+          WHERE ${agent_metadata.status} IN ('working', 'stalled')
+        `,
+        []
+      ),
+    ]);
+
+    const forceStopIds = patrol.detectGUPPViolations(this.sql, currentWorking);
+
+    // Force-stop agents in the container (best-effort)
+    for (const agentId of forceStopIds) {
+      dispatch
+        .stopAgentInContainer(this.env, townId, agentId)
+        .catch(err =>
+          console.warn(`${TOWN_LOG} witnessPatrol: force-stop failed for agent=${agentId}`, err)
+        );
+    }
+
+    // ── Orphaned work detection ────────────────────────────────────
+    patrol.detectOrphanedWork(this.sql);
+
+    // ── Agent garbage collection ───────────────────────────────────
+    const gcCount = patrol.agentGC(this.sql);
+    if (gcCount > 0) {
+      // Clean up AgentDO storage for GC'd agents (best-effort)
+      console.log(`${TOWN_LOG} witnessPatrol: GC'd ${gcCount} agent(s)`);
+    }
+
+    // ── Per-bead timeout enforcement ───────────────────────────────
+    const timedOut = patrol.checkTimerGates(this.sql);
+    for (const { agentId } of timedOut) {
+      if (agentId) {
+        dispatch
+          .stopAgentInContainer(this.env, townId, agentId)
+          .catch(err =>
+            console.warn(
+              `${TOWN_LOG} witnessPatrol: failed to stop timed-out agent=${agentId}`,
+              err
+            )
+          );
       }
+    }
+  }
+
+  /**
+   * Deacon patrol: stale hook detection, stranded convoy feeding,
+   * crash loop detection.
+   *
+   * Mechanical checks that complement the witness patrol. See #442.
+   */
+  private deaconPatrol(): void {
+    // ── Stale hook detection ───────────────────────────────────────
+    patrol.detectStaleHooks(this.sql);
+
+    // ── Stranded convoy feeding ────────────────────────────────────
+    patrol.feedStrandedConvoys(this.sql, this.townId);
+
+    // ── Crash loop detection ───────────────────────────────────────
+    patrol.detectCrashLoops(this.sql);
+  }
+
+  /**
+   * If triage_request beads are queued, dispatch a short-lived triage
+   * agent to process them. The triage agent gets a focused prompt with
+   * the pending requests and a narrow tool set.
+   *
+   * Skips dispatch if a triage agent is already working.
+   */
+  private async maybeDispatchTriageAgent(): Promise<void> {
+    const pendingCount = patrol.countPendingTriageRequests(this.sql);
+    if (pendingCount === 0) return;
+
+    // Check if a triage batch bead is already in progress (meaning a
+    // triage agent is working). We can't filter by role since triage
+    // uses polecat role; instead check for an open gt:triage batch bead.
+    const existingBatch = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${beads.bead_id} FROM ${beads}
+          WHERE ${beads.type} = 'issue'
+            AND ${beads.labels} LIKE ?
+            AND ${beads.status} IN ('open', 'in_progress')
+            AND ${beads.created_by} = 'patrol'
+          LIMIT 1
+        `,
+        [patrol.TRIAGE_LABEL_LIKE.replace(patrol.TRIAGE_REQUEST_LABEL, patrol.TRIAGE_BATCH_LABEL)]
+      ),
+    ];
+    if (existingBatch.length > 0) {
+      console.log(
+        `${TOWN_LOG} maybeDispatchTriageAgent: triage agent already working, skipping (${pendingCount} pending)`
+      );
+      return;
+    }
+
+    // Validate preconditions before creating any beads to avoid
+    // leaked phantom issue beads on early-return paths.
+    const rigList = rigs.listRigs(this.sql);
+    if (rigList.length === 0) {
+      console.warn(`${TOWN_LOG} maybeDispatchTriageAgent: no rigs available, skipping`);
+      return;
+    }
+    const rigId = rigList[0].id;
+
+    const rigConfig = await this.getRigConfig(rigId);
+    if (!rigConfig) {
+      console.warn(`${TOWN_LOG} maybeDispatchTriageAgent: no rig config for rig=${rigId}`);
+      return;
+    }
+
+    console.log(
+      `${TOWN_LOG} maybeDispatchTriageAgent: ${pendingCount} pending triage request(s), dispatching agent`
+    );
+
+    const townConfig = await this.getTownConfig();
+    const kilocodeToken = await this.resolveKilocodeToken();
+
+    // Build the triage prompt from pending requests
+    const pendingRequests = patrol.listPendingTriageRequests(this.sql);
+    const { buildTriageSystemPrompt } = await import('../prompts/triage-system.prompt');
+    const systemPrompt = buildTriageSystemPrompt(pendingRequests);
+
+    // Only now create the synthetic bead — preconditions are verified.
+    const triageBead = beadOps.createBead(this.sql, {
+      type: 'issue',
+      title: `Triage batch: ${pendingCount} request(s)`,
+      body: 'Process all pending triage request beads and resolve each one.',
+      priority: 'high',
+      labels: [patrol.TRIAGE_BATCH_LABEL],
+      created_by: 'patrol',
+    });
+
+    const triageAgent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
+    agents.hookBead(this.sql, triageAgent.id, triageBead.bead_id);
+
+    const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
+      townId: this.townId,
+      rigId,
+      userId: rigConfig.userId,
+      agentId: triageAgent.id,
+      agentName: triageAgent.name,
+      role: 'polecat',
+      identity: triageAgent.identity,
+      beadId: triageBead.bead_id,
+      beadTitle: triageBead.title,
+      beadBody: triageBead.body ?? '',
+      checkpoint: null,
+      gitUrl: rigConfig.gitUrl,
+      defaultBranch: rigConfig.defaultBranch,
+      kilocodeToken,
+      townConfig,
+      systemPromptOverride: systemPrompt,
+      platformIntegrationId: rigConfig.platformIntegrationId,
+    });
+
+    if (started) {
+      // Mark the agent as working so the duplicate-guard on the next
+      // alarm tick sees it and skips dispatch.
+      agents.updateAgentStatus(this.sql, triageAgent.id, 'working');
+    } else {
+      agents.unhookBead(this.sql, triageAgent.id);
+      beadOps.updateBeadStatus(this.sql, triageBead.bead_id, 'failed', triageAgent.id);
+      console.error(`${TOWN_LOG} maybeDispatchTriageAgent: triage agent failed to start`);
     }
   }
 
@@ -2008,6 +2595,10 @@ export class TownDO extends DurableObject<Env> {
     // (entry.bead_id). The source bead stays closed with its original
     // polecat assignee preserved.
     agents.hookBead(this.sql, refineryAgent.id, entry.id);
+
+    // Mark as working before the async container start (same I/O gate
+    // rationale as dispatchAgent — see comment there).
+    agents.updateAgentStatus(this.sql, refineryAgent.id, 'working');
 
     const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
       townId: this.townId,
@@ -2444,6 +3035,234 @@ export class TownDO extends DurableObject<Env> {
   // ══════════════════════════════════════════════════════════════════
   // Cleanup
   // ══════════════════════════════════════════════════════════════════
+
+  /**
+   * Health check: verify the alarm is set and return basic town status.
+   * Called by the GastownUserDO watchdog alarm to ensure each town's
+   * alarm loop is firing. Re-arms the alarm if it's missing.
+   */
+  async healthCheck(): Promise<{
+    townId: string;
+    alarmSet: boolean;
+    activeAgents: number;
+    pendingBeads: number;
+  }> {
+    await this.ensureInitialized();
+    const townId = this.townId;
+
+    // Check if alarm is set
+    const currentAlarm = await this.ctx.storage.getAlarm();
+    const alarmSet = currentAlarm !== null && currentAlarm > Date.now();
+
+    // Re-arm if missing — this is the whole point of the watchdog
+    if (!alarmSet) {
+      console.warn(`${TOWN_LOG} healthCheck: alarm not set for town=${townId}, re-arming`);
+      await this.ctx.storage.setAlarm(Date.now() + ACTIVE_ALARM_INTERVAL_MS);
+    }
+
+    const activeAgents = Number(
+      [
+        ...query(
+          this.sql,
+          /* sql */ `SELECT COUNT(*) AS cnt FROM ${agent_metadata} WHERE ${agent_metadata.status} IN ('working', 'stalled')`,
+          []
+        ),
+      ][0]?.cnt ?? 0
+    );
+
+    const pendingBeads = Number(
+      [
+        ...query(
+          this.sql,
+          /* sql */ `SELECT COUNT(*) AS cnt FROM ${beads} WHERE ${beads.status} IN ('open', 'in_progress') AND ${beads.type} NOT IN ('agent', 'message')`,
+          []
+        ),
+      ][0]?.cnt ?? 0
+    );
+
+    return { townId, alarmSet, activeAgents, pendingBeads };
+  }
+
+  /**
+   * Return a structured snapshot of the alarm loop and patrol state
+   * for the dashboard Status tab.
+   */
+  async getAlarmStatus(): Promise<{
+    alarm: {
+      nextFireAt: string | null;
+      intervalMs: number;
+      intervalLabel: string;
+    };
+    agents: {
+      working: number;
+      idle: number;
+      stalled: number;
+      dead: number;
+      total: number;
+    };
+    beads: {
+      open: number;
+      inProgress: number;
+      failed: number;
+      triageRequests: number;
+    };
+    patrol: {
+      guppWarnings: number;
+      guppEscalations: number;
+      stalledAgents: number;
+      orphanedHooks: number;
+    };
+    recentEvents: Array<{
+      time: string;
+      type: string;
+      message: string;
+    }>;
+  }> {
+    await this.ensureInitialized();
+
+    const currentAlarm = await this.ctx.storage.getAlarm();
+    const active = this.hasActiveWork();
+    const intervalMs = active ? ACTIVE_ALARM_INTERVAL_MS : IDLE_ALARM_INTERVAL_MS;
+
+    // Agent counts by status
+    const agentRows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${agent_metadata.status} AS status, COUNT(*) AS cnt
+          FROM ${agent_metadata}
+          GROUP BY ${agent_metadata.status}
+        `,
+        []
+      ),
+    ];
+    const agentCounts = { working: 0, idle: 0, stalled: 0, dead: 0, total: 0 };
+    for (const row of agentRows) {
+      const s = String(row.status);
+      const c = Number(row.cnt);
+      if (s in agentCounts) (agentCounts as Record<string, number>)[s] = c;
+      agentCounts.total += c;
+    }
+
+    // Bead counts
+    const beadRows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${beads.status} AS status, COUNT(*) AS cnt
+          FROM ${beads}
+          WHERE ${beads.type} NOT IN ('agent', 'message')
+          GROUP BY ${beads.status}
+        `,
+        []
+      ),
+    ];
+    const beadCounts = { open: 0, inProgress: 0, failed: 0, triageRequests: 0 };
+    for (const row of beadRows) {
+      const s = String(row.status);
+      const c = Number(row.cnt);
+      if (s === 'open') beadCounts.open = c;
+      else if (s === 'in_progress') beadCounts.inProgress = c;
+      else if (s === 'failed') beadCounts.failed = c;
+    }
+
+    // Triage request count (issue beads with gt:triage-request label)
+    beadCounts.triageRequests = patrol.countPendingTriageRequests(this.sql);
+
+    // Patrol indicators — count active warnings/issues
+    const guppWarnings = Number(
+      [
+        ...query(
+          this.sql,
+          /* sql */ `
+            SELECT COUNT(*) AS cnt FROM ${beads}
+            WHERE ${beads.type} = 'message'
+              AND ${beads.title} = 'GUPP_CHECK'
+              AND ${beads.status} = 'open'
+          `,
+          []
+        ),
+      ][0]?.cnt ?? 0
+    );
+
+    const guppEscalations = Number(
+      [
+        ...query(
+          this.sql,
+          /* sql */ `
+            SELECT COUNT(*) AS cnt FROM ${beads}
+            WHERE ${beads.type} = 'message'
+              AND ${beads.title} = 'GUPP_ESCALATION'
+              AND ${beads.status} = 'open'
+          `,
+          []
+        ),
+      ][0]?.cnt ?? 0
+    );
+
+    const stalledAgents = agentCounts.stalled;
+
+    // Only count idle+hooked agents as orphaned if they've been idle for
+    // longer than the dispatch cooldown. Agents that were just hooked by
+    // feedStrandedConvoys or restarted with backoff are legitimately
+    // waiting for the next scheduler tick.
+    const orphanedHooks = Number(
+      [
+        ...query(
+          this.sql,
+          /* sql */ `
+            SELECT COUNT(*) AS cnt FROM ${agent_metadata}
+            WHERE ${agent_metadata.status} = 'idle'
+              AND ${agent_metadata.current_hook_bead_id} IS NOT NULL
+              AND (
+                ${agent_metadata.last_activity_at} IS NULL
+                OR ${agent_metadata.last_activity_at} < datetime('now', '-5 minutes')
+              )
+          `,
+          []
+        ),
+      ][0]?.cnt ?? 0
+    );
+
+    // Recent bead events (last 20) for the activity feed
+    const recentRows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT be.created_at, be.event_type, be.new_value, be.agent_id, be.bead_id,
+                 b.${beads.columns.title} AS bead_title
+          FROM bead_events AS be
+          LEFT JOIN ${beads} AS b ON be.bead_id = b.${beads.columns.bead_id}
+          ORDER BY be.created_at DESC
+          LIMIT 20
+        `,
+        []
+      ),
+    ];
+
+    const recentEvents = recentRows.map(row => ({
+      time: String(row.created_at),
+      type: String(row.event_type),
+      message: formatEventMessage(row),
+    }));
+
+    return {
+      alarm: {
+        nextFireAt: currentAlarm ? new Date(Number(currentAlarm)).toISOString() : null,
+        intervalMs,
+        intervalLabel: active ? 'active (5s)' : 'idle (60s)',
+      },
+      agents: agentCounts,
+      beads: beadCounts,
+      patrol: {
+        guppWarnings,
+        guppEscalations,
+        stalledAgents,
+        orphanedHooks,
+      },
+      recentEvents,
+    };
+  }
 
   async destroy(): Promise<void> {
     console.log(`${TOWN_LOG} destroy: clearing all storage and alarms`);

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -981,12 +981,21 @@ export class TownDO extends DurableObject<Env> {
   }
 
   /** Build the rig list for mayor agent startup (browse worktree setup on fresh containers). */
-  private rigListForMayor(): Array<{ rigId: string; gitUrl: string; defaultBranch: string }> {
-    return rigs.listRigs(this.sql).map(r => ({
-      rigId: r.id,
-      gitUrl: r.git_url,
-      defaultBranch: r.default_branch,
-    }));
+  private async rigListForMayor(): Promise<
+    Array<{ rigId: string; gitUrl: string; defaultBranch: string; platformIntegrationId?: string }>
+  > {
+    const rigRecords = rigs.listRigs(this.sql);
+    return Promise.all(
+      rigRecords.map(async r => {
+        const rc = await this.getRigConfig(r.id);
+        return {
+          rigId: r.id,
+          gitUrl: r.git_url,
+          defaultBranch: r.default_branch,
+          platformIntegrationId: rc?.platformIntegrationId,
+        };
+      })
+    );
   }
 
   // ══════════════════════════════════════════════════════════════════
@@ -1056,7 +1065,7 @@ export class TownDO extends DurableObject<Env> {
         defaultBranch: rigConfig?.defaultBranch ?? 'main',
         kilocodeToken,
         townConfig,
-        rigs: this.rigListForMayor(),
+        rigs: await this.rigListForMayor(),
       });
 
       if (started) {
@@ -1139,7 +1148,7 @@ export class TownDO extends DurableObject<Env> {
       defaultBranch: rigConfig?.defaultBranch ?? 'main',
       kilocodeToken,
       townConfig,
-      rigs: this.rigListForMayor(),
+      rigs: await this.rigListForMayor(),
     });
 
     if (started) {
@@ -3225,7 +3234,7 @@ export class TownDO extends DurableObject<Env> {
               AND ${agent_metadata.current_hook_bead_id} IS NOT NULL
               AND (
                 ${agent_metadata.last_activity_at} IS NULL
-                OR ${agent_metadata.last_activity_at} < datetime('now', '-5 minutes')
+                OR ${agent_metadata.last_activity_at} < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-5 minutes')
               )
           `,
           []

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -820,7 +820,9 @@ export class TownDO extends DurableObject<Env> {
         case 'ESCALATE_TO_MAYOR':
         case 'ESCALATE': {
           const message = input.resolution_notes || triageBead.title || 'Triage escalation';
-          this.sendMayorMessage(`[Triage Escalation] ${message}`).catch(err =>
+          this.sendMayorMessage(
+            `[Triage Escalation] ${message}\n\nAgent: ${targetAgentId ?? 'unknown'}\nBead: ${snapshotHookedBeadId ?? 'unknown'}`
+          ).catch(err =>
             console.warn(`${TOWN_LOG} resolveTriage: mayor notification failed:`, err)
           );
           break;
@@ -915,6 +917,16 @@ export class TownDO extends DurableObject<Env> {
         resolution_notes: input.resolution_notes,
       },
     });
+
+    // If this triage request was created for an escalation, close the
+    // linked escalation bead too so it doesn't sit open indefinitely.
+    const escalationBeadId =
+      typeof triageBead.metadata?.escalation_bead_id === 'string'
+        ? triageBead.metadata.escalation_bead_id
+        : null;
+    if (escalationBeadId) {
+      beadOps.updateBeadStatus(this.sql, escalationBeadId, 'closed', input.agent_id);
+    }
 
     console.log(
       `${TOWN_LOG} resolveTriage: bead=${input.triage_request_bead_id} action=${input.action}`
@@ -1854,7 +1866,27 @@ export class TownDO extends DurableObject<Env> {
     const escalation = this.getEscalation(beadId);
     if (!escalation) throw new Error('Failed to create escalation');
 
-    // Notify mayor for medium+ severity
+    // Create a triage request so the patrol→triage→resolve loop can
+    // act on the escalation. Without this, escalation beads sit open
+    // with no assignee and no automated follow-up.
+    patrol.createTriageRequest(this.sql, {
+      triageType: 'escalation',
+      agentBeadId: input.source_agent_id ?? null,
+      title: `Escalation (${input.severity}): ${input.message.slice(0, 80)}`,
+      context: {
+        escalation_bead_id: beadId,
+        severity: input.severity,
+        rig_id: input.source_rig_id,
+        category: input.category,
+      },
+      options:
+        input.severity === 'low'
+          ? ['NUDGE', 'CLOSE_BEAD', 'PROVIDE_GUIDANCE']
+          : ['ESCALATE_TO_MAYOR', 'RESTART', 'CLOSE_BEAD', 'REASSIGN_BEAD'],
+      rigId: input.source_rig_id,
+    });
+
+    // Notify mayor directly for medium+ severity (in addition to triage)
     if (input.severity !== 'low') {
       this.sendMayorMessage(
         `[Escalation:${input.severity}] rig=${input.source_rig_id} ${input.message}`

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1818,6 +1818,23 @@ export class TownDO extends DurableObject<Env> {
     const beadId = generateId();
     const timestamp = now();
 
+    // Resolve convoy context from the source agent's hooked bead so the
+    // escalation is associated with the convoy for display and future
+    // automated handling (Phase 4: convoy-aware triage).
+    let convoyId: string | null = null;
+    let sourceBeadId: string | null = null;
+    if (input.source_agent_id) {
+      const agent = agents.getAgent(this.sql, input.source_agent_id);
+      if (agent?.current_hook_bead_id) {
+        sourceBeadId = agent.current_hook_bead_id;
+        convoyId = beadOps.getConvoyForBead(this.sql, sourceBeadId);
+      }
+    }
+
+    const metadata: Record<string, unknown> = {};
+    if (convoyId) metadata.convoy_id = convoyId;
+    if (sourceBeadId) metadata.source_bead_id = sourceBeadId;
+
     // Create the escalation bead
     query(
       this.sql,
@@ -1842,7 +1859,7 @@ export class TownDO extends DurableObject<Env> {
         null,
         input.severity === 'critical' ? 'critical' : input.severity === 'high' ? 'high' : 'medium',
         JSON.stringify(['gt:escalation', `severity:${input.severity}`]),
-        '{}',
+        JSON.stringify(metadata),
         input.source_agent_id ?? null,
         timestamp,
         timestamp,
@@ -1878,6 +1895,8 @@ export class TownDO extends DurableObject<Env> {
         severity: input.severity,
         rig_id: input.source_rig_id,
         category: input.category,
+        convoy_id: convoyId,
+        source_bead_id: sourceBeadId,
       },
       options:
         input.severity === 'low'

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -799,18 +799,18 @@ export class TownDO extends DurableObject<Env> {
           break;
         }
         case 'CLOSE_BEAD': {
-          // Stop the agent in the container first so it can't push stale
-          // changes after the bead is marked failed.
-          if (targetAgent?.status === 'working' || targetAgent?.status === 'stalled') {
-            dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
-          }
           // Fail the bead that was hooked when the triage request was
           // created (not the agent's current hook, which may differ).
           const beadToClose = snapshotHookedBeadId ?? targetAgent?.current_hook_bead_id;
           if (beadToClose) {
             beadOps.updateBeadStatus(this.sql, beadToClose, 'failed', input.agent_id);
-            // Only unhook if the agent is still hooked to this bead
+            // Only stop and unhook if the agent is still working on this
+            // specific bead. If the agent has moved on, stopping it would
+            // abort unrelated work.
             if (targetAgent?.current_hook_bead_id === beadToClose) {
+              if (targetAgent.status === 'working' || targetAgent.status === 'stalled') {
+                dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
+              }
               agents.unhookBead(this.sql, targetAgentId);
             }
           }
@@ -839,16 +839,16 @@ export class TownDO extends DurableObject<Env> {
           break;
         }
         case 'REASSIGN_BEAD': {
-          // Stop the agent in the container before reassigning so the old
-          // polecat can't push changes for work being handed off.
-          if (targetAgent?.status === 'working' || targetAgent?.status === 'stalled') {
-            dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
-          }
           // Target the bead from the triage snapshot, not the agent's current hook.
           const beadToReassign = snapshotHookedBeadId ?? targetAgent?.current_hook_bead_id;
           if (beadToReassign) {
-            // Only unhook if the agent is still hooked to this bead
+            // Only stop and unhook if the agent is still working on this
+            // specific bead. If the agent has moved on, stopping it would
+            // abort unrelated work.
             if (targetAgent?.current_hook_bead_id === beadToReassign) {
+              if (targetAgent.status === 'working' || targetAgent.status === 'stalled') {
+                dispatch.stopAgentInContainer(this.env, this.townId, targetAgentId).catch(() => {});
+              }
               agents.unhookBead(this.sql, targetAgentId);
             }
             // Reset the bead to open so the scheduler can re-assign it

--- a/cloudflare-gastown/src/dos/town/agents.ts
+++ b/cloudflare-gastown/src/dos/town/agents.ts
@@ -346,12 +346,31 @@ export function getOrCreateAgent(
 ): Agent {
   // Town-wide singletons: one per town, not tied to a rig.
   const townSingletonRoles = ['mayor'];
+  // Per-rig singletons: one per rig (the refinery processes reviews
+  // sequentially, so there should never be two for the same rig).
+  const rigSingletonRoles = ['refinery'];
 
   if (townSingletonRoles.includes(role)) {
     const existing = listAgents(sql, { role });
     if (existing.length > 0) return existing[0];
+  } else if (rigSingletonRoles.includes(role)) {
+    // Return the existing agent regardless of status. The caller is
+    // responsible for checking whether it's idle before dispatching.
+    const existing = [
+      ...query(
+        sql,
+        /* sql */ `
+          ${AGENT_JOIN}
+          WHERE ${agent_metadata.role} = ?
+            AND ${beads.rig_id} = ?
+          LIMIT 1
+        `,
+        [role, rigId]
+      ),
+    ];
+    if (existing.length > 0) return toAgent(AgentBeadRecord.parse(existing[0]));
   } else {
-    // Per-rig agents (polecat, refinery): reuse an idle one in the SAME rig.
+    // Per-rig agents (polecat): reuse an idle one in the SAME rig.
     // Agents are tied to a rig's worktree/repo — reusing one from a different
     // rig would dispatch it into the wrong repository.
     const idle = [

--- a/cloudflare-gastown/src/dos/town/agents.ts
+++ b/cloudflare-gastown/src/dos/town/agents.ts
@@ -335,7 +335,7 @@ export function allocatePolecatName(sql: SqlStorage): string {
 
 /**
  * Find an idle agent of the given role, or create one.
- * For singleton roles (witness, refinery, mayor), reuse existing.
+ * For singleton roles (mayor), reuse existing.
  * For polecats, create a new one.
  */
 export function getOrCreateAgent(
@@ -345,7 +345,7 @@ export function getOrCreateAgent(
   townId: string
 ): Agent {
   // Town-wide singletons: one per town, not tied to a rig.
-  const townSingletonRoles = ['witness', 'mayor'];
+  const townSingletonRoles = ['mayor'];
 
   if (townSingletonRoles.includes(role)) {
     const existing = listAgents(sql, { role });

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -99,8 +99,6 @@ export function systemPromptForRole(params: {
       switch (params.role) {
         case 'refinery':
           return `${base} You review code quality and merge PRs. Check for correctness, style, and test coverage.`;
-        case 'witness':
-          return `${base} You monitor agent health and report anomalies.`;
         default:
           return base;
       }
@@ -172,6 +170,8 @@ export async function startAgentInContainer(
     platformIntegrationId?: string;
     /** For convoy beads: the convoy's feature branch to branch from instead of defaultBranch. */
     convoyFeatureBranch?: string;
+    /** All rigs in the town (mayor only) — used to set up browse worktrees on fresh containers. */
+    rigs?: Array<{ rigId: string; gitUrl: string; defaultBranch: string }>;
   }
 ): Promise<boolean> {
   console.log(
@@ -259,6 +259,10 @@ export async function startAgentInContainer(
         defaultBranch: params.defaultBranch,
         envVars,
         platformIntegrationId: params.platformIntegrationId,
+        // For convoy agents, start from the convoy's feature branch so the
+        // worktree includes all previously merged convoy work.
+        startPoint: params.convoyFeatureBranch ? `origin/${params.convoyFeatureBranch}` : undefined,
+        rigs: params.rigs,
       }),
     });
 

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -171,7 +171,12 @@ export async function startAgentInContainer(
     /** For convoy beads: the convoy's feature branch to branch from instead of defaultBranch. */
     convoyFeatureBranch?: string;
     /** All rigs in the town (mayor only) — used to set up browse worktrees on fresh containers. */
-    rigs?: Array<{ rigId: string; gitUrl: string; defaultBranch: string }>;
+    rigs?: Array<{
+      rigId: string;
+      gitUrl: string;
+      defaultBranch: string;
+      platformIntegrationId?: string;
+    }>;
   }
 ): Promise<boolean> {
   console.log(

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -365,6 +365,11 @@ export async function checkAgentContainerStatus(
     const container = getTownContainerStub(env, townId);
     // TODO: Generally you should use containerFetch which waits for ports to be available
     const response = await container.fetch(`http://container/agents/${agentId}/status`);
+    // 404 means the container is running but has no record of this agent
+    // (e.g. after container eviction). Report as 'not_found' so
+    // witnessPatrol can immediately reset and redispatch the agent
+    // instead of waiting for the 2-hour GUPP timeout.
+    if (response.status === 404) return { status: 'not_found' };
     if (!response.ok) return { status: 'unknown' };
     const data: unknown = await response.json();
     if (typeof data === 'object' && data !== null && 'status' in data) {

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -1,0 +1,633 @@
+/**
+ * Witness & Deacon patrol functions for the TownDO alarm handler.
+ *
+ * All mechanical checks run as deterministic code. Ambiguous situations
+ * produce triage request beads (type='issue', label='gt:triage-request')
+ * with structured context for an on-demand LLM triage agent to resolve.
+ *
+ * See #442 for the full design.
+ */
+
+import { z } from 'zod';
+import { beads, BeadRecord as BeadRecordSchema } from '../../db/tables/beads.table';
+import { agent_metadata, AgentMetadataRecord } from '../../db/tables/agent-metadata.table';
+import { bead_dependencies } from '../../db/tables/bead-dependencies.table';
+import { query } from '../../util/query.util';
+import { sendMail } from './mail';
+import { deleteAgent, getOrCreateAgent, hookBead, unhookBead } from './agents';
+import { createBead, logBeadEvent, updateBeadStatus } from './beads';
+
+const LOG = '[patrol]';
+
+// ── Thresholds ──────────────────────────────────────────────────────
+
+/** First GUPP warning (existing behavior) */
+export const GUPP_WARN_MS = 30 * 60_000; // 30 min
+/** Escalate to mayor after second threshold */
+export const GUPP_ESCALATE_MS = 60 * 60_000; // 1h
+/** Force-stop agent after third threshold */
+export const GUPP_FORCE_STOP_MS = 2 * 60 * 60_000; // 2h
+/** Agents dead/completed for longer than this are GC'd */
+export const AGENT_GC_RETENTION_MS = 24 * 60 * 60_000; // 24h
+/** Per-bead timeout (if metadata.timeout_ms is set) */
+export const DEFAULT_BEAD_TIMEOUT_MS = 4 * 60 * 60_000; // 4h fallback
+/** Hook considered stale after this duration with no dispatch activity */
+export const STALE_HOOK_MS = 30 * 60_000; // 30 min
+/** Agent failing repeatedly within this window is a crash loop */
+export const CRASH_LOOP_WINDOW_MS = 30 * 60_000; // 30 min
+/** Minimum failures within the window to flag a crash loop */
+export const CRASH_LOOP_THRESHOLD = 3;
+
+// ── Triage request types ────────────────────────────────────────────
+
+export type TriageType =
+  | 'dirty_polecat'
+  | 'stuck_agent'
+  | 'help_request'
+  | 'zombie_confirm'
+  | 'crash_loop';
+
+export type TriageRequestMetadata = {
+  triage_type: TriageType;
+  agent_bead_id: string | null;
+  /** The bead the agent was hooked to when the triage request was created.
+   *  Resolve actions should target this bead, not the agent's current hook
+   *  (which may have changed by the time the triage agent resolves it). */
+  hooked_bead_id: string | null;
+  context: Record<string, unknown>;
+  options: string[];
+};
+
+// ── Triage request creation ─────────────────────────────────────────
+
+/** Label used to identify triage request beads (type='issue'). */
+export const TRIAGE_REQUEST_LABEL = 'gt:triage-request';
+
+/** Label used to identify the triage agent's batch bead. */
+export const TRIAGE_BATCH_LABEL = 'gt:triage';
+
+/** SQL LIKE pattern for querying triage request beads by label. */
+export const TRIAGE_LABEL_LIKE = `%"${TRIAGE_REQUEST_LABEL}"%`;
+
+/** Create a triage request bead for the LLM triage agent to resolve. */
+export function createTriageRequest(
+  sql: SqlStorage,
+  params: {
+    triageType: TriageType;
+    agentBeadId: string | null;
+    /** The bead the agent was hooked to at the time of the request. */
+    hookedBeadId?: string | null;
+    title: string;
+    context: Record<string, unknown>;
+    options: string[];
+    rigId?: string;
+  }
+): void {
+  // Deduplicate: skip if an open triage request of the same type already
+  // exists for this agent
+  if (params.agentBeadId) {
+    const existing = [
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${beads.bead_id} FROM ${beads}
+          WHERE ${beads.type} = 'issue'
+            AND ${beads.labels} LIKE ?
+            AND ${beads.status} = 'open'
+            AND ${beads.assignee_agent_bead_id} = ?
+            AND json_extract(${beads.metadata}, '$.triage_type') = ?
+          LIMIT 1
+        `,
+        [TRIAGE_LABEL_LIKE, params.agentBeadId, params.triageType]
+      ),
+    ];
+    if (existing.length > 0) return;
+  }
+
+  const metadata: TriageRequestMetadata = {
+    triage_type: params.triageType,
+    agent_bead_id: params.agentBeadId,
+    hooked_bead_id: params.hookedBeadId ?? null,
+    context: params.context,
+    options: params.options,
+  };
+
+  createBead(sql, {
+    type: 'issue',
+    title: params.title,
+    body: JSON.stringify(params.context),
+    priority: 'medium',
+    metadata,
+    labels: [TRIAGE_REQUEST_LABEL],
+    assignee_agent_bead_id: params.agentBeadId ?? undefined,
+    rig_id: params.rigId,
+  });
+
+  console.log(
+    `${LOG} createTriageRequest: type=${params.triageType} agent=${params.agentBeadId ?? 'none'}`
+  );
+}
+
+// ── Witness patrol sub-checks ───────────────────────────────────────
+
+/**
+ * Tiered GUPP violation handling:
+ * - 30 min: send GUPP_CHECK mail (existing behavior)
+ * - 1h: escalate to mayor
+ * - 2h: force-stop agent, create triage request for dirty polecat
+ *
+ * Returns agent IDs that were force-stopped (caller should stop them
+ * in the container).
+ */
+export function detectGUPPViolations(
+  sql: SqlStorage,
+  workingAgents: Array<{
+    bead_id: string;
+    current_hook_bead_id: string | null;
+    last_activity_at: string | null;
+  }>
+): string[] {
+  const nowMs = Date.now();
+  const forceStopIds: string[] = [];
+
+  for (const agent of workingAgents) {
+    if (!agent.last_activity_at) continue;
+    const staleMs = nowMs - new Date(agent.last_activity_at).getTime();
+
+    if (staleMs >= GUPP_FORCE_STOP_MS) {
+      // Tier 3: force-stop and flag for triage
+      forceStopIds.push(agent.bead_id);
+
+      createTriageRequest(sql, {
+        triageType: 'stuck_agent',
+        agentBeadId: agent.bead_id,
+        hookedBeadId: agent.current_hook_bead_id,
+        title: `Force-stopped agent after ${Math.round(staleMs / 60_000)}min GUPP violation`,
+        context: {
+          last_activity_at: agent.last_activity_at,
+          stale_minutes: Math.round(staleMs / 60_000),
+          action_taken: 'force_stop',
+        },
+        options: ['RESTART', 'ESCALATE_TO_MAYOR', 'CLOSE_BEAD'],
+      });
+
+      // Mark agent as stalled
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${agent_metadata}
+          SET ${agent_metadata.columns.status} = 'stalled'
+          WHERE ${agent_metadata.bead_id} = ?
+        `,
+        [agent.bead_id]
+      );
+
+      console.log(
+        `${LOG} GUPP force-stop: agent=${agent.bead_id} stale=${Math.round(staleMs / 60_000)}min`
+      );
+    } else if (staleMs >= GUPP_ESCALATE_MS) {
+      // Tier 2: create a triage request for the stuck agent. The triage
+      // agent (or mayor, if escalated) will decide whether to restart,
+      // nudge, or force-stop. Also warn the stuck agent directly.
+      const existingEsc = [
+        ...query(
+          sql,
+          /* sql */ `
+            SELECT ${beads.bead_id} FROM ${beads}
+            WHERE ${beads.type} = 'message'
+              AND ${beads.assignee_agent_bead_id} = ?
+              AND ${beads.title} = 'GUPP_ESCALATION'
+              AND ${beads.status} = 'open'
+            LIMIT 1
+          `,
+          [agent.bead_id]
+        ),
+      ];
+      if (existingEsc.length === 0) {
+        // Notify the stuck agent
+        sendMail(sql, {
+          from_agent_id: 'patrol',
+          to_agent_id: agent.bead_id,
+          subject: 'GUPP_ESCALATION',
+          body: `You have been inactive for ${Math.round(staleMs / 60_000)} minutes. This has been escalated. You will be force-stopped if inactivity continues.`,
+        });
+
+        // Create a triage request so the triage agent (or mayor) is aware
+        createTriageRequest(sql, {
+          triageType: 'stuck_agent',
+          agentBeadId: agent.bead_id,
+          hookedBeadId: agent.current_hook_bead_id,
+          title: `Agent inactive for ${Math.round(staleMs / 60_000)}min — GUPP escalation`,
+          context: {
+            last_activity_at: agent.last_activity_at,
+            stale_minutes: Math.round(staleMs / 60_000),
+            tier: 'escalation',
+          },
+          options: ['RESTART', 'NUDGE', 'ESCALATE_TO_MAYOR', 'CLOSE_BEAD'],
+        });
+
+        console.log(`${LOG} GUPP escalation: agent=${agent.bead_id}`);
+      }
+    } else if (staleMs >= GUPP_WARN_MS) {
+      // Tier 1: send warning mail (existing behavior, idempotent)
+      const existingGupp = [
+        ...query(
+          sql,
+          /* sql */ `
+            SELECT ${beads.bead_id} FROM ${beads}
+            WHERE ${beads.type} = 'message'
+              AND ${beads.assignee_agent_bead_id} = ?
+              AND ${beads.title} = 'GUPP_CHECK'
+              AND ${beads.status} = 'open'
+            LIMIT 1
+          `,
+          [agent.bead_id]
+        ),
+      ];
+      if (existingGupp.length === 0) {
+        sendMail(sql, {
+          from_agent_id: 'patrol',
+          to_agent_id: agent.bead_id,
+          subject: 'GUPP_CHECK',
+          body: 'You have had work hooked for 30+ minutes with no activity. Are you stuck? If so, call gt_escalate.',
+        });
+      }
+    }
+  }
+
+  return forceStopIds;
+}
+
+/**
+ * Detect orphaned work: idle agents with a hooked bead but no recent
+ * dispatch activity. These agents were assigned work but never started.
+ *
+ * Different from schedulePendingWork which handles the cooldown/retry
+ * loop — this catches agents that have been idle+hooked for an
+ * unreasonably long time (beyond what the scheduler would tolerate).
+ */
+export function detectOrphanedWork(sql: SqlStorage): void {
+  const cutoff = new Date(Date.now() - STALE_HOOK_MS).toISOString();
+
+  const rows = AgentMetadataRecord.pick({
+    bead_id: true,
+    current_hook_bead_id: true,
+    dispatch_attempts: true,
+    last_activity_at: true,
+  })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id},
+                 ${agent_metadata.current_hook_bead_id},
+                 ${agent_metadata.dispatch_attempts},
+                 ${agent_metadata.last_activity_at}
+          FROM ${agent_metadata}
+          WHERE ${agent_metadata.status} = 'idle'
+            AND ${agent_metadata.current_hook_bead_id} IS NOT NULL
+            AND ${agent_metadata.dispatch_attempts} >= 5
+            AND (${agent_metadata.last_activity_at} IS NULL OR ${agent_metadata.last_activity_at} < ?)
+        `,
+        [cutoff]
+      ),
+    ]);
+
+  for (const row of rows) {
+    // These agents have exhausted dispatch attempts AND are still hooked.
+    // schedulePendingWork should have failed the bead — this is a safety net.
+    console.log(
+      `${LOG} orphaned work detected: agent=${row.bead_id} hook=${row.current_hook_bead_id} attempts=${row.dispatch_attempts}`
+    );
+
+    // Actually fail the bead and unhook the agent (matching schedulePendingWork behavior)
+    if (row.current_hook_bead_id) {
+      updateBeadStatus(sql, row.current_hook_bead_id, 'failed', row.bead_id);
+      unhookBead(sql, row.bead_id);
+    }
+  }
+}
+
+/**
+ * Garbage-collect dead/completed agents past the retention period.
+ * Agents in 'idle' status with no hooked bead whose creation time
+ * exceeds the retention threshold and that have been idle for longer
+ * than the retention period are deleted.
+ *
+ * Only targets polecats and refinery agents — the mayor singleton
+ * is never GC'd.
+ */
+export function agentGC(sql: SqlStorage): number {
+  const cutoff = new Date(Date.now() - AGENT_GC_RETENTION_MS).toISOString();
+
+  // Find agents eligible for GC: idle polecats/refinery with no hook,
+  // whose last activity is older than the retention period
+  const rows = AgentMetadataRecord.pick({ bead_id: true })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id}
+          FROM ${agent_metadata}
+          WHERE ${agent_metadata.status} IN ('idle', 'dead')
+            AND ${agent_metadata.current_hook_bead_id} IS NULL
+            AND ${agent_metadata.role} IN ('polecat', 'refinery')
+            AND (
+              ${agent_metadata.last_activity_at} IS NOT NULL
+              AND ${agent_metadata.last_activity_at} < ?
+            )
+        `,
+        [cutoff]
+      ),
+    ]);
+
+  for (const row of rows) {
+    console.log(`${LOG} agentGC: deleting agent=${row.bead_id}`);
+    deleteAgent(sql, row.bead_id);
+  }
+
+  return rows.length;
+}
+
+/**
+ * Enforce per-bead timeouts. Beads with metadata.timeout_ms that have
+ * been in_progress for longer than their timeout are failed.
+ *
+ * Returns timed-out bead IDs and their assigned agent IDs (so the
+ * caller can stop the agent processes in the container).
+ */
+export function checkTimerGates(
+  sql: SqlStorage
+): Array<{ beadId: string; agentId: string | null }> {
+  const nowMs = Date.now();
+  const timedOut: Array<{ beadId: string; agentId: string | null }> = [];
+
+  // Find in_progress beads with a timeout_ms in metadata
+  const rows = BeadRecordSchema.pick({
+    bead_id: true,
+    metadata: true,
+    updated_at: true,
+    assignee_agent_bead_id: true,
+  })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${beads.bead_id}, ${beads.metadata}, ${beads.updated_at}, ${beads.assignee_agent_bead_id}
+          FROM ${beads}
+          WHERE ${beads.status} = 'in_progress'
+            AND ${beads.type} IN ('issue', 'molecule')
+            AND json_extract(${beads.metadata}, '$.timeout_ms') IS NOT NULL
+        `,
+        []
+      ),
+    ]);
+
+  for (const row of rows) {
+    const timeoutMs = Number(row.metadata?.timeout_ms ?? DEFAULT_BEAD_TIMEOUT_MS);
+    if (!timeoutMs || isNaN(timeoutMs) || timeoutMs <= 0) continue;
+
+    const elapsedMs = nowMs - new Date(row.updated_at).getTime();
+    if (elapsedMs > timeoutMs) {
+      // Fail the bead and unhook the assigned agent so the scheduler
+      // can recover the slot (matching schedulePendingWork's failure path).
+      // updateBeadStatus already logs a status_changed event internally,
+      // so no additional logBeadEvent call is needed here.
+      updateBeadStatus(sql, row.bead_id, 'failed', row.assignee_agent_bead_id ?? 'patrol');
+
+      if (row.assignee_agent_bead_id) {
+        unhookBead(sql, row.assignee_agent_bead_id);
+      }
+
+      timedOut.push({ beadId: row.bead_id, agentId: row.assignee_agent_bead_id ?? null });
+      console.log(
+        `${LOG} checkTimerGates: bead=${row.bead_id} timed out after ${Math.round(elapsedMs / 60_000)}min (limit=${Math.round(timeoutMs / 60_000)}min)`
+      );
+    }
+  }
+
+  return timedOut;
+}
+
+// ── Deacon patrol sub-checks ────────────────────────────────────────
+
+/**
+ * Detect stale hooks: agents that have been idle with a hook for an
+ * extended period without any dispatch activity. This catches cases
+ * where schedulePendingWork's cooldown/retry loop failed silently.
+ *
+ * Different from detectOrphanedWork (which catches exhausted retries) —
+ * this catches agents that are hooked+idle but haven't even been
+ * attempted recently.
+ */
+export function detectStaleHooks(sql: SqlStorage): void {
+  const cutoff = new Date(Date.now() - STALE_HOOK_MS).toISOString();
+
+  const rows = AgentMetadataRecord.pick({
+    bead_id: true,
+    current_hook_bead_id: true,
+    dispatch_attempts: true,
+    last_activity_at: true,
+  })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id},
+                 ${agent_metadata.current_hook_bead_id},
+                 ${agent_metadata.dispatch_attempts},
+                 ${agent_metadata.last_activity_at}
+          FROM ${agent_metadata}
+          WHERE ${agent_metadata.status} = 'idle'
+            AND ${agent_metadata.current_hook_bead_id} IS NOT NULL
+            AND ${agent_metadata.dispatch_attempts} < 5
+            AND (${agent_metadata.last_activity_at} IS NULL OR ${agent_metadata.last_activity_at} < ?)
+        `,
+        [cutoff]
+      ),
+    ]);
+
+  for (const row of rows) {
+    // Reset last_activity_at to trigger schedulePendingWork to pick it up
+    // on the next alarm cycle (it skips agents with recent activity).
+    query(
+      sql,
+      /* sql */ `
+        UPDATE ${agent_metadata}
+        SET ${agent_metadata.columns.last_activity_at} = NULL
+        WHERE ${agent_metadata.bead_id} = ?
+      `,
+      [row.bead_id]
+    );
+
+    console.log(
+      `${LOG} stale hook nudge: agent=${row.bead_id} hook=${row.current_hook_bead_id} attempts=${row.dispatch_attempts}`
+    );
+  }
+}
+
+/**
+ * Feed stranded convoys: find active convoys that have open beads with
+ * no assigned agent. Auto-sling by assigning idle polecats.
+ */
+export function feedStrandedConvoys(sql: SqlStorage, townId: string): void {
+  // Find open issue beads that:
+  // 1. Belong to an active convoy (tracked by a convoy bead)
+  // 2. Have no assigned agent
+  const StrandedBeadRow = z.object({
+    bead_id: z.string(),
+    rig_id: z.string().nullable(),
+    convoy_bead_id: z.string(),
+  });
+
+  const rows = StrandedBeadRow.array().parse([
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT ${beads.bead_id},
+               ${beads.rig_id},
+               ${bead_dependencies.depends_on_bead_id} AS convoy_bead_id
+        FROM ${bead_dependencies}
+        INNER JOIN ${beads} ON ${bead_dependencies.bead_id} = ${beads.bead_id}
+        INNER JOIN ${beads} AS convoy ON ${bead_dependencies.depends_on_bead_id} = convoy.${beads.columns.bead_id}
+        WHERE ${bead_dependencies.dependency_type} = 'tracks'
+          AND convoy.${beads.columns.type} = 'convoy'
+          AND convoy.${beads.columns.status} = 'open'
+          AND ${beads.status} = 'open'
+          AND ${beads.type} = 'issue'
+          AND ${beads.assignee_agent_bead_id} IS NULL
+      `,
+      []
+    ),
+  ]);
+
+  if (rows.length === 0) return;
+
+  console.log(`${LOG} feedStrandedConvoys: found ${rows.length} unassigned convoy bead(s)`);
+
+  // For each stranded bead, find or create an idle polecat in the same rig
+  // and hook it. The next schedulePendingWork cycle will dispatch it.
+  // We import getOrCreateAgent inline to avoid circular dependency issues.
+  for (const row of rows) {
+    const rigId = row.rig_id;
+    if (!rigId) continue;
+
+    try {
+      const agent = getOrCreateAgent(sql, 'polecat', rigId, townId);
+      hookBead(sql, agent.id, row.bead_id);
+      // Clear last_activity_at so schedulePendingWork picks this up on
+      // the next alarm tick instead of waiting for the dispatch cooldown.
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${agent_metadata}
+          SET ${agent_metadata.columns.last_activity_at} = NULL
+          WHERE ${agent_metadata.bead_id} = ?
+        `,
+        [agent.id]
+      );
+      console.log(
+        `${LOG} feedStrandedConvoys: assigned agent=${agent.id} to bead=${row.bead_id} in convoy=${row.convoy_bead_id}`
+      );
+    } catch (err) {
+      console.warn(
+        `${LOG} feedStrandedConvoys: failed to assign agent to bead=${row.bead_id}:`,
+        err
+      );
+    }
+  }
+}
+
+/**
+ * Detect crash loops: agents that have failed repeatedly within a
+ * short window. Creates a triage request for LLM assessment.
+ *
+ * Crash loop detection uses the bead_events table to count recent
+ * status_changed events to 'failed' for each agent.
+ */
+export function detectCrashLoops(sql: SqlStorage): void {
+  const windowCutoff = new Date(Date.now() - CRASH_LOOP_WINDOW_MS).toISOString();
+
+  // Count recent failure events per agent
+  const CrashRow = z.object({
+    agent_id: z.string(),
+    fail_count: z.number(),
+  });
+
+  const rows = CrashRow.array().parse([
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT be.agent_id, COUNT(*) AS fail_count
+        FROM bead_events AS be
+        WHERE be.event_type = 'status_changed'
+          AND be.new_value = 'failed'
+          AND be.agent_id IS NOT NULL
+          AND be.created_at > ?
+        GROUP BY be.agent_id
+        HAVING fail_count >= ?
+      `,
+      [windowCutoff, CRASH_LOOP_THRESHOLD]
+    ),
+  ]);
+
+  for (const row of rows) {
+    createTriageRequest(sql, {
+      triageType: 'crash_loop',
+      agentBeadId: row.agent_id,
+      title: `Crash loop detected: ${row.fail_count} failures in ${CRASH_LOOP_WINDOW_MS / 60_000}min`,
+      context: {
+        agent_id: row.agent_id,
+        fail_count: row.fail_count,
+        window_minutes: CRASH_LOOP_WINDOW_MS / 60_000,
+      },
+      options: ['RESTART_WITH_BACKOFF', 'REASSIGN_BEAD', 'ESCALATE_TO_MAYOR'],
+    });
+
+    console.log(
+      `${LOG} crash loop: agent=${row.agent_id} failures=${row.fail_count} in ${CRASH_LOOP_WINDOW_MS / 60_000}min`
+    );
+  }
+}
+
+// ── Pending triage requests ─────────────────────────────────────────
+
+/** Count open triage request beads (issue beads with gt:triage-request label). */
+export function countPendingTriageRequests(sql: SqlStorage): number {
+  const rows = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT COUNT(*) AS cnt FROM ${beads}
+        WHERE ${beads.type} = 'issue'
+          AND ${beads.labels} LIKE ?
+          AND ${beads.status} = 'open'
+      `,
+      [TRIAGE_LABEL_LIKE]
+    ),
+  ];
+  return Number(z.object({ cnt: z.number() }).parse(rows[0]).cnt);
+}
+
+/** List open triage request beads for the triage agent prompt. */
+export function listPendingTriageRequests(sql: SqlStorage): z.output<typeof BeadRecordSchema>[] {
+  const rows = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT * FROM ${beads}
+        WHERE ${beads.type} = 'issue'
+          AND ${beads.labels} LIKE ?
+          AND ${beads.status} = 'open'
+        ORDER BY ${beads.created_at} ASC
+        LIMIT 20
+      `,
+      [TRIAGE_LABEL_LIKE]
+    ),
+  ];
+  return BeadRecordSchema.array().parse(rows);
+}

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -45,7 +45,8 @@ export type TriageType =
   | 'stuck_agent'
   | 'help_request'
   | 'zombie_confirm'
-  | 'crash_loop';
+  | 'crash_loop'
+  | 'escalation';
 
 export type TriageRequestMetadata = {
   triage_type: TriageType;

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -15,7 +15,7 @@ import { bead_dependencies } from '../../db/tables/bead-dependencies.table';
 import { query } from '../../util/query.util';
 import { sendMail } from './mail';
 import { deleteAgent, getOrCreateAgent, hookBead, unhookBead } from './agents';
-import { createBead, logBeadEvent, updateBeadStatus } from './beads';
+import { createBead, updateBeadStatus } from './beads';
 
 const LOG = '[patrol]';
 

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -464,6 +464,17 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   if (!agent) throw new Error(`Agent ${agentId} not found`);
   if (!agent.current_hook_bead_id) throw new Error(`Agent ${agentId} has no hooked bead`);
 
+  // Triage batch beads don't produce code — close and unhook without
+  // submitting to the review queue. Only applies to system-created triage
+  // beads (created_by = 'patrol'). User-created beads that happen to carry
+  // the gt:triage label go through normal review flow.
+  const hookedBead = getBead(sql, agent.current_hook_bead_id);
+  if (hookedBead?.labels.includes('gt:triage') && hookedBead.created_by === 'patrol') {
+    closeBead(sql, agent.current_hook_bead_id, agentId);
+    unhookBead(sql, agentId);
+    return;
+  }
+
   if (agent.role === 'refinery') {
     // The refinery handles merging (direct strategy) or PR creation (pr strategy)
     // itself. When it calls gt_done:

--- a/cloudflare-gastown/src/dos/town/rigs.ts
+++ b/cloudflare-gastown/src/dos/town/rigs.ts
@@ -54,18 +54,61 @@ export function addRig(
   }
 ): RigRecord {
   const timestamp = new Date().toISOString();
-  query(
-    sql,
-    /* sql */ `
-      INSERT INTO rigs (id, name, git_url, default_branch, config, created_at)
-      VALUES (?, ?, ?, ?, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET
-        name = excluded.name,
-        git_url = excluded.git_url,
-        default_branch = excluded.default_branch
-    `,
-    [input.rigId, input.name, input.gitUrl, input.defaultBranch, '{}', timestamp]
-  );
+  try {
+    query(
+      sql,
+      /* sql */ `
+        INSERT INTO rigs (id, name, git_url, default_branch, config, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          name = excluded.name,
+          git_url = excluded.git_url,
+          default_branch = excluded.default_branch
+      `,
+      [input.rigId, input.name, input.gitUrl, input.defaultBranch, '{}', timestamp]
+    );
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('UNIQUE constraint failed: rigs.name')) {
+      // A rig with this name already exists under a different ID.
+      // Clean up the stale entry only if it's truly orphaned (has no
+      // open or in-progress beads). Otherwise surface the conflict.
+      const staleRig = query(sql, /* sql */ `SELECT id FROM rigs WHERE name = ? AND id != ?`, [
+        input.name,
+        input.rigId,
+      ]);
+      const staleId = [...staleRig][0]?.id as string | undefined;
+      if (staleId) {
+        const activeBeads = query(
+          sql,
+          /* sql */ `SELECT COUNT(*) AS cnt FROM beads WHERE rig_id = ? AND status IN ('open', 'in_progress')`,
+          [staleId]
+        );
+        const count = Number([...activeBeads][0]?.cnt ?? 0);
+        if (count > 0) {
+          throw new Error(
+            `A rig named "${input.name}" already exists (id=${staleId}) with ${count} active bead(s). ` +
+              `Delete it first before creating a new rig with the same name.`
+          );
+        }
+        // Truly orphaned — safe to remove
+        query(sql, /* sql */ `DELETE FROM rigs WHERE id = ?`, [staleId]);
+      }
+      query(
+        sql,
+        /* sql */ `
+          INSERT INTO rigs (id, name, git_url, default_branch, config, created_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            git_url = excluded.git_url,
+            default_branch = excluded.default_branch
+        `,
+        [input.rigId, input.name, input.gitUrl, input.defaultBranch, '{}', timestamp]
+      );
+    } else {
+      throw err;
+    }
+  }
 
   const rig = getRig(sql, input.rigId);
   if (!rig) throw new Error('Failed to create rig');

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { cors } from 'hono/cors';
 import { getTownContainerStub } from './dos/TownContainer.do';
+import { getTownDOStub } from './dos/Town.do';
 import { resError } from './util/res.util';
 import { dashboardHtml } from './ui/dashboard.ui';
 import {
@@ -44,6 +45,7 @@ import {
   handleCompleteReview,
 } from './handlers/rig-review-queue.handler';
 import { handleCreateEscalation } from './handlers/rig-escalations.handler';
+import { handleResolveTriage } from './handlers/rig-triage.handler';
 import { handleListBeadEvents } from './handlers/rig-bead-events.handler';
 import { handleListTownEvents } from './handlers/town-events.handler';
 import {
@@ -265,6 +267,12 @@ app.post('/api/towns/:townId/rigs/:rigId/escalations', c =>
   handleCreateEscalation(c, c.req.param())
 );
 
+// ── Triage ──────────────────────────────────────────────────────────────
+
+app.post('/api/towns/:townId/rigs/:rigId/triage/resolve', c =>
+  handleResolveTriage(c, c.req.param())
+);
+
 // ── Kilo User Auth ──────────────────────────────────────────────────────
 // Validate Kilo user JWT (signed with NEXTAUTH_SECRET) for dashboard/user
 // routes. Skip in development. Container→worker routes use the agent JWT
@@ -440,6 +448,7 @@ app.onError((err, c) => {
 
 const WS_STREAM_PATTERN = /^\/api\/towns\/([^/]+)\/container\/agents\/([^/]+)\/stream$/;
 const WS_PTY_PATTERN = /^\/api\/towns\/([^/]+)\/container\/agents\/([^/]+)\/pty\/([^/]+)\/connect$/;
+const WS_STATUS_PATTERN = /^\/api\/towns\/([^/]+)\/status\/ws$/;
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -473,6 +482,15 @@ export default {
           `[gastown-worker] WS upgrade (pty): townId=${townId} agentId=${agentId} ptyId=${ptyId}`
         );
         const stub = getTownContainerStub(env, townId);
+        return stub.fetch(request);
+      }
+
+      // Town alarm status (real-time push)
+      const statusMatch = url.pathname.match(WS_STATUS_PATTERN);
+      if (statusMatch) {
+        const townId = statusMatch[1];
+        console.log(`[gastown-worker] WS upgrade (status): townId=${townId}`);
+        const stub = getTownDOStub(env, townId);
         return stub.fetch(request);
       }
     }

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -415,6 +415,7 @@ app.use(
       userId: c.get('kiloUserId') ?? '',
       isAdmin: c.get('kiloIsAdmin') ?? false,
       apiTokenPepper: c.get('kiloApiTokenPepper') ?? null,
+      gastownAccess: c.get('kiloGastownAccess') ?? false,
     }),
     onError: ({ error, path }: { error: Error; path?: string }) => {
       console.error(`[gastown-trpc] error on ${path ?? 'unknown'}:`, error.message);

--- a/cloudflare-gastown/src/handlers/rig-triage.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-triage.handler.ts
@@ -1,0 +1,64 @@
+import type { Context } from 'hono';
+import { z } from 'zod';
+import { getTownDOStub } from '../dos/Town.do';
+import { resSuccess, resError } from '../util/res.util';
+import { parseJsonBody } from '../util/parse-json-body.util';
+import { getEnforcedAgentId } from '../middleware/auth.middleware';
+import type { GastownEnv } from '../gastown.worker';
+
+const VALID_TRIAGE_ACTIONS = [
+  'RESTART',
+  'RESTART_WITH_BACKOFF',
+  'CLOSE_BEAD',
+  'ESCALATE',
+  'ESCALATE_TO_MAYOR',
+  'NUDGE',
+  'REASSIGN_BEAD',
+  'DISCARD',
+  'PROVIDE_GUIDANCE',
+] as const;
+
+const ResolveTriageBody = z.object({
+  triage_request_bead_id: z.string().min(1),
+  action: z
+    .string()
+    .min(1)
+    .transform(v => v.toUpperCase())
+    .pipe(z.enum(VALID_TRIAGE_ACTIONS)),
+  resolution_notes: z.string(),
+});
+
+export async function handleResolveTriage(c: Context<GastownEnv>, params: { rigId: string }) {
+  const agentId = getEnforcedAgentId(c);
+  if (!agentId) {
+    return c.json(resError('Agent authentication required'), 401);
+  }
+
+  const parsed = ResolveTriageBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+  const townId = c.get('townId');
+  const town = getTownDOStub(c.env, townId);
+
+  // Verify this agent is actually working on a triage batch. Without this
+  // check, any rig agent (polecat, refinery) could call the endpoint and
+  // trigger restart/close/escalate side effects on other agents.
+  const hookedBead = await town.getHookedBead(agentId);
+  if (
+    !hookedBead ||
+    !hookedBead.labels.includes('gt:triage') ||
+    hookedBead.created_by !== 'patrol'
+  ) {
+    return c.json(resError('Only triage agents can resolve triage requests'), 403);
+  }
+
+  const bead = await town.resolveTriage({
+    agent_id: agentId,
+    ...parsed.data,
+  });
+  return c.json(resSuccess(bead), 200);
+}

--- a/cloudflare-gastown/src/handlers/rig-triage.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-triage.handler.ts
@@ -28,7 +28,7 @@ const ResolveTriageBody = z.object({
   resolution_notes: z.string(),
 });
 
-export async function handleResolveTriage(c: Context<GastownEnv>, params: { rigId: string }) {
+export async function handleResolveTriage(c: Context<GastownEnv>, _params: { rigId: string }) {
   const agentId = getEnforcedAgentId(c);
   if (!agentId) {
     return c.json(resError('Agent authentication required'), 401);

--- a/cloudflare-gastown/src/middleware/auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/auth.middleware.ts
@@ -11,6 +11,7 @@ export type AuthVariables = {
   kiloUserId: string;
   kiloIsAdmin: boolean;
   kiloApiTokenPepper: string | null;
+  kiloGastownAccess: boolean;
 };
 
 import { resolveSecret } from '../util/secret.util';

--- a/cloudflare-gastown/src/middleware/kilo-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/kilo-auth.middleware.ts
@@ -33,6 +33,7 @@ export const kiloAuthMiddleware = createMiddleware<GastownEnv>(async (c, next) =
     c.set('kiloUserId', payload.kiloUserId);
     c.set('kiloIsAdmin', payload.isAdmin === true);
     c.set('kiloApiTokenPepper', payload.apiTokenPepper ?? null);
+    c.set('kiloGastownAccess', payload.gastownAccess === true);
   } catch (err) {
     console.warn(
       '[kilo-auth] token verification failed:',

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -166,6 +166,41 @@ When calling gt_sling, write clear, actionable descriptions:
 
 The polecat works autonomously — it cannot ask you questions mid-task. Front-load ALL necessary context in the body. A polecat with a detailed body succeeds. A polecat with a vague body flounders.
 
+## Browsing Rig Codebases
+
+You have READ-ONLY access to every rig's codebase in your town. Each rig has a checked-out copy of its default branch at:
+
+\`/workspace/rigs/<rigId>/browse/\`
+
+Use gt_list_rigs to discover rig IDs, then browse the codebase using your standard file-reading tools (Read, Grep, Glob). This is how you build context to write better bead descriptions.
+
+**Before browsing a rig, always pull the latest changes first:**
+\`\`\`bash
+cd /workspace/rigs/<rigId>/browse && git pull --rebase --autostash
+\`\`\`
+
+**Browsing workflow:**
+1. Call gt_list_rigs to get rig IDs
+2. Pull latest in the browse directory
+3. Explore the codebase (directory structure, key files, dependencies, etc.)
+4. Use what you learn to write precise, context-rich bead descriptions when slinging
+
+This is especially useful when:
+- The user's request is vague and you need to understand the codebase structure first
+- You need to identify the right files, components, or modules for a task
+- You want to include specific file paths and function names in bead bodies
+- You need to understand existing patterns before delegating work
+
+## DO NOT EDIT FILES
+
+**You must NEVER edit, write, create, or delete files.** Your role is coordination, not implementation. All code changes must go through polecats via gt_sling or gt_sling_batch.
+
+If you catch yourself about to use Edit, Write, or any file-modification tool — STOP. Instead, sling a bead describing the change you want.
+
+You may READ files to build context. You must NEVER WRITE files. The browse worktrees are for observation only. Any change you make there will be lost and could corrupt the shared repo state.
+
+The only exception is running \`git pull\` in a browse directory to get the latest code.
+
 ## Important
 
 - You maintain context across messages. This is a continuous conversation.

--- a/cloudflare-gastown/src/prompts/refinery-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/refinery-system.prompt.ts
@@ -108,6 +108,18 @@ This bead is part of a **review-then-land** convoy. Your job for this intermedia
 
 The final merge/PR to main happens automatically once ALL beads in the convoy are done. Do NOT create a PR for this intermediate step.`;
   }
+  if (ctx.mergeMode === 'review-then-land' && !ctx.isIntermediateStep) {
+    return `
+## Convoy Context — Final Landing
+This is the **final landing merge** for a review-then-land convoy. All individual beads have been reviewed and merged into the convoy's feature branch. Your job is to:
+
+1. **Review the combined diff** — the feature branch contains the accumulated work of all convoy beads. Review the full diff against the target branch to ensure everything integrates correctly.
+2. **Run quality gates** — this is the last check before the work lands on the target branch. All gates must pass against the combined changes.
+3. **If approved, perform the merge or create a PR** — use the merge strategy shown above. This IS the final landing, so follow the merge/PR instructions below to land the convoy on the target branch.
+4. **If changes needed, escalate** — since there's no single polecat to send rework to, call \`gt_escalate\` with severity "medium" describing the issue. Do NOT attempt to fix the code yourself.
+
+This merge represents all the work in the convoy landing together. Treat it with the same rigor as a large feature branch merge.`;
+  }
   if (ctx.mergeMode === 'review-and-merge') {
     return `
 ## Convoy Context

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -1,0 +1,73 @@
+/**
+ * Build the system prompt for a triage agent.
+ *
+ * The triage agent is a short-lived LLM session spawned by the TownDO
+ * alarm handler when mechanical patrol checks produce ambiguous results.
+ * It processes a batch of triage_request beads, makes a judgment call
+ * for each, and exits. See #442.
+ */
+
+type TriageRequestBead = {
+  bead_id: string;
+  title: string;
+  body: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export function buildTriageSystemPrompt(pendingRequests: TriageRequestBead[]): string {
+  const situations = pendingRequests
+    .map((req, i) => {
+      const meta = req.metadata ?? {};
+      const triageType = String(meta.triage_type ?? 'unknown').toUpperCase();
+      const options = Array.isArray(meta.options) ? (meta.options as string[]).join(' | ') : 'N/A';
+      const context =
+        typeof meta.context === 'object' && meta.context !== null
+          ? JSON.stringify(meta.context, null, 2)
+          : (req.body ?? 'No additional context');
+
+      return `${i + 1}. [${triageType}] ${req.title}
+   Triage request ID: ${req.bead_id}
+   Context:
+${context
+  .split('\n')
+  .map(line => `     ${line}`)
+  .join('\n')}
+   Options: ${options}`;
+    })
+    .join('\n\n');
+
+  return `You are a Gastown triage agent. Your job is to assess ambiguous situations
+that the mechanical patrol checks could not resolve automatically.
+
+You will be given a list of situations. For each one:
+1. Read the context carefully.
+2. Assess the situation and choose the best action from the available options.
+3. Call gt_triage_resolve with the triage request bead ID and your chosen action.
+4. Briefly explain your reasoning in the resolution_notes field.
+
+When you have resolved all situations, call gt_bead_close on your hooked bead to signal completion.
+Do NOT call gt_done — it submits work to the review queue, which is not appropriate for triage.
+
+## Guidelines
+
+- **Be decisive.** The system is waiting on your judgment. Do not deliberate excessively.
+- **Prefer least-disruptive actions.** RESTART over CLOSE_BEAD. NUDGE over ESCALATE.
+- **Escalate genuinely hard problems.** If a situation requires human context you don't have, escalate rather than guess.
+- **Never skip a triage request.** Every pending request must be resolved.
+
+## Available Tools
+
+- **gt_triage_resolve** — Resolve a triage request. Provide the triage_request_bead_id, chosen action, and brief notes.
+- **gt_mail_send** — Send guidance to a stuck agent.
+- **gt_escalate** — Forward a problem to the Mayor or human operators.
+- **gt_bead_close** — Close your hooked bead when all triage requests have been processed.
+
+## Situations to Assess
+
+${situations}
+
+---
+
+Process each situation above. For each one, call gt_triage_resolve with your decision.
+When all are resolved, call gt_bead_close on your hooked bead to signal completion.`;
+}

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -69,5 +69,5 @@ ${situations}
 ---
 
 Process each situation above. For each one, call gt_triage_resolve with your decision.
-When all are resolved, call gt_bead_close on your hooked bead to signal completion.`;
+When all are resolved, call gt_done to signal completion.`;
 }

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -45,8 +45,8 @@ You will be given a list of situations. For each one:
 3. Call gt_triage_resolve with the triage request bead ID and your chosen action.
 4. Briefly explain your reasoning in the resolution_notes field.
 
-When you have resolved all situations, call gt_bead_close on your hooked bead to signal completion.
-Do NOT call gt_done — it submits work to the review queue, which is not appropriate for triage.
+When you have resolved all situations, call gt_done to signal completion.
+This will close the triage batch, unhook you, and return you to idle.
 
 ## Guidelines
 

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -18,7 +18,7 @@ export function buildTriageSystemPrompt(pendingRequests: TriageRequestBead[]): s
   const situations = pendingRequests
     .map((req, i) => {
       const meta = req.metadata ?? {};
-      const triageType = String(meta.triage_type ?? 'unknown').toUpperCase();
+      const triageType = `${(meta.triage_type ?? 'unknown') as string}`.toUpperCase();
       const options = Array.isArray(meta.options) ? (meta.options as string[]).join(' | ') : 'N/A';
       const context =
         typeof meta.context === 'object' && meta.context !== null

--- a/cloudflare-gastown/src/trpc/init.ts
+++ b/cloudflare-gastown/src/trpc/init.ts
@@ -24,3 +24,15 @@ export const procedure = t.procedure.use(async ({ ctx, next }) => {
   }
   return next({ ctx });
 });
+
+/**
+ * Gastown access procedure — requires a valid JWT with `gastownAccess`
+ * (set by the token endpoint after PostHog flag evaluation). Falls back
+ * to `isAdmin` for backward compatibility with pre-migration tokens.
+ */
+export const gastownProcedure = procedure.use(async ({ ctx, next }) => {
+  if (!ctx.gastownAccess && !ctx.isAdmin) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Gastown access required' });
+  }
+  return next({ ctx });
+});

--- a/cloudflare-gastown/src/trpc/init.ts
+++ b/cloudflare-gastown/src/trpc/init.ts
@@ -5,6 +5,7 @@ export type TRPCContext = {
   userId: string;
   isAdmin: boolean;
   apiTokenPepper: string | null;
+  gastownAccess: boolean;
 };
 
 const t = initTRPC.context<TRPCContext>().create();

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -70,9 +70,15 @@ async function refreshGitCredentials(
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-function requireAdmin(ctx: TRPCContext): { id: string; api_token_pepper: string | null } {
-  if (!ctx.isAdmin) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'Admin access required' });
+/**
+ * Require Gastown access. The token endpoint evaluates the PostHog
+ * feature flag and embeds `gastownAccess` in the JWT, so the worker
+ * doesn't need its own PostHog call. Falls back to `isAdmin` for
+ * backward compatibility with tokens minted before the flag migration.
+ */
+function requireGastownAccess(ctx: TRPCContext): { id: string; api_token_pepper: string | null } {
+  if (!ctx.gastownAccess && !ctx.isAdmin) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Gastown access required' });
   }
   return { id: ctx.userId, api_token_pepper: ctx.apiTokenPepper };
 }
@@ -126,7 +132,7 @@ export const gastownRouter = router({
     .input(z.object({ name: z.string().min(1).max(64) }))
     .output(RpcTownOutput)
     .mutation(async ({ ctx, input }) => {
-      const user = requireAdmin(ctx);
+      const user = requireGastownAccess(ctx);
       const userStub = getGastownUserStub(ctx.env, user.id);
       const town = await userStub.createTown({ name: input.name, owner_user_id: user.id });
 
@@ -143,7 +149,7 @@ export const gastownRouter = router({
     }),
 
   listTowns: procedure.output(z.array(RpcTownOutput)).query(async ({ ctx }) => {
-    requireAdmin(ctx);
+    requireGastownAccess(ctx);
     const userStub = getGastownUserStub(ctx.env, ctx.userId);
     return userStub.listTowns();
   }),
@@ -152,14 +158,14 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcTownOutput)
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       return verifyTownOwnership(ctx.env, ctx.userId, input.townId);
     }),
 
   deleteTown: procedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       await userStub.deleteTown(input.townId);
@@ -179,7 +185,7 @@ export const gastownRouter = router({
     )
     .output(RpcRigOutput)
     .mutation(async ({ ctx, input }) => {
-      const user = requireAdmin(ctx);
+      const user = requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, user.id, input.townId);
 
       // Generate kilocode token for agent LLM gateway auth
@@ -244,7 +250,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(z.array(RpcRigOutput))
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       return userStub.listRigs(input.townId);
@@ -254,7 +260,7 @@ export const gastownRouter = router({
     .input(z.object({ rigId: z.string().uuid() }))
     .output(RpcRigDetailOutput)
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
@@ -266,7 +272,7 @@ export const gastownRouter = router({
   deleteRig: procedure
     .input(z.object({ rigId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       await userStub.deleteRig(input.rigId);
@@ -283,7 +289,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadOutput))
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeads({ rig_id: rig.id, status: input.status });
@@ -292,7 +298,7 @@ export const gastownRouter = router({
   deleteBead: procedure
     .input(z.object({ rigId: z.string().uuid(), beadId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteBead(input.beadId);
@@ -304,7 +310,7 @@ export const gastownRouter = router({
     .input(z.object({ rigId: z.string().uuid() }))
     .output(z.array(RpcAgentOutput))
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listAgents({ rig_id: rig.id });
@@ -313,7 +319,7 @@ export const gastownRouter = router({
   deleteAgent: procedure
     .input(z.object({ rigId: z.string().uuid(), agentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteAgent(input.agentId);
@@ -332,7 +338,7 @@ export const gastownRouter = router({
     )
     .output(RpcSlingResultOutput)
     .mutation(async ({ ctx, input }) => {
-      const user = requireAdmin(ctx);
+      const user = requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, user.id, input.rigId);
 
       // Best-effort: refresh git credentials before dispatching
@@ -365,7 +371,7 @@ export const gastownRouter = router({
     )
     .output(RpcMayorSendResultOutput)
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       const townStub = getTownDOStub(ctx.env, input.townId);
@@ -377,7 +383,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcMayorStatusOutput)
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.setTownId(input.townId);
@@ -388,7 +394,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcMayorSendResultOutput)
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       // Best-effort: refresh git credentials from the first rig with a GitHub URL
@@ -416,7 +422,7 @@ export const gastownRouter = router({
     .input(z.object({ agentId: z.string().uuid(), townId: z.string().uuid() }))
     .output(RpcStreamTicketOutput)
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       // Proxy to container control server to get a stream ticket
@@ -447,7 +453,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid(), agentId: z.string().uuid() }))
     .output(RpcPtySessionOutput)
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       // Proxy to container control server to create a PTY session
@@ -484,7 +490,7 @@ export const gastownRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       const containerStub = getTownContainerStub(ctx.env, input.townId);
@@ -510,7 +516,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcTownConfigSchema)
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getTownConfig();
@@ -525,7 +531,7 @@ export const gastownRouter = router({
     )
     .output(RpcTownConfigSchema)
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.updateTownConfig(input.config);
@@ -544,7 +550,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeadEvents({
@@ -564,7 +570,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.listBeadEvents({
@@ -581,7 +587,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcConvoyDetailOutput))
     .query(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.listConvoysDetailed();
@@ -596,7 +602,7 @@ export const gastownRouter = router({
     )
     .output(RpcConvoyDetailOutput.nullable())
     .mutation(async ({ ctx, input }) => {
-      requireAdmin(ctx);
+      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       const convoy = await townStub.closeConvoy(input.convoyId);

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -28,6 +28,7 @@ import {
   RpcSlingResultOutput,
   RpcRigDetailOutput,
   RpcConvoyDetailOutput,
+  RpcAlarmStatusOutput,
 } from './schemas';
 import type { TRPCContext } from './init';
 
@@ -185,6 +186,15 @@ export const gastownRouter = router({
       await townStub.setTownId(input.townId);
       await townStub.updateTownConfig({ kilocode_token: kilocodeToken });
 
+      // Resolve git credentials BEFORE configureRig so that
+      // townConfig.git_auth.github_token is populated when
+      // setupRigRepoInContainer reads it for the proactive clone.
+      try {
+        await refreshGitCredentials(ctx.env, input.townId, input.gitUrl, user.id);
+      } catch (err) {
+        console.warn('[gastown-trpc] createRig: git credential refresh failed', err);
+      }
+
       const userStub = getGastownUserStub(ctx.env, user.id);
       const rig = await userStub.createRig({
         town_id: input.townId,
@@ -225,13 +235,6 @@ export const gastownRouter = router({
         throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to configure rig' });
       }
 
-      // Best-effort: resolve git credentials from the git-token-service
-      try {
-        await refreshGitCredentials(ctx.env, input.townId, input.gitUrl, user.id);
-      } catch (err) {
-        console.warn('[gastown-trpc] createRig: git credential refresh failed', err);
-      }
-
       return rig;
     }),
 
@@ -259,7 +262,12 @@ export const gastownRouter = router({
   deleteRig: gastownProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
+      // Remove from Town DO first so the name is freed before the user
+      // record is deleted. If this fails the user record is still intact
+      // and the user can retry.
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      await townStub.removeRig(input.rigId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       await userStub.deleteRig(input.rigId);
     }),
@@ -368,6 +376,16 @@ export const gastownRouter = router({
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.setTownId(input.townId);
       return townStub.getMayorStatus();
+    }),
+
+  getAlarmStatus: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(RpcAlarmStatusOutput)
+    .query(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.setTownId(input.townId);
+      return townStub.getAlarmStatus();
     }),
 
   ensureMayor: gastownProcedure

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/await-thenable -- DO RPC stubs return Rpc.Promisified which is thenable at runtime */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
-import { router, procedure } from './init';
+import { router, gastownProcedure } from './init';
 import { getTownDOStub } from '../dos/Town.do';
 import { getTownContainerStub } from '../dos/TownContainer.do';
 import { getGastownUserStub } from '../dos/GastownUser.do';
@@ -70,16 +70,8 @@ async function refreshGitCredentials(
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-/**
- * Require Gastown access. The token endpoint evaluates the PostHog
- * feature flag and embeds `gastownAccess` in the JWT, so the worker
- * doesn't need its own PostHog call. Falls back to `isAdmin` for
- * backward compatibility with tokens minted before the flag migration.
- */
-function requireGastownAccess(ctx: TRPCContext): { id: string; api_token_pepper: string | null } {
-  if (!ctx.gastownAccess && !ctx.isAdmin) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'Gastown access required' });
-  }
+/** Extract user identity fields from the tRPC context. */
+function userFromCtx(ctx: TRPCContext): { id: string; api_token_pepper: string | null } {
   return { id: ctx.userId, api_token_pepper: ctx.apiTokenPepper };
 }
 
@@ -128,11 +120,11 @@ async function mintKilocodeToken(env: Env, user: { id: string; api_token_pepper:
 export const gastownRouter = router({
   // ── Towns ───────────────────────────────────────────────────────────
 
-  createTown: procedure
+  createTown: gastownProcedure
     .input(z.object({ name: z.string().min(1).max(64) }))
     .output(RpcTownOutput)
     .mutation(async ({ ctx, input }) => {
-      const user = requireGastownAccess(ctx);
+      const user = userFromCtx(ctx);
       const userStub = getGastownUserStub(ctx.env, user.id);
       const town = await userStub.createTown({ name: input.name, owner_user_id: user.id });
 
@@ -148,24 +140,21 @@ export const gastownRouter = router({
       return town;
     }),
 
-  listTowns: procedure.output(z.array(RpcTownOutput)).query(async ({ ctx }) => {
-    requireGastownAccess(ctx);
+  listTowns: gastownProcedure.output(z.array(RpcTownOutput)).query(async ({ ctx }) => {
     const userStub = getGastownUserStub(ctx.env, ctx.userId);
     return userStub.listTowns();
   }),
 
-  getTown: procedure
+  getTown: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcTownOutput)
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       return verifyTownOwnership(ctx.env, ctx.userId, input.townId);
     }),
 
-  deleteTown: procedure
+  deleteTown: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       await userStub.deleteTown(input.townId);
@@ -173,7 +162,7 @@ export const gastownRouter = router({
 
   // ── Rigs ────────────────────────────────────────────────────────────
 
-  createRig: procedure
+  createRig: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -185,7 +174,7 @@ export const gastownRouter = router({
     )
     .output(RpcRigOutput)
     .mutation(async ({ ctx, input }) => {
-      const user = requireGastownAccess(ctx);
+      const user = userFromCtx(ctx);
       await verifyTownOwnership(ctx.env, user.id, input.townId);
 
       // Generate kilocode token for agent LLM gateway auth
@@ -246,21 +235,19 @@ export const gastownRouter = router({
       return rig;
     }),
 
-  listRigs: procedure
+  listRigs: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .output(z.array(RpcRigOutput))
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       return userStub.listRigs(input.townId);
     }),
 
-  getRig: procedure
+  getRig: gastownProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .output(RpcRigDetailOutput)
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
@@ -269,10 +256,9 @@ export const gastownRouter = router({
       return { ...rig, agents: agentList, beads: beadList };
     }),
 
-  deleteRig: procedure
+  deleteRig: gastownProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const userStub = getGastownUserStub(ctx.env, ctx.userId);
       await userStub.deleteRig(input.rigId);
@@ -280,7 +266,7 @@ export const gastownRouter = router({
 
   // ── Beads ───────────────────────────────────────────────────────────
 
-  listBeads: procedure
+  listBeads: gastownProcedure
     .input(
       z.object({
         rigId: z.string().uuid(),
@@ -289,16 +275,14 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadOutput))
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeads({ rig_id: rig.id, status: input.status });
     }),
 
-  deleteBead: procedure
+  deleteBead: gastownProcedure
     .input(z.object({ rigId: z.string().uuid(), beadId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteBead(input.beadId);
@@ -306,20 +290,18 @@ export const gastownRouter = router({
 
   // ── Agents ──────────────────────────────────────────────────────────
 
-  listAgents: procedure
+  listAgents: gastownProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .output(z.array(RpcAgentOutput))
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listAgents({ rig_id: rig.id });
     }),
 
-  deleteAgent: procedure
+  deleteAgent: gastownProcedure
     .input(z.object({ rigId: z.string().uuid(), agentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteAgent(input.agentId);
@@ -327,7 +309,7 @@ export const gastownRouter = router({
 
   // ── Work Assignment ─────────────────────────────────────────────────
 
-  sling: procedure
+  sling: gastownProcedure
     .input(
       z.object({
         rigId: z.string().uuid(),
@@ -338,7 +320,7 @@ export const gastownRouter = router({
     )
     .output(RpcSlingResultOutput)
     .mutation(async ({ ctx, input }) => {
-      const user = requireGastownAccess(ctx);
+      const user = userFromCtx(ctx);
       const rig = await verifyRigOwnership(ctx.env, user.id, input.rigId);
 
       // Best-effort: refresh git credentials before dispatching
@@ -360,7 +342,7 @@ export const gastownRouter = router({
 
   // ── Mayor ───────────────────────────────────────────────────────────
 
-  sendMessage: procedure
+  sendMessage: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -371,7 +353,6 @@ export const gastownRouter = router({
     )
     .output(RpcMayorSendResultOutput)
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       const townStub = getTownDOStub(ctx.env, input.townId);
@@ -379,22 +360,20 @@ export const gastownRouter = router({
       return townStub.sendMayorMessage(input.message, input.model);
     }),
 
-  getMayorStatus: procedure
+  getMayorStatus: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcMayorStatusOutput)
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.setTownId(input.townId);
       return townStub.getMayorStatus();
     }),
 
-  ensureMayor: procedure
+  ensureMayor: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcMayorSendResultOutput)
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       // Best-effort: refresh git credentials from the first rig with a GitHub URL
@@ -418,11 +397,10 @@ export const gastownRouter = router({
 
   // ── Agent Streams ───────────────────────────────────────────────────
 
-  getAgentStreamUrl: procedure
+  getAgentStreamUrl: gastownProcedure
     .input(z.object({ agentId: z.string().uuid(), townId: z.string().uuid() }))
     .output(RpcStreamTicketOutput)
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       // Proxy to container control server to get a stream ticket
@@ -449,11 +427,10 @@ export const gastownRouter = router({
 
   // ── PTY ─────────────────────────────────────────────────────────────
 
-  createPtySession: procedure
+  createPtySession: gastownProcedure
     .input(z.object({ townId: z.string().uuid(), agentId: z.string().uuid() }))
     .output(RpcPtySessionOutput)
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       // Proxy to container control server to create a PTY session
@@ -479,7 +456,7 @@ export const gastownRouter = router({
       return { pty: ptyData, wsUrl };
     }),
 
-  resizePtySession: procedure
+  resizePtySession: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -490,7 +467,6 @@ export const gastownRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
 
       const containerStub = getTownContainerStub(ctx.env, input.townId);
@@ -512,17 +488,16 @@ export const gastownRouter = router({
 
   // ── Town Configuration ──────────────────────────────────────────────
 
-  getTownConfig: procedure
+  getTownConfig: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcTownConfigSchema)
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getTownConfig();
     }),
 
-  updateTownConfig: procedure
+  updateTownConfig: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -531,7 +506,6 @@ export const gastownRouter = router({
     )
     .output(RpcTownConfigSchema)
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.updateTownConfig(input.config);
@@ -539,7 +513,7 @@ export const gastownRouter = router({
 
   // ── Events ──────────────────────────────────────────────────────────
 
-  getBeadEvents: procedure
+  getBeadEvents: gastownProcedure
     .input(
       z.object({
         rigId: z.string().uuid(),
@@ -550,7 +524,6 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeadEvents({
@@ -560,7 +533,7 @@ export const gastownRouter = router({
       });
     }),
 
-  getTownEvents: procedure
+  getTownEvents: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -570,7 +543,6 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.listBeadEvents({
@@ -579,7 +551,7 @@ export const gastownRouter = router({
       });
     }),
 
-  listConvoys: procedure
+  listConvoys: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -587,13 +559,12 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcConvoyDetailOutput))
     .query(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.listConvoysDetailed();
     }),
 
-  closeConvoy: procedure
+  closeConvoy: gastownProcedure
     .input(
       z.object({
         townId: z.string().uuid(),
@@ -602,7 +573,6 @@ export const gastownRouter = router({
     )
     .output(RpcConvoyDetailOutput.nullable())
     .mutation(async ({ ctx, input }) => {
-      requireGastownAccess(ctx);
       await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       const convoy = await townStub.closeConvoy(input.convoyId);

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -53,10 +53,10 @@ export const BeadOutput = z.object({
 export const AgentOutput = z.object({
   id: z.string(),
   rig_id: z.string().nullable(),
-  role: z.enum(['polecat', 'refinery', 'mayor', 'witness']),
+  role: z.enum(['polecat', 'refinery', 'mayor']).or(z.string()),
   name: z.string(),
   identity: z.string(),
-  status: z.enum(['idle', 'working', 'stalled', 'dead']),
+  status: z.enum(['idle', 'working', 'stalled', 'dead']).or(z.string()),
   current_hook_bead_id: z.string().nullable(),
   dispatch_attempts: z.number().default(0),
   last_activity_at: z.string().nullable(),
@@ -184,4 +184,40 @@ export const RpcPtySessionOutput = rpcSafe(PtySessionOutput);
 export const RpcConvoyOutput = rpcSafe(ConvoyOutput);
 export const RpcConvoyDetailOutput = rpcSafe(ConvoyDetailOutput);
 export const RpcSlingResultOutput = rpcSafe(SlingResultOutput);
+
+// Alarm status
+const AlarmStatusOutput = z.object({
+  alarm: z.object({
+    nextFireAt: z.string().nullable(),
+    intervalMs: z.number(),
+    intervalLabel: z.string(),
+  }),
+  agents: z.object({
+    working: z.number(),
+    idle: z.number(),
+    stalled: z.number(),
+    dead: z.number(),
+    total: z.number(),
+  }),
+  beads: z.object({
+    open: z.number(),
+    inProgress: z.number(),
+    failed: z.number(),
+    triageRequests: z.number(),
+  }),
+  patrol: z.object({
+    guppWarnings: z.number(),
+    guppEscalations: z.number(),
+    stalledAgents: z.number(),
+    orphanedHooks: z.number(),
+  }),
+  recentEvents: z.array(
+    z.object({
+      time: z.string(),
+      type: z.string(),
+      message: z.string(),
+    })
+  ),
+});
+export const RpcAlarmStatusOutput = rpcSafe(AlarmStatusOutput);
 export const RpcRigDetailOutput = rpcSafe(RigDetailOutput);

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -48,7 +48,7 @@ export type BeadFilter = {
 
 // -- Agents (now beads + agent_metadata) --
 
-export const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness']);
+export const AgentRole = z.enum(['polecat', 'refinery', 'mayor']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 export const AgentStatus = z.enum(['idle', 'working', 'stalled', 'dead']);

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -93,7 +93,7 @@ export function dashboardHtml(): string {
         <option value="polecat">polecat</option>
         <option value="refinery">refinery</option>
         <option value="mayor">mayor</option>
-        <option value="witness">witness</option>
+
       </select>
       <input type="text" id="agentIdentity" placeholder="identity" style="min-width:120px" />
       <button class="primary" onclick="registerAgent()">Register</button>

--- a/packages/worker-utils/src/kilo-token.ts
+++ b/packages/worker-utils/src/kilo-token.ts
@@ -15,6 +15,7 @@ export const kiloTokenPayload = z.object({
   env: z.string().optional(),
   // Optional extras from JWTTokenExtraPayload
   isAdmin: z.boolean().optional(),
+  gastownAccess: z.boolean().optional(),
   botId: z.string().optional(),
   organizationId: z.string().optional(),
   organizationRole: z.enum(['owner', 'member', 'billing_manager']).optional(),

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -29,7 +29,7 @@ import HeaderLogo from '@/components/HeaderLogo';
 import OrganizationSwitcher from './OrganizationSwitcher';
 import SidebarMenuList from './SidebarMenuList';
 import SidebarUserFooter from './SidebarUserFooter';
-import { ENABLE_DEPLOY_FEATURE, ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
 import { isEnabledForUser } from '@/lib/code-indexing/util';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
@@ -39,8 +39,8 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
 
   // Feature flags
   const isAutoTriageFeatureEnabled = useFeatureFlagEnabled('auto-triage-feature');
+  const isGastownEnabled = useFeatureFlagEnabled('gastown-access');
   const isDevelopment = process.env.NODE_ENV === 'development';
-  const isAdmin = user?.is_admin ?? false;
 
   // Dashboard group
   const dashboardItems: Array<{
@@ -120,7 +120,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
-    ...(ENABLE_GASTOWN_FEATURE && isAdmin
+    ...(isGastownEnabled || isDevelopment
       ? [
           {
             title: 'Gastown',

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -31,7 +31,7 @@ import SidebarMenuList from './SidebarMenuList';
 import SidebarUserFooter from './SidebarUserFooter';
 import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
 import { isEnabledForUser } from '@/lib/code-indexing/util';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
+import { useFeatureFlagEnabled, useFeatureFlagVariantKey } from 'posthog-js/react';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 
 export default function PersonalAppSidebar(props: React.ComponentProps<typeof Sidebar>) {
@@ -39,7 +39,10 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
 
   // Feature flags
   const isAutoTriageFeatureEnabled = useFeatureFlagEnabled('auto-triage-feature');
-  const isGastownEnabled = useFeatureFlagEnabled('gastown-access');
+  // Strict boolean check — matches isReleaseToggleEnabled on the server side.
+  // useFeatureFlagVariantKey returns the raw flag value (true | string | undefined),
+  // so === true rejects multivariate string variants.
+  const isGastownEnabled = useFeatureFlagVariantKey('gastown-access') === true;
   const isDevelopment = process.env.NODE_ENV === 'development';
 
   // Dashboard group

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -120,7 +120,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
-    ...(isGastownEnabled
+    ...(isGastownEnabled || isDevelopment
       ? [
           {
             title: 'Gastown',

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -31,7 +31,7 @@ import SidebarMenuList from './SidebarMenuList';
 import SidebarUserFooter from './SidebarUserFooter';
 import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
 import { isEnabledForUser } from '@/lib/code-indexing/util';
-import { useFeatureFlagEnabled, useFeatureFlagVariantKey } from 'posthog-js/react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 
 export default function PersonalAppSidebar(props: React.ComponentProps<typeof Sidebar>) {
@@ -39,10 +39,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
 
   // Feature flags
   const isAutoTriageFeatureEnabled = useFeatureFlagEnabled('auto-triage-feature');
-  // Strict boolean check — matches isReleaseToggleEnabled on the server side.
-  // useFeatureFlagVariantKey returns the raw flag value (true | string | undefined),
-  // so === true rejects multivariate string variants.
-  const isGastownEnabled = useFeatureFlagVariantKey('gastown-access') === true;
+  const isGastownEnabled = useFeatureFlagEnabled('gastown-access');
   const isDevelopment = process.env.NODE_ENV === 'development';
 
   // Dashboard group

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -120,7 +120,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
-    ...(isGastownEnabled || isDevelopment
+    ...(isGastownEnabled
       ? [
           {
             title: 'Gastown',

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { AgentsPageClient } from './AgentsPageClient';
 
 export default async function AgentsPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -10,7 +9,6 @@ export default async function AgentsPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/agents`
   );
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <AgentsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { AgentsPageClient } from './AgentsPageClient';
 
 export default async function AgentsPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -8,6 +10,7 @@ export default async function AgentsPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/agents`
   );
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
   return <AgentsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { AgentsPageClient } from './AgentsPageClient';
 
 export default async function AgentsPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -9,6 +8,6 @@ export default async function AgentsPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/agents`
   );
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id))) return notFound();
   return <AgentsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { AgentsPageClient } from './AgentsPageClient';
 
@@ -9,6 +9,6 @@ export default async function AgentsPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/agents`
   );
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <AgentsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { BeadsPageClient } from './BeadsPageClient';
 
@@ -9,6 +9,6 @@ export default async function BeadsPage({ params }: { params: Promise<{ townId: 
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/beads`
   );
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <BeadsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { BeadsPageClient } from './BeadsPageClient';
 
 export default async function BeadsPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -8,6 +10,7 @@ export default async function BeadsPage({ params }: { params: Promise<{ townId: 
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/beads`
   );
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
   return <BeadsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { BeadsPageClient } from './BeadsPageClient';
 
 export default async function BeadsPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -10,7 +9,6 @@ export default async function BeadsPage({ params }: { params: Promise<{ townId: 
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/beads`
   );
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <BeadsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { BeadsPageClient } from './BeadsPageClient';
 
 export default async function BeadsPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -9,6 +8,6 @@ export default async function BeadsPage({ params }: { params: Promise<{ townId: 
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/beads`
   );
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id))) return notFound();
   return <BeadsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { MailPageClient } from './MailPageClient';
 
 export default async function MailPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -10,7 +9,6 @@ export default async function MailPage({ params }: { params: Promise<{ townId: s
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/mail`
   );
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <MailPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { MailPageClient } from './MailPageClient';
 
 export default async function MailPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -8,6 +10,7 @@ export default async function MailPage({ params }: { params: Promise<{ townId: s
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/mail`
   );
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
   return <MailPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { MailPageClient } from './MailPageClient';
 
@@ -9,6 +9,6 @@ export default async function MailPage({ params }: { params: Promise<{ townId: s
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/mail`
   );
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <MailPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { MailPageClient } from './MailPageClient';
 
 export default async function MailPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -9,6 +8,6 @@ export default async function MailPage({ params }: { params: Promise<{ townId: s
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/mail`
   );
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id))) return notFound();
   return <MailPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { MergesPageClient } from './MergesPageClient';
 
 export default async function MergesPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -10,7 +9,6 @@ export default async function MergesPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/merges`
   );
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <MergesPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { MergesPageClient } from './MergesPageClient';
 
@@ -9,6 +9,6 @@ export default async function MergesPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/merges`
   );
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <MergesPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { MergesPageClient } from './MergesPageClient';
 
 export default async function MergesPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -8,6 +10,7 @@ export default async function MergesPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/merges`
   );
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
   return <MergesPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { MergesPageClient } from './MergesPageClient';
 
 export default async function MergesPage({ params }: { params: Promise<{ townId: string }> }) {
@@ -9,6 +8,6 @@ export default async function MergesPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/merges`
   );
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id))) return notFound();
   return <MergesPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { ObservabilityPageClient } from './ObservabilityPageClient';
 
@@ -13,6 +13,6 @@ export default async function ObservabilityPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/observability`
   );
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <ObservabilityPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { ObservabilityPageClient } from './ObservabilityPageClient';
 
 export default async function ObservabilityPage({
@@ -12,6 +14,7 @@ export default async function ObservabilityPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/observability`
   );
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
   return <ObservabilityPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { ObservabilityPageClient } from './ObservabilityPageClient';
 
 export default async function ObservabilityPage({
@@ -14,7 +13,6 @@ export default async function ObservabilityPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/observability`
   );
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <ObservabilityPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { ObservabilityPageClient } from './ObservabilityPageClient';
 
 export default async function ObservabilityPage({
@@ -13,6 +12,6 @@ export default async function ObservabilityPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/observability`
   );
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id))) return notFound();
   return <ObservabilityPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { TownOverviewPageClient } from './TownOverviewPageClient';
 
 export default async function TownOverviewPage({
@@ -13,8 +12,7 @@ export default async function TownOverviewPage({
   const { townId } = await params;
   const user = await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
 
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) {
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { TownOverviewPageClient } from './TownOverviewPageClient';
 
@@ -12,7 +12,7 @@ export default async function TownOverviewPage({
   const { townId } = await params;
   const user = await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
 
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { TownOverviewPageClient } from './TownOverviewPageClient';
 
 export default async function TownOverviewPage({
@@ -11,7 +13,8 @@ export default async function TownOverviewPage({
   const { townId } = await params;
   const user = await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
 
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) {
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { TownOverviewPageClient } from './TownOverviewPageClient';
 
 export default async function TownOverviewPage({
@@ -12,7 +11,7 @@ export default async function TownOverviewPage({
   const { townId } = await params;
   const user = await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
 
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
+  if (!(await isGastownEnabled(user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { RigDetailPageClient } from './RigDetailPageClient';
 
@@ -14,7 +14,7 @@ export default async function RigDetailPage({
     `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`
   );
 
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { RigDetailPageClient } from './RigDetailPageClient';
 
 export default async function RigDetailPage({
@@ -13,7 +15,8 @@ export default async function RigDetailPage({
     `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`
   );
 
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) {
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { RigDetailPageClient } from './RigDetailPageClient';
 
 export default async function RigDetailPage({
@@ -15,8 +14,7 @@ export default async function RigDetailPage({
     `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`
   );
 
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) {
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { RigDetailPageClient } from './RigDetailPageClient';
 
 export default async function RigDetailPage({
@@ -14,7 +13,7 @@ export default async function RigDetailPage({
     `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`
   );
 
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
+  if (!(await isGastownEnabled(user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/settings/page.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/page.tsx
@@ -1,6 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { TownSettingsPageClient } from './TownSettingsPageClient';
 
@@ -13,6 +13,6 @@ export default async function TownSettingsPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/settings`
   );
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <TownSettingsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/settings/page.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/page.tsx
@@ -1,6 +1,8 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { TownSettingsPageClient } from './TownSettingsPageClient';
 
 export default async function TownSettingsPage({
@@ -12,6 +14,7 @@ export default async function TownSettingsPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/settings`
   );
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) return notFound();
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
   return <TownSettingsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/settings/page.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/page.tsx
@@ -1,8 +1,7 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { TownSettingsPageClient } from './TownSettingsPageClient';
 
 export default async function TownSettingsPage({
@@ -14,7 +13,6 @@ export default async function TownSettingsPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/settings`
   );
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) return notFound();
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
   return <TownSettingsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/settings/page.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/page.tsx
@@ -1,7 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { TownSettingsPageClient } from './TownSettingsPageClient';
 
 export default async function TownSettingsPage({
@@ -13,6 +12,6 @@ export default async function TownSettingsPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/settings`
   );
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id))) return notFound();
   return <TownSettingsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/page.tsx
+++ b/src/app/(app)/gastown/page.tsx
@@ -1,13 +1,13 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { TownListPageClient } from './TownListPageClient';
 
 export default async function GastownPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
 
-  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
+  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/page.tsx
+++ b/src/app/(app)/gastown/page.tsx
@@ -1,13 +1,12 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { TownListPageClient } from './TownListPageClient';
 
 export default async function GastownPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
 
-  if (!(await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
+  if (!(await isGastownEnabled(user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/page.tsx
+++ b/src/app/(app)/gastown/page.tsx
@@ -1,15 +1,13 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
-import { IS_DEVELOPMENT } from '@/lib/constants';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 import { TownListPageClient } from './TownListPageClient';
 
 export default async function GastownPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
 
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
-  if (!hasAccess && !IS_DEVELOPMENT) {
+  if (!(await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/page.tsx
+++ b/src/app/(app)/gastown/page.tsx
@@ -1,12 +1,15 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
-import { ENABLE_GASTOWN_FEATURE } from '@/lib/constants';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import { TownListPageClient } from './TownListPageClient';
 
 export default async function GastownPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
 
-  if (!ENABLE_GASTOWN_FEATURE || !user.is_admin) {
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id);
+  if (!hasAccess && !IS_DEVELOPMENT) {
     return notFound();
   }
 

--- a/src/app/api/gastown/token/route.ts
+++ b/src/app/api/gastown/token/route.ts
@@ -2,8 +2,7 @@ import 'server-only';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { generateApiToken } from '@/lib/tokens';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 
 const ONE_HOUR_SECONDS = 60 * 60;
 
@@ -27,7 +26,7 @@ export async function POST() {
   if (authFailedResponse) return authFailedResponse;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const hasAccess = await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id);
+  const hasAccess = await isGastownEnabled(user.id);
 
   if (!hasAccess) {
     return NextResponse.json({ error: 'Gastown access denied' }, { status: 403 });

--- a/src/app/api/gastown/token/route.ts
+++ b/src/app/api/gastown/token/route.ts
@@ -2,8 +2,8 @@ import 'server-only';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { generateApiToken } from '@/lib/tokens';
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 
 const ONE_HOUR_SECONDS = 60 * 60;
 
@@ -27,8 +27,7 @@ export async function POST() {
   if (authFailedResponse) return authFailedResponse;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const isDev = process.env.NODE_ENV === 'development';
-  const hasAccess = isDev || (await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id));
+  const hasAccess = await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id);
 
   if (!hasAccess) {
     return NextResponse.json({ error: 'Gastown access denied' }, { status: 403 });

--- a/src/app/api/gastown/token/route.ts
+++ b/src/app/api/gastown/token/route.ts
@@ -2,6 +2,8 @@ import 'server-only';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { generateApiToken } from '@/lib/tokens';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_FLAGS } from '@/lib/gastown/feature-flags';
 
 const ONE_HOUR_SECONDS = 60 * 60;
 
@@ -15,16 +17,29 @@ const ONE_HOUR_SECONDS = 60 * 60;
  * (same-origin). The returned token is sent as `Authorization: Bearer <token>`
  * to the worker's tRPC endpoint (cross-origin).
  *
- * The JWT includes `isAdmin` and `apiTokenPepper` so the worker can verify
- * admin access and mint kilo API tokens without a DB round-trip.
+ * Access is controlled by the `gastown-access` PostHog feature flag.
+ * The JWT includes `gastownAccess`, `isAdmin`, and `apiTokenPepper` so
+ * the worker can enforce access and mint kilo API tokens without a DB
+ * round-trip.
  */
 export async function POST() {
-  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) return authFailedResponse;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const token = generateApiToken(user, { isAdmin: true }, { expiresIn: ONE_HOUR_SECONDS });
-  const expiresAt = new Date(Date.now() + 55 * 60 * 1000).toISOString(); // 55 min (5 min buffer before 1h expiry)
+  const isDev = process.env.NODE_ENV === 'development';
+  const hasAccess = isDev || (await isFeatureFlagEnabled(GASTOWN_FLAGS.access, user.id));
+
+  if (!hasAccess) {
+    return NextResponse.json({ error: 'Gastown access denied' }, { status: 403 });
+  }
+
+  const token = generateApiToken(
+    user,
+    { isAdmin: user.is_admin, gastownAccess: true },
+    { expiresIn: ONE_HOUR_SECONDS }
+  );
+  const expiresAt = new Date(Date.now() + 55 * 60 * 1000).toISOString();
 
   return NextResponse.json({ token, expiresAt });
 }

--- a/src/app/api/gastown/token/route.ts
+++ b/src/app/api/gastown/token/route.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { generateApiToken } from '@/lib/tokens';
-import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { GASTOWN_ACCESS_FLAG } from '@/lib/gastown/feature-flags';
 
 const ONE_HOUR_SECONDS = 60 * 60;
@@ -27,7 +27,7 @@ export async function POST() {
   if (authFailedResponse) return authFailedResponse;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const hasAccess = await isReleaseToggleEnabled(GASTOWN_ACCESS_FLAG, user.id);
+  const hasAccess = await isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, user.id);
 
   if (!hasAccess) {
     return NextResponse.json({ error: 'Gastown access denied' }, { status: 403 });

--- a/src/components/gastown/ConvoyTimeline.tsx
+++ b/src/components/gastown/ConvoyTimeline.tsx
@@ -158,23 +158,26 @@ function ConvoyCard({
       {/* Convoy header */}
       <div className="mb-2 flex items-center justify-between">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-medium text-violet-400">
+          <span className="shrink-0 rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-medium text-violet-400">
             CONVOY
           </span>
-          <span className="max-w-[300px] truncate text-xs font-medium text-white/70">
+          <span
+            className="min-w-0 shrink truncate text-xs font-medium text-white/70"
+            title={convoy.title}
+          >
             {convoy.title}
           </span>
           {convoy.feature_branch && (
             <span
-              className="flex items-center gap-1 text-[9px] text-white/25"
+              className="flex min-w-0 shrink items-center gap-1 text-[9px] text-white/25"
               title={convoy.feature_branch}
             >
-              <GitBranch className="size-2.5" />
-              <span className="max-w-[140px] truncate font-mono">{convoy.feature_branch}</span>
+              <GitBranch className="size-2.5 shrink-0" />
+              <span className="min-w-0 truncate font-mono">{convoy.feature_branch}</span>
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <span className="font-mono text-[10px] text-white/30">
             {convoy.closed_beads}/{convoy.total_beads}
           </span>

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC, gastownWsUrl } from '@/lib/gastown/trpc';
+
 import { useSidebar } from '@/components/ui/sidebar';
 import { useTerminalBar } from './TerminalBarContext';
-import { ChevronDown, ChevronUp, Crown, Terminal as TerminalIcon, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, Crown, Activity, Terminal as TerminalIcon, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
@@ -35,6 +36,7 @@ export function TerminalBar({ townId }: TerminalBarProps) {
   const sidebarLeft = isMobile ? '0px' : sidebarState === 'expanded' ? '16rem' : '3rem';
 
   const allTabs = [
+    { id: 'status', label: 'Status', kind: 'status' as const, agentId: '' },
     { id: 'mayor', label: 'Mayor', kind: 'mayor' as const, agentId: '' },
     ...agentTabs,
   ];
@@ -93,8 +95,11 @@ export function TerminalBar({ townId }: TerminalBarProps) {
                   {isMayor && (
                     <Crown className="size-3 shrink-0 text-[color:oklch(95%_0.15_108_/_0.6)]" />
                   )}
+                  {tab.kind === 'status' && (
+                    <Activity className="size-3 shrink-0 text-[color:oklch(85%_0.12_200_/_0.6)]" />
+                  )}
                   <span className="max-w-[120px] truncate">{tab.label}</span>
-                  {!isMayor && (
+                  {!isMayor && tab.kind !== 'status' && (
                     <button
                       onClick={e => {
                         e.stopPropagation();
@@ -126,6 +131,8 @@ export function TerminalBar({ townId }: TerminalBarProps) {
           >
             {activeTab.kind === 'mayor' ? (
               <MayorTerminalPane townId={townId} collapsed={collapsed} />
+            ) : activeTab.kind === 'status' ? (
+              <AlarmStatusPane townId={townId} />
             ) : (
               <AgentTerminalPane townId={townId} agentId={activeTab.agentId} />
             )}
@@ -134,6 +141,308 @@ export function TerminalBar({ townId }: TerminalBarProps) {
       </AnimatePresence>
     </div>
   );
+}
+
+// ── Alarm Status Pane ────────────────────────────────────────────────────
+
+type AlarmStatus = {
+  alarm: { nextFireAt: string | null; intervalMs: number; intervalLabel: string };
+  agents: { working: number; idle: number; stalled: number; dead: number; total: number };
+  beads: { open: number; inProgress: number; failed: number; triageRequests: number };
+  patrol: {
+    guppWarnings: number;
+    guppEscalations: number;
+    stalledAgents: number;
+    orphanedHooks: number;
+  };
+  recentEvents: Array<{ time: string; type: string; message: string }>;
+};
+
+/**
+ * Hook that connects to the TownDO status WebSocket and returns the
+ * latest alarm status snapshot. Falls back to tRPC polling if the
+ * WebSocket fails or disconnects.
+ */
+function useAlarmStatusWs(townId: string): {
+  data: AlarmStatus | null;
+  connected: boolean;
+  error: string | null;
+} {
+  const [data, setData] = useState<AlarmStatus | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  const connect = useCallback(() => {
+    if (!mountedRef.current) return;
+    const wsUrl = gastownWsUrl(`/api/towns/${townId}/status/ws`);
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (!mountedRef.current) return;
+      setConnected(true);
+      setError(null);
+    };
+
+    ws.onmessage = (e: MessageEvent) => {
+      if (!mountedRef.current || typeof e.data !== 'string') return;
+      try {
+        setData(JSON.parse(e.data) as AlarmStatus);
+      } catch {
+        // Ignore malformed messages
+      }
+    };
+
+    ws.onclose = () => {
+      if (!mountedRef.current) return;
+      setConnected(false);
+      // Reconnect after 3s
+      reconnectTimerRef.current = setTimeout(connect, 3_000);
+    };
+
+    ws.onerror = () => {
+      if (!mountedRef.current) return;
+      setError('WebSocket connection failed');
+    };
+  }, [townId]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    connect();
+    return () => {
+      mountedRef.current = false;
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      wsRef.current?.close(1000, 'Component unmount');
+      wsRef.current = null;
+    };
+  }, [connect]);
+
+  return { data, connected, error };
+}
+
+function AlarmStatusPane({ townId }: { townId: string }) {
+  const { data, connected, error } = useAlarmStatusWs(townId);
+
+  if (!data && !error) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-white/30">
+        Connecting to alarm status...
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-red-400/60">{error}</div>
+    );
+  }
+
+  if (!data) return null;
+
+  const hasIssues =
+    data.patrol.guppWarnings > 0 ||
+    data.patrol.guppEscalations > 0 ||
+    data.patrol.stalledAgents > 0 ||
+    data.patrol.orphanedHooks > 0;
+
+  return (
+    <div className="relative flex h-full gap-3 overflow-hidden p-3 text-[11px] text-white/70">
+      {/* Connection indicator */}
+      <div className="absolute top-1.5 right-3 z-10 flex items-center gap-1.5">
+        <span
+          className={`size-1.5 rounded-full ${connected ? 'bg-emerald-400' : 'animate-pulse bg-yellow-400'}`}
+        />
+        <span className="text-[10px] text-white/35">{connected ? 'Live' : 'Reconnecting...'}</span>
+      </div>
+
+      {/* Left column: status cards */}
+      <div className="flex w-[340px] shrink-0 flex-col gap-2 overflow-y-auto">
+        {/* Alarm */}
+        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
+          <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+            <Activity className="size-3" />
+            Alarm Loop
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            <StatusRow label="Interval" value={data.alarm.intervalLabel} />
+            <StatusRow
+              label="Next fire"
+              value={data.alarm.nextFireAt ? formatRelativeTime(data.alarm.nextFireAt) : 'not set'}
+              warn={!data.alarm.nextFireAt}
+            />
+          </div>
+        </div>
+
+        {/* Agents */}
+        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
+          <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+            Agents ({data.agents.total})
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            <StatusRow
+              label="Working"
+              value={data.agents.working}
+              highlight={data.agents.working > 0}
+            />
+            <StatusRow label="Idle" value={data.agents.idle} />
+            <StatusRow label="Stalled" value={data.agents.stalled} warn={data.agents.stalled > 0} />
+            <StatusRow label="Dead" value={data.agents.dead} warn={data.agents.dead > 0} />
+          </div>
+        </div>
+
+        {/* Beads */}
+        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
+          <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+            Beads
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            <StatusRow label="Open" value={data.beads.open} />
+            <StatusRow
+              label="In Progress"
+              value={data.beads.inProgress}
+              highlight={data.beads.inProgress > 0}
+            />
+            <StatusRow label="Failed" value={data.beads.failed} warn={data.beads.failed > 0} />
+            <StatusRow
+              label="Triage"
+              value={data.beads.triageRequests}
+              warn={data.beads.triageRequests > 0}
+            />
+          </div>
+        </div>
+
+        {/* Patrol */}
+        <div
+          className={`rounded-md border p-2 ${
+            hasIssues
+              ? 'border-yellow-500/20 bg-yellow-500/[0.03]'
+              : 'border-white/[0.06] bg-white/[0.02]'
+          }`}
+        >
+          <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+            Patrol {hasIssues ? '(issues detected)' : ''}
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            <StatusRow
+              label="GUPP Warns"
+              value={data.patrol.guppWarnings}
+              warn={data.patrol.guppWarnings > 0}
+            />
+            <StatusRow
+              label="GUPP Escalations"
+              value={data.patrol.guppEscalations}
+              warn={data.patrol.guppEscalations > 0}
+            />
+            <StatusRow
+              label="Stalled"
+              value={data.patrol.stalledAgents}
+              warn={data.patrol.stalledAgents > 0}
+            />
+            <StatusRow
+              label="Orphaned Hooks"
+              value={data.patrol.orphanedHooks}
+              warn={data.patrol.orphanedHooks > 0}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Right column: event feed */}
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-md border border-white/[0.06] bg-white/[0.02]">
+        <div className="border-b border-white/[0.06] px-2.5 py-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+          Recent Events
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {data.recentEvents.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-white/20">
+              No recent events
+            </div>
+          ) : (
+            <div className="divide-y divide-white/[0.04]">
+              {data.recentEvents.map((event, i) => (
+                <div key={i} className="flex items-baseline gap-2 px-2.5 py-1.5">
+                  <span className="shrink-0 text-[10px] text-white/25 tabular-nums">
+                    {formatTime(event.time)}
+                  </span>
+                  <span
+                    className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-medium ${eventTypeColor(event.type)}`}
+                  >
+                    {event.type}
+                  </span>
+                  <span className="min-w-0 truncate">{event.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusRow({
+  label,
+  value,
+  warn,
+  highlight,
+}: {
+  label: string;
+  value: string | number;
+  warn?: boolean;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-white/35">{label}</span>
+      <span
+        className={`tabular-nums ${
+          warn ? 'text-yellow-400/80' : highlight ? 'text-emerald-400/80' : 'text-white/60'
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function formatRelativeTime(iso: string): string {
+  const diff = new Date(iso).getTime() - Date.now();
+  if (diff < 0) return 'overdue';
+  if (diff < 1000) return 'now';
+  if (diff < 60_000) return `${Math.round(diff / 1000)}s`;
+  return `${Math.round(diff / 60_000)}m`;
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function eventTypeColor(type: string): string {
+  switch (type) {
+    case 'status_changed':
+      return 'bg-blue-500/15 text-blue-400/70';
+    case 'assigned':
+      return 'bg-emerald-500/15 text-emerald-400/70';
+    case 'pr_created':
+    case 'pr_merged':
+      return 'bg-purple-500/15 text-purple-400/70';
+    case 'pr_creation_failed':
+    case 'escalation_created':
+      return 'bg-yellow-500/15 text-yellow-400/70';
+    default:
+      return 'bg-white/5 text-white/40';
+  }
 }
 
 // ── Mayor Terminal Pane ──────────────────────────────────────────────────
@@ -226,6 +535,10 @@ function MayorTerminalPane({ townId, collapsed }: { townId: string; collapsed: b
           selectionBackground: '#3a3a5a',
         },
         allowProposedApi: true,
+        // Disable xterm's scrollback so kilo's TUI handles all scrolling.
+        // Without this, xterm's viewport captures mouse wheel events and
+        // prevents the TUI's own scroll from working.
+        scrollback: 0,
       });
 
       term.loadAddon(fitAddon);
@@ -410,6 +723,7 @@ function AgentTerminalPane({ townId, agentId }: { townId: string; agentId: strin
           selectionBackground: '#3a3a5a',
         },
         allowProposedApi: true,
+        scrollback: 0,
       });
 
       term.loadAddon(fitAddon);

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -224,9 +224,22 @@ function useAlarmStatusWs(townId: string): {
 }
 
 function AlarmStatusPane({ townId }: { townId: string }) {
-  const { data, connected, error } = useAlarmStatusWs(townId);
+  const { data: wsData, connected: wsConnected, error: wsError } = useAlarmStatusWs(townId);
+  const trpc = useGastownTRPC();
 
-  if (!data && !error) {
+  // Fall back to polling when WebSocket is unavailable (blocked, errored,
+  // or never connected). The tRPC query is disabled while the WS is
+  // providing data to avoid redundant requests.
+  const wsFailed = !!wsError && !wsData;
+  const pollingQuery = useQuery({
+    ...trpc.gastown.getAlarmStatus.queryOptions({ townId }),
+    enabled: wsFailed,
+    refetchInterval: wsFailed ? 5_000 : false,
+  });
+
+  const data = wsData ?? (pollingQuery.data as AlarmStatus | undefined) ?? null;
+
+  if (!data && !wsError && !pollingQuery.error) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-white/30">
         Connecting to alarm status...
@@ -234,13 +247,13 @@ function AlarmStatusPane({ townId }: { townId: string }) {
     );
   }
 
-  if (error && !data) {
+  if (!data) {
     return (
-      <div className="flex h-full items-center justify-center text-xs text-red-400/60">{error}</div>
+      <div className="flex h-full items-center justify-center text-xs text-red-400/60">
+        {wsError ?? 'Failed to load status'}
+      </div>
     );
   }
-
-  if (!data) return null;
 
   const hasIssues =
     data.patrol.guppWarnings > 0 ||
@@ -253,9 +266,11 @@ function AlarmStatusPane({ townId }: { townId: string }) {
       {/* Connection indicator */}
       <div className="absolute top-1.5 right-3 z-10 flex items-center gap-1.5">
         <span
-          className={`size-1.5 rounded-full ${connected ? 'bg-emerald-400' : 'animate-pulse bg-yellow-400'}`}
+          className={`size-1.5 rounded-full ${wsConnected ? 'bg-emerald-400' : wsFailed ? 'bg-blue-400' : 'animate-pulse bg-yellow-400'}`}
         />
-        <span className="text-[10px] text-white/35">{connected ? 'Live' : 'Reconnecting...'}</span>
+        <span className="text-[10px] text-white/35">
+          {wsConnected ? 'Live' : wsFailed ? 'Polling' : 'Reconnecting...'}
+        </span>
       </div>
 
       {/* Left column: status cards */}

--- a/src/components/gastown/TerminalBarContext.tsx
+++ b/src/components/gastown/TerminalBarContext.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext, useState, useCallback, type ReactNode } from
 type TerminalTab = {
   id: string;
   label: string;
-  kind: 'mayor' | 'agent';
+  kind: 'mayor' | 'agent' | 'status';
   agentId: string;
 };
 

--- a/src/components/gastown/useXtermPty.ts
+++ b/src/components/gastown/useXtermPty.ts
@@ -100,6 +100,8 @@ export function useXtermPty({
           selectionBackground: '#3a3a5a',
         },
         allowProposedApi: true,
+        // Disable xterm's scrollback so kilo's TUI handles all scrolling.
+        scrollback: 0,
       });
 
       term.loadAddon(fitAddon);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,7 +33,6 @@ export const TRIAL_DURATION_DAYS = 14;
 export const AUTOCOMPLETE_MODEL = 'codestral-2508';
 
 export const ENABLE_DEPLOY_FEATURE = true;
-export const ENABLE_GASTOWN_FEATURE = true;
 
 export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 

--- a/src/lib/gastown/feature-flags.ts
+++ b/src/lib/gastown/feature-flags.ts
@@ -1,26 +1,11 @@
 /**
- * PostHog feature flag names for Gastown progressive rollout.
+ * PostHog feature flag name for Gastown access.
  *
- * These flags are managed in the PostHog dashboard. PostHog handles
- * allowlists, percentage rollout, and kill-switch natively.
+ * Managed in the PostHog dashboard. PostHog handles allowlists,
+ * percentage rollout, and kill-switch natively.
  *
- * Rollout stages (configured in PostHog):
- *   1. Admin-only: flag targets users where `is_admin` property is true
- *   2. Allowlist: flag targets specific users/cohorts in PostHog
- *   3. Percentage: flag rolls out to N% of users (by distinct ID hash)
- *   4. GA: flag enabled for 100% of users (or flag removed entirely)
- *
- * Kill-switch: disable the flag in PostHog → all non-admin access is cut.
+ * Kill-switch: disable the flag in PostHog → all access is cut.
  *
  * See #901 for details.
  */
-export const GASTOWN_FLAGS = {
-  /** Top-level Gastown access. Replaces the binary is_admin gate from #537. */
-  access: 'gastown-access',
-  /** Convoy creation (gt_sling_batch) and convoy UI. */
-  convoys: 'gastown-convoys',
-  /** PR merge strategy — gate the 'pr' option, default to 'direct'. */
-  pr_merge: 'gastown-pr-merge',
-  /** Adding a second rig to a town. */
-  multi_rig: 'gastown-multi-rig',
-} as const;
+export const GASTOWN_ACCESS_FLAG = 'gastown-access';

--- a/src/lib/gastown/feature-flags.ts
+++ b/src/lib/gastown/feature-flags.ts
@@ -1,0 +1,26 @@
+/**
+ * PostHog feature flag names for Gastown progressive rollout.
+ *
+ * These flags are managed in the PostHog dashboard. PostHog handles
+ * allowlists, percentage rollout, and kill-switch natively.
+ *
+ * Rollout stages (configured in PostHog):
+ *   1. Admin-only: flag targets users where `is_admin` property is true
+ *   2. Allowlist: flag targets specific users/cohorts in PostHog
+ *   3. Percentage: flag rolls out to N% of users (by distinct ID hash)
+ *   4. GA: flag enabled for 100% of users (or flag removed entirely)
+ *
+ * Kill-switch: disable the flag in PostHog → all non-admin access is cut.
+ *
+ * See #901 for details.
+ */
+export const GASTOWN_FLAGS = {
+  /** Top-level Gastown access. Replaces the binary is_admin gate from #537. */
+  access: 'gastown-access',
+  /** Convoy creation (gt_sling_batch) and convoy UI. */
+  convoys: 'gastown-convoys',
+  /** PR merge strategy — gate the 'pr' option, default to 'direct'. */
+  pr_merge: 'gastown-pr-merge',
+  /** Adding a second rig to a town. */
+  multi_rig: 'gastown-multi-rig',
+} as const;

--- a/src/lib/gastown/feature-flags.ts
+++ b/src/lib/gastown/feature-flags.ts
@@ -1,11 +1,21 @@
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+
+const GASTOWN_ACCESS_FLAG = 'gastown-access';
+
 /**
- * PostHog feature flag name for Gastown access.
+ * Check whether the current user has Gastown access.
  *
- * Managed in the PostHog dashboard. PostHog handles allowlists,
- * percentage rollout, and kill-switch natively.
- *
- * Kill-switch: disable the flag in PostHog → all access is cut.
+ * In non-production environments the flag is always enabled so local
+ * development works without PostHog configuration. In production,
+ * access is controlled by the `gastown-access` PostHog feature flag
+ * (allowlists, percentage rollout, and kill-switch are managed in the
+ * PostHog dashboard).
  *
  * See #901 for details.
  */
-export const GASTOWN_ACCESS_FLAG = 'gastown-access';
+export async function isGastownEnabled(userId: string): Promise<boolean> {
+  if (process.env.NODE_ENV !== 'production') {
+    return true;
+  }
+  return isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, userId);
+}

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -103,10 +103,10 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         agents: {
           id: string;
           rig_id: string | null;
-          role: 'mayor' | 'polecat' | 'refinery';
+          role: string;
           name: string;
           identity: string;
-          status: 'dead' | 'idle' | 'stalled' | 'working';
+          status: string;
           current_hook_bead_id: string | null;
           dispatch_attempts: number;
           last_activity_at: string | null;
@@ -193,10 +193,10 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
       output: {
         id: string;
         rig_id: string | null;
-        role: 'mayor' | 'polecat' | 'refinery';
+        role: string;
         name: string;
         identity: string;
-        status: 'dead' | 'idle' | 'stalled' | 'working';
+        status: string;
         current_hook_bead_id: string | null;
         dispatch_attempts: number;
         last_activity_at: string | null;
@@ -248,10 +248,10 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         agent: {
           id: string;
           rig_id: string | null;
-          role: 'mayor' | 'polecat' | 'refinery';
+          role: string;
           name: string;
           identity: string;
-          status: 'dead' | 'idle' | 'stalled' | 'working';
+          status: string;
           current_hook_bead_id: string | null;
           dispatch_attempts: number;
           last_activity_at: string | null;
@@ -695,10 +695,10 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             agents: {
               id: string;
               rig_id: string | null;
-              role: 'mayor' | 'polecat' | 'refinery';
+              role: string;
               name: string;
               identity: string;
-              status: 'dead' | 'idle' | 'stalled' | 'working';
+              status: string;
               current_hook_bead_id: string | null;
               dispatch_attempts: number;
               last_activity_at: string | null;
@@ -785,10 +785,10 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
           output: {
             id: string;
             rig_id: string | null;
-            role: 'mayor' | 'polecat' | 'refinery';
+            role: string;
             name: string;
             identity: string;
-            status: 'dead' | 'idle' | 'stalled' | 'working';
+            status: string;
             current_hook_bead_id: string | null;
             dispatch_attempts: number;
             last_activity_at: string | null;
@@ -840,10 +840,10 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             agent: {
               id: string;
               rig_id: string | null;
-              role: 'mayor' | 'polecat' | 'refinery';
+              role: string;
               name: string;
               identity: string;
-              status: 'dead' | 'idle' | 'stalled' | 'working';
+              status: string;
               current_hook_bead_id: string | null;
               dispatch_attempts: number;
               last_activity_at: string | null;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,543 +1,581 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    createTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            name: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    createTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        name: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
     }>;
-    listTowns: import("@trpc/server").TRPCQueryProcedure<{
-        input: void;
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
+    listTowns: import('@trpc/server').TRPCQueryProcedure<{
+      input: void;
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getTown: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    createRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        name: string;
+        gitUrl: string;
+        defaultBranch?: string | undefined;
+        platformIntegrationId?: string | undefined;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    listRigs: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getRig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+        agents: {
+          id: string;
+          rig_id: string | null;
+          role: 'mayor' | 'polecat' | 'refinery';
+          name: string;
+          identity: string;
+          status: 'dead' | 'idle' | 'stalled' | 'working';
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
         }[];
-        meta: object;
-    }>;
-    getTown: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    createRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    listRigs: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
+        beads: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    getRig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-            agents: {
-                id: string;
-                rig_id: string | null;
-                role: "mayor" | "polecat" | "refinery";
-                name: string;
-                identity: string;
-                status: "dead" | "idle" | "stalled" | "working";
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-            }[];
-            beads: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            }[];
-        };
-        meta: object;
+    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: void;
-        meta: object;
+    listBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
     }>;
-    listBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        }[];
-        meta: object;
+    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-        };
-        output: void;
-        meta: object;
+    listAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: 'mayor' | 'polecat' | 'refinery';
+        name: string;
+        identity: string;
+        status: 'dead' | 'idle' | 'stalled' | 'working';
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+      }[];
+      meta: object;
     }>;
-    listAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: "mayor" | "polecat" | "refinery";
-            name: string;
-            identity: string;
-            status: "dead" | "idle" | "stalled" | "working";
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-        }[];
-        meta: object;
+    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        agentId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            agentId: string;
+    sling: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        title: string;
+        body?: string | undefined;
+        model?: string | undefined;
+      };
+      output: {
+        bead: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         };
-        output: void;
-        meta: object;
+        agent: {
+          id: string;
+          rig_id: string | null;
+          role: 'mayor' | 'polecat' | 'refinery';
+          name: string;
+          identity: string;
+          status: 'dead' | 'idle' | 'stalled' | 'working';
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+        };
+      };
+      meta: object;
     }>;
-    sling: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            title: string;
-            body?: string | undefined;
-            model?: string | undefined;
-        };
-        output: {
-            bead: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            agent: {
-                id: string;
-                rig_id: string | null;
-                role: "mayor" | "polecat" | "refinery";
-                name: string;
-                identity: string;
-                status: "dead" | "idle" | "stalled" | "working";
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-            };
-        };
-        meta: object;
+    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        message: string;
+        model?: string | undefined;
+        rigId?: string | undefined;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
     }>;
-    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            message: string;
-            model?: string | undefined;
-            rigId?: string | undefined;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            configured: boolean;
-            townId: string | null;
-            session: {
-                agentId: string;
-                sessionId: string;
-                status: "active" | "idle" | "starting";
-                lastActivityAt: string;
-            } | null;
-        };
-        meta: object;
-    }>;
-    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
-            };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
-            };
-            beads: {
-                open: number;
-                inProgress: number;
-                failed: number;
-                triageRequests: number;
-            };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
-            };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
-        };
-        meta: object;
-    }>;
-    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            agentId: string;
-            townId: string;
-        };
-        output: {
-            url: string;
-            ticket: string;
-        };
-        meta: object;
-    }>;
-    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: {
-            pty: {
-                [x: string]: unknown;
-                id: string;
-            };
-            wsUrl: string;
-        };
-        meta: object;
-    }>;
-    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-            ptyId: string;
-            cols: number;
-            rows: number;
-        };
-        output: void;
-        meta: object;
-    }>;
-    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
-                sleep_after_minutes?: number | undefined;
-            } | undefined;
-        };
-        meta: object;
-    }>;
-    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            config: {
-                env_vars?: Record<string, string> | undefined;
-                git_auth?: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                } | undefined;
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy?: "direct" | "pr" | undefined;
-                refinery?: {
-                    gates?: string[] | undefined;
-                    auto_merge?: boolean | undefined;
-                    require_clean_merge?: boolean | undefined;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-            };
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
-                sleep_after_minutes?: number | undefined;
-            } | undefined;
-        };
-        meta: object;
-    }>;
-    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-        }[];
-        meta: object;
-    }>;
-    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-        }[];
-        meta: object;
-    }>;
-    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        }[];
-        meta: object;
-    }>;
-    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
+    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        configured: boolean;
+        townId: string | null;
+        session: {
+          agentId: string;
+          sessionId: string;
+          status: 'active' | 'idle' | 'starting';
+          lastActivityAt: string;
         } | null;
-        meta: object;
+      };
+      meta: object;
     }>;
-}>>;
+    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
+        };
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
+        };
+        beads: {
+          open: number;
+          inProgress: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
+        }[];
+      };
+      meta: object;
+    }>;
+    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
+    }>;
+    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        agentId: string;
+        townId: string;
+      };
+      output: {
+        url: string;
+        ticket: string;
+      };
+      meta: object;
+    }>;
+    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: {
+        pty: {
+          [x: string]: unknown;
+          id: string;
+        };
+        wsUrl: string;
+      };
+      meta: object;
+    }>;
+    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+        ptyId: string;
+        cols: number;
+        rows: number;
+      };
+      output: void;
+      meta: object;
+    }>;
+    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
+        };
+        owner_user_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+      };
+      meta: object;
+    }>;
+    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        config: {
+          env_vars?: Record<string, string> | undefined;
+          git_auth?:
+            | {
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
+              }
+            | undefined;
+          owner_user_id?: string | undefined;
+          kilocode_token?: string | undefined;
+          default_model?: string | undefined;
+          small_model?: string | undefined;
+          max_polecats_per_rig?: number | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          refinery?:
+            | {
+                gates?: string[] | undefined;
+                auto_merge?: boolean | undefined;
+                require_clean_merge?: boolean | undefined;
+              }
+            | undefined;
+          alarm_interval_active?: number | undefined;
+          alarm_interval_idle?: number | undefined;
+          container?:
+            | {
+                sleep_after_minutes?: number | undefined;
+              }
+            | undefined;
+        };
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
+        };
+        owner_user_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+      };
+      meta: object;
+    }>;
+    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
+        }[];
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      }[];
+      meta: object;
+    }>;
+    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
+        }[];
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      } | null;
+      meta: object;
+    }>;
+  }>
+>;
 export type GastownRouter = typeof gastownRouter;
 /**
  * Wrapped router that nests gastownRouter under a `gastown` key.
@@ -545,550 +583,591 @@ export type GastownRouter = typeof gastownRouter;
  * matching the existing RootRouter shape so components don't need
  * to change their procedure paths.
  */
-export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    gastown: import("@trpc/server").TRPCBuiltRouter<{
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    gastown: import('@trpc/server').TRPCBuiltRouter<
+      {
         ctx: TRPCContext;
         meta: object;
-        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
         transformer: false;
-    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-        createTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                name: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
+      },
+      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+        createTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            name: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
         }>;
-        listTowns: import("@trpc/server").TRPCQueryProcedure<{
-            input: void;
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
+        listTowns: import('@trpc/server').TRPCQueryProcedure<{
+          input: void;
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getTown: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        createRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        listRigs: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getRig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+            agents: {
+              id: string;
+              rig_id: string | null;
+              role: 'mayor' | 'polecat' | 'refinery';
+              name: string;
+              identity: string;
+              status: 'dead' | 'idle' | 'stalled' | 'working';
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
             }[];
-            meta: object;
-        }>;
-        getTown: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        createRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                name: string;
-                gitUrl: string;
-                defaultBranch?: string | undefined;
-                platformIntegrationId?: string | undefined;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        listRigs: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
+            beads: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        getRig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-                agents: {
-                    id: string;
-                    rig_id: string | null;
-                    role: "mayor" | "polecat" | "refinery";
-                    name: string;
-                    identity: string;
-                    status: "dead" | "idle" | "stalled" | "working";
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                }[];
-                beads: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                }[];
-            };
-            meta: object;
+        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: void;
-            meta: object;
+        listBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
         }>;
-        listBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            }[];
-            meta: object;
+        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-            };
-            output: void;
-            meta: object;
+        listAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: 'mayor' | 'polecat' | 'refinery';
+            name: string;
+            identity: string;
+            status: 'dead' | 'idle' | 'stalled' | 'working';
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+          }[];
+          meta: object;
         }>;
-        listAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: "mayor" | "polecat" | "refinery";
-                name: string;
-                identity: string;
-                status: "dead" | "idle" | "stalled" | "working";
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-            }[];
-            meta: object;
+        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            agentId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                agentId: string;
+        sling: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            title: string;
+            body?: string | undefined;
+            model?: string | undefined;
+          };
+          output: {
+            bead: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             };
-            output: void;
-            meta: object;
+            agent: {
+              id: string;
+              rig_id: string | null;
+              role: 'mayor' | 'polecat' | 'refinery';
+              name: string;
+              identity: string;
+              status: 'dead' | 'idle' | 'stalled' | 'working';
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+            };
+          };
+          meta: object;
         }>;
-        sling: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                title: string;
-                body?: string | undefined;
-                model?: string | undefined;
-            };
-            output: {
-                bead: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                };
-                agent: {
-                    id: string;
-                    rig_id: string | null;
-                    role: "mayor" | "polecat" | "refinery";
-                    name: string;
-                    identity: string;
-                    status: "dead" | "idle" | "stalled" | "working";
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                };
-            };
-            meta: object;
+        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            message: string;
+            model?: string | undefined;
+            rigId?: string | undefined;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
         }>;
-        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                message: string;
-                model?: string | undefined;
-                rigId?: string | undefined;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                configured: boolean;
-                townId: string | null;
-                session: {
-                    agentId: string;
-                    sessionId: string;
-                    status: "active" | "idle" | "starting";
-                    lastActivityAt: string;
-                } | null;
-            };
-            meta: object;
-        }>;
-        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
-                };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
-                };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    failed: number;
-                    triageRequests: number;
-                };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
-                };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
-            };
-            meta: object;
-        }>;
-        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                agentId: string;
-                townId: string;
-            };
-            output: {
-                url: string;
-                ticket: string;
-            };
-            meta: object;
-        }>;
-        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: {
-                pty: {
-                    [x: string]: unknown;
-                    id: string;
-                };
-                wsUrl: string;
-            };
-            meta: object;
-        }>;
-        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-                ptyId: string;
-                cols: number;
-                rows: number;
-            };
-            output: void;
-            meta: object;
-        }>;
-        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-            };
-            meta: object;
-        }>;
-        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                config: {
-                    env_vars?: Record<string, string> | undefined;
-                    git_auth?: {
-                        github_token?: string | undefined;
-                        gitlab_token?: string | undefined;
-                        gitlab_instance_url?: string | undefined;
-                        platform_integration_id?: string | undefined;
-                    } | undefined;
-                    owner_user_id?: string | undefined;
-                    kilocode_token?: string | undefined;
-                    default_model?: string | undefined;
-                    small_model?: string | undefined;
-                    max_polecats_per_rig?: number | undefined;
-                    merge_strategy?: "direct" | "pr" | undefined;
-                    refinery?: {
-                        gates?: string[] | undefined;
-                        auto_merge?: boolean | undefined;
-                        require_clean_merge?: boolean | undefined;
-                    } | undefined;
-                    alarm_interval_active?: number | undefined;
-                    alarm_interval_idle?: number | undefined;
-                    container?: {
-                        sleep_after_minutes?: number | undefined;
-                    } | undefined;
-                };
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-            };
-            meta: object;
-        }>;
-        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
-            }[];
-            meta: object;
-        }>;
-        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
-            }[];
-            meta: object;
-        }>;
-        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            }[];
-            meta: object;
-        }>;
-        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
+        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            configured: boolean;
+            townId: string | null;
+            session: {
+              agentId: string;
+              sessionId: string;
+              status: 'active' | 'idle' | 'starting';
+              lastActivityAt: string;
             } | null;
-            meta: object;
+          };
+          meta: object;
         }>;
-    }>>;
-}>>;
+        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
+            };
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
+            };
+            beads: {
+              open: number;
+              inProgress: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
+            }[];
+          };
+          meta: object;
+        }>;
+        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
+        }>;
+        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            agentId: string;
+            townId: string;
+          };
+          output: {
+            url: string;
+            ticket: string;
+          };
+          meta: object;
+        }>;
+        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: {
+            pty: {
+              [x: string]: unknown;
+              id: string;
+            };
+            wsUrl: string;
+          };
+          meta: object;
+        }>;
+        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+            ptyId: string;
+            cols: number;
+            rows: number;
+          };
+          output: void;
+          meta: object;
+        }>;
+        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+          };
+          meta: object;
+        }>;
+        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            config: {
+              env_vars?: Record<string, string> | undefined;
+              git_auth?:
+                | {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                  }
+                | undefined;
+              owner_user_id?: string | undefined;
+              kilocode_token?: string | undefined;
+              default_model?: string | undefined;
+              small_model?: string | undefined;
+              max_polecats_per_rig?: number | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              refinery?:
+                | {
+                    gates?: string[] | undefined;
+                    auto_merge?: boolean | undefined;
+                    require_clean_merge?: boolean | undefined;
+                  }
+                | undefined;
+              alarm_interval_active?: number | undefined;
+              alarm_interval_idle?: number | undefined;
+              container?:
+                | {
+                    sleep_after_minutes?: number | undefined;
+                  }
+                | undefined;
+            };
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+          };
+          meta: object;
+        }>;
+        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          }[];
+          meta: object;
+        }>;
+        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          } | null;
+          meta: object;
+        }>;
+      }>
+    >;
+  }>
+>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,620 +1,63 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
+export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
     ctx: TRPCContext;
     meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
     transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    createTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        name: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listTowns: import('@trpc/server').TRPCQueryProcedure<{
-      input: void;
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getTown: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    createRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        name: string;
-        gitUrl: string;
-        defaultBranch?: string | undefined;
-        platformIntegrationId?: string | undefined;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listRigs: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getRig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-        agents: {
-          id: string;
-          rig_id: string | null;
-          role: 'mayor' | 'polecat' | 'refinery' | 'witness';
-          name: string;
-          identity: string;
-          status: 'dead' | 'idle' | 'stalled' | 'working';
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-        }[];
-        beads: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
-        }[];
-      };
-      meta: object;
-    }>;
-    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listBeads: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        beadId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listAgents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        rig_id: string | null;
-        role: 'mayor' | 'polecat' | 'refinery' | 'witness';
-        name: string;
-        identity: string;
-        status: 'dead' | 'idle' | 'stalled' | 'working';
-        current_hook_bead_id: string | null;
-        dispatch_attempts: number;
-        last_activity_at: string | null;
-        checkpoint?: unknown;
-        created_at: string;
-      }[];
-      meta: object;
-    }>;
-    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        agentId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    sling: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        title: string;
-        body?: string | undefined;
-        model?: string | undefined;
-      };
-      output: {
-        bead: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    createTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            name: string;
         };
-        agent: {
-          id: string;
-          rig_id: string | null;
-          role: 'mayor' | 'polecat' | 'refinery' | 'witness';
-          name: string;
-          identity: string;
-          status: 'dead' | 'idle' | 'stalled' | 'working';
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
+        output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
         };
-      };
-      meta: object;
-    }>;
-    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        message: string;
-        model?: string | undefined;
-        rigId?: string | undefined;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        configured: boolean;
-        townId: string | null;
-        session: {
-          agentId: string;
-          sessionId: string;
-          status: 'active' | 'idle' | 'starting';
-          lastActivityAt: string;
-        } | null;
-      };
-      meta: object;
-    }>;
-    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        agentId: string;
-        townId: string;
-      };
-      output: {
-        url: string;
-        ticket: string;
-      };
-      meta: object;
-    }>;
-    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-      };
-      output: {
-        pty: {
-          [x: string]: unknown;
-          id: string;
-        };
-        wsUrl: string;
-      };
-      meta: object;
-    }>;
-    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-        ptyId: string;
-        cols: number;
-        rows: number;
-      };
-      output: void;
-      meta: object;
-    }>;
-    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
-        };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-      };
-      meta: object;
-    }>;
-    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        config: {
-          env_vars?: Record<string, string> | undefined;
-          git_auth?:
-            | {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-              }
-            | undefined;
-          owner_user_id?: string | undefined;
-          kilocode_token?: string | undefined;
-          default_model?: string | undefined;
-          small_model?: string | undefined;
-          max_polecats_per_rig?: number | undefined;
-          merge_strategy?: 'direct' | 'pr' | undefined;
-          refinery?:
-            | {
-                gates?: string[] | undefined;
-                auto_merge?: boolean | undefined;
-                require_clean_merge?: boolean | undefined;
-              }
-            | undefined;
-          alarm_interval_active?: number | undefined;
-          alarm_interval_idle?: number | undefined;
-          container?:
-            | {
-                sleep_after_minutes?: number | undefined;
-              }
-            | undefined;
-        };
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
-        };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-      };
-      meta: object;
-    }>;
-    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        beadId?: string | undefined;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      }[];
-      meta: object;
-    }>;
-    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        convoyId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      } | null;
-      meta: object;
-    }>;
-  }>
->;
-export type GastownRouter = typeof gastownRouter;
-/**
- * Wrapped router that nests gastownRouter under a `gastown` key.
- * This preserves the `trpc.gastown.X` call pattern on the frontend,
- * matching the existing RootRouter shape so components don't need
- * to change their procedure paths.
- */
-export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
-    ctx: TRPCContext;
-    meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
-    transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    gastown: import('@trpc/server').TRPCBuiltRouter<
-      {
-        ctx: TRPCContext;
         meta: object;
-        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
-        transformer: false;
-      },
-      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-        createTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            name: string;
-          };
-          output: {
+    }>;
+    listTowns: import("@trpc/server").TRPCQueryProcedure<{
+        input: void;
+        output: {
             id: string;
             name: string;
             owner_user_id: string;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        listTowns: import('@trpc/server').TRPCQueryProcedure<{
-          input: void;
-          output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getTown: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getTown: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             name: string;
             owner_user_id: string;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        createRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    createRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             name: string;
             gitUrl: string;
             defaultBranch?: string | undefined;
             platformIntegrationId?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -623,14 +66,14 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        listRigs: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    listRigs: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -639,14 +82,14 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getRig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getRig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -656,350 +99,352 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             updated_at: string;
             agents: {
-              id: string;
-              rig_id: string | null;
-              role: 'mayor' | 'polecat' | 'refinery' | 'witness';
-              name: string;
-              identity: string;
-              status: 'dead' | 'idle' | 'stalled' | 'working';
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
+                id: string;
+                rig_id: string | null;
+                role: "mayor" | "polecat" | "refinery";
+                name: string;
+                identity: string;
+                status: "dead" | "idle" | "stalled" | "working";
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
             }[];
             beads: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             }[];
-          };
-          meta: object;
-        }>;
-        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listBeads: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    listBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
-          };
-          output: {
+            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+        };
+        output: {
             bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'open';
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "open";
             title: string;
             body: string | null;
             rig_id: string | null;
             parent_bead_id: string | null;
             assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
+            priority: "critical" | "high" | "low" | "medium";
             labels: string[];
             metadata: Record<string, unknown>;
             created_by: string | null;
             created_at: string;
             updated_at: string;
             closed_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             beadId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listAgents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    listAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             rig_id: string | null;
-            role: 'mayor' | 'polecat' | 'refinery' | 'witness';
+            role: "mayor" | "polecat" | "refinery";
             name: string;
             identity: string;
-            status: 'dead' | 'idle' | 'stalled' | 'working';
+            status: "dead" | "idle" | "stalled" | "working";
             current_hook_bead_id: string | null;
             dispatch_attempts: number;
             last_activity_at: string | null;
             checkpoint?: unknown;
             created_at: string;
-          }[];
-          meta: object;
-        }>;
-        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             agentId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        sling: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    sling: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             title: string;
             body?: string | undefined;
             model?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             bead: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             };
             agent: {
-              id: string;
-              rig_id: string | null;
-              role: 'mayor' | 'polecat' | 'refinery' | 'witness';
-              name: string;
-              identity: string;
-              status: 'dead' | 'idle' | 'stalled' | 'working';
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
+                id: string;
+                rig_id: string | null;
+                role: "mayor" | "polecat" | "refinery";
+                name: string;
+                identity: string;
+                status: "dead" | "idle" | "stalled" | "working";
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
             };
-          };
-          meta: object;
-        }>;
-        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             message: string;
             model?: string | undefined;
             rigId?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             configured: boolean;
             townId: string | null;
             session: {
-              agentId: string;
-              sessionId: string;
-              status: 'active' | 'idle' | 'starting';
-              lastActivityAt: string;
+                agentId: string;
+                sessionId: string;
+                status: "active" | "idle" | "starting";
+                lastActivityAt: string;
             } | null;
-          };
-          meta: object;
-        }>;
-        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
+            alarm: {
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
+            };
+            agents: {
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
+            };
+            beads: {
+                open: number;
+                inProgress: number;
+                failed: number;
+                triageRequests: number;
+            };
+            patrol: {
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
+            };
+            recentEvents: {
+                time: string;
+                type: string;
+                message: string;
+            }[];
+        };
+        meta: object;
+    }>;
+    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
             agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             agentId: string;
             townId: string;
-          };
-          output: {
+        };
+        output: {
             url: string;
             ticket: string;
-          };
-          meta: object;
-        }>;
-        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             agentId: string;
-          };
-          output: {
+        };
+        output: {
             pty: {
-              [x: string]: unknown;
-              id: string;
+                [x: string]: unknown;
+                id: string;
             };
             wsUrl: string;
-          };
-          meta: object;
-        }>;
-        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             agentId: string;
             ptyId: string;
             cols: number;
             rows: number;
-          };
-          output: void;
-          meta: object;
-        }>;
-        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             env_vars: Record<string, string>;
             git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
             };
             owner_user_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
             alarm_interval_active?: number | undefined;
             alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
-          };
-          meta: object;
-        }>;
-        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
+        };
+        meta: object;
+    }>;
+    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             config: {
-              env_vars?: Record<string, string> | undefined;
-              git_auth?:
-                | {
+                env_vars?: Record<string, string> | undefined;
+                git_auth?: {
                     github_token?: string | undefined;
                     gitlab_token?: string | undefined;
                     gitlab_instance_url?: string | undefined;
                     platform_integration_id?: string | undefined;
-                  }
-                | undefined;
-              owner_user_id?: string | undefined;
-              kilocode_token?: string | undefined;
-              default_model?: string | undefined;
-              small_model?: string | undefined;
-              max_polecats_per_rig?: number | undefined;
-              merge_strategy?: 'direct' | 'pr' | undefined;
-              refinery?:
-                | {
+                } | undefined;
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy?: "direct" | "pr" | undefined;
+                refinery?: {
                     gates?: string[] | undefined;
                     auto_merge?: boolean | undefined;
                     require_clean_merge?: boolean | undefined;
-                  }
-                | undefined;
-              alarm_interval_active?: number | undefined;
-              alarm_interval_idle?: number | undefined;
-              container?:
-                | {
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
                     sleep_after_minutes?: number | undefined;
-                  }
-                | undefined;
+                } | undefined;
             };
-          };
-          output: {
+        };
+        output: {
             env_vars: Record<string, string>;
             git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
             };
             owner_user_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
             alarm_interval_active?: number | undefined;
             alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
-          };
-          meta: object;
-        }>;
-        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
+        };
+        meta: object;
+    }>;
+    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
             beadId?: string | undefined;
             since?: string | undefined;
             limit?: number | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -1010,16 +455,16 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             rig_id?: string | undefined;
             rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
             since?: string | undefined;
             limit?: number | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -1030,17 +475,17 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             rig_id?: string | undefined;
             rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             title: string;
-            status: 'active' | 'landed';
+            status: "active" | "landed";
             total_beads: number;
             closed_beads: number;
             created_by: string | null;
@@ -1049,28 +494,28 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             feature_branch: string | null;
             merge_mode: string | null;
             beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
             }[];
             dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
+                bead_id: string;
+                depends_on_bead_id: string;
             }[];
-          }[];
-          meta: object;
-        }>;
-        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             convoyId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             title: string;
-            status: 'active' | 'landed';
+            status: "active" | "landed";
             total_beads: number;
             closed_beads: number;
             created_by: string | null;
@@ -1079,21 +524,571 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             feature_branch: string | null;
             merge_mode: string | null;
             beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
             }[];
             dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
+                bead_id: string;
+                depends_on_bead_id: string;
             }[];
-          } | null;
-          meta: object;
+        } | null;
+        meta: object;
+    }>;
+}>>;
+export type GastownRouter = typeof gastownRouter;
+/**
+ * Wrapped router that nests gastownRouter under a `gastown` key.
+ * This preserves the `trpc.gastown.X` call pattern on the frontend,
+ * matching the existing RootRouter shape so components don't need
+ * to change their procedure paths.
+ */
+export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    gastown: import("@trpc/server").TRPCBuiltRouter<{
+        ctx: TRPCContext;
+        meta: object;
+        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        transformer: false;
+    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+        createTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                name: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
         }>;
-      }>
-    >;
-  }>
->;
+        listTowns: import("@trpc/server").TRPCQueryProcedure<{
+            input: void;
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getTown: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        createRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                name: string;
+                gitUrl: string;
+                defaultBranch?: string | undefined;
+                platformIntegrationId?: string | undefined;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        listRigs: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getRig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+                agents: {
+                    id: string;
+                    rig_id: string | null;
+                    role: "mayor" | "polecat" | "refinery";
+                    name: string;
+                    identity: string;
+                    status: "dead" | "idle" | "stalled" | "working";
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                }[];
+                beads: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                }[];
+            };
+            meta: object;
+        }>;
+        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        listBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        listAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
+                role: "mayor" | "polecat" | "refinery";
+                name: string;
+                identity: string;
+                status: "dead" | "idle" | "stalled" | "working";
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+            }[];
+            meta: object;
+        }>;
+        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                agentId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        sling: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                title: string;
+                body?: string | undefined;
+                model?: string | undefined;
+            };
+            output: {
+                bead: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                };
+                agent: {
+                    id: string;
+                    rig_id: string | null;
+                    role: "mayor" | "polecat" | "refinery";
+                    name: string;
+                    identity: string;
+                    status: "dead" | "idle" | "stalled" | "working";
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                };
+            };
+            meta: object;
+        }>;
+        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                message: string;
+                model?: string | undefined;
+                rigId?: string | undefined;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                configured: boolean;
+                townId: string | null;
+                session: {
+                    agentId: string;
+                    sessionId: string;
+                    status: "active" | "idle" | "starting";
+                    lastActivityAt: string;
+                } | null;
+            };
+            meta: object;
+        }>;
+        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                agentId: string;
+                townId: string;
+            };
+            output: {
+                url: string;
+                ticket: string;
+            };
+            meta: object;
+        }>;
+        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+            };
+            output: {
+                pty: {
+                    [x: string]: unknown;
+                    id: string;
+                };
+                wsUrl: string;
+            };
+            meta: object;
+        }>;
+        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+                ptyId: string;
+                cols: number;
+                rows: number;
+            };
+            output: void;
+            meta: object;
+        }>;
+        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+            };
+            meta: object;
+        }>;
+        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                config: {
+                    env_vars?: Record<string, string> | undefined;
+                    git_auth?: {
+                        github_token?: string | undefined;
+                        gitlab_token?: string | undefined;
+                        gitlab_instance_url?: string | undefined;
+                        platform_integration_id?: string | undefined;
+                    } | undefined;
+                    owner_user_id?: string | undefined;
+                    kilocode_token?: string | undefined;
+                    default_model?: string | undefined;
+                    small_model?: string | undefined;
+                    max_polecats_per_rig?: number | undefined;
+                    merge_strategy?: "direct" | "pr" | undefined;
+                    refinery?: {
+                        gates?: string[] | undefined;
+                        auto_merge?: boolean | undefined;
+                        require_clean_merge?: boolean | undefined;
+                    } | undefined;
+                    alarm_interval_active?: number | undefined;
+                    alarm_interval_idle?: number | undefined;
+                    container?: {
+                        sleep_after_minutes?: number | undefined;
+                    } | undefined;
+                };
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+            };
+            meta: object;
+        }>;
+        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            }[];
+            meta: object;
+        }>;
+        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
+        }>;
+    }>>;
+}>>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -64,19 +64,29 @@ export declare const AgentOutput: z.ZodObject<
   {
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodEnum<{
-      mayor: 'mayor';
-      polecat: 'polecat';
-      refinery: 'refinery';
-    }>;
+    role: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          mayor: 'mayor';
+          polecat: 'polecat';
+          refinery: 'refinery';
+        }>,
+        z.ZodString,
+      ]
+    >;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodEnum<{
-      dead: 'dead';
-      idle: 'idle';
-      stalled: 'stalled';
-      working: 'working';
-    }>;
+    status: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          dead: 'dead';
+          idle: 'idle';
+          stalled: 'stalled';
+          working: 'working';
+        }>,
+        z.ZodString,
+      ]
+    >;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
@@ -253,19 +263,29 @@ export declare const SlingResultOutput: z.ZodObject<
       {
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodEnum<{
-          mayor: 'mayor';
-          polecat: 'polecat';
-          refinery: 'refinery';
-        }>;
+        role: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              mayor: 'mayor';
+              polecat: 'polecat';
+              refinery: 'refinery';
+            }>,
+            z.ZodString,
+          ]
+        >;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodEnum<{
-          dead: 'dead';
-          idle: 'idle';
-          stalled: 'stalled';
-          working: 'working';
-        }>;
+        status: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              dead: 'dead';
+              idle: 'idle';
+              stalled: 'stalled';
+              working: 'working';
+            }>,
+            z.ZodString,
+          ]
+        >;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
@@ -292,19 +312,29 @@ export declare const RigDetailOutput: z.ZodObject<
         {
           id: z.ZodString;
           rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-          }>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
           name: z.ZodString;
           identity: z.ZodString;
-          status: z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
           current_hook_bead_id: z.ZodNullable<z.ZodString>;
           dispatch_attempts: z.ZodDefault<z.ZodNumber>;
           last_activity_at: z.ZodNullable<z.ZodString>;
@@ -433,19 +463,29 @@ export declare const RpcAgentOutput: z.ZodPipe<
     {
       id: z.ZodString;
       rig_id: z.ZodNullable<z.ZodString>;
-      role: z.ZodEnum<{
-        mayor: 'mayor';
-        polecat: 'polecat';
-        refinery: 'refinery';
-      }>;
+      role: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            mayor: 'mayor';
+            polecat: 'polecat';
+            refinery: 'refinery';
+          }>,
+          z.ZodString,
+        ]
+      >;
       name: z.ZodString;
       identity: z.ZodString;
-      status: z.ZodEnum<{
-        dead: 'dead';
-        idle: 'idle';
-        stalled: 'stalled';
-        working: 'working';
-      }>;
+      status: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            dead: 'dead';
+            idle: 'idle';
+            stalled: 'stalled';
+            working: 'working';
+          }>,
+          z.ZodString,
+        ]
+      >;
       current_hook_bead_id: z.ZodNullable<z.ZodString>;
       dispatch_attempts: z.ZodDefault<z.ZodNumber>;
       last_activity_at: z.ZodNullable<z.ZodString>;
@@ -646,19 +686,29 @@ export declare const RpcSlingResultOutput: z.ZodPipe<
         {
           id: z.ZodString;
           rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-          }>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
           name: z.ZodString;
           identity: z.ZodString;
-          status: z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
           current_hook_bead_id: z.ZodNullable<z.ZodString>;
           dispatch_attempts: z.ZodDefault<z.ZodNumber>;
           last_activity_at: z.ZodNullable<z.ZodString>;
@@ -742,19 +792,29 @@ export declare const RpcRigDetailOutput: z.ZodPipe<
           {
             id: z.ZodString;
             rig_id: z.ZodNullable<z.ZodString>;
-            role: z.ZodEnum<{
-              mayor: 'mayor';
-              polecat: 'polecat';
-              refinery: 'refinery';
-            }>;
+            role: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  mayor: 'mayor';
+                  polecat: 'polecat';
+                  refinery: 'refinery';
+                }>,
+                z.ZodString,
+              ]
+            >;
             name: z.ZodString;
             identity: z.ZodString;
-            status: z.ZodEnum<{
-              dead: 'dead';
-              idle: 'idle';
-              stalled: 'stalled';
-              working: 'working';
-            }>;
+            status: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  dead: 'dead';
+                  idle: 'idle';
+                  stalled: 'stalled';
+                  working: 'working';
+                }>,
+                z.ZodString,
+              ]
+            >;
             current_hook_bead_id: z.ZodNullable<z.ZodString>;
             dispatch_attempts: z.ZodDefault<z.ZodNumber>;
             last_activity_at: z.ZodNullable<z.ZodString>;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,16 +1,12 @@
-import { z } from 'zod';
-export declare const TownOutput: z.ZodObject<
-  {
+import type { z } from 'zod';
+export declare const TownOutput: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const RigOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const RigOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -19,26 +15,23 @@ export declare const RigOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const BeadOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadOutput: z.ZodObject<{
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-      agent: 'agent';
-      convoy: 'convoy';
-      escalation: 'escalation';
-      issue: 'issue';
-      merge_request: 'merge_request';
-      message: 'message';
-      molecule: 'molecule';
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
     }>;
     status: z.ZodEnum<{
-      closed: 'closed';
-      failed: 'failed';
-      in_progress: 'in_progress';
-      open: 'open';
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        open: "open";
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -46,10 +39,10 @@ export declare const BeadOutput: z.ZodObject<
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-      critical: 'critical';
-      high: 'high';
-      low: 'low';
-      medium: 'medium';
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -57,37 +50,30 @@ export declare const BeadOutput: z.ZodObject<
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const AgentOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const AgentOutput: z.ZodObject<{
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
     role: z.ZodEnum<{
-      mayor: 'mayor';
-      polecat: 'polecat';
-      refinery: 'refinery';
-      witness: 'witness';
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
     }>;
     name: z.ZodString;
     identity: z.ZodString;
     status: z.ZodEnum<{
-      dead: 'dead';
-      idle: 'idle';
-      stalled: 'stalled';
-      working: 'working';
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
     }>;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
     checkpoint: z.ZodOptional<z.ZodUnknown>;
     created_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const BeadEventOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadEventOutput: z.ZodObject<{
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -98,68 +84,45 @@ export declare const BeadEventOutput: z.ZodObject<
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const MayorSendResultOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorSendResultOutput: z.ZodObject<{
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-      active: 'active';
-      idle: 'idle';
-      starting: 'starting';
+        active: "active";
+        idle: "idle";
+        starting: "starting";
     }>;
-  },
-  z.core.$strip
->;
-export declare const MayorStatusOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorStatusOutput: z.ZodObject<{
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<
-      z.ZodObject<
-        {
-          agentId: z.ZodString;
-          sessionId: z.ZodString;
-          status: z.ZodEnum<{
-            active: 'active';
-            idle: 'idle';
-            starting: 'starting';
-          }>;
-          lastActivityAt: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const StreamTicketOutput: z.ZodObject<
-  {
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const StreamTicketOutput: z.ZodObject<{
     url: z.ZodString;
     ticket: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const PtySessionOutput: z.ZodObject<
-  {
-    pty: z.ZodObject<
-      {
+}, z.core.$strip>;
+export declare const PtySessionOutput: z.ZodObject<{
+    pty: z.ZodObject<{
         id: z.ZodString;
-      },
-      z.core.$loose
-    >;
+    }, z.core.$loose>;
     wsUrl: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const ConvoyOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -168,16 +131,13 @@ export declare const ConvoyOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const ConvoyDetailOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyDetailOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -186,49 +146,35 @@ export declare const ConvoyDetailOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          title: z.ZodString;
-          status: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_name: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-    dependency_edges: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          depends_on_bead_id: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const SlingResultOutput: z.ZodObject<
-  {
-    bead: z.ZodObject<
-      {
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const SlingResultOutput: z.ZodObject<{
+    bead: z.ZodObject<{
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-          agent: 'agent';
-          convoy: 'convoy';
-          escalation: 'escalation';
-          issue: 'issue';
-          merge_request: 'merge_request';
-          message: 'message';
-          molecule: 'molecule';
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
         }>;
         status: z.ZodEnum<{
-          closed: 'closed';
-          failed: 'failed';
-          in_progress: 'in_progress';
-          open: 'open';
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            open: "open";
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -236,10 +182,10 @@ export declare const SlingResultOutput: z.ZodObject<
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-          critical: 'critical';
-          high: 'high';
-          low: 'low';
-          medium: 'medium';
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -247,40 +193,31 @@ export declare const SlingResultOutput: z.ZodObject<
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-      },
-      z.core.$strip
-    >;
-    agent: z.ZodObject<
-      {
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
         role: z.ZodEnum<{
-          mayor: 'mayor';
-          polecat: 'polecat';
-          refinery: 'refinery';
-          witness: 'witness';
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
         }>;
         name: z.ZodString;
         identity: z.ZodString;
         status: z.ZodEnum<{
-          dead: 'dead';
-          idle: 'idle';
-          stalled: 'stalled';
-          working: 'working';
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
         }>;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
         checkpoint: z.ZodOptional<z.ZodUnknown>;
         created_at: z.ZodString;
-      },
-      z.core.$strip
-    >;
-  },
-  z.core.$strip
->;
-export declare const RigDetailOutput: z.ZodObject<
-  {
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const RigDetailOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -289,474 +226,377 @@ export declare const RigDetailOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<
-      z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-            witness: 'witness';
-          }>;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const RpcTownOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      name: z.ZodString;
-      owner_user_id: z.ZodString;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_id: z.ZodString;
-      type: z.ZodEnum<{
-        agent: 'agent';
-        convoy: 'convoy';
-        escalation: 'escalation';
-        issue: 'issue';
-        merge_request: 'merge_request';
-        message: 'message';
-        molecule: 'molecule';
-      }>;
-      status: z.ZodEnum<{
-        closed: 'closed';
-        failed: 'failed';
-        in_progress: 'in_progress';
-        open: 'open';
-      }>;
-      title: z.ZodString;
-      body: z.ZodNullable<z.ZodString>;
-      rig_id: z.ZodNullable<z.ZodString>;
-      parent_bead_id: z.ZodNullable<z.ZodString>;
-      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-      priority: z.ZodEnum<{
-        critical: 'critical';
-        high: 'high';
-        low: 'low';
-        medium: 'medium';
-      }>;
-      labels: z.ZodArray<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      closed_at: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAgentOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      rig_id: z.ZodNullable<z.ZodString>;
-      role: z.ZodEnum<{
-        mayor: 'mayor';
-        polecat: 'polecat';
-        refinery: 'refinery';
-        witness: 'witness';
-      }>;
-      name: z.ZodString;
-      identity: z.ZodString;
-      status: z.ZodEnum<{
-        dead: 'dead';
-        idle: 'idle';
-        stalled: 'stalled';
-        working: 'working';
-      }>;
-      current_hook_bead_id: z.ZodNullable<z.ZodString>;
-      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-      last_activity_at: z.ZodNullable<z.ZodString>;
-      checkpoint: z.ZodOptional<z.ZodUnknown>;
-      created_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadEventOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_event_id: z.ZodString;
-      bead_id: z.ZodString;
-      agent_id: z.ZodNullable<z.ZodString>;
-      event_type: z.ZodString;
-      old_value: z.ZodNullable<z.ZodString>;
-      new_value: z.ZodNullable<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_at: z.ZodString;
-      rig_id: z.ZodOptional<z.ZodString>;
-      rig_name: z.ZodOptional<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      agentId: z.ZodString;
-      sessionStatus: z.ZodEnum<{
-        active: 'active';
-        idle: 'idle';
-        starting: 'starting';
-      }>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      configured: z.ZodBoolean;
-      townId: z.ZodNullable<z.ZodString>;
-      session: z.ZodNullable<
-        z.ZodObject<
-          {
-            agentId: z.ZodString;
-            sessionId: z.ZodString;
-            status: z.ZodEnum<{
-              active: 'active';
-              idle: 'idle';
-              starting: 'starting';
-            }>;
-            lastActivityAt: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcStreamTicketOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      url: z.ZodString;
-      ticket: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcPtySessionOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      pty: z.ZodObject<
-        {
-          id: z.ZodString;
-        },
-        z.core.$loose
-      >;
-      wsUrl: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            title: z.ZodString;
-            status: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_name: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-      dependency_edges: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            depends_on_bead_id: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcSlingResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead: z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >;
-      agent: z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-            witness: 'witness';
-          }>;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-        },
-        z.core.$strip
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      agents: z.ZodArray<
-        z.ZodObject<
-          {
-            id: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            role: z.ZodEnum<{
-              mayor: 'mayor';
-              polecat: 'polecat';
-              refinery: 'refinery';
-              witness: 'witness';
-            }>;
-            name: z.ZodString;
-            identity: z.ZodString;
-            status: z.ZodEnum<{
-              dead: 'dead';
-              idle: 'idle';
-              stalled: 'stalled';
-              working: 'working';
-            }>;
-            current_hook_bead_id: z.ZodNullable<z.ZodString>;
-            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-            last_activity_at: z.ZodNullable<z.ZodString>;
-            checkpoint: z.ZodOptional<z.ZodUnknown>;
-            created_at: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            type: z.ZodEnum<{
-              agent: 'agent';
-              convoy: 'convoy';
-              escalation: 'escalation';
-              issue: 'issue';
-              merge_request: 'merge_request';
-              message: 'message';
-              molecule: 'molecule';
-            }>;
-            status: z.ZodEnum<{
-              closed: 'closed';
-              failed: 'failed';
-              in_progress: 'in_progress';
-              open: 'open';
-            }>;
-            title: z.ZodString;
-            body: z.ZodNullable<z.ZodString>;
-            rig_id: z.ZodNullable<z.ZodString>;
-            parent_bead_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-            priority: z.ZodEnum<{
-              critical: 'critical';
-              high: 'high';
-              low: 'low';
-              medium: 'medium';
-            }>;
-            labels: z.ZodArray<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            created_by: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-            closed_at: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodString;
+    owner_user_id: z.ZodString;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_id: z.ZodString;
+    type: z.ZodEnum<{
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
+    }>;
+    status: z.ZodEnum<{
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        open: "open";
+    }>;
+    title: z.ZodString;
+    body: z.ZodNullable<z.ZodString>;
+    rig_id: z.ZodNullable<z.ZodString>;
+    parent_bead_id: z.ZodNullable<z.ZodString>;
+    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    labels: z.ZodArray<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    closed_at: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    rig_id: z.ZodNullable<z.ZodString>;
+    role: z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>;
+    name: z.ZodString;
+    identity: z.ZodString;
+    status: z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>;
+    current_hook_bead_id: z.ZodNullable<z.ZodString>;
+    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+    last_activity_at: z.ZodNullable<z.ZodString>;
+    checkpoint: z.ZodOptional<z.ZodUnknown>;
+    created_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_event_id: z.ZodString;
+    bead_id: z.ZodString;
+    agent_id: z.ZodNullable<z.ZodString>;
+    event_type: z.ZodString;
+    old_value: z.ZodNullable<z.ZodString>;
+    new_value: z.ZodNullable<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_at: z.ZodString;
+    rig_id: z.ZodOptional<z.ZodString>;
+    rig_name: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    agentId: z.ZodString;
+    sessionStatus: z.ZodEnum<{
+        active: "active";
+        idle: "idle";
+        starting: "starting";
+    }>;
+}, z.core.$strip>>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    configured: z.ZodBoolean;
+    townId: z.ZodNullable<z.ZodString>;
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    url: z.ZodString;
+    ticket: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    pty: z.ZodObject<{
+        id: z.ZodString;
+    }, z.core.$loose>;
+    wsUrl: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead: z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+    }, z.core.$strip>;
+}, z.core.$strip>>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    alarm: z.ZodObject<{
+        nextFireAt: z.ZodNullable<z.ZodString>;
+        intervalMs: z.ZodNumber;
+        intervalLabel: z.ZodString;
+    }, z.core.$strip>;
+    agents: z.ZodObject<{
+        working: z.ZodNumber;
+        idle: z.ZodNumber;
+        stalled: z.ZodNumber;
+        dead: z.ZodNumber;
+        total: z.ZodNumber;
+    }, z.core.$strip>;
+    beads: z.ZodObject<{
+        open: z.ZodNumber;
+        inProgress: z.ZodNumber;
+        failed: z.ZodNumber;
+        triageRequests: z.ZodNumber;
+    }, z.core.$strip>;
+    patrol: z.ZodObject<{
+        guppWarnings: z.ZodNumber;
+        guppEscalations: z.ZodNumber;
+        stalledAgents: z.ZodNumber;
+        orphanedHooks: z.ZodNumber;
+    }, z.core.$strip>;
+    recentEvents: z.ZodArray<z.ZodObject<{
+        time: z.ZodString;
+        type: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,12 +1,16 @@
 import type { z } from 'zod';
-export declare const TownOutput: z.ZodObject<{
+export declare const TownOutput: z.ZodObject<
+  {
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const RigOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const RigOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -15,23 +19,26 @@ export declare const RigOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const BeadOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadOutput: z.ZodObject<
+  {
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
+      agent: 'agent';
+      convoy: 'convoy';
+      escalation: 'escalation';
+      issue: 'issue';
+      merge_request: 'merge_request';
+      message: 'message';
+      molecule: 'molecule';
     }>;
     status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        open: "open";
+      closed: 'closed';
+      failed: 'failed';
+      in_progress: 'in_progress';
+      open: 'open';
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -39,10 +46,10 @@ export declare const BeadOutput: z.ZodObject<{
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
+      critical: 'critical';
+      high: 'high';
+      low: 'low';
+      medium: 'medium';
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -50,30 +57,36 @@ export declare const BeadOutput: z.ZodObject<{
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const AgentOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const AgentOutput: z.ZodObject<
+  {
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
     role: z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
+      mayor: 'mayor';
+      polecat: 'polecat';
+      refinery: 'refinery';
     }>;
     name: z.ZodString;
     identity: z.ZodString;
     status: z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
+      dead: 'dead';
+      idle: 'idle';
+      stalled: 'stalled';
+      working: 'working';
     }>;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
     checkpoint: z.ZodOptional<z.ZodUnknown>;
     created_at: z.ZodString;
-}, z.core.$strip>;
-export declare const BeadEventOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadEventOutput: z.ZodObject<
+  {
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -84,45 +97,68 @@ export declare const BeadEventOutput: z.ZodObject<{
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>;
-export declare const MayorSendResultOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorSendResultOutput: z.ZodObject<
+  {
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
+      active: 'active';
+      idle: 'idle';
+      starting: 'starting';
     }>;
-}, z.core.$strip>;
-export declare const MayorStatusOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorStatusOutput: z.ZodObject<
+  {
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const StreamTicketOutput: z.ZodObject<{
+    session: z.ZodNullable<
+      z.ZodObject<
+        {
+          agentId: z.ZodString;
+          sessionId: z.ZodString;
+          status: z.ZodEnum<{
+            active: 'active';
+            idle: 'idle';
+            starting: 'starting';
+          }>;
+          lastActivityAt: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const StreamTicketOutput: z.ZodObject<
+  {
     url: z.ZodString;
     ticket: z.ZodString;
-}, z.core.$strip>;
-export declare const PtySessionOutput: z.ZodObject<{
-    pty: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const PtySessionOutput: z.ZodObject<
+  {
+    pty: z.ZodObject<
+      {
         id: z.ZodString;
-    }, z.core.$loose>;
+      },
+      z.core.$loose
+    >;
     wsUrl: z.ZodString;
-}, z.core.$strip>;
-export declare const ConvoyOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -131,13 +167,16 @@ export declare const ConvoyOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const ConvoyDetailOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -146,35 +185,49 @@ export declare const ConvoyDetailOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const SlingResultOutput: z.ZodObject<{
-    bead: z.ZodObject<{
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          title: z.ZodString;
+          status: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_name: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+    dependency_edges: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          depends_on_bead_id: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const SlingResultOutput: z.ZodObject<
+  {
+    bead: z.ZodObject<
+      {
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
+          agent: 'agent';
+          convoy: 'convoy';
+          escalation: 'escalation';
+          issue: 'issue';
+          merge_request: 'merge_request';
+          message: 'message';
+          molecule: 'molecule';
         }>;
         status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            open: "open";
+          closed: 'closed';
+          failed: 'failed';
+          in_progress: 'in_progress';
+          open: 'open';
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -182,10 +235,10 @@ export declare const SlingResultOutput: z.ZodObject<{
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
+          critical: 'critical';
+          high: 'high';
+          low: 'low';
+          medium: 'medium';
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -193,31 +246,39 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+    agent: z.ZodObject<
+      {
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
         role: z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
+          mayor: 'mayor';
+          polecat: 'polecat';
+          refinery: 'refinery';
         }>;
         name: z.ZodString;
         identity: z.ZodString;
         status: z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
+          dead: 'dead';
+          idle: 'idle';
+          stalled: 'stalled';
+          working: 'working';
         }>;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
         checkpoint: z.ZodOptional<z.ZodUnknown>;
         created_at: z.ZodString;
-    }, z.core.$strip>;
-}, z.core.$strip>;
-export declare const RigDetailOutput: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RigDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -226,377 +287,524 @@ export declare const RigDetailOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    name: z.ZodString;
-    owner_user_id: z.ZodString;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_id: z.ZodString;
-    type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
-    }>;
-    status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        open: "open";
-    }>;
-    title: z.ZodString;
-    body: z.ZodNullable<z.ZodString>;
-    rig_id: z.ZodNullable<z.ZodString>;
-    parent_bead_id: z.ZodNullable<z.ZodString>;
-    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-    priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
-    }>;
-    labels: z.ZodArray<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>;
-    name: z.ZodString;
-    identity: z.ZodString;
-    status: z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>;
-    current_hook_bead_id: z.ZodNullable<z.ZodString>;
-    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-    last_activity_at: z.ZodNullable<z.ZodString>;
-    checkpoint: z.ZodOptional<z.ZodUnknown>;
-    created_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_event_id: z.ZodString;
-    bead_id: z.ZodString;
-    agent_id: z.ZodNullable<z.ZodString>;
-    event_type: z.ZodString;
-    old_value: z.ZodNullable<z.ZodString>;
-    new_value: z.ZodNullable<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_at: z.ZodString;
-    rig_id: z.ZodOptional<z.ZodString>;
-    rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    agentId: z.ZodString;
-    sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
-    }>;
-}, z.core.$strip>>;
-export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    configured: z.ZodBoolean;
-    townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    url: z.ZodString;
-    ticket: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    pty: z.ZodObject<{
-        id: z.ZodString;
-    }, z.core.$loose>;
-    wsUrl: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead: z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-    }, z.core.$strip>;
-}, z.core.$strip>>;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    alarm: z.ZodObject<{
-        nextFireAt: z.ZodNullable<z.ZodString>;
-        intervalMs: z.ZodNumber;
-        intervalLabel: z.ZodString;
-    }, z.core.$strip>;
-    agents: z.ZodObject<{
-        working: z.ZodNumber;
-        idle: z.ZodNumber;
-        stalled: z.ZodNumber;
-        dead: z.ZodNumber;
-        total: z.ZodNumber;
-    }, z.core.$strip>;
-    beads: z.ZodObject<{
-        open: z.ZodNumber;
-        inProgress: z.ZodNumber;
-        failed: z.ZodNumber;
-        triageRequests: z.ZodNumber;
-    }, z.core.$strip>;
-    patrol: z.ZodObject<{
-        guppWarnings: z.ZodNumber;
-        guppEscalations: z.ZodNumber;
-        stalledAgents: z.ZodNumber;
-        orphanedHooks: z.ZodNumber;
-    }, z.core.$strip>;
-    recentEvents: z.ZodArray<z.ZodObject<{
-        time: z.ZodString;
-        type: z.ZodString;
-        message: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
+    agents: z.ZodArray<
+      z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodEnum<{
+            mayor: 'mayor';
+            polecat: 'polecat';
+            refinery: 'refinery';
+          }>;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodEnum<{
+            dead: 'dead';
+            idle: 'idle';
+            stalled: 'stalled';
+            working: 'working';
+          }>;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RpcTownOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      name: z.ZodString;
+      owner_user_id: z.ZodString;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_id: z.ZodString;
+      type: z.ZodEnum<{
+        agent: 'agent';
+        convoy: 'convoy';
+        escalation: 'escalation';
+        issue: 'issue';
+        merge_request: 'merge_request';
+        message: 'message';
+        molecule: 'molecule';
+      }>;
+      status: z.ZodEnum<{
+        closed: 'closed';
+        failed: 'failed';
+        in_progress: 'in_progress';
+        open: 'open';
+      }>;
+      title: z.ZodString;
+      body: z.ZodNullable<z.ZodString>;
+      rig_id: z.ZodNullable<z.ZodString>;
+      parent_bead_id: z.ZodNullable<z.ZodString>;
+      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+      priority: z.ZodEnum<{
+        critical: 'critical';
+        high: 'high';
+        low: 'low';
+        medium: 'medium';
+      }>;
+      labels: z.ZodArray<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      closed_at: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAgentOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      rig_id: z.ZodNullable<z.ZodString>;
+      role: z.ZodEnum<{
+        mayor: 'mayor';
+        polecat: 'polecat';
+        refinery: 'refinery';
+      }>;
+      name: z.ZodString;
+      identity: z.ZodString;
+      status: z.ZodEnum<{
+        dead: 'dead';
+        idle: 'idle';
+        stalled: 'stalled';
+        working: 'working';
+      }>;
+      current_hook_bead_id: z.ZodNullable<z.ZodString>;
+      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+      last_activity_at: z.ZodNullable<z.ZodString>;
+      checkpoint: z.ZodOptional<z.ZodUnknown>;
+      created_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadEventOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_event_id: z.ZodString;
+      bead_id: z.ZodString;
+      agent_id: z.ZodNullable<z.ZodString>;
+      event_type: z.ZodString;
+      old_value: z.ZodNullable<z.ZodString>;
+      new_value: z.ZodNullable<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_at: z.ZodString;
+      rig_id: z.ZodOptional<z.ZodString>;
+      rig_name: z.ZodOptional<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      agentId: z.ZodString;
+      sessionStatus: z.ZodEnum<{
+        active: 'active';
+        idle: 'idle';
+        starting: 'starting';
+      }>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      configured: z.ZodBoolean;
+      townId: z.ZodNullable<z.ZodString>;
+      session: z.ZodNullable<
+        z.ZodObject<
+          {
+            agentId: z.ZodString;
+            sessionId: z.ZodString;
+            status: z.ZodEnum<{
+              active: 'active';
+              idle: 'idle';
+              starting: 'starting';
+            }>;
+            lastActivityAt: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      url: z.ZodString;
+      ticket: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcPtySessionOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      pty: z.ZodObject<
+        {
+          id: z.ZodString;
+        },
+        z.core.$loose
+      >;
+      wsUrl: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            title: z.ZodString;
+            status: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_name: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+      dependency_edges: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            depends_on_bead_id: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcSlingResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead: z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >;
+      agent: z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodEnum<{
+            mayor: 'mayor';
+            polecat: 'polecat';
+            refinery: 'refinery';
+          }>;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodEnum<{
+            dead: 'dead';
+            idle: 'idle';
+            stalled: 'stalled';
+            working: 'working';
+          }>;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+        },
+        z.core.$strip
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      alarm: z.ZodObject<
+        {
+          nextFireAt: z.ZodNullable<z.ZodString>;
+          intervalMs: z.ZodNumber;
+          intervalLabel: z.ZodString;
+        },
+        z.core.$strip
+      >;
+      agents: z.ZodObject<
+        {
+          working: z.ZodNumber;
+          idle: z.ZodNumber;
+          stalled: z.ZodNumber;
+          dead: z.ZodNumber;
+          total: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      beads: z.ZodObject<
+        {
+          open: z.ZodNumber;
+          inProgress: z.ZodNumber;
+          failed: z.ZodNumber;
+          triageRequests: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      patrol: z.ZodObject<
+        {
+          guppWarnings: z.ZodNumber;
+          guppEscalations: z.ZodNumber;
+          stalledAgents: z.ZodNumber;
+          orphanedHooks: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      recentEvents: z.ZodArray<
+        z.ZodObject<
+          {
+            time: z.ZodString;
+            type: z.ZodString;
+            message: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      agents: z.ZodArray<
+        z.ZodObject<
+          {
+            id: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            role: z.ZodEnum<{
+              mayor: 'mayor';
+              polecat: 'polecat';
+              refinery: 'refinery';
+            }>;
+            name: z.ZodString;
+            identity: z.ZodString;
+            status: z.ZodEnum<{
+              dead: 'dead';
+              idle: 'idle';
+              stalled: 'stalled';
+              working: 'working';
+            }>;
+            current_hook_bead_id: z.ZodNullable<z.ZodString>;
+            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+            last_activity_at: z.ZodNullable<z.ZodString>;
+            checkpoint: z.ZodOptional<z.ZodUnknown>;
+            created_at: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            type: z.ZodEnum<{
+              agent: 'agent';
+              convoy: 'convoy';
+              escalation: 'escalation';
+              issue: 'issue';
+              merge_request: 'merge_request';
+              message: 'message';
+              molecule: 'molecule';
+            }>;
+            status: z.ZodEnum<{
+              closed: 'closed';
+              failed: 'failed';
+              in_progress: 'in_progress';
+              open: 'open';
+            }>;
+            title: z.ZodString;
+            body: z.ZodNullable<z.ZodString>;
+            rig_id: z.ZodNullable<z.ZodString>;
+            parent_bead_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+            priority: z.ZodEnum<{
+              critical: 'critical';
+              high: 'high';
+              low: 'low';
+              medium: 'medium';
+            }>;
+            labels: z.ZodArray<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            created_by: z.ZodNullable<z.ZodString>;
+            created_at: z.ZodString;
+            updated_at: z.ZodString;
+            closed_at: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;

--- a/src/lib/posthog-feature-flags.ts
+++ b/src/lib/posthog-feature-flags.ts
@@ -8,6 +8,12 @@ import { captureException, startSpan } from '@sentry/nextjs';
 const posthogClient = PostHogClient();
 
 /**
+ * Flags that should return true in development where PostHog is stubbed out.
+ * Add a flag name here so local dev works without PostHog configuration.
+ */
+const DEV_ENABLED_FLAGS = new Set(['gastown-access']);
+
+/**
  * Generic server action to fetch any PostHog feature flag value
  * @param flagName - The name of the PostHog feature flag to fetch
  * @param distinctId - Optional distinct ID for the feature flag request (defaults to 'server-config-fetch')
@@ -58,6 +64,10 @@ export async function isFeatureFlagEnabled(
   flagName: string,
   distinctId: string = 'server-config-fetch'
 ): Promise<boolean> {
+  if (process.env.NODE_ENV !== 'production' && DEV_ENABLED_FLAGS.has(flagName)) {
+    return true;
+  }
+
   try {
     // For boolean flags, we can use getFeatureFlag instead of getFeatureFlagPayload
     const isEnabled = await startSpan({ name: flagName, op: 'posthog-feature-flag' }, async () => {

--- a/src/lib/posthog-feature-flags.ts
+++ b/src/lib/posthog-feature-flags.ts
@@ -8,12 +8,6 @@ import { captureException, startSpan } from '@sentry/nextjs';
 const posthogClient = PostHogClient();
 
 /**
- * Flags that should return true in development where PostHog is stubbed out.
- * Add a flag name here so local dev works without PostHog configuration.
- */
-const DEV_ENABLED_FLAGS = new Set(['gastown-access']);
-
-/**
  * Generic server action to fetch any PostHog feature flag value
  * @param flagName - The name of the PostHog feature flag to fetch
  * @param distinctId - Optional distinct ID for the feature flag request (defaults to 'server-config-fetch')
@@ -64,10 +58,6 @@ export async function isFeatureFlagEnabled(
   flagName: string,
   distinctId: string = 'server-config-fetch'
 ): Promise<boolean> {
-  if (process.env.NODE_ENV !== 'production' && DEV_ENABLED_FLAGS.has(flagName)) {
-    return true;
-  }
-
   try {
     // For boolean flags, we can use getFeatureFlag instead of getFeatureFlagPayload
     const isEnabled = await startSpan({ name: flagName, op: 'posthog-feature-flag' }, async () => {

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -14,6 +14,7 @@ export type JWTTokenExtraPayload = {
   organizationRole?: OrganizationRole;
   internalApiUse?: boolean;
   isAdmin?: boolean;
+  gastownAccess?: boolean;
   createdOnPlatform?: string;
   tokenSource?: string;
 };


### PR DESCRIPTION
## Summary

Replace the binary `is_admin` gate from #537 with PostHog feature flags for progressive rollout. All flag management — allowlists, percentage rollout, kill-switch — is handled through the PostHog dashboard. No custom DB tables, admin UI, or flag evaluation infrastructure needed.

**Gate points updated (all 4 layers):**
1. **9 Next.js server pages** — `isFeatureFlagEnabled('gastown-access', user.id)` with dev-mode bypass
2. **Sidebar** — `useFeatureFlagEnabled('gastown-access')` (client-side PostHog hook, same pattern as `auto-triage-feature`)
3. **Token endpoint** (`/api/gastown/token`) — evaluates PostHog flag, embeds `gastownAccess: true` in JWT, returns 403 if denied
4. **Gastown worker tRPC** — `requireGastownAccess()` checks `gastownAccess` JWT claim, falls back to `isAdmin` for backward compatibility

**Sub-feature flag names defined** (in `src/lib/gastown/feature-flags.ts`):
- `gastown-access` — top-level gate
- `gastown-convoys` — convoy creation
- `gastown-pr-merge` — PR merge strategy
- `gastown-multi-rig` — second rig per town

These follow the existing PostHog flag pattern used by `auto-triage-feature`, `code-review-cloud-agent-next`, etc.

**Backward compatibility:** When the `gastown-access` flag doesn't exist in PostHog (or PostHog is unavailable in non-production), the dev-mode bypass allows local development. In production, `isFeatureFlagEnabled` returns `false` when the flag is missing, so access is denied by default (same as the old `is_admin` gate for non-admins). The worker accepts both `gastownAccess` and `isAdmin` JWT claims, so old tokens continue to work.

Closes #901

## Verification

- [x] `pnpm typecheck` — all 29 workspace packages pass
- [x] Verified `ENABLE_GASTOWN_FEATURE` has zero remaining references after removal
- [x] Verified `requireAdmin` has zero remaining references in gastown worker after rename

## Visual Changes

N/A

## Reviewer Notes

- The `ENABLE_GASTOWN_FEATURE` compile-time constant has been removed — it had no consumers after this change. The PostHog kill-switch is strictly better (no redeploy needed).
- The `cohorts` column on `kilocode_users` was investigated and found to be completely dead code (never populated, read, or used). It is not relevant to this feature.
- The `gastown-access` flag must be created in PostHog before this can be deployed. Initially configure it to target users where `is_admin` is `true` to preserve the current behavior, then progressively widen access.
- Dev-mode bypass (`IS_DEVELOPMENT`) follows the same pattern as `auto-fix/page.tsx` to ensure local development works without PostHog.