### PR TITLE
feat(gastown): alarm-driven witness/deacon patrol with on-demand triage

### DIFF
--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -162,6 +162,20 @@ export class GastownClient {
     }
   }
 
+  async triageResolve(
+    triageBeadId: string,
+    action: string,
+    notes?: string
+  ): Promise<{ resolved: boolean; action: string }> {
+    return this.request<{ resolved: boolean; action: string }>(
+      this.rigPath(`/triage/${triageBeadId}/resolve`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ action, notes }),
+      }
+    );
+  }
+
   async advanceMoleculeStep(summary: string): Promise<{
     moleculeId: string;
     previousStep: number;

--- a/cloudflare-gastown/container/plugin/tools.ts
+++ b/cloudflare-gastown/container/plugin/tools.ts
@@ -166,6 +166,33 @@ export function createTools(client: GastownClient) {
       },
     }),
 
+    gt_triage_resolve: tool({
+      description:
+        'Resolve a triage request bead with a chosen action. ' +
+        'The TownDO will execute the action (restart agent, escalate, discard). ' +
+        'Call this for each triage request in your queue.',
+      args: {
+        triage_bead_id: tool.schema
+          .string()
+          .describe('The bead_id of the triage_request bead to resolve'),
+        action: tool.schema
+          .enum(['RESTART', 'ESCALATE', 'DISCARD'])
+          .describe(
+            'RESTART: reset the agent to idle for redispatch. ' +
+              'ESCALATE: forward to Mayor. ' +
+              'DISCARD: unhook agent and return bead to open.'
+          ),
+        notes: tool.schema
+          .string()
+          .describe('Optional reasoning notes logged with the resolution')
+          .optional(),
+      },
+      async execute(args) {
+        const result = await client.triageResolve(args.triage_bead_id, args.action, args.notes);
+        return `Triage request ${args.triage_bead_id} resolved with action=${result.action}`;
+      },
+    }),
+
     gt_mol_advance: tool({
       description:
         'Complete the current molecule step and advance to the next one. ' +

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // ── Agent roles (mirrors worker types) ──────────────────────────────────
 
-export const AgentRole = z.enum(['mayor', 'polecat', 'refinery', 'witness']);
+export const AgentRole = z.enum(['mayor', 'polecat', 'refinery', 'witness', 'triage']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 // ── Control server request/response schemas ─────────────────────────────

--- a/cloudflare-gastown/src/db/tables/agent-metadata.table.ts
+++ b/cloudflare-gastown/src/db/tables/agent-metadata.table.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
 
-const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness']);
+const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness', 'triage']);
 const AgentProcessStatus = z.enum(['idle', 'working', 'stalled', 'dead']);
 
 export const AgentMetadataRecord = z.object({
@@ -35,7 +35,7 @@ export const agent_metadata = getTableFromZodSchema('agent_metadata', AgentMetad
 export function createTableAgentMetadata(): string {
   return getCreateTableQueryFromTable(agent_metadata, {
     bead_id: `text primary key references beads(bead_id)`,
-    role: `text not null check(role in ('polecat', 'refinery', 'mayor', 'witness'))`,
+    role: `text not null check(role in ('polecat', 'refinery', 'mayor', 'witness', 'triage'))`,
     identity: `text not null unique`,
     container_process_id: `text`,
     status: `text not null default 'idle' check(status in ('idle', 'working', 'stalled', 'dead'))`,

--- a/cloudflare-gastown/src/db/tables/beads.table.ts
+++ b/cloudflare-gastown/src/db/tables/beads.table.ts
@@ -13,6 +13,7 @@ export const BeadType = z.enum([
   'convoy',
   'molecule',
   'agent',
+  'triage_request',
 ]);
 
 export const BeadStatus = z.enum(['open', 'in_progress', 'closed', 'failed']);
@@ -113,7 +114,7 @@ export const beads = getTableFromZodSchema('beads', BeadRecord);
 export function createTableBeads(): string {
   return getCreateTableQueryFromTable(beads, {
     bead_id: `text primary key`,
-    type: `text not null check(type in ('issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'))`,
+    type: `text not null check(type in ('issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent', 'triage_request'))`,
     status: `text not null default 'open' check(status in ('open', 'in_progress', 'closed', 'failed'))`,
     title: `text not null`,
     body: `text`,

--- a/cloudflare-gastown/src/dos/GastownUser.do.ts
+++ b/cloudflare-gastown/src/dos/GastownUser.do.ts
@@ -258,6 +258,13 @@ export class GastownUserDO extends DurableObject<Env> {
     );
   }
 
+  async unregisterActiveTown(townId: string): Promise<void> {
+    await this.ensureInitialized();
+    query(this.sql, /* sql */ `DELETE FROM ${user_towns} WHERE ${user_towns.columns.id} = ?`, [
+      townId,
+    ]);
+  }
+
   async listAllTownIds(): Promise<string[]> {
     await this.ensureInitialized();
     const rows = [

--- a/cloudflare-gastown/src/dos/GastownUser.do.ts
+++ b/cloudflare-gastown/src/dos/GastownUser.do.ts
@@ -223,6 +223,53 @@ export class GastownUserDO extends DurableObject<Env> {
   async ping(): Promise<string> {
     return 'pong';
   }
+
+  // ── Watchdog Registry ─────────────────────────────────────────────────
+  // The well-known GastawnUserDO instance with ID 'watchdog' acts as a
+  // global active-town registry. TownDOs register themselves here when
+  // they arm alarms; the cron watchdog reads this list to check each town.
+
+  async registerActiveTown(townId: string): Promise<void> {
+    await this.ensureInitialized();
+    // Use the user_towns table but with a special marker so we don't
+    // conflict with real per-user town records. The 'watchdog' DO instance
+    // only ever holds these registry entries.
+    const existing = [
+      ...query(
+        this.sql,
+        /* sql */ `SELECT ${user_towns.columns.id} FROM ${user_towns} WHERE ${user_towns.columns.id} = ?`,
+        [townId]
+      ),
+    ];
+    if (existing.length > 0) return;
+    const timestamp = now();
+    query(
+      this.sql,
+      /* sql */ `
+        INSERT INTO ${user_towns} (
+          ${user_towns.columns.id},
+          ${user_towns.columns.name},
+          ${user_towns.columns.owner_user_id},
+          ${user_towns.columns.created_at},
+          ${user_towns.columns.updated_at}
+        ) VALUES (?, ?, 'watchdog', ?, ?)
+      `,
+      [townId, townId, timestamp, timestamp]
+    );
+  }
+
+  async listAllTownIds(): Promise<string[]> {
+    await this.ensureInitialized();
+    const rows = [
+      ...query(this.sql, /* sql */ `SELECT ${user_towns.columns.id} FROM ${user_towns}`, []),
+    ];
+    return rows
+      .map(r => {
+        const parsed = user_towns.columns.id ? String((r as Record<string, unknown>).id) : '';
+        return parsed;
+      })
+      .filter(Boolean);
+  }
 }
 
 export function getGastownUserStub(env: Env, userId: string) {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2302,6 +2302,20 @@ export class TownDO extends DurableObject<Env> {
           subject: `TRIAGE_ESCALATION:${triageType}`,
           body: `Triage agent escalated ${triageType} for agent "${agentName}". Notes: ${notes ?? 'none'}`,
         });
+        // Reset last_activity_at so witnessPatrol won't re-create a triage_request
+        // for this agent on the very next alarm tick. The escalation is now in
+        // the Mayor's hands; give the system a full GUPP window before reconsidering.
+        if (agentBeadId) {
+          query(
+            this.sql,
+            /* sql */ `
+              UPDATE ${agent_metadata}
+              SET ${agent_metadata.columns.last_activity_at} = ?
+              WHERE ${agent_metadata.bead_id} = ?
+            `,
+            [now(), agentBeadId]
+          );
+        }
         break;
       }
       case 'DISCARD': {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -42,6 +42,7 @@ import { bead_dependencies } from '../db/tables/bead-dependencies.table';
 import { query } from '../util/query.util';
 import { getAgentDOStub } from './Agent.do';
 import { getTownContainerStub } from './TownContainer.do';
+import { getGastownUserStub } from './GastownUser.do';
 
 import { BeadPriority } from '../types';
 import type {
@@ -77,6 +78,10 @@ const MAX_DISPATCH_ATTEMPTS = 5;
 // Escalation constants
 const STALE_ESCALATION_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 const MAX_RE_ESCALATIONS = 3;
+
+// Deacon patrol constants
+const STALE_HOOK_THRESHOLD_MS = 60 * 60_000; // 1 hour — bead hooked but agent never dispatched
+const GUPP_TRIAGE_THRESHOLD_MS = 60 * 60_000; // 1 hour — GUPP_CHECK sent but agent still inactive
 const SEVERITY_ORDER = ['low', 'medium', 'high', 'critical'] as const;
 
 function generateId(): string {
@@ -1553,6 +1558,16 @@ export class TownDO extends DurableObject<Env> {
       console.error(`${TOWN_LOG} alarm: witnessPatrol failed`, err);
     }
     try {
+      await this.deaconPatrol();
+    } catch (err) {
+      console.error(`${TOWN_LOG} alarm: deaconPatrol failed`, err);
+    }
+    try {
+      await this.maybeDispatchTriageAgent();
+    } catch (err) {
+      console.error(`${TOWN_LOG} alarm: maybeDispatchTriageAgent failed`, err);
+    }
+    try {
       await this.deliverPendingMail();
     } catch (err) {
       console.warn(`${TOWN_LOG} alarm: deliverPendingMail failed`, err);
@@ -1802,11 +1817,18 @@ export class TownDO extends DurableObject<Env> {
   }
 
   /**
-   * Witness patrol: detect dead/stale agents, orphaned beads.
+   * Witness patrol: detect dead/stale agents and flag ambiguous cases for triage.
+   *
+   * Mechanical behaviors (no LLM needed):
+   * - Agent exited cleanly → push to review queue
+   * - Agent exited unexpectedly → reset to idle for redispatch
+   * - GUPP violation with no activity → send GUPP_CHECK mail
+   * - GUPP violation with prior unanswered GUPP_CHECK → create triage_request
    */
   private async witnessPatrol(): Promise<void> {
     const townId = this.townId;
     const guppThreshold = new Date(Date.now() - GUPP_THRESHOLD_MS).toISOString();
+    const guppTriageThreshold = new Date(Date.now() - GUPP_TRIAGE_THRESHOLD_MS).toISOString();
 
     const WorkingAgentRow = AgentMetadataRecord.pick({
       bead_id: true,
@@ -1833,44 +1855,460 @@ export class TownDO extends DurableObject<Env> {
 
       if (containerInfo.status === 'not_found' || containerInfo.status === 'exited') {
         if (containerInfo.exitReason === 'completed') {
+          // Agent finished cleanly — push into review queue
           reviewQueue.agentCompleted(this.sql, agentId, { status: 'completed' });
           continue;
         }
+        // Agent exited unexpectedly — reset to idle so schedulePendingWork retries
         query(
           this.sql,
-          /* sql */ `UPDATE ${agent_metadata} SET ${agent_metadata.columns.status} = 'idle', ${agent_metadata.columns.last_activity_at} = ? WHERE ${agent_metadata.bead_id} = ?`,
+          /* sql */ `
+            UPDATE ${agent_metadata}
+            SET ${agent_metadata.columns.status} = 'idle',
+                ${agent_metadata.columns.last_activity_at} = ?
+            WHERE ${agent_metadata.bead_id} = ?
+          `,
           [now(), agentId]
         );
         continue;
       }
 
-      // GUPP violation check
+      // GUPP violation: working but no activity for 30+ min
       if (lastActivity && lastActivity < guppThreshold) {
-        // Check for existing GUPP mail
+        // Check for an existing open GUPP_CHECK mail
         const existingGupp = [
           ...query(
             this.sql,
             /* sql */ `
-              SELECT ${beads.bead_id} FROM ${beads}
+              SELECT ${beads.bead_id}, ${beads.created_at} FROM ${beads}
               WHERE ${beads.type} = 'message'
                 AND ${beads.assignee_agent_bead_id} = ?
                 AND ${beads.title} = 'GUPP_CHECK'
                 AND ${beads.status} = 'open'
+              ORDER BY ${beads.created_at} ASC
               LIMIT 1
             `,
             [agentId]
           ),
         ];
+
         if (existingGupp.length === 0) {
+          // No prior GUPP_CHECK — send one now
           mail.sendMail(this.sql, {
             from_agent_id: 'witness',
             to_agent_id: agentId,
             subject: 'GUPP_CHECK',
             body: 'You have had work hooked for 30+ minutes with no activity. Are you stuck? If so, call gt_escalate.',
           });
+        } else {
+          // Prior GUPP_CHECK was sent but agent is still inactive — escalate to triage
+          const guppRow = z
+            .object({ bead_id: z.string(), created_at: z.string() })
+            .parse(existingGupp[0]);
+          const guppSentAt = guppRow.created_at;
+          if (guppSentAt < guppTriageThreshold) {
+            // GUPP_CHECK sent >1hr ago with no response — queue for triage
+            this.createTriageRequestIfAbsent(agentId, 'stuck_agent', {
+              reason: 'GUPP_CHECK sent 1hr+ ago with no response from agent',
+              last_activity_at: lastActivity,
+              gupp_check_sent_at: guppSentAt,
+            });
+          }
         }
       }
     }
+  }
+
+  /**
+   * Deacon patrol: redispatch failed beads, detect stale hooks, feed stranded convoys.
+   *
+   * Mechanical behaviors (no LLM needed):
+   * - Beads hooked by an idle agent with no recent dispatch → stale hook cleanup
+   * - Open convoy-tracked beads with no assignee → auto-sling them
+   */
+  private async deaconPatrol(): Promise<void> {
+    this.detectStaleHooks();
+    await this.feedStrandedConvoys();
+  }
+
+  /**
+   * Detect stale hooks: an agent is idle but has a bead hooked, and has had no
+   * dispatch activity for longer than STALE_HOOK_THRESHOLD_MS. This happens when:
+   * - The eager fire-and-forget dispatch failed silently
+   * - The agent was reset to idle but never re-dispatched due to a code bug
+   *
+   * Mechanical action: reset the bead's assignee so schedulePendingWork can retry.
+   */
+  private detectStaleHooks(): void {
+    const staleThreshold = new Date(Date.now() - STALE_HOOK_THRESHOLD_MS).toISOString();
+
+    const StaleHookRow = AgentMetadataRecord.pick({
+      bead_id: true,
+      current_hook_bead_id: true,
+      last_activity_at: true,
+    });
+    const staleAgents = StaleHookRow.array().parse([
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id}, ${agent_metadata.current_hook_bead_id}, ${agent_metadata.last_activity_at}
+          FROM ${agent_metadata}
+          WHERE ${agent_metadata.status} = 'idle'
+            AND ${agent_metadata.current_hook_bead_id} IS NOT NULL
+            AND (${agent_metadata.last_activity_at} IS NULL OR ${agent_metadata.last_activity_at} < ?)
+        `,
+        [staleThreshold]
+      ),
+    ]);
+
+    for (const agent of staleAgents) {
+      const hookBeadId = agent.current_hook_bead_id;
+      if (!hookBeadId) continue;
+
+      // Re-arm the agent as idle with no hook so schedulePendingWork will
+      // re-hook and redispatch it on the next alarm tick.
+      console.log(
+        `${TOWN_LOG} detectStaleHooks: resetting stale hook agentId=${agent.bead_id} beadId=${hookBeadId}`
+      );
+      query(
+        this.sql,
+        /* sql */ `
+          UPDATE ${agent_metadata}
+          SET ${agent_metadata.columns.current_hook_bead_id} = NULL,
+              ${agent_metadata.columns.status} = 'idle',
+              ${agent_metadata.columns.dispatch_attempts} = 0,
+              ${agent_metadata.columns.last_activity_at} = ?
+          WHERE ${agent_metadata.bead_id} = ?
+        `,
+        [now(), agent.bead_id]
+      );
+      // Remove assignee from the bead so slingBead's hook logic can re-hook it
+      query(
+        this.sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.assignee_agent_bead_id} = NULL,
+              ${beads.columns.status} = 'open',
+              ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [now(), hookBeadId]
+      );
+    }
+  }
+
+  /**
+   * Feed stranded convoys: open issue beads tracked by a convoy with no assigned
+   * agent are auto-dispatched by re-hooking an idle agent.
+   *
+   * This handles the case where a convoy was created but some beads never got
+   * dispatched (e.g., concurrency cap prevented initial dispatch, or an agent
+   * was deleted after hooking).
+   */
+  private async feedStrandedConvoys(): Promise<void> {
+    // Find open issue beads that belong to a convoy (via bead_dependencies with
+    // dependency_type='tracks') and have no assignee agent.
+    const StrandedBeadRow = z.object({
+      bead_id: z.string(),
+      rig_id: z.string().nullable(),
+    });
+    const strandedBeads = StrandedBeadRow.array().parse([
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${beads.bead_id}, ${beads.rig_id}
+          FROM ${beads}
+          INNER JOIN ${bead_dependencies} ON ${bead_dependencies.bead_id} = ${beads.bead_id}
+          WHERE ${beads.type} = 'issue'
+            AND ${beads.status} = 'open'
+            AND ${beads.assignee_agent_bead_id} IS NULL
+            AND ${bead_dependencies.dependency_type} = 'tracks'
+          LIMIT 10
+        `,
+        []
+      ),
+    ]);
+
+    if (strandedBeads.length === 0) return;
+    console.log(`${TOWN_LOG} feedStrandedConvoys: found ${strandedBeads.length} stranded bead(s)`);
+
+    for (const row of strandedBeads) {
+      if (!row.rig_id) continue;
+      // Verify the convoy that tracks this bead is still open
+      const convoyId = beadOps.getConvoyForBead(this.sql, row.bead_id);
+      if (!convoyId) continue;
+      const convoyBead = beadOps.getBead(this.sql, convoyId);
+      if (!convoyBead || convoyBead.status === 'closed' || convoyBead.status === 'failed') continue;
+
+      // Hook an idle polecat to this bead — this mirrors the slingBead logic
+      const polecat = agents.getOrCreateAgent(this.sql, 'polecat', row.rig_id, this.townId);
+      try {
+        agents.hookBead(this.sql, polecat.id, row.bead_id);
+        console.log(
+          `${TOWN_LOG} feedStrandedConvoys: hooked bead=${row.bead_id} to agent=${polecat.id}`
+        );
+      } catch (err) {
+        // Agent already hooked to another bead — skip
+        console.warn(
+          `${TOWN_LOG} feedStrandedConvoys: failed to hook bead=${row.bead_id}`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+  }
+
+  /**
+   * Create a triage_request bead for an ambiguous situation, if one doesn't
+   * already exist for this agent + triage_type combination.
+   */
+  private createTriageRequestIfAbsent(
+    agentId: string,
+    triageType: string,
+    context: Record<string, unknown>
+  ): void {
+    const existing = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${beads.bead_id} FROM ${beads}
+          WHERE ${beads.type} = 'triage_request'
+            AND ${beads.status} = 'open'
+            AND json_extract(${beads.metadata}, '$.agent_bead_id') = ?
+            AND json_extract(${beads.metadata}, '$.triage_type') = ?
+          LIMIT 1
+        `,
+        [agentId, triageType]
+      ),
+    ];
+    if (existing.length > 0) return;
+
+    const triageBeadId = generateId();
+    const timestamp = now();
+    const metadata = JSON.stringify({ triage_type: triageType, agent_bead_id: agentId, context });
+    query(
+      this.sql,
+      /* sql */ `
+        INSERT INTO ${beads} (
+          ${beads.columns.bead_id}, ${beads.columns.type}, ${beads.columns.status},
+          ${beads.columns.title}, ${beads.columns.body}, ${beads.columns.rig_id},
+          ${beads.columns.parent_bead_id}, ${beads.columns.assignee_agent_bead_id},
+          ${beads.columns.priority}, ${beads.columns.labels}, ${beads.columns.metadata},
+          ${beads.columns.created_by}, ${beads.columns.created_at}, ${beads.columns.updated_at},
+          ${beads.columns.closed_at}
+        ) VALUES (?, 'triage_request', 'open', ?, NULL, NULL, NULL, NULL,
+                  'medium', '[]', ?, 'witness', ?, ?, NULL)
+      `,
+      [triageBeadId, `[${triageType}] agent=${agentId.slice(0, 8)}`, metadata, timestamp, timestamp]
+    );
+    console.log(
+      `${TOWN_LOG} createTriageRequest: created triage_request=${triageBeadId} type=${triageType} agent=${agentId}`
+    );
+  }
+
+  /**
+   * Dispatch a short-lived triage agent when triage_request beads are queued.
+   * The triage agent processes all pending requests and exits. LLM cost is
+   * proportional to actual ambiguity in the system, not to wall-clock uptime.
+   */
+  private async maybeDispatchTriageAgent(): Promise<void> {
+    const openTriageRows = z
+      .object({ bead_id: z.string(), metadata: z.string() })
+      .array()
+      .parse([
+        ...query(
+          this.sql,
+          /* sql */ `
+            SELECT ${beads.bead_id}, ${beads.metadata}
+            FROM ${beads}
+            WHERE ${beads.type} = 'triage_request'
+              AND ${beads.status} = 'open'
+            ORDER BY ${beads.created_at} ASC
+          `,
+          []
+        ),
+      ]);
+
+    if (openTriageRows.length === 0) return;
+
+    // Check if a triage agent is already running
+    const activeTriageAgents = agents.listAgents(this.sql, { role: 'triage', status: 'working' });
+    if (activeTriageAgents.length > 0) {
+      console.log(
+        `${TOWN_LOG} maybeDispatchTriageAgent: triage agent already active, skipping dispatch`
+      );
+      return;
+    }
+
+    console.log(
+      `${TOWN_LOG} maybeDispatchTriageAgent: ${openTriageRows.length} triage request(s) queued — dispatching triage agent`
+    );
+
+    // Use the first rig for git context (triage agent doesn't write code
+    // but needs a repo to run `kilo serve` in)
+    const rigList = rigs.listRigs(this.sql);
+    const rigConfig = rigList.length > 0 ? await this.getRigConfig(rigList[0].id) : null;
+    const townConfig = await this.getTownConfig();
+    const kilocodeToken = await this.resolveKilocodeToken();
+
+    if (!kilocodeToken) {
+      console.warn(`${TOWN_LOG} maybeDispatchTriageAgent: no kilocodeToken, deferring`);
+      return;
+    }
+
+    // Build triage context summary for the system prompt
+    const situations = openTriageRows.map((row, i) => {
+      let meta: Record<string, unknown> = {};
+      try {
+        meta = JSON.parse(row.metadata) as Record<string, unknown>;
+      } catch {
+        // ignore
+      }
+      return `${i + 1}. [${meta.triage_type ?? 'unknown'}] triage_bead_id=${row.bead_id}\n   Context: ${JSON.stringify(meta.context ?? {})}\n   Options: see gt_triage_resolve`;
+    });
+
+    const triagePrompt = [
+      'You are a Gastown triage agent. Process the following queued situations and resolve each one.',
+      'For each triage request, assess the situation and call gt_triage_resolve with the chosen action.',
+      'When all requests are resolved, call gt_done.',
+      '',
+      'Situations to assess:',
+      ...situations,
+    ].join('\n');
+
+    // Triage agents are ephemeral town-wide — no rig affiliation needed
+    const triageRigId = rigConfig ? rigList[0].id : `triage-${this.townId}`;
+    const triageAgent = agents.getOrCreateAgent(this.sql, 'triage', triageRigId, this.townId);
+
+    const { buildTriageSystemPrompt } = await import('../prompts/triage-system.prompt');
+    const systemPrompt = buildTriageSystemPrompt({
+      townId: this.townId,
+      identity: triageAgent.identity,
+    });
+
+    const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
+      townId: this.townId,
+      rigId: triageRigId,
+      userId: townConfig.owner_user_id ?? rigConfig?.userId ?? this.townId,
+      agentId: triageAgent.id,
+      agentName: 'triage',
+      role: 'triage',
+      identity: triageAgent.identity,
+      beadId: openTriageRows[0].bead_id,
+      beadTitle: `Triage: ${openTriageRows.length} situation(s) queued`,
+      beadBody: triagePrompt,
+      checkpoint: null,
+      gitUrl: rigConfig?.gitUrl ?? '',
+      defaultBranch: rigConfig?.defaultBranch ?? 'main',
+      kilocodeToken,
+      townConfig,
+      systemPromptOverride: systemPrompt,
+      platformIntegrationId: rigConfig?.platformIntegrationId,
+    });
+
+    if (started) {
+      agents.updateAgentStatus(this.sql, triageAgent.id, 'working');
+    } else {
+      console.error(`${TOWN_LOG} maybeDispatchTriageAgent: failed to start triage agent`);
+    }
+  }
+
+  /**
+   * Resolve a triage request: mark the bead closed and apply the chosen action.
+   * Called by the triage agent via the gt_triage_resolve tool.
+   */
+  async resolveTriageRequest(
+    triageBeadId: string,
+    action: string,
+    notes?: string
+  ): Promise<{ resolved: boolean; action: string }> {
+    await this.ensureInitialized();
+
+    const triadBead = beadOps.getBead(this.sql, triageBeadId);
+    if (!triadBead || triadBead.type !== 'triage_request') {
+      console.warn(
+        `${TOWN_LOG} resolveTriageRequest: bead not found or wrong type: ${triageBeadId}`
+      );
+      return { resolved: false, action };
+    }
+    if (triadBead.status === 'closed') {
+      return { resolved: true, action };
+    }
+
+    let meta: Record<string, unknown> = {};
+    try {
+      meta = triadBead.metadata as Record<string, unknown>;
+    } catch {
+      // continue with empty meta
+    }
+
+    const triageType = typeof meta.triage_type === 'string' ? meta.triage_type : 'unknown';
+    const agentBeadId = typeof meta.agent_bead_id === 'string' ? meta.agent_bead_id : null;
+
+    console.log(
+      `${TOWN_LOG} resolveTriageRequest: triageBeadId=${triageBeadId} type=${triageType} action=${action} agent=${agentBeadId ?? 'none'}`
+    );
+
+    // Apply the mechanical action
+    switch (action) {
+      case 'RESTART': {
+        if (agentBeadId) {
+          // Reset agent to idle so schedulePendingWork will redispatch
+          query(
+            this.sql,
+            /* sql */ `
+              UPDATE ${agent_metadata}
+              SET ${agent_metadata.columns.status} = 'idle',
+                  ${agent_metadata.columns.dispatch_attempts} = 0,
+                  ${agent_metadata.columns.last_activity_at} = ?
+              WHERE ${agent_metadata.bead_id} = ?
+            `,
+            [now(), agentBeadId]
+          );
+          // Stop any lingering container process
+          dispatch.stopAgentInContainer(this.env, this.townId, agentBeadId).catch(() => undefined);
+          console.log(`${TOWN_LOG} resolveTriageRequest: RESTART — reset agent ${agentBeadId}`);
+        }
+        break;
+      }
+      case 'ESCALATE': {
+        const agentName = agentBeadId
+          ? (beadOps.getBead(this.sql, agentBeadId)?.title ?? agentBeadId)
+          : 'unknown agent';
+        mail.sendMail(this.sql, {
+          from_agent_id: 'triage',
+          to_agent_id: 'mayor',
+          subject: `TRIAGE_ESCALATION:${triageType}`,
+          body: `Triage agent escalated ${triageType} for agent "${agentName}". Notes: ${notes ?? 'none'}`,
+        });
+        break;
+      }
+      case 'DISCARD': {
+        if (agentBeadId) {
+          // Unhook agent and reset bead to open for manual re-assignment
+          agents.unhookBead(this.sql, agentBeadId);
+          query(
+            this.sql,
+            /* sql */ `
+              UPDATE ${agent_metadata}
+              SET ${agent_metadata.columns.status} = 'idle',
+                  ${agent_metadata.columns.dispatch_attempts} = 0
+              WHERE ${agent_metadata.bead_id} = ?
+            `,
+            [agentBeadId]
+          );
+        }
+        break;
+      }
+      default:
+        console.warn(
+          `${TOWN_LOG} resolveTriageRequest: unknown action "${action}", closing bead anyway`
+        );
+    }
+
+    // Close the triage_request bead
+    beadOps.updateBeadStatus(this.sql, triageBeadId, 'closed', 'triage');
+
+    return { resolved: true, action };
   }
 
   /**
@@ -2439,6 +2877,33 @@ export class TownDO extends DurableObject<Env> {
     if (!current || current < Date.now()) {
       await this.ctx.storage.setAlarm(Date.now() + ACTIVE_ALARM_INTERVAL_MS);
     }
+    // Register this town with the global watchdog registry so the cron
+    // health watchdog can discover and ping it.
+    if (this.townId) {
+      const watchdog = getGastownUserStub(this.env, 'watchdog');
+      watchdog.registerActiveTown(this.townId).catch(err => {
+        console.warn(`${TOWN_LOG} armAlarmIfNeeded: failed to register with watchdog`, err);
+      });
+    }
+  }
+
+  /**
+   * Re-arm the alarm if it has stalled. Called by the external health watchdog
+   * cron (every 5 minutes) to recover towns whose alarm failed to reschedule.
+   *
+   * This is safe to call at any time — it only sets an alarm if none is pending
+   * or the pending one is overdue.
+   */
+  async pingAlarm(): Promise<{ townId: string; alarmRearmed: boolean }> {
+    await this.ensureInitialized();
+    const current = await this.ctx.storage.getAlarm();
+    const now = Date.now();
+    const isOverdue = !current || current < now;
+    if (isOverdue) {
+      console.log(`${TOWN_LOG} pingAlarm: re-arming stalled alarm for town=${this.townId}`);
+      await this.ctx.storage.setAlarm(now + ACTIVE_ALARM_INTERVAL_MS);
+    }
+    return { townId: this.townId, alarmRearmed: isOverdue };
   }
 
   // ══════════════════════════════════════════════════════════════════

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1875,8 +1875,9 @@ export class TownDO extends DurableObject<Env> {
 
       // GUPP violation: working but no activity for 30+ min
       if (lastActivity && lastActivity < guppThreshold) {
-        // Check for an existing open GUPP_CHECK mail
-        const existingGupp = [
+        // Check for any prior GUPP_CHECK (open OR closed — mail.readAndDeliverMail
+        // closes message beads on delivery, so we must check both statuses)
+        const priorGupp = [
           ...query(
             this.sql,
             /* sql */ `
@@ -1884,7 +1885,7 @@ export class TownDO extends DurableObject<Env> {
               WHERE ${beads.type} = 'message'
                 AND ${beads.assignee_agent_bead_id} = ?
                 AND ${beads.title} = 'GUPP_CHECK'
-                AND ${beads.status} = 'open'
+                AND ${beads.status} IN ('open', 'closed')
               ORDER BY ${beads.created_at} ASC
               LIMIT 1
             `,
@@ -1892,7 +1893,7 @@ export class TownDO extends DurableObject<Env> {
           ),
         ];
 
-        if (existingGupp.length === 0) {
+        if (priorGupp.length === 0) {
           // No prior GUPP_CHECK — send one now
           mail.sendMail(this.sql, {
             from_agent_id: 'witness',
@@ -1901,17 +1902,17 @@ export class TownDO extends DurableObject<Env> {
             body: 'You have had work hooked for 30+ minutes with no activity. Are you stuck? If so, call gt_escalate.',
           });
         } else {
-          // Prior GUPP_CHECK was sent but agent is still inactive — escalate to triage
+          // A GUPP_CHECK was already sent; if the agent is still inactive >1hr
+          // after it was sent, queue a triage request
           const guppRow = z
             .object({ bead_id: z.string(), created_at: z.string() })
-            .parse(existingGupp[0]);
-          const guppSentAt = guppRow.created_at;
-          if (guppSentAt < guppTriageThreshold) {
+            .parse(priorGupp[0]);
+          if (guppRow.created_at < guppTriageThreshold) {
             // GUPP_CHECK sent >1hr ago with no response — queue for triage
             this.createTriageRequestIfAbsent(agentId, 'stuck_agent', {
               reason: 'GUPP_CHECK sent 1hr+ ago with no response from agent',
               last_activity_at: lastActivity,
-              gupp_check_sent_at: guppSentAt,
+              gupp_check_sent_at: guppRow.created_at,
             });
           }
         }
@@ -2163,7 +2164,8 @@ export class TownDO extends DurableObject<Env> {
       } catch {
         // ignore
       }
-      return `${i + 1}. [${meta.triage_type ?? 'unknown'}] triage_bead_id=${row.bead_id}\n   Context: ${JSON.stringify(meta.context ?? {})}\n   Options: see gt_triage_resolve`;
+      const triType = typeof meta.triage_type === 'string' ? meta.triage_type : 'unknown';
+      return `${i + 1}. [${triType}] triage_bead_id=${row.bead_id}\n   Context: ${JSON.stringify(meta.context ?? {})}\n   Options: see gt_triage_resolve`;
     });
 
     const triagePrompt = [
@@ -2228,6 +2230,7 @@ export class TownDO extends DurableObject<Env> {
   async resolveTriageRequest(
     triageBeadId: string,
     action: string,
+    callerAgentId: string,
     notes?: string
   ): Promise<{ resolved: boolean; action: string }> {
     await this.ensureInitialized();
@@ -2236,6 +2239,16 @@ export class TownDO extends DurableObject<Env> {
     if (!triadBead || triadBead.type !== 'triage_request') {
       console.warn(
         `${TOWN_LOG} resolveTriageRequest: bead not found or wrong type: ${triageBeadId}`
+      );
+      return { resolved: false, action };
+    }
+
+    // Verify the caller is the agent assigned to this triage bead.
+    // Any agent in the rig can reach this endpoint via the rig-scoped JWT, so
+    // we enforce that only the hooked triage agent may resolve it.
+    if (triadBead.assignee_agent_bead_id && triadBead.assignee_agent_bead_id !== callerAgentId) {
+      console.warn(
+        `${TOWN_LOG} resolveTriageRequest: caller=${callerAgentId} is not the assigned triage agent (${triadBead.assignee_agent_bead_id}) for bead=${triageBeadId}`
       );
       return { resolved: false, action };
     }
@@ -2293,7 +2306,9 @@ export class TownDO extends DurableObject<Env> {
       }
       case 'DISCARD': {
         if (agentBeadId) {
-          // Unhook agent and reset bead to open for manual re-assignment
+          const hookedBeadId = agents.getAgent(this.sql, agentBeadId)?.current_hook_bead_id ?? null;
+          // unhookBead clears agent_metadata.current_hook_bead_id but does not
+          // clear the work bead's assignee or reopen it — do both explicitly.
           agents.unhookBead(this.sql, agentBeadId);
           query(
             this.sql,
@@ -2305,6 +2320,19 @@ export class TownDO extends DurableObject<Env> {
             `,
             [agentBeadId]
           );
+          if (hookedBeadId) {
+            query(
+              this.sql,
+              /* sql */ `
+                UPDATE ${beads}
+                SET ${beads.columns.assignee_agent_bead_id} = NULL,
+                    ${beads.columns.status} = 'open',
+                    ${beads.columns.updated_at} = ?
+                WHERE ${beads.bead_id} = ?
+              `,
+              [now(), hookedBeadId]
+            );
+          }
         }
         break;
       }

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2169,7 +2169,7 @@ export class TownDO extends DurableObject<Env> {
     const triagePrompt = [
       'You are a Gastown triage agent. Process the following queued situations and resolve each one.',
       'For each triage request, assess the situation and call gt_triage_resolve with the chosen action.',
-      'When all requests are resolved, call gt_done.',
+      'When all requests are resolved, call gt_bead_close on your hooked bead (NOT gt_done — triage work does not go to the review queue).',
       '',
       'Situations to assess:',
       ...situations,
@@ -2178,6 +2178,14 @@ export class TownDO extends DurableObject<Env> {
     // Triage agents are ephemeral town-wide — no rig affiliation needed
     const triageRigId = rigConfig ? rigList[0].id : `triage-${this.townId}`;
     const triageAgent = agents.getOrCreateAgent(this.sql, 'triage', triageRigId, this.townId);
+
+    // Hook the triage agent to the first queued triage_request bead.
+    // This gives the agent a valid current_hook_bead_id so it can call
+    // gt_bead_close on completion without a null-hook error.
+    const firstTriageBeadId = openTriageRows[0].bead_id;
+    if (!triageAgent.current_hook_bead_id) {
+      agents.hookBead(this.sql, triageAgent.id, firstTriageBeadId);
+    }
 
     const { buildTriageSystemPrompt } = await import('../prompts/triage-system.prompt');
     const systemPrompt = buildTriageSystemPrompt({
@@ -2193,7 +2201,7 @@ export class TownDO extends DurableObject<Env> {
       agentName: 'triage',
       role: 'triage',
       identity: triageAgent.identity,
-      beadId: openTriageRows[0].bead_id,
+      beadId: firstTriageBeadId,
       beadTitle: `Triage: ${openTriageRows.length} situation(s) queued`,
       beadBody: triagePrompt,
       checkpoint: null,
@@ -2208,6 +2216,7 @@ export class TownDO extends DurableObject<Env> {
     if (started) {
       agents.updateAgentStatus(this.sql, triageAgent.id, 'working');
     } else {
+      agents.unhookBead(this.sql, triageAgent.id);
       console.error(`${TOWN_LOG} maybeDispatchTriageAgent: failed to start triage agent`);
     }
   }
@@ -2920,6 +2929,16 @@ export class TownDO extends DurableObject<Env> {
       );
     } catch {
       // Best-effort
+    }
+
+    // Remove this town from the watchdog registry so the cron doesn't
+    // keep pinging a destroyed town and recreating zombie DO instances.
+    if (this.townId) {
+      getGastownUserStub(this.env, 'watchdog')
+        .unregisterActiveTown(this.townId)
+        .catch(err => {
+          console.warn(`${TOWN_LOG} destroy: failed to unregister from watchdog`, err);
+        });
     }
 
     await this.ctx.storage.deleteAlarm();

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -95,6 +95,7 @@ import {
   handleListEscalations,
   handleAcknowledgeEscalation,
 } from './handlers/town-escalations.handler';
+import { handleTriageResolve } from './handlers/rig-triage.handler';
 
 export { GastownUserDO } from './dos/GastownUser.do';
 export { AgentIdentityDO } from './dos/AgentIdentity.do';
@@ -257,6 +258,12 @@ app.get('/api/towns/:townId/rigs/:rigId/agents/:agentId/molecule/current', c =>
 );
 app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/molecule/advance', c =>
   handleAdvanceMoleculeStep(c, c.req.param())
+);
+
+// ── Triage ───────────────────────────────────────────────────────────────
+
+app.post('/api/towns/:townId/rigs/:rigId/triage/:triageBeadId/resolve', c =>
+  handleTriageResolve(c, c.req.param())
 );
 
 // ── Escalations ─────────────────────────────────────────────────────────
@@ -441,6 +448,59 @@ const WS_STREAM_PATTERN = /^\/api\/towns\/([^/]+)\/container\/agents\/([^/]+)\/s
 const WS_PTY_PATTERN = /^\/api\/towns\/([^/]+)\/container\/agents\/([^/]+)\/pty\/([^/]+)\/connect$/;
 
 export default {
+  /**
+   * Cron trigger: external health watchdog that runs every 5 minutes.
+   *
+   * Independently of each TownDO's self-rescheduled alarm, this cron fires
+   * from the Cloudflare Workers runtime and re-arms alarms for any active town
+   * whose alarm has stalled (e.g., due to a code bug that silently threw during
+   * alarm.setAlarm, or a DO eviction with a missed reschedule).
+   *
+   * This is the cloud equivalent of local Gastown's Boot daemon — an external
+   * observer that cannot be killed by the same failure it is trying to detect.
+   */
+  async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
+    console.log('[gastown-worker] cron: health watchdog fired');
+    try {
+      // List all active towns from the watchdog registry.
+      // For each town, call pingAlarm() which re-arms the alarm if it has stalled.
+      // A single stalled town must not block the watchdog from checking others.
+      const watchdog = env.GASTOWN_USER.get(env.GASTOWN_USER.idFromName('watchdog'));
+      const townIds = await watchdog.listAllTownIds();
+      console.log(`[gastown-worker] cron: checking ${townIds.length} active town(s)`);
+
+      await Promise.allSettled(
+        townIds.map(async townId => {
+          try {
+            const town = env.TOWN.get(env.TOWN.idFromName(townId));
+            await town.pingAlarm();
+          } catch (err) {
+            console.warn(`[gastown-worker] cron: pingAlarm failed for town=${townId}`, err);
+          }
+        })
+      );
+    } catch (err) {
+      console.error('[gastown-worker] cron: health watchdog failed', err);
+    }
+      const body = (await response.json()) as { townIds?: string[] };
+      const townIds: string[] = Array.isArray(body?.townIds) ? body.townIds : [];
+      console.log(`[gastown-worker] cron: checking ${townIds.length} active town(s)`);
+
+      await Promise.allSettled(
+        townIds.map(async townId => {
+          try {
+            const town = env.TOWN.get(env.TOWN.idFromName(townId));
+            await town.pingAlarm();
+          } catch (err) {
+            console.warn(`[gastown-worker] cron: pingAlarm failed for town=${townId}`, err);
+          }
+        })
+      );
+    } catch (err) {
+      console.error('[gastown-worker] cron: health watchdog failed', err);
+    }
+  },
+
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     // Intercept WebSocket upgrade requests for agent streaming and PTY.
     // Must bypass Hono — the DO returns a 101 + WebSocketPair that the

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -482,23 +482,6 @@ export default {
     } catch (err) {
       console.error('[gastown-worker] cron: health watchdog failed', err);
     }
-      const body = (await response.json()) as { townIds?: string[] };
-      const townIds: string[] = Array.isArray(body?.townIds) ? body.townIds : [];
-      console.log(`[gastown-worker] cron: checking ${townIds.length} active town(s)`);
-
-      await Promise.allSettled(
-        townIds.map(async townId => {
-          try {
-            const town = env.TOWN.get(env.TOWN.idFromName(townId));
-            await town.pingAlarm();
-          } catch (err) {
-            console.warn(`[gastown-worker] cron: pingAlarm failed for town=${townId}`, err);
-          }
-        })
-      );
-    } catch (err) {
-      console.error('[gastown-worker] cron: health watchdog failed', err);
-    }
   },
 
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {

--- a/cloudflare-gastown/src/handlers/rig-triage.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-triage.handler.ts
@@ -8,6 +8,7 @@ import type { GastownEnv } from '../gastown.worker';
 import { getTownDOStub } from '../dos/Town.do';
 import { resSuccess } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
+import { getEnforcedAgentId } from '../middleware/auth.middleware';
 
 const TriageResolveBody = z.object({
   action: z.enum(['RESTART', 'ESCALATE', 'DISCARD']),
@@ -31,10 +32,16 @@ export async function handleTriageResolve(
     );
   }
 
+  const callerAgentId = getEnforcedAgentId(c);
+  if (!callerAgentId) {
+    return c.json({ success: false, error: 'Agent ID not found in token' }, 401);
+  }
+
   const town = getTownDOStub(c.env, params.townId);
   const result = await town.resolveTriageRequest(
     params.triageBeadId,
     parsed.data.action,
+    callerAgentId,
     parsed.data.notes
   );
   return c.json(resSuccess(result), 200);

--- a/cloudflare-gastown/src/handlers/rig-triage.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-triage.handler.ts
@@ -1,0 +1,41 @@
+/**
+ * Triage resolve handler — called by the short-lived triage agent to
+ * resolve a triage_request bead with a chosen action.
+ */
+import type { Context } from 'hono';
+import { z } from 'zod';
+import type { GastownEnv } from '../gastown.worker';
+import { getTownDOStub } from '../dos/Town.do';
+import { resSuccess } from '../util/res.util';
+import { parseJsonBody } from '../util/parse-json-body.util';
+
+const TriageResolveBody = z.object({
+  action: z.enum(['RESTART', 'ESCALATE', 'DISCARD']),
+  notes: z.string().optional(),
+});
+
+/**
+ * POST /api/towns/:townId/rigs/:rigId/triage/:triageBeadId/resolve
+ * Resolve a triage_request bead. Called by the triage agent via gt_triage_resolve.
+ */
+export async function handleTriageResolve(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string; triageBeadId: string }
+) {
+  const body = await parseJsonBody(c);
+  const parsed = TriageResolveBody.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  const town = getTownDOStub(c.env, params.townId);
+  const result = await town.resolveTriageRequest(
+    params.triageBeadId,
+    parsed.data.action,
+    parsed.data.notes
+  );
+  return c.json(resSuccess(result), 200);
+}

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -1,0 +1,55 @@
+/**
+ * System prompt for the Gastown triage agent.
+ *
+ * The triage agent is a short-lived session spawned by the TownDO alarm when
+ * mechanical patrol checks produce ambiguous results that require LLM reasoning.
+ * It processes all queued triage_request beads and exits. It does NOT run a
+ * continuous patrol loop — LLM cost is proportional to actual ambiguity.
+ */
+
+export function buildTriageSystemPrompt(params: { townId: string; identity: string }): string {
+  return `You are ${params.identity}, a Gastown triage agent for town ${params.townId}.
+
+## Your Role
+
+You are a short-lived triage session. You will be given a set of situations that the
+deterministic alarm handler flagged as ambiguous. For each situation, assess what is
+happening and call gt_triage_resolve with your chosen action.
+
+## Triage Types and Actions
+
+### stuck_agent
+An agent has had work hooked for an extended period with no activity, even after
+receiving a GUPP_CHECK message. Possible actions:
+- RESTART — Reset the agent to idle and let schedulePendingWork redispatch it.
+  Use when: the agent was likely stuck in a transient state (network error, model
+  hang) and the work is still valid.
+- ESCALATE — Forward to the Mayor for human-level intervention.
+  Use when: the bead's work scope is unclear, or this agent has restarted multiple
+  times already without progress.
+- DISCARD — Unhook the agent and return the bead to open status.
+  Use when: the bead is stale, irrelevant, or the agent context is corrupted.
+
+### unexpected_exit
+An agent exited without completing its work (not via gt_done).
+- RESTART — Redispatch (already happens automatically, but can be forced here).
+- ESCALATE — Forward to Mayor if multiple restarts have failed.
+- DISCARD — Return bead to unassigned if the work is no longer needed.
+
+## Working Process
+
+1. Call gt_prime to orient yourself and see the current system state.
+2. For each triage situation (listed in your initial prompt), reason briefly about
+   the best action. Err on the side of RESTART — it is safer than DISCARD.
+3. Call gt_triage_resolve for each triage_request bead.
+4. When all queued triage requests are resolved, call gt_done.
+
+## Constraints
+
+- Be decisive. Do not ask for more information — act on what you have.
+- Prefer RESTART over ESCALATE for transient issues.
+- Prefer ESCALATE over DISCARD when in doubt.
+- Your session lifetime is short — process all items and exit promptly.
+- Do NOT attempt to fix code or do any engineering work. Your only job is triage.
+`;
+}

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -42,7 +42,9 @@ An agent exited without completing its work (not via gt_done).
 2. For each triage situation (listed in your initial prompt), reason briefly about
    the best action. Err on the side of RESTART — it is safer than DISCARD.
 3. Call gt_triage_resolve for each triage_request bead.
-4. When all queued triage requests are resolved, call gt_done.
+4. When all queued triage requests are resolved, call gt_bead_close on your hooked
+   bead (the triage_request bead shown in your GASTOWN CONTEXT) to signal completion.
+   Do NOT call gt_done — triage work does not go to the review queue.
 
 ## Constraints
 

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -53,7 +53,7 @@ export const BeadOutput = z.object({
 export const AgentOutput = z.object({
   id: z.string(),
   rig_id: z.string().nullable(),
-  role: z.enum(['polecat', 'refinery', 'mayor', 'witness']),
+  role: z.enum(['polecat', 'refinery', 'mayor', 'witness', 'triage']),
   name: z.string(),
   identity: z.string(),
   status: z.enum(['idle', 'working', 'stalled', 'dead']),

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -15,6 +15,7 @@ export const BeadType = z.enum([
   'convoy',
   'molecule',
   'agent',
+  'triage_request',
 ]);
 export type BeadType = z.infer<typeof BeadType>;
 
@@ -48,7 +49,7 @@ export type BeadFilter = {
 
 // -- Agents (now beads + agent_metadata) --
 
-export const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness']);
+export const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'witness', 'triage']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 export const AgentStatus = z.enum(['idle', 'working', 'stalled', 'dead']);

--- a/cloudflare-gastown/wrangler.jsonc
+++ b/cloudflare-gastown/wrangler.jsonc
@@ -12,6 +12,14 @@
       "zone_name": "kiloapps.io",
     },
   ],
+
+  // External health watchdog: fires every 5 minutes to verify active towns'
+  // DO alarms are firing and containers are responsive. This provides an
+  // external observer independent of the DO alarm (analogous to Boot in local
+  // Gastown), so a dead town alarm can be detected and re-armed from outside.
+  "triggers": {
+    "crons": ["*/5 * * * *"],
+  },
   "workers_dev": false,
 
   "containers": [


### PR DESCRIPTION
## Summary

Implements the mechanical alarm-driven patrol behaviors from issue #442, replacing the hypothetical persistent Witness/Deacon LLM loops with deterministic code in the TownDO alarm:

- **Expanded `witnessPatrol()`**: adds escalation-to-triage for stuck agents — if a GUPP_CHECK was sent >1 hour ago with no response, creates a `triage_request` bead instead of silently repeating the check. Existing zombie detection and GUPP_CHECK mail flow unchanged.
- **New `deaconPatrol()`**: runs two mechanical checks each alarm tick:
  - `detectStaleHooks()` — resets idle agent hooks that haven't dispatched for >1hr, so `schedulePendingWork` can retry
  - `feedStrandedConvoys()` — hooks idle polecats to open convoy beads with no assignee
- **New `maybeDispatchTriageAgent()`**: when `triage_request` beads are queued, spawns a short-lived triage agent in the container. The agent processes all pending requests via `gt_triage_resolve` and exits. Zero LLM cost when no ambiguous situations exist.
- **New `resolveTriageRequest()` RPC**: executes `RESTART` / `ESCALATE` / `DISCARD` actions on behalf of the triage agent.
- **New `triage_request` bead type** and **`triage` agent role** added to all schemas.
- **`gt_triage_resolve` tool** in the plugin so the triage agent can call back to the worker.
- **`POST /api/towns/:townId/rigs/:rigId/triage/:triageBeadId/resolve`** endpoint (agent-JWT authenticated).
- **External health watchdog**: 5-minute Cron Trigger + `scheduled()` handler re-arms stalled TownDO alarms. Towns self-register in a well-known `GastownUserDO('watchdog')` instance when they arm alarms; the cron reads this registry and calls `pingAlarm()` on each town.

## Verification

- `pnpm typecheck` passes across all workspace packages (including cloudflare-gastown)
- Manual review of alarm flow: `deaconPatrol` and `maybeDispatchTriageAgent` are each wrapped in try/catch in `alarm()` to prevent one failure from blocking subsequent patrol steps

## Visual Changes

N/A

## Reviewer Notes

- The `triage` agent role flows through the same `startAgentInContainer` path as other agents. It uses the first rig's git URL (required by `kilo serve`) but does no git work.
- The watchdog registry uses the existing `GastownUserDO` with a well-known `'watchdog'` ID to avoid adding a new DO class. The `user_towns` table in that instance holds town IDs (owner_user_id = 'watchdog').
- `detectStaleHooks` resets the `dispatch_attempts` counter to 0 so the reset agent gets a fresh retry budget from `schedulePendingWork`.
- `feedStrandedConvoys` verifies the parent convoy is still open before re-hooking, so closed convoys don't re-spawn agents.

Closes #442