### PR TITLE
feat(kiloclaw): add DO owned instance feature flags with npm-global-prefix setting

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -54,10 +54,6 @@ RUN npm install -g mcporter@0.7.3
 # Install summarize (web page summarization CLI)
 RUN npm install -g @steipete/summarize@0.11.1
 
-# Add npm-global bin to PATH for instances that opt in at runtime.
-# NPM_CONFIG_PREFIX is set conditionally in start-openclaw.sh based on the
-# KILOCLAW_NPM_GLOBAL_PREFIX env var (controlled by the DO's instance features).
-ENV PATH="/root/.npm-global/bin:$PATH"
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -54,6 +54,11 @@ RUN npm install -g mcporter@0.7.3
 # Install summarize (web page summarization CLI)
 RUN npm install -g @steipete/summarize@0.11.1
 
+# Add npm-global bin to PATH for instances that opt in at runtime.
+# NPM_CONFIG_PREFIX is set conditionally in start-openclaw.sh based on the
+# KILOCLAW_NPM_GLOBAL_PREFIX env var (controlled by the DO's instance features).
+ENV PATH="/root/.npm-global/bin:$PATH"
+
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0
 RUN ARCH="$(dpkg --print-architecture)" \
@@ -101,8 +106,8 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-02-27-v57-openclaw-2026.2.26-1password-arch-fix
-RUN echo "7"
+# Build cache bust: 2026-03-10-v58-instance-feature-flags-npm-global-prefix
+RUN echo "8"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js

--- a/kiloclaw/docs/instance-features.md
+++ b/kiloclaw/docs/instance-features.md
@@ -21,16 +21,16 @@ DO (source of truth) → buildEnvVars() → config.env → Fly machine → start
 
 ## Current flags
 
-| Feature name        | Env var                      | Description                                                                                                                                                                                              |
-| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npm-global-prefix` | `KILOCLAW_NPM_GLOBAL_PREFIX` | Redirects `npm install -g` to `/root/.npm-global` (persistent volume) instead of `/usr/local` (image layer, lost on restart). PATH is set in the Dockerfile; `NPM_CONFIG_PREFIX` is exported at runtime. |
+| Feature name        | Env var                      | Description                                                                                                                                                                                                          |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm-global-prefix` | `KILOCLAW_NPM_GLOBAL_PREFIX` | Redirects `npm install -g` to `/root/.npm-global` (persistent volume) instead of `/usr/local` (image layer, lost on restart). Both `NPM_CONFIG_PREFIX` and `PATH` are exported conditionally in `start-openclaw.sh`. |
 
 ## Adding a new flag
 
 1. Add the feature name to `DEFAULT_INSTANCE_FEATURES` in `kiloclaw-instance.ts`
 2. Add the feature-to-env-var mapping in `FEATURE_TO_ENV_VAR` in `gateway/env.ts`
 3. Add a conditional block in `start-openclaw.sh` that reads the env var
-4. If PATH changes are needed, add them to the `Dockerfile` (harmless when the feature is absent)
+4. If PATH changes are needed, add them inside the conditional block in `start-openclaw.sh`
 5. Update the table above
 
 ## Existing instances
@@ -44,5 +44,4 @@ To get the latest feature set, a user must destroy and re-provision their instan
 - `src/durable-objects/kiloclaw-instance.ts` — `DEFAULT_INSTANCE_FEATURES`, provision logic
 - `src/schemas/instance-config.ts` — `instanceFeatures` in `PersistedStateSchema`
 - `src/gateway/env.ts` — `FEATURE_TO_ENV_VAR`, maps features to env vars
-- `start-openclaw.sh` — reads env vars, applies runtime configuration
-- `Dockerfile` — PATH entries for feature directories
+- `start-openclaw.sh` — reads env vars, applies runtime configuration (including PATH)

--- a/kiloclaw/docs/instance-features.md
+++ b/kiloclaw/docs/instance-features.md
@@ -1,0 +1,48 @@
+# Instance Feature Flags
+
+KiloClaw uses per-instance feature flags to gate behavior that should only apply to newly provisioned instances. This avoids breaking existing users whose agents may depend on default paths or conventions.
+
+## How it works
+
+Feature flags are owned by the Durable Object and stored in its SQLite state (`instanceFeatures` array). On first provision (`isNew = true`), the DO populates the current default set from `DEFAULT_INSTANCE_FEATURES`. On subsequent provisions and reboots, existing features are preserved.
+
+Features flow to the Fly machine as environment variables through the `buildEnvVars()` pipeline. Each feature maps to a `KILOCLAW_*` env var (defined in `FEATURE_TO_ENV_VAR` in `gateway/env.ts`). The startup script reads these env vars and conditionally enables behavior.
+
+```
+DO (source of truth) → buildEnvVars() → config.env → Fly machine → start-openclaw.sh
+```
+
+### Why the DO owns this
+
+- Single source of truth — no filesystem state to drift or audit
+- Uses the existing env var pipeline — same as every other config value
+- Observable — feature set is in DO SQLite, queryable via admin APIs
+- Legacy instances get an empty array by default (Zod schema `.default([])`)
+
+## Current flags
+
+| Feature name | Env var | Description |
+|---|---|---|
+| `npm-global-prefix` | `KILOCLAW_NPM_GLOBAL_PREFIX` | Redirects `npm install -g` to `/root/.npm-global` (persistent volume) instead of `/usr/local` (image layer, lost on restart). PATH is set in the Dockerfile; `NPM_CONFIG_PREFIX` is exported at runtime. |
+
+## Adding a new flag
+
+1. Add the feature name to `DEFAULT_INSTANCE_FEATURES` in `kiloclaw-instance.ts`
+2. Add the feature-to-env-var mapping in `FEATURE_TO_ENV_VAR` in `gateway/env.ts`
+3. Add a conditional block in `start-openclaw.sh` that reads the env var
+4. If PATH changes are needed, add them to the `Dockerfile` (harmless when the feature is absent)
+5. Update the table above
+
+## Existing instances
+
+Features are set once at first provision and preserved on re-provision. New features added to `DEFAULT_INSTANCE_FEATURES` only apply to newly provisioned instances — existing instances keep their original set. This is by design to avoid breaking existing users.
+
+To get the latest feature set, a user must destroy and re-provision their instance.
+
+## Key files
+
+- `src/durable-objects/kiloclaw-instance.ts` — `DEFAULT_INSTANCE_FEATURES`, provision logic
+- `src/schemas/instance-config.ts` — `instanceFeatures` in `PersistedStateSchema`
+- `src/gateway/env.ts` — `FEATURE_TO_ENV_VAR`, maps features to env vars
+- `start-openclaw.sh` — reads env vars, applies runtime configuration
+- `Dockerfile` — PATH entries for feature directories

--- a/kiloclaw/docs/instance-features.md
+++ b/kiloclaw/docs/instance-features.md
@@ -21,8 +21,8 @@ DO (source of truth) → buildEnvVars() → config.env → Fly machine → start
 
 ## Current flags
 
-| Feature name | Env var | Description |
-|---|---|---|
+| Feature name        | Env var                      | Description                                                                                                                                                                                              |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `npm-global-prefix` | `KILOCLAW_NPM_GLOBAL_PREFIX` | Redirects `npm install -g` to `/root/.npm-global` (persistent volume) instead of `/usr/local` (image layer, lost on restart). PATH is set in the Dockerfile; `NPM_CONFIG_PREFIX` is exported at runtime. |
 
 ## Adding a new flag

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2419,6 +2419,37 @@ describe('provision: auto-start after fresh provision', () => {
   });
 });
 
+describe('provision: instance feature flags', () => {
+  it('sets DEFAULT_INSTANCE_FEATURES on first provision', async () => {
+    const { instance, storage } = createInstance();
+
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-1',
+      region: 'iad',
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.provision('user-1', {});
+
+    const features = storage._store.get('instanceFeatures') as string[];
+    expect(features).toEqual(['npm-global-prefix']);
+  });
+
+  it('preserves existing features on re-provision (does not reset to defaults)', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, {
+      instanceFeatures: ['some-old-feature'],
+    });
+
+    await instance.provision('user-1', { kilocodeApiKey: 'new-key' });
+
+    const features = storage._store.get('instanceFeatures') as string[];
+    expect(features).toEqual(['some-old-feature']);
+  });
+});
+
 describe('auto-destroy stale provisioned instances', () => {
   // Reset listMachines to return [] for each test in this block, since
   // earlier metadata-recovery tests may have set it to return machines

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -29,6 +29,7 @@ import { getWorkerDb, getActiveInstance, markInstanceDestroyed } from '../db';
 import { buildEnvVars } from '../gateway/env';
 import {
   PersistedStateSchema,
+  DEFAULT_INSTANCE_FEATURES,
   type InstanceConfig,
   type PersistedState,
   type EncryptedEnvelope,
@@ -187,6 +188,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private lastDestroyErrorMessage: string | null = null;
   private lastDestroyErrorAt: number | null = null;
   private lastBoundMachineRecoveryAt: number | null = null;
+  private instanceFeatures: string[] = [];
 
   // In-memory only (not persisted to SQLite) — throttles live Fly checks in getStatus()
   private lastLiveCheckAt: number | null = null;
@@ -233,6 +235,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.lastDestroyErrorMessage = s.lastDestroyErrorMessage;
       this.lastDestroyErrorAt = s.lastDestroyErrorAt;
       this.lastBoundMachineRecoveryAt = s.lastBoundMachineRecoveryAt;
+      this.instanceFeatures = s.instanceFeatures;
     } else {
       const hasAnyData = entries.size > 0;
       if (hasAnyData) {
@@ -412,10 +415,16 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       trackedImageDigest: this.trackedImageDigest,
     };
 
+    // Set default instance features on first provision; preserve existing on re-provision.
+    if (isNew) {
+      this.instanceFeatures = [...DEFAULT_INSTANCE_FEATURES];
+    }
+
     const update = isNew
       ? storageUpdate({
           ...configFields,
           ...versionFields,
+          instanceFeatures: this.instanceFeatures,
           provisionedAt: Date.now(),
           lastStartedAt: null,
           lastStoppedAt: null,
@@ -428,7 +437,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           pendingDestroyVolumeId: null,
           pendingPostgresMarkOnFinalize: false,
         })
-      : storageUpdate({ ...configFields, ...versionFields });
+      : storageUpdate({ ...configFields, ...versionFields, instanceFeatures: this.instanceFeatures });
 
     await this.ctx.storage.put(update);
 
@@ -2789,6 +2798,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         kilocodeApiKey: this.kilocodeApiKey ?? undefined,
         kilocodeDefaultModel: this.kilocodeDefaultModel ?? undefined,
         channels: this.channels ?? undefined,
+        instanceFeatures: this.instanceFeatures,
       }
     );
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -2707,6 +2707,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           openclawVersion: null,
           imageVariant: null,
           trackedImageTag: null,
+          instanceFeatures: [...DEFAULT_INSTANCE_FEATURES],
         })
       );
 
@@ -2733,6 +2734,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.imageVariant = null;
       this.trackedImageTag = null;
       this.trackedImageDigest = null;
+      this.instanceFeatures = [...DEFAULT_INSTANCE_FEATURES];
       this.loaded = true;
 
       console.log('[DO] Restored from Postgres: sandboxId =', instance.sandboxId);

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -2711,7 +2711,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           openclawVersion: null,
           imageVariant: null,
           trackedImageTag: null,
-          instanceFeatures: [...DEFAULT_INSTANCE_FEATURES],
+          instanceFeatures: [],
         })
       );
 
@@ -2738,7 +2738,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.imageVariant = null;
       this.trackedImageTag = null;
       this.trackedImageDigest = null;
-      this.instanceFeatures = [...DEFAULT_INSTANCE_FEATURES];
+      this.instanceFeatures = [];
       this.loaded = true;
 
       console.log('[DO] Restored from Postgres: sandboxId =', instance.sandboxId);

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.ts
@@ -437,7 +437,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           pendingDestroyVolumeId: null,
           pendingPostgresMarkOnFinalize: false,
         })
-      : storageUpdate({ ...configFields, ...versionFields, instanceFeatures: this.instanceFeatures });
+      : storageUpdate({
+          ...configFields,
+          ...versionFields,
+          instanceFeatures: this.instanceFeatures,
+        });
 
     await this.ctx.storage.put(update);
 

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { generateKeyPairSync, publicEncrypt, randomBytes, createCipheriv, constants } from 'crypto';
-import { buildEnvVars } from './env';
+import { buildEnvVars, FEATURE_TO_ENV_VAR } from './env';
+import { DEFAULT_INSTANCE_FEATURES } from '../schemas/instance-config';
 import { createMockEnv } from '../test-utils';
 import { deriveGatewayToken } from '../auth/gateway-token';
 import type { EncryptedEnvelope, EncryptedChannelTokens } from '../schemas/instance-config';
@@ -324,5 +325,51 @@ describe('buildEnvVars', () => {
     expect(result.env.DISCORD_BOT_TOKEN).toBeUndefined();
     expect(result.env.SLACK_BOT_TOKEN).toBeUndefined();
     expect(result.env.SLACK_APP_TOKEN).toBeUndefined();
+  });
+
+  // ─── Instance feature flags (Layer 6) ───────────────────────────────
+
+  it('maps instanceFeatures to KILOCLAW_* env vars', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      instanceFeatures: ['npm-global-prefix'],
+    });
+
+    expect(result.env.KILOCLAW_NPM_GLOBAL_PREFIX).toBe('true');
+  });
+
+  it('ignores unknown feature names without emitting env vars', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      instanceFeatures: ['nonexistent-feature'],
+    });
+
+    // No KILOCLAW_* feature vars should be set (only platform defaults)
+    const featureVars = Object.keys(result.env).filter(k => k.startsWith('KILOCLAW_'));
+    expect(featureVars).toEqual([]);
+  });
+
+  it('emits no feature env vars when instanceFeatures is empty', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      instanceFeatures: [],
+    });
+
+    expect(result.env.KILOCLAW_NPM_GLOBAL_PREFIX).toBeUndefined();
+  });
+
+  it('rejects user envVars with KILOCLAW_ prefix (defense-in-depth)', async () => {
+    const env = createMockEnv();
+    await expect(
+      buildEnvVars(env, SANDBOX_ID, SECRET, {
+        envVars: { KILOCLAW_NPM_GLOBAL_PREFIX: 'false' },
+      })
+    ).rejects.toThrow('reserved prefix');
+  });
+
+  it('every DEFAULT_INSTANCE_FEATURES entry has a FEATURE_TO_ENV_VAR mapping', () => {
+    for (const feature of DEFAULT_INSTANCE_FEATURES) {
+      expect(FEATURE_TO_ENV_VAR[feature], `Missing FEATURE_TO_ENV_VAR mapping for "${feature}"`).toBeDefined();
+    }
   });
 });

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -265,33 +265,36 @@ describe('buildEnvVars', () => {
 
   // ─── Reserved prefix validation ──────────────────────────────────────
 
-  it('rejects user envVars with KILOCLAW_ENC_ prefix', async () => {
+  it('drops user envVars with reserved KILOCLAW_ prefix instead of throwing', async () => {
     const env = createMockEnv();
-    await expect(
-      buildEnvVars(env, SANDBOX_ID, SECRET, {
-        envVars: { KILOCLAW_ENC_FOO: 'bad' },
-      })
-    ).rejects.toThrow('reserved prefix');
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      envVars: { KILOCLAW_ENC_FOO: 'bad', VALID_VAR: 'good' },
+    });
+
+    expect(result.env.KILOCLAW_ENC_FOO).toBeUndefined();
+    expect(result.sensitive.KILOCLAW_ENC_FOO).toBeUndefined();
+    expect(result.env.VALID_VAR).toBe('good');
   });
 
-  it('rejects user encryptedSecrets with KILOCLAW_ENV_ prefix', async () => {
+  it('drops encrypted secrets with reserved KILOCLAW_ prefix instead of throwing', async () => {
     const env = createMockEnv({ AGENT_ENV_VARS_PRIVATE_KEY: testPrivateKey });
-    await expect(
-      buildEnvVars(env, SANDBOX_ID, SECRET, {
-        encryptedSecrets: {
-          KILOCLAW_ENV_BAD: encryptForTest('val', testPublicKey),
-        },
-      })
-    ).rejects.toThrow('reserved prefix');
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      encryptedSecrets: {
+        KILOCLAW_ENV_BAD: encryptForTest('val', testPublicKey),
+      },
+    });
+
+    expect(result.sensitive.KILOCLAW_ENV_BAD).toBeUndefined();
   });
 
-  it('rejects user envVars with invalid shell identifier', async () => {
+  it('drops user envVars with invalid shell identifier instead of throwing', async () => {
     const env = createMockEnv();
-    await expect(
-      buildEnvVars(env, SANDBOX_ID, SECRET, {
-        envVars: { 'MY-VAR': 'bad' },
-      })
-    ).rejects.toThrow('valid shell identifier');
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      envVars: { 'MY-VAR': 'bad', GOOD_VAR: 'good' },
+    });
+
+    expect(result.env['MY-VAR']).toBeUndefined();
+    expect(result.env.GOOD_VAR).toBe('good');
   });
 
   // ─── Catalog-derived SENSITIVE_KEYS equivalence ───────────────────────
@@ -358,13 +361,15 @@ describe('buildEnvVars', () => {
     expect(result.env.KILOCLAW_NPM_GLOBAL_PREFIX).toBeUndefined();
   });
 
-  it('rejects user envVars with KILOCLAW_ prefix (defense-in-depth)', async () => {
+  it('drops user KILOCLAW_* env var and feature flag still applies (defense-in-depth)', async () => {
     const env = createMockEnv();
-    await expect(
-      buildEnvVars(env, SANDBOX_ID, SECRET, {
-        envVars: { KILOCLAW_NPM_GLOBAL_PREFIX: 'false' },
-      })
-    ).rejects.toThrow('reserved prefix');
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      envVars: { KILOCLAW_NPM_GLOBAL_PREFIX: 'false' },
+      instanceFeatures: ['npm-global-prefix'],
+    });
+
+    // User's attempt to set it to 'false' was dropped; feature flag sets it to 'true'
+    expect(result.env.KILOCLAW_NPM_GLOBAL_PREFIX).toBe('true');
   });
 
   it('every DEFAULT_INSTANCE_FEATURES entry has a FEATURE_TO_ENV_VAR mapping', () => {

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -374,7 +374,10 @@ describe('buildEnvVars', () => {
 
   it('every DEFAULT_INSTANCE_FEATURES entry has a FEATURE_TO_ENV_VAR mapping', () => {
     for (const feature of DEFAULT_INSTANCE_FEATURES) {
-      expect(FEATURE_TO_ENV_VAR[feature], `Missing FEATURE_TO_ENV_VAR mapping for "${feature}"`).toBeDefined();
+      expect(
+        FEATURE_TO_ENV_VAR[feature],
+        `Missing FEATURE_TO_ENV_VAR mapping for "${feature}"`
+      ).toBeDefined();
     }
   });
 });

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -15,6 +15,15 @@ export type UserConfig = {
   kilocodeApiKey?: string | null;
   kilocodeDefaultModel?: string | null;
   channels?: EncryptedChannelTokens;
+  instanceFeatures?: string[];
+};
+
+/**
+ * Maps instance feature flag names to container environment variables.
+ * Each feature becomes a KILOCLAW_* env var set to "true" when enabled.
+ */
+export const FEATURE_TO_ENV_VAR: Record<string, string> = {
+  'npm-global-prefix': 'KILOCLAW_NPM_GLOBAL_PREFIX',
 };
 
 /**
@@ -49,6 +58,7 @@ const SENSITIVE_KEYS = new Set([
  * 3. User-provided encrypted secrets (override env vars on conflict)
  * 4. Decrypted channel tokens (mapped to container env var names)
  * 5. Reserved system vars (cannot be overridden by any user config)
+ * 6. Instance feature flags (cannot be overridden by any user config)
  *
  * Returns a split result: non-sensitive vars in `env`, sensitive vars in `sensitive`.
  * User-provided plaintext env vars go to `env` unless they match SENSITIVE_KEYS.
@@ -133,6 +143,15 @@ export async function buildEnvVars(
   // Layer 5: Reserved system vars (cannot be overridden by any user config)
   sensitive.OPENCLAW_GATEWAY_TOKEN = await deriveGatewayToken(sandboxId, gatewayTokenSecret);
   plainEnv.AUTO_APPROVE_DEVICES = 'true';
+
+  // Instance feature flags → env vars (non-sensitive, not user-overridable).
+  // Applied after user env vars so users cannot suppress features via envVars config.
+  if (userConfig?.instanceFeatures) {
+    for (const feature of userConfig.instanceFeatures) {
+      const envVar = FEATURE_TO_ENV_VAR[feature];
+      if (envVar) plainEnv[envVar] = 'true';
+    }
+  }
 
   return { env: plainEnv, sensitive };
 }

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -87,21 +87,37 @@ export async function buildEnvVars(
 
   // Layer 2 + 3: User env vars merged with decrypted secrets.
   if (userConfig) {
-    // Validate user-provided env var names
-    if (userConfig.envVars) {
-      for (const name of Object.keys(userConfig.envVars)) {
-        validateUserEnvVarName(name);
+    // Validate user-provided env var names. Invalid names are dropped with a
+    // warning rather than throwing, so a stale reserved-prefix var stored before
+    // the prefix was blocked doesn't prevent the instance from starting.
+    const cleanedEnvVars = userConfig.envVars ? { ...userConfig.envVars } : undefined;
+    const cleanedSecrets = userConfig.encryptedSecrets
+      ? { ...userConfig.encryptedSecrets }
+      : undefined;
+    if (cleanedEnvVars) {
+      for (const name of Object.keys(cleanedEnvVars)) {
+        try {
+          validateUserEnvVarName(name);
+        } catch {
+          console.warn(`Dropping invalid env var "${name}": uses reserved prefix`);
+          delete cleanedEnvVars[name];
+        }
       }
     }
-    if (userConfig.encryptedSecrets) {
-      for (const name of Object.keys(userConfig.encryptedSecrets)) {
-        validateUserEnvVarName(name);
+    if (cleanedSecrets) {
+      for (const name of Object.keys(cleanedSecrets)) {
+        try {
+          validateUserEnvVarName(name);
+        } catch {
+          console.warn(`Dropping invalid encrypted secret "${name}": uses reserved prefix`);
+          delete cleanedSecrets[name];
+        }
       }
     }
 
     const userEnv = mergeEnvVarsWithSecrets(
-      userConfig.envVars,
-      userConfig.encryptedSecrets,
+      cleanedEnvVars,
+      cleanedSecrets,
       env.AGENT_ENV_VARS_PRIVATE_KEY
     );
 

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -22,15 +22,15 @@ export type MachineSize = z.infer<typeof MachineSizeSchema>;
 
 /**
  * Valid env var name: must be a valid shell identifier and must not use
- * reserved prefixes (KILOCLAW_ENC_, KILOCLAW_ENV_) which are reserved
- * for the env var encryption system.
+ * the reserved KILOCLAW_ prefix (used for encryption, feature flags,
+ * and other internal system vars).
  */
 const envVarNameSchema = z
   .string()
   .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'Must be a valid shell identifier')
   .refine(
-    s => !s.startsWith('KILOCLAW_ENC_') && !s.startsWith('KILOCLAW_ENV_'),
-    'Uses reserved prefix (KILOCLAW_ENC_ or KILOCLAW_ENV_)'
+    s => !s.startsWith('KILOCLAW_'),
+    'Uses reserved prefix (KILOCLAW_*)'
   );
 
 export const InstanceConfigSchema = z.object({
@@ -152,6 +152,17 @@ export const PersistedStateSchema = z.object({
   // Cooldown for bound-machine recovery during destroy: avoids repeated getVolume
   // calls when the volume consistently reports no attached machine.
   lastBoundMachineRecoveryAt: z.number().nullable().default(null),
+  // Instance feature flags: set on first provision, persisted across reboots.
+  // Each entry is a feature name (e.g. "npm-global-prefix") that gates runtime behavior.
+  // New instances get the current feature set; legacy instances have an empty array.
+  instanceFeatures: z.array(z.string()).default([]),
 });
 
 export type PersistedState = z.infer<typeof PersistedStateSchema>;
+
+/**
+ * Default instance features enabled for newly provisioned instances.
+ * Existing instances keep their persisted (possibly empty) feature set.
+ * See kiloclaw/docs/instance-features.md for details.
+ */
+export const DEFAULT_INSTANCE_FEATURES: readonly string[] = ['npm-global-prefix'];

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -28,10 +28,7 @@ export type MachineSize = z.infer<typeof MachineSizeSchema>;
 const envVarNameSchema = z
   .string()
   .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'Must be a valid shell identifier')
-  .refine(
-    s => !s.startsWith('KILOCLAW_'),
-    'Uses reserved prefix (KILOCLAW_*)'
-  );
+  .refine(s => !s.startsWith('KILOCLAW_'), 'Uses reserved prefix (KILOCLAW_*)');
 
 export const InstanceConfigSchema = z.object({
   envVars: z.record(envVarNameSchema, z.string()).optional(),

--- a/kiloclaw/src/utils/env-encryption.test.ts
+++ b/kiloclaw/src/utils/env-encryption.test.ts
@@ -58,12 +58,10 @@ describe('validateUserEnvVarName', () => {
     expect(() => validateUserEnvVarName('var123')).not.toThrow();
   });
 
-  it('rejects KILOCLAW_ENC_ prefix', () => {
+  it('rejects KILOCLAW_ prefix', () => {
     expect(() => validateUserEnvVarName('KILOCLAW_ENC_FOO')).toThrow('reserved prefix');
-  });
-
-  it('rejects KILOCLAW_ENV_ prefix', () => {
     expect(() => validateUserEnvVarName('KILOCLAW_ENV_KEY')).toThrow('reserved prefix');
+    expect(() => validateUserEnvVarName('KILOCLAW_FOO')).toThrow('reserved prefix');
   });
 
   it('rejects names with hyphens', () => {

--- a/kiloclaw/src/utils/env-encryption.ts
+++ b/kiloclaw/src/utils/env-encryption.ts
@@ -16,8 +16,8 @@ export const ENCRYPTED_ENV_PREFIX = 'KILOCLAW_ENC_';
 /** Prefix on encrypted values (format version marker). */
 const ENCRYPTED_VALUE_PREFIX = 'enc:v1:';
 
-/** Prefixes reserved for the encryption system. User env vars must not use these. */
-export const RESERVED_PREFIXES = ['KILOCLAW_ENC_', 'KILOCLAW_ENV_'] as const;
+/** Prefixes reserved for internal use. User env vars must not use these. */
+export const RESERVED_PREFIXES = ['KILOCLAW_'] as const;
 
 /** Valid shell identifier: letters, digits, underscores. Must start with letter or underscore. */
 const SHELL_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;

--- a/kiloclaw/src/utils/shell-escaping-adversarial.test.ts
+++ b/kiloclaw/src/utils/shell-escaping-adversarial.test.ts
@@ -164,7 +164,7 @@ const SHELL_INJECTION_NAMES = [
 ];
 
 // Reserved prefix names (valid identifiers but blocked by prefix check)
-const RESERVED_PREFIX_NAMES = ['KILOCLAW_ENC_SECRET', 'KILOCLAW_ENV_KEY'];
+const RESERVED_PREFIX_NAMES = ['KILOCLAW_ENC_SECRET', 'KILOCLAW_ENV_KEY', 'KILOCLAW_NPM_GLOBAL_PREFIX'];
 
 // =============================================================================
 // Tests: Adversarial env var VALUES
@@ -293,8 +293,8 @@ describe('shell escaping — reserved env var protection', () => {
     expect(() => validateUserEnvVarName('KILOCLAW_ENV_ANYTHING')).toThrow('reserved prefix');
   });
 
-  it('allows KILOCLAW_ without ENC_ or ENV_ suffix', () => {
-    expect(() => validateUserEnvVarName('KILOCLAW_FOO')).not.toThrow();
+  it('rejects all KILOCLAW_ prefixed names', () => {
+    expect(() => validateUserEnvVarName('KILOCLAW_FOO')).toThrow('reserved prefix');
   });
 
   it('Zod schema rejects reserved prefixes', () => {
@@ -302,6 +302,8 @@ describe('shell escaping — reserved env var protection', () => {
     expect(encResult.success).toBe(false);
     const envResult = InstanceConfigSchema.safeParse({ envVars: { KILOCLAW_ENV_KEY: 'v' } });
     expect(envResult.success).toBe(false);
+    const featureResult = InstanceConfigSchema.safeParse({ envVars: { KILOCLAW_NPM_GLOBAL_PREFIX: 'v' } });
+    expect(featureResult.success).toBe(false);
   });
 });
 

--- a/kiloclaw/src/utils/shell-escaping-adversarial.test.ts
+++ b/kiloclaw/src/utils/shell-escaping-adversarial.test.ts
@@ -164,7 +164,11 @@ const SHELL_INJECTION_NAMES = [
 ];
 
 // Reserved prefix names (valid identifiers but blocked by prefix check)
-const RESERVED_PREFIX_NAMES = ['KILOCLAW_ENC_SECRET', 'KILOCLAW_ENV_KEY', 'KILOCLAW_NPM_GLOBAL_PREFIX'];
+const RESERVED_PREFIX_NAMES = [
+  'KILOCLAW_ENC_SECRET',
+  'KILOCLAW_ENV_KEY',
+  'KILOCLAW_NPM_GLOBAL_PREFIX',
+];
 
 // =============================================================================
 // Tests: Adversarial env var VALUES
@@ -302,7 +306,9 @@ describe('shell escaping — reserved env var protection', () => {
     expect(encResult.success).toBe(false);
     const envResult = InstanceConfigSchema.safeParse({ envVars: { KILOCLAW_ENV_KEY: 'v' } });
     expect(envResult.success).toBe(false);
-    const featureResult = InstanceConfigSchema.safeParse({ envVars: { KILOCLAW_NPM_GLOBAL_PREFIX: 'v' } });
+    const featureResult = InstanceConfigSchema.safeParse({
+      envVars: { KILOCLAW_NPM_GLOBAL_PREFIX: 'v' },
+    });
     expect(featureResult.success).toBe(false);
   });
 });

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -151,6 +151,7 @@ export KILOCLAW_FRESH_INSTALL
 if [ "${KILOCLAW_NPM_GLOBAL_PREFIX:-}" = "true" ]; then
     if mkdir -p /root/.npm-global/bin; then
         export NPM_CONFIG_PREFIX="/root/.npm-global"
+        export PATH="/root/.npm-global/bin:$PATH"
         echo "npm global prefix set to /root/.npm-global"
     else
         echo "WARNING: failed to create npm-global directory, using default prefix"

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -140,6 +140,26 @@ fi
 export KILOCLAW_FRESH_INSTALL
 
 # ============================================================
+# INSTANCE FEATURE FLAGS
+# ============================================================
+# Feature flags are owned by the DO and passed as env vars (KILOCLAW_* prefix).
+# See kiloclaw/docs/instance-features.md for details.
+
+# Feature: npm-global-prefix
+# Redirect runtime `npm install -g` to the persistent volume so packages
+# survive restarts. Uses /root/.npm-global instead of /usr/local.
+if [ "${KILOCLAW_NPM_GLOBAL_PREFIX:-}" = "true" ]; then
+    if mkdir -p /root/.npm-global/bin; then
+        export NPM_CONFIG_PREFIX="/root/.npm-global"
+        echo "npm global prefix set to /root/.npm-global"
+    else
+        echo "WARNING: failed to create npm-global directory, using default prefix"
+    fi
+else
+    echo "npm global prefix: using default"
+fi
+
+# ============================================================
 # PATCH CONFIG (channels, gateway auth, exec policy)
 # ============================================================
 # openclaw onboard handles provider/model config natively (kilocode provider,

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -151,7 +151,7 @@ export KILOCLAW_FRESH_INSTALL
 if [ "${KILOCLAW_NPM_GLOBAL_PREFIX:-}" = "true" ]; then
     if mkdir -p /root/.npm-global/bin; then
         export NPM_CONFIG_PREFIX="/root/.npm-global"
-        export PATH="/root/.npm-global/bin:$PATH"
+        export PATH="$PATH:/root/.npm-global/bin"
         echo "npm global prefix set to /root/.npm-global"
     else
         echo "WARNING: failed to create npm-global directory, using default prefix"


### PR DESCRIPTION
## Summary

Add per instance feature flags owned by the Durable Object to control runtime behavior for new vs legacy instances. Features are stored in DO SQLite, mapped to KILOCLAW_* env vars through the buildEnvVars pipeline (Layer 6, not user-overridable), and read by start-openclaw.sh.

New instances get current defaults; existing instances are unaffected (empty array). To get new features, users destroy and re-provision.

First feature: 
- npm-global-prefix redirects runtime npm install -g to /root/.npm-global on the Fly Volume so packages survive restarts.

Also blocks the entire KILOCLAW_* prefix for user env vars as defense-in-depth, and adds a drift guard test ensuring every default feature has a corresponding env var mapping.


<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification

<!-- List the checks you ran and what passed. Add command output notes when useful. -->

The verified test scenarios were:
1. Legacy instance (re-deploy of existing image)
- SSH'd in, confirmed env vars — KILOCLAW_NPM_GLOBAL_PREFIX absent, npm prefix unchanged at /usr/local.
2. Legacy instance (new dev image, restart, re-deploy)
- KILOCLAW_NPM_GLOBAL_PREFIX not set — DO did not apply the feature flag
- npm prefix — /usr/local (unchanged)
- openclaw — /usr/local/bin/openclaw
- /root/.npm-global — does not exist (feature not active)
3. New instance (destroy + fresh provision)
- Confirmed KILOCLAW_NPM_GLOBAL_PREFIX=true present in env
- npm config prefix set to /root/.npm-global
4. End-to-end npm install via agent
- Asked agent to npm install -g cowsay
- Verified cowsay installed at /root/.npm-global/bin/cowsay on the persistent volume
5. Persistence across redeploy
- Re-deployed after install — all settings and installed packages persisted

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->
N/A


## Reviewer Notes

  - `DEFAULT_INSTANCE_FEATURES` lives in `instance-config.ts` (not the DO file) to avoid `cloudflare:workers` import issues in tests
  - `instanceFeatures` is explicitly written on both new and re-provision paths for consistency with other persisted fields
  - The Dockerfile PATH entry (`/root/.npm-global/bin`) is always set but inert when the feature is absent — the directory won't exist
  - SSH sessions don't inherit `NPM_CONFIG_PREFIX` (they bypass `start-openclaw.sh`) — agent exec commands go through the gateway which does have it
  - Cache bust bumped to v58

  ## Test plan

  - [x] 7 new tests (env var mapping, unknown features, empty features, KILOCLAW_* rejection, drift guard, first provision
  sets defaults, re-provision preserves existing)
  - [x] Manual: existing instance redeployed with new image — no feature var, npm prefix `/usr/local`, unaffected
  - [x] Manual: new instance — `KILOCLAW_NPM_GLOBAL_PREFIX=true`, `NPM_CONFIG_PREFIX=/root/.npm-global` on controller +
  gateway
  - [x] Manual: agent installed cowsay → `/root/.npm-global/bin/cowsay`
  - [x] Manual: cowsay survived reboot