### PR TITLE
fix(cloud-agent-next): include step and error detail in session restore failure messages

### DIFF
--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1317,6 +1317,8 @@ export class SessionService {
 
         // Parse stdout JSON for structured error info
         let code: number | undefined;
+        let step: string | undefined;
+        let restoreError: string | undefined;
         try {
           const parsed = JSON.parse(restoreResult.stdout?.trim() ?? '{}') as Record<
             string,
@@ -1324,6 +1326,12 @@ export class SessionService {
           >;
           if (typeof parsed.code === 'number') {
             code = parsed.code;
+          }
+          if (typeof parsed.step === 'string') {
+            step = parsed.step;
+          }
+          if (typeof parsed.error === 'string') {
+            restoreError = parsed.error;
           }
         } catch {
           // non-JSON stdout, ignore
@@ -1335,10 +1343,15 @@ export class SessionService {
             404
           );
         }
-        throw new SessionSnapshotRestoreError(
-          `Cold-start session restore failed: exit ${restoreResult.exitCode}`,
-          code
-        );
+
+        const detail = [
+          `exit ${restoreResult.exitCode}`,
+          step && `step=${step}`,
+          restoreError && `error=${restoreError}`,
+        ]
+          .filter(Boolean)
+          .join(', ');
+        throw new SessionSnapshotRestoreError(`Cold-start session restore failed: ${detail}`, code);
       }
 
       // Log structured summary from restore script


### PR DESCRIPTION
## Summary

When `kilo-restore-session.js` fails, the structured stdout (containing `step`, `error`, and `code` fields) was logged locally inside the Durable Object but lost by the time the error propagated through the tRPC chain to logpush. The error message only said `"Cold-start session restore failed: exit 1"`, making it impossible to diagnose failures from logpush alone.

This change enriches the `SessionSnapshotRestoreError` message at the throw site to include `step` and `error` fields extracted from the restore script's JSON stdout. The richer message flows naturally through the existing error chain (`SessionSnapshotRestoreError` → `ExecutionError.workspaceSetupFailed` → `TRPCError`) without any downstream changes.

**Before:** `"Failed to prepare workspace: Cold-start session restore failed: exit 1"`
**After:** `"Failed to prepare workspace: Cold-start session restore failed: exit 1, step=import, error=kilo import failed exitCode=1"`

## Verification

- [x] `pnpm run typecheck` — passed (tsgo + wrapper)
- [x] `pnpm run test` — 642 tests passed, 25 test files
- [x] Verified existing test assertions use substring matching (`toThrow('Cold-start session restore failed')`) and remain compatible with the enriched message

## Visual Changes

N/A

## Reviewer Notes

- Single file change: `cloud-agent-next/src/session-service.ts` — extends the existing stdout JSON parsing block (which already extracts `code`) to also extract `step` and `error`.
- No new error class fields, no changes to orchestrator/CloudAgentSession/session-execution.
- The `as Record<string, unknown>` cast on `JSON.parse` matches the existing pattern at this location.