### PR TITLE
fix(kiloclaw): clarify "Upgrade & Redeploy" copy

### DIFF
--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -200,7 +200,7 @@ export function InstanceControls({
               <Label htmlFor="upgrade" className="block cursor-pointer leading-tight">
                 <span className="text-foreground text-sm font-medium">Upgrade to latest</span>
                 <span className="text-muted-foreground mt-0.5 block text-xs">
-                  Upgrade to the latest KiloClaw version, redeploy and apply pending config changes.
+                  Upgrade to the latest supported KiloClaw version, redeploy and apply pending config changes.
                 </span>
               </Label>
             </div>


### PR DESCRIPTION
## Summary
- Changes "Upgrade to the latest KiloClaw version" to "Upgrade to the latest **supported** KiloClaw version" in the Redeploy dialog's "Upgrade to latest" radio option.
- Clarifies that the upgrade targets the latest *supported* platform image, not necessarily the absolute latest OpenClaw release.