### PR TITLE
feat(kiloclaw): replace hardcoded channel env maps with secret catalog lookups

### DIFF
--- a/kiloclaw/package.json
+++ b/kiloclaw/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@kilocode/db": "workspace:*",
     "@kilocode/encryption": "workspace:*",
+    "@kilocode/kiloclaw-secret-catalog": "workspace:*",
     "@kilocode/worker-utils": "workspace:*",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -119,6 +119,11 @@ export const FIELD_KEY_TO_ENTRY: ReadonlyMap<string, SecretCatalogEntry> = new M
   SECRET_CATALOG.flatMap(entry => entry.fields.map(field => [field.key, entry]))
 );
 
+/** Set of all env var names from catalog entries (for SENSITIVE_KEYS classification) */
+export const ALL_SECRET_ENV_VARS: ReadonlySet<string> = new Set(
+  SECRET_CATALOG.flatMap(entry => entry.fields.map(field => field.envVar))
+);
+
 /**
  * Get all entries for a given category, sorted by order (undefined sorts last).
  */

--- a/kiloclaw/packages/secret-catalog/src/index.ts
+++ b/kiloclaw/packages/secret-catalog/src/index.ts
@@ -25,6 +25,7 @@ export {
   ALL_SECRET_FIELD_KEYS,
   FIELD_KEY_TO_ENV_VAR,
   FIELD_KEY_TO_ENTRY,
+  ALL_SECRET_ENV_VARS,
   getEntriesByCategory,
 } from './catalog.js';
 

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -292,4 +292,37 @@ describe('buildEnvVars', () => {
       })
     ).rejects.toThrow('valid shell identifier');
   });
+
+  // ─── Catalog-derived SENSITIVE_KEYS equivalence ───────────────────────
+  // Verifies that switching from hardcoded SENSITIVE_KEYS to catalog-derived
+  // ALL_SECRET_ENV_VARS produces identical classification behavior.
+  // The catalog contains the exact same 4 env var names that were hardcoded.
+
+  it('classifies all catalog channel env vars as sensitive (catalog-derived SENSITIVE_KEYS)', async () => {
+    const env = createMockEnv({ AGENT_ENV_VARS_PRIVATE_KEY: testPrivateKey });
+
+    // Provide all 4 channel env var names as plaintext user env vars.
+    // They should all land in the sensitive bucket because SENSITIVE_KEYS
+    // is now derived from the catalog (which includes all 4).
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      envVars: {
+        TELEGRAM_BOT_TOKEN: 'tg-plain',
+        DISCORD_BOT_TOKEN: 'discord-plain',
+        SLACK_BOT_TOKEN: 'slack-bot-plain',
+        SLACK_APP_TOKEN: 'slack-app-plain',
+      },
+    });
+
+    // All 4 must be in sensitive — same behavior as the old hardcoded set
+    expect(result.sensitive.TELEGRAM_BOT_TOKEN).toBe('tg-plain');
+    expect(result.sensitive.DISCORD_BOT_TOKEN).toBe('discord-plain');
+    expect(result.sensitive.SLACK_BOT_TOKEN).toBe('slack-bot-plain');
+    expect(result.sensitive.SLACK_APP_TOKEN).toBe('slack-app-plain');
+
+    // None should leak into the plaintext env bucket
+    expect(result.env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(result.env.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(result.env.SLACK_BOT_TOKEN).toBeUndefined();
+    expect(result.env.SLACK_APP_TOKEN).toBeUndefined();
+  });
 });

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -1,3 +1,4 @@
+import { ALL_SECRET_ENV_VARS } from '@kilocode/kiloclaw-secret-catalog';
 import type { KiloClawEnv } from '../types';
 import type { EncryptedEnvelope, EncryptedChannelTokens } from '../schemas/instance-config';
 import { deriveGatewayToken } from '../auth/gateway-token';
@@ -30,14 +31,13 @@ export type EnvVarsBuild = {
 /**
  * Env var names that are always classified as sensitive.
  * Values for these keys go into the `sensitive` bucket.
+ *
+ * Derived from the secret catalog to automatically include all channel/secret env vars.
  */
 const SENSITIVE_KEYS = new Set([
   'KILOCODE_API_KEY',
   'OPENCLAW_GATEWAY_TOKEN',
-  'TELEGRAM_BOT_TOKEN',
-  'DISCORD_BOT_TOKEN',
-  'SLACK_BOT_TOKEN',
-  'SLACK_APP_TOKEN',
+  ...ALL_SECRET_ENV_VARS,
 ]);
 
 /**

--- a/kiloclaw/src/utils/encryption.test.ts
+++ b/kiloclaw/src/utils/encryption.test.ts
@@ -233,5 +233,25 @@ describe('encryption utilities', () => {
       const channels: EncryptedChannelTokens = {};
       expect(decryptChannelTokens(channels, privateKey)).toEqual({});
     });
+
+    it('skips unknown channel keys not in the secret catalog (warn + continue)', () => {
+      // Simulate a channels object with a key that is not registered in the secret
+      // catalog (e.g. stale DO state from a rolled-back schema change, or a key
+      // added to EncryptedChannelTokens before the catalog was updated).
+      // The function should skip the unknown key gracefully rather than throwing,
+      // so a single unrecognised key does not prevent the machine from starting.
+      const channels = {
+        unknownFutureToken: encryptForTest('some-token', publicKey),
+        telegramBotToken: encryptForTest('tg-token', publicKey),
+      } as unknown as EncryptedChannelTokens;
+
+      const result = decryptChannelTokens(channels, privateKey);
+
+      // Known key is still decrypted correctly
+      expect(result.TELEGRAM_BOT_TOKEN).toBe('tg-token');
+      // Unknown key is silently skipped — no entry in result
+      expect(Object.keys(result)).not.toContain('unknownFutureToken');
+      expect(Object.keys(result)).toHaveLength(1);
+    });
   });
 });

--- a/kiloclaw/src/utils/encryption.ts
+++ b/kiloclaw/src/utils/encryption.ts
@@ -11,6 +11,7 @@
  */
 
 import { createDecipheriv, privateDecrypt, constants } from 'crypto';
+import { FIELD_KEY_TO_ENV_VAR } from '@kilocode/kiloclaw-secret-catalog';
 import type { EncryptedEnvelope, EncryptedChannelTokens } from '../schemas/instance-config';
 
 export class EncryptionConfigurationError extends Error {
@@ -146,20 +147,16 @@ export function mergeEnvVarsWithSecrets(
 }
 
 /**
- * Channel token env var mapping.
- * Maps channel config keys to the container env var names expected by start-openclaw.sh.
- */
-const CHANNEL_ENV_MAP: Record<keyof EncryptedChannelTokens, string> = {
-  telegramBotToken: 'TELEGRAM_BOT_TOKEN',
-  discordBotToken: 'DISCORD_BOT_TOKEN',
-  slackBotToken: 'SLACK_BOT_TOKEN',
-  slackAppToken: 'SLACK_APP_TOKEN',
-};
-
-/**
  * Decrypt encrypted channel tokens and map to container env var names.
  *
+ * Uses FIELD_KEY_TO_ENV_VAR from the secret catalog to map channel config keys
+ * to the container env var names expected by start-openclaw.sh.
+ *
  * Example: channels.telegramBotToken -> TELEGRAM_BOT_TOKEN
+ *
+ * Unknown keys (e.g. stale DO state from a rolled-back schema change) are
+ * skipped with a console.warn rather than throwing, so a single unrecognised
+ * key does not prevent the machine from starting.
  */
 export function decryptChannelTokens(
   channels: EncryptedChannelTokens,
@@ -167,10 +164,21 @@ export function decryptChannelTokens(
 ): Record<string, string> {
   const result: Record<string, string> = {};
 
-  for (const channelKey of Object.keys(CHANNEL_ENV_MAP) as (keyof EncryptedChannelTokens)[]) {
+  for (const channelKey of Object.keys(channels) as (keyof EncryptedChannelTokens)[]) {
     const envelope = channels[channelKey];
     if (envelope) {
-      result[CHANNEL_ENV_MAP[channelKey]] = decryptWithPrivateKey(envelope, privateKeyPem);
+      const envVarName = FIELD_KEY_TO_ENV_VAR.get(channelKey);
+      if (!envVarName) {
+        // Gracefully skip unknown keys rather than hard-failing.
+        // This can happen if DO state contains a key that was removed from the
+        // catalog (e.g. after a schema rollback) or added to EncryptedChannelTokens
+        // before the catalog was updated.
+        console.warn(
+          `[decryptChannelTokens] Unknown channel key '${channelKey}' — not in secret catalog. Skipping.`
+        );
+        continue;
+      }
+      result[envVarName] = decryptWithPrivateKey(envelope, privateKeyPem);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1388,6 +1388,9 @@ importers:
       '@kilocode/encryption':
         specifier: workspace:*
         version: link:../packages/encryption
+      '@kilocode/kiloclaw-secret-catalog':
+        specifier: workspace:*
+        version: link:packages/secret-catalog
       '@kilocode/worker-utils':
         specifier: workspace:*
         version: link:../packages/worker-utils


### PR DESCRIPTION


<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
  Replace hardcoded channel-to-env-var mappings in the CF Worker with catalog-derived
  lookups from @kilocode/kiloclaw-secret-catalog (PR1, #857). Behavior is identical —
  only the source of truth changes.

  - Replace CHANNEL_ENV_MAP in encryption.ts with FIELD_KEY_TO_ENV_VAR from catalog
  - Replace hardcoded SENSITIVE_KEYS in env.ts with catalog-derived ALL_SECRET_ENV_VARS
  - Unknown channel keys in DO state are gracefully skipped (warn + continue) instead of
  silently ignored
  - Add ALL_SECRET_ENV_VARS export to the secret catalog package
<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification

<!-- List the checks you ran and what passed. Add command output notes when useful. -->

- [x]   - pnpm --filter kiloclaw run test — 505 tests pass (504 existing + 1 new)
- [x]   - pnpm --filter @kilocode/kiloclaw-secret-catalog run test — 30 tests pass
- [x]   - pnpm --filter kiloclaw run typecheck — clean
- [x]   - New buildEnvVars equivalence test confirms catalog-derived SENSITIVE_KEYS classifies
- [x]   all 4 channel env vars identically to the old hardcoded set
- [x]   - New test confirms unknown channel keys are skipped gracefully without blocking
- [x]   machine startup




## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->
N/A

| Before | After |
| ------ | ----- |
|        |       |

## Reviewer Notes
  - Depends on #857 (already merged)
  - Non-breaking: catalog contains the exact same 4 field→env-var mappings that were
  hardcoded (TELEGRAM_BOT_TOKEN, DISCORD_BOT_TOKEN, SLACK_BOT_TOKEN, SLACK_APP_TOKEN)
  - One subtle behavioral change: decryptChannelTokens now iterates over input channels
  keys instead of the old map keys. Unknown keys produce a console.warn + skip rather
  than being silently ignored — same outcome (key not in result) but with observability

This doesn't touch storage. It only changes how the worker reads stored data:           
  - DO state format is unchanged — channels field still holds EncryptedChannelTokens
  - Decryption logic (decryptWithPrivateKey) is unchanged                                
  - Only the key→env-var mapping source changed (hardcoded map → catalog map with identical values)


<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
