### PR TITLE
fix(kiloclaw): fix Restore Default Config button always disabled

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -90,8 +90,8 @@ RUN cd /tmp/controller-build \
     && bun install --frozen-lockfile \
     && CONTROLLER_VERSION="$(date -u +'%Y.%-m.%-d')" \
     && bun build src/index.ts --outfile=/usr/local/bin/kiloclaw-controller.js --target=node --minify \
-       --define "KILOCLAW_CONTROLLER_VERSION='\"${CONTROLLER_VERSION}\"'" \
-       --define "KILOCLAW_CONTROLLER_COMMIT='\"${CONTROLLER_COMMIT}\"'" \
+       --define "KILOCLAW_CONTROLLER_VERSION=\"${CONTROLLER_VERSION}\"" \
+       --define "KILOCLAW_CONTROLLER_COMMIT=\"${CONTROLLER_COMMIT}\"" \
     && rm -rf /tmp/controller-build
 
 # Create OpenClaw directories

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -251,7 +251,10 @@ export function SettingsTab({
   const isRunning = status.status === 'running';
   const { data: controllerVersion } = useControllerVersion(isRunning);
   const { data: myPin } = useKiloClawMyPin();
-  const supportsConfigRestore = calverAtLeast(controllerVersion?.version, '2026.2.26');
+  const supportsConfigRestore = calverAtLeast(
+    cleanVersion(controllerVersion?.version),
+    '2026.2.26'
+  );
 
   const channelStatus = config?.channels ?? {
     telegram: false,


### PR DESCRIPTION
## Summary

- The "Restore Default Config" button in KiloClaw Settings > Danger Zone was permanently disabled for all users due to a `bun build --define` quoting bug in the Dockerfile.
- The `--define` flag wrapped the controller version string in extra single quotes (`'\"...\"'`), embedding literal double-quote characters in the runtime value (e.g. `"2026.2.26"` instead of `2026.2.26`). When `calverAtLeast()` split this by `.` and called `Number()`, it produced `NaN` and returned `false`.
- Two fixes applied: (1) corrected `--define` syntax in the Dockerfile so the version string is clean at the source, and (2) applied the existing `cleanVersion()` helper to the version before comparison, as defense-in-depth for already-deployed controller images that have the bad quoting baked in.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` (kiloclaw) — all 517 tests pass
- [x] Manual local verification: built the controller with both the broken and fixed `--define` syntax, inspected the bundled output:
  - **Broken** build inlines `e='"2026.2.26"'` (13-char string with embedded `"` chars) → `calverAtLeast` splits to `[NaN, 2, NaN]` → returns `false`
  - **Fixed** build inlines `e="2026.2.26"` (9-char clean string) → `calverAtLeast` splits to `[2026, 2, 26]` → returns `true`

Verification commands:
```bash
# Build with current (broken) --define:
CONTROLLER_VERSION="2026.2.26" bun build src/index.ts --outfile=/tmp/broken.js --target=node --minify \
  --define "KILOCLAW_CONTROLLER_VERSION='\"${CONTROLLER_VERSION}\"'"
# Inspect: shows e='"2026.2.26"' (embedded quotes)

# Build with fixed --define:
CONTROLLER_VERSION="2026.2.26" bun build src/index.ts --outfile=/tmp/fixed.js --target=node --minify \
  --define "KILOCLAW_CONTROLLER_VERSION=\"${CONTROLLER_VERSION}\""
# Inspect: shows e="2026.2.26" (clean)

# Confirm calverAtLeast behavior:
node -e "
function calverAtLeast(v, min) {
  if (!v) return false;
  const p = v.split('.').map(Number), m = min.split('.').map(Number);
  for (let i = 0; i < m.length; i++) {
    const a = p[i]??0, b = m[i]??0;
    if (Number.isNaN(a)||Number.isNaN(b)) return false;
    if (a>b) return true; if (a<b) return false;
  }
  return true;
}
console.log('Broken:', calverAtLeast('\"2026.2.26\"', '2026.2.26'));  // false
console.log('Fixed:', calverAtLeast('2026.2.26', '2026.2.26'));       // true
"
```

## Visual Changes

N/A — the button was already rendered but permanently disabled. After this fix it becomes enabled when the controller version meets the minimum requirement.

## Reviewer Notes

- The Dockerfile fix (`--define` quoting) is the root cause fix but only takes effect on the **next image build**. Existing deployed controller images still have the embedded quotes.
- The frontend `cleanVersion()` wrapping is defense-in-depth that makes the button work immediately for users with already-deployed images, without requiring a redeploy.
- The same quoting issue affected `KILOCLAW_CONTROLLER_COMMIT` — fixed in the same change. This value isn't used in any comparison logic today, but is now correct for any future use.
- `cleanVersion()` was already used for `openclawVersion` from the same `controllerVersion` object (lines 286-287); applying it to `version` is consistent.