### PR TITLE
fix(code-reviews): show model and tokens in review summary for v2 reviews

### DIFF
--- a/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -18,7 +18,12 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { updateCodeReviewStatus, getCodeReviewById } from '@/lib/code-reviews/db/code-reviews';
+import {
+  updateCodeReviewStatus,
+  updateCodeReviewUsage,
+  getCodeReviewById,
+  getSessionUsageFromBilling,
+} from '@/lib/code-reviews/db/code-reviews';
 import { tryDispatchPendingReviews } from '@/lib/code-reviews/dispatch/dispatch-pending-reviews';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 import { logExceptInTest, errorExceptInTest } from '@/lib/utils.server';
@@ -112,7 +117,14 @@ function normalizePayload(raw: StatusUpdatePayload): {
 
 /**
  * Read a review's usage data, polling with exponential backoff if not yet available.
- * Handles the race between the orchestrator's usage report and the cloud agent's completion callback.
+ *
+ * For v1 (SSE) reviews the orchestrator reports usage before the completion
+ * callback fires, so a short poll handles the race.  For v2 (cloud-agent-next)
+ * reviews the orchestrator never reports usage — we fall back to aggregating
+ * from the billing tables (microdollar_usage) keyed by cli_session_id.
+ *
+ * When the billing fallback is used we also back-fill the code_reviews record
+ * so subsequent reads (e.g. the admin panel) don't need the aggregation again.
  */
 async function getReviewUsageData(reviewId: string) {
   const MAX_RETRIES = 3;
@@ -120,16 +132,43 @@ async function getReviewUsageData(reviewId: string) {
 
   let review = await getCodeReviewById(reviewId);
 
+  // Short poll: usage may arrive from the orchestrator just before the callback
   for (let attempt = 0; attempt < MAX_RETRIES && review && !review.model; attempt++) {
     await new Promise(resolve => setTimeout(resolve, BASE_DELAY_MS * 2 ** attempt));
     review = await getCodeReviewById(reviewId);
   }
 
-  return {
-    model: review?.model ?? null,
-    tokensIn: review?.total_tokens_in ?? null,
-    tokensOut: review?.total_tokens_out ?? null,
-  };
+  if (review?.model) {
+    return {
+      model: review.model,
+      tokensIn: review.total_tokens_in ?? null,
+      tokensOut: review.total_tokens_out ?? null,
+    };
+  }
+
+  // Fallback: aggregate from billing tables (covers v2 / cloud-agent-next reviews)
+  if (review?.cli_session_id) {
+    const billing = await getSessionUsageFromBilling(review.cli_session_id);
+    if (billing) {
+      // Back-fill the code_reviews record so we don't repeat this aggregation
+      updateCodeReviewUsage(reviewId, {
+        model: billing.model,
+        totalTokensIn: billing.totalTokensIn,
+        totalTokensOut: billing.totalTokensOut,
+        totalCostMusd: billing.totalCostMusd,
+      }).catch(err => {
+        logExceptInTest('[code-review-status] Failed to back-fill usage from billing', err);
+      });
+
+      return {
+        model: billing.model,
+        tokensIn: billing.totalTokensIn,
+        tokensOut: billing.totalTokensOut,
+      };
+    }
+  }
+
+  return { model: null, tokensIn: null, tokensOut: null };
 }
 
 /**

--- a/src/lib/code-reviews/db/code-reviews.ts
+++ b/src/lib/code-reviews/db/code-reviews.ts
@@ -6,8 +6,12 @@
  */
 
 import { db } from '@/lib/drizzle';
-import { cloud_agent_code_reviews } from '@kilocode/db/schema';
-import { eq, and, desc, count, ne, inArray } from 'drizzle-orm';
+import {
+  cloud_agent_code_reviews,
+  microdollar_usage,
+  microdollar_usage_metadata,
+} from '@kilocode/db/schema';
+import { eq, and, desc, count, ne, inArray, sql, sum } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import type { CreateReviewParams, CodeReviewStatus, ListReviewsParams, Owner } from '../core';
 import type { CloudAgentCodeReview } from '@kilocode/db/schema';
@@ -477,5 +481,67 @@ export async function userOwnsReview(reviewId: string, userId: string): Promise<
       extra: { reviewId, userId },
     });
     throw error;
+  }
+}
+
+/**
+ * Result of aggregating billing usage for a session.
+ */
+export type SessionUsageSummary = {
+  model: string;
+  totalTokensIn: number;
+  totalTokensOut: number;
+  totalCostMusd: number;
+};
+
+/**
+ * Aggregates LLM usage from the billing tables for a given kilo session ID.
+ *
+ * This is the fallback path for v2 (cloud-agent-next) reviews where the
+ * orchestrator does not accumulate usage from SSE events.  The billing
+ * system (processUsage → microdollar_usage) already records per-request
+ * usage keyed by session_id, so we aggregate here.
+ *
+ * Returns the model with the highest token volume (the primary review model)
+ * along with totals across all LLM calls in the session.
+ */
+export async function getSessionUsageFromBilling(
+  cliSessionId: string
+): Promise<SessionUsageSummary | null> {
+  try {
+    const rows = await db
+      .select({
+        model: microdollar_usage.model,
+        totalTokensIn: sum(microdollar_usage.input_tokens).mapWith(Number),
+        totalTokensOut: sum(microdollar_usage.output_tokens).mapWith(Number),
+        totalCostMusd: sum(microdollar_usage.cost).mapWith(Number),
+      })
+      .from(microdollar_usage)
+      .innerJoin(
+        microdollar_usage_metadata,
+        eq(microdollar_usage.id, microdollar_usage_metadata.id)
+      )
+      .where(eq(microdollar_usage_metadata.session_id, cliSessionId))
+      .groupBy(microdollar_usage.model)
+      .orderBy(
+        sql`sum(${microdollar_usage.input_tokens} + ${microdollar_usage.output_tokens}) desc`
+      )
+      .limit(1);
+
+    const row = rows[0];
+    if (!row?.model || row.totalTokensIn == null) return null;
+
+    return {
+      model: row.model,
+      totalTokensIn: row.totalTokensIn,
+      totalTokensOut: row.totalTokensOut ?? 0,
+      totalCostMusd: row.totalCostMusd ?? 0,
+    };
+  } catch (error) {
+    captureException(error, {
+      tags: { operation: 'getSessionUsageFromBilling' },
+      extra: { cliSessionId },
+    });
+    return null;
   }
 }

--- a/src/lib/code-reviews/db/code-reviews.ts
+++ b/src/lib/code-reviews/db/code-reviews.ts
@@ -502,40 +502,51 @@ export type SessionUsageSummary = {
  * system (processUsage → microdollar_usage) already records per-request
  * usage keyed by session_id, so we aggregate here.
  *
- * Returns the model with the highest token volume (the primary review model)
- * along with totals across all LLM calls in the session.
+ * Uses two queries:
+ * 1. Session-wide totals (tokens + cost across all models)
+ * 2. The model with the most tokens (the primary review model name)
+ *
+ * This avoids undercounting when a session uses more than one model.
  */
 export async function getSessionUsageFromBilling(
   cliSessionId: string
 ): Promise<SessionUsageSummary | null> {
   try {
-    const rows = await db
+    const sessionFilter = eq(microdollar_usage_metadata.session_id, cliSessionId);
+    const joinCondition = eq(microdollar_usage.id, microdollar_usage_metadata.id);
+
+    // 1. Session-wide totals (all models combined)
+    const [totals] = await db
       .select({
-        model: microdollar_usage.model,
         totalTokensIn: sum(microdollar_usage.input_tokens).mapWith(Number),
         totalTokensOut: sum(microdollar_usage.output_tokens).mapWith(Number),
         totalCostMusd: sum(microdollar_usage.cost).mapWith(Number),
       })
       .from(microdollar_usage)
-      .innerJoin(
-        microdollar_usage_metadata,
-        eq(microdollar_usage.id, microdollar_usage_metadata.id)
-      )
-      .where(eq(microdollar_usage_metadata.session_id, cliSessionId))
+      .innerJoin(microdollar_usage_metadata, joinCondition)
+      .where(sessionFilter);
+
+    if (totals?.totalTokensIn == null) return null;
+
+    // 2. Pick the model with the most tokens (the primary review model)
+    const [topModel] = await db
+      .select({ model: microdollar_usage.model })
+      .from(microdollar_usage)
+      .innerJoin(microdollar_usage_metadata, joinCondition)
+      .where(sessionFilter)
       .groupBy(microdollar_usage.model)
       .orderBy(
         sql`sum(${microdollar_usage.input_tokens} + ${microdollar_usage.output_tokens}) desc`
       )
       .limit(1);
 
-    const row = rows[0];
-    if (!row?.model || row.totalTokensIn == null) return null;
+    if (!topModel?.model) return null;
 
     return {
-      model: row.model,
-      totalTokensIn: row.totalTokensIn,
-      totalTokensOut: row.totalTokensOut ?? 0,
-      totalCostMusd: row.totalCostMusd ?? 0,
+      model: topModel.model,
+      totalTokensIn: totals.totalTokensIn,
+      totalTokensOut: totals.totalTokensOut ?? 0,
+      totalCostMusd: totals.totalCostMusd ?? 0,
     };
   } catch (error) {
     captureException(error, {


### PR DESCRIPTION
## Summary

[PR #407](https://github.com/Kilo-Org/cloud/pull/407) added model + token info to the PR review summary comment (the "Reviewed by claude-sonnet-4.6 · 12,345 tokens" footer). But it only works for v1 (SSE-based) reviews. All reviews now run on v2 (cloud-agent-next), which is callback-based — it never streams SSE events, so usage data is never collected and the `model`, `total_tokens_in`, `total_tokens_out` columns stay null.

**The fix:** when the `code_reviews` record has no usage data, we query the billing tables (`microdollar_usage` + `microdollar_usage_metadata`) by `cli_session_id`. The billing system already tracks every LLM call with model, tokens, and cost — we just aggregate it per session. We also back-fill the `code_reviews` record so future reads don't repeat the aggregation.

## Verification

- [x] `pnpm typecheck` — no new errors (pre-existing errors in kiloclaw only)
- [x] `pnpm test usage-footer` — 10/10 pass
- [x] Read through the billing schema to confirm `microdollar_usage_metadata.session_id` matches `code_reviews.cli_session_id`

## Visual Changes

N/A

## Reviewer Notes

- The billing query groups by model and picks the one with the most tokens (the primary review model). This handles sessions that use multiple models (e.g. a cheaper model for sub-tasks).
- The back-fill write to `code_reviews` is fire-and-forget (`.catch()`) — if it fails, the footer still shows correctly; we just won't cache the result.
- Long-term, cloud-agent-next could include usage data in its `ExecutionCallbackPayload`, but that's a bigger change. This fix works today with no changes outside the Next.js app.