### PR TITLE
feat(cloud-agent-next): add session sharing for V2 sessions

### DIFF
--- a/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
+++ b/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
@@ -276,15 +276,26 @@ export function SessionsPageContent() {
                 )}
 
                 {selectedSession.source === 'v2' && (
-                  <div className="space-y-2">
-                    <p className="text-muted-foreground text-xs">
-                      Use the CLI to fork this session:
-                    </p>
-                    <CopyableCommand
-                      command={`kilo --session ${selectedSession.sessionId} --fork`}
-                      className="bg-muted rounded-md px-3 py-2 text-sm"
-                    />
-                  </div>
+                  <>
+                    {/* Open in Editor (v2) */}
+                    <div className="flex justify-center">
+                      <OpenInEditorButton
+                        sessionId={selectedSession.sessionId}
+                        pathOverride={`/s/${selectedSession.sessionId}`}
+                      />
+                    </div>
+
+                    {/* Fork in CLI (v2) */}
+                    <div className="space-y-2">
+                      <p className="text-muted-foreground text-xs">
+                        Or use the CLI to fork this session:
+                      </p>
+                      <CopyableCommand
+                        command={`kilo --session ${selectedSession.sessionId} --cloud-fork`}
+                        className="bg-muted rounded-md px-3 py-2 text-sm"
+                      />
+                    </div>
+                  </>
                 )}
               </div>
             </div>

--- a/src/components/cloud-agent-next/SessionActionsDialog.tsx
+++ b/src/components/cloud-agent-next/SessionActionsDialog.tsx
@@ -12,15 +12,12 @@ import { Button } from '@/components/ui/button';
 import { Loader2, Copy, Check, Share2, GitFork } from 'lucide-react';
 import { useRawTRPCClient } from '@/lib/trpc/utils';
 import { toast } from 'sonner';
-import { CliSessionSharedState } from '@/types/cli-session-shared-state';
-import { OpenInEditorButton } from '@/app/share/[shareId]/open-in-editor-button';
-import { OpenInCliButton } from '@/app/share/[shareId]/open-in-cli-button';
 import { CopyableCommand } from '@/components/CopyableCommand';
 
 type SessionActionsDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** The Kilo session ID (UUID from cliSessions.session_id) */
+  /** The Kilo session ID (UUID from cli_sessions_v2.session_id) */
   kiloSessionId?: string;
   sessionTitle?: string;
   repository?: string;
@@ -47,12 +44,11 @@ export function SessionActionsDialog({
     setIsSharing(true);
 
     try {
-      const result = await trpc.cliSessions.share.mutate({
+      const result = await trpc.cliSessionsV2.share.mutate({
         session_id: kiloSessionId,
-        shared_state: CliSessionSharedState.Public,
       });
 
-      const url = new URL(`/share/${result.share_id}`, window.location.origin).toString();
+      const url = new URL(`/s/${result.public_id}`, window.location.origin).toString();
       setShareUrl(url);
       toast.success('Session shared successfully');
     } catch (error) {
@@ -186,33 +182,15 @@ export function SessionActionsDialog({
               <h3 className="text-sm font-medium">Fork Session</h3>
             </div>
             <p className="text-muted-foreground text-xs">
-              Fork this session to continue working on it in your editor or CLI
+              Fork this session to continue working on it in your CLI
             </p>
 
-            {kiloSessionId && (
-              <div className="space-y-3">
-                {/* Open in Editor */}
-                <div className="flex justify-center">
-                  <OpenInEditorButton sessionId={kiloSessionId} />
-                </div>
-
-                {/* Open in CLI */}
-                <div className="flex justify-center">
-                  <OpenInCliButton command={`kilocode --fork ${kiloSessionId}`} />
-                </div>
-
-                {/* Manual fork command */}
-                <div className="space-y-2">
-                  <p className="text-muted-foreground text-xs">Or use the fork command manually:</p>
-                  <CopyableCommand
-                    command={`/session fork ${kiloSessionId}`}
-                    className="bg-muted rounded-md px-3 py-2 text-sm"
-                  />
-                </div>
-              </div>
-            )}
-
-            {!kiloSessionId && (
+            {kiloSessionId ? (
+              <CopyableCommand
+                command={`kilo --session ${kiloSessionId} --fork`}
+                className="bg-muted rounded-md px-3 py-2 text-sm"
+              />
+            ) : (
               <p className="text-muted-foreground text-center text-sm">
                 Session ID not available yet
               </p>

--- a/src/components/cloud-agent-next/SessionActionsDialog.tsx
+++ b/src/components/cloud-agent-next/SessionActionsDialog.tsx
@@ -187,7 +187,7 @@ export function SessionActionsDialog({
 
             {kiloSessionId ? (
               <CopyableCommand
-                command={`kilo --session ${kiloSessionId} --fork`}
+                command={`kilo --session ${kiloSessionId} --cloud-fork`}
                 className="bg-muted rounded-md px-3 py-2 text-sm"
               />
             ) : (

--- a/src/components/cloud-agent-next/SessionActionsDialog.tsx
+++ b/src/components/cloud-agent-next/SessionActionsDialog.tsx
@@ -13,6 +13,7 @@ import { Loader2, Copy, Check, Share2, GitFork } from 'lucide-react';
 import { useRawTRPCClient } from '@/lib/trpc/utils';
 import { toast } from 'sonner';
 import { CopyableCommand } from '@/components/CopyableCommand';
+import { OpenInEditorButton } from '@/app/share/[shareId]/open-in-editor-button';
 
 type SessionActionsDialogProps = {
   open: boolean;
@@ -182,14 +183,26 @@ export function SessionActionsDialog({
               <h3 className="text-sm font-medium">Fork Session</h3>
             </div>
             <p className="text-muted-foreground text-xs">
-              Fork this session to continue working on it in your CLI
+              Fork this session to continue working on it in your editor or CLI
             </p>
 
             {kiloSessionId ? (
-              <CopyableCommand
-                command={`kilo --session ${kiloSessionId} --cloud-fork`}
-                className="bg-muted rounded-md px-3 py-2 text-sm"
-              />
+              <div className="space-y-3">
+                <div className="flex justify-center">
+                  <OpenInEditorButton
+                    sessionId={kiloSessionId}
+                    pathOverride={`/s/${kiloSessionId}`}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-muted-foreground text-xs">Use this command in CLI:</p>
+                  <CopyableCommand
+                    command={`kilo --session ${kiloSessionId} --cloud-fork`}
+                    className="bg-muted rounded-md px-3 py-2 text-sm"
+                  />
+                </div>
+              </div>
             ) : (
               <p className="text-muted-foreground text-center text-sm">
                 Session ID not available yet

--- a/src/components/cloud-agent-next/ShareSessionDialog.tsx
+++ b/src/components/cloud-agent-next/ShareSessionDialog.tsx
@@ -13,12 +13,11 @@ import { Button } from '@/components/ui/button';
 import { Loader2, Copy, Check } from 'lucide-react';
 import { useRawTRPCClient } from '@/lib/trpc/utils';
 import { toast } from 'sonner';
-import { CliSessionSharedState } from '@/types/cli-session-shared-state';
 
 type ShareSessionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** The Kilo session ID (UUID from cliSessions.session_id) */
+  /** The Kilo session ID (UUID from cli_sessions_v2.session_id) */
   kiloSessionId?: string;
 };
 
@@ -37,12 +36,11 @@ export function ShareSessionDialog({ open, onOpenChange, kiloSessionId }: ShareS
     setIsSharing(true);
 
     try {
-      const result = await trpc.cliSessions.share.mutate({
+      const result = await trpc.cliSessionsV2.share.mutate({
         session_id: kiloSessionId,
-        shared_state: CliSessionSharedState.Public,
       });
 
-      const url = `${window.location.origin}/share/${result.share_id}`;
+      const url = `${window.location.origin}/s/${result.public_id}`;
       setShareUrl(url);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to share session';

--- a/src/lib/session-ingest-client.test.ts
+++ b/src/lib/session-ingest-client.test.ts
@@ -1,7 +1,12 @@
 import { captureException } from '@sentry/nextjs';
 import { generateInternalServiceToken } from '@/lib/tokens';
 import type { SessionSnapshot } from './session-ingest-client';
-import { fetchSessionSnapshot, fetchSessionMessages, deleteSession } from './session-ingest-client';
+import {
+  fetchSessionSnapshot,
+  fetchSessionMessages,
+  deleteSession,
+  shareSession,
+} from './session-ingest-client';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -256,6 +261,119 @@ describe('deleteSession', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       'https://ingest.test.example.com/api/session/ses_with%20spaces%26special',
+      expect.any(Object)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shareSession
+// ---------------------------------------------------------------------------
+
+describe('shareSession', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockCaptureException.mockReset();
+    mockGenerateInternalServiceToken.mockReset().mockReturnValue('mock-jwt-token');
+  });
+
+  it('returns public_id on success', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, public_id: 'pub_abc123' }),
+    });
+
+    const result = await shareSession('ses_abc123', 'user_123');
+
+    expect(result).toEqual({ public_id: 'pub_abc123' });
+  });
+
+  it('calls POST on the correct URL', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, public_id: 'pub_abc123' }),
+    });
+
+    await shareSession('ses_abc123', 'user_123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ingest.test.example.com/api/session/ses_abc123/share',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('sends correct Authorization header', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, public_id: 'pub_abc123' }),
+    });
+
+    await shareSession('ses_abc123', 'user_123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: { Authorization: 'Bearer mock-jwt-token' } })
+    );
+  });
+
+  it('generates token for the given userId', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, public_id: 'pub_abc123' }),
+    });
+
+    await shareSession('ses_abc123', 'user_test_456');
+
+    expect(mockGenerateInternalServiceToken).toHaveBeenCalledWith('user_test_456');
+  });
+
+  it('throws on 404', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    await expect(shareSession('ses_nonexistent', 'user_123')).rejects.toThrow('Session not found');
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('throws and calls captureException on 500', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve('something broke'),
+    });
+
+    await expect(shareSession('ses_abc123', 'user_123')).rejects.toThrow(
+      'Session ingest share failed: 500 Internal Server Error - something broke'
+    );
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { source: 'session-ingest-client', endpoint: 'share' },
+        extra: { sessionId: 'ses_abc123', status: 500 },
+      })
+    );
+  });
+
+  it('encodes session ID in URL', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, public_id: 'pub_abc123' }),
+    });
+
+    await shareSession('ses_with spaces&special', 'user_123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ingest.test.example.com/api/session/ses_with%20spaces%26special/share',
       expect.any(Object)
     );
   });

--- a/src/lib/session-ingest-client.ts
+++ b/src/lib/session-ingest-client.ts
@@ -97,6 +97,63 @@ export async function fetchSessionMessages(
   return snapshot?.messages ?? null;
 }
 
+// ---------------------------------------------------------------------------
+// Share
+// ---------------------------------------------------------------------------
+
+const ShareResponseSchema = z.object({
+  success: z.literal(true),
+  public_id: z.string(),
+});
+
+/**
+ * Share a session via the session-ingest worker.
+ *
+ * Calls POST /session/:sessionId/share which is idempotent — if the session
+ * already has a public_id, the existing one is returned.
+ *
+ * @returns The public_id used to construct the /s/{public_id} share URL.
+ */
+export async function shareSession(
+  sessionId: string,
+  userId: string
+): Promise<{ public_id: string }> {
+  if (!SESSION_INGEST_WORKER_URL) {
+    throw new Error('SESSION_INGEST_WORKER_URL is not configured');
+  }
+
+  const token = generateInternalServiceToken(userId);
+  const url = `${SESSION_INGEST_WORKER_URL}/api/session/${encodeURIComponent(sessionId)}/share`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (response.status === 404) {
+    throw new Error('Session not found');
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    const error = new Error(
+      `Session ingest share failed: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`
+    );
+    captureException(error, {
+      tags: { source: 'session-ingest-client', endpoint: 'share' },
+      extra: { sessionId, status: response.status },
+    });
+    throw error;
+  }
+
+  const body = ShareResponseSchema.parse(await response.json());
+  return { public_id: body.public_id };
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
 /**
  * Delete a session via the session-ingest worker.
  *

--- a/src/routers/cli-sessions-v2-router.ts
+++ b/src/routers/cli-sessions-v2-router.ts
@@ -12,6 +12,7 @@ import { generateApiToken } from '@/lib/tokens';
 import {
   fetchSessionMessages,
   deleteSession as deleteSessionIngest,
+  shareSession as shareSessionIngest,
 } from '@/lib/session-ingest-client';
 import { baseGetSessionNextOutputSchema } from './cloud-agent-next-schemas';
 import { sanitizeGitUrl } from '@/routers/cli-sessions-router';
@@ -93,6 +94,10 @@ const GetByCloudAgentSessionIdInputSchema = z.object({
 });
 
 const DeleteSessionInputSchema = z.object({
+  session_id: sessionIdField,
+});
+
+const ShareSessionInputSchema = z.object({
   session_id: sessionIdField,
 });
 
@@ -367,5 +372,31 @@ export const cliSessionsV2Router = createTRPCRouter({
     await deleteSessionIngest(session_id, ctx.user.id);
 
     return { success: true, session_id };
+  }),
+
+  /**
+   * Share a V2 session by generating a public_id.
+   *
+   * Delegates to the session-ingest worker which is idempotent — if the session
+   * already has a public_id, the existing one is returned.
+   */
+  share: baseProcedure.input(ShareSessionInputSchema).mutation(async ({ ctx, input }) => {
+    const { session_id } = input;
+    await getSessionWithOwnerCheck(session_id, ctx.user.id);
+
+    try {
+      const result = await shareSessionIngest(session_id, ctx.user.id);
+      return { public_id: result.public_id };
+    } catch (error) {
+      captureException(error, {
+        tags: { source: 'cli-sessions-v2-router', endpoint: 'share' },
+        extra: { session_id },
+      });
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to share session',
+        cause: error,
+      });
+    }
   }),
 });


### PR DESCRIPTION
## Summary

Add session sharing support to the V2 session pipeline by delegating to the session-ingest worker's `POST /session/:id/share` endpoint, and restore the cloud chat session actions editor deep link so users can reopen sessions directly from the dialog.

- **New `shareSession` ingest client function** (`session-ingest-client.ts`) - calls the ingest worker's share endpoint, which is idempotent and returns the existing `public_id` when a session was already shared.
- **New `share` tRPC mutation** (`cli-sessions-v2-router.ts`) - exposes sharing via the V2 router with ownership verification before delegating to the ingest client.
- **Migrated V2 dialogs to the V2 share flow** - `SessionActionsDialog` and `ShareSessionDialog` now call `cliSessionsV2.share` and generate `/s/{public_id}` share URLs.
- **Restored session actions editor opening** - `src/components/cloud-agent-next/SessionActionsDialog.tsx` now shows `OpenInEditorButton` again and uses the extension deep link path `/s/{sessionId}`, producing `vscode://kilocode.kilo-code/kilocode/s/{sessionId}`.
- **Kept the CLI fallback command in place** - the fork section still shows the existing `kilo --session <id> --cloud-fork` command for terminal users.

## Verification

- `pnpm typecheck` ✅

## Visual Changes

| Before | After |
| ------ | ----- |
| Cloud chat V2 session actions showed only the CLI command in the fork section | Cloud chat V2 session actions show `Open in VS Code` plus the existing CLI command |
| Session actions editor deep link was missing | Session actions editor deep link opens `vscode://kilocode.kilo-code/kilocode/s/{sessionId}` |
| V2 share URLs used legacy dialog behavior | V2 share URLs use `/s/{public_id}` |

## Reviewer Notes

- The editor deep link in the cloud chat session actions dialog is intentionally based on the live Kilo session id, not the public share id.
- This only updates the V2 session actions dialog; the shared web page and CLI import flow remain unchanged.