### PR TITLE
fix(cloud-agent-next): clean up workspace on failed cold-start resume

### DIFF
--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -36,6 +36,7 @@ import {
   cloneGitHubRepo as mockCloneGitHubRepo,
   manageBranch as mockManageBranch,
   restoreWorkspace as mockRestoreWorkspace,
+  cleanupWorkspace as mockCleanupWorkspace,
 } from './workspace.js';
 import { InvalidSessionMetadataError, SessionService } from './session-service.js';
 import type { SandboxInstance, SessionId, SessionContext, ExecutionSession } from './types.js';
@@ -929,6 +930,148 @@ describe('SessionService', () => {
       ).rejects.toThrow('session not found');
 
       expect(fetchMock).toHaveBeenCalled();
+    });
+
+    it('removes workspace when kilo import fails during cold start so retry can reclone', async () => {
+      const mockDOGetMetadata = vi.fn();
+      const payload = JSON.stringify({ info: {}, messages: [{ info: {}, parts: [] }] });
+      const fetchMock = vi.fn().mockResolvedValue(new Response(payload));
+      const envWithIngest: PersistenceEnv = {
+        ...mockEnv,
+        SESSION_INGEST: {
+          fetch: fetchMock,
+        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
+          get: vi.fn(() => ({
+            getMetadata: mockDOGetMetadata,
+            updateMetadata: vi.fn().mockResolvedValue(undefined),
+            deleteSession: vi.fn().mockResolvedValue(undefined),
+          })),
+        } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
+      };
+      const fakeSession = {
+        exec: vi.fn().mockImplementation((cmd: string) => {
+          if (cmd.includes('test -d') && cmd.includes('.git')) {
+            return Promise.resolve({ success: true, exitCode: 1, stdout: '', stderr: '' });
+          }
+          if (cmd.includes('kilo import')) {
+            return Promise.resolve({
+              success: false,
+              exitCode: 1,
+              stdout: '',
+              stderr: 'import failed',
+            });
+          }
+          return Promise.resolve({ success: true, exitCode: 0, stdout: '', stderr: '' });
+        }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: sandboxExec,
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const kiloSessionId = 'ses_test_kilo_session_id_0001';
+      const metadata = {
+        version: 123456789,
+        sessionId,
+        orgId,
+        userId,
+        timestamp: 123456789,
+        githubRepo: 'facebook/react',
+        githubToken: 'test-token',
+        kiloSessionId,
+      };
+      mockDOGetMetadata.mockResolvedValue(metadata);
+
+      const service = new SessionService();
+      await expect(
+        service.resume({
+          sandbox,
+          sandboxId: `${orgId}__${userId}`,
+          orgId,
+          userId,
+          sessionId,
+          kilocodeToken: 'test-token',
+          kilocodeModel: 'test-model',
+          env: envWithIngest,
+        })
+      ).rejects.toThrow('Session snapshot import failed');
+
+      const workspacePath = `/workspace/${orgId}/${userId}/sessions/${sessionId}`;
+      const sessionHome = `/home/${sessionId}`;
+      expect(mockCleanupWorkspace).toHaveBeenCalledWith(fakeSession, workspacePath, sessionHome);
+    });
+
+    it('does not remove workspace when SessionSnapshotRestoreError (404) is thrown', async () => {
+      const mockDOGetMetadata = vi.fn();
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+      const envWithIngest: PersistenceEnv = {
+        ...mockEnv,
+        SESSION_INGEST: {
+          fetch: fetchMock,
+        } as unknown as PersistenceEnv['SESSION_INGEST'],
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
+          get: vi.fn(() => ({
+            getMetadata: mockDOGetMetadata,
+            updateMetadata: vi.fn().mockResolvedValue(undefined),
+            deleteSession: vi.fn().mockResolvedValue(undefined),
+          })),
+        } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
+      };
+      const fakeSession = {
+        exec: vi
+          .fn()
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
+          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandboxExec = vi.fn().mockResolvedValue({ exitCode: 0 });
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: sandboxExec,
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const kiloSessionId = 'ses_test_kilo_session_id_0001';
+      const metadata = {
+        version: 123456789,
+        sessionId,
+        orgId,
+        userId,
+        timestamp: 123456789,
+        githubRepo: 'facebook/react',
+        githubToken: 'test-token',
+        kiloSessionId,
+      };
+      mockDOGetMetadata.mockResolvedValue(metadata);
+
+      const service = new SessionService();
+      await expect(
+        service.resume({
+          sandbox,
+          sandboxId: `${orgId}__${userId}`,
+          orgId,
+          userId,
+          sessionId,
+          kilocodeToken: 'test-token',
+          kilocodeModel: 'test-model',
+          env: envWithIngest,
+        })
+      ).rejects.toThrow('session not found');
+
+      // cleanupWorkspace should NOT have been called for 404 errors (permanent failure)
+      expect(mockCleanupWorkspace).not.toHaveBeenCalled();
     });
   });
 

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -1074,6 +1074,69 @@ describe('SessionService', () => {
       const sessionHome = `/home/${sessionId}`;
       expect(mockCleanupWorkspace).toHaveBeenCalledWith(fakeSession, workspacePath, sessionHome);
     });
+
+    it('removes workspace when restoreWorkspace (clone/branch) fails during cold start', async () => {
+      mockedRestoreWorkspace.mockRejectedValueOnce(new Error('branch checkout failed'));
+
+      const mockDOGetMetadata = vi.fn();
+      const envWithIngest: PersistenceEnv = {
+        ...mockEnv,
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(() => 'mock-do-id' as unknown as DurableObjectId),
+          get: vi.fn(() => ({
+            getMetadata: mockDOGetMetadata,
+            updateMetadata: vi.fn().mockResolvedValue(undefined),
+            deleteSession: vi.fn().mockResolvedValue(undefined),
+          })),
+        } as unknown as PersistenceEnv['CLOUD_AGENT_SESSION'],
+      };
+      const fakeSession = {
+        exec: vi
+          .fn()
+          .mockResolvedValueOnce({ success: true, exitCode: 1, stdout: '', stderr: '' })
+          .mockResolvedValue({ success: true, exitCode: 0, stdout: '', stderr: '' }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const kiloSessionId = 'ses_test_kilo_session_id_0001';
+      const metadata = {
+        version: 123456789,
+        sessionId,
+        orgId,
+        userId,
+        timestamp: 123456789,
+        githubRepo: 'facebook/react',
+        githubToken: 'test-token',
+        kiloSessionId,
+      };
+      mockDOGetMetadata.mockResolvedValue(metadata);
+
+      const service = new SessionService();
+      await expect(
+        service.resume({
+          sandbox,
+          sandboxId: `${orgId}__${userId}`,
+          orgId,
+          userId,
+          sessionId,
+          kilocodeToken: 'test-token',
+          kilocodeModel: 'test-model',
+          env: envWithIngest,
+        })
+      ).rejects.toThrow('branch checkout failed');
+
+      const workspacePath = `/workspace/${orgId}/${userId}/sessions/${sessionId}`;
+      const sessionHome = `/home/${sessionId}`;
+      expect(mockCleanupWorkspace).toHaveBeenCalledWith(fakeSession, workspacePath, sessionHome);
+    });
   });
 
   describe('Environment Variable Injection', () => {

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -1009,7 +1009,7 @@ describe('SessionService', () => {
       expect(mockCleanupWorkspace).toHaveBeenCalledWith(fakeSession, workspacePath, sessionHome);
     });
 
-    it('does not remove workspace when SessionSnapshotRestoreError (404) is thrown', async () => {
+    it('removes workspace when SessionSnapshotRestoreError (404) is thrown', async () => {
       const mockDOGetMetadata = vi.fn();
       const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       const envWithIngest: PersistenceEnv = {
@@ -1070,8 +1070,9 @@ describe('SessionService', () => {
         })
       ).rejects.toThrow('session not found');
 
-      // cleanupWorkspace should NOT have been called for 404 errors (permanent failure)
-      expect(mockCleanupWorkspace).not.toHaveBeenCalled();
+      const workspacePath = `/workspace/${orgId}/${userId}/sessions/${sessionId}`;
+      const sessionHome = `/home/${sessionId}`;
+      expect(mockCleanupWorkspace).toHaveBeenCalledWith(fakeSession, workspacePath, sessionHome);
     });
   });
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1454,24 +1454,23 @@ export class SessionService {
         `Session ${sessionId} has no kiloSessionId in metadata. Cannot restore snapshot.`
       );
     }
-    // Clone first so .git exists when `kilo import` runs — the CLI derives the
-    // project ID from the repo's root commit hash; without a repo the FK on
-    // session.project_id fails.
-    await restoreWorkspace(session, context.workspacePath, context.branchName, {
-      githubRepo: metadata.githubRepo,
-      githubToken: freshGithubToken ?? metadata.githubToken,
-      gitUrl: metadata.gitUrl,
-      gitToken: freshGitToken ?? metadata.gitToken,
-      gitAuthorEnv: getGitAuthorEnv(env, metadata.githubAppType),
-      lastSeenBranch: metadata.upstreamBranch,
-      platform: context.platform,
-    });
-
-    // Wrap post-clone steps so that any failure removes the workspace
-    // directory. Without this, `.git` survives and the next retry sees
-    // `isColdStart = false`, skipping the full restore flow — leaving the
-    // session in a broken half-initialized state.
+    // Wrap clone and all post-clone steps so that any failure removes the
+    // workspace directory. Without this, `.git` survives and the next retry
+    // sees `isColdStart = false`, skipping the full restore flow — leaving
+    // the session in a broken half-initialized state.
     try {
+      // Clone first so .git exists when `kilo import` runs — the CLI derives
+      // the project ID from the repo's root commit hash; without a repo the
+      // FK on session.project_id fails.
+      await restoreWorkspace(session, context.workspacePath, context.branchName, {
+        githubRepo: metadata.githubRepo,
+        githubToken: freshGithubToken ?? metadata.githubToken,
+        gitUrl: metadata.gitUrl,
+        gitToken: freshGitToken ?? metadata.gitToken,
+        gitAuthorEnv: getGitAuthorEnv(env, metadata.githubAppType),
+        lastSeenBranch: metadata.upstreamBranch,
+        platform: context.platform,
+      });
       // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
       await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
       await writeGlobalRules(sandbox, context.sessionHome, sessionId);
@@ -1522,7 +1521,7 @@ export class SessionService {
           sessionId,
           error: error instanceof Error ? error.message : String(error),
         })
-        .warn('Post-clone cold-start step failed; removing workspace for clean retry');
+        .warn('Cold-start resume step failed; removing workspace for clean retry');
       await cleanupWorkspace(session, context.workspacePath, context.sessionHome);
 
       throw error;

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1467,47 +1467,71 @@ export class SessionService {
       platform: context.platform,
     });
 
-    // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
-    await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
-    await writeGlobalRules(sandbox, context.sessionHome, sessionId);
+    // Wrap post-clone steps so that a transient failure (e.g. `kilo import`)
+    // removes the workspace directory. Without this, `.git` survives and the
+    // next retry sees `isColdStart = false`, skipping the full restore flow —
+    // leaving the session in a broken half-initialized state.
+    // `SessionSnapshotRestoreError` (404) is permanent and is re-thrown without
+    // cleanup since retrying won't help.
+    try {
+      // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
+      await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
+      await writeGlobalRules(sandbox, context.sessionHome, sessionId);
 
-    // Fetch snapshot from session-ingest DO and buffer it for sandbox writeFile (string-only API).
-    const internalSecret = await env.INTERNAL_API_SECRET_PROD.get();
-    const response = await env.SESSION_INGEST.fetch(
-      new Request(`https://session-ingest/internal/session/${metadata.kiloSessionId}/export`, {
-        headers: {
-          'X-Internal-Secret': internalSecret,
-          'X-Kilo-User-Id': userId,
-        },
-      })
-    );
-
-    if (response.status === 404) {
-      throw new SessionSnapshotRestoreError(
-        `Session snapshot restore failed: session not found`,
-        404
+      // Fetch snapshot from session-ingest DO and buffer it for sandbox writeFile (string-only API).
+      const internalSecret = await env.INTERNAL_API_SECRET_PROD.get();
+      const response = await env.SESSION_INGEST.fetch(
+        new Request(`https://session-ingest/internal/session/${metadata.kiloSessionId}/export`, {
+          headers: {
+            'X-Internal-Secret': internalSecret,
+            'X-Kilo-User-Id': userId,
+          },
+        })
       );
-    }
-    if (!response.ok) {
-      throw new Error(`Session export failed: ${response.status}`);
-    }
 
-    const snapshotPayload = await response.text();
+      if (response.status === 404) {
+        throw new SessionSnapshotRestoreError(
+          `Session snapshot restore failed: session not found`,
+          404
+        );
+      }
+      if (!response.ok) {
+        throw new Error(`Session export failed: ${response.status}`);
+      }
 
-    // Extract diffs client-side from the streamed snapshot messages.
-    const diffs = SessionService.extractDiffsFromMessages(snapshotPayload);
+      const snapshotPayload = await response.text();
 
-    await this.restoreSessionSnapshot(session, sessionId, userId, snapshotPayload);
+      // Extract diffs client-side from the streamed snapshot messages.
+      const diffs = SessionService.extractDiffsFromMessages(snapshotPayload);
 
-    // Apply file-level changes from the previous session on top of the fresh clone.
-    // This runs after kilo import (conversation restore) since the CLI doesn't need
-    // the file state during import — it only restores its internal session DB.
-    await this.applySessionDiff(session, sessionId, userId, context.workspacePath, diffs);
+      await this.restoreSessionSnapshot(session, sessionId, userId, snapshotPayload);
 
-    // Re-run setup commands (fresh clone, need to reinstall)
-    if (metadata.setupCommands && metadata.setupCommands.length > 0) {
-      logger.info('Re-running setup commands after fresh clone');
-      await runSetupCommands(session, context, metadata.setupCommands, false); // lenient
+      // Apply file-level changes from the previous session on top of the fresh clone.
+      // This runs after kilo import (conversation restore) since the CLI doesn't need
+      // the file state during import — it only restores its internal session DB.
+      await this.applySessionDiff(session, sessionId, userId, context.workspacePath, diffs);
+
+      // Re-run setup commands (fresh clone, need to reinstall)
+      if (metadata.setupCommands && metadata.setupCommands.length > 0) {
+        logger.info('Re-running setup commands after fresh clone');
+        await runSetupCommands(session, context, metadata.setupCommands, false); // lenient
+      }
+    } catch (error) {
+      if (error instanceof SessionSnapshotRestoreError) {
+        throw error;
+      }
+
+      // Remove the workspace and sessionHome so the next retry sees a true
+      // cold start and re-runs the full restore from scratch.
+      logger
+        .withFields({
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .warn('Post-clone cold-start step failed; removing workspace for clean retry');
+      await cleanupWorkspace(session, context.workspacePath, context.sessionHome);
+
+      throw error;
     }
   }
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1467,12 +1467,10 @@ export class SessionService {
       platform: context.platform,
     });
 
-    // Wrap post-clone steps so that a transient failure (e.g. `kilo import`)
-    // removes the workspace directory. Without this, `.git` survives and the
-    // next retry sees `isColdStart = false`, skipping the full restore flow —
-    // leaving the session in a broken half-initialized state.
-    // `SessionSnapshotRestoreError` (404) is permanent and is re-thrown without
-    // cleanup since retrying won't help.
+    // Wrap post-clone steps so that any failure removes the workspace
+    // directory. Without this, `.git` survives and the next retry sees
+    // `isColdStart = false`, skipping the full restore flow — leaving the
+    // session in a broken half-initialized state.
     try {
       // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
       await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
@@ -1517,10 +1515,6 @@ export class SessionService {
         await runSetupCommands(session, context, metadata.setupCommands, false); // lenient
       }
     } catch (error) {
-      if (error instanceof SessionSnapshotRestoreError) {
-        throw error;
-      }
-
       // Remove the workspace and sessionHome so the next retry sees a true
       // cold start and re-runs the full restore from scratch.
       logger


### PR DESCRIPTION
## Summary

When a post-clone step (e.g. `kilo import`, snapshot fetch, diff apply) fails during cold-start resume, the workspace directory — including `.git` — was left behind. On the next retry, `handleColdStartResume` saw `isColdStart = false` (because `.git` existed) and skipped the full restore flow, leaving the session in a broken half-initialized state.

This wraps the post-clone steps in `handleColdStartResume` in a try/catch that calls `cleanupWorkspace()` on failure, removing the workspace and session home directories so the next retry sees a true cold start and re-runs the full restore from scratch. This applies to all failure modes, including `SessionSnapshotRestoreError` (404).

Two tests are added covering the workspace-cleanup behavior on import failure and on 404 snapshot response.

## Verification

- [x] `pnpm vitest run` — all 641 tests pass
- [x] `pnpm typecheck` — passes
- [ ] _Additional verification details_

## Visual Changes

N/A

## Reviewer Notes

- The `cleanupWorkspace` helper (from `workspace.ts`) removes both the workspace directory and the session home directory using `session.exec()`. This is best-effort — the original error is always re-thrown.
- The initial commit excluded 404 from cleanup; the follow-up commit (`02d0959`) corrected this to also clean up on 404 since a stale `.git` causes the same warm-start misrouting regardless of the error type.