### PR TITLE
fix(cloud-agent-next): add pre-flight check before wrapper startup

### DIFF
--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -862,7 +862,7 @@ describe('WrapperClient', () => {
           return Promise.resolve({ exitCode: 0, stdout: '1.0.0' });
         }
         if (cmd.startsWith('test -f')) {
-          return Promise.resolve({ exitCode: 1, stdout: '' });
+          return Promise.resolve({ exitCode: 1, stdout: 'ok' });
         }
         return Promise.resolve(createCurlError(7, 'Connection refused'));
       });
@@ -934,7 +934,7 @@ describe('WrapperClient', () => {
           return Promise.reject(new Error('sandbox timeout'));
         }
         if (cmd.startsWith('test -f')) {
-          return Promise.resolve({ exitCode: 1, stdout: '' });
+          return Promise.resolve({ exitCode: 1, stdout: 'ok' });
         }
         return Promise.resolve(createCurlError(7, 'Connection refused'));
       });
@@ -948,6 +948,38 @@ describe('WrapperClient', () => {
           workspacePath: '/workspace/test',
         })
       ).rejects.toThrow(/not found in container/);
+    });
+
+    it('shell-quotes wrapperPath in the pre-flight file check', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version')) {
+          return Promise.resolve({ exitCode: 0, stdout: '1.0.0' });
+        }
+        if (cmd.startsWith('test -f')) {
+          return Promise.resolve({ exitCode: 0, stdout: '' });
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        wrapperPath: "./wrapper's folder/wrapper.js; touch /tmp/pwned",
+      });
+
+      expect(session.exec).toHaveBeenCalledWith(
+        "test -f './wrapper'\\''s folder/wrapper.js; touch /tmp/pwned'",
+        expect.objectContaining({ cwd: '/workspace/test', timeout: 5_000 })
+      );
     });
   });
 

--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -862,7 +862,7 @@ describe('WrapperClient', () => {
           return Promise.resolve({ exitCode: 0, stdout: '1.0.0' });
         }
         if (cmd.startsWith('test -f')) {
-          return Promise.resolve({ exitCode: 1, stdout: 'ok' });
+          return Promise.resolve({ exitCode: 1, stdout: '' });
         }
         return Promise.resolve(createCurlError(7, 'Connection refused'));
       });
@@ -934,7 +934,7 @@ describe('WrapperClient', () => {
           return Promise.reject(new Error('sandbox timeout'));
         }
         if (cmd.startsWith('test -f')) {
-          return Promise.resolve({ exitCode: 1, stdout: 'ok' });
+          return Promise.resolve({ exitCode: 1, stdout: '' });
         }
         return Promise.resolve(createCurlError(7, 'Connection refused'));
       });
@@ -979,6 +979,29 @@ describe('WrapperClient', () => {
       expect(session.exec).toHaveBeenCalledWith(
         "test -f './wrapper'\\''s folder/wrapper.js; touch /tmp/pwned'",
         expect.objectContaining({ cwd: '/workspace/test', timeout: 5_000 })
+      );
+    });
+
+    it('shell-quotes wrapperPath in the startup command', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+        wrapperPath: "./wrapper's folder/wrapper.js; touch /tmp/pwned",
+      });
+
+      expect(session.startProcess).toHaveBeenCalledWith(
+        "WRAPPER_PORT=5000 KILO_SERVER_PORT=4600 WORKSPACE_PATH=/workspace/test bun run './wrapper'\\''s folder/wrapper.js; touch /tmp/pwned' --agent-session test-session",
+        expect.objectContaining({ cwd: '/workspace/test' })
       );
     });
   });

--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -31,13 +31,30 @@ type MockExecResult = {
   stderr?: string;
 };
 
+/** Pre-flight commands issued by ensureRunning before starting the wrapper */
+const isPreflightCommand = (cmd: string) =>
+  cmd.startsWith('bun --version') || cmd.startsWith('test -f ');
+
+const preflightResult = (cmd: string): MockExecResult =>
+  cmd.startsWith('bun --version')
+    ? { exitCode: 0, stdout: '1.0.0' }
+    : { exitCode: 0, stdout: 'ok' };
+
 const createMockSession = (
   execResult: MockExecResult | ((cmd: string) => MockExecResult)
 ): ExecutionSession => {
   const execFn =
     typeof execResult === 'function'
-      ? vi.fn().mockImplementation((cmd: string) => Promise.resolve(execResult(cmd)))
-      : vi.fn().mockResolvedValue(execResult);
+      ? vi
+          .fn()
+          .mockImplementation((cmd: string) =>
+            Promise.resolve(isPreflightCommand(cmd) ? preflightResult(cmd) : execResult(cmd))
+          )
+      : vi
+          .fn()
+          .mockImplementation((cmd: string) =>
+            Promise.resolve(isPreflightCommand(cmd) ? preflightResult(cmd) : execResult)
+          );
 
   // Mock startProcess that returns a process with waitForPort and getLogs
   const startProcessFn = vi.fn().mockImplementation(() =>
@@ -783,6 +800,108 @@ describe('WrapperClient', () => {
       expect(startProcessCall[0]).toContain('WRAPPER_PORT=5000');
       expect(startProcessCall[0]).toContain('KILO_SERVER_PORT=4600');
       expect(startProcessCall[0]).toContain('WORKSPACE_PATH=/workspace/test');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-flight checks
+  // -------------------------------------------------------------------------
+
+  describe('pre-flight checks', () => {
+    it('throws WrapperNotReadyError when bun exits with SIGILL (exit code 132)', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      // Override exec to simulate SIGILL on bun --version
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version')) {
+          return Promise.resolve({ exitCode: 132, stderr: '' });
+        }
+        if (cmd.startsWith('test -f')) {
+          return Promise.resolve({ exitCode: 0, stdout: 'ok' });
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await expect(
+        client.ensureRunning({
+          sessionId: 'test-session',
+          kiloServerPort: 4600,
+          workspacePath: '/workspace/test',
+        })
+      ).rejects.toThrow(/SIGILL/);
+    });
+
+    it('throws WrapperNotReadyError when bun exits with non-zero code', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version')) {
+          return Promise.resolve({ exitCode: 127, stderr: 'bun: not found' });
+        }
+        if (cmd.startsWith('test -f')) {
+          return Promise.resolve({ exitCode: 0, stdout: 'ok' });
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await expect(
+        client.ensureRunning({
+          sessionId: 'test-session',
+          kiloServerPort: 4600,
+          workspacePath: '/workspace/test',
+        })
+      ).rejects.toThrow(/bun runtime is broken.*exit code 127/);
+    });
+
+    it('throws WrapperNotReadyError when wrapper binary is missing', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version')) {
+          return Promise.resolve({ exitCode: 0, stdout: '1.0.0' });
+        }
+        if (cmd.startsWith('test -f')) {
+          return Promise.resolve({ exitCode: 1, stdout: '' });
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await expect(
+        client.ensureRunning({
+          sessionId: 'test-session',
+          kiloServerPort: 4600,
+          workspacePath: '/workspace/test',
+        })
+      ).rejects.toThrow(/not found in container/);
+    });
+
+    it('proceeds when pre-flight exec itself fails (e.g. sandbox timeout)', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version') || cmd.startsWith('test -f')) {
+          return Promise.reject(new Error('sandbox timeout'));
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      // Should not throw ÃÃÂ¢ pre-flight failure is non-blocking
+      await client.ensureRunning({
+        sessionId: 'test-session',
+        kiloServerPort: 4600,
+        workspacePath: '/workspace/test',
+      });
+
+      expect(session.startProcess).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -903,6 +903,52 @@ describe('WrapperClient', () => {
 
       expect(session.startProcess).toHaveBeenCalledTimes(1);
     });
+
+    it('surfaces fatal bun SIGILL even when the file check rejects', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version')) {
+          return Promise.resolve({ exitCode: 132, stderr: '' });
+        }
+        if (cmd.startsWith('test -f')) {
+          return Promise.reject(new Error('sandbox timeout'));
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await expect(
+        client.ensureRunning({
+          sessionId: 'test-session',
+          kiloServerPort: 4600,
+          workspacePath: '/workspace/test',
+        })
+      ).rejects.toThrow(/SIGILL/);
+    });
+
+    it('surfaces missing wrapper even when the bun check rejects', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('bun --version')) {
+          return Promise.reject(new Error('sandbox timeout'));
+        }
+        if (cmd.startsWith('test -f')) {
+          return Promise.resolve({ exitCode: 1, stdout: '' });
+        }
+        return Promise.resolve(createCurlError(7, 'Connection refused'));
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await expect(
+        client.ensureRunning({
+          sessionId: 'test-session',
+          kiloServerPort: 4600,
+          workspacePath: '/workspace/test',
+        })
+      ).rejects.toThrow(/not found in container/);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -894,7 +894,7 @@ describe('WrapperClient', () => {
 
       const client = new WrapperClient({ session, port: defaultPort });
 
-      // Should not throw ÃÃÂ¢ pre-flight failure is non-blocking
+      // Should not throw; pre-flight failure is non-blocking
       await client.ensureRunning({
         sessionId: 'test-session',
         kiloServerPort: 4600,

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -130,11 +130,16 @@ export class WrapperClient {
   private readonly port: number;
   private readonly baseUrl: string;
 
+  private shellQuote(value: string): string {
+    return `'${value.replace(/'/g, "'\\''")}'`;
+  }
+
   private async runPreflightChecks(options: {
     wrapperPath: string;
     workspacePath: string;
   }): Promise<void> {
     const { wrapperPath, workspacePath } = options;
+    const quotedWrapperPath = this.shellQuote(wrapperPath);
 
     // Verify bun runtime and wrapper binary before the full start+waitForPort loop.
     // A fast `bun --version` catches SIGILL (exit 132) on hosts whose CPU lacks
@@ -143,7 +148,7 @@ export class WrapperClient {
     try {
       const [bunResult, fileResult] = await Promise.allSettled([
         this.session.exec('bun --version', { timeout: 5_000 }),
-        this.session.exec(`test -f ${wrapperPath} && echo ok`, {
+        this.session.exec(`test -f ${quotedWrapperPath}`, {
           timeout: 5_000,
           cwd: workspacePath,
         }),
@@ -159,7 +164,7 @@ export class WrapperClient {
         );
       }
 
-      if (fileResult.status === 'fulfilled' && !fileResult.value.stdout?.includes('ok')) {
+      if (fileResult.status === 'fulfilled' && fileResult.value.exitCode !== 0) {
         throw new WrapperNotReadyError(
           `Wrapper pre-flight failed: ${wrapperPath} not found in container`
         );
@@ -225,11 +230,11 @@ export class WrapperClient {
 
     if (body) {
       // Escape single quotes in JSON
-      const json = JSON.stringify(body).replace(/'/g, "'\\''");
-      command += ` -d '${json}'`;
+      const json = this.shellQuote(JSON.stringify(body));
+      command += ` -d ${json}`;
     }
 
-    command += ` '${url}'`;
+    command += ` ${this.shellQuote(url)}`;
 
     // Execute curl in the container
     const result = await this.session.exec(command);

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -244,6 +244,43 @@ export class WrapperClient {
       logger.debug('WrapperClient: wrapper not running, starting...');
     }
 
+    // Pre-flight: verify bun runtime and wrapper binary are functional before
+    // committing to the full start+waitForPort loop.  A fast `bun --version`
+    // catches SIGILL (exit 132) on hosts whose CPU lacks required instructions,
+    // missing/corrupt binaries, etc.  We also verify the wrapper script exists.
+    try {
+      const [bunCheck, fileCheck] = await Promise.all([
+        this.session.exec('bun --version', { timeout: 5_000 }),
+        this.session.exec(`test -f ${wrapperPath} && echo ok`, { timeout: 5_000 }),
+      ]);
+
+      if (bunCheck.exitCode !== 0) {
+        const detail =
+          bunCheck.exitCode === 132
+            ? 'SIGILL â bun binary incompatible with host CPU'
+            : `exit code ${bunCheck.exitCode}`;
+        throw new WrapperNotReadyError(
+          `Wrapper pre-flight failed: bun runtime is broken (${detail}). stderr: ${bunCheck.stderr?.trim() ?? '(empty)'}`
+        );
+      }
+
+      if (!fileCheck.stdout?.includes('ok')) {
+        throw new WrapperNotReadyError(
+          `Wrapper pre-flight failed: ${wrapperPath} not found in container`
+        );
+      }
+
+      logger.debug('WrapperClient: pre-flight passed', {
+        bunVersion: bunCheck.stdout?.trim(),
+      });
+    } catch (error) {
+      if (error instanceof WrapperNotReadyError) throw error;
+      // exec itself failed (e.g. sandbox connectivity) â log but don't block
+      logger.warn('WrapperClient: pre-flight check failed to execute, proceeding anyway', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     // Start the wrapper process using startProcess so it's trackable via listProcesses()
     // The command includes a session marker so we can find this wrapper later
     const sessionMarker = getWrapperSessionMarker(sessionId);

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -341,7 +341,7 @@ export class WrapperClient {
     if (upstreamBranch) envParts.push(`UPSTREAM_BRANCH=${upstreamBranch}`);
     if (model) envParts.push(`MODEL=${model}`);
 
-    const command = `${envParts.join(' ')} bun run ${wrapperPath} ${sessionMarker}`;
+    const command = `${envParts.join(' ')} bun run ${this.shellQuote(wrapperPath)} ${sessionMarker}`;
 
     let lastError: Error | undefined;
 

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -130,6 +130,83 @@ export class WrapperClient {
   private readonly port: number;
   private readonly baseUrl: string;
 
+  private async runPreflightChecks(options: {
+    wrapperPath: string;
+    workspacePath: string;
+  }): Promise<void> {
+    const { wrapperPath, workspacePath } = options;
+
+    // Verify bun runtime and wrapper binary before the full start+waitForPort loop.
+    // A fast `bun --version` catches SIGILL (exit 132) on hosts whose CPU lacks
+    // required instructions, missing/corrupt binaries, etc. We also verify the
+    // wrapper script exists.
+    try {
+      const [bunResult, fileResult] = await Promise.allSettled([
+        this.session.exec('bun --version', { timeout: 5_000 }),
+        this.session.exec(`test -f ${wrapperPath} && echo ok`, {
+          timeout: 5_000,
+          cwd: workspacePath,
+        }),
+      ]);
+
+      if (bunResult.status === 'fulfilled' && bunResult.value.exitCode !== 0) {
+        const detail =
+          bunResult.value.exitCode === 132
+            ? 'SIGILL -- bun binary incompatible with host CPU'
+            : `exit code ${bunResult.value.exitCode}`;
+        throw new WrapperNotReadyError(
+          `Wrapper pre-flight failed: bun runtime is broken (${detail}). stderr: ${bunResult.value.stderr?.trim() ?? '(empty)'}`
+        );
+      }
+
+      if (fileResult.status === 'fulfilled' && !fileResult.value.stdout?.includes('ok')) {
+        throw new WrapperNotReadyError(
+          `Wrapper pre-flight failed: ${wrapperPath} not found in container`
+        );
+      }
+
+      if (bunResult.status === 'rejected' && fileResult.status === 'rejected') {
+        logger.warn('WrapperClient: pre-flight check failed to execute, proceeding anyway', {
+          bunError:
+            bunResult.reason instanceof Error ? bunResult.reason.message : String(bunResult.reason),
+          fileError:
+            fileResult.reason instanceof Error
+              ? fileResult.reason.message
+              : String(fileResult.reason),
+        });
+        return;
+      }
+
+      if (bunResult.status === 'rejected') {
+        logger.warn('WrapperClient: bun pre-flight exec failed, proceeding anyway', {
+          error:
+            bunResult.reason instanceof Error ? bunResult.reason.message : String(bunResult.reason),
+        });
+      }
+
+      if (fileResult.status === 'rejected') {
+        logger.warn('WrapperClient: file pre-flight exec failed, proceeding anyway', {
+          error:
+            fileResult.reason instanceof Error
+              ? fileResult.reason.message
+              : String(fileResult.reason),
+        });
+      }
+
+      if (bunResult.status === 'fulfilled') {
+        logger.debug('WrapperClient: pre-flight passed', {
+          bunVersion: bunResult.value.stdout?.trim(),
+        });
+      }
+    } catch (error) {
+      if (error instanceof WrapperNotReadyError) throw error;
+
+      logger.warn('WrapperClient: pre-flight check failed unexpectedly, proceeding anyway', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   constructor(options: WrapperClientOptions) {
     this.session = options.session;
     this.port = options.port;
@@ -244,78 +321,7 @@ export class WrapperClient {
       logger.debug('WrapperClient: wrapper not running, starting...');
     }
 
-    // Pre-flight: verify bun runtime and wrapper binary are functional before
-    // committing to the full start+waitForPort loop.  A fast `bun --version`
-    // catches SIGILL (exit 132) on hosts whose CPU lacks required instructions,
-    // missing/corrupt binaries, etc.  We also verify the wrapper script exists.
-    try {
-      const [bunResult, fileResult] = await Promise.allSettled([
-        this.session.exec('bun --version', { timeout: 5_000 }),
-        this.session.exec(`test -f ${wrapperPath} && echo ok`, {
-          timeout: 5_000,
-          cwd: workspacePath,
-        }),
-      ]);
-
-      // Check for fatal bun failures even if the other probe rejected
-      if (bunResult.status === 'fulfilled' && bunResult.value.exitCode !== 0) {
-        const detail =
-          bunResult.value.exitCode === 132
-            ? 'SIGILL â bun binary incompatible with host CPU'
-            : `exit code ${bunResult.value.exitCode}`;
-        throw new WrapperNotReadyError(
-          `Wrapper pre-flight failed: bun runtime is broken (${detail}). stderr: ${bunResult.value.stderr?.trim() ?? '(empty)'}`
-        );
-      }
-
-      if (fileResult.status === 'fulfilled' && !fileResult.value.stdout?.includes('ok')) {
-        throw new WrapperNotReadyError(
-          `Wrapper pre-flight failed: ${wrapperPath} not found in container`
-        );
-      }
-
-      // If both rejected, the exec transport itself is broken — warn but proceed
-      if (bunResult.status === 'rejected' && fileResult.status === 'rejected') {
-        logger.warn('WrapperClient: pre-flight check failed to execute, proceeding anyway', {
-          bunError:
-            bunResult.reason instanceof Error ? bunResult.reason.message : String(bunResult.reason),
-          fileError:
-            fileResult.reason instanceof Error
-              ? fileResult.reason.message
-              : String(fileResult.reason),
-        });
-      } else {
-        // At least one succeeded — if the other rejected, log it but don't block
-        if (bunResult.status === 'rejected') {
-          logger.warn('WrapperClient: bun pre-flight exec failed, proceeding anyway', {
-            error:
-              bunResult.reason instanceof Error
-                ? bunResult.reason.message
-                : String(bunResult.reason),
-          });
-        }
-        if (fileResult.status === 'rejected') {
-          logger.warn('WrapperClient: file pre-flight exec failed, proceeding anyway', {
-            error:
-              fileResult.reason instanceof Error
-                ? fileResult.reason.message
-                : String(fileResult.reason),
-          });
-        }
-
-        if (bunResult.status === 'fulfilled') {
-          logger.debug('WrapperClient: pre-flight passed', {
-            bunVersion: bunResult.value.stdout?.trim(),
-          });
-        }
-      }
-    } catch (error) {
-      if (error instanceof WrapperNotReadyError) throw error;
-      // Unexpected error — log but don't block
-      logger.warn('WrapperClient: pre-flight check failed unexpectedly, proceeding anyway', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    await this.runPreflightChecks({ wrapperPath, workspacePath });
 
     // Start the wrapper process using startProcess so it's trackable via listProcesses()
     // The command includes a session marker so we can find this wrapper later

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -249,34 +249,70 @@ export class WrapperClient {
     // catches SIGILL (exit 132) on hosts whose CPU lacks required instructions,
     // missing/corrupt binaries, etc.  We also verify the wrapper script exists.
     try {
-      const [bunCheck, fileCheck] = await Promise.all([
+      const [bunResult, fileResult] = await Promise.allSettled([
         this.session.exec('bun --version', { timeout: 5_000 }),
-        this.session.exec(`test -f ${wrapperPath} && echo ok`, { timeout: 5_000 }),
+        this.session.exec(`test -f ${wrapperPath} && echo ok`, {
+          timeout: 5_000,
+          cwd: workspacePath,
+        }),
       ]);
 
-      if (bunCheck.exitCode !== 0) {
+      // Check for fatal bun failures even if the other probe rejected
+      if (bunResult.status === 'fulfilled' && bunResult.value.exitCode !== 0) {
         const detail =
-          bunCheck.exitCode === 132
-            ? 'SIGILL â bun binary incompatible with host CPU'
-            : `exit code ${bunCheck.exitCode}`;
+          bunResult.value.exitCode === 132
+            ? 'SIGILL â bun binary incompatible with host CPU'
+            : `exit code ${bunResult.value.exitCode}`;
         throw new WrapperNotReadyError(
-          `Wrapper pre-flight failed: bun runtime is broken (${detail}). stderr: ${bunCheck.stderr?.trim() ?? '(empty)'}`
+          `Wrapper pre-flight failed: bun runtime is broken (${detail}). stderr: ${bunResult.value.stderr?.trim() ?? '(empty)'}`
         );
       }
 
-      if (!fileCheck.stdout?.includes('ok')) {
+      if (fileResult.status === 'fulfilled' && !fileResult.value.stdout?.includes('ok')) {
         throw new WrapperNotReadyError(
           `Wrapper pre-flight failed: ${wrapperPath} not found in container`
         );
       }
 
-      logger.debug('WrapperClient: pre-flight passed', {
-        bunVersion: bunCheck.stdout?.trim(),
-      });
+      // If both rejected, the exec transport itself is broken — warn but proceed
+      if (bunResult.status === 'rejected' && fileResult.status === 'rejected') {
+        logger.warn('WrapperClient: pre-flight check failed to execute, proceeding anyway', {
+          bunError:
+            bunResult.reason instanceof Error ? bunResult.reason.message : String(bunResult.reason),
+          fileError:
+            fileResult.reason instanceof Error
+              ? fileResult.reason.message
+              : String(fileResult.reason),
+        });
+      } else {
+        // At least one succeeded — if the other rejected, log it but don't block
+        if (bunResult.status === 'rejected') {
+          logger.warn('WrapperClient: bun pre-flight exec failed, proceeding anyway', {
+            error:
+              bunResult.reason instanceof Error
+                ? bunResult.reason.message
+                : String(bunResult.reason),
+          });
+        }
+        if (fileResult.status === 'rejected') {
+          logger.warn('WrapperClient: file pre-flight exec failed, proceeding anyway', {
+            error:
+              fileResult.reason instanceof Error
+                ? fileResult.reason.message
+                : String(fileResult.reason),
+          });
+        }
+
+        if (bunResult.status === 'fulfilled') {
+          logger.debug('WrapperClient: pre-flight passed', {
+            bunVersion: bunResult.value.stdout?.trim(),
+          });
+        }
+      }
     } catch (error) {
       if (error instanceof WrapperNotReadyError) throw error;
-      // exec itself failed (e.g. sandbox connectivity) â log but don't block
-      logger.warn('WrapperClient: pre-flight check failed to execute, proceeding anyway', {
+      // Unexpected error — log but don't block
+      logger.warn('WrapperClient: pre-flight check failed unexpectedly, proceeding anyway', {
         error: error instanceof Error ? error.message : String(error),
       });
     }


### PR DESCRIPTION
## Summary

Adds a pre-flight validation step in `WrapperClient.ensureRunning()` that runs before the wrapper process start retry loop. The check executes `bun --version` and verifies the wrapper script exists inside the container, catching fundamental environment issues (CPU incompatibility, missing binaries) before committing to the full start+waitForPort cycle.

This was motivated by investigating a production case where a user experienced a 100% wrapper failure rate across multiple days and container image versions. The wrapper process was crashing immediately with SIGILL (exit code 132, illegal CPU instruction) and exit code 1, but the error surfaced as an opaque `ProcessExitedBeforeReadyError` with no actionable diagnostic information. The pre-flight check would have immediately identified the bun runtime incompatibility.

Key behaviors:
- SIGILL (exit 132) produces `"Wrapper pre-flight failed: bun runtime is broken (SIGILL -- bun binary incompatible with host CPU)"`
- Other non-zero exits include the exit code and stderr in the error message
- Missing wrapper binary produces `"not found in container"` error
- If the pre-flight exec itself fails (e.g., sandbox connectivity issue), it logs a warning and proceeds with normal startup -- the check is additive, not a hard gate

## Verification

- [x] `pnpm run test -- --run src/kilo/wrapper-client.test` -- 426 tests pass (4 new pre-flight tests added)
- [x] `pnpm run typecheck` -- no new errors (pre-existing `jose` module error in `packages/worker-utils` unrelated)
- [x] Verified no PII or user-specific data in the diff

## Visual Changes

N/A

## Reviewer Notes

- The pre-flight runs both checks (`bun --version` + `test -f <wrapperPath>`) in parallel with a 5s timeout each, so the latency cost on the happy path is minimal
- Test mocks in `createMockSession` were updated to auto-handle pre-flight commands so existing tests remain unchanged
- The `ExecOptions.timeout` parameter is typed in `@cloudflare/sandbox` -- verified it's supported