### PR TITLE
fix(auto-fix): guard create-pr endpoint against review-comment tickets

### DIFF
--- a/src/app/api/internal/auto-fix/create-pr/route.ts
+++ b/src/app/api/internal/auto-fix/create-pr/route.ts
@@ -19,7 +19,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getFixTicketById, updateFixTicketStatus } from '@/lib/auto-fix/db/fix-tickets';
 import { logExceptInTest, errorExceptInTest } from '@/lib/utils.server';
-import { captureException } from '@sentry/nextjs';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
 import { createPullRequest } from '@/lib/auto-fix/github/create-pull-request';
 import { postIssueComment } from '@/lib/auto-fix/github/post-comment';
@@ -66,6 +66,44 @@ export async function POST(req: NextRequest) {
     if (!ticket) {
       logExceptInTest('[auto-fix-create-pr] Ticket not found', { ticketId });
       return NextResponse.json({ error: 'Ticket not found' }, { status: 404 });
+    }
+
+    // Review-comment tickets should never go through this endpoint.
+    // They are handled entirely via handleCommentReply in the pr-callback route.
+    if (ticket.review_comment_id != null) {
+      errorExceptInTest(
+        '[auto-fix-create-pr] Rejecting review-comment ticket — use pr-callback instead',
+        { ticketId, reviewCommentId: ticket.review_comment_id }
+      );
+      captureMessage('create-pr called for review-comment ticket', {
+        level: 'warning',
+        tags: { source: 'auto-fix-create-pr' },
+        extra: {
+          ticketId,
+          sessionId,
+          reviewCommentId: ticket.review_comment_id,
+          triggerSource: ticket.trigger_source,
+        },
+      });
+      return NextResponse.json(
+        { error: 'Review-comment tickets are handled via pr-callback, not create-pr' },
+        { status: 400 }
+      );
+    }
+
+    const isTerminalState =
+      ticket.status === 'completed' || ticket.status === 'failed' || ticket.status === 'cancelled';
+
+    if (isTerminalState) {
+      logExceptInTest('[auto-fix-create-pr] Ticket already in terminal state, skipping', {
+        ticketId,
+        currentStatus: ticket.status,
+      });
+      return NextResponse.json({
+        success: true,
+        message: 'Ticket already in terminal state',
+        currentStatus: ticket.status,
+      });
     }
 
     try {


### PR DESCRIPTION
## Summary

When `@kilo fix it` is used on a review comment, cloud-agent-next calls both `/api/internal/auto-fix/pr-callback` (the correct path) and the legacy `/api/internal/auto-fix/create-pr` endpoint. The `pr-callback` route correctly posts the result on the review thread, but `create-pr` had no guards — it would also try to create a PR and post an issue-level comment on the PR main thread, causing duplicate notifications.

Confirmed via Axiom logs on PR #927: `pr-callback` handled the failure at 13:36:28, then `create-pr` fired at 13:36:33 and posted a spurious "Auto-Fix Update" comment on the PR main thread.

This adds two guards to the `create-pr` endpoint:
- **Review-comment rejection** — if the ticket has a `review_comment_id`, return 400 (these tickets belong in `pr-callback` → `handleCommentReply`).
- **Terminal-state check** — if the ticket is already completed/failed/cancelled, return early instead of re-processing.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `prettier --write` — no changes needed
- [x] `eslint` — no warnings or errors

## Visual Changes

N/A

## Reviewer Notes

The `create-pr` endpoint appears to be legacy — no code in the current orchestrator constructs its URL. It's called by cloud-agent-next externally. Even if that external call is eventually removed, these guards are cheap insurance against the same class of bug.