### PR TITLE
refactor(cloud-agent-next): extract failExecution to deduplicate failure cleanup

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -85,6 +85,10 @@ const LAST_ACTIVITY_KEY = 'last_activity';
 /** Kilo server idle timeout: 15 minutes */
 const KILO_SERVER_IDLE_TIMEOUT_MS_DEFAULT = 15 * 60 * 1000;
 
+/** Grace period before failing execution after wrapper disconnect (ms).
+ *  Covers the wrapper's ~31s reconnection window (5 attempts with exponential backoff). */
+const DISCONNECT_GRACE_MS = 35_000;
+
 export class CloudAgentSession extends DurableObject {
   private executionQueries: ExecutionQueries;
   private eventQueries: EventQueries;
@@ -95,6 +99,7 @@ export class CloudAgentSession extends DurableObject {
   private ingestHandlerSessionId?: SessionId;
   private sessionId?: SessionId;
   private orchestrator?: ExecutionOrchestrator;
+  private disconnectGraceTimer: ReturnType<typeof setTimeout> | null = null;
 
   private isTerminalStatus(
     status: ExecutionStatus
@@ -229,6 +234,7 @@ export class CloudAgentSession extends DurableObject {
         updateKiloSessionId: (id: string) => this.updateKiloSessionId(id),
         updateUpstreamBranch: (branch: string) => this.updateUpstreamBranch(branch),
         clearActiveExecution: () => this.clearActiveExecution(),
+        cancelDisconnectGrace: () => this.cancelDisconnectGrace(),
         getExecution: async (executionId: string) => {
           const execution = await this.executionQueries.get(executionId as ExecutionId);
           if (!execution) return null;
@@ -375,29 +381,15 @@ export class CloudAgentSession extends DurableObject {
       const ingestHandler = await this.getIngestHandler();
       const disconnectedExecutionId = ingestHandler.handleIngestClose(ws);
 
-      // If the wrapper disconnected while its execution was still active, fail it immediately
+      // If the wrapper disconnected while its execution was still active, start a
+      // grace period before failing. This gives the wrapper time to reconnect
+      // (exponential backoff: 1s, 2s, 4s, 8s, 16s ≈ 31s total window).
       if (disconnectedExecutionId) {
         const activeExecutionId = await this.executionQueries.getActiveExecutionId();
         if (activeExecutionId === disconnectedExecutionId) {
           const execution = await this.executionQueries.get(activeExecutionId);
-          // Only act if execution is still running or pending (not already terminal)
           if (execution && (execution.status === 'running' || execution.status === 'pending')) {
-            logger
-              .withFields({
-                sessionId: this.sessionId,
-                executionId: activeExecutionId,
-                wsCloseCode: code,
-                wsCloseReason: reason,
-              })
-              .warn('Wrapper disconnected while execution active - marking as failed');
-
-            await this.failExecution({
-              executionId: activeExecutionId,
-              status: 'failed',
-              error: 'Wrapper disconnected',
-              streamEventType: 'wrapper_disconnected',
-              streamPayload: { wsCloseCode: code, wsCloseReason: reason },
-            });
+            this.startDisconnectGrace(activeExecutionId, code, reason);
           }
         }
       }
@@ -1210,6 +1202,91 @@ export class CloudAgentSession extends DurableObject {
   }
 
   /**
+   * Cancel any pending disconnect grace timer.
+   * Called when the wrapper reconnects, when another codepath fails the
+   * execution, or defensively before starting a new grace timer.
+   */
+  private cancelDisconnectGrace(): void {
+    if (this.disconnectGraceTimer) {
+      clearTimeout(this.disconnectGraceTimer);
+      this.disconnectGraceTimer = null;
+    }
+  }
+
+  /**
+   * Start the disconnect grace period for a wrapper that just disconnected.
+   * Gives the wrapper time to reconnect (exponential backoff: ~31s window)
+   * before marking the execution as failed.
+   */
+  private startDisconnectGrace(
+    executionId: ExecutionId,
+    wsCloseCode: number,
+    wsCloseReason: string
+  ): void {
+    logger
+      .withFields({
+        sessionId: this.sessionId,
+        executionId,
+        wsCloseCode,
+        wsCloseReason,
+        graceMs: DISCONNECT_GRACE_MS,
+      })
+      .warn('Wrapper disconnected — starting grace period before marking as failed');
+
+    this.cancelDisconnectGrace();
+
+    this.disconnectGraceTimer = setTimeout(() => {
+      this.disconnectGraceTimer = null;
+      void this.handleDisconnectGraceExpired(executionId, wsCloseCode, wsCloseReason);
+    }, DISCONNECT_GRACE_MS);
+  }
+
+  /**
+   * Handle expiration of the disconnect grace period.
+   * Re-checks whether the wrapper reconnected or the execution completed
+   * during the grace window before failing it.
+   */
+  private async handleDisconnectGraceExpired(
+    executionId: ExecutionId,
+    wsCloseCode: number,
+    wsCloseReason: string
+  ): Promise<void> {
+    // Re-check: wrapper may have reconnected during grace period
+    const ingestHandler = await this.getIngestHandler();
+    if (ingestHandler.hasActiveConnection(executionId)) {
+      logger
+        .withFields({ executionId })
+        .info('Wrapper reconnected during grace period — skipping failure');
+      return;
+    }
+
+    // Re-check execution state (may have completed normally during grace period)
+    const currentExecution = await this.executionQueries.get(executionId);
+    if (
+      !currentExecution ||
+      (currentExecution.status !== 'running' && currentExecution.status !== 'pending')
+    ) {
+      logger
+        .withFields({
+          executionId,
+          status: currentExecution?.status,
+        })
+        .info('Execution no longer active during grace period — skipping failure');
+      return;
+    }
+
+    logger.withFields({ executionId }).warn('Grace period expired — marking execution as failed');
+
+    await this.failExecution({
+      executionId,
+      status: 'failed',
+      error: 'Wrapper disconnected',
+      streamEventType: 'wrapper_disconnected',
+      streamPayload: { wsCloseCode, wsCloseReason },
+    });
+  }
+
+  /**
    * Fail an execution with full cleanup.
    * Idempotent — safe to call if execution is already terminal.
    *
@@ -1229,6 +1306,10 @@ export class CloudAgentSession extends DurableObject {
     streamPayload?: Record<string, unknown>;
   }): Promise<boolean> {
     const { executionId, status, error, streamEventType, streamPayload } = params;
+
+    // Clear disconnect grace timer — prevents double-failure if another codepath
+    // already failed the execution while the timer was pending.
+    this.cancelDisconnectGrace();
 
     // 1. Update status (enqueues callback notification on terminal)
     const statusResult = await this.updateExecutionStatus({

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -86,8 +86,19 @@ const LAST_ACTIVITY_KEY = 'last_activity';
 const KILO_SERVER_IDLE_TIMEOUT_MS_DEFAULT = 15 * 60 * 1000;
 
 /** Grace period before failing execution after wrapper disconnect (ms).
- *  Covers the wrapper's ~31s reconnection window (5 attempts with exponential backoff). */
-const DISCONNECT_GRACE_MS = 35_000;
+ *  Covers the first few reconnection attempts (exponential backoff: 1s, 2s, 4s …). */
+const DISCONNECT_GRACE_MS = 10_000;
+
+/** DO storage key for persisting disconnect grace state across hibernation. */
+const DISCONNECT_GRACE_KEY = 'disconnect_grace';
+
+/** Stored in DO storage under DISCONNECT_GRACE_KEY while a grace period is active. */
+type DisconnectGraceState = {
+  executionId: ExecutionId;
+  disconnectedAt: number;
+  wsCloseCode: number;
+  wsCloseReason: string;
+};
 
 export class CloudAgentSession extends DurableObject {
   private executionQueries: ExecutionQueries;
@@ -99,7 +110,6 @@ export class CloudAgentSession extends DurableObject {
   private ingestHandlerSessionId?: SessionId;
   private sessionId?: SessionId;
   private orchestrator?: ExecutionOrchestrator;
-  private disconnectGraceTimer: ReturnType<typeof setTimeout> | null = null;
 
   private isTerminalStatus(
     status: ExecutionStatus
@@ -383,13 +393,13 @@ export class CloudAgentSession extends DurableObject {
 
       // If the wrapper disconnected while its execution was still active, start a
       // grace period before failing. This gives the wrapper time to reconnect
-      // (exponential backoff: 1s, 2s, 4s, 8s, 16s ≈ 31s total window).
+      // (exponential backoff: 1s, 2s, 4s …).
       if (disconnectedExecutionId) {
         const activeExecutionId = await this.executionQueries.getActiveExecutionId();
         if (activeExecutionId === disconnectedExecutionId) {
           const execution = await this.executionQueries.get(activeExecutionId);
           if (execution && (execution.status === 'running' || execution.status === 'pending')) {
-            this.startDisconnectGrace(activeExecutionId, code, reason);
+            await this.startDisconnectGrace(activeExecutionId, code, reason);
           }
         }
       }
@@ -855,6 +865,10 @@ export class CloudAgentSession extends DurableObject {
       .info('Alarm fired');
 
     try {
+      // Check disconnect grace period first — this alarm may have been
+      // rescheduled specifically for the grace deadline.
+      await this.checkDisconnectGrace();
+
       // Check if session should be deleted due to inactivity (90 days)
       const lastActivity = await this.ctx.storage.get<number>(LAST_ACTIVITY_KEY);
       if (lastActivity && now - lastActivity > Limits.SESSION_TTL_MS) {
@@ -1202,27 +1216,27 @@ export class CloudAgentSession extends DurableObject {
   }
 
   /**
-   * Cancel any pending disconnect grace timer.
-   * Called when the wrapper reconnects, when another codepath fails the
-   * execution, or defensively before starting a new grace timer.
+   * Cancel any pending disconnect grace period.
+   * Clears the storage-persisted state so the next alarm ignores it.
+   * Called when the wrapper reconnects or when another codepath fails
+   * the execution.
    */
-  private cancelDisconnectGrace(): void {
-    if (this.disconnectGraceTimer) {
-      clearTimeout(this.disconnectGraceTimer);
-      this.disconnectGraceTimer = null;
-    }
+  private async cancelDisconnectGrace(): Promise<void> {
+    await this.ctx.storage.delete(DISCONNECT_GRACE_KEY);
   }
 
   /**
    * Start the disconnect grace period for a wrapper that just disconnected.
-   * Gives the wrapper time to reconnect (exponential backoff: ~31s window)
-   * before marking the execution as failed.
+   * Persists state to DO storage (survives hibernation) and reschedules the
+   * alarm to fire at the grace deadline so it runs even if the DO sleeps.
    */
-  private startDisconnectGrace(
+  private async startDisconnectGrace(
     executionId: ExecutionId,
     wsCloseCode: number,
     wsCloseReason: string
-  ): void {
+  ): Promise<void> {
+    const now = Date.now();
+
     logger
       .withFields({
         sessionId: this.sessionId,
@@ -1233,24 +1247,38 @@ export class CloudAgentSession extends DurableObject {
       })
       .warn('Wrapper disconnected — starting grace period before marking as failed');
 
-    this.cancelDisconnectGrace();
+    const graceState: DisconnectGraceState = {
+      executionId,
+      disconnectedAt: now,
+      wsCloseCode,
+      wsCloseReason,
+    };
+    await this.ctx.storage.put(DISCONNECT_GRACE_KEY, graceState);
 
-    this.disconnectGraceTimer = setTimeout(() => {
-      this.disconnectGraceTimer = null;
-      void this.handleDisconnectGraceExpired(executionId, wsCloseCode, wsCloseReason);
-    }, DISCONNECT_GRACE_MS);
+    // Reschedule alarm to fire at the grace deadline. The alarm handler
+    // always reschedules itself afterward, so the normal reaper cadence
+    // self-heals once this fires.
+    await this.ctx.storage.setAlarm(now + DISCONNECT_GRACE_MS);
   }
 
   /**
-   * Handle expiration of the disconnect grace period.
+   * Check and handle an expired disconnect grace period.
+   * Called from alarm() before normal reaper duties.
    * Re-checks whether the wrapper reconnected or the execution completed
    * during the grace window before failing it.
    */
-  private async handleDisconnectGraceExpired(
-    executionId: ExecutionId,
-    wsCloseCode: number,
-    wsCloseReason: string
-  ): Promise<void> {
+  private async checkDisconnectGrace(): Promise<void> {
+    const graceState = await this.ctx.storage.get<DisconnectGraceState>(DISCONNECT_GRACE_KEY);
+    if (!graceState) return;
+
+    const elapsed = Date.now() - graceState.disconnectedAt;
+    if (elapsed < DISCONNECT_GRACE_MS) return; // alarm fired early (e.g. reaper cadence)
+
+    // Grace period has elapsed — clear the state first to avoid re-processing
+    await this.ctx.storage.delete(DISCONNECT_GRACE_KEY);
+
+    const { executionId, wsCloseCode, wsCloseReason } = graceState;
+
     // Re-check: wrapper may have reconnected during grace period
     const ingestHandler = await this.getIngestHandler();
     if (ingestHandler.hasActiveConnection(executionId)) {
@@ -1307,9 +1335,9 @@ export class CloudAgentSession extends DurableObject {
   }): Promise<boolean> {
     const { executionId, status, error, streamEventType, streamPayload } = params;
 
-    // Clear disconnect grace timer — prevents double-failure if another codepath
-    // already failed the execution while the timer was pending.
-    this.cancelDisconnectGrace();
+    // Clear disconnect grace state — prevents double-failure if another codepath
+    // already failed the execution while a grace period was pending.
+    await this.cancelDisconnectGrace();
 
     // 1. Update status (enqueues callback notification on terminal)
     const statusResult = await this.updateExecutionStatus({

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -391,42 +391,12 @@ export class CloudAgentSession extends DurableObject {
               })
               .warn('Wrapper disconnected while execution active - marking as failed');
 
-            const now = Date.now();
-
-            // Mark execution as failed — if another codepath already moved it
-            // to a terminal state, skip the broadcast and cleanup.
-            const statusResult = await this.updateExecutionStatus({
+            await this.failExecution({
               executionId: activeExecutionId,
               status: 'failed',
               error: 'Wrapper disconnected',
-              completedAt: now,
-            });
-
-            if (!statusResult.ok) {
-              logger
-                .withFields({ executionId: activeExecutionId, error: statusResult.error })
-                .info('Skipping disconnect cleanup - status transition failed');
-              return;
-            }
-
-            // Clear active execution (updateStatus should do this, but ensure it)
-            await this.executionQueries.clearActiveExecution();
-
-            // Clear interrupt flag if set
-            await this.executionQueries.clearInterrupt();
-
-            // Insert a synthetic wrapper_disconnected event so /stream clients are notified
-            const sessionId = await this.requireSessionId();
-            this.insertAndBroadcastEvent({
-              executionId: activeExecutionId,
-              sessionId,
               streamEventType: 'wrapper_disconnected',
-              payload: JSON.stringify({
-                reason: 'Wrapper disconnected',
-                wsCloseCode: code,
-                wsCloseReason: reason,
-              }),
-              timestamp: now,
+              streamPayload: { wsCloseCode: code, wsCloseReason: reason },
             });
           }
         }
@@ -1019,40 +989,11 @@ export class CloudAgentSession extends DurableObject {
           })
           .info('Marking stale execution as failed');
 
-        // Mark as failed — if another codepath already moved it to a terminal
-        // state (e.g. webSocketClose), skip cleanup and broadcast.
-        const statusResult = await this.updateExecutionStatus({
+        await this.failExecution({
           executionId: activeExecutionId,
           status: 'failed',
           error: 'Execution timeout - no heartbeat received',
-          completedAt: now,
-        });
-
-        if (!statusResult.ok) {
-          logger
-            .withFields({ executionId: activeExecutionId, error: statusResult.error })
-            .info('Skipping reaper cleanup - status transition failed');
-          return;
-        }
-
-        // Clear active execution (updateStatus should do this, but ensure it)
-        await this.executionQueries.clearActiveExecution();
-
-        // Clear interrupt flag if set
-        await this.executionQueries.clearInterrupt();
-
-        // Notify /stream clients that the execution was reaped
-        const sessionId = await this.requireSessionId();
-        const errorPayload = JSON.stringify({
-          error: 'Execution timeout - no heartbeat received',
-          fatal: true,
-        });
-        this.insertAndBroadcastEvent({
-          executionId: activeExecutionId,
-          sessionId,
           streamEventType: 'error',
-          payload: errorPayload,
-          timestamp: now,
         });
       }
     }
@@ -1071,37 +1012,11 @@ export class CloudAgentSession extends DurableObject {
           })
           .info('Marking stuck pending execution as failed');
 
-        // Mark as failed — if another codepath already moved it to a terminal
-        // state, skip cleanup and broadcast.
-        const statusResult = await this.updateExecutionStatus({
+        await this.failExecution({
           executionId: activeExecutionId,
           status: 'failed',
           error: 'Execution timeout - wrapper never connected',
-          completedAt: now,
-        });
-
-        if (!statusResult.ok) {
-          logger
-            .withFields({ executionId: activeExecutionId, error: statusResult.error })
-            .info('Skipping pending timeout cleanup - status transition failed');
-          return;
-        }
-
-        await this.executionQueries.clearActiveExecution();
-        await this.executionQueries.clearInterrupt();
-
-        // Notify /stream clients that the pending execution timed out
-        const sessionId = await this.requireSessionId();
-        const errorPayload = JSON.stringify({
-          error: 'Execution timeout - wrapper never connected',
-          fatal: true,
-        });
-        this.insertAndBroadcastEvent({
-          executionId: activeExecutionId,
-          sessionId,
           streamEventType: 'error',
-          payload: errorPayload,
-          timestamp: now,
         });
       }
     }
@@ -1295,6 +1210,66 @@ export class CloudAgentSession extends DurableObject {
   }
 
   /**
+   * Fail an execution with full cleanup.
+   * Idempotent — safe to call if execution is already terminal.
+   *
+   * Performs:
+   * 1. Update execution status to terminal (enqueues callback)
+   * 2. Clear active execution (safety net)
+   * 3. Clear interrupt flag
+   * 4. Broadcast event to /stream clients
+   *
+   * Returns false if the execution was already terminal (no-op).
+   */
+  private async failExecution(params: {
+    executionId: ExecutionId;
+    status: 'failed' | 'interrupted';
+    error: string;
+    streamEventType: string;
+    streamPayload?: Record<string, unknown>;
+  }): Promise<boolean> {
+    const { executionId, status, error, streamEventType, streamPayload } = params;
+
+    // 1. Update status (enqueues callback notification on terminal)
+    const statusResult = await this.updateExecutionStatus({
+      executionId,
+      status,
+      error,
+      completedAt: Date.now(),
+    });
+
+    if (!statusResult.ok) {
+      logger
+        .withFields({ executionId, error: statusResult.error })
+        .info('failExecution: status transition rejected (already terminal?)');
+      return false;
+    }
+
+    // 2. Clear active execution (idempotent safety net — updateStatus clears it
+    //    internally for the active execution, but another may have been set)
+    await this.executionQueries.clearActiveExecution();
+
+    // 3. Clear interrupt flag
+    await this.executionQueries.clearInterrupt();
+
+    // 4. Broadcast to /stream clients
+    const sessionId = await this.requireSessionId();
+    this.insertAndBroadcastEvent({
+      executionId,
+      sessionId,
+      streamEventType,
+      payload: JSON.stringify({
+        error,
+        fatal: true,
+        ...streamPayload,
+      }),
+      timestamp: Date.now(),
+    });
+
+    return true;
+  }
+
+  /**
    * Update execution heartbeat timestamp.
    */
   async updateExecutionHeartbeat(executionId: ExecutionId, timestamp: number): Promise<boolean> {
@@ -1339,6 +1314,23 @@ export class CloudAgentSession extends DurableObject {
       streamEventType: 'error',
       payload,
       timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * RPC wrapper for failExecution — allows external callers (e.g. interrupt
+   * handler) to perform a full execution failure with cleanup.
+   */
+  async failExecutionRpc(params: {
+    executionId: string;
+    error: string;
+    streamEventType?: string;
+  }): Promise<boolean> {
+    return this.failExecution({
+      executionId: params.executionId as ExecutionId,
+      status: 'failed',
+      error: params.error,
+      streamEventType: params.streamEventType ?? 'error',
     });
   }
 
@@ -1940,19 +1932,12 @@ export class CloudAgentSession extends DurableObject {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
 
-      // Update status first (enqueues callback notification on terminal)
-      await this.updateExecutionStatus({
+      await this.failExecution({
         executionId,
         status: 'failed',
         error: errorMessage,
-        completedAt: Date.now(),
+        streamEventType: 'error',
       });
-
-      // Clear active execution (updateExecutionStatus does not clear it)
-      await this.executionQueries.clearActiveExecution();
-
-      // Broadcast error event so /stream clients are notified
-      await this.emitExecutionError(executionId, errorMessage);
 
       throw error;
     }

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -244,6 +244,7 @@ export class CloudAgentSession extends DurableObject {
         updateKiloSessionId: (id: string) => this.updateKiloSessionId(id),
         updateUpstreamBranch: (branch: string) => this.updateUpstreamBranch(branch),
         clearActiveExecution: () => this.clearActiveExecution(),
+        getActiveExecutionId: () => this.executionQueries.getActiveExecutionId(),
         cancelDisconnectGrace: () => this.cancelDisconnectGrace(),
         getExecution: async (executionId: string) => {
           const execution = await this.executionQueries.get(executionId as ExecutionId);
@@ -1339,6 +1340,10 @@ export class CloudAgentSession extends DurableObject {
     // already failed the execution while a grace period was pending.
     await this.cancelDisconnectGrace();
 
+    // Snapshot active execution before updateStatus clears it — we need this to
+    // decide whether to clean up the interrupt flag afterward.
+    const wasActive = (await this.executionQueries.getActiveExecutionId()) === executionId;
+
     // 1. Update status (enqueues callback notification on terminal)
     const statusResult = await this.updateExecutionStatus({
       executionId,
@@ -1354,12 +1359,17 @@ export class CloudAgentSession extends DurableObject {
       return false;
     }
 
-    // 2. Clear active execution (idempotent safety net — updateStatus clears it
-    //    internally for the active execution, but another may have been set)
-    await this.executionQueries.clearActiveExecution();
-
-    // 3. Clear interrupt flag
-    await this.executionQueries.clearInterrupt();
+    // 2. Clear active execution + interrupt only if this was the active execution.
+    //    updateStatus already clears active_execution_id internally when it matches,
+    //    so the clear here is a safety net. We skip both clears when this execution
+    //    wasn't active to avoid clobbering a newer execution that started in between.
+    if (wasActive) {
+      const activeId = await this.executionQueries.getActiveExecutionId();
+      if (activeId === executionId) {
+        await this.executionQueries.clearActiveExecution();
+      }
+      await this.executionQueries.clearInterrupt();
+    }
 
     // 4. Broadcast to /stream clients
     const sessionId = await this.requireSessionId();
@@ -2070,6 +2080,10 @@ export class CloudAgentSession extends DurableObject {
     const sessionId = await this.resolveSessionId();
     logger.withFields({ sessionId, executionId, status, error }).info('onExecutionComplete called');
 
+    // Snapshot active execution before updateStatus clears it — we need this to
+    // decide whether to clean up the interrupt flag afterward.
+    const wasActive = (await this.executionQueries.getActiveExecutionId()) === executionId;
+
     // Update execution status
     const updateResult = await this.updateExecutionStatus({
       executionId,
@@ -2084,15 +2098,17 @@ export class CloudAgentSession extends DurableObject {
         .warn('Failed to update execution status');
     }
 
-    // Check if this was the active execution
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
-    if (activeExecutionId === executionId) {
-      // Clear the active execution
-      await this.executionQueries.clearActiveExecution();
+    // Clear active execution + interrupt only if this was the active execution.
+    // updateStatus already clears active_execution_id internally when it matches,
+    // so the clear here is a safety net. We skip both clears when this execution
+    // wasn't active to avoid clobbering a newer execution that started in between.
+    if (wasActive) {
+      const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+      if (activeExecutionId === executionId) {
+        await this.executionQueries.clearActiveExecution();
+      }
+      await this.executionQueries.clearInterrupt();
     }
-
-    // Clear any interrupt flag that may have been set
-    await this.executionQueries.clearInterrupt();
 
     logger.withFields({ sessionId, executionId }).info('Execution complete - session is idle');
   }

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -255,43 +255,15 @@ export function createSessionManagementHandlers() {
                 .withFields({ executionId: activeExecutionId })
                 .info('No processes found during interrupt - clearing stale active execution');
 
-              const statusResult = await withDORetry(
+              await withDORetry(
                 getStub,
-                async stub => {
-                  const r = await stub.updateExecutionStatus({
+                stub =>
+                  stub.failExecutionRpc({
                     executionId: activeExecutionId,
-                    status: 'failed',
                     error: 'Interrupted - no running processes found',
-                    completedAt: Date.now(),
-                  });
-                  return { ok: r.ok } as { ok: boolean };
-                },
-                'updateExecutionStatus'
+                  }),
+                'failExecutionRpc'
               );
-
-              // If another codepath already moved the execution to a terminal
-              // state, skip cleanup to avoid spurious events.
-              if (!statusResult.ok) {
-                logger
-                  .withFields({ executionId: activeExecutionId })
-                  .info('Skipping interrupt cleanup - status transition failed');
-              } else {
-                await withDORetry(
-                  getStub,
-                  stub => stub.clearActiveExecution(),
-                  'clearActiveExecution'
-                );
-
-                await withDORetry(
-                  getStub,
-                  stub =>
-                    stub.emitExecutionError(
-                      activeExecutionId,
-                      'Interrupted - no running processes found'
-                    ),
-                  'emitExecutionError'
-                );
-              }
             }
 
             return result;

--- a/cloud-agent-next/src/session/ingest-handlers/execution-lifecycle.ts
+++ b/cloud-agent-next/src/session/ingest-handlers/execution-lifecycle.ts
@@ -7,6 +7,7 @@ export type ExecutionLifecycleContext = {
     error?: string
   ) => Promise<void>;
   clearActiveExecution: () => Promise<void>;
+  getActiveExecutionId: () => Promise<string | null>;
   logger: { info: (msg: string, data?: object) => void };
 };
 
@@ -21,8 +22,21 @@ export async function handleExecutionComplete(
 ): Promise<void> {
   ctx.logger.info('Execution complete', { executionId, status, error });
 
+  // Snapshot active execution before updateStatus clears it — we need this to
+  // decide whether to clean up afterward.
+  const wasActive = (await ctx.getActiveExecutionId()) === executionId;
+
   // Update the execution status and completedAt in storage
   await ctx.updateExecutionStatus(executionId, status, error);
 
-  await ctx.clearActiveExecution();
+  // Clear active execution only if this was the active execution.
+  // updateStatus already clears active_execution_id internally when it matches,
+  // so the clear here is a safety net. We skip when this execution wasn't active
+  // to avoid clobbering a newer execution that started in between.
+  if (wasActive) {
+    const activeId = await ctx.getActiveExecutionId();
+    if (activeId === executionId) {
+      await ctx.clearActiveExecution();
+    }
+  }
 }

--- a/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/cloud-agent-next/src/websocket/ingest.test.ts
@@ -30,6 +30,7 @@ function createFakeDOContext(): IngestDOContext {
     updateKiloSessionId: vi.fn().mockResolvedValue(undefined),
     updateUpstreamBranch: vi.fn().mockResolvedValue(undefined),
     clearActiveExecution: vi.fn().mockResolvedValue(undefined),
+    getActiveExecutionId: vi.fn().mockResolvedValue(null),
     getExecution: vi.fn().mockResolvedValue(null),
     transitionToRunning: vi.fn().mockResolvedValue(true),
     updateHeartbeat: vi.fn().mockResolvedValue(undefined),

--- a/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/cloud-agent-next/src/websocket/ingest.test.ts
@@ -4,6 +4,7 @@ import type { EventQueries } from '../session/queries/index.js';
 import type { SessionId, ExecutionId } from '../types/ids.js';
 
 const SESSION_ID = 'sess_test' as SessionId;
+const EXECUTION_ID = 'exc_test' as ExecutionId;
 
 function createFakeState() {
   return {
@@ -46,47 +47,103 @@ function createFakeWebSocket(attachment: unknown = null) {
   } as unknown as WebSocket;
 }
 
-function createHandler() {
-  return createIngestHandler(
-    createFakeState(),
-    createFakeEventQueries(),
-    SESSION_ID,
-    vi.fn(),
-    createFakeDOContext()
-  );
+function makeAttachment(overrides?: Partial<IngestAttachment>): IngestAttachment {
+  return {
+    executionId: EXECUTION_ID,
+    connectedAt: Date.now(),
+    kiloSessionState: { captured: false },
+    lastHeartbeatUpdate: Date.now(),
+    ...overrides,
+  };
 }
 
 describe('createIngestHandler', () => {
   describe('handleIngestClose', () => {
     it('returns null when WebSocket has no attachment', () => {
-      const handler = createHandler();
+      const state = createFakeState();
+      const handler = createIngestHandler(
+        state,
+        createFakeEventQueries(),
+        SESSION_ID,
+        vi.fn(),
+        createFakeDOContext()
+      );
       const ws = createFakeWebSocket(null);
 
-      const result = handler.handleIngestClose(ws);
-
-      expect(result).toBeNull();
+      expect(handler.handleIngestClose(ws)).toBeNull();
     });
 
-    it('returns null when WebSocket is not the active connection', () => {
-      const handler = createHandler();
-      const attachment: IngestAttachment = {
-        executionId: 'exc_test' as ExecutionId,
-        connectedAt: Date.now(),
-        kiloSessionState: { captured: false },
-        lastHeartbeatUpdate: Date.now(),
-      };
-      const ws = createFakeWebSocket(attachment);
+    it('returns executionId when no other ingest sockets remain', () => {
+      const state = createFakeState();
+      // No remaining sockets for this execution
+      vi.mocked(state.getWebSockets).mockReturnValue([]);
 
-      // This WS was never registered via handleIngestRequest,
-      // so it won't be in the internal activeConnections map.
-      const result = handler.handleIngestClose(ws);
+      const handler = createIngestHandler(
+        state,
+        createFakeEventQueries(),
+        SESSION_ID,
+        vi.fn(),
+        createFakeDOContext()
+      );
+      const ws = createFakeWebSocket(makeAttachment());
 
-      expect(result).toBeNull();
+      expect(handler.handleIngestClose(ws)).toBe(EXECUTION_ID);
+      expect(state.getWebSockets).toHaveBeenCalledWith(`ingest:${EXECUTION_ID}`);
     });
 
-    // The positive case (returns executionId when the WS is the active connection)
-    // requires going through handleIngestRequest, which uses WebSocketPair and
-    // state.acceptWebSocket — Cloudflare Worker APIs unavailable in vitest Node.
-    // That path is covered by integration tests in test/.
+    it('returns null when a replacement ingest socket exists', () => {
+      const state = createFakeState();
+      const replacementWs = createFakeWebSocket();
+      // A replacement socket still exists for this execution
+      vi.mocked(state.getWebSockets).mockReturnValue([replacementWs]);
+
+      const handler = createIngestHandler(
+        state,
+        createFakeEventQueries(),
+        SESSION_ID,
+        vi.fn(),
+        createFakeDOContext()
+      );
+      const ws = createFakeWebSocket(makeAttachment());
+
+      expect(handler.handleIngestClose(ws)).toBeNull();
+    });
+
+    // The positive case through the full handleIngestRequest → handleIngestClose
+    // flow requires WebSocketPair and state.acceptWebSocket — Cloudflare Worker
+    // APIs unavailable in vitest Node. That path is covered by integration tests.
+  });
+
+  describe('hasActiveConnection', () => {
+    it('returns true when getWebSockets finds ingest sockets', () => {
+      const state = createFakeState();
+      vi.mocked(state.getWebSockets).mockReturnValue([createFakeWebSocket()]);
+
+      const handler = createIngestHandler(
+        state,
+        createFakeEventQueries(),
+        SESSION_ID,
+        vi.fn(),
+        createFakeDOContext()
+      );
+
+      expect(handler.hasActiveConnection(EXECUTION_ID)).toBe(true);
+      expect(state.getWebSockets).toHaveBeenCalledWith(`ingest:${EXECUTION_ID}`);
+    });
+
+    it('returns false when getWebSockets finds no ingest sockets', () => {
+      const state = createFakeState();
+      vi.mocked(state.getWebSockets).mockReturnValue([]);
+
+      const handler = createIngestHandler(
+        state,
+        createFakeEventQueries(),
+        SESSION_ID,
+        vi.fn(),
+        createFakeDOContext()
+      );
+
+      expect(handler.hasActiveConnection(EXECUTION_ID)).toBe(false);
+    });
   });
 });

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -63,6 +63,7 @@ const createExecutionLifecycleContext = (doContext: IngestDOContext) => ({
     err?: string
   ) => doContext.updateExecutionStatus(id, status, err),
   clearActiveExecution: () => doContext.clearActiveExecution(),
+  getActiveExecutionId: () => doContext.getActiveExecutionId(),
   logger: console,
 });
 
@@ -114,6 +115,8 @@ export type IngestDOContext = {
   updateUpstreamBranch: (branch: string) => Promise<void>;
   /** Clear the active execution when done */
   clearActiveExecution: () => Promise<void>;
+  /** Get the currently active execution ID (if any) */
+  getActiveExecutionId: () => Promise<string | null>;
   /** Get execution data for validation (including ingestToken) */
   getExecution: (executionId: string) => Promise<ExecutionData | null>;
   /** Transition execution status to 'running' when wrapper connects */

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -126,6 +126,8 @@ export type IngestDOContext = {
     status: 'completed' | 'failed' | 'interrupted',
     error?: string
   ) => Promise<void>;
+  /** Cancel the disconnect grace timer when wrapper reconnects */
+  cancelDisconnectGrace?: () => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -242,6 +244,9 @@ export function createIngestHandler(
 
       // Track the connection
       activeConnections.set(executionId, server);
+
+      // Cancel any pending disconnect grace timer — wrapper reconnected
+      doContext.cancelDisconnectGrace?.();
 
       // Set initial heartbeat
       void doContext.updateHeartbeat(executionId, now);

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -156,11 +156,6 @@ export function createIngestHandler(
   broadcastFn: (event: StoredEvent) => void,
   doContext: IngestDOContext
 ) {
-  // Track active ingest connections per execution
-  // Note: This map is reset on hibernation, but we can reconstruct
-  // from state.getWebSockets() using tags if needed
-  const activeConnections = new Map<ExecutionId, WebSocket>();
-
   return {
     /**
      * Handle incoming /ingest WebSocket upgrade request.
@@ -169,7 +164,7 @@ export function createIngestHandler(
      * 1. Validate WebSocket upgrade header
      * 2. Extract and validate executionId and token from query params
      * 3. Validate execution exists and token matches
-     * 4. Close any existing connection for this execution
+     * 4. Close any existing sockets for this execution (including hibernated ones)
      * 5. Transition execution status to 'running'
      * 6. Accept WebSocket with hibernation support and ingest tag
      * 7. Store execution ID in attachment for hibernation-safe access
@@ -206,15 +201,16 @@ export function createIngestHandler(
         return new Response('Execution not active', { status: 409 });
       }
 
-      // Check for existing connection - close old one if exists
-      const existingWs = activeConnections.get(executionId);
-      if (existingWs) {
+      // Close any existing ingest sockets for this execution (including
+      // hibernated ones that wouldn't appear in an in-memory map).
+      // state.getWebSockets() is the authoritative source — it survives
+      // hibernation and excludes already-disconnected sockets.
+      for (const existingWs of state.getWebSockets(`ingest:${executionId}`)) {
         try {
           existingWs.close(1000, 'Replaced by new connection');
         } catch {
           // Ignore close errors on already-closed connections
         }
-        activeConnections.delete(executionId);
       }
 
       // Transition execution status to 'running' if not already
@@ -241,9 +237,6 @@ export function createIngestHandler(
       // Use ingest:{executionId} tag for identification
       state.acceptWebSocket(server, [`ingest:${executionId}`]);
       server.serializeAttachment(attachment);
-
-      // Track the connection
-      activeConnections.set(executionId, server);
 
       // Cancel any pending disconnect grace timer — wrapper reconnected
       doContext.cancelDisconnectGrace?.();
@@ -431,52 +424,40 @@ export function createIngestHandler(
     /**
      * Handle ingest WebSocket close.
      *
-     * Removes the connection from tracking if it's the current
-     * connection for this execution (avoids removing a replacement
-     * connection that was already established).
+     * Returns the executionId only when no other ingest sockets remain
+     * for that execution — i.e. the wrapper is truly disconnected, not
+     * just being replaced by a reconnection.
+     *
+     * Uses state.getWebSockets() which is authoritative across hibernation
+     * and excludes already-disconnected sockets.
      *
      * @param ws - The WebSocket that closed
      */
     handleIngestClose(ws: WebSocket): ExecutionId | null {
       const attachment = ws.deserializeAttachment() as IngestAttachment | null;
-      if (attachment) {
-        const { executionId } = attachment;
-        // Only remove from tracking if this is the current connection for this execution
-        if (activeConnections.get(executionId) === ws) {
-          activeConnections.delete(executionId);
-          return executionId;
-        }
-      }
-      return null;
+      if (!attachment) return null;
+
+      const { executionId } = attachment;
+
+      // If another ingest socket still exists for this execution (e.g. a
+      // replacement connection), the wrapper isn't truly gone.
+      const remaining = state.getWebSockets(`ingest:${executionId}`);
+      if (remaining.length > 0) return null;
+
+      return executionId;
     },
 
     /**
      * Check if an execution has an active ingest connection.
      *
+     * Uses state.getWebSockets() which is authoritative across hibernation
+     * and excludes already-disconnected sockets.
+     *
      * @param executionId - Execution ID to check
      * @returns True if there's an active connection for this execution
      */
     hasActiveConnection(executionId: ExecutionId): boolean {
-      return activeConnections.has(executionId);
-    },
-
-    /**
-     * Get count of active ingest connections.
-     *
-     * @returns Number of active ingest WebSocket connections
-     */
-    getActiveConnectionCount(): number {
-      return activeConnections.size;
-    },
-
-    /**
-     * Get WebSocket for a specific execution (for testing/debugging).
-     *
-     * @param executionId - Execution ID to get connection for
-     * @returns WebSocket if found, undefined otherwise
-     */
-    getConnection(executionId: ExecutionId): WebSocket | undefined {
-      return activeConnections.get(executionId);
+      return state.getWebSockets(`ingest:${executionId}`).length > 0;
     },
   };
 }

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -126,8 +126,8 @@ export type IngestDOContext = {
     status: 'completed' | 'failed' | 'interrupted',
     error?: string
   ) => Promise<void>;
-  /** Cancel the disconnect grace timer when wrapper reconnects */
-  cancelDisconnectGrace?: () => void;
+  /** Cancel the disconnect grace period when wrapper reconnects */
+  cancelDisconnectGrace?: () => Promise<void>;
 };
 
 // ---------------------------------------------------------------------------
@@ -238,8 +238,8 @@ export function createIngestHandler(
       state.acceptWebSocket(server, [`ingest:${executionId}`]);
       server.serializeAttachment(attachment);
 
-      // Cancel any pending disconnect grace timer — wrapper reconnected
-      doContext.cancelDisconnectGrace?.();
+      // Cancel any pending disconnect grace period — wrapper reconnected
+      await doContext.cancelDisconnectGrace?.();
 
       // Set initial heartbeat
       void doContext.updateHeartbeat(executionId, now);

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -450,4 +450,177 @@ describe('Disconnect handling & reaper', () => {
     expect(result.execution?.status).toBe('failed');
     expect(result.interruptAfter).toBe(false);
   });
+
+  // ---------------------------------------------------------------------------
+  // failExecutionRpc — direct RPC path for external callers
+  // ---------------------------------------------------------------------------
+
+  it('failExecutionRpc marks execution as failed with full cleanup', async () => {
+    const userId = 'user_rpc_1';
+    const sessionId = 'agent_rpc_1';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_rpc_cleanup' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Set the interrupt flag so we can verify it gets cleared
+      await instance.requestInterrupt();
+
+      const rpcResult = await instance.failExecutionRpc({
+        executionId: excId,
+        error: 'Interrupted - no running processes found',
+      });
+
+      const execution = await instance.getExecution(excId);
+      const activeExecId = await instance.getActiveExecutionId();
+      const interruptAfter = await instance.isInterruptRequested();
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorEvents = events.filter(e => e.stream_event_type === 'error');
+
+      return { rpcResult, execution, activeExecId, interruptAfter, errorEvents };
+    });
+
+    expect(result.rpcResult).toBe(true);
+    expect(result.execution?.status).toBe('failed');
+    expect(result.execution?.error).toContain('Interrupted - no running processes found');
+    expect(result.activeExecId).toBeNull();
+    expect(result.interruptAfter).toBe(false);
+    expect(result.errorEvents).toHaveLength(1);
+
+    const payload = JSON.parse(result.errorEvents[0].payload);
+    expect(payload.fatal).toBe(true);
+    expect(payload.error).toContain('Interrupted - no running processes found');
+  });
+
+  it('failExecutionRpc returns false for already-terminal execution', async () => {
+    const userId = 'user_rpc_2';
+    const sessionId = 'agent_rpc_2';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_rpc_terminal' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      // Transition to running, then to failed
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'failed',
+        error: 'already dead',
+      });
+
+      // Count events before the RPC call
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const eventsBefore = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorCountBefore = eventsBefore.filter(e => e.stream_event_type === 'error').length;
+
+      // Now call failExecutionRpc on the already-terminal execution
+      const rpcResult = await instance.failExecutionRpc({
+        executionId: excId,
+        error: 'should be a no-op',
+      });
+
+      const eventsAfter = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorCountAfter = eventsAfter.filter(e => e.stream_event_type === 'error').length;
+
+      return { rpcResult, errorCountBefore, errorCountAfter };
+    });
+
+    expect(result.rpcResult).toBe(false);
+    expect(result.errorCountAfter).toBe(result.errorCountBefore);
+  });
+
+  it('failExecutionRpc passes custom streamEventType', async () => {
+    const userId = 'user_rpc_3';
+    const sessionId = 'agent_rpc_3';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_rpc_custom_type' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      const rpcResult = await instance.failExecutionRpc({
+        executionId: excId,
+        error: 'test',
+        streamEventType: 'wrapper_disconnected',
+      });
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const customEvents = events.filter(e => e.stream_event_type === 'wrapper_disconnected');
+
+      return { rpcResult, customEvents };
+    });
+
+    expect(result.rpcResult).toBe(true);
+    expect(result.customEvents).toHaveLength(1);
+    expect(result.customEvents[0].stream_event_type).toBe('wrapper_disconnected');
+  });
 });

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -333,6 +333,202 @@ describe('Disconnect handling & reaper', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Disconnect grace period (alarm-based, survives hibernation)
+  // ---------------------------------------------------------------------------
+
+  it('alarm fires disconnect grace and marks execution as failed', async () => {
+    const userId = 'user_grace_1';
+    const sessionId = 'agent_grace_1';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_grace_expired' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Fresh heartbeat so the reaper's stale-execution check won't trigger
+      await instance.updateExecutionHeartbeat(excId, now - 5_000);
+
+      // Simulate writing the disconnect grace state directly into storage
+      // (normally done by webSocketClose → startDisconnectGrace, which we
+      // can't call without a real ingest WebSocket).
+      const graceState = {
+        executionId: excId,
+        disconnectedAt: now - 15_000, // 15s ago — well past the 10s grace
+        wsCloseCode: 1006,
+        wsCloseReason: 'WebSocket disconnected without sending Close frame.',
+      };
+      await state.storage.put('disconnect_grace', graceState);
+
+      // Run the alarm — should detect expired grace and fail the execution
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+      const activeExecId = await instance.getActiveExecutionId();
+
+      // The grace state should be cleared after processing
+      const graceAfter = await state.storage.get('disconnect_grace');
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const disconnectEvents = events.filter(e => e.stream_event_type === 'wrapper_disconnected');
+
+      return { execution, activeExecId, graceAfter, disconnectEvents };
+    });
+
+    expect(result.execution?.status).toBe('failed');
+    expect(result.execution?.error).toBe('Wrapper disconnected');
+    expect(result.activeExecId).toBeNull();
+    expect(result.graceAfter).toBeUndefined();
+    expect(result.disconnectEvents).toHaveLength(1);
+
+    const payload = JSON.parse(result.disconnectEvents[0].payload);
+    expect(payload.wsCloseCode).toBe(1006);
+  });
+
+  it('alarm skips disconnect grace when period has not yet elapsed', async () => {
+    const userId = 'user_grace_2';
+    const sessionId = 'agent_grace_2';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_grace_not_expired' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      await instance.updateExecutionHeartbeat(excId, now - 5_000);
+
+      // Grace period started only 3s ago — not yet expired (10s threshold)
+      const graceState = {
+        executionId: excId,
+        disconnectedAt: now - 3_000,
+        wsCloseCode: 1006,
+        wsCloseReason: 'test',
+      };
+      await state.storage.put('disconnect_grace', graceState);
+
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+      const activeExecId = await instance.getActiveExecutionId();
+      // Grace state should still be present (not yet expired)
+      const graceAfter = await state.storage.get('disconnect_grace');
+
+      return { execution, activeExecId, graceAfter };
+    });
+
+    expect(result.execution?.status).toBe('running');
+    expect(result.activeExecId).toBe('exc_grace_not_expired');
+    expect(result.graceAfter).toBeDefined();
+  });
+
+  it('alarm skips disconnect grace when execution already completed', async () => {
+    const userId = 'user_grace_3';
+    const sessionId = 'agent_grace_3';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_grace_completed' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Complete the execution before the alarm fires
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'completed',
+      });
+
+      // Grace state from before the execution completed
+      const graceState = {
+        executionId: excId,
+        disconnectedAt: now - 15_000,
+        wsCloseCode: 1006,
+        wsCloseReason: 'test',
+      };
+      await state.storage.put('disconnect_grace', graceState);
+
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+
+      // Grace state should be cleared even though we didn't fail
+      const graceAfter = await state.storage.get('disconnect_grace');
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+      const events = eventQueries.findByFilters({ executionIds: [excId] });
+      const disconnectEvents = events.filter(e => e.stream_event_type === 'wrapper_disconnected');
+
+      return { execution, graceAfter, disconnectEvents };
+    });
+
+    expect(result.execution?.status).toBe('completed');
+    expect(result.graceAfter).toBeUndefined();
+    expect(result.disconnectEvents).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
   // failExecution idempotency & interrupt cleanup
   // ---------------------------------------------------------------------------
 

--- a/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -331,4 +331,123 @@ describe('Disconnect handling & reaper', () => {
     expect(delta).toBeGreaterThanOrEqual(295_000);
     expect(delta).toBeLessThanOrEqual(305_000);
   });
+
+  // ---------------------------------------------------------------------------
+  // failExecution idempotency & interrupt cleanup
+  // ---------------------------------------------------------------------------
+
+  it('reaper is idempotent - second alarm after failure produces no additional events', async () => {
+    const userId = 'user_reaper_5';
+    const sessionId = 'agent_reaper_5';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_idempotent' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Stale heartbeat — exceeds the 90s threshold
+      await instance.updateExecutionHeartbeat(excId, now - 200_000);
+
+      // First alarm: should mark execution as failed and insert error event
+      await instance.alarm();
+
+      const db = drizzle(state.storage, { logger: false });
+      const eventQueries = createEventQueries(db, state.storage.sql);
+
+      const eventsAfterFirst = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorCountAfterFirst = eventsAfterFirst.filter(
+        e => e.stream_event_type === 'error'
+      ).length;
+
+      // Second alarm: execution is already terminal — should be a no-op
+      await instance.alarm();
+
+      const eventsAfterSecond = eventQueries.findByFilters({ executionIds: [excId] });
+      const errorCountAfterSecond = eventsAfterSecond.filter(
+        e => e.stream_event_type === 'error'
+      ).length;
+
+      const execution = await instance.getExecution(excId);
+      const activeExecId = await instance.getActiveExecutionId();
+
+      return { errorCountAfterFirst, errorCountAfterSecond, execution, activeExecId };
+    });
+
+    expect(result.errorCountAfterFirst).toBe(1);
+    expect(result.errorCountAfterSecond).toBe(1);
+    expect(result.execution?.status).toBe('failed');
+    expect(result.activeExecId).toBeNull();
+  });
+
+  it('reaper clears interrupt flag when marking stale execution as failed', async () => {
+    const userId = 'user_reaper_6';
+    const sessionId = 'agent_reaper_6';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async (instance, state) => {
+      const now = Date.now();
+
+      await instance.updateMetadata({
+        version: now,
+        sessionId,
+        userId,
+        timestamp: now,
+      });
+
+      const excId = 'exc_interrupt_clear' as ExecutionId;
+      await instance.addExecution({
+        executionId: excId,
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: excId,
+      });
+      await instance.setActiveExecution(excId);
+
+      await instance.updateExecutionStatus({
+        executionId: excId,
+        status: 'running',
+      });
+
+      // Stale heartbeat
+      await instance.updateExecutionHeartbeat(excId, now - 200_000);
+
+      // Set the interrupt flag before the reaper runs
+      await instance.requestInterrupt();
+      const interruptBefore = await instance.isInterruptRequested();
+
+      // Run the alarm — reaper should fail the execution AND clear the interrupt
+      await instance.alarm();
+
+      const execution = await instance.getExecution(excId);
+      const interruptAfter = await instance.isInterruptRequested();
+
+      return { execution, interruptBefore, interruptAfter };
+    });
+
+    expect(result.interruptBefore).toBe(true);
+    expect(result.execution?.status).toBe('failed');
+    expect(result.interruptAfter).toBe(false);
+  });
 });

--- a/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -34,12 +34,14 @@ const createMockKiloClient = (): KiloClient => ({
   answerPermission: vi.fn().mockResolvedValue(true),
   answerQuestion: vi.fn().mockResolvedValue(true),
   rejectQuestion: vi.fn().mockResolvedValue(true),
+  generateCommitMessage: vi.fn().mockResolvedValue({ message: 'test commit' }),
 });
 
 const createMockConnectionManager = (): ConnectionManager => ({
   open: vi.fn().mockResolvedValue(undefined),
   close: vi.fn().mockResolvedValue(undefined),
   isConnected: vi.fn().mockReturnValue(false),
+  isReconnecting: vi.fn().mockReturnValue(false),
 });
 
 const createDefaultConfig = (overrides: Partial<LifecycleConfig> = {}): LifecycleConfig => ({
@@ -564,6 +566,25 @@ describe('createLifecycleManager', () => {
       );
       expect(errorCalls).toHaveLength(1);
       expect(errorCalls[0][0].data.messageId).toBe('msg_short');
+    });
+
+    it('skips SSE health checks while reconnecting', async () => {
+      const mgr = createManager();
+      (connectionManager.isConnected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (connectionManager.isReconnecting as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      state.startJob(createJobContext());
+      state.addInflight('msg_1', Date.now() + 600_000);
+      // Record initial SSE activity so the inactivity check has a baseline
+      state.recordSseEvent();
+
+      mgr.start();
+
+      // Advance past SSE inactivity timeout (120s) + check interval
+      await vi.advanceTimersByTimeAsync(130_000);
+
+      // abortSession should NOT have been called because we're reconnecting
+      expect(kiloClient.abortSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -1,0 +1,716 @@
+/**
+ * Unit tests for ingest WebSocket reconnection logic in createConnectionManager.
+ *
+ * Tests exponential backoff, event buffering during disconnection,
+ * heartbeat pause/resume, and close-during-reconnect scenarios.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createConnectionManager,
+  type ConnectionCallbacks,
+} from '../../../wrapper/src/connection.js';
+import { WrapperState, type JobContext } from '../../../wrapper/src/state.js';
+import type { KiloClient } from '../../../wrapper/src/kilo-client.js';
+import type { IngestEvent } from '../../../src/shared/protocol.js';
+
+// ---------------------------------------------------------------------------
+// Polyfills for Node.js test environment
+// ---------------------------------------------------------------------------
+
+// CloseEvent is a browser API not available in Node — provide a minimal shim
+if (typeof CloseEvent === 'undefined') {
+  const g = globalThis as Record<string, unknown>;
+  g.CloseEvent = class extends Event {
+    code: number;
+    reason: string;
+    wasClean: boolean;
+    constructor(type: string, init?: { code?: number; reason?: string; wasClean?: boolean }) {
+      super(type);
+      this.code = init?.code ?? 0;
+      this.reason = init?.reason ?? '';
+      this.wasClean = init?.wasClean ?? false;
+    }
+  };
+}
+
+// MessageEvent may also be missing in some Node versions
+if (typeof MessageEvent === 'undefined') {
+  const g = globalThis as Record<string, unknown>;
+  g.MessageEvent = class extends Event {
+    data: unknown;
+    constructor(type: string, init?: { data?: unknown }) {
+      super(type);
+      this.data = init?.data;
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MockWebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  sent: string[] = [];
+  url: string;
+
+  constructor(url: string, _options?: unknown) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(_code?: number, _reason?: string): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  simulateClose(code = 1006, reason = ''): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close', { code, reason }));
+  }
+
+  simulateError(): void {
+    this.onerror?.(new Event('error'));
+  }
+
+  static reset(): void {
+    MockWebSocket.instances = [];
+  }
+
+  static get latest(): MockWebSocket | undefined {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const createJobContext = (): JobContext => ({
+  executionId: 'exec_test',
+  sessionId: 'session_abc',
+  userId: 'user_xyz',
+  kiloSessionId: 'kilo_sess_456',
+  ingestUrl: 'wss://ingest.example.com/ingest',
+  ingestToken: 'token_secret',
+  kilocodeToken: 'kilo_token_789',
+});
+
+const createCallbacks = (): ConnectionCallbacks & {
+  onReconnecting: ReturnType<typeof vi.fn>;
+  onReconnected: ReturnType<typeof vi.fn>;
+  onDisconnect: ReturnType<typeof vi.fn>;
+} => ({
+  onMessageComplete: vi.fn(),
+  onTerminalError: vi.fn(),
+  onCommand: vi.fn(),
+  onDisconnect: vi.fn(),
+  onCompletionSignal: vi.fn(),
+  onReconnecting: vi.fn(),
+  onReconnected: vi.fn(),
+});
+
+const createMockKiloClient = (): KiloClient => ({
+  listSessions: vi.fn().mockResolvedValue([]),
+  createSession: vi.fn().mockResolvedValue({ id: 'kilo_sess', time: { created: '', updated: '' } }),
+  getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess', time: { created: '', updated: '' } }),
+  sendPromptAsync: vi.fn().mockResolvedValue(undefined),
+  abortSession: vi.fn().mockResolvedValue(true),
+  checkHealth: vi.fn().mockResolvedValue({ healthy: true, version: '1.0.0' }),
+  sendCommand: vi.fn().mockResolvedValue(undefined),
+  answerPermission: vi.fn().mockResolvedValue(true),
+  answerQuestion: vi.fn().mockResolvedValue(true),
+  rejectQuestion: vi.fn().mockResolvedValue(true),
+  generateCommitMessage: vi.fn().mockResolvedValue({ message: 'test commit' }),
+});
+
+/**
+ * Mock fetch to simulate a never-ending SSE stream.
+ * The ReadableStream stays open so the SSE consumer never closes.
+ */
+function stubFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(() => {
+      const stream = new ReadableStream({
+        start() {
+          // Never push data — keeps SSE consumer alive without events
+        },
+      });
+      return Promise.resolve(
+        new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      );
+    })
+  );
+}
+
+/**
+ * Open the connection manager, simulating WS open so the promise resolves.
+ * Returns the initial MockWebSocket instance.
+ */
+async function openConnection(
+  manager: ReturnType<typeof createConnectionManager>
+): Promise<MockWebSocket> {
+  const openPromise = manager.open();
+  // openIngestWs creates a WS and waits for onopen
+  const ws = MockWebSocket.latest!;
+  ws.simulateOpen();
+  // openSSEConsumer calls fetch (mocked above), then resolves
+  await openPromise;
+  return ws;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ingest WS reconnection', () => {
+  let state: WrapperState;
+  let callbacks: ReturnType<typeof createCallbacks>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.reset();
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    stubFetch();
+
+    state = new WrapperState();
+    state.startJob(createJobContext());
+    callbacks = createCallbacks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function createManager() {
+    return createConnectionManager(
+      state,
+      { kiloServerPort: 4000, kiloClient: createMockKiloClient() },
+      callbacks
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Test: unexpected close triggers reconnection
+  // -------------------------------------------------------------------------
+
+  it('attempts reconnection on unexpected WS close', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // Unexpected close (code 1006 = abnormal closure)
+    ws.simulateClose(1006);
+
+    expect(callbacks.onDisconnect).not.toHaveBeenCalled();
+    expect(manager.isReconnecting()).toBe(true);
+    expect(callbacks.onReconnecting).toHaveBeenCalledWith(1);
+
+    // Advance past first backoff (1s)
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // A new WS should have been created
+    const newWs = MockWebSocket.latest!;
+    expect(newWs).not.toBe(ws);
+    newWs.simulateOpen();
+
+    // Wait for reconnect promise to resolve
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnected).toHaveBeenCalled();
+    expect(manager.isReconnecting()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: reconnection fails after all attempts
+  // -------------------------------------------------------------------------
+
+  it('calls onDisconnect after all reconnection attempts fail', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+    expect(manager.isReconnecting()).toBe(true);
+
+    // Backoff delays: 1s, 2s, 4s, 8s, 16s
+    const delays = [1_000, 2_000, 4_000, 8_000, 16_000];
+
+    for (let i = 0; i < delays.length; i++) {
+      expect(callbacks.onReconnecting).toHaveBeenCalledWith(i + 1);
+      await vi.advanceTimersByTimeAsync(delays[i]);
+
+      // New WS created — simulate error so openIngestWs rejects
+      const attemptWs = MockWebSocket.latest!;
+      attemptWs.simulateError();
+
+      // Let the rejection propagate and next attempt to schedule
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    // After 5 failures, onDisconnect should fire
+    expect(callbacks.onDisconnect).toHaveBeenCalledWith(
+      'ingest websocket closed (reconnection failed)'
+    );
+    expect(manager.isReconnecting()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: expected close (closedByUs) — no reconnection
+  // -------------------------------------------------------------------------
+
+  it('does not reconnect when connection is closed by us', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // close() sets closedByUs = true, then calls ws.close()
+    await manager.close();
+
+    // The WS is already closed by close(), but simulate the onclose event
+    // that arrives after (close() sets ingestWs=null, so onclose with stale ws is ignored)
+    ws.simulateClose(1000, 'normal close');
+
+    expect(callbacks.onDisconnect).not.toHaveBeenCalled();
+    expect(manager.isReconnecting()).toBe(false);
+
+    // Advance timers to verify no reconnection attempts
+    await vi.advanceTimersByTimeAsync(60_000);
+    // Only the initial WS should exist (no new connections attempted)
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: close code 4000 (execution done) — no reconnection
+  // -------------------------------------------------------------------------
+
+  it('does not reconnect on close code 4000 (execution done)', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(4000);
+
+    expect(callbacks.onDisconnect).toHaveBeenCalledWith('ingest websocket closed (execution done)');
+    expect(manager.isReconnecting()).toBe(false);
+
+    // Verify no reconnection attempts
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: events are buffered during reconnection and flushed on reconnect
+  // -------------------------------------------------------------------------
+
+  it('buffers events during reconnection and flushes on reconnect', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // Simulate unexpected close
+    ws.simulateClose(1006);
+    expect(manager.isReconnecting()).toBe(true);
+
+    // Send events via state.sendToIngest while disconnected
+    const event1: IngestEvent = {
+      streamEventType: 'kilocode',
+      timestamp: new Date().toISOString(),
+      data: { event: 'test_event_1' },
+    };
+    const event2: IngestEvent = {
+      streamEventType: 'output',
+      timestamp: new Date().toISOString(),
+      data: { text: 'some output' },
+    };
+    state.sendToIngest(event1);
+    state.sendToIngest(event2);
+
+    // Events should NOT have been sent to the old WS
+    // (old WS is closed, so nothing is sent — events are buffered internally)
+    const oldWsSentAfterClose = ws.sent.filter(msg => {
+      const parsed = JSON.parse(msg);
+      return parsed.streamEventType === 'kilocode' || parsed.streamEventType === 'output';
+    });
+    // The old WS may have sent a heartbeat before close; filter to our test events
+    expect(oldWsSentAfterClose).toHaveLength(0);
+
+    // Advance past first backoff (1s) and reconnect
+    await vi.advanceTimersByTimeAsync(1_000);
+    const newWs = MockWebSocket.latest!;
+    expect(newWs).not.toBe(ws);
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Verify wrapper_resumed marker was sent
+    const resumeMsg = newWs.sent.find(msg => {
+      const parsed = JSON.parse(msg);
+      return parsed.streamEventType === 'wrapper_resumed';
+    });
+    expect(resumeMsg).toBeDefined();
+    const parsedResume = JSON.parse(resumeMsg!);
+    expect(parsedResume.data.bufferedEvents).toBe(2);
+    expect(parsedResume.data.eventsLost).toBe(false);
+
+    // Verify buffered events were flushed to new WS
+    const flushedEvents = newWs.sent
+      .map(msg => JSON.parse(msg))
+      .filter(
+        (e: { streamEventType: string }) =>
+          e.streamEventType === 'kilocode' || e.streamEventType === 'output'
+      );
+    expect(flushedEvents).toHaveLength(2);
+    expect(flushedEvents[0].data.event).toBe('test_event_1');
+    expect(flushedEvents[1].data.text).toBe('some output');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: SSE consumer stays alive during reconnection
+  // -------------------------------------------------------------------------
+
+  it('keeps SSE consumer alive during WS reconnection', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // SSE consumer was created (fetch was called once)
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Simulate unexpected WS close
+    ws.simulateClose(1006);
+    expect(manager.isReconnecting()).toBe(true);
+
+    // The SSE consumer's onClose callback should NOT have fired
+    // (only WS disconnected, not SSE). Verify via onDisconnect not being called.
+    expect(callbacks.onDisconnect).not.toHaveBeenCalled();
+
+    // Reconnect
+    await vi.advanceTimersByTimeAsync(1_000);
+    MockWebSocket.latest!.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // SSE consumer should still be alive (no new fetch calls for SSE re-creation)
+    // The SSE consumer was set up once during open() and stays running.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: close() during reconnection cancels it
+  // -------------------------------------------------------------------------
+
+  it('cancels reconnection when close() is called during reconnect', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+    expect(manager.isReconnecting()).toBe(true);
+
+    const instanceCountBefore = MockWebSocket.instances.length;
+
+    // Call close() while reconnecting
+    await manager.close();
+    expect(manager.isReconnecting()).toBe(false);
+
+    // Advance past all possible backoff delays (1+2+4+8+16 = 31s)
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // No new WebSocket connections should have been attempted
+    expect(MockWebSocket.instances).toHaveLength(instanceCountBefore);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: heartbeat pauses during reconnection and resumes on reconnect
+  // -------------------------------------------------------------------------
+
+  it('pauses heartbeat during reconnection and resumes after reconnect', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // Heartbeat starts after open() — fires every 20s
+    // Advance 20s to see a heartbeat on the initial WS
+    await vi.advanceTimersByTimeAsync(20_000);
+    const heartbeats = ws.sent.filter(msg => {
+      const parsed = JSON.parse(msg);
+      return parsed.streamEventType === 'heartbeat';
+    });
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1);
+
+    const sentCountBefore = ws.sent.length;
+
+    // Simulate unexpected close — heartbeat should stop
+    ws.simulateClose(1006);
+
+    // Advance 20s — no heartbeat should be sent (heartbeat paused)
+    await vi.advanceTimersByTimeAsync(20_000);
+    // Old WS should not have received any new messages after close
+    expect(ws.sent.length).toBe(sentCountBefore);
+
+    // Reconnect: advance past 1s backoff (total advanced: 20s+20s+1s since close,
+    // but reconnect timer is from close time, and we already advanced 20s)
+    // We need to advance from the start of reconnection. Since we already advanced
+    // 20s for the heartbeat check, the 1s reconnect timer has already elapsed.
+    // A new WS should have been created.
+    const newWs = MockWebSocket.latest!;
+    expect(newWs).not.toBe(ws);
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnected).toHaveBeenCalled();
+
+    // Clear sent array on new WS to track fresh heartbeats
+    newWs.sent.length = 0;
+
+    // Advance 20s — heartbeat should resume on the new WS
+    await vi.advanceTimersByTimeAsync(20_000);
+    const newHeartbeats = newWs.sent.filter(msg => {
+      const parsed = JSON.parse(msg);
+      return parsed.streamEventType === 'heartbeat';
+    });
+    expect(newHeartbeats.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: exponential backoff delays
+  // -------------------------------------------------------------------------
+
+  it('uses exponential backoff delays for reconnection attempts', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+
+    // Track when each new WS instance is created by checking instance count
+    // Backoff: attempt 1 = 1s, attempt 2 = 2s, attempt 3 = 4s
+    const delays = [1_000, 2_000, 4_000];
+
+    for (let i = 0; i < delays.length; i++) {
+      const countBefore = MockWebSocket.instances.length;
+
+      // Advance just under the delay — no new WS yet
+      await vi.advanceTimersByTimeAsync(delays[i] - 1);
+      expect(MockWebSocket.instances).toHaveLength(countBefore);
+
+      // Advance the remaining 1ms — new WS should appear
+      await vi.advanceTimersByTimeAsync(1);
+      expect(MockWebSocket.instances).toHaveLength(countBefore + 1);
+
+      // Simulate failure to trigger next attempt
+      MockWebSocket.latest!.simulateError();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: onReconnecting fires with correct attempt number
+  // -------------------------------------------------------------------------
+
+  it('fires onReconnecting with incrementing attempt number', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+
+    // First attempt fires immediately on close
+    expect(callbacks.onReconnecting).toHaveBeenCalledWith(1);
+
+    // Fail attempt 1
+    await vi.advanceTimersByTimeAsync(1_000);
+    MockWebSocket.latest!.simulateError();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnecting).toHaveBeenCalledWith(2);
+
+    // Fail attempt 2
+    await vi.advanceTimersByTimeAsync(2_000);
+    MockWebSocket.latest!.simulateError();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnecting).toHaveBeenCalledWith(3);
+    expect(callbacks.onReconnecting).toHaveBeenCalledTimes(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: WS messages received after reconnect are dispatched as commands
+  // -------------------------------------------------------------------------
+
+  it('dispatches commands received on the reconnected WS', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const newWs = MockWebSocket.latest!;
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Simulate a command message on the new WS
+    const cmd = { type: 'ping' };
+    newWs.onmessage?.(new MessageEvent('message', { data: JSON.stringify(cmd) }));
+
+    expect(callbacks.onCommand).toHaveBeenCalledWith(cmd);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: stale onclose from old WS is ignored during reconnection
+  // -------------------------------------------------------------------------
+
+  it('ignores onclose from a stale WebSocket instance', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // Trigger reconnection
+    ws.simulateClose(1006);
+    expect(manager.isReconnecting()).toBe(true);
+
+    // Reconnect successfully
+    await vi.advanceTimersByTimeAsync(1_000);
+    const newWs = MockWebSocket.latest!;
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(manager.isReconnecting()).toBe(false);
+    callbacks.onDisconnect.mockClear();
+    callbacks.onReconnecting.mockClear();
+
+    // Now fire another close on the OLD ws — should be ignored
+    // (the code checks `if (ingestWs !== ws) return;`)
+    ws.simulateClose(1006);
+
+    expect(callbacks.onDisconnect).not.toHaveBeenCalled();
+    expect(manager.isReconnecting()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: successful reconnect on later attempt (not the first)
+  // -------------------------------------------------------------------------
+
+  it('reconnects successfully on a later attempt after initial failures', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+
+    // Fail attempt 1
+    await vi.advanceTimersByTimeAsync(1_000);
+    MockWebSocket.latest!.simulateError();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Fail attempt 2
+    await vi.advanceTimersByTimeAsync(2_000);
+    MockWebSocket.latest!.simulateError();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Succeed attempt 3
+    await vi.advanceTimersByTimeAsync(4_000);
+    const newWs = MockWebSocket.latest!;
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnected).toHaveBeenCalledTimes(1);
+    expect(callbacks.onDisconnect).not.toHaveBeenCalled();
+    expect(manager.isReconnecting()).toBe(false);
+    expect(callbacks.onReconnecting).toHaveBeenCalledTimes(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: isConnected reflects disconnected state during reconnection
+  // -------------------------------------------------------------------------
+
+  it('returns false from isConnected during reconnection', async () => {
+    const manager = createManager();
+    await openConnection(manager);
+
+    // Initially connected
+    expect(manager.isConnected()).toBe(true);
+
+    // Simulate unexpected close
+    MockWebSocket.latest!.simulateClose(1006);
+
+    // During reconnection, not connected
+    expect(manager.isConnected()).toBe(false);
+    expect(manager.isReconnecting()).toBe(true);
+
+    // Reconnect
+    await vi.advanceTimersByTimeAsync(1_000);
+    MockWebSocket.latest!.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // isConnected remains false because SSE consumer is still set from initial open,
+    // but we need the WS to be open. After reconnect the WS is open, so it depends
+    // on whether sseConsumer is non-null. Since we didn't close the SSE consumer,
+    // isConnected should be true.
+    expect(manager.isConnected()).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: no buffer overflow marker when buffer hasn't overflowed
+  // -------------------------------------------------------------------------
+
+  it('sends wrapper_resumed with eventsLost=false when buffer does not overflow', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+
+    // Buffer a single event
+    state.sendToIngest({
+      streamEventType: 'output',
+      timestamp: new Date().toISOString(),
+      data: { text: 'test' },
+    });
+
+    // Reconnect
+    await vi.advanceTimersByTimeAsync(1_000);
+    const newWs = MockWebSocket.latest!;
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const resumeMsg = newWs.sent.find(msg => JSON.parse(msg).streamEventType === 'wrapper_resumed');
+    expect(resumeMsg).toBeDefined();
+    expect(JSON.parse(resumeMsg!).data.eventsLost).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: no wrapper_resumed when no events were buffered
+  // -------------------------------------------------------------------------
+
+  it('does not send wrapper_resumed when no events were buffered', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    ws.simulateClose(1006);
+
+    // Don't send any events during disconnection
+
+    // Reconnect
+    await vi.advanceTimersByTimeAsync(1_000);
+    const newWs = MockWebSocket.latest!;
+    newWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const resumeMsg = newWs.sent.find(msg => JSON.parse(msg).streamEventType === 'wrapper_resumed');
+    expect(resumeMsg).toBeUndefined();
+  });
+});

--- a/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -304,24 +304,6 @@ describe('ingest WS reconnection', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Test: close code 4000 (execution done) — no reconnection
-  // -------------------------------------------------------------------------
-
-  it('does not reconnect on close code 4000 (execution done)', async () => {
-    const manager = createManager();
-    const ws = await openConnection(manager);
-
-    ws.simulateClose(4000);
-
-    expect(callbacks.onDisconnect).toHaveBeenCalledWith('ingest websocket closed (execution done)');
-    expect(manager.isReconnecting()).toBe(false);
-
-    // Verify no reconnection attempts
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(MockWebSocket.instances).toHaveLength(1);
-  });
-
-  // -------------------------------------------------------------------------
   // Test: events are buffered during reconnection and flushed on reconnect
   // -------------------------------------------------------------------------
 

--- a/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -713,4 +713,71 @@ describe('ingest WS reconnection', () => {
     const resumeMsg = newWs.sent.find(msg => JSON.parse(msg).streamEventType === 'wrapper_resumed');
     expect(resumeMsg).toBeUndefined();
   });
+
+  // -------------------------------------------------------------------------
+  // Test: close() during in-flight reconnect discards stale socket
+  // -------------------------------------------------------------------------
+
+  it('discards stale socket when close() is called during in-flight reconnect', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // Trigger reconnection
+    ws.simulateClose(1006);
+    expect(manager.isReconnecting()).toBe(true);
+
+    // Advance past the backoff timer — openIngestWs() is called, new WS created
+    await vi.advanceTimersByTimeAsync(1_000);
+    const reconnectWs = MockWebSocket.latest!;
+    expect(reconnectWs).not.toBe(ws);
+
+    // close() is called before the reconnect WS opens — generation increments
+    await manager.close();
+    expect(manager.isReconnecting()).toBe(false);
+
+    // Now the WS opens (stale) — the generation check should discard it
+    reconnectWs.simulateOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnected).not.toHaveBeenCalled();
+
+    // Verify no heartbeats are running on the stale socket
+    reconnectWs.sent.length = 0;
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(reconnectWs.sent).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test: closedByUs flag does not leak into next execution
+  // -------------------------------------------------------------------------
+
+  it('does not leak closedByUs flag into the next execution', async () => {
+    const manager = createManager();
+    const ws = await openConnection(manager);
+
+    // close() sets closedByUs=true, closes WS, then resets closedByUs=false
+    await manager.close();
+
+    // Old WS fires onclose (stale socket — ignored by guard)
+    ws.simulateClose(1000, 'normal close');
+
+    // Simulate starting a new execution with a fresh manager on the same state
+    // (In production, state.startJob() is called for the new job. Here we
+    // just create a new manager to ensure closedByUs doesn't carry over.)
+    const callbacks2 = createCallbacks();
+    const manager2 = createConnectionManager(
+      state,
+      { kiloServerPort: 4000, kiloClient: createMockKiloClient() },
+      callbacks2
+    );
+    const ws2 = await openConnection(manager2);
+
+    // Simulate unexpected close on the new connection
+    ws2.simulateClose(1006);
+
+    // Should trigger reconnection, NOT be swallowed by closedByUs
+    expect(manager2.isReconnecting()).toBe(true);
+    expect(callbacks2.onDisconnect).not.toHaveBeenCalled();
+    expect(callbacks2.onReconnecting).toHaveBeenCalledWith(1);
+  });
 });

--- a/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/reconnection.test.ts
@@ -257,8 +257,8 @@ describe('ingest WS reconnection', () => {
     ws.simulateClose(1006);
     expect(manager.isReconnecting()).toBe(true);
 
-    // Backoff delays: 1s, 2s, 4s, 8s, 16s
-    const delays = [1_000, 2_000, 4_000, 8_000, 16_000];
+    // Backoff delays: 1s, 2s, 4s (3 attempts)
+    const delays = [1_000, 2_000, 4_000];
 
     for (let i = 0; i < delays.length; i++) {
       expect(callbacks.onReconnecting).toHaveBeenCalledWith(i + 1);
@@ -272,7 +272,7 @@ describe('ingest WS reconnection', () => {
       await vi.advanceTimersByTimeAsync(0);
     }
 
-    // After 5 failures, onDisconnect should fire
+    // After 3 failures, onDisconnect should fire
     expect(callbacks.onDisconnect).toHaveBeenCalledWith(
       'ingest websocket closed (reconnection failed)'
     );

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -54,12 +54,24 @@ export type ConnectionCallbacks = {
   onDisconnect: (reason: string) => void;
   /** Called on any completion event to signal post-processing waiters */
   onCompletionSignal: () => void;
+  /** Called when the ingest WS starts reconnecting */
+  onReconnecting?: (attempt: number) => void;
+  /** Called when the ingest WS successfully reconnects */
+  onReconnected?: () => void;
 };
 
 type WebSocketCtor = new (
   url: string,
   options?: { headers?: Record<string, string> } | string | string[]
 ) => WebSocket;
+
+/** DO sends this close code to signal execution is done — don't reconnect */
+const CLOSE_CODE_EXECUTION_DONE = 4000;
+
+/** Maximum number of reconnection attempts before giving up */
+const MAX_RECONNECT_ATTEMPTS = 5;
+/** Base delay for exponential backoff (1 second) */
+const RECONNECT_BASE_DELAY_MS = 1_000;
 
 // ---------------------------------------------------------------------------
 // Connection Manager
@@ -72,6 +84,8 @@ export type ConnectionManager = {
   close: () => Promise<void>;
   /** Check if currently connected. */
   isConnected: () => boolean;
+  /** Whether the ingest WS is currently attempting to reconnect */
+  isReconnecting: () => boolean;
 };
 
 /**
@@ -88,6 +102,11 @@ export function createConnectionManager(
   let sseConsumer: SSEConsumer | null = null;
   let ingestWs: WebSocket | null = null;
   let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+
+  let closedByUs = false;
+  let reconnecting = false;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Event buffer for disconnection periods
   const MAX_BUFFER_SIZE = 1000;
@@ -171,12 +190,31 @@ export function createConnectionManager(
         resolve();
       };
 
-      ws.onclose = () => {
-        logToFile(`ingest WS closed: ${wsUrl}`);
-        if (ingestWs === ws) {
-          ingestWs = null;
-          callbacks.onDisconnect('ingest websocket closed');
+      ws.onclose = (event: CloseEvent) => {
+        logToFile(
+          `ingest WS closed: code=${event.code} reason=${event.reason || '(none)'} url=${wsUrl}`
+        );
+        if (ingestWs !== ws) return; // Stale socket — ignore
+
+        ingestWs = null;
+
+        if (closedByUs) {
+          // Expected close (during drain/shutdown) — don't reconnect
+          closedByUs = false;
+          return;
         }
+
+        if (event.code === CLOSE_CODE_EXECUTION_DONE) {
+          // DO says execution is done — don't reconnect
+          logToFile('ingest WS closed by DO (execution done) — not reconnecting');
+          callbacks.onDisconnect('ingest websocket closed (execution done)');
+          return;
+        }
+
+        // Unexpected close — attempt reconnection
+        logToFile('ingest WS closed unexpectedly — starting reconnection');
+        stopHeartbeat();
+        attemptReconnect();
       };
 
       ws.onerror = () => {
@@ -351,6 +389,59 @@ export function createConnectionManager(
     }
   }
 
+  function attemptReconnect(): void {
+    if (reconnecting) return;
+    reconnecting = true;
+    reconnectAttempt = 0;
+    scheduleReconnect();
+  }
+
+  function scheduleReconnect(): void {
+    reconnectAttempt++;
+    if (reconnectAttempt > MAX_RECONNECT_ATTEMPTS) {
+      logToFile(`reconnection failed after ${MAX_RECONNECT_ATTEMPTS} attempts — giving up`);
+      reconnecting = false;
+      reconnectAttempt = 0;
+      callbacks.onDisconnect('ingest websocket closed (reconnection failed)');
+      return;
+    }
+
+    const delay = RECONNECT_BASE_DELAY_MS * Math.pow(2, reconnectAttempt - 1);
+    logToFile(`reconnect attempt ${reconnectAttempt}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`);
+    callbacks.onReconnecting?.(reconnectAttempt);
+
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      openIngestWs()
+        .then(() => {
+          logToFile(`reconnected successfully on attempt ${reconnectAttempt}`);
+          reconnecting = false;
+          reconnectAttempt = 0;
+          startHeartbeat();
+          // Update state's WS reference to match the reconnected socket
+          const sseAbort = state.sseAbortController;
+          if (ingestWs && sseAbort) {
+            state.setConnections(ingestWs, sseAbort);
+          }
+          callbacks.onReconnected?.();
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          logToFile(`reconnect attempt ${reconnectAttempt} failed: ${msg}`);
+          scheduleReconnect();
+        });
+    }, delay);
+  }
+
+  function cancelReconnect(): void {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    reconnecting = false;
+    reconnectAttempt = 0;
+  }
+
   return {
     open: async () => {
       logToFile('opening connections');
@@ -367,8 +458,7 @@ export function createConnectionManager(
 
     close: async () => {
       logToFile('closing connections');
-
-      // Stop heartbeat
+      cancelReconnect();
       stopHeartbeat();
 
       // Stop SSE consumer
@@ -379,6 +469,7 @@ export function createConnectionManager(
 
       // Close ingest WS
       if (ingestWs) {
+        closedByUs = true;
         try {
           ingestWs.close();
         } catch {
@@ -397,5 +488,7 @@ export function createConnectionManager(
     isConnected: () => {
       return ingestWs !== null && ingestWs.readyState === WebSocket.OPEN && sseConsumer !== null;
     },
+
+    isReconnecting: () => reconnecting,
   };
 }

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -107,6 +107,7 @@ export function createConnectionManager(
   let reconnecting = false;
   let reconnectAttempt = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let generation = 0;
 
   // Event buffer for disconnection periods
   const MAX_BUFFER_SIZE = 1000;
@@ -396,6 +397,30 @@ export function createConnectionManager(
     scheduleReconnect();
   }
 
+  function completeReconnect(): void {
+    logToFile(`reconnected successfully on attempt ${reconnectAttempt}`);
+    reconnecting = false;
+    reconnectAttempt = 0;
+    startHeartbeat();
+    const sseAbort = state.sseAbortController;
+    if (ingestWs && sseAbort) {
+      state.setConnections(ingestWs, sseAbort);
+    }
+    callbacks.onReconnected?.();
+  }
+
+  function discardStaleReconnect(): void {
+    logToFile('reconnect succeeded but connection was closed — discarding stale socket');
+    if (ingestWs) {
+      try {
+        ingestWs.close();
+      } catch {
+        /* ignore */
+      }
+      ingestWs = null;
+    }
+  }
+
   function scheduleReconnect(): void {
     reconnectAttempt++;
     if (reconnectAttempt > MAX_RECONNECT_ATTEMPTS) {
@@ -412,20 +437,17 @@ export function createConnectionManager(
 
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
+      const gen = generation;
       openIngestWs()
         .then(() => {
-          logToFile(`reconnected successfully on attempt ${reconnectAttempt}`);
-          reconnecting = false;
-          reconnectAttempt = 0;
-          startHeartbeat();
-          // Update state's WS reference to match the reconnected socket
-          const sseAbort = state.sseAbortController;
-          if (ingestWs && sseAbort) {
-            state.setConnections(ingestWs, sseAbort);
+          if (gen !== generation) {
+            discardStaleReconnect();
+            return;
           }
-          callbacks.onReconnected?.();
+          completeReconnect();
         })
         .catch((err: unknown) => {
+          if (gen !== generation) return;
           const msg = err instanceof Error ? err.message : String(err);
           logToFile(`reconnect attempt ${reconnectAttempt} failed: ${msg}`);
           scheduleReconnect();
@@ -458,6 +480,7 @@ export function createConnectionManager(
 
     close: async () => {
       logToFile('closing connections');
+      generation++;
       cancelReconnect();
       stopHeartbeat();
 
@@ -477,6 +500,7 @@ export function createConnectionManager(
         }
         ingestWs = null;
       }
+      closedByUs = false;
 
       // Clear state references
       state.clearConnections();

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -65,9 +65,6 @@ type WebSocketCtor = new (
   options?: { headers?: Record<string, string> } | string | string[]
 ) => WebSocket;
 
-/** DO sends this close code to signal execution is done — don't reconnect */
-const CLOSE_CODE_EXECUTION_DONE = 4000;
-
 /** Maximum number of reconnection attempts before giving up.
  *  3 attempts ≈ 7s total (1+2+4), fitting within the DO's 10s grace period. */
 const MAX_RECONNECT_ATTEMPTS = 3;
@@ -203,13 +200,6 @@ export function createConnectionManager(
         if (closedByUs) {
           // Expected close (during drain/shutdown) — don't reconnect
           closedByUs = false;
-          return;
-        }
-
-        if (event.code === CLOSE_CODE_EXECUTION_DONE) {
-          // DO says execution is done — don't reconnect
-          logToFile('ingest WS closed by DO (execution done) — not reconnecting');
-          callbacks.onDisconnect('ingest websocket closed (execution done)');
           return;
         }
 

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -68,8 +68,9 @@ type WebSocketCtor = new (
 /** DO sends this close code to signal execution is done — don't reconnect */
 const CLOSE_CODE_EXECUTION_DONE = 4000;
 
-/** Maximum number of reconnection attempts before giving up */
-const MAX_RECONNECT_ATTEMPTS = 5;
+/** Maximum number of reconnection attempts before giving up.
+ *  3 attempts ≈ 7s total (1+2+4), fitting within the DO's 10s grace period. */
+const MAX_RECONNECT_ATTEMPTS = 3;
 /** Base delay for exponential backoff (1 second) */
 const RECONNECT_BASE_DELAY_MS = 1_000;
 

--- a/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -144,6 +144,10 @@ export function createLifecycleManager(
     // Only check when has job context
     if (!state.hasJob) return;
 
+    // Skip SSE health checks while the ingest WS is reconnecting — the SSE stream
+    // is still alive, we just can't relay events until the WS reconnects.
+    if (connectionManager.isReconnecting()) return;
+
     const now = Date.now();
 
     // Check SSE inactivity while active (inflight > 0)

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -208,6 +208,13 @@ async function main() {
         // Signal completion to lifecycle manager for post-processing waiters
         getLifecycleManager().signalCompletion();
       },
+      onReconnecting: (attempt: number) => {
+        logToFile(`ingest WS reconnecting: attempt ${attempt}`);
+      },
+      onReconnected: () => {
+        logToFile('ingest WS reconnected');
+        state.clearLastError();
+      },
     }
   );
 


### PR DESCRIPTION
## Summary

Extracts the repeated execution-failure sequence (update status → clear active execution → clear interrupt → broadcast stream event) into a single idempotent `failExecution()` private method on `CloudAgentSession`. Four call sites that previously duplicated this 20+ line pattern now delegate to it: wrapper disconnect, reaper stale-running timeout, reaper pending-start timeout, and the orchestrator catch block.

A public `failExecutionRpc()` wrapper is added so external callers (the interrupt handler in `session-management.ts`) can perform a full failure with cleanup in a single DO call, replacing three separate `withDORetry` calls (`updateExecutionStatus`, `clearActiveExecution`, `emitExecutionError`) with one.

Two new integration tests verify reaper idempotency (second alarm after failure produces no duplicate events) and interrupt-flag cleanup (reaper clears the interrupt flag when failing a stale execution).

## Visual Changes

N/A

## Reviewer Notes

- The `wrapper_disconnected` stream event payload shape changed slightly: old `{ reason, wsCloseCode, wsCloseReason }` → new `{ error, fatal: true, wsCloseCode, wsCloseReason }`. No consumer in the codebase reads the `reason` field (frontend checks only the `streamEventType` discriminator), so this is a safe change.
- `failExecutionRpc` uses `as ExecutionId` — consistent with existing codebase convention at other RPC/WebSocket boundaries (14 occurrences in `src/`).
- `onExecutionComplete` was intentionally not refactored to use `failExecution` because it handles all terminal statuses (including `completed`) and has different active-execution clearing logic (conditional on matching ID rather than unconditional).