### PR TITLE
feat(kiloclaw): add headless Chromium browser support

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -5,7 +5,7 @@ ENV NODE_VERSION=22.13.1
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates curl gnupg git xz-utils unzip jq ripgrep rsync zstd \
-       build-essential python3 ffmpeg tmux \
+       build-essential python3 ffmpeg tmux chromium \
     && ARCH="$(dpkg --print-architecture)" \
     && case "${ARCH}" in \
          amd64) NODE_ARCH="x64" ;; \

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -92,6 +92,11 @@ describe('generateBaseConfig', () => {
     expect(config.tools.exec.host).toBe('gateway');
     expect(config.tools.exec.security).toBe('allowlist');
     expect(config.tools.exec.ask).toBe('on-miss');
+
+    // Browser
+    expect(config.browser.enabled).toBe(true);
+    expect(config.browser.headless).toBe(true);
+    expect(config.browser.noSandbox).toBe(true);
   });
 
   it('always sets tool profile to full on restore', () => {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -172,6 +172,14 @@ export function generateBaseConfig(
   config.tools.exec.security = 'allowlist';
   config.tools.exec.ask = 'on-miss';
 
+  // Browser: headless Chromium for the browser tool in Docker.
+  // OpenClaw auto-detects /usr/bin/chromium and adds --disable-dev-shm-usage on Linux.
+  // noSandbox is required in containers (Chromium's setuid sandbox needs kernel namespacing).
+  config.browser = config.browser ?? {};
+  config.browser.enabled = true;
+  config.browser.headless = true;
+  config.browser.noSandbox = true;
+
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {
     const dmPolicy = env.TELEGRAM_DM_POLICY || 'pairing';

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -268,6 +268,14 @@ config.tools.exec.host = 'gateway';
 config.tools.exec.security = 'allowlist';
 config.tools.exec.ask = 'on-miss';
 
+// Browser: headless Chromium for the browser tool in Docker.
+// OpenClaw auto-detects /usr/bin/chromium and adds --disable-dev-shm-usage on Linux.
+// noSandbox is required in containers (Chromium's setuid sandbox needs kernel namespacing).
+config.browser = config.browser || {};
+config.browser.enabled = true;
+config.browser.headless = true;
+config.browser.noSandbox = true;
+
 // Telegram configuration
 // Overwrite entire channel object to drop stale keys that would fail
 // OpenClaw's strict config validation (matches moltworker behavior)

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-03-09',
+    description:
+      'Added headless Chromium browser support. OpenClaw\'s built-in browser tool now works out of the box for web browsing, screenshots, and CDP automation. Requires the "full" tool profile.',
+    category: 'feature',
+    deployHint: 'redeploy_required',
+  },
+  {
     date: '2026-03-05',
     description:
       'New deploys now default to the "full" tool profile, giving agents access to all tools including exec, filesystem, web search, and messaging. Existing instances can change their profile in the Control UI under Settings > Config > Tools > Tool Profile.',


### PR DESCRIPTION


## Summary

  - Install chromium in the Docker image so OpenClaw's built-in browser tool works out of the
  box                                    
  - Configure browser.headless, browser.noSandbox, and browser.enabled in the openclaw.json
  config patch for containerized operation
  - Sync the same browser config to config-writer.ts so config restores don't lose browser
  support

<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification

<!-- List the checks you ran and what passed. Add command output notes when useful. -->

  - Deploy a fresh kiloclaw instance (destroy + recreate to trigger fresh install path)
  - Verify which chromium returns /usr/bin/chromium on the Fly machine
  - Verify cat /root/.openclaw/openclaw.json | grep -A4 browser shows enabled: true, headless:
  true, noSandbox: true
  - Verify Chromium processes are running (ps -ef | grep chromium)
  - Ask the agent to use the browser tool (e.g. "use the browser tool to open
  https://example.com and take a screenshot") — confirms end-to-end CDP functionality
  - All 505 kiloclaw tests pass

## Visual Changes
  None — this is backend/infrastructure only.
<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
| ------ | ----- |
|        |       |

## Reviewer Notes

  - OpenClaw auto-detects /usr/bin/chromium on Linux and auto-adds --disable-dev-shm-usage, so
  no executablePath config is needed
  - noSandbox: true is required in containers — Chromium's setuid sandbox needs kernel
  namespacing that's unavailable in Docker/Fly
  - The chromium apt package installs to /usr/bin/ which is outside the Fly Volume mount at
  /root, so it survives volume mounts and restarts
  - Image size increases ~200-250 MB due to Chromium and its dependencies
  - Existing instances need tools.profile: "full" to see the browser tool — the "messaging"
  profile (onboard default) doesn't include it. Fresh installs already get "full" via the
  startup script

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
