### PR TITLE
fix(cloud-agent-next): avoid OOM by downloading snapshot in sandbox

### DIFF
--- a/cloud-agent-next/Dockerfile
+++ b/cloud-agent-next/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 	&& mkdir -p -m 755 /etc/apt/sources.list.d \
 	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 	&& apt update \
-	&& apt install gh -y
+	&& apt install gh jq -y
 
 # Install GitLab CLI (glab) - download official .deb from GitLab releases
 RUN GLAB_VERSION="1.80.4" \
@@ -39,9 +39,10 @@ RUN npm install -g pnpm @kilocode/cli@${KILOCODE_CLI_VERSION}
 COPY wrapper /tmp/wrapper-build/wrapper
 COPY src/shared /tmp/wrapper-build/src/shared
 
-# Build the wrapper bundle
+# Build the wrapper bundle and restore-session script
 RUN cd /tmp/wrapper-build/wrapper && \
     bun build src/main.ts --outfile=/usr/local/bin/kilocode-wrapper.js --target=bun --minify && \
+    bun build src/restore-session.ts --outfile=/usr/local/bin/kilo-restore-session.js --target=bun --minify && \
     rm -rf /tmp/wrapper-build
 
 # DO NOT override USER, WORKDIR, or ENTRYPOINT from the base image

--- a/cloud-agent-next/Dockerfile.dev
+++ b/cloud-agent-next/Dockerfile.dev
@@ -12,7 +12,7 @@ ARG KILOCODE_CLI_VERSION="next"
 # This builds kilo-cli from source and copies the linux-x64 binary here.
 
 # Install ripgrep and Generate locales to suppress setlocale warnings
-RUN apt-get update && apt-get install -y --no-install-recommends ripgrep locales && \
+RUN apt-get update && apt-get install -y --no-install-recommends ripgrep jq locales && \
 	   sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 	   locale-gen && \
 	   apt-get clean && \
@@ -34,14 +34,15 @@ RUN npm install -g pnpm @kilocode/cli@${KILOCODE_CLI_VERSION}
 #COPY kilo /usr/local/bin/kilo
 #RUN chmod +x /usr/local/bin/kilo
 
-# === Build wrapper bundle inside container ===
-# This ensures the wrapper is built with the same Bun version that will run it,
+# === Build wrapper bundle and restore-session script inside container ===
+# This ensures both scripts are built with the same Bun version that will run them,
 # avoiding any compatibility issues between build and runtime environments.
 COPY wrapper /tmp/wrapper-build/wrapper
 COPY src/shared /tmp/wrapper-build/src/shared
 
 RUN cd /tmp/wrapper-build/wrapper && \
     bun build src/main.ts --outfile=/usr/local/bin/kilocode-wrapper.js --target=bun --minify && \
+    bun build src/restore-session.ts --outfile=/usr/local/bin/kilo-restore-session.js --target=bun --minify && \
     rm -rf /tmp/wrapper-build
 
 # DO NOT override USER, WORKDIR, or ENTRYPOINT from the base image

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -97,6 +97,7 @@ describe('SessionService', () => {
 
     const env: PersistenceEnv = {
       ...mockEnv,
+      KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
       CLOUD_AGENT_SESSION: {
         idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
         get: vi.fn().mockReturnValue(metadataStub),
@@ -173,17 +174,7 @@ describe('SessionService', () => {
       expect(result.context.sessionId).toBe(sessionId);
     });
 
-    it('does not restore session snapshot during initiate (no fetch call)', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(new Response(JSON.stringify({ info: {}, messages: [] })));
-      const envWithIngest: PersistenceEnv = {
-        ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
-      };
-
+    it('does not restore session snapshot during initiate (no curl/import)', async () => {
       const fakeSession = {
         exec: vi.fn().mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
@@ -213,17 +204,22 @@ describe('SessionService', () => {
         kilocodeToken: 'token',
         kilocodeModel: 'test-model',
         githubRepo: 'acme/repo',
-        env: envWithIngest,
+        env: mockEnv,
       });
 
-      expect(fetchMock).not.toHaveBeenCalled();
-      expect(fakeSession.writeFile).not.toHaveBeenCalled();
+      // No curl, kilo import, or restore script should run during initiate
+      const curlCalls = fakeSession.exec.mock.calls.filter(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('curl')
+      );
+      expect(curlCalls).toHaveLength(0);
       expect(fakeSession.exec).not.toHaveBeenCalledWith(
         `kilo import "/tmp/kilo-session-export-${sessionId}.json"`
       );
-      expect(fakeSession.deleteFile).not.toHaveBeenCalledWith(
-        `/tmp/kilo-session-export-${sessionId}.json`
+      const restoreCalls = fakeSession.exec.mock.calls.filter(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('kilo-restore-session.js')
       );
+      expect(restoreCalls).toHaveLength(0);
     });
 
     it('uses manageBranch for upstream branches during initiate', async () => {
@@ -347,6 +343,7 @@ describe('SessionService', () => {
       const mockDOGetMetadata = vi.fn();
       const testEnv = {
         ...mockEnv,
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -418,6 +415,7 @@ describe('SessionService', () => {
       const mockDOGetMetadata = vi.fn();
       const testEnv = {
         ...mockEnv,
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -489,6 +487,7 @@ describe('SessionService', () => {
       const mockDOGetMetadata = vi.fn();
       const testEnv = {
         ...mockEnv,
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -551,6 +550,7 @@ describe('SessionService', () => {
 
       const testEnv = {
         ...mockEnv,
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -581,13 +581,9 @@ describe('SessionService', () => {
 
     it('restores workspace then session snapshot when workspace is missing', async () => {
       const mockDOGetMetadata = vi.fn();
-      const payload = JSON.stringify({ info: {}, messages: [] });
-      const fetchMock = vi.fn().mockResolvedValue(new Response(payload));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -600,8 +596,18 @@ describe('SessionService', () => {
       const fakeSession = {
         exec: vi
           .fn()
-          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
-          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' }) // repo check fails
+          .mockResolvedValue({
+            success: true,
+            exitCode: 0,
+            stdout: JSON.stringify({
+              ok: true,
+              downloaded: true,
+              imported: true,
+              diffs: { applied: 0, skipped: 0, total: 0 },
+            }),
+            stderr: '',
+          }), // restore script + any subsequent calls
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
@@ -639,68 +645,42 @@ describe('SessionService', () => {
         env: envWithIngest,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `https://session-ingest/internal/session/${kiloSessionId}/export`,
-        })
+      // Verify restore script was called (instead of curl)
+      const restoreCall = fakeSession.exec.mock.calls.find(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('kilo-restore-session.js')
       );
-      expect(fakeSession.writeFile).toHaveBeenCalledWith(
-        `/tmp/kilo-session-export-${sessionId}.json`,
-        payload
-      );
-      expect(fakeSession.exec).toHaveBeenCalledWith(
-        `kilo import "/tmp/kilo-session-export-${sessionId}.json"`
-      );
-      expect(fakeSession.deleteFile).toHaveBeenCalledWith(
-        `/tmp/kilo-session-export-${sessionId}.json`
-      );
+      expect(restoreCall).toBeDefined();
+      expect(restoreCall![0]).toContain(kiloSessionId);
+      expect(restoreCall![0]).toContain(`/workspace/${orgId}/${userId}/sessions/${sessionId}`);
+
       expect(result.context.githubRepo).toBe('facebook/react');
       expect(result.context.githubToken).toBe('test-token');
 
-      // Verify restoreWorkspace (git clone) ran before kilo import
-      const kiloImportCallIndex = fakeSession.exec.mock.calls.findIndex(
-        (args: string[]) => typeof args[0] === 'string' && args[0].includes('kilo import')
+      // Verify restoreWorkspace (git clone) ran before restore script
+      const restoreScriptCallIndex = fakeSession.exec.mock.calls.findIndex(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('kilo-restore-session.js')
       );
-      expect(kiloImportCallIndex).toBeGreaterThanOrEqual(0);
+      expect(restoreScriptCallIndex).toBeGreaterThanOrEqual(0);
       const restoreWorkspaceOrder = mockedRestoreWorkspace.mock.invocationCallOrder[0];
-      const kiloImportOrder = fakeSession.exec.mock.invocationCallOrder[kiloImportCallIndex];
-      expect(restoreWorkspaceOrder).toBeLessThan(kiloImportOrder);
+      const restoreScriptOrder = fakeSession.exec.mock.invocationCallOrder[restoreScriptCallIndex];
+      expect(restoreWorkspaceOrder).toBeLessThan(restoreScriptOrder);
 
-      // Verify writeAuthFile ran before kilo import so KiloSessions.bootstrap() can authenticate
+      // Verify writeAuthFile ran before restore script
       const authWriteCallIndex = sandboxWriteFile.mock.calls.findIndex(
         (args: string[]) => typeof args[0] === 'string' && args[0].includes('auth.json')
       );
       expect(authWriteCallIndex).toBeGreaterThanOrEqual(0);
       const authWriteOrder = sandboxWriteFile.mock.invocationCallOrder[authWriteCallIndex];
-      expect(authWriteOrder).toBeLessThan(kiloImportOrder);
+      expect(authWriteOrder).toBeLessThan(restoreScriptOrder);
     });
 
-    it('applies session diff after restoring snapshot during cold start', async () => {
+    it('runs restore script in sandbox during cold start', async () => {
       const mockDOGetMetadata = vi.fn();
-      const snapshotWithDiffs = {
-        info: {},
-        messages: [
-          {
-            info: {
-              summary: {
-                diffs: [
-                  { file: 'src/index.ts', after: 'new content', status: 'modified' },
-                  { file: 'src/new-file.ts', after: 'brand new file', status: 'added' },
-                  { file: 'src/removed.ts', after: '', status: 'deleted' },
-                ],
-              },
-            },
-            parts: [],
-          },
-        ],
-      };
-      const snapshotPayload = JSON.stringify(snapshotWithDiffs);
-      const fetchMock = vi.fn().mockResolvedValue(new Response(snapshotPayload));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -713,8 +693,18 @@ describe('SessionService', () => {
       const fakeSession = {
         exec: vi
           .fn()
-          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
-          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' }) // repo check
+          .mockResolvedValue({
+            success: true,
+            exitCode: 0,
+            stdout: JSON.stringify({
+              ok: true,
+              downloaded: true,
+              imported: true,
+              diffs: { applied: 3, skipped: 0, total: 3 },
+            }),
+            stderr: '',
+          }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
@@ -751,60 +741,33 @@ describe('SessionService', () => {
         env: envWithIngest,
       });
 
-      // Verify fetch was called with the streaming export endpoint
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `https://session-ingest/internal/session/${kiloSessionId}/export`,
-        })
-      );
-
-      // Verify modified file was written
-      expect(fakeSession.writeFile).toHaveBeenCalledWith(
-        `/workspace/${orgId}/${userId}/sessions/${sessionId}/src/index.ts`,
-        'new content'
-      );
-
-      // Verify added file was written
-      expect(fakeSession.writeFile).toHaveBeenCalledWith(
-        `/workspace/${orgId}/${userId}/sessions/${sessionId}/src/new-file.ts`,
-        'brand new file'
-      );
-
-      // Verify deleted file was removed
-      expect(fakeSession.deleteFile).toHaveBeenCalledWith(
-        `/workspace/${orgId}/${userId}/sessions/${sessionId}/src/removed.ts`
-      );
-
-      // Verify mkdir was called for parent directories
-      expect(fakeSession.exec).toHaveBeenCalledWith(
-        `mkdir -p '/workspace/${orgId}/${userId}/sessions/${sessionId}/src'`
-      );
-
-      // Verify session diff was applied AFTER kilo import
-      const kiloImportCallIndex = fakeSession.exec.mock.calls.findIndex(
-        (args: string[]) => typeof args[0] === 'string' && args[0].includes('kilo import')
-      );
-      expect(kiloImportCallIndex).toBeGreaterThanOrEqual(0);
-      const kiloImportOrder = fakeSession.exec.mock.invocationCallOrder[kiloImportCallIndex];
-
-      const mkdirCallIndex = fakeSession.exec.mock.calls.findIndex(
+      // Verify restore script was called with correct args
+      const restoreCall = fakeSession.exec.mock.calls.find(
         (args: string[]) =>
-          typeof args[0] === 'string' && args[0].includes('mkdir -p') && args[0].includes('/src')
+          typeof args[0] === 'string' && args[0].includes('kilo-restore-session.js')
       );
-      expect(mkdirCallIndex).toBeGreaterThanOrEqual(0);
-      const mkdirOrder = fakeSession.exec.mock.invocationCallOrder[mkdirCallIndex];
-      expect(mkdirOrder).toBeGreaterThan(kiloImportOrder);
+      expect(restoreCall).toBeDefined();
+      expect(restoreCall![0]).toContain(kiloSessionId);
+      expect(restoreCall![0]).toContain(`/workspace/${orgId}/${userId}/sessions/${sessionId}`);
+
+      // No diff script should be written to sandbox
+      const diffScriptWriteCall = fakeSession.writeFile.mock.calls.find(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('kilo-apply-diffs')
+      );
+      expect(diffScriptWriteCall).toBeUndefined();
+
+      // No curl call
+      const curlCalls = fakeSession.exec.mock.calls.filter(
+        (args: string[]) => typeof args[0] === 'string' && args[0].includes('curl')
+      );
+      expect(curlCalls).toHaveLength(0);
     });
 
-    it('skips session diff gracefully when no diffs in messages', async () => {
+    it('completes cold start when restore script reports no diffs', async () => {
       const mockDOGetMetadata = vi.fn();
-      const payload = JSON.stringify({ info: {}, messages: [{ info: {}, parts: [] }] });
-      const fetchMock = vi.fn().mockResolvedValue(new Response(payload));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -817,8 +780,18 @@ describe('SessionService', () => {
       const fakeSession = {
         exec: vi
           .fn()
-          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
-          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' }) // repo check
+          .mockResolvedValue({
+            success: true,
+            exitCode: 0,
+            stdout: JSON.stringify({
+              ok: true,
+              downloaded: true,
+              imported: true,
+              diffs: { applied: 0, skipped: 0, total: 0 },
+            }),
+            stderr: '',
+          }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
@@ -844,7 +817,7 @@ describe('SessionService', () => {
       mockDOGetMetadata.mockResolvedValue(metadata);
 
       const service = new SessionService();
-      // Should not throw — null diff is gracefully handled
+      // Should not throw — zero diffs is handled gracefully
       await service.resume({
         sandbox,
         sandboxId: `${orgId}__${userId}`,
@@ -856,27 +829,19 @@ describe('SessionService', () => {
         env: envWithIngest,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `https://session-ingest/internal/session/${kiloSessionId}/export`,
-        })
+      // Verify restore script was called (not curl)
+      const restoreCall = fakeSession.exec.mock.calls.find(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('kilo-restore-session.js')
       );
-
-      // No file writes for diff (only the kilo import tmp file)
-      const diffWriteCalls = fakeSession.writeFile.mock.calls.filter(
-        (args: string[]) => !args[0].includes('/tmp/kilo-session-export-')
-      );
-      expect(diffWriteCalls).toHaveLength(0);
+      expect(restoreCall).toBeDefined();
     });
 
-    it('throws when session export returns 404 (session not found)', async () => {
+    it('throws when restore script fails with 404 (session not found)', async () => {
       const mockDOGetMetadata = vi.fn();
-      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        KILO_SESSION_INGEST_URL: 'https://session-ingest.example.com',
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -889,7 +854,18 @@ describe('SessionService', () => {
       const fakeSession = {
         exec: vi
           .fn()
-          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' }) // repo check
+          .mockResolvedValueOnce({
+            success: true,
+            exitCode: 1,
+            stdout: JSON.stringify({
+              ok: false,
+              error: 'snapshot not found (404)',
+              code: 404,
+              step: 'download',
+            }),
+            stderr: 'restore-session: snapshot not found (404)',
+          }) // restore script fails with 404
           .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
@@ -928,8 +904,6 @@ describe('SessionService', () => {
           env: envWithIngest,
         })
       ).rejects.toThrow('session not found');
-
-      expect(fetchMock).toHaveBeenCalled();
     });
 
     it('removes workspace when kilo import fails during cold start so retry can reclone', async () => {
@@ -1657,22 +1631,34 @@ describe('SessionService', () => {
         getMetadata: vi.fn().mockResolvedValue(metadata),
       });
 
-      const execResults = [
-        { success: true, exitCode: 0, stdout: '' }, // repo check - repo doesn't exist
-        { success: true, exitCode: 0, stdout: '' }, // kilo import succeeds
-        { success: true, exitCode: 0, stdout: 'command 1 ok', stderr: '' }, // npm install
-        { success: false, exitCode: 1, stdout: '', stderr: 'command 2 failed' }, // npm run build fails
-        { success: true, exitCode: 0, stdout: 'command 3 ok', stderr: '' }, // npm test
-      ];
-
       const fakeSession = {
         exec: vi
           .fn()
-          .mockResolvedValueOnce(execResults[0])
-          .mockResolvedValueOnce(execResults[1])
-          .mockResolvedValueOnce(execResults[2])
-          .mockResolvedValueOnce(execResults[3])
-          .mockResolvedValueOnce(execResults[4]),
+          .mockResolvedValueOnce({ success: true, exitCode: 0, stdout: '' }) // repo check - no .git
+          .mockResolvedValueOnce({
+            success: true,
+            exitCode: 0,
+            stdout: JSON.stringify({
+              ok: true,
+              downloaded: true,
+              imported: true,
+              diffs: { applied: 0, skipped: 0, total: 0 },
+            }),
+            stderr: '',
+          }) // restore script
+          .mockResolvedValueOnce({ success: true, exitCode: 0, stdout: 'command 1 ok', stderr: '' }) // npm install
+          .mockResolvedValueOnce({
+            success: false,
+            exitCode: 1,
+            stdout: '',
+            stderr: 'command 2 failed',
+          }) // npm run build fails
+          .mockResolvedValueOnce({
+            success: true,
+            exitCode: 0,
+            stdout: 'command 3 ok',
+            stderr: '',
+          }), // npm test
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),
@@ -1699,8 +1685,8 @@ describe('SessionService', () => {
         env: testEnv,
       });
 
-      // All three setup commands should be executed (after the initial repo check)
-      expect(fakeSession.exec).toHaveBeenCalledTimes(5); // 1 repo check + 1 import + 3 setup commands
+      // 1 repo check + 1 restore script + 3 setup commands = 5
+      expect(fakeSession.exec).toHaveBeenCalledTimes(5);
       expect(fakeSession.exec).toHaveBeenNthCalledWith(3, 'npm install', {
         cwd: `/workspace/org/user/sessions/${sessionId}`,
         timeout: 120000,

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -908,13 +908,8 @@ describe('SessionService', () => {
 
     it('removes workspace when kilo import fails during cold start so retry can reclone', async () => {
       const mockDOGetMetadata = vi.fn();
-      const payload = JSON.stringify({ info: {}, messages: [{ info: {}, parts: [] }] });
-      const fetchMock = vi.fn().mockResolvedValue(new Response(payload));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -929,12 +924,12 @@ describe('SessionService', () => {
           if (cmd.includes('test -d') && cmd.includes('.git')) {
             return Promise.resolve({ success: true, exitCode: 1, stdout: '', stderr: '' });
           }
-          if (cmd.includes('kilo import')) {
+          if (cmd.includes('kilo-restore-session')) {
             return Promise.resolve({
               success: false,
               exitCode: 1,
-              stdout: '',
-              stderr: 'import failed',
+              stdout: '{"error":"import failed"}',
+              stderr: 'restore script failed',
             });
           }
           return Promise.resolve({ success: true, exitCode: 0, stdout: '', stderr: '' });
@@ -976,7 +971,7 @@ describe('SessionService', () => {
           kilocodeModel: 'test-model',
           env: envWithIngest,
         })
-      ).rejects.toThrow('Session snapshot import failed');
+      ).rejects.toThrow('Cold-start session restore failed');
 
       const workspacePath = `/workspace/${orgId}/${userId}/sessions/${sessionId}`;
       const sessionHome = `/home/${sessionId}`;
@@ -985,12 +980,8 @@ describe('SessionService', () => {
 
     it('removes workspace when SessionSnapshotRestoreError (404) is thrown', async () => {
       const mockDOGetMetadata = vi.fn();
-      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       const envWithIngest: PersistenceEnv = {
         ...mockEnv,
-        SESSION_INGEST: {
-          fetch: fetchMock,
-        } as unknown as PersistenceEnv['SESSION_INGEST'],
         CLOUD_AGENT_SESSION: {
           idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
           get: vi.fn(() => ({
@@ -1001,10 +992,20 @@ describe('SessionService', () => {
         } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
       };
       const fakeSession = {
-        exec: vi
-          .fn()
-          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
-          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+        exec: vi.fn().mockImplementation((cmd: string) => {
+          if (cmd.includes('test -d') && cmd.includes('.git')) {
+            return Promise.resolve({ success: true, exitCode: 1, stdout: '', stderr: '' });
+          }
+          if (cmd.includes('kilo-restore-session')) {
+            return Promise.resolve({
+              success: false,
+              exitCode: 1,
+              stdout: JSON.stringify({ code: 404, error: 'session not found' }),
+              stderr: '',
+            });
+          }
+          return Promise.resolve({ success: true, exitCode: 0, stdout: '', stderr: '' });
+        }),
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
         writeFile: vi.fn().mockResolvedValue(undefined),
         deleteFile: vi.fn().mockResolvedValue(undefined),

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'node:path';
-import { z } from 'zod';
 import type {
   ExecutionSession,
   SandboxInstance,
@@ -934,185 +932,6 @@ export class SessionService {
   }
 
   /**
-   * Write a snapshot payload to a temp file, run `kilo import`, then clean up.
-   *
-   * @param snapshotPayload - Pre-fetched JSON string of the session snapshot.
-   */
-  private async restoreSessionSnapshot(
-    session: ExecutionSession,
-    sessionId: string,
-    userId: string,
-    snapshotPayload: string
-  ): Promise<void> {
-    const tmpPath = `/tmp/kilo-session-export-${sessionId}.json`;
-    let wroteSnapshot = false;
-    try {
-      await session.writeFile(tmpPath, snapshotPayload);
-      wroteSnapshot = true;
-
-      const importResult = await session.exec(`kilo import "${tmpPath}"`);
-      if (importResult.exitCode !== 0) {
-        logger
-          .withFields({
-            sessionId,
-            userId,
-            exitCode: importResult.exitCode,
-            stderr: importResult.stderr,
-            stdout: importResult.stdout,
-          })
-          .error('Session snapshot import failed');
-        throw new Error(`Session snapshot import failed with exit code ${importResult.exitCode}`);
-      }
-    } catch (error) {
-      logger
-        .withFields({
-          sessionId,
-          userId,
-          error: error instanceof Error ? error.message : String(error),
-        })
-        .error('Session snapshot restore failed');
-      throw error instanceof Error ? error : new Error(String(error));
-    } finally {
-      if (wroteSnapshot) {
-        try {
-          await session.deleteFile(tmpPath);
-        } catch (error) {
-          logger
-            .withFields({
-              sessionId,
-              userId,
-              error: error instanceof Error ? error.message : String(error),
-            })
-            .debug('Failed to delete session snapshot temp file');
-        }
-      }
-    }
-  }
-
-  /**
-   * Apply file-level changes from a pre-parsed diff array on top of the freshly
-   * cloned repo.  Called during cold-start resume after `restoreSessionSnapshot`.
-   *
-   * Each diff entry contains the full `after` content, so we simply write (or
-   * delete) files to recreate the workspace state from the previous session.
-   *
-   * @param diffs - Pre-parsed `FileDiff[]` array (or `null` when no diff exists).
-   */
-  private async applySessionDiff(
-    session: ExecutionSession,
-    sessionId: string,
-    userId: string,
-    workspacePath: string,
-    diffs: Array<{
-      file: string;
-      after: string;
-      status?: 'added' | 'deleted' | 'modified';
-    }> | null
-  ): Promise<void> {
-    if (!Array.isArray(diffs) || diffs.length === 0) {
-      return;
-    }
-
-    let applied = 0;
-    let skipped = 0;
-
-    for (const diff of diffs) {
-      if (!diff.file) {
-        skipped++;
-        continue;
-      }
-
-      // Skip binary files — they have empty after content
-      if (diff.status !== 'deleted' && !diff.after) {
-        skipped++;
-        continue;
-      }
-
-      const filePath = resolve(workspacePath, diff.file);
-      if (!filePath.startsWith(workspacePath + '/')) {
-        logger
-          .withFields({ sessionId, userId, file: diff.file })
-          .warn('Skipping diff entry with path outside workspace');
-        skipped++;
-        continue;
-      }
-
-      try {
-        if (diff.status === 'deleted') {
-          await session.deleteFile(filePath);
-          applied++;
-        } else {
-          // Ensure parent directory exists.
-          // Use single-quoted path to prevent shell metacharacter injection.
-          const lastSlash = filePath.lastIndexOf('/');
-          if (lastSlash > 0) {
-            const parentDir = filePath.substring(0, lastSlash);
-            const escaped = parentDir.replaceAll("'", "'\\''");
-            await session.exec(`mkdir -p '${escaped}'`);
-          }
-          await session.writeFile(filePath, diff.after);
-          applied++;
-        }
-      } catch (error) {
-        logger
-          .withFields({
-            sessionId,
-            userId,
-            file: diff.file,
-            status: diff.status,
-            error: error instanceof Error ? error.message : String(error),
-          })
-          .warn('Failed to apply file diff (non-fatal, continuing)');
-        skipped++;
-      }
-    }
-
-    logger
-      .withFields({ sessionId, userId, applied, skipped, total: diffs.length })
-      .info('Applied session diff');
-  }
-
-  /**
-   * Extract last-write-wins file diffs from streamed snapshot messages.
-   * The snapshot format is `{ info, messages: [{ info: { summary: { diffs } }, parts }] }`.
-   * Returns null when no diffs exist.
-   */
-  private static extractDiffsFromMessages(
-    payload: string
-  ): Array<{ file: string; after: string; status?: 'added' | 'deleted' | 'modified' }> | null {
-    const fileDiffSchema = z.object({
-      file: z.string(),
-      after: z.string().default(''),
-      status: z.enum(['added', 'deleted', 'modified']).default('modified'),
-    });
-
-    try {
-      const parsed = JSON.parse(payload) as {
-        messages?: Array<{ info?: { summary?: { diffs?: unknown[] } } }>;
-      };
-      if (!parsed.messages) return null;
-
-      const byFile = new Map<string, z.infer<typeof fileDiffSchema>>();
-
-      for (const msg of parsed.messages) {
-        const diffs = msg.info?.summary?.diffs;
-        if (!Array.isArray(diffs)) continue;
-
-        for (const d of diffs) {
-          const result = fileDiffSchema.safeParse(d);
-          if (!result.success) continue;
-          byFile.set(result.data.file, result.data);
-        }
-      }
-
-      if (byFile.size === 0) return null;
-      return [...byFile.values()];
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * Initialize a cloud-agent session by resuming an existing kilo session.
    *
    * Client provides both kiloSessionId and githubRepo (parsed from git_url).
@@ -1475,38 +1294,62 @@ export class SessionService {
       await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
       await writeGlobalRules(sandbox, context.sessionHome, sessionId);
 
-      // Fetch snapshot from session-ingest DO and buffer it for sandbox writeFile (string-only API).
-      const internalSecret = await env.INTERNAL_API_SECRET_PROD.get();
-      const response = await env.SESSION_INGEST.fetch(
-        new Request(`https://session-ingest/internal/session/${metadata.kiloSessionId}/export`, {
-          headers: {
-            'X-Internal-Secret': internalSecret,
-            'X-Kilo-User-Id': userId,
-          },
-        })
+      // Single restore script handles download, import, and diff application inside
+      // the sandbox — the snapshot never enters worker memory.
+      logger.info('Starting cold-start session restore');
+
+      const escapedId = metadata.kiloSessionId.replaceAll("'", "'\\''");
+      const escapedWorkspace = context.workspacePath.replaceAll("'", "'\\''");
+      const restoreResult = await session.exec(
+        `bun /usr/local/bin/kilo-restore-session.js '${escapedId}' '${escapedWorkspace}'`
       );
 
-      if (response.status === 404) {
+      if (restoreResult.exitCode !== 0) {
+        logger
+          .withFields({
+            sessionId,
+            userId,
+            exitCode: restoreResult.exitCode,
+            stderr: restoreResult.stderr,
+            stdout: restoreResult.stdout,
+          })
+          .error('Cold-start session restore failed');
+
+        // Parse stdout JSON for structured error info
+        let code: number | undefined;
+        try {
+          const parsed = JSON.parse(restoreResult.stdout?.trim() ?? '{}') as Record<
+            string,
+            unknown
+          >;
+          if (typeof parsed.code === 'number') {
+            code = parsed.code;
+          }
+        } catch {
+          // non-JSON stdout, ignore
+        }
+
+        if (code === 404) {
+          throw new SessionSnapshotRestoreError(
+            'Session snapshot restore failed: session not found',
+            404
+          );
+        }
         throw new SessionSnapshotRestoreError(
-          `Session snapshot restore failed: session not found`,
-          404
+          `Cold-start session restore failed: exit ${restoreResult.exitCode}`,
+          code
         );
       }
-      if (!response.ok) {
-        throw new Error(`Session export failed: ${response.status}`);
+
+      // Log structured summary from restore script
+      try {
+        const summary = JSON.parse(restoreResult.stdout?.trim() ?? '{}') as Record<string, unknown>;
+        logger
+          .withFields({ sessionId, userId, ...summary })
+          .info('Cold-start session restore completed');
+      } catch {
+        // non-JSON stdout, non-fatal
       }
-
-      const snapshotPayload = await response.text();
-
-      // Extract diffs client-side from the streamed snapshot messages.
-      const diffs = SessionService.extractDiffsFromMessages(snapshotPayload);
-
-      await this.restoreSessionSnapshot(session, sessionId, userId, snapshotPayload);
-
-      // Apply file-level changes from the previous session on top of the fresh clone.
-      // This runs after kilo import (conversation restore) since the CLI doesn't need
-      // the file state during import — it only restores its internal session DB.
-      await this.applySessionDiff(session, sessionId, userId, context.workspacePath, diffs);
 
       // Re-run setup commands (fresh clone, need to reinstall)
       if (metadata.setupCommands && metadata.setupCommands.length > 0) {

--- a/cloud-agent-next/wrapper/build.ts
+++ b/cloud-agent-next/wrapper/build.ts
@@ -7,4 +7,12 @@ await Bun.build({
   sourcemap: 'external',
 });
 
-console.log('Build complete: dist/wrapper.js');
+await Bun.build({
+  entrypoints: ['./src/restore-session.ts'],
+  outdir: './dist',
+  naming: 'restore-session.js',
+  target: 'bun',
+  minify: true,
+});
+
+console.log('Build complete: dist/wrapper.js, dist/restore-session.js');

--- a/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -254,7 +254,7 @@ describe('restoreSession', () => {
 
   it('skips diffs with path traversal', async () => {
     const snapshot = makeSnapshot([
-      { file: '../../../etc/passwd', after: 'malicious', status: 'modified' },
+      { file: '../escaped.txt', after: 'malicious', status: 'modified' },
       { file: 'safe.txt', after: 'safe content', status: 'modified' },
     ]);
     mockFetchOk(snapshot);
@@ -268,8 +268,8 @@ describe('restoreSession', () => {
       expect(result.diffs.total).toBe(2);
     }
 
-    // Verify malicious path was NOT written
-    expect(fs.existsSync(path.resolve(workspace, '../../../etc/passwd'))).toBe(false);
+    // Verify traversal target was NOT written outside the workspace
+    expect(fs.existsSync(path.join(tmpDir, 'escaped.txt'))).toBe(false);
 
     // Verify safe file was written
     expect(fs.readFileSync(path.join(workspace, 'safe.txt'), 'utf-8')).toBe('safe content');

--- a/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { restoreSession, extractDiffs } from './restore-session';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSnapshot(diffs: Array<{ file: string; after: string; status: string }>): string {
+  return JSON.stringify({
+    messages: [{ info: { summary: { diffs } } }],
+  });
+}
+
+function makeMultiMessageSnapshot(
+  ...messageDiffs: Array<Array<{ file: string; after: string; status: string }>>
+): string {
+  return JSON.stringify({
+    messages: messageDiffs.map(diffs => ({ info: { summary: { diffs } } })),
+  });
+}
+
+/** Wraps a fetch-like function with a no-op `preconnect` so it satisfies Bun's `typeof fetch`. */
+function asFetch(
+  fn: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>
+): typeof fetch {
+  return Object.assign(fn, { preconnect: fetch.preconnect });
+}
+
+function mockFetchOk(body: string): void {
+  globalThis.fetch = asFetch(() =>
+    Promise.resolve(
+      new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+  );
+}
+
+function mockFetchStatus(status: number, body = ''): void {
+  globalThis.fetch = asFetch(() => Promise.resolve(new Response(body, { status })));
+}
+
+function writeMockKilo(binDir: string, exitCode: number): void {
+  const script = `#!/bin/sh\nexit ${exitCode}\n`;
+  const kiloPath = path.join(binDir, 'kilo');
+  fs.writeFileSync(kiloPath, script, { mode: 0o755 });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('restoreSession', () => {
+  let tmpDir: string;
+  let workspace: string;
+  let binDir: string;
+  let savedEnv: Record<string, string | undefined>;
+  let originalFetch: typeof globalThis.fetch;
+
+  const SESSION_ID = 'ses_test123';
+  const TMP_PATH = `/tmp/kilo-session-export-${SESSION_ID}.json`;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'restore-test-'));
+    workspace = path.join(tmpDir, 'workspace');
+    binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+
+    writeMockKilo(binDir, 0);
+
+    savedEnv = {
+      KILO_SESSION_INGEST_URL: process.env.KILO_SESSION_INGEST_URL,
+      KILOCODE_TOKEN: process.env.KILOCODE_TOKEN,
+      PATH: process.env.PATH,
+    };
+
+    process.env.KILO_SESSION_INGEST_URL = 'http://localhost:9999';
+    process.env.KILOCODE_TOKEN = 'test-token';
+    process.env.PATH = `${binDir}:${process.env.PATH}`;
+
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    globalThis.fetch = originalFetch;
+
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    try {
+      fs.unlinkSync(TMP_PATH);
+    } catch {
+      // may already be cleaned up
+    }
+  });
+
+  // ---- Environment validation ----
+
+  it('returns error when KILO_SESSION_INGEST_URL is missing', async () => {
+    delete process.env.KILO_SESSION_INGEST_URL;
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('KILO_SESSION_INGEST_URL');
+      expect(result.code).toBeNull();
+      expect(result.step).toBe('download');
+    }
+  });
+
+  it('returns error when KILOCODE_TOKEN is missing', async () => {
+    delete process.env.KILOCODE_TOKEN;
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('KILOCODE_TOKEN');
+      expect(result.code).toBeNull();
+      expect(result.step).toBe('download');
+    }
+  });
+
+  it('returns error mentioning both vars when both are missing', async () => {
+    delete process.env.KILO_SESSION_INGEST_URL;
+    delete process.env.KILOCODE_TOKEN;
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('KILO_SESSION_INGEST_URL');
+      expect(result.error).toContain('KILOCODE_TOKEN');
+    }
+  });
+
+  // ---- Download failures ----
+
+  it('returns 404 error when snapshot not found', async () => {
+    mockFetchStatus(404);
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(404);
+      expect(result.step).toBe('download');
+    }
+  });
+
+  it('returns 502 error on server errors', async () => {
+    mockFetchStatus(500);
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(502);
+      expect(result.step).toBe('download');
+    }
+  });
+
+  it('returns download error when fetch throws', async () => {
+    globalThis.fetch = asFetch(() => Promise.reject(new Error('network failure')));
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('network failure');
+      expect(result.code).toBeNull();
+      expect(result.step).toBe('download');
+    }
+  });
+
+  // ---- Import failures ----
+
+  it('returns import error when kilo import fails', async () => {
+    const snapshot = makeSnapshot([{ file: 'src/index.ts', after: 'content', status: 'modified' }]);
+    mockFetchOk(snapshot);
+    writeMockKilo(binDir, 1);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.step).toBe('import');
+      expect(result.error).toContain('kilo import failed');
+    }
+  });
+
+  // ---- Happy paths ----
+
+  it('downloads snapshot, imports, and applies diffs', async () => {
+    const snapshot = makeSnapshot([
+      { file: 'src/index.ts', after: "console.log('hello');", status: 'modified' },
+      { file: 'old-file.txt', after: '', status: 'deleted' },
+    ]);
+    mockFetchOk(snapshot);
+
+    // Create file that should be deleted
+    fs.writeFileSync(path.join(workspace, 'old-file.txt'), 'old content');
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 2, skipped: 0, total: 2 },
+    });
+
+    // Verify modified file was written
+    const created = fs.readFileSync(path.join(workspace, 'src/index.ts'), 'utf-8');
+    expect(created).toBe("console.log('hello');");
+
+    // Verify deleted file was removed
+    expect(fs.existsSync(path.join(workspace, 'old-file.txt'))).toBe(false);
+  });
+
+  it('succeeds with zero diffs when messages array is empty', async () => {
+    mockFetchOk(JSON.stringify({ messages: [] }));
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 0, skipped: 0, total: 0 },
+    });
+  });
+
+  it('succeeds with zero diffs when messages have no diffs field', async () => {
+    mockFetchOk(JSON.stringify({ messages: [{ info: {} }] }));
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 0, skipped: 0, total: 0 },
+    });
+  });
+
+  // ---- Path traversal protection ----
+
+  it('skips diffs with path traversal', async () => {
+    const snapshot = makeSnapshot([
+      { file: '../../../etc/passwd', after: 'malicious', status: 'modified' },
+      { file: 'safe.txt', after: 'safe content', status: 'modified' },
+    ]);
+    mockFetchOk(snapshot);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.diffs.skipped).toBe(1);
+      expect(result.diffs.applied).toBe(1);
+      expect(result.diffs.total).toBe(2);
+    }
+
+    // Verify malicious path was NOT written
+    expect(fs.existsSync(path.resolve(workspace, '../../../etc/passwd'))).toBe(false);
+
+    // Verify safe file was written
+    expect(fs.readFileSync(path.join(workspace, 'safe.txt'), 'utf-8')).toBe('safe content');
+  });
+
+  // ---- Deduplication ----
+
+  it('deduplicates diffs by file path with last-write-wins', async () => {
+    const snapshot = makeMultiMessageSnapshot(
+      [{ file: 'dup.txt', after: 'first version', status: 'modified' }],
+      [{ file: 'dup.txt', after: 'second version', status: 'modified' }]
+    );
+    mockFetchOk(snapshot);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Deduplicated to 1 unique diff
+      expect(result.diffs.total).toBe(1);
+      expect(result.diffs.applied).toBe(1);
+    }
+
+    // Second message wins
+    expect(fs.readFileSync(path.join(workspace, 'dup.txt'), 'utf-8')).toBe('second version');
+  });
+
+  // ---- Skipping empty after ----
+
+  it('skips non-deleted diffs with empty after content', async () => {
+    const snapshot = makeSnapshot([
+      { file: 'empty.txt', after: '', status: 'modified' },
+      { file: 'real.txt', after: 'real content', status: 'modified' },
+    ]);
+    mockFetchOk(snapshot);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.diffs.applied).toBe(1);
+      expect(result.diffs.skipped).toBe(1);
+      expect(result.diffs.total).toBe(2);
+    }
+
+    expect(fs.existsSync(path.join(workspace, 'empty.txt'))).toBe(false);
+    expect(fs.readFileSync(path.join(workspace, 'real.txt'), 'utf-8')).toBe('real content');
+  });
+
+  // ---- Temp file cleanup ----
+
+  it('cleans up temp file on success', async () => {
+    mockFetchOk(makeSnapshot([{ file: 'a.txt', after: 'content', status: 'modified' }]));
+
+    const result = await restoreSession(SESSION_ID, workspace);
+    expect(result.ok).toBe(true);
+    expect(fs.existsSync(TMP_PATH)).toBe(false);
+  });
+
+  it('cleans up temp file on import failure', async () => {
+    mockFetchOk(makeSnapshot([{ file: 'a.txt', after: 'content', status: 'modified' }]));
+    writeMockKilo(binDir, 1);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+    expect(result.ok).toBe(false);
+    expect(fs.existsSync(TMP_PATH)).toBe(false);
+  });
+
+  // ---- Fetch URL construction ----
+
+  it('sends correct URL and auth header', async () => {
+    let capturedUrl: string | undefined;
+    let capturedHeaders: Headers | undefined;
+
+    globalThis.fetch = asFetch((input, init) => {
+      capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : '';
+      if (init?.headers) {
+        capturedHeaders = new Headers(init.headers);
+      }
+      return Promise.resolve(new Response(makeSnapshot([]), { status: 200 }));
+    });
+
+    await restoreSession(SESSION_ID, workspace);
+
+    expect(capturedUrl).toBe(`http://localhost:9999/api/session/${SESSION_ID}/export`);
+    expect(capturedHeaders?.get('Authorization')).toBe('Bearer test-token');
+  });
+
+  it('URL-encodes the session ID', async () => {
+    let capturedUrl: string | undefined;
+
+    // Use chars that need URL-encoding but are filesystem-safe (the
+    // function writes to /tmp/kilo-session-export-<id>.json)
+    const specialId = 'ses special&chars=1';
+
+    globalThis.fetch = asFetch(input => {
+      capturedUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : '';
+      return Promise.resolve(new Response(makeSnapshot([]), { status: 200 }));
+    });
+
+    await restoreSession(specialId, workspace);
+
+    expect(capturedUrl).toContain(encodeURIComponent(specialId));
+  });
+
+  // ---- Nested directory creation ----
+
+  it('creates nested directories for diff file paths', async () => {
+    const snapshot = makeSnapshot([
+      { file: 'deep/nested/dir/file.ts', after: 'nested content', status: 'modified' },
+    ]);
+    mockFetchOk(snapshot);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(true);
+    expect(fs.readFileSync(path.join(workspace, 'deep/nested/dir/file.ts'), 'utf-8')).toBe(
+      'nested content'
+    );
+  });
+
+  // ---- Delete of already-absent file ----
+
+  it('counts delete as applied even if file does not exist', async () => {
+    const snapshot = makeSnapshot([{ file: 'nonexistent.txt', after: '', status: 'deleted' }]);
+    mockFetchOk(snapshot);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.diffs.applied).toBe(1);
+      expect(result.diffs.skipped).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDiffs (subprocess-based diff extraction)
+// ---------------------------------------------------------------------------
+
+describe('extractDiffs', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'extract-diffs-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('extracts diffs from a valid snapshot', async () => {
+    const filePath = path.join(tmpDir, 'snapshot.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        messages: [
+          {
+            info: {
+              summary: { diffs: [{ file: 'a.ts', after: 'content-a', status: 'modified' }] },
+            },
+          },
+          { info: { summary: { diffs: [{ file: 'b.ts', after: 'content-b', status: 'added' }] } } },
+        ],
+      })
+    );
+
+    const diffs = await extractDiffs(filePath);
+    expect(diffs).toEqual([
+      { file: 'a.ts', after: 'content-a', status: 'modified' },
+      { file: 'b.ts', after: 'content-b', status: 'added' },
+    ]);
+  });
+
+  it('deduplicates by file path with last-write-wins', async () => {
+    const filePath = path.join(tmpDir, 'snapshot.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        messages: [
+          {
+            info: { summary: { diffs: [{ file: 'dup.ts', after: 'first', status: 'modified' }] } },
+          },
+          {
+            info: { summary: { diffs: [{ file: 'dup.ts', after: 'second', status: 'modified' }] } },
+          },
+        ],
+      })
+    );
+
+    const diffs = await extractDiffs(filePath);
+    expect(diffs).toHaveLength(1);
+    expect(diffs?.[0]?.after).toBe('second');
+  });
+
+  it('returns empty array when no diffs exist', async () => {
+    const filePath = path.join(tmpDir, 'snapshot.json');
+    fs.writeFileSync(filePath, JSON.stringify({ messages: [{ info: {} }] }));
+
+    const diffs = await extractDiffs(filePath);
+    expect(diffs).toEqual([]);
+  });
+
+  it('returns null on invalid JSON', async () => {
+    const filePath = path.join(tmpDir, 'snapshot.json');
+    fs.writeFileSync(filePath, 'not valid json {{{');
+
+    const diffs = await extractDiffs(filePath);
+    expect(diffs).toBeNull();
+  });
+
+  it('returns null when file does not exist', async () => {
+    const diffs = await extractDiffs(path.join(tmpDir, 'nonexistent.json'));
+    expect(diffs).toBeNull();
+  });
+
+  it('returns null when file is empty', async () => {
+    const filePath = path.join(tmpDir, 'empty.json');
+    fs.writeFileSync(filePath, '');
+
+    const diffs = await extractDiffs(filePath);
+    expect(diffs).toBeNull();
+  });
+});

--- a/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -329,6 +329,21 @@ describe('restoreSession', () => {
     expect(fs.existsSync(TMP_PATH)).toBe(false);
   });
 
+  it('cleans up temp file when Bun.write throws during download', async () => {
+    // Simulate a partial write: pre-create the temp file so it exists on disk,
+    // then have fetch() reject — the catch path should still unlink it.
+    fs.writeFileSync(TMP_PATH, 'partial snapshot data');
+
+    globalThis.fetch = asFetch(() => Promise.reject(new Error('connection reset')));
+
+    const result = await restoreSession(SESSION_ID, workspace);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.step).toBe('download');
+    }
+    expect(fs.existsSync(TMP_PATH)).toBe(false);
+  });
+
   it('cleans up temp file on import failure', async () => {
     mockFetchOk(makeSnapshot([{ file: 'a.txt', after: 'content', status: 'modified' }]));
     writeMockKilo(binDir, 1);

--- a/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.ts
@@ -1,0 +1,228 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RestoreResult =
+  | {
+      ok: true;
+      downloaded: true;
+      imported: true;
+      diffs: { applied: number; skipped: number; total: number };
+    }
+  | { ok: false; error: string; code: number | null; step: 'download' | 'import' | 'diffs' };
+
+type SnapshotDiff = {
+  file: string;
+  after: string;
+  status: string;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function log(msg: string): void {
+  console.error(`restore-session: ${msg}`);
+}
+
+function fail(
+  error: string,
+  code: number | null,
+  step: Extract<RestoreResult, { ok: false }>['step']
+): RestoreResult {
+  return { ok: false, error, code, step };
+}
+
+function tryUnlink(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+    log('cleaned up temp file');
+  } catch {
+    // temp file may not exist yet
+  }
+}
+
+// jq filter that extracts diffs from the snapshot JSON using last-write-wins
+// deduplication by file path. Runs as a subprocess so the full parsed snapshot
+// is never loaded into the main process's heap — jq's C-native parser uses
+// ~half the memory of a V8 heap.
+const JQ_EXTRACT_DIFFS_FILTER =
+  'reduce (.messages[]?.info.summary.diffs[]? // empty) as $d ({}; .[$d.file] = $d) | [.[]]';
+
+/**
+ * Extract last-write-wins diffs from a snapshot file via a jq subprocess so the
+ * full snapshot JSON is never loaded into the main process's heap.
+ */
+export async function extractDiffs(snapshotPath: string): Promise<SnapshotDiff[] | null> {
+  const proc = Bun.spawn(['jq', '-c', JQ_EXTRACT_DIFFS_FILTER, snapshotPath], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    log(`jq failed exitCode=${exitCode} stderr=${stderr.trim()}`);
+    return null;
+  }
+  const stdout = await new Response(proc.stdout).text();
+  try {
+    return JSON.parse(stdout) as SnapshotDiff[];
+  } catch (err) {
+    log(`jq output parse failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main logic
+// ---------------------------------------------------------------------------
+
+export async function restoreSession(
+  kiloSessionId: string,
+  workspacePath: string
+): Promise<RestoreResult> {
+  const ingestUrl = process.env.KILO_SESSION_INGEST_URL;
+  const token = process.env.KILOCODE_TOKEN;
+  const tmpPath = `/tmp/kilo-session-export-${kiloSessionId}.json`;
+
+  log(`starting kiloSessionId=${kiloSessionId} workspace=${workspacePath}`);
+
+  if (!ingestUrl || !token) {
+    const missing = [!ingestUrl && 'KILO_SESSION_INGEST_URL', !token && 'KILOCODE_TOKEN']
+      .filter(Boolean)
+      .join(', ');
+    return fail(`missing env vars: ${missing}`, null, 'download');
+  }
+
+  log(`ingestUrl=${ingestUrl}`);
+
+  // ---- Step 1: Download snapshot (stream directly to disk) ----
+  log('downloading snapshot');
+  try {
+    const url = `${ingestUrl}/api/session/${encodeURIComponent(kiloSessionId)}/export`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(300_000),
+    });
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        log('snapshot not found (404)');
+        return fail('snapshot not found (404)', 404, 'download');
+      }
+      log(`download failed status=${res.status}`);
+      return fail(`download failed status=${res.status}`, 502, 'download');
+    }
+
+    const bytesWritten = await Bun.write(tmpPath, res);
+    log(`snapshot downloaded bytes=${bytesWritten}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return fail(message, null, 'download');
+  }
+
+  try {
+    // ---- Step 2: Run kilo import ----
+    log('running kilo import');
+    const importProc = Bun.spawn(['kilo', 'import', tmpPath], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: process.env,
+    });
+    const exitCode = await importProc.exited;
+
+    if (exitCode !== 0) {
+      log(`kilo import failed exitCode=${exitCode}`);
+      return fail(`kilo import failed exitCode=${exitCode}`, null, 'import');
+    }
+    log('kilo import succeeded');
+
+    // ---- Step 3: Apply diffs ----
+    // Extract diffs in a subprocess so the full snapshot JSON is never loaded
+    // into this process's heap — only the small diff array crosses the boundary.
+    const uniqueDiffs = await extractDiffs(tmpPath);
+    if (uniqueDiffs === null) {
+      return fail('failed to parse snapshot JSON', null, 'diffs');
+    }
+    const total = uniqueDiffs.length;
+
+    if (total === 0) {
+      log('no diffs to apply');
+      return {
+        ok: true,
+        downloaded: true,
+        imported: true,
+        diffs: { applied: 0, skipped: 0, total: 0 },
+      };
+    }
+
+    log(`found ${total} unique file diffs`);
+
+    const resolvedWorkspace = path.resolve(workspacePath);
+    let applied = 0;
+    let skipped = 0;
+
+    for (const diff of uniqueDiffs) {
+      const fp = path.resolve(resolvedWorkspace, diff.file);
+
+      if (!fp.startsWith(resolvedWorkspace + '/')) {
+        log(`skipping diff outside workspace file=${fp}`);
+        skipped++;
+        continue;
+      }
+
+      try {
+        if (diff.status === 'deleted') {
+          try {
+            fs.unlinkSync(fp);
+          } catch {
+            // file may already be absent
+          }
+          applied++;
+        } else if (diff.after) {
+          fs.mkdirSync(path.dirname(fp), { recursive: true });
+          fs.writeFileSync(fp, diff.after);
+          applied++;
+        } else {
+          skipped++;
+        }
+      } catch {
+        log(`failed to apply diff file=${fp}`);
+        skipped++;
+      }
+    }
+
+    log(`diffs applied=${applied} skipped=${skipped} total=${total}`);
+    log('completed successfully');
+
+    return { ok: true, downloaded: true, imported: true, diffs: { applied, skipped, total } };
+  } finally {
+    tryUnlink(tmpPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint — only runs when executed directly, not when imported
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const [kiloSessionId, workspacePath] = process.argv.slice(2);
+  if (!kiloSessionId || !workspacePath) {
+    console.log(
+      JSON.stringify({
+        ok: false,
+        error: 'Usage: kilo-restore-session <kiloSessionId> <workspacePath>',
+        code: null,
+        step: 'download',
+      })
+    );
+    process.exit(1);
+  }
+  void restoreSession(kiloSessionId, workspacePath).then(result => {
+    console.log(JSON.stringify(result));
+    process.exit(result.ok ? 0 : 1);
+  });
+}

--- a/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.ts
@@ -120,6 +120,7 @@ export async function restoreSession(
     const bytesWritten = await Bun.write(tmpPath, res);
     log(`snapshot downloaded bytes=${bytesWritten}`);
   } catch (err) {
+    tryUnlink(tmpPath);
     const message = err instanceof Error ? err.message : String(err);
     return fail(message, null, 'download');
   }

--- a/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.ts
@@ -179,8 +179,8 @@ export async function restoreSession(
         if (diff.status === 'deleted') {
           try {
             fs.unlinkSync(fp);
-          } catch {
-            // file may already be absent
+          } catch (err: unknown) {
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
           }
           applied++;
         } else if (diff.after) {

--- a/src/components/cloud-agent-next/AutocommitStatus.tsx
+++ b/src/components/cloud-agent-next/AutocommitStatus.tsx
@@ -57,7 +57,9 @@ function StatusIndicator({ status }: { status: AutocommitStatusType }) {
                   {truncateCommitMessage(status.commitMessage ?? status.message)}
                 </span>
               </TooltipTrigger>
-              <TooltipContent side="top">{status.commitMessage ?? status.message}</TooltipContent>
+              <TooltipContent side="top" className="max-w-sm whitespace-pre-wrap">
+                {status.commitMessage ?? status.message}
+              </TooltipContent>
             </Tooltip>
           ) : (
             <span>{status.message}</span>


### PR DESCRIPTION
## Summary

- Move snapshot download from worker memory to sandbox via `curl` — the full JSON never materializes in the 128MB worker
- Replace worker-side diff extraction (`extractDiffsFromMessages`) and application (`applySessionDiff`) with a sandbox-side Node script that reads, deduplicates, and applies diffs directly on disk
- Refactor `restoreSessionSnapshot` to accept a file path (curl writes directly) instead of a string payload
- Remove `resolve` and `zod` imports that were only used by deleted methods

Depends on PR #884 which adds the streaming `/api/session/:id/export` endpoint.

## Test plan

- [x] All 601 existing tests pass (updated 4 cold-start tests for new exec-based flow)
- [x] Typecheck passes
- [x] Integration test: cold-start resume with real session to verify curl download + kilo import + diff application