### PR TITLE
fix(cloud-agent-next): surface restore script failure details in logs and error messages

### DIFF
--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1305,39 +1305,47 @@ export class SessionService {
       );
 
       if (restoreResult.exitCode !== 0) {
-        logger
-          .withFields({
-            sessionId,
-            userId,
-            exitCode: restoreResult.exitCode,
-            stderr: restoreResult.stderr,
-            stdout: restoreResult.stdout,
-          })
-          .error('Cold-start session restore failed');
-
-        // Parse stdout JSON for structured error info
-        let code: number | undefined;
+        // Parse the script's structured JSON output for diagnostic fields
+        let restoreStep: string | undefined;
+        let restoreError: string | undefined;
+        let restoreCode: number | undefined;
         try {
           const parsed = JSON.parse(restoreResult.stdout?.trim() ?? '{}') as Record<
             string,
             unknown
           >;
-          if (typeof parsed.code === 'number') {
-            code = parsed.code;
-          }
+          if (typeof parsed.step === 'string') restoreStep = parsed.step;
+          if (typeof parsed.error === 'string') restoreError = parsed.error;
+          if (typeof parsed.code === 'number') restoreCode = parsed.code;
         } catch {
           // non-JSON stdout, ignore
         }
 
-        if (code === 404) {
+        logger
+          .withFields({
+            sessionId,
+            userId,
+            exitCode: restoreResult.exitCode,
+            restoreStep,
+            restoreError,
+            restoreCode,
+            stderr: restoreResult.stderr,
+          })
+          .error('Cold-start session restore failed');
+
+        if (restoreCode === 404) {
           throw new SessionSnapshotRestoreError(
             'Session snapshot restore failed: session not found',
             404
           );
         }
+
+        const detail = restoreStep
+          ? `step=${restoreStep} error=${restoreError ?? 'unknown'}`
+          : `stdout=${restoreResult.stdout?.trim()}`;
         throw new SessionSnapshotRestoreError(
-          `Cold-start session restore failed: exit ${restoreResult.exitCode}`,
-          code
+          `Cold-start session restore failed: ${detail} (exit ${restoreResult.exitCode})`,
+          restoreCode
         );
       }
 


### PR DESCRIPTION
## Summary

When the restore session script (`kilo-restore-session.js`) fails, the worker logs raw `stdout`/`stderr` as structured fields via `.withFields()`, but the script's parsed diagnostic fields (`step`, `error`, `code`) are mostly discarded — only `code` is extracted for 404 detection. This makes it hard to diagnose restore failures in Axiom since the useful info is buried inside a JSON blob within the log message string.

This change:
- Parses `step`, `error`, and `code` from the script's JSON stdout **before** logging, and includes them as top-level structured fields (`restoreStep`, `restoreError`, `restoreCode`) in the log entry — directly queryable in Axiom
- Drops raw `stdout` from log fields (redundant once parsed); keeps `stderr` for human-readable diagnostics
- Enriches the thrown `SessionSnapshotRestoreError` message with the parsed step/error (e.g., `"Cold-start session restore failed: step=import error='kilo import failed exitCode=1' (exit 1)"`) so downstream logging captures the diagnosis
- Falls back to including raw stdout in the error message when stdout isn't valid JSON

## Verification

- [x] `pnpm run test` — 642 tests passed
- [x] `pnpm run typecheck` — clean (tsgo + wrapper)
- [ ] _Additional verification by reviewer_

## Visual Changes

N/A

## Reviewer Notes

- The existing test assertion on the generic failure path uses `.rejects.toThrow('Cold-start session restore failed')` which is a substring match — the new message format `"Cold-start session restore failed: ... (exit 1)"` still matches, so no test changes needed.
- The 404 error path and its message are unchanged.
- `restoreStep`/`restoreError`/`restoreCode` will be `undefined` (omitted from the JSON) when stdout isn't valid JSON — the log shape degrades gracefully.