### PR TITLE
feat(admin): Code review admin dashboard for cloud-agent-next

### DIFF
--- a/src/app/admin/api/code-reviews/hooks.ts
+++ b/src/app/admin/api/code-reviews/hooks.ts
@@ -9,6 +9,7 @@ export type FilterParams = {
   userId?: string;
   organizationId?: string;
   ownershipType?: 'all' | 'personal' | 'organization';
+  agentVersion?: 'all' | 'v1' | 'v2';
 };
 
 export function useCodeReviewOverviewStats(params: FilterParams) {

--- a/src/app/admin/api/code-reviews/hooks.ts
+++ b/src/app/admin/api/code-reviews/hooks.ts
@@ -28,6 +28,14 @@ export function useCodeReviewDailyStats(params: FilterParams) {
   });
 }
 
+export function useCodeReviewPerformanceStats(params: FilterParams) {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.admin.codeReviews.getPerformanceStats.queryOptions(params),
+    enabled: Boolean(params.startDate && params.endDate),
+  });
+}
+
 export function useCodeReviewErrorAnalysis(params: FilterParams) {
   const trpc = useTRPC();
   return useQuery({

--- a/src/app/admin/code-reviews/page.tsx
+++ b/src/app/admin/code-reviews/page.tsx
@@ -454,11 +454,20 @@ export default function CodeReviewsPage() {
         )}
 
         {/* Error State */}
-        {(overviewQuery.error || dailyQuery.error) && (
+        {(overviewQuery.error ||
+          dailyQuery.error ||
+          performanceQuery.error ||
+          errorQuery.error ||
+          segmentationQuery.error) && (
           <div className="rounded-lg border border-red-200 bg-red-50 p-4">
             <p className="text-sm text-red-800">
               Error loading data:{' '}
-              {overviewQuery.error?.message || dailyQuery.error?.message || 'Unknown error'}
+              {overviewQuery.error?.message ||
+                dailyQuery.error?.message ||
+                performanceQuery.error?.message ||
+                errorQuery.error?.message ||
+                segmentationQuery.error?.message ||
+                'Unknown error'}
             </p>
           </div>
         )}

--- a/src/app/admin/code-reviews/page.tsx
+++ b/src/app/admin/code-reviews/page.tsx
@@ -31,6 +31,7 @@ const breadcrumbs = (
 
 type RangeType = '7d' | '30d' | '90d';
 type OwnershipType = 'all' | 'personal' | 'organization';
+type AgentVersionType = 'all' | 'v1' | 'v2';
 
 type SelectedUser = {
   id: string;
@@ -54,6 +55,7 @@ export default function CodeReviewsPage() {
 
   // Filter state
   const [ownershipType, setOwnershipType] = useState<OwnershipType>('all');
+  const [agentVersion, setAgentVersion] = useState<AgentVersionType>('all');
   const [selectedUser, setSelectedUser] = useState<SelectedUser | null>(null);
   const [selectedOrg, setSelectedOrg] = useState<SelectedOrg | null>(null);
 
@@ -92,8 +94,9 @@ export default function CodeReviewsPage() {
       userId: selectedUser?.id,
       organizationId: selectedOrg?.id,
       ownershipType: selectedUser || selectedOrg ? undefined : ownershipType,
+      agentVersion,
     }),
-    [startDate, endDate, selectedUser, selectedOrg, ownershipType]
+    [startDate, endDate, selectedUser, selectedOrg, ownershipType, agentVersion]
   );
 
   // Queries
@@ -142,11 +145,13 @@ export default function CodeReviewsPage() {
     setSelectedUser(null);
     setSelectedOrg(null);
     setOwnershipType('all');
+    setAgentVersion('all');
     setUserSearchQuery('');
     setOrgSearchQuery('');
   };
 
-  const hasActiveFilter = selectedUser || selectedOrg || ownershipType !== 'all';
+  const hasActiveFilter =
+    selectedUser || selectedOrg || ownershipType !== 'all' || agentVersion !== 'all';
 
   // Handle CSV export
   const handleExport = useCallback(async () => {
@@ -246,6 +251,24 @@ export default function CodeReviewsPage() {
                   className="h-4 w-4"
                 />
                 {type === 'all' ? 'All' : type === 'personal' ? 'Personal' : 'Organizations'}
+              </label>
+            ))}
+          </div>
+
+          {/* Agent Version Filter */}
+          <div className="flex flex-wrap items-center gap-4">
+            <span className="text-sm font-medium">Agent Version:</span>
+            {(['all', 'v1', 'v2'] as AgentVersionType[]).map(version => (
+              <label key={version} className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="agentVersion"
+                  value={version}
+                  checked={agentVersion === version}
+                  onChange={() => setAgentVersion(version)}
+                  className="h-4 w-4"
+                />
+                {version === 'all' ? 'All Versions' : version.toUpperCase()}
               </label>
             ))}
           </div>

--- a/src/app/admin/code-reviews/page.tsx
+++ b/src/app/admin/code-reviews/page.tsx
@@ -7,6 +7,7 @@ import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
 import { CodeReviewStats } from '@/app/admin/components/CodeReviewStats';
 import { CodeReviewDailyChart } from '@/app/admin/components/CodeReviewDailyChart';
 import { CodeReviewErrorAnalysis } from '@/app/admin/components/CodeReviewErrorAnalysis';
+import { CodeReviewPerformanceChart } from '@/app/admin/components/CodeReviewPerformanceChart';
 import { CodeReviewUserSegmentation } from '@/app/admin/components/CodeReviewUserSegmentation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -14,6 +15,7 @@ import { RefreshCw, Download, X, Search, User, Building2 } from 'lucide-react';
 import {
   useCodeReviewOverviewStats,
   useCodeReviewDailyStats,
+  useCodeReviewPerformanceStats,
   useCodeReviewErrorAnalysis,
   useCodeReviewUserSegmentation,
   useSearchUsers,
@@ -102,15 +104,17 @@ export default function CodeReviewsPage() {
   // Queries
   const overviewQuery = useCodeReviewOverviewStats(filterParams);
   const dailyQuery = useCodeReviewDailyStats(filterParams);
+  const performanceQuery = useCodeReviewPerformanceStats(filterParams);
   const errorQuery = useCodeReviewErrorAnalysis(filterParams);
   const segmentationQuery = useCodeReviewUserSegmentation(filterParams);
 
   const handleRefresh = useCallback(() => {
     void overviewQuery.refetch();
     void dailyQuery.refetch();
+    void performanceQuery.refetch();
     void errorQuery.refetch();
     void segmentationQuery.refetch();
-  }, [overviewQuery, dailyQuery, errorQuery, segmentationQuery]);
+  }, [overviewQuery, dailyQuery, performanceQuery, errorQuery, segmentationQuery]);
 
   // Handle selecting a user from search
   const handleSelectUser = (user: SelectedUser) => {
@@ -170,10 +174,11 @@ export default function CodeReviewsPage() {
     }
   }, [trpcClient, filterParams, startDate, endDate, isExporting]);
 
-  const isLoading = overviewQuery.isLoading || dailyQuery.isLoading;
+  const isLoading = overviewQuery.isLoading || dailyQuery.isLoading || performanceQuery.isLoading;
   const isRefreshing =
     overviewQuery.isFetching ||
     dailyQuery.isFetching ||
+    performanceQuery.isFetching ||
     errorQuery.isFetching ||
     segmentationQuery.isFetching;
 
@@ -425,6 +430,14 @@ export default function CodeReviewsPage() {
 
             {/* Daily Chart */}
             {dailyQuery.data && <CodeReviewDailyChart data={dailyQuery.data} />}
+
+            {/* Performance Trend */}
+            {performanceQuery.data && (
+              <CodeReviewPerformanceChart
+                data={performanceQuery.data}
+                agentVersion={agentVersion}
+              />
+            )}
 
             {/* User Segmentation */}
             {segmentationQuery.data && (

--- a/src/app/admin/components/CodeReviewErrorAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewErrorAnalysis.tsx
@@ -31,8 +31,23 @@ type ErrorAnalysisData = {
   details: DetailData[];
 };
 
+const CATEGORY_COLORS: Record<string, string> = {
+  'Rate Limited': 'bg-amber-500',
+  Timeout: 'bg-orange-500',
+  'Context Window Exceeded': 'bg-purple-500',
+  'Auth / Permission Error': 'bg-red-500',
+  'Not Found': 'bg-slate-500',
+  'Upstream Server Error': 'bg-rose-600',
+  'Network Error': 'bg-sky-500',
+  'Parse Error': 'bg-indigo-500',
+  'Unknown Error': 'bg-gray-400',
+  Other: 'bg-gray-500',
+};
+
 export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
-  const totalErrors = data.details.reduce((sum, error) => sum + error.count, 0);
+  const totalCategoryErrors = data.categories.reduce((sum, cat) => sum + cat.count, 0);
+  const totalDetailErrors = data.details.reduce((sum, error) => sum + error.count, 0);
+  const maxCategoryCount = Math.max(...data.categories.map(c => c.count), 1);
 
   if (data.details.length === 0) {
     return (
@@ -55,16 +70,43 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
       <CardHeader>
         <CardTitle>Error Analysis</CardTitle>
         <CardDescription>
-          {data.details.length} unique error types, {totalErrors.toLocaleString()} total failures
+          {data.categories.length} error categories, {totalCategoryErrors.toLocaleString()} total
+          failures
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-6">
+        {/* Category horizontal bar chart */}
+        <div className="space-y-2">
+          {data.categories.map(cat => {
+            const pct = totalCategoryErrors > 0 ? (cat.count / totalCategoryErrors) * 100 : 0;
+            const barWidth = (cat.count / maxCategoryCount) * 100;
+            const colorClass = CATEGORY_COLORS[cat.category] ?? 'bg-gray-500';
+            return (
+              <div key={cat.category} className="flex items-center gap-3">
+                <span className="w-44 shrink-0 truncate text-right text-xs font-medium">
+                  {cat.category}
+                </span>
+                <div className="bg-muted relative h-5 flex-1 overflow-hidden rounded">
+                  <div
+                    className={`${colorClass} absolute inset-y-0 left-0 rounded transition-all`}
+                    style={{ width: `${barWidth}%` }}
+                  />
+                </div>
+                <span className="text-muted-foreground w-20 shrink-0 text-right text-xs">
+                  {cat.count.toLocaleString()} ({pct.toFixed(1)}%)
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Detail table */}
         <div className="max-h-[400px] overflow-auto">
           <Table>
             <TableHeader>
               <TableRow>
                 <TableHead>Category</TableHead>
-                <TableHead className="w-[40%]">Error Type</TableHead>
+                <TableHead className="w-[40%]">Error Message</TableHead>
                 <TableHead className="text-right">Count</TableHead>
                 <TableHead className="text-right">% of Errors</TableHead>
                 <TableHead>First Seen</TableHead>
@@ -83,7 +125,7 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
                   </TableCell>
                   <TableCell className="text-right font-medium">{error.count}</TableCell>
                   <TableCell className="text-muted-foreground text-right">
-                    {((error.count / totalErrors) * 100).toFixed(1)}%
+                    {((error.count / totalDetailErrors) * 100).toFixed(1)}%
                   </TableCell>
                   <TableCell className="text-muted-foreground text-xs">
                     {formatDate(error.firstOccurrence)}

--- a/src/app/admin/components/CodeReviewErrorAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewErrorAnalysis.tsx
@@ -46,7 +46,9 @@ const CATEGORY_COLORS: Record<string, string> = {
 
 export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
   const totalCategoryErrors = data.categories.reduce((sum, cat) => sum + cat.count, 0);
-  const totalDetailErrors = data.details.reduce((sum, error) => sum + error.count, 0);
+  // Use category totals (uncapped) as the denominator so percentages are accurate
+  // even when the detail list is truncated to top 50.
+  const totalErrors = totalCategoryErrors;
   const maxCategoryCount = Math.max(...data.categories.map(c => c.count), 1);
 
   if (data.details.length === 0) {
@@ -125,7 +127,7 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
                   </TableCell>
                   <TableCell className="text-right font-medium">{error.count}</TableCell>
                   <TableCell className="text-muted-foreground text-right">
-                    {((error.count / totalDetailErrors) * 100).toFixed(1)}%
+                    {((error.count / totalErrors) * 100).toFixed(1)}%
                   </TableCell>
                   <TableCell className="text-muted-foreground text-xs">
                     {formatDate(error.firstOccurrence)}

--- a/src/app/admin/components/CodeReviewErrorAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewErrorAnalysis.tsx
@@ -11,17 +11,30 @@ import {
 } from '@/components/ui/table';
 import { formatDate } from '@/lib/admin-utils';
 
-type ErrorData = {
-  errorType: string;
+type CategoryData = {
+  category: string;
   count: number;
   firstOccurrence: string;
   lastOccurrence: string;
 };
 
-export function CodeReviewErrorAnalysis({ data }: { data: ErrorData[] }) {
-  const totalErrors = data.reduce((sum, error) => sum + error.count, 0);
+type DetailData = {
+  errorType: string;
+  category: string;
+  count: number;
+  firstOccurrence: string;
+  lastOccurrence: string;
+};
 
-  if (data.length === 0) {
+type ErrorAnalysisData = {
+  categories: CategoryData[];
+  details: DetailData[];
+};
+
+export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
+  const totalErrors = data.details.reduce((sum, error) => sum + error.count, 0);
+
+  if (data.details.length === 0) {
     return (
       <Card>
         <CardHeader>
@@ -42,7 +55,7 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorData[] }) {
       <CardHeader>
         <CardTitle>Error Analysis</CardTitle>
         <CardDescription>
-          {data.length} unique error types, {totalErrors.toLocaleString()} total failures
+          {data.details.length} unique error types, {totalErrors.toLocaleString()} total failures
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -50,7 +63,8 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorData[] }) {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-[50%]">Error Type</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead className="w-[40%]">Error Type</TableHead>
                 <TableHead className="text-right">Count</TableHead>
                 <TableHead className="text-right">% of Errors</TableHead>
                 <TableHead>First Seen</TableHead>
@@ -58,8 +72,9 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorData[] }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.map((error, idx) => (
+              {data.details.map((error, idx) => (
                 <TableRow key={idx}>
+                  <TableCell className="text-xs">{error.category}</TableCell>
                   <TableCell
                     className="max-w-[400px] truncate font-mono text-xs"
                     title={error.errorType}

--- a/src/app/admin/components/CodeReviewPerformanceChart.tsx
+++ b/src/app/admin/components/CodeReviewPerformanceChart.tsx
@@ -49,7 +49,11 @@ type CustomTooltipProps = {
 function formatSeconds(seconds: number | undefined): string {
   if (seconds == null || seconds === 0) return '-';
   if (seconds < 60) return `${Math.round(seconds)}s`;
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  if (seconds < 3600) {
+    const m = Math.floor(seconds / 60);
+    const s = Math.round(seconds - m * 60);
+    return s > 0 ? `${m}m ${s}s` : `${m}m`;
+  }
   return `${(seconds / 3600).toFixed(1)}h`;
 }
 

--- a/src/app/admin/components/CodeReviewPerformanceChart.tsx
+++ b/src/app/admin/components/CodeReviewPerformanceChart.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { format, parseISO } from 'date-fns';
+
+type PerformanceRow = {
+  day: string;
+  agentVersion: string;
+  avgSeconds: number;
+  p50Seconds: number;
+  p90Seconds: number;
+  count: number;
+};
+
+type PivotedDataPoint = {
+  day: string;
+  v1Avg?: number;
+  v1P50?: number;
+  v1P90?: number;
+  v2Avg?: number;
+  v2P50?: number;
+  v2P90?: number;
+};
+
+type TooltipPayload = {
+  payload: PivotedDataPoint;
+  dataKey: string;
+  value: number;
+  name: string;
+  color: string;
+};
+
+type CustomTooltipProps = {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  label?: string;
+};
+
+function formatSeconds(seconds: number | undefined): string {
+  if (seconds == null || seconds === 0) return '-';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  return `${(seconds / 3600).toFixed(1)}h`;
+}
+
+/**
+ * Pivot interleaved rows [{day, agentVersion, ...}] into one row per day
+ * with v1/v2 columns for recharts.
+ */
+function pivotByDay(rows: PerformanceRow[]): PivotedDataPoint[] {
+  const map = new Map<string, PivotedDataPoint>();
+  for (const row of rows) {
+    const existing = map.get(row.day) ?? { day: row.day };
+    if (row.agentVersion === 'v1') {
+      existing.v1Avg = row.avgSeconds;
+      existing.v1P50 = row.p50Seconds;
+      existing.v1P90 = row.p90Seconds;
+    } else if (row.agentVersion === 'v2') {
+      existing.v2Avg = row.avgSeconds;
+      existing.v2P50 = row.p50Seconds;
+      existing.v2P90 = row.p90Seconds;
+    }
+    map.set(row.day, existing);
+  }
+  return Array.from(map.values()).sort((a, b) => a.day.localeCompare(b.day));
+}
+
+export function CodeReviewPerformanceChart({
+  data,
+  agentVersion,
+}: {
+  data: PerformanceRow[];
+  agentVersion: 'all' | 'v1' | 'v2';
+}) {
+  const chartData = pivotByDay(data).map(row => ({
+    ...row,
+    day: format(parseISO(row.day), 'MM/dd'),
+  }));
+
+  const showV1 = agentVersion === 'all' || agentVersion === 'v1';
+  const showV2 = agentVersion === 'all' || agentVersion === 'v2';
+
+  const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+    if (!active || !payload || payload.length === 0) return null;
+    const d = payload[0]?.payload;
+    if (!d) return null;
+
+    return (
+      <div className="bg-background rounded-lg border p-3 shadow-sm">
+        <p className="text-sm font-medium">{label}</p>
+        <div className="mt-2 space-y-1">
+          {showV1 && d.v1Avg != null && (
+            <>
+              <p className="text-xs font-medium text-blue-600">V1</p>
+              <p className="text-xs">
+                <span className="text-muted-foreground">Avg:</span> {formatSeconds(d.v1Avg)}
+                {' / '}
+                <span className="text-muted-foreground">P50:</span> {formatSeconds(d.v1P50)}
+                {' / '}
+                <span className="text-muted-foreground">P90:</span> {formatSeconds(d.v1P90)}
+              </p>
+            </>
+          )}
+          {showV2 && d.v2Avg != null && (
+            <>
+              <p className="text-xs font-medium text-emerald-600">V2</p>
+              <p className="text-xs">
+                <span className="text-muted-foreground">Avg:</span> {formatSeconds(d.v2Avg)}
+                {' / '}
+                <span className="text-muted-foreground">P50:</span> {formatSeconds(d.v2P50)}
+                {' / '}
+                <span className="text-muted-foreground">P90:</span> {formatSeconds(d.v2P90)}
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  if (chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Execution Time Trend</CardTitle>
+          <CardDescription>No completed reviews in selected period</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Execution Time Trend</CardTitle>
+        <CardDescription>
+          Daily avg / p50 / p90 execution time (excludes queue wait)
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-[350px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 60 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis
+                dataKey="day"
+                angle={-45}
+                textAnchor="end"
+                height={80}
+                tick={{ fontSize: 10 }}
+              />
+              <YAxis
+                tick={{ fontSize: 10 }}
+                tickFormatter={v => formatSeconds(v)}
+                label={{
+                  value: 'Execution Time',
+                  angle: -90,
+                  position: 'insideLeft',
+                  style: { fontSize: 12 },
+                }}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend />
+
+              {showV1 && (
+                <>
+                  <Line
+                    type="monotone"
+                    dataKey="v1P90"
+                    stroke="#93c5fd"
+                    strokeWidth={1}
+                    strokeDasharray="4 2"
+                    dot={false}
+                    name="V1 P90"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="v1Avg"
+                    stroke="#3b82f6"
+                    strokeWidth={2}
+                    dot={{ r: 2 }}
+                    name="V1 Avg"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="v1P50"
+                    stroke="#1d4ed8"
+                    strokeWidth={1}
+                    strokeDasharray="4 2"
+                    dot={false}
+                    name="V1 P50"
+                  />
+                </>
+              )}
+
+              {showV2 && (
+                <>
+                  <Line
+                    type="monotone"
+                    dataKey="v2P90"
+                    stroke="#6ee7b7"
+                    strokeWidth={1}
+                    strokeDasharray="4 2"
+                    dot={false}
+                    name="V2 P90"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="v2Avg"
+                    stroke="#10b981"
+                    strokeWidth={2}
+                    dot={{ r: 2 }}
+                    name="V2 Avg"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="v2P50"
+                    stroke="#047857"
+                    strokeWidth={1}
+                    strokeDasharray="4 2"
+                    dot={false}
+                    name="V2 P50"
+                  />
+                </>
+              )}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/components/CodeReviewStats.tsx
+++ b/src/app/admin/components/CodeReviewStats.tsx
@@ -2,6 +2,14 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
+type VersionBreakdownRow = {
+  agentVersion: string;
+  total: number;
+  completed: number;
+  failed: number;
+  avgDurationSeconds: number;
+};
+
 type StatsData = {
   totalReviews: number;
   completedCount: number;
@@ -12,6 +20,7 @@ type StatsData = {
   successRate: number;
   failureRate: number;
   avgDurationSeconds: number;
+  versionBreakdown?: VersionBreakdownRow[];
 };
 
 export function CodeReviewStats({ data }: { data: StatsData }) {
@@ -22,6 +31,14 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
     return `${(seconds / 3600).toFixed(1)}h`;
   };
 
+  // Build a map for quick version lookup
+  const byVersion = new Map<string, VersionBreakdownRow>();
+  for (const row of data.versionBreakdown ?? []) {
+    byVersion.set(row.agentVersion, row);
+  }
+
+  const showVersionBreakdown = byVersion.size > 0;
+
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
       <Card>
@@ -30,6 +47,19 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
         </CardHeader>
         <CardContent>
           <div className="text-3xl font-bold">{data.totalReviews.toLocaleString()}</div>
+          {showVersionBreakdown && (
+            <div className="text-muted-foreground mt-2 space-y-0.5 text-xs">
+              {['v1', 'v2'].map(v => {
+                const row = byVersion.get(v);
+                if (!row) return null;
+                return (
+                  <div key={v}>
+                    {v.toUpperCase()}: {row.total.toLocaleString()}
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -40,6 +70,19 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
         </CardHeader>
         <CardContent>
           <div className="text-3xl font-bold text-green-600">{data.successRate.toFixed(1)}%</div>
+          {showVersionBreakdown && (
+            <div className="text-muted-foreground mt-2 space-y-0.5 text-xs">
+              {['v1', 'v2'].map(v => {
+                const row = byVersion.get(v);
+                if (!row) return null;
+                return (
+                  <div key={v}>
+                    {v.toUpperCase()}: {row.completed.toLocaleString()} completed
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -53,6 +96,19 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
         </CardHeader>
         <CardContent>
           <div className="text-3xl font-bold text-red-600">{data.failureRate.toFixed(1)}%</div>
+          {showVersionBreakdown && (
+            <div className="text-muted-foreground mt-2 space-y-0.5 text-xs">
+              {['v1', 'v2'].map(v => {
+                const row = byVersion.get(v);
+                if (!row) return null;
+                return (
+                  <div key={v}>
+                    {v.toUpperCase()}: {row.failed.toLocaleString()} failed
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -63,6 +119,19 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
         </CardHeader>
         <CardContent>
           <div className="text-3xl font-bold">{formatDuration(data.avgDurationSeconds)}</div>
+          {showVersionBreakdown && (
+            <div className="text-muted-foreground mt-2 space-y-0.5 text-xs">
+              {['v1', 'v2'].map(v => {
+                const row = byVersion.get(v);
+                if (!row) return null;
+                return (
+                  <div key={v}>
+                    {v.toUpperCase()}: {formatDuration(row.avgDurationSeconds)}
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -144,7 +144,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       !agentVersion || agentVersion === 'all'
         ? await db
             .select({
-              agent_version: sql<string>`COALESCE(${cloud_agent_code_reviews.agent_version}, 'unknown')`,
+              agent_version: sql<string>`COALESCE(${cloud_agent_code_reviews.agent_version}, 'v1')`,
               total: sql<number>`COUNT(*)`,
               completed: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_code_reviews.status} = 'completed')`,
               failed: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_code_reviews.status} = 'failed' AND ${excludeInsufficientCreditsError})`,
@@ -408,7 +408,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     const result = await db
       .select({
         day: sql<string>`DATE_TRUNC('day', ${cloud_agent_code_reviews.created_at})::date::text`,
-        agent_version: sql<string>`COALESCE(${cloud_agent_code_reviews.agent_version}, 'unknown')`,
+        agent_version: sql<string>`COALESCE(${cloud_agent_code_reviews.agent_version}, 'v1')`,
         avg_seconds: sql<number>`AVG(${durationExpr})`,
         p50_seconds: sql<number>`percentile_cont(0.5) WITHIN GROUP (ORDER BY ${durationExpr})`,
         p90_seconds: sql<number>`percentile_cont(0.9) WITHIN GROUP (ORDER BY ${durationExpr})`,

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -159,7 +159,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
             })
             .from(cloud_agent_code_reviews)
             .where(and(...baseConditions))
-            .groupBy(cloud_agent_code_reviews.agent_version)
+            .groupBy(sql`COALESCE(${cloud_agent_code_reviews.agent_version}, 'v1')`)
         : undefined;
 
     return {
@@ -425,7 +425,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       .where(and(...conditions))
       .groupBy(
         sql`DATE_TRUNC('day', ${cloud_agent_code_reviews.created_at})`,
-        cloud_agent_code_reviews.agent_version
+        sql`COALESCE(${cloud_agent_code_reviews.agent_version}, 'v1')`
       )
       .orderBy(sql`DATE_TRUNC('day', ${cloud_agent_code_reviews.created_at})`);
 

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -402,6 +402,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     const agentVersionFilter = buildAgentVersionFilter(agentVersion);
 
     const conditions = [
+      eq(cloud_agent_code_reviews.status, 'completed'),
       gte(cloud_agent_code_reviews.created_at, startDate),
       lt(cloud_agent_code_reviews.created_at, endDate),
       isNotNull(cloud_agent_code_reviews.completed_at),

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -354,6 +354,50 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     };
   }),
 
+  // Get daily performance percentiles (execution time = completed_at - started_at)
+  getPerformanceStats: adminProcedure.input(FilterSchema).query(async ({ input }) => {
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
+    const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
+
+    const conditions = [
+      gte(cloud_agent_code_reviews.created_at, startDate),
+      lt(cloud_agent_code_reviews.created_at, endDate),
+      isNotNull(cloud_agent_code_reviews.completed_at),
+      isNotNull(cloud_agent_code_reviews.started_at),
+      ownershipFilter,
+      agentVersionFilter,
+    ].filter(Boolean) as SQL[];
+
+    const durationExpr = sql`EXTRACT(EPOCH FROM (${cloud_agent_code_reviews.completed_at}::timestamp - ${cloud_agent_code_reviews.started_at}::timestamp))`;
+
+    const result = await db
+      .select({
+        day: sql<string>`DATE_TRUNC('day', ${cloud_agent_code_reviews.created_at})::date::text`,
+        agent_version: sql<string>`COALESCE(${cloud_agent_code_reviews.agent_version}, 'unknown')`,
+        avg_seconds: sql<number>`AVG(${durationExpr})`,
+        p50_seconds: sql<number>`percentile_cont(0.5) WITHIN GROUP (ORDER BY ${durationExpr})`,
+        p90_seconds: sql<number>`percentile_cont(0.9) WITHIN GROUP (ORDER BY ${durationExpr})`,
+        count: sql<number>`COUNT(*)`,
+      })
+      .from(cloud_agent_code_reviews)
+      .where(and(...conditions))
+      .groupBy(
+        sql`DATE_TRUNC('day', ${cloud_agent_code_reviews.created_at})`,
+        cloud_agent_code_reviews.agent_version
+      )
+      .orderBy(sql`DATE_TRUNC('day', ${cloud_agent_code_reviews.created_at})`);
+
+    return result.map(row => ({
+      day: row.day,
+      agentVersion: row.agent_version,
+      avgSeconds: Number(row.avg_seconds) || 0,
+      p50Seconds: Number(row.p50_seconds) || 0,
+      p90Seconds: Number(row.p90_seconds) || 0,
+      count: Number(row.count) || 0,
+    }));
+  }),
+
   // Get CSV export data
   getExportData: adminProcedure.input(FilterSchema).query(async ({ input }) => {
     const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -29,6 +29,7 @@ const FilterSchema = z.object({
   userId: z.string().min(1).optional(), // Filter by specific user
   organizationId: z.string().uuid().optional(), // Filter by specific organization
   ownershipType: z.enum(['all', 'personal', 'organization']).optional().default('all'),
+  agentVersion: z.enum(['all', 'v1', 'v2']).optional().default('all'),
 });
 
 /**
@@ -64,16 +65,24 @@ function buildOwnershipFilter(
   return conditions.length > 0 ? and(...conditions) : undefined;
 }
 
+/** Returns a SQL condition filtering by agent_version, or undefined for 'all'. */
+function buildAgentVersionFilter(agentVersion?: 'all' | 'v1' | 'v2'): SQL | undefined {
+  if (!agentVersion || agentVersion === 'all') return undefined;
+  return eq(cloud_agent_code_reviews.agent_version, agentVersion);
+}
+
 export const adminCodeReviewsRouter = createTRPCRouter({
   // Get overview KPIs
   getOverviewStats: adminProcedure.input(FilterSchema).query(async ({ input }) => {
-    const { startDate, endDate, userId, organizationId, ownershipType } = input;
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
     const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
 
     const conditions = [
       gte(cloud_agent_code_reviews.created_at, startDate),
       lt(cloud_agent_code_reviews.created_at, endDate),
       ownershipFilter,
+      agentVersionFilter,
     ].filter(Boolean) as SQL[];
 
     const result = await db
@@ -126,13 +135,15 @@ export const adminCodeReviewsRouter = createTRPCRouter({
 
   // Get daily time series data
   getDailyStats: adminProcedure.input(FilterSchema).query(async ({ input }) => {
-    const { startDate, endDate, userId, organizationId, ownershipType } = input;
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
     const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
 
     const conditions = [
       gte(cloud_agent_code_reviews.created_at, startDate),
       lt(cloud_agent_code_reviews.created_at, endDate),
       ownershipFilter,
+      agentVersionFilter,
     ].filter(Boolean) as SQL[];
 
     const result = await db
@@ -166,8 +177,9 @@ export const adminCodeReviewsRouter = createTRPCRouter({
 
   // Get error analysis (excludes "Insufficient credits" billing errors from the list)
   getErrorAnalysis: adminProcedure.input(FilterSchema).query(async ({ input }) => {
-    const { startDate, endDate, userId, organizationId, ownershipType } = input;
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
     const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
 
     const conditions = [
       eq(cloud_agent_code_reviews.status, 'failed'),
@@ -175,6 +187,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       gte(cloud_agent_code_reviews.created_at, startDate),
       lt(cloud_agent_code_reviews.created_at, endDate),
       ownershipFilter,
+      agentVersionFilter,
     ].filter(Boolean) as SQL[];
 
     const result = await db
@@ -200,13 +213,15 @@ export const adminCodeReviewsRouter = createTRPCRouter({
 
   // Get user segmentation (note: this doesn't use filters since it shows top users/orgs for selection)
   getUserSegmentation: adminProcedure.input(FilterSchema).query(async ({ input }) => {
-    const { startDate, endDate, userId, organizationId, ownershipType } = input;
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
     const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
 
     const baseConditions = [
       gte(cloud_agent_code_reviews.created_at, startDate),
       lt(cloud_agent_code_reviews.created_at, endDate),
       ownershipFilter,
+      agentVersionFilter,
     ].filter(Boolean) as SQL[];
 
     // Personal vs Org breakdown
@@ -312,13 +327,15 @@ export const adminCodeReviewsRouter = createTRPCRouter({
 
   // Get CSV export data
   getExportData: adminProcedure.input(FilterSchema).query(async ({ input }) => {
-    const { startDate, endDate, userId, organizationId, ownershipType } = input;
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
     const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
 
     const conditions = [
       gte(cloud_agent_code_reviews.created_at, startDate),
       lt(cloud_agent_code_reviews.created_at, endDate),
       ownershipFilter,
+      agentVersionFilter,
     ].filter(Boolean) as SQL[];
 
     const result = await db

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -116,6 +116,28 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     const terminalCount =
       completedCount + failedCount + interruptedCount + cancelledCount + insufficientCreditsCount;
 
+    // Per-version breakdown (only when viewing all versions)
+    const baseConditions = [
+      gte(cloud_agent_code_reviews.created_at, startDate),
+      lt(cloud_agent_code_reviews.created_at, endDate),
+      ownershipFilter,
+    ].filter(Boolean) as SQL[];
+
+    const versionBreakdown =
+      !agentVersion || agentVersion === 'all'
+        ? await db
+            .select({
+              agent_version: sql<string>`COALESCE(${cloud_agent_code_reviews.agent_version}, 'unknown')`,
+              total: sql<number>`COUNT(*)`,
+              completed: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_code_reviews.status} = 'completed')`,
+              failed: sql<number>`COUNT(*) FILTER (WHERE ${cloud_agent_code_reviews.status} = 'failed' AND ${excludeInsufficientCreditsError})`,
+              avg_duration_seconds: sql<number>`AVG(EXTRACT(EPOCH FROM (${cloud_agent_code_reviews.completed_at}::timestamp - ${cloud_agent_code_reviews.started_at}::timestamp))) FILTER (WHERE ${cloud_agent_code_reviews.completed_at} IS NOT NULL AND ${cloud_agent_code_reviews.started_at} IS NOT NULL)`,
+            })
+            .from(cloud_agent_code_reviews)
+            .where(and(...baseConditions))
+            .groupBy(cloud_agent_code_reviews.agent_version)
+        : undefined;
+
     return {
       totalReviews: total,
       completedCount,
@@ -130,6 +152,13 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       // Note: cancelled and insufficient credits are neutral (not success, not failure)
       failureRate: terminalCount > 0 ? ((failedCount + interruptedCount) / terminalCount) * 100 : 0,
       avgDurationSeconds: Number(stats.avg_duration_seconds) || 0,
+      versionBreakdown: versionBreakdown?.map(row => ({
+        agentVersion: row.agent_version,
+        total: Number(row.total) || 0,
+        completed: Number(row.completed) || 0,
+        failed: Number(row.failed) || 0,
+        avgDurationSeconds: Number(row.avg_duration_seconds) || 0,
+      })),
     };
   }),
 

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -23,6 +23,23 @@ import {
  */
 const excludeInsufficientCreditsError = sql`COALESCE(${cloud_agent_code_reviews.error_message}, '') NOT LIKE '%Insufficient credits%'`;
 
+/**
+ * Categorize error messages into high-level buckets via SQL CASE WHEN.
+ * Pattern matching is ordered from most-specific to least-specific.
+ */
+const errorCategoryExpr = sql<string>`CASE
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%rate limit%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Rate limit%' OR ${cloud_agent_code_reviews.error_message} LIKE '%429%' THEN 'Rate Limited'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%timeout%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Timeout%' OR ${cloud_agent_code_reviews.error_message} LIKE '%ETIMEDOUT%' OR ${cloud_agent_code_reviews.error_message} LIKE '%timed out%' THEN 'Timeout'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%context window%' OR ${cloud_agent_code_reviews.error_message} LIKE '%token limit%' OR ${cloud_agent_code_reviews.error_message} LIKE '%too large%' OR ${cloud_agent_code_reviews.error_message} LIKE '%maximum context length%' THEN 'Context Window Exceeded'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%authentication%' OR ${cloud_agent_code_reviews.error_message} LIKE '%401%' OR ${cloud_agent_code_reviews.error_message} LIKE '%403%' OR ${cloud_agent_code_reviews.error_message} LIKE '%permission%' THEN 'Auth / Permission Error'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%not found%' OR ${cloud_agent_code_reviews.error_message} LIKE '%404%' THEN 'Not Found'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%500%' OR ${cloud_agent_code_reviews.error_message} LIKE '%502%' OR ${cloud_agent_code_reviews.error_message} LIKE '%503%' OR ${cloud_agent_code_reviews.error_message} LIKE '%internal server%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Internal Server%' THEN 'Upstream Server Error'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%ECONNREFUSED%' OR ${cloud_agent_code_reviews.error_message} LIKE '%ECONNRESET%' OR ${cloud_agent_code_reviews.error_message} LIKE '%socket hang up%' OR ${cloud_agent_code_reviews.error_message} LIKE '%network%' THEN 'Network Error'
+  WHEN ${cloud_agent_code_reviews.error_message} LIKE '%parse%' OR ${cloud_agent_code_reviews.error_message} LIKE '%JSON%' OR ${cloud_agent_code_reviews.error_message} LIKE '%unexpected token%' THEN 'Parse Error'
+  WHEN ${cloud_agent_code_reviews.error_message} IS NULL THEN 'Unknown Error'
+  ELSE 'Other'
+END`;
+
 const FilterSchema = z.object({
   startDate: z.string().date(), // ISO date string YYYY-MM-DD
   endDate: z.string().date(), // ISO date string YYYY-MM-DD
@@ -219,25 +236,52 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       agentVersionFilter,
     ].filter(Boolean) as SQL[];
 
-    const result = await db
+    // Categorized error summary
+    const categorized = await db
       .select({
-        error_type: sql<string>`COALESCE(SUBSTRING(${cloud_agent_code_reviews.error_message} FROM 1 FOR 100), 'Unknown Error')`,
+        category: errorCategoryExpr,
         count: sql<number>`COUNT(*)`,
         first_occurrence: sql<string>`MIN(${cloud_agent_code_reviews.created_at})::text`,
         last_occurrence: sql<string>`MAX(${cloud_agent_code_reviews.created_at})::text`,
       })
       .from(cloud_agent_code_reviews)
       .where(and(...conditions))
-      .groupBy(sql`SUBSTRING(${cloud_agent_code_reviews.error_message} FROM 1 FOR 100)`)
+      .groupBy(errorCategoryExpr)
+      .orderBy(desc(sql`COUNT(*)`));
+
+    // Raw error messages (top 50, for drill-down table)
+    const raw = await db
+      .select({
+        error_type: sql<string>`COALESCE(SUBSTRING(${cloud_agent_code_reviews.error_message} FROM 1 FOR 200), 'Unknown Error')`,
+        category: errorCategoryExpr,
+        count: sql<number>`COUNT(*)`,
+        first_occurrence: sql<string>`MIN(${cloud_agent_code_reviews.created_at})::text`,
+        last_occurrence: sql<string>`MAX(${cloud_agent_code_reviews.created_at})::text`,
+      })
+      .from(cloud_agent_code_reviews)
+      .where(and(...conditions))
+      .groupBy(
+        sql`SUBSTRING(${cloud_agent_code_reviews.error_message} FROM 1 FOR 200)`,
+        errorCategoryExpr
+      )
       .orderBy(desc(sql`COUNT(*)`))
       .limit(50);
 
-    return result.map(row => ({
-      errorType: row.error_type,
-      count: Number(row.count) || 0,
-      firstOccurrence: row.first_occurrence,
-      lastOccurrence: row.last_occurrence,
-    }));
+    return {
+      categories: categorized.map(row => ({
+        category: row.category,
+        count: Number(row.count) || 0,
+        firstOccurrence: row.first_occurrence,
+        lastOccurrence: row.last_occurrence,
+      })),
+      details: raw.map(row => ({
+        errorType: row.error_type,
+        category: row.category,
+        count: Number(row.count) || 0,
+        firstOccurrence: row.first_occurrence,
+        lastOccurrence: row.last_occurrence,
+      })),
+    };
   }),
 
   // Get user segmentation (note: this doesn't use filters since it shows top users/orgs for selection)

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -8,7 +8,7 @@ import {
   organizations,
 } from '@kilocode/db/schema';
 import * as z from 'zod';
-import { sql, and, gte, lt, eq, isNotNull, desc, ilike, or, type SQL } from 'drizzle-orm';
+import { sql, and, gte, lt, eq, isNotNull, isNull, desc, ilike, or, type SQL } from 'drizzle-orm';
 import {
   REVIEW_PROMO_MODEL,
   REVIEW_PROMO_START,
@@ -85,6 +85,13 @@ function buildOwnershipFilter(
 /** Returns a SQL condition filtering by agent_version, or undefined for 'all'. */
 function buildAgentVersionFilter(agentVersion?: 'all' | 'v1' | 'v2'): SQL | undefined {
   if (!agentVersion || agentVersion === 'all') return undefined;
+  // NULL agent_version is treated as 'v1' (schema default + existing normalization)
+  if (agentVersion === 'v1') {
+    return or(
+      eq(cloud_agent_code_reviews.agent_version, 'v1'),
+      isNull(cloud_agent_code_reviews.agent_version)
+    );
+  }
   return eq(cloud_agent_code_reviews.agent_version, agentVersion);
 }
 

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -328,13 +328,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
             kilocode_users,
             eq(cloud_agent_code_reviews.owned_by_user_id, kilocode_users.id)
           )
-          .where(
-            and(
-              isNotNull(cloud_agent_code_reviews.owned_by_user_id),
-              gte(cloud_agent_code_reviews.created_at, startDate),
-              lt(cloud_agent_code_reviews.created_at, endDate)
-            )
-          )
+          .where(and(isNotNull(cloud_agent_code_reviews.owned_by_user_id), ...baseConditions))
           .groupBy(
             cloud_agent_code_reviews.owned_by_user_id,
             kilocode_users.google_user_email,
@@ -360,11 +354,7 @@ export const adminCodeReviewsRouter = createTRPCRouter({
             eq(cloud_agent_code_reviews.owned_by_organization_id, organizations.id)
           )
           .where(
-            and(
-              isNotNull(cloud_agent_code_reviews.owned_by_organization_id),
-              gte(cloud_agent_code_reviews.created_at, startDate),
-              lt(cloud_agent_code_reviews.created_at, endDate)
-            )
+            and(isNotNull(cloud_agent_code_reviews.owned_by_organization_id), ...baseConditions)
           )
           .groupBy(
             cloud_agent_code_reviews.owned_by_organization_id,


### PR DESCRIPTION
## Summary

- This updates the admin code review dashboard so the team can see how the two review systems (`v1` and `v2`) are doing
- Managers can now filter the dashboard by review system, compare `v1` and `v2` in the top stats, and see a simple speed trend over time
- Error reporting is easier to read now: similar failures are grouped into clear categories, and the dashboard shows which problem types happen most often
- This helps the team answer simple product questions faster: which version is used more, which version is faster, and what kinds of failures are happening

## Verification

- [x] `pnpm typecheck` - passed
- [x] `pnpm lint` - passed

## Visual Changes

<img width="757" height="209" alt="Screenshot 2026-03-10 at 15 56 34" src="https://github.com/user-attachments/assets/c42a1b85-4eb4-4f88-b1ff-381188c999b6" />

<img width="2261" height="1313" alt="Screenshot 2026-03-10 at 15 56 46" src="https://github.com/user-attachments/assets/56638f54-57dc-4ce5-9502-ae63a36db452" />


## Reviewer Notes

- No database change
- Existing dashboard calls still work because the new filter defaults to "all"
- Speed numbers use active review time only, so waiting in queue does not skew the chart