### PR TITLE
fix(security): supersede duplicate Dependabot findings

### DIFF
--- a/cloudflare-security-auto-analysis/src/db/queries.ts
+++ b/cloudflare-security-auto-analysis/src/db/queries.ts
@@ -543,12 +543,17 @@ export async function setFindingRunning(
     );
 }
 
+/**
+ * Mark a finding's analysis as completed.
+ * Returns false if the finding was superseded (guard tripped, no rows updated).
+ * The caller should clear analysis_status when this returns false.
+ */
 export async function setFindingCompleted(
   db: WorkerDb,
   findingId: string,
   analysis: SecurityFindingAnalysis
-): Promise<void> {
-  await db
+): Promise<boolean> {
+  const rows = await db
     .update(security_findings)
     .set({
       analysis_status: 'completed',
@@ -565,15 +570,23 @@ export async function setFindingCompleted(
           not(like(security_findings.ignored_reason, 'superseded:%'))
         )
       )
-    );
+    )
+    .returning({ id: security_findings.id });
+
+  return rows.length > 0;
 }
 
+/**
+ * Mark a finding's analysis as failed.
+ * Returns false if the finding was superseded (guard tripped, no rows updated).
+ * The caller should clear analysis_status when this returns false.
+ */
 export async function setFindingFailed(
   db: WorkerDb,
   findingId: string,
   errorMessage: string
-): Promise<void> {
-  await db
+): Promise<boolean> {
+  const rows = await db
     .update(security_findings)
     .set({
       analysis_status: 'failed',
@@ -589,5 +602,22 @@ export async function setFindingFailed(
           not(like(security_findings.ignored_reason, 'superseded:%'))
         )
       )
-    );
+    )
+    .returning({ id: security_findings.id });
+
+  return rows.length > 0;
+}
+
+/**
+ * Clear analysis_status so a superseded finding no longer counts against
+ * the owner's concurrency cap in countRunningAnalyses().
+ */
+export async function clearAnalysisStatus(db: WorkerDb, findingId: string): Promise<void> {
+  await db
+    .update(security_findings)
+    .set({
+      analysis_status: null,
+      updated_at: sql`now()`.mapWith(String),
+    })
+    .where(eq(security_findings.id, findingId));
 }

--- a/cloudflare-security-auto-analysis/src/db/queries.ts
+++ b/cloudflare-security-auto-analysis/src/db/queries.ts
@@ -504,7 +504,15 @@ export async function setFindingPending(
       cli_session_id: null,
       updated_at: sql`now()`.mapWith(String),
     })
-    .where(eq(security_findings.id, findingId));
+    .where(
+      and(
+        eq(security_findings.id, findingId),
+        or(
+          isNull(security_findings.ignored_reason),
+          not(like(security_findings.ignored_reason, 'superseded:%'))
+        )
+      )
+    );
 }
 
 export async function setFindingRunning(
@@ -524,7 +532,15 @@ export async function setFindingRunning(
       ),
       updated_at: sql`now()`.mapWith(String),
     })
-    .where(eq(security_findings.id, findingId));
+    .where(
+      and(
+        eq(security_findings.id, findingId),
+        or(
+          isNull(security_findings.ignored_reason),
+          not(like(security_findings.ignored_reason, 'superseded:%'))
+        )
+      )
+    );
 }
 
 export async function setFindingCompleted(

--- a/cloudflare-security-auto-analysis/src/db/queries.ts
+++ b/cloudflare-security-auto-analysis/src/db/queries.ts
@@ -7,7 +7,7 @@ import {
   kilocode_users,
   organization_memberships,
 } from '@kilocode/db/schema';
-import { and, asc, count, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm';
+import { and, asc, count, eq, inArray, isNull, lte, not, like, or, sql } from 'drizzle-orm';
 import type { QueueOwner, SecurityAgentConfig, SecurityFindingAnalysis } from '../types.js';
 import {
   AUTO_ANALYSIS_OWNER_CAP,
@@ -541,7 +541,15 @@ export async function setFindingCompleted(
       analysis_completed_at: sql`now()`.mapWith(String),
       updated_at: sql`now()`.mapWith(String),
     })
-    .where(eq(security_findings.id, findingId));
+    .where(
+      and(
+        eq(security_findings.id, findingId),
+        or(
+          isNull(security_findings.ignored_reason),
+          not(like(security_findings.ignored_reason, 'superseded:%'))
+        )
+      )
+    );
 }
 
 export async function setFindingFailed(
@@ -557,5 +565,13 @@ export async function setFindingFailed(
       analysis_completed_at: sql`now()`.mapWith(String),
       updated_at: sql`now()`.mapWith(String),
     })
-    .where(eq(security_findings.id, findingId));
+    .where(
+      and(
+        eq(security_findings.id, findingId),
+        or(
+          isNull(security_findings.ignored_reason),
+          not(like(security_findings.ignored_reason, 'superseded:%'))
+        )
+      )
+    );
 }

--- a/cloudflare-security-auto-analysis/src/launch.ts
+++ b/cloudflare-security-auto-analysis/src/launch.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import type { WorkerDb } from '@kilocode/db/client';
 import {
+  clearAnalysisStatus,
   getSecurityFindingById,
   setFindingCompleted,
   setFindingFailed,
@@ -156,7 +157,13 @@ export async function startSecurityAnalysis(
         triggeredByUserId: params.actorUser.id,
         correlationId,
       };
-      await setFindingCompleted(params.db, params.findingId, triageOnlyAnalysis);
+      const written = await setFindingCompleted(params.db, params.findingId, triageOnlyAnalysis);
+      if (!written) {
+        // Finding was superseded between lease acquisition and completion.
+        // Clear stale analysis_status so it doesn't count against the concurrency cap.
+        await clearAnalysisStatus(params.db, params.findingId);
+        return { started: false, error: 'Finding was superseded during analysis' };
+      }
       return { started: true, triageOnly: true };
     }
 
@@ -202,13 +209,23 @@ export async function startSecurityAnalysis(
 
     if (!prepareResponse.ok) {
       const errorText = await prepareResponse.text();
-      await setFindingFailed(params.db, params.findingId, errorText);
+      if (!(await setFindingFailed(params.db, params.findingId, errorText))) {
+        await clearAnalysisStatus(params.db, params.findingId);
+      }
       return { started: false, error: errorText };
     }
 
     const parsedPrepare = PrepareSessionResponseSchema.safeParse(await prepareResponse.json());
     if (!parsedPrepare.success) {
-      await setFindingFailed(params.db, params.findingId, 'Invalid prepareSession response shape');
+      if (
+        !(await setFindingFailed(
+          params.db,
+          params.findingId,
+          'Invalid prepareSession response shape'
+        ))
+      ) {
+        await clearAnalysisStatus(params.db, params.findingId);
+      }
       return { started: false, error: 'Invalid prepareSession response shape' };
     }
 
@@ -228,7 +245,9 @@ export async function startSecurityAnalysis(
 
     if (!initiateResponse.ok) {
       const errorText = await initiateResponse.text();
-      await setFindingFailed(params.db, params.findingId, errorText);
+      if (!(await setFindingFailed(params.db, params.findingId, errorText))) {
+        await clearAnalysisStatus(params.db, params.findingId);
+      }
 
       if (initiateResponse.status === 402) {
         throw new InsufficientCreditsError(errorText || 'Insufficient credits');
@@ -242,11 +261,15 @@ export async function startSecurityAnalysis(
 
     const parsedInitiate = InitiateResponseSchema.safeParse(await initiateResponse.json());
     if (!parsedInitiate.success) {
-      await setFindingFailed(
-        params.db,
-        params.findingId,
-        'Invalid initiateFromKilocodeSessionV2 response shape'
-      );
+      if (
+        !(await setFindingFailed(
+          params.db,
+          params.findingId,
+          'Invalid initiateFromKilocodeSessionV2 response shape'
+        ))
+      ) {
+        await clearAnalysisStatus(params.db, params.findingId);
+      }
       return {
         started: false,
         error: 'Invalid initiateFromKilocodeSessionV2 response shape',
@@ -267,7 +290,9 @@ export async function startSecurityAnalysis(
       error: errorMessage,
     });
 
-    await setFindingFailed(params.db, params.findingId, errorMessage);
+    if (!(await setFindingFailed(params.db, params.findingId, errorMessage))) {
+      await clearAnalysisStatus(params.db, params.findingId);
+    }
     return { started: false, error: errorMessage };
   }
 }

--- a/cloudflare-security-sync/src/sync.ts
+++ b/cloudflare-security-sync/src/sync.ts
@@ -6,12 +6,13 @@
  */
 
 import { z } from 'zod';
-import { eq, and, isNotNull, sql } from 'drizzle-orm';
+import { eq, and, inArray, isNotNull, or, sql } from 'drizzle-orm';
 import type { WorkerDb } from '@kilocode/db/client';
 import {
   agent_configs,
   platform_integrations,
   security_findings,
+  security_analysis_queue,
   security_audit_log,
 } from '@kilocode/db/schema';
 import { SecurityAuditLogAction } from '@kilocode/db/schema-types';
@@ -391,7 +392,9 @@ async function upsertSecurityFinding(
 ): Promise<void> {
   const { finding, owner, platformIntegrationId, repoFullName, slaDueAt } = params;
 
-  // Fields that are updated on conflict (shared between insert and upsert)
+  // Fields that are updated on conflict (shared between insert and upsert).
+  // status, ignored_reason, and ignored_by are excluded here because the
+  // ON CONFLICT clause needs conditional logic to preserve superseded state.
   const mutableFields = {
     severity: finding.severity,
     ghsa_id: finding.ghsa_id,
@@ -400,9 +403,6 @@ async function upsertSecurityFinding(
     patched_version: finding.patched_version,
     title: finding.title,
     description: finding.description,
-    status: finding.status,
-    ignored_reason: finding.ignored_reason,
-    ignored_by: finding.ignored_by,
     fixed_at: finding.fixed_at,
     sla_due_at: slaDueAt,
     dependabot_html_url: finding.dependabot_html_url,
@@ -425,6 +425,9 @@ async function upsertSecurityFinding(
       package_ecosystem: finding.package_ecosystem,
       manifest_path: finding.manifest_path,
       first_detected_at: finding.first_detected_at,
+      status: finding.status,
+      ignored_reason: finding.ignored_reason,
+      ignored_by: finding.ignored_by,
       ...mutableFields,
     })
     .onConflictDoUpdate({
@@ -435,10 +438,101 @@ async function upsertSecurityFinding(
       ],
       set: {
         ...mutableFields,
+        status: sql`CASE WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.status} ELSE ${finding.status} END`,
+        ignored_reason: sql`CASE WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_reason} ELSE ${finding.ignored_reason} END`,
+        ignored_by: sql`CASE WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_by} ELSE ${finding.ignored_by} END`,
         last_synced_at: sql`now()`,
         updated_at: sql`now()`,
       },
     });
+}
+
+type SupersedeResult = { count: number; supersededFindingIds: string[] };
+
+async function supersedeDuplicateFindings(
+  db: WorkerDb,
+  repoFullName: string
+): Promise<SupersedeResult> {
+  try {
+    const result = await db.execute<{ id: string }>(sql`
+      WITH ranked AS (
+        SELECT
+          id,
+          ROW_NUMBER() OVER (
+            PARTITION BY repo_full_name, source, ghsa_id, package_name, manifest_path
+            ORDER BY source_id::int DESC
+          ) AS rn,
+          FIRST_VALUE(id) OVER (
+            PARTITION BY repo_full_name, source, ghsa_id, package_name, manifest_path
+            ORDER BY source_id::int DESC
+          ) AS canonical_id
+        FROM security_findings
+        WHERE repo_full_name = ${repoFullName}
+          AND source = 'dependabot'
+          AND ghsa_id IS NOT NULL
+          AND status = 'open'
+      ),
+      superseded AS (
+        UPDATE security_findings
+        SET
+          status = 'ignored',
+          ignored_reason = 'superseded:' || ranked.canonical_id,
+          ignored_by = 'system',
+          updated_at = now()
+        FROM ranked
+        WHERE security_findings.id = ranked.id
+          AND ranked.rn > 1
+        RETURNING security_findings.id
+      )
+      SELECT id FROM superseded
+    `);
+    const supersededFindingIds = result.rows.map(r => r.id);
+    return { count: supersededFindingIds.length, supersededFindingIds };
+  } catch (error) {
+    // Best-effort: don't let dedup failures break the sync.
+    console.error(`Error superseding duplicate findings for ${repoFullName}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { count: 0, supersededFindingIds: [] };
+  }
+}
+
+/**
+ * Remove superseded findings from the auto-analysis queue so the worker
+ * doesn't analyze findings that are no longer open.
+ */
+async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Promise<number> {
+  if (findingIds.length === 0) return 0;
+
+  try {
+    const result = await db
+      .update(security_analysis_queue)
+      .set({
+        queue_status: 'completed',
+        failure_code: 'SKIPPED_NO_LONGER_ELIGIBLE',
+        claim_token: null,
+        claimed_at: null,
+        claimed_by_job_id: null,
+        updated_at: sql`now()`,
+      })
+      .where(
+        and(
+          inArray(security_analysis_queue.finding_id, findingIds),
+          or(
+            eq(security_analysis_queue.queue_status, 'queued'),
+            eq(security_analysis_queue.queue_status, 'pending')
+          )
+        )
+      )
+      .returning({ id: security_analysis_queue.id });
+
+    return result.length;
+  } catch (error) {
+    console.error('Error dequeuing superseded findings from analysis queue', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return 0;
+  }
 }
 
 async function writeAuditLog(
@@ -674,6 +768,18 @@ async function syncRepo(params: {
         alertNumber: finding.source_id,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  const { count: supersededCount, supersededFindingIds } = await supersedeDuplicateFindings(
+    database,
+    repoFullName
+  );
+  if (supersededCount > 0) {
+    console.info(`Superseded ${supersededCount} duplicate finding(s) for ${repoFullName}`);
+    const dequeued = await dequeueSupersededFindings(database, supersededFindingIds);
+    if (dequeued > 0) {
+      console.info(`Dequeued ${dequeued} superseded finding(s) from auto-analysis queue`);
     }
   }
 

--- a/cloudflare-security-sync/src/sync.ts
+++ b/cloudflare-security-sync/src/sync.ts
@@ -501,9 +501,10 @@ async function supersedeDuplicateFindings(
  * Remove superseded findings from the auto-analysis queue so the worker
  * doesn't analyze findings that are no longer open.
  *
- * Also clears `analysis_status` on the findings themselves so a lease
- * acquired between supersede and dequeue doesn't keep the finding
- * counted against the owner's concurrency cap.
+ * Clears `analysis_status` for `pending` findings so they no longer count
+ * against the owner's concurrency cap. Already-running analyses are left
+ * alone — the callback route guards against superseded findings, so those
+ * jobs will be discarded when they report back.
  */
 async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Promise<number> {
   if (findingIds.length === 0) return 0;
@@ -530,8 +531,12 @@ async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Pr
       )
       .returning({ id: security_analysis_queue.id });
 
-    // Clear any in-flight analysis_status so countRunningAnalyses no longer
-    // counts these superseded findings against the owner's concurrency cap.
+    // Clear pending analysis_status so countRunningAnalyses no longer counts
+    // these superseded findings against the owner's concurrency cap.
+    // Running analyses are left alone — the callback route checks
+    // finding.ignored_reason and will skip superseded findings when the job
+    // completes, avoiding a race where we clear the status and the callback
+    // immediately writes it back.
     await db
       .update(security_findings)
       .set({
@@ -541,10 +546,7 @@ async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Pr
       .where(
         and(
           inArray(security_findings.id, findingIds),
-          or(
-            eq(security_findings.analysis_status, 'pending'),
-            eq(security_findings.analysis_status, 'running')
-          )
+          eq(security_findings.analysis_status, 'pending')
         )
       );
 

--- a/cloudflare-security-sync/src/sync.ts
+++ b/cloudflare-security-sync/src/sync.ts
@@ -500,6 +500,10 @@ async function supersedeDuplicateFindings(
 /**
  * Remove superseded findings from the auto-analysis queue so the worker
  * doesn't analyze findings that are no longer open.
+ *
+ * Also clears `analysis_status` on the findings themselves so a lease
+ * acquired between supersede and dequeue doesn't keep the finding
+ * counted against the owner's concurrency cap.
  */
 async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Promise<number> {
   if (findingIds.length === 0) return 0;
@@ -525,6 +529,24 @@ async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Pr
         )
       )
       .returning({ id: security_analysis_queue.id });
+
+    // Clear any in-flight analysis_status so countRunningAnalyses no longer
+    // counts these superseded findings against the owner's concurrency cap.
+    await db
+      .update(security_findings)
+      .set({
+        analysis_status: null,
+        updated_at: sql`now()`,
+      })
+      .where(
+        and(
+          inArray(security_findings.id, findingIds),
+          or(
+            eq(security_findings.analysis_status, 'pending'),
+            eq(security_findings.analysis_status, 'running')
+          )
+        )
+      );
 
     return result.length;
   } catch (error) {

--- a/cloudflare-security-sync/src/sync.ts
+++ b/cloudflare-security-sync/src/sync.ts
@@ -460,11 +460,11 @@ async function supersedeDuplicateFindings(
           id,
           ROW_NUMBER() OVER (
             PARTITION BY repo_full_name, source, ghsa_id, package_name, manifest_path
-            ORDER BY source_id::int DESC
+            ORDER BY CASE WHEN source_id ~ '^\d+$' THEN source_id::int ELSE 0 END DESC
           ) AS rn,
           FIRST_VALUE(id) OVER (
             PARTITION BY repo_full_name, source, ghsa_id, package_name, manifest_path
-            ORDER BY source_id::int DESC
+            ORDER BY CASE WHEN source_id ~ '^\d+$' THEN source_id::int ELSE 0 END DESC
           ) AS canonical_id
         FROM security_findings
         WHERE repo_full_name = ${repoFullName}

--- a/cloudflare-security-sync/src/sync.ts
+++ b/cloudflare-security-sync/src/sync.ts
@@ -503,8 +503,8 @@ async function supersedeDuplicateFindings(
  *
  * Clears `analysis_status` for `pending` findings so they no longer count
  * against the owner's concurrency cap. Already-running analyses are left
- * alone — the callback route guards against superseded findings, so those
- * jobs will be discarded when they report back.
+ * alone — the callback route transitions their queue rows when the job
+ * reports back, releasing the concurrency slot at that point.
  */
 async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Promise<number> {
   if (findingIds.length === 0) return 0;
@@ -533,10 +533,8 @@ async function dequeueSupersededFindings(db: WorkerDb, findingIds: string[]): Pr
 
     // Clear pending analysis_status so countRunningAnalyses no longer counts
     // these superseded findings against the owner's concurrency cap.
-    // Running analyses are left alone — the callback route checks
-    // finding.ignored_reason and will skip superseded findings when the job
-    // completes, avoiding a race where we clear the status and the callback
-    // immediately writes it back.
+    // Running analyses are left alone — the callback route transitions their
+    // queue rows when the job completes, releasing the concurrency slot.
     await db
       .update(security_findings)
       .set({

--- a/cloudflare-security-sync/src/sync.ts
+++ b/cloudflare-security-sync/src/sync.ts
@@ -460,11 +460,11 @@ async function supersedeDuplicateFindings(
           id,
           ROW_NUMBER() OVER (
             PARTITION BY repo_full_name, source, ghsa_id, package_name, manifest_path
-            ORDER BY CASE WHEN source_id ~ '^\d+$' THEN source_id::int ELSE 0 END DESC
+            ORDER BY CASE WHEN source_id ~ '^[0-9]+$' THEN source_id::int ELSE 0 END DESC
           ) AS rn,
           FIRST_VALUE(id) OVER (
             PARTITION BY repo_full_name, source, ghsa_id, package_name, manifest_path
-            ORDER BY CASE WHEN source_id ~ '^\d+$' THEN source_id::int ELSE 0 END DESC
+            ORDER BY CASE WHEN source_id ~ '^[0-9]+$' THEN source_id::int ELSE 0 END DESC
           ) AS canonical_id
         FROM security_findings
         WHERE repo_full_name = ${repoFullName}

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
@@ -66,8 +66,13 @@ jest.mock('@/lib/security-agent/db/security-findings', () => ({
   getSecurityFindingById: mockGetSecurityFindingById,
 }));
 
+const mockClearAnalysisStatus = jest.fn() as jest.MockedFunction<
+  typeof securityAnalysisModule.clearAnalysisStatus
+>;
+
 jest.mock('@/lib/security-agent/db/security-analysis', () => ({
   updateAnalysisStatus: mockUpdateAnalysisStatus,
+  clearAnalysisStatus: mockClearAnalysisStatus,
   transitionAutoAnalysisQueueFromCallback: mockTransitionAutoAnalysisQueueFromCallback,
 }));
 
@@ -236,7 +241,7 @@ beforeEach(async () => {
   jest.clearAllMocks();
   jest.useFakeTimers();
   afterPromises = [];
-  mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+  mockUpdateAnalysisStatus.mockResolvedValue(true);
   mockTransitionAutoAnalysisQueueFromCallback.mockResolvedValue(undefined);
   mockFinalizeAnalysis.mockResolvedValue(undefined);
   ({ POST } = await import('./route'));
@@ -332,9 +337,7 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
         toStatus: 'completed',
         failureCode: 'SKIPPED_NO_LONGER_ELIGIBLE',
       });
-      expect(mockUpdateAnalysisStatus).toHaveBeenCalledWith(FINDING_ID, 'failed', {
-        error: 'Superseded before callback arrived',
-      });
+      expect(mockClearAnalysisStatus).toHaveBeenCalledWith(FINDING_ID);
     });
 
     it('skips processing when finding is already completed', async () => {

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
@@ -311,7 +311,7 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       );
     });
 
-    it('skips processing when finding has been superseded but transitions queue row', async () => {
+    it('skips processing when finding has been superseded but transitions queue row and clears analysis_status', async () => {
       mockGetSecurityFindingById.mockResolvedValue(
         createMockFinding({
           status: 'ignored',
@@ -327,11 +327,13 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       const body = await response.json();
       expect(body.success).toBe(true);
       expect(body.message).toBe('Superseded finding ignored');
-      expect(mockUpdateAnalysisStatus).not.toHaveBeenCalled();
       expect(mockTransitionAutoAnalysisQueueFromCallback).toHaveBeenCalledWith({
         findingId: FINDING_ID,
         toStatus: 'completed',
         failureCode: 'SKIPPED_NO_LONGER_ELIGIBLE',
+      });
+      expect(mockUpdateAnalysisStatus).toHaveBeenCalledWith(FINDING_ID, 'failed', {
+        error: 'Superseded before callback arrived',
       });
     });
 

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
@@ -311,6 +311,26 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       );
     });
 
+    it('skips processing when finding has been superseded', async () => {
+      mockGetSecurityFindingById.mockResolvedValue(
+        createMockFinding({
+          status: 'ignored',
+          ignored_reason: 'superseded:finding-canonical-1',
+          ignored_by: 'system',
+        })
+      );
+      const req = makeRequest(FINDING_ID, completedPayload);
+
+      const response = await POST(req, makeParams(FINDING_ID));
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.message).toBe('Superseded finding ignored');
+      expect(mockUpdateAnalysisStatus).not.toHaveBeenCalled();
+      expect(mockTransitionAutoAnalysisQueueFromCallback).not.toHaveBeenCalled();
+    });
+
     it('skips processing when finding is already completed', async () => {
       mockGetSecurityFindingById.mockResolvedValue(
         createMockFinding({ analysis_status: 'completed' })

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.test.ts
@@ -311,7 +311,7 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       );
     });
 
-    it('skips processing when finding has been superseded', async () => {
+    it('skips processing when finding has been superseded but transitions queue row', async () => {
       mockGetSecurityFindingById.mockResolvedValue(
         createMockFinding({
           status: 'ignored',
@@ -328,7 +328,11 @@ describe('POST /api/internal/security-analysis-callback/[findingId]', () => {
       expect(body.success).toBe(true);
       expect(body.message).toBe('Superseded finding ignored');
       expect(mockUpdateAnalysisStatus).not.toHaveBeenCalled();
-      expect(mockTransitionAutoAnalysisQueueFromCallback).not.toHaveBeenCalled();
+      expect(mockTransitionAutoAnalysisQueueFromCallback).toHaveBeenCalledWith({
+        findingId: FINDING_ID,
+        toStatus: 'completed',
+        failureCode: 'SKIPPED_NO_LONGER_ELIGIBLE',
+      });
     });
 
     it('skips processing when finding is already completed', async () => {

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -5,6 +5,7 @@ import { captureException, captureMessage } from '@sentry/nextjs';
 import { getSecurityFindingById } from '@/lib/security-agent/db/security-findings';
 import {
   updateAnalysisStatus,
+  clearAnalysisStatus,
   transitionAutoAnalysisQueueFromCallback,
   type AutoAnalysisFailureCode,
 } from '@/lib/security-agent/db/security-analysis';
@@ -147,9 +148,9 @@ export async function POST(
         toStatus: 'completed',
         failureCode: 'SKIPPED_NO_LONGER_ELIGIBLE',
       });
-      await updateAnalysisStatus(findingId, 'failed', {
-        error: 'Superseded before callback arrived',
-      });
+      // Use clearAnalysisStatus (not updateAnalysisStatus) because the finding
+      // is already superseded and updateAnalysisStatus's guard would no-op.
+      await clearAnalysisStatus(findingId);
       return NextResponse.json({ success: true, message: 'Superseded finding ignored' });
     }
 
@@ -179,9 +180,13 @@ export async function POST(
             findingId,
             status: unknownStatus,
           });
-          await updateAnalysisStatus(findingId, 'failed', {
-            error: `Unknown callback status: ${unknownStatus}`,
-          });
+          if (
+            !(await updateAnalysisStatus(findingId, 'failed', {
+              error: `Unknown callback status: ${unknownStatus}`,
+            }))
+          ) {
+            await clearAnalysisStatus(findingId);
+          }
           await transitionAutoAnalysisQueueFromCallback({
             findingId,
             toStatus: 'failed',
@@ -254,9 +259,13 @@ async function handleAnalysisCompleted(
 
   if (!triggeredByUserId) {
     logError('Missing triggeredByUserId in analysis context', { findingId, correlationId });
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: 'Cannot process callback — triggeredByUserId missing from analysis context',
-    });
+    if (
+      !(await updateAnalysisStatus(findingId, 'failed', {
+        error: 'Cannot process callback — triggeredByUserId missing from analysis context',
+      }))
+    ) {
+      await clearAnalysisStatus(findingId);
+    }
     await transitionAutoAnalysisQueueFromCallback({
       findingId,
       toStatus: 'failed',
@@ -269,9 +278,13 @@ async function handleAnalysisCompleted(
   const kiloSessionId = payload.kiloSessionId;
   if (!kiloSessionId) {
     logError('Callback missing kiloSessionId', { findingId, correlationId });
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: 'Callback missing kiloSessionId — cannot retrieve analysis result',
-    });
+    if (
+      !(await updateAnalysisStatus(findingId, 'failed', {
+        error: 'Callback missing kiloSessionId — cannot retrieve analysis result',
+      }))
+    ) {
+      await clearAnalysisStatus(findingId);
+    }
     await transitionAutoAnalysisQueueFromCallback({
       findingId,
       toStatus: 'failed',
@@ -330,9 +343,13 @@ async function handleAnalysisCompleted(
       kiloSessionId,
       attempts: maxAttempts,
     });
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: 'Analysis completed but result could not be retrieved from ingest service',
-    });
+    if (
+      !(await updateAnalysisStatus(findingId, 'failed', {
+        error: 'Analysis completed but result could not be retrieved from ingest service',
+      }))
+    ) {
+      await clearAnalysisStatus(findingId);
+    }
     await transitionAutoAnalysisQueueFromCallback({
       findingId,
       toStatus: 'failed',
@@ -365,9 +382,13 @@ async function handleAnalysisCompleted(
       correlationId,
       triggeredByUserId,
     });
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: `User ${triggeredByUserId} not found — cannot run Tier 3 extraction`,
-    });
+    if (
+      !(await updateAnalysisStatus(findingId, 'failed', {
+        error: `User ${triggeredByUserId} not found — cannot run Tier 3 extraction`,
+      }))
+    ) {
+      await clearAnalysisStatus(findingId);
+    }
     await transitionAutoAnalysisQueueFromCallback({
       findingId,
       toStatus: 'failed',
@@ -482,7 +503,9 @@ async function handleAnalysisFailed(
     });
   }
 
-  await updateAnalysisStatus(findingId, 'failed', { error: errorMessage });
+  if (!(await updateAnalysisStatus(findingId, 'failed', { error: errorMessage }))) {
+    await clearAnalysisStatus(findingId);
+  }
   await transitionAutoAnalysisQueueFromCallback({
     findingId,
     toStatus: 'failed',

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -133,6 +133,16 @@ export async function POST(
       return NextResponse.json({ success: true, message: 'Stale callback ignored' });
     }
 
+    // Skip if finding was superseded — the analysis result is no longer relevant.
+    if (finding.ignored_reason?.startsWith('superseded:')) {
+      log('Finding was superseded, skipping callback', {
+        findingId,
+        ignoredReason: finding.ignored_reason,
+        callbackStatus: payload.status,
+      });
+      return NextResponse.json({ success: true, message: 'Superseded finding ignored' });
+    }
+
     // Skip if already in a terminal state
     if (finding.analysis_status === 'completed' || finding.analysis_status === 'failed') {
       log('Finding already in terminal state, skipping callback', {

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -134,7 +134,8 @@ export async function POST(
     }
 
     // Skip if finding was superseded — the analysis result is no longer relevant.
-    // Transition the queue row so it doesn't permanently hold a concurrency slot.
+    // Transition the queue row and clear analysis_status so this finding no longer
+    // counts against the owner's concurrency cap in countRunningAnalyses().
     if (finding.ignored_reason?.startsWith('superseded:')) {
       log('Finding was superseded, skipping callback', {
         findingId,
@@ -145,6 +146,9 @@ export async function POST(
         findingId,
         toStatus: 'completed',
         failureCode: 'SKIPPED_NO_LONGER_ELIGIBLE',
+      });
+      await updateAnalysisStatus(findingId, 'failed', {
+        error: 'Superseded before callback arrived',
       });
       return NextResponse.json({ success: true, message: 'Superseded finding ignored' });
     }

--- a/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
+++ b/src/app/api/internal/security-analysis-callback/[findingId]/route.ts
@@ -134,11 +134,17 @@ export async function POST(
     }
 
     // Skip if finding was superseded — the analysis result is no longer relevant.
+    // Transition the queue row so it doesn't permanently hold a concurrency slot.
     if (finding.ignored_reason?.startsWith('superseded:')) {
       log('Finding was superseded, skipping callback', {
         findingId,
         ignoredReason: finding.ignored_reason,
         callbackStatus: payload.status,
+      });
+      await transitionAutoAnalysisQueueFromCallback({
+        findingId,
+        toStatus: 'completed',
+        failureCode: 'SKIPPED_NO_LONGER_ELIGIBLE',
       });
       return NextResponse.json({ success: true, message: 'Superseded finding ignored' });
     }

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -5,7 +5,7 @@ import {
   security_analysis_owner_state,
   type SecurityFinding,
 } from '@kilocode/db/schema';
-import { eq, and, sql, count, isNotNull, desc, or, isNull } from 'drizzle-orm';
+import { eq, and, sql, count, isNotNull, desc, or, isNull, inArray } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import type {
   AutoAnalysisMinSeverity,
@@ -670,6 +670,41 @@ export async function enqueueBacklogFindings(params: {
   `);
 
   return result.rows.length;
+}
+
+/**
+ * Remove superseded findings from the auto-analysis queue so the worker
+ * doesn't analyze findings that are no longer open.
+ *
+ * Targets both `queued` and `pending` (claimed but not yet running) rows
+ * because the auto-analysis worker may claim rows between per-finding
+ * enqueue and this repo-level cleanup.
+ */
+export async function dequeueSupersededFindings(findingIds: string[]): Promise<number> {
+  if (findingIds.length === 0) return 0;
+
+  const result = await db
+    .update(security_analysis_queue)
+    .set({
+      queue_status: 'completed',
+      failure_code: 'SKIPPED_NO_LONGER_ELIGIBLE',
+      claim_token: null,
+      claimed_at: null,
+      claimed_by_job_id: null,
+      updated_at: sql`now()`,
+    })
+    .where(
+      and(
+        inArray(security_analysis_queue.finding_id, findingIds),
+        or(
+          eq(security_analysis_queue.queue_status, 'queued'),
+          eq(security_analysis_queue.queue_status, 'pending')
+        )
+      )
+    )
+    .returning({ id: security_analysis_queue.id });
+
+  return result.length;
 }
 
 export async function transitionAutoAnalysisQueueFromCallback(params: {

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -125,6 +125,10 @@ export function isFindingEligibleForAutoAnalysis(params: {
   return { eligible: effectiveRank <= maxRank, severityRank: effectiveRank };
 }
 
+/**
+ * Update the analysis status of a finding.
+ * Returns false if the finding was superseded (guard tripped, no rows updated).
+ */
 export async function updateAnalysisStatus(
   findingId: string,
   status: SecurityFindingAnalysisStatus,
@@ -134,7 +138,7 @@ export async function updateAnalysisStatus(
     error?: string;
     analysis?: SecurityFindingAnalysis;
   } = {}
-): Promise<void> {
+): Promise<boolean> {
   try {
     const updateData: Record<string, unknown> = {
       analysis_status: status,
@@ -172,7 +176,7 @@ export async function updateAnalysisStatus(
       updateData.analysis_completed_at = sql`now()`;
     }
 
-    await db
+    const rows = await db
       .update(security_findings)
       .set(updateData)
       .where(
@@ -183,7 +187,10 @@ export async function updateAnalysisStatus(
             not(like(security_findings.ignored_reason, 'superseded:%'))
           )
         )
-      );
+      )
+      .returning({ id: security_findings.id });
+
+    return rows.length > 0;
   } catch (error) {
     captureException(error, {
       tags: { operation: 'updateAnalysisStatus' },
@@ -191,6 +198,20 @@ export async function updateAnalysisStatus(
     });
     throw error;
   }
+}
+
+/**
+ * Clear analysis_status so a superseded finding no longer counts against
+ * the owner's concurrency cap in countRunningAnalyses().
+ */
+export async function clearAnalysisStatus(findingId: string): Promise<void> {
+  await db
+    .update(security_findings)
+    .set({
+      analysis_status: null,
+      updated_at: sql`now()`,
+    })
+    .where(eq(security_findings.id, findingId));
 }
 
 export async function countRunningAnalyses(owner: SecurityReviewOwner): Promise<number> {

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -682,8 +682,8 @@ export async function enqueueBacklogFindings(params: {
  *
  * Clears `analysis_status` for `pending` findings so they no longer count
  * against the owner's concurrency cap. Already-running analyses are left
- * alone — the callback route guards against superseded findings, so those
- * jobs will be discarded when they report back.
+ * alone — the callback route transitions their queue rows when the job
+ * reports back, releasing the concurrency slot at that point.
  */
 export async function dequeueSupersededFindings(findingIds: string[]): Promise<number> {
   if (findingIds.length === 0) return 0;
@@ -711,10 +711,8 @@ export async function dequeueSupersededFindings(findingIds: string[]): Promise<n
 
   // Clear pending analysis_status so countRunningAnalyses no longer counts
   // these superseded findings against the owner's concurrency cap.
-  // Running analyses are left alone — the callback route checks
-  // finding.ignored_reason and will skip superseded findings when the job
-  // completes, avoiding a race where we clear the status and the callback
-  // immediately writes it back.
+  // Running analyses are left alone — the callback route transitions their
+  // queue rows when the job completes, releasing the concurrency slot.
   await db
     .update(security_findings)
     .set({

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -680,9 +680,10 @@ export async function enqueueBacklogFindings(params: {
  * because the auto-analysis worker may claim rows between per-finding
  * enqueue and this repo-level cleanup.
  *
- * Also clears `analysis_status` on the findings themselves so a lease
- * acquired between supersede and dequeue doesn't keep the finding
- * counted against the owner's concurrency cap.
+ * Clears `analysis_status` for `pending` findings so they no longer count
+ * against the owner's concurrency cap. Already-running analyses are left
+ * alone — the callback route guards against superseded findings, so those
+ * jobs will be discarded when they report back.
  */
 export async function dequeueSupersededFindings(findingIds: string[]): Promise<number> {
   if (findingIds.length === 0) return 0;
@@ -708,8 +709,12 @@ export async function dequeueSupersededFindings(findingIds: string[]): Promise<n
     )
     .returning({ id: security_analysis_queue.id });
 
-  // Clear any in-flight analysis_status so countRunningAnalyses no longer
-  // counts these superseded findings against the owner's concurrency cap.
+  // Clear pending analysis_status so countRunningAnalyses no longer counts
+  // these superseded findings against the owner's concurrency cap.
+  // Running analyses are left alone — the callback route checks
+  // finding.ignored_reason and will skip superseded findings when the job
+  // completes, avoiding a race where we clear the status and the callback
+  // immediately writes it back.
   await db
     .update(security_findings)
     .set({
@@ -719,10 +724,7 @@ export async function dequeueSupersededFindings(findingIds: string[]): Promise<n
     .where(
       and(
         inArray(security_findings.id, findingIds),
-        or(
-          eq(security_findings.analysis_status, 'pending'),
-          eq(security_findings.analysis_status, 'running')
-        )
+        eq(security_findings.analysis_status, 'pending')
       )
     );
 

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -5,7 +5,7 @@ import {
   security_analysis_owner_state,
   type SecurityFinding,
 } from '@kilocode/db/schema';
-import { eq, and, sql, count, isNotNull, desc, or, isNull, inArray } from 'drizzle-orm';
+import { eq, and, sql, count, isNotNull, desc, or, isNull, inArray, not, like } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import type {
   AutoAnalysisMinSeverity,
@@ -172,7 +172,18 @@ export async function updateAnalysisStatus(
       updateData.analysis_completed_at = sql`now()`;
     }
 
-    await db.update(security_findings).set(updateData).where(eq(security_findings.id, findingId));
+    await db
+      .update(security_findings)
+      .set(updateData)
+      .where(
+        and(
+          eq(security_findings.id, findingId),
+          or(
+            isNull(security_findings.ignored_reason),
+            not(like(security_findings.ignored_reason, 'superseded:%'))
+          )
+        )
+      );
   } catch (error) {
     captureException(error, {
       tags: { operation: 'updateAnalysisStatus' },

--- a/src/lib/security-agent/db/security-analysis.ts
+++ b/src/lib/security-agent/db/security-analysis.ts
@@ -679,6 +679,10 @@ export async function enqueueBacklogFindings(params: {
  * Targets both `queued` and `pending` (claimed but not yet running) rows
  * because the auto-analysis worker may claim rows between per-finding
  * enqueue and this repo-level cleanup.
+ *
+ * Also clears `analysis_status` on the findings themselves so a lease
+ * acquired between supersede and dequeue doesn't keep the finding
+ * counted against the owner's concurrency cap.
  */
 export async function dequeueSupersededFindings(findingIds: string[]): Promise<number> {
   if (findingIds.length === 0) return 0;
@@ -703,6 +707,24 @@ export async function dequeueSupersededFindings(findingIds: string[]): Promise<n
       )
     )
     .returning({ id: security_analysis_queue.id });
+
+  // Clear any in-flight analysis_status so countRunningAnalyses no longer
+  // counts these superseded findings against the owner's concurrency cap.
+  await db
+    .update(security_findings)
+    .set({
+      analysis_status: null,
+      updated_at: sql`now()`,
+    })
+    .where(
+      and(
+        inArray(security_findings.id, findingIds),
+        or(
+          eq(security_findings.analysis_status, 'pending'),
+          eq(security_findings.analysis_status, 'running')
+        )
+      )
+    );
 
   return result.length;
 }

--- a/src/lib/security-agent/db/security-findings.test.ts
+++ b/src/lib/security-agent/db/security-findings.test.ts
@@ -3,7 +3,7 @@ import { db } from '@/lib/drizzle';
 import { security_findings } from '@kilocode/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { upsertSecurityFinding } from './security-findings';
+import { upsertSecurityFinding, supersedeDuplicateFindings } from './security-findings';
 import type { DependabotAlertRaw, ParsedSecurityFinding, SecurityReviewOwner } from '../core/types';
 
 const rawDependabotAlertFixture: DependabotAlertRaw = {
@@ -184,5 +184,220 @@ describe('upsertSecurityFinding', () => {
       .where(eq(security_findings.id, result.findingId));
 
     expect(row.cwe_ids).toBeNull();
+  });
+});
+
+describe('supersedeDuplicateFindings', () => {
+  it('supersedes older duplicate for same ghsa/package/manifest, keeping highest source_id', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/supersede-basic-repo';
+
+    // Insert two findings with different source_ids but same ghsa/package/manifest
+    const older = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '5', ghsa_id: 'GHSA-aaaa-bbbb-cccc' }),
+      owner,
+      repoFullName: repo,
+    });
+    const newer = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '10', ghsa_id: 'GHSA-aaaa-bbbb-cccc' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    const result = await supersedeDuplicateFindings(repo);
+    expect(result.count).toBe(1);
+    expect(result.supersededFindingIds).toEqual([older.findingId]);
+
+    const [olderRow] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, older.findingId));
+
+    expect(olderRow.status).toBe('ignored');
+    expect(olderRow.ignored_reason).toBe(`superseded:${newer.findingId}`);
+    expect(olderRow.ignored_by).toBe('system');
+
+    const [newerRow] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, newer.findingId));
+
+    expect(newerRow.status).toBe('open');
+  });
+
+  it('does not supersede findings with different manifest paths', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/supersede-manifest-repo';
+
+    await upsertSecurityFinding({
+      ...makeFinding({
+        source_id: '30',
+        ghsa_id: 'GHSA-dddd-eeee-ffff',
+        manifest_path: 'package.json',
+      }),
+      owner,
+      repoFullName: repo,
+    });
+    await upsertSecurityFinding({
+      ...makeFinding({
+        source_id: '31',
+        ghsa_id: 'GHSA-dddd-eeee-ffff',
+        manifest_path: 'apps/web/package.json',
+      }),
+      owner,
+      repoFullName: repo,
+    });
+
+    const result = await supersedeDuplicateFindings(repo);
+    expect(result.count).toBe(0);
+    expect(result.supersededFindingIds).toEqual([]);
+
+    const rows = await db
+      .select()
+      .from(security_findings)
+      .where(and(eq(security_findings.repo_full_name, repo), eq(security_findings.status, 'open')));
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it('does not supersede findings with null ghsa_id', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/supersede-null-ghsa-repo';
+
+    await upsertSecurityFinding({
+      ...makeFinding({ source_id: '40', ghsa_id: null }),
+      owner,
+      repoFullName: repo,
+    });
+    await upsertSecurityFinding({
+      ...makeFinding({ source_id: '41', ghsa_id: null }),
+      owner,
+      repoFullName: repo,
+    });
+
+    const result = await supersedeDuplicateFindings(repo);
+    expect(result.count).toBe(0);
+    expect(result.supersededFindingIds).toEqual([]);
+  });
+
+  it('does not supersede findings that are not open', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/supersede-status-repo';
+
+    await upsertSecurityFinding({
+      ...makeFinding({ source_id: '50', ghsa_id: 'GHSA-gggg-hhhh-iiii', status: 'fixed' }),
+      owner,
+      repoFullName: repo,
+    });
+    await upsertSecurityFinding({
+      ...makeFinding({ source_id: '51', ghsa_id: 'GHSA-gggg-hhhh-iiii', status: 'open' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    const result = await supersedeDuplicateFindings(repo);
+    expect(result.count).toBe(0);
+    expect(result.supersededFindingIds).toEqual([]);
+
+    // The open one should remain open (it's the only open one in the group)
+    const [openRow] = await db
+      .select()
+      .from(security_findings)
+      .where(and(eq(security_findings.repo_full_name, repo), eq(security_findings.status, 'open')));
+
+    expect(openRow).toBeDefined();
+    expect(openRow.source_id).toBe('51');
+  });
+
+  it('is idempotent', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/supersede-idempotent-repo';
+
+    await upsertSecurityFinding({
+      ...makeFinding({ source_id: '60', ghsa_id: 'GHSA-jjjj-kkkk-llll' }),
+      owner,
+      repoFullName: repo,
+    });
+    await upsertSecurityFinding({
+      ...makeFinding({ source_id: '61', ghsa_id: 'GHSA-jjjj-kkkk-llll' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    const firstResult = await supersedeDuplicateFindings(repo);
+    expect(firstResult.count).toBe(1);
+
+    const secondResult = await supersedeDuplicateFindings(repo);
+    expect(secondResult.count).toBe(0);
+    expect(secondResult.supersededFindingIds).toEqual([]);
+  });
+
+  it('handles multiple duplicate groups in the same repo independently', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/supersede-multi-group-repo';
+
+    // Group 1: GHSA-aaaa with two findings
+    const group1Older = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '70', ghsa_id: 'GHSA-mmmm-nnnn-oooo', package_name: 'lodash' }),
+      owner,
+      repoFullName: repo,
+    });
+    const group1Newer = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '71', ghsa_id: 'GHSA-mmmm-nnnn-oooo', package_name: 'lodash' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    // Group 2: GHSA-bbbb with two findings
+    const group2Older = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '80', ghsa_id: 'GHSA-pppp-qqqq-rrrr', package_name: 'express' }),
+      owner,
+      repoFullName: repo,
+    });
+    const group2Newer = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '81', ghsa_id: 'GHSA-pppp-qqqq-rrrr', package_name: 'express' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    const result = await supersedeDuplicateFindings(repo);
+    expect(result.count).toBe(2);
+    expect(result.supersededFindingIds).toEqual(
+      expect.arrayContaining([group1Older.findingId, group2Older.findingId])
+    );
+
+    // Verify group 1
+    const [g1OlderRow] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, group1Older.findingId));
+    expect(g1OlderRow.status).toBe('ignored');
+    expect(g1OlderRow.ignored_reason).toBe(`superseded:${group1Newer.findingId}`);
+
+    const [g1NewerRow] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, group1Newer.findingId));
+    expect(g1NewerRow.status).toBe('open');
+
+    // Verify group 2
+    const [g2OlderRow] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, group2Older.findingId));
+    expect(g2OlderRow.status).toBe('ignored');
+    expect(g2OlderRow.ignored_reason).toBe(`superseded:${group2Newer.findingId}`);
+
+    const [g2NewerRow] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, group2Newer.findingId));
+    expect(g2NewerRow.status).toBe('open');
   });
 });

--- a/src/lib/security-agent/db/security-findings.ts
+++ b/src/lib/security-agent/db/security-findings.ts
@@ -83,6 +83,8 @@ export type UpsertSecurityFindingResult = {
   findingId: string;
   wasInserted: boolean;
   previousStatus: SecurityFindingStatus | null;
+  /** The status actually persisted — may differ from the input when a superseded row is preserved. */
+  effectiveStatus: SecurityFindingStatus;
   findingCreatedAt: string;
 };
 
@@ -97,11 +99,14 @@ export async function upsertSecurityFinding(
       findingId: string;
       wasInserted: boolean;
       previousStatus: SecurityFindingStatus | null;
+      effectiveStatus: SecurityFindingStatus;
       findingCreatedAt: string;
     }>(sql`
       WITH existing_match AS (
         SELECT ${security_findings.id} AS id,
                ${security_findings.status} AS previous_status,
+               ${security_findings.ignored_reason} AS ignored_reason,
+               ${security_findings.ignored_by} AS ignored_by,
                ${security_findings.created_at} AS created_at
         FROM ${security_findings}
         WHERE ${security_findings.repo_full_name} = ${params.repoFullName}
@@ -119,9 +124,18 @@ export async function upsertSecurityFinding(
           ${sql.identifier(security_findings.patched_version.name)} = ${params.patched_version},
           ${sql.identifier(security_findings.title.name)} = ${params.title},
           ${sql.identifier(security_findings.description.name)} = ${params.description},
-          ${sql.identifier(security_findings.status.name)} = ${params.status},
-          ${sql.identifier(security_findings.ignored_reason.name)} = ${params.ignored_reason},
-          ${sql.identifier(security_findings.ignored_by.name)} = ${params.ignored_by},
+          ${sql.identifier(security_findings.status.name)} = CASE
+            WHEN existing_match.ignored_reason LIKE 'superseded:%' THEN existing_match.previous_status
+            ELSE ${params.status}
+          END,
+          ${sql.identifier(security_findings.ignored_reason.name)} = CASE
+            WHEN existing_match.ignored_reason LIKE 'superseded:%' THEN existing_match.ignored_reason
+            ELSE ${params.ignored_reason}
+          END,
+          ${sql.identifier(security_findings.ignored_by.name)} = CASE
+            WHEN existing_match.ignored_reason LIKE 'superseded:%' THEN existing_match.ignored_by
+            ELSE ${params.ignored_by}
+          END,
           ${sql.identifier(security_findings.fixed_at.name)} = ${params.fixed_at},
           ${sql.identifier(security_findings.sla_due_at.name)} = ${params.slaDueAt?.toISOString() || null},
           ${sql.identifier(security_findings.dependabot_html_url.name)} = ${params.dependabot_html_url},
@@ -136,6 +150,7 @@ export async function upsertSecurityFinding(
         RETURNING
           ${security_findings.id} AS id,
           existing_match.previous_status AS previous_status,
+          ${security_findings.status} AS effective_status,
           ${security_findings.created_at} AS created_at
       ),
       inserted AS (
@@ -200,6 +215,7 @@ export async function upsertSecurityFinding(
         ON CONFLICT (${sql.identifier(security_findings.repo_full_name.name)}, ${sql.identifier(security_findings.source.name)}, ${sql.identifier(security_findings.source_id.name)}) DO NOTHING
         RETURNING ${security_findings.id} AS id,
           NULL::text AS previous_status,
+          ${security_findings.status} AS effective_status,
           ${security_findings.created_at} AS created_at
       ),
       -- fallback: concurrent insert race — previous_status reflects the current row state
@@ -210,6 +226,7 @@ export async function upsertSecurityFinding(
         SELECT
           ${security_findings.id} AS id,
           ${security_findings.status} AS previous_status,
+          ${security_findings.status} AS effective_status,
           ${security_findings.created_at} AS created_at
         FROM ${security_findings}
         WHERE ${security_findings.repo_full_name} = ${params.repoFullName}
@@ -220,16 +237,17 @@ export async function upsertSecurityFinding(
         LIMIT 1
       ),
       chosen AS (
-        SELECT id, false AS was_inserted, previous_status, created_at FROM updated
+        SELECT id, false AS was_inserted, previous_status, effective_status, created_at FROM updated
         UNION ALL
-        SELECT id, true AS was_inserted, previous_status, created_at FROM inserted
+        SELECT id, true AS was_inserted, previous_status, effective_status, created_at FROM inserted
         UNION ALL
-        SELECT id, false AS was_inserted, previous_status, created_at FROM fallback
+        SELECT id, false AS was_inserted, previous_status, effective_status, created_at FROM fallback
       )
       SELECT
         chosen.id AS "findingId",
         chosen.was_inserted AS "wasInserted",
         chosen.previous_status AS "previousStatus",
+        chosen.effective_status AS "effectiveStatus",
         chosen.created_at AS "findingCreatedAt"
       FROM chosen
       LIMIT 1
@@ -245,6 +263,67 @@ export async function upsertSecurityFinding(
     captureException(error, {
       tags: { operation: 'upsertSecurityFinding' },
       extra: { params },
+    });
+    throw error;
+  }
+}
+
+/**
+ * GitHub sometimes creates a new Dependabot alert (new alert number) for the
+ * same GHSA/package/manifest when an advisory is updated. Keep the newest
+ * alert open and mark older duplicates as ignored with a superseded reference.
+ */
+export type SupersedeResult = { count: number; supersededFindingIds: string[] };
+
+export async function supersedeDuplicateFindings(repoFullName: string): Promise<SupersedeResult> {
+  try {
+    const { rows } = await db.execute<{ id: string }>(sql`
+    WITH ranked AS (
+      SELECT
+        ${security_findings.id} AS id,
+        ROW_NUMBER() OVER (
+          PARTITION BY ${security_findings.repo_full_name},
+                       ${security_findings.source},
+                       ${security_findings.ghsa_id},
+                       ${security_findings.package_name},
+                       ${security_findings.manifest_path}
+          ORDER BY ${security_findings.source_id}::int DESC
+        ) AS rn,
+        FIRST_VALUE(${security_findings.id}) OVER (
+          PARTITION BY ${security_findings.repo_full_name},
+                       ${security_findings.source},
+                       ${security_findings.ghsa_id},
+                       ${security_findings.package_name},
+                       ${security_findings.manifest_path}
+          ORDER BY ${security_findings.source_id}::int DESC
+        ) AS canonical_id
+      FROM ${security_findings}
+      WHERE ${security_findings.repo_full_name} = ${repoFullName}
+        AND ${security_findings.source} = 'dependabot'
+        AND ${security_findings.ghsa_id} IS NOT NULL
+        AND ${security_findings.status} = 'open'
+    ),
+    superseded AS (
+      UPDATE ${security_findings}
+      SET
+        ${sql.identifier(security_findings.status.name)} = 'ignored',
+        ${sql.identifier(security_findings.ignored_reason.name)} = 'superseded:' || ranked.canonical_id,
+        ${sql.identifier(security_findings.ignored_by.name)} = 'system',
+        ${sql.identifier(security_findings.updated_at.name)} = now()
+      FROM ranked
+      WHERE ${security_findings.id} = ranked.id
+        AND ranked.rn > 1
+      RETURNING ${security_findings.id}
+    )
+    SELECT id FROM superseded
+  `);
+
+    const supersededFindingIds = rows.map(r => r.id);
+    return { count: supersededFindingIds.length, supersededFindingIds };
+  } catch (error) {
+    captureException(error, {
+      tags: { operation: 'supersedeDuplicateFindings' },
+      extra: { repoFullName },
     });
     throw error;
   }

--- a/src/lib/security-agent/db/security-findings.ts
+++ b/src/lib/security-agent/db/security-findings.ts
@@ -287,7 +287,7 @@ export async function supersedeDuplicateFindings(repoFullName: string): Promise<
                        ${security_findings.ghsa_id},
                        ${security_findings.package_name},
                        ${security_findings.manifest_path}
-          ORDER BY ${security_findings.source_id}::int DESC
+          ORDER BY CASE WHEN ${security_findings.source_id} ~ '^\d+$' THEN ${security_findings.source_id}::int ELSE 0 END DESC
         ) AS rn,
         FIRST_VALUE(${security_findings.id}) OVER (
           PARTITION BY ${security_findings.repo_full_name},
@@ -295,7 +295,7 @@ export async function supersedeDuplicateFindings(repoFullName: string): Promise<
                        ${security_findings.ghsa_id},
                        ${security_findings.package_name},
                        ${security_findings.manifest_path}
-          ORDER BY ${security_findings.source_id}::int DESC
+          ORDER BY CASE WHEN ${security_findings.source_id} ~ '^\d+$' THEN ${security_findings.source_id}::int ELSE 0 END DESC
         ) AS canonical_id
       FROM ${security_findings}
       WHERE ${security_findings.repo_full_name} = ${repoFullName}

--- a/src/lib/security-agent/db/security-findings.ts
+++ b/src/lib/security-agent/db/security-findings.ts
@@ -287,7 +287,7 @@ export async function supersedeDuplicateFindings(repoFullName: string): Promise<
                        ${security_findings.ghsa_id},
                        ${security_findings.package_name},
                        ${security_findings.manifest_path}
-          ORDER BY CASE WHEN ${security_findings.source_id} ~ '^\d+$' THEN ${security_findings.source_id}::int ELSE 0 END DESC
+          ORDER BY CASE WHEN ${security_findings.source_id} ~ '^[0-9]+$' THEN ${security_findings.source_id}::int ELSE 0 END DESC
         ) AS rn,
         FIRST_VALUE(${security_findings.id}) OVER (
           PARTITION BY ${security_findings.repo_full_name},
@@ -295,7 +295,7 @@ export async function supersedeDuplicateFindings(repoFullName: string): Promise<
                        ${security_findings.ghsa_id},
                        ${security_findings.package_name},
                        ${security_findings.manifest_path}
-          ORDER BY CASE WHEN ${security_findings.source_id} ~ '^\d+$' THEN ${security_findings.source_id}::int ELSE 0 END DESC
+          ORDER BY CASE WHEN ${security_findings.source_id} ~ '^[0-9]+$' THEN ${security_findings.source_id}::int ELSE 0 END DESC
         ) AS canonical_id
       FROM ${security_findings}
       WHERE ${security_findings.repo_full_name} = ${repoFullName}

--- a/src/lib/security-agent/services/analysis-service.test.ts
+++ b/src/lib/security-agent/services/analysis-service.test.ts
@@ -34,12 +34,17 @@ jest.mock('@/lib/security-agent/db/security-findings', () => ({
   getSecurityFindingById: mockGetSecurityFindingById,
 }));
 
+const mockClearAnalysisStatus = jest.fn() as jest.MockedFunction<
+  typeof securityAnalysisModule.clearAnalysisStatus
+>;
+
 jest.mock('@/lib/security-agent/db/security-analysis', () => {
   const actual: { isFindingEligibleForAutoAnalysis: unknown } = jest.requireActual(
     '@/lib/security-agent/db/security-analysis'
   );
   return {
     updateAnalysisStatus: mockUpdateAnalysisStatus,
+    clearAnalysisStatus: mockClearAnalysisStatus,
     tryAcquireAnalysisStartLease: mockTryAcquireAnalysisStartLease,
     isFindingEligibleForAutoAnalysis: actual.isFindingEligibleForAutoAnalysis,
     AUTO_ANALYSIS_MAX_ATTEMPTS: 5,
@@ -151,7 +156,7 @@ describe('analysis-service', () => {
     mockGetSecurityFindingById.mockResolvedValue(
       mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
     );
-    mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+    mockUpdateAnalysisStatus.mockResolvedValue(true);
     mockTriageSecurityFinding.mockResolvedValue({
       needsSandboxAnalysis: true,
       needsSandboxReasoning: 'Runtime dependency with high severity',
@@ -228,7 +233,7 @@ describe('analysis-service', () => {
     mockGetSecurityFindingById.mockResolvedValue(
       mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
     );
-    mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+    mockUpdateAnalysisStatus.mockResolvedValue(true);
     mockTriageSecurityFinding.mockResolvedValue({
       needsSandboxAnalysis: true,
       needsSandboxReasoning: 'Needs analysis',
@@ -289,7 +294,7 @@ describe('analysis-service', () => {
     mockGetSecurityFindingById.mockResolvedValue(
       mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
     );
-    mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+    mockUpdateAnalysisStatus.mockResolvedValue(true);
     mockTriageSecurityFinding.mockResolvedValue({
       needsSandboxAnalysis: true,
       needsSandboxReasoning: 'Needs analysis',
@@ -347,7 +352,7 @@ describe('analysis-service', () => {
     mockGetSecurityFindingById.mockResolvedValue(
       mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
     );
-    mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+    mockUpdateAnalysisStatus.mockResolvedValue(true);
     mockTriageSecurityFinding.mockResolvedValue({
       needsSandboxAnalysis: false,
       needsSandboxReasoning: 'Dev dependency, low severity',
@@ -394,7 +399,7 @@ describe('analysis-service', () => {
     mockGetSecurityFindingById.mockResolvedValue(
       mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
     );
-    mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+    mockUpdateAnalysisStatus.mockResolvedValue(true);
     mockTriageSecurityFinding.mockResolvedValue({
       needsSandboxAnalysis: true,
       needsSandboxReasoning: 'Needs analysis',
@@ -462,7 +467,7 @@ describe('analysis-service', () => {
       mockGetSecurityFindingById.mockResolvedValue(
         mockFinding as Awaited<ReturnType<typeof mockGetSecurityFindingById>>
       );
-      mockUpdateAnalysisStatus.mockResolvedValue(undefined);
+      mockUpdateAnalysisStatus.mockResolvedValue(true);
       mockGenerateApiToken.mockReturnValue('test-token');
       mockPrepareSession.mockResolvedValue({
         cloudAgentSessionId: 'ses-agent-mode',

--- a/src/lib/security-agent/services/analysis-service.ts
+++ b/src/lib/security-agent/services/analysis-service.ts
@@ -6,7 +6,11 @@ import {
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { generateApiToken } from '@/lib/tokens';
 import { getSecurityFindingById } from '../db/security-findings';
-import { updateAnalysisStatus, tryAcquireAnalysisStartLease } from '../db/security-analysis';
+import {
+  updateAnalysisStatus,
+  clearAnalysisStatus,
+  tryAcquireAnalysisStartLease,
+} from '../db/security-analysis';
 import type {
   AnalysisMode,
   SecurityFindingAnalysis,
@@ -134,17 +138,25 @@ export async function finalizeAnalysis(
   organizationId?: string
 ): Promise<void> {
   if (!rawMarkdown.trim()) {
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: 'No response received from analysis agent',
-    });
+    if (
+      !(await updateAnalysisStatus(findingId, 'failed', {
+        error: 'No response received from analysis agent',
+      }))
+    ) {
+      await clearAnalysisStatus(findingId);
+    }
     return;
   }
 
   const finding = await getSecurityFindingById(findingId);
   if (!finding) {
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: 'Finding not found during finalization',
-    });
+    if (
+      !(await updateAnalysisStatus(findingId, 'failed', {
+        error: 'Finding not found during finalization',
+      }))
+    ) {
+      await clearAnalysisStatus(findingId);
+    }
     return;
   }
 
@@ -181,7 +193,10 @@ export async function finalizeAnalysis(
     correlationId,
   };
 
-  await updateAnalysisStatus(findingId, 'completed', { analysis });
+  if (!(await updateAnalysisStatus(findingId, 'completed', { analysis }))) {
+    await clearAnalysisStatus(findingId);
+    return;
+  }
 
   const triggeredBy = existingAnalysis?.triggeredByUserId ?? userId;
   trackSecurityAgentAnalysisCompleted({
@@ -373,7 +388,11 @@ export async function startSecurityAnalysis(params: {
         correlationId,
       };
 
-      await updateAnalysisStatus(findingId, 'completed', { analysis });
+      const written = await updateAnalysisStatus(findingId, 'completed', { analysis });
+      if (!written) {
+        await clearAnalysisStatus(findingId);
+        return { started: false, error: 'Finding was superseded during analysis' };
+      }
 
       trackSecurityAgentAnalysisCompleted({
         distinctId: user.id,
@@ -494,22 +513,26 @@ export async function startSecurityAnalysis(params: {
         });
       }
 
-      await updateAnalysisStatus(findingId, 'failed', { error: userMessage });
+      if (!(await updateAnalysisStatus(findingId, 'failed', { error: userMessage }))) {
+        await clearAnalysisStatus(findingId);
+      }
       return { started: false, error: userMessage, errorCode };
     }
 
     return { started: true, triageOnly: false };
   } catch (error) {
     if (error instanceof InsufficientCreditsError) {
-      await updateAnalysisStatus(findingId, 'failed', { error: error.message });
+      if (!(await updateAnalysisStatus(findingId, 'failed', { error: error.message }))) {
+        await clearAnalysisStatus(findingId);
+      }
       throw error;
     }
 
     const classified = classifyAnalysisError(error);
 
-    await updateAnalysisStatus(findingId, 'failed', {
-      error: classified.userMessage,
-    });
+    if (!(await updateAnalysisStatus(findingId, 'failed', { error: classified.userMessage }))) {
+      await clearAnalysisStatus(findingId);
+    }
     if (isUserActionableError(classified.code)) {
       warn('Analysis failed (user-actionable)', {
         correlationId,

--- a/src/lib/security-agent/services/sync-service.test.ts
+++ b/src/lib/security-agent/services/sync-service.test.ts
@@ -27,6 +27,12 @@ const mockGetOwnerAutoAnalysisEnabledAt = jest.fn() as jest.MockedFunction<
 const mockSyncAutoAnalysisQueueForFinding = jest.fn() as jest.MockedFunction<
   typeof analysisDbModule.syncAutoAnalysisQueueForFinding
 >;
+const mockSupersedeDuplicateFindings = jest.fn() as jest.MockedFunction<
+  typeof findingsDbModule.supersedeDuplicateFindings
+>;
+const mockDequeueSupersededFindings = jest.fn() as jest.MockedFunction<
+  typeof analysisDbModule.dequeueSupersededFindings
+>;
 const mockSyncLogger = jest.fn();
 
 jest.mock('../github/dependabot-api', () => ({
@@ -39,6 +45,7 @@ jest.mock('../parsers/dependabot-parser', () => ({
 
 jest.mock('../db/security-findings', () => ({
   upsertSecurityFinding: mockUpsertSecurityFinding,
+  supersedeDuplicateFindings: mockSupersedeDuplicateFindings,
 }));
 
 jest.mock('../db/security-config', () => ({
@@ -49,6 +56,7 @@ jest.mock('../db/security-config', () => ({
 jest.mock('../db/security-analysis', () => ({
   getOwnerAutoAnalysisEnabledAt: mockGetOwnerAutoAnalysisEnabledAt,
   syncAutoAnalysisQueueForFinding: mockSyncAutoAnalysisQueueForFinding,
+  dequeueSupersededFindings: mockDequeueSupersededFindings,
 }));
 
 jest.mock('@/lib/drizzle', () => ({ db: {} }));
@@ -124,6 +132,7 @@ describe('sync-service queue enqueue wiring', () => {
       findingId: 'finding-1',
       wasInserted: true,
       previousStatus: null,
+      effectiveStatus: 'open',
       findingCreatedAt: '2026-01-01T00:00:00.000Z',
     });
     mockSyncAutoAnalysisQueueForFinding.mockResolvedValue({
@@ -132,6 +141,11 @@ describe('sync-service queue enqueue wiring', () => {
       boundarySkipCount: 0,
       unknownSeverityCount: 0,
     });
+    mockSupersedeDuplicateFindings.mockResolvedValue({
+      count: 0,
+      supersededFindingIds: [],
+    });
+    mockDequeueSupersededFindings.mockResolvedValue(0);
   });
 
   it('passes upsert metadata into auto-analysis queue sync', async () => {
@@ -146,9 +160,35 @@ describe('sync-service queue enqueue wiring', () => {
       expect.objectContaining({
         findingId: 'finding-1',
         previousStatus: null,
+        currentStatus: 'open',
         findingCreatedAt: '2026-01-01T00:00:00.000Z',
         autoAnalysisEnabled: true,
         isAgentEnabled: true,
+      })
+    );
+  });
+
+  it('uses effectiveStatus (not payload status) so superseded findings are not re-queued', async () => {
+    mockUpsertSecurityFinding.mockResolvedValue({
+      findingId: 'finding-superseded',
+      wasInserted: false,
+      previousStatus: 'ignored',
+      effectiveStatus: 'ignored',
+      findingCreatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    await syncDependabotAlertsForRepo({
+      owner: { userId: 'user-1' },
+      platformIntegrationId: 'integration-1',
+      installationId: 'inst-1',
+      repoFullName: 'acme/repo',
+    });
+
+    expect(mockSyncAutoAnalysisQueueForFinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        findingId: 'finding-superseded',
+        previousStatus: 'ignored',
+        currentStatus: 'ignored',
       })
     );
   });

--- a/src/lib/security-agent/services/sync-service.ts
+++ b/src/lib/security-agent/services/sync-service.ts
@@ -6,11 +6,12 @@ import { eq, and, isNotNull } from 'drizzle-orm';
 import { fetchAllDependabotAlerts } from '../github/dependabot-api';
 import { hasSecurityReviewPermissions } from '../github/permissions';
 import { parseDependabotAlerts } from '../parsers/dependabot-parser';
-import { upsertSecurityFinding } from '../db/security-findings';
+import { upsertSecurityFinding, supersedeDuplicateFindings } from '../db/security-findings';
 import { getSecurityAgentConfig, getSecurityAgentConfigWithStatus } from '../db/security-config';
 import {
   getOwnerAutoAnalysisEnabledAt,
   syncAutoAnalysisQueueForFinding,
+  dequeueSupersededFindings,
   type AutoAnalysisQueueSyncResult,
 } from '../db/security-analysis';
 import { upsertAgentConfigForOwner } from '@/lib/agent-config/db/agent-configs';
@@ -115,7 +116,7 @@ export async function syncDependabotAlertsForRepo(params: {
             findingId: upsertResult.findingId,
             findingCreatedAt: upsertResult.findingCreatedAt,
             previousStatus: upsertResult.previousStatus,
-            currentStatus: finding.status,
+            currentStatus: upsertResult.effectiveStatus,
             severity: finding.severity,
             isAgentEnabled,
             autoAnalysisEnabled: config.auto_analysis_enabled,
@@ -153,6 +154,24 @@ export async function syncDependabotAlertsForRepo(params: {
           extra: { repoFullName, alertNumber: finding.source_id },
         });
       }
+    }
+
+    try {
+      const { count: supersededCount, supersededFindingIds } =
+        await supersedeDuplicateFindings(repoFullName);
+      if (supersededCount > 0) {
+        log(`Superseded ${supersededCount} duplicate finding(s) for ${repoFullName}`);
+        const dequeued = await dequeueSupersededFindings(supersededFindingIds);
+        if (dequeued > 0) {
+          log(`Dequeued ${dequeued} superseded finding(s) from auto-analysis queue`);
+        }
+      }
+    } catch (error) {
+      logError(`Error superseding duplicate findings for ${repoFullName}`, { error });
+      captureException(error, {
+        tags: { operation: 'syncDependabotAlertsForRepo', step: 'supersedeDuplicates' },
+        extra: { repoFullName },
+      });
     }
 
     const repoDurationMs = Math.round(performance.now() - repoStartTime);


### PR DESCRIPTION
## Summary

GitHub sometimes creates new Dependabot alerts (with new alert numbers) for the same GHSA/package/manifest when an advisory is updated, causing duplicate open findings in our database. This PR adds a deduplication step that marks older duplicates as `ignored` with a `superseded:<canonical_id>` reference, keeping only the newest alert (highest `source_id`) open.

Changes span both sync paths:
- **Cloudflare sync worker** (`cloudflare-security-sync/src/sync.ts`): adds `supersedeDuplicateFindings()` and calls it after upserting findings. The upsert's `ON CONFLICT` clause now conditionally preserves superseded state so re-syncs don't overwrite it.
- **Main app sync service** (`src/lib/security-agent/services/sync-service.ts`): calls the shared `supersedeDuplicateFindings()` from the DB layer after upserting findings.
- **DB layer** (`src/lib/security-agent/db/security-findings.ts`): adds the exported `supersedeDuplicateFindings()` function and updates `upsertSecurityFinding` to preserve superseded state via conditional SQL.

## Verification

- [x] `pnpm typecheck` — passed (all packages)
- [x] Tests in `security-findings.test.ts` — 6 new tests for `supersedeDuplicateFindings` (require DB connection; verified structure and imports compile)
- [x] _Additional verification by reviewer_

## Visual Changes

N/A

## Reviewer Notes

- The dedup query uses a CTE with `ROW_NUMBER()` partitioned by `(repo_full_name, source, ghsa_id, package_name, manifest_path)` and ordered by `source_id::int DESC`. This assumes `source_id` for Dependabot alerts is always a numeric string (the alert number). Non-numeric `source_id` values would cause a cast error, but this is guarded by the `source = 'dependabot'` filter.
- The `superseded:` prefix in `ignored_reason` is used as a sentinel in the upsert's `CASE` expressions to prevent re-syncs from reopening superseded findings. This creates a coupling between the two functions — changing the prefix format requires updating both.
- The Cloudflare worker has its own copy of `supersedeDuplicateFindings` using raw SQL (no Drizzle available in that context), while the main app version uses Drizzle's `sql` template tag. Both implementations should produce identical behavior.
- Error handling: the Cloudflare worker version logs and swallows errors (best-effort), while the main app version captures to Sentry and re-throws, with a try/catch in the caller that logs and continues.