### PR TITLE
fix(patrol): harden triage feedback loop safeguards

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2464,8 +2464,13 @@ export class TownDO extends DurableObject<Env> {
     if (pendingCount === 0) return;
 
     // Check if a triage batch bead is already in progress (meaning a
-    // triage agent is working). We can't filter by role since triage
-    // uses polecat role; instead check for an open gt:triage batch bead.
+    // triage agent is working), or recently failed (cooldown to prevent
+    // rapid retry loops). Skip dispatch in either case.
+    const triageBatchLike = patrol.TRIAGE_LABEL_LIKE.replace(
+      patrol.TRIAGE_REQUEST_LABEL,
+      patrol.TRIAGE_BATCH_LABEL
+    );
+    const cooldownCutoff = new Date(Date.now() - DISPATCH_COOLDOWN_MS).toISOString();
     const existingBatch = [
       ...query(
         this.sql,
@@ -2473,16 +2478,19 @@ export class TownDO extends DurableObject<Env> {
           SELECT ${beads.bead_id} FROM ${beads}
           WHERE ${beads.type} = 'issue'
             AND ${beads.labels} LIKE ?
-            AND ${beads.status} IN ('open', 'in_progress')
             AND ${beads.created_by} = 'patrol'
+            AND (
+              ${beads.status} IN ('open', 'in_progress')
+              OR (${beads.status} = 'failed' AND ${beads.updated_at} > ?)
+            )
           LIMIT 1
         `,
-        [patrol.TRIAGE_LABEL_LIKE.replace(patrol.TRIAGE_REQUEST_LABEL, patrol.TRIAGE_BATCH_LABEL)]
+        [triageBatchLike, cooldownCutoff]
       ),
     ];
     if (existingBatch.length > 0) {
       console.log(
-        `${TOWN_LOG} maybeDispatchTriageAgent: triage agent already working, skipping (${pendingCount} pending)`
+        `${TOWN_LOG} maybeDispatchTriageAgent: triage batch bead active or in cooldown, skipping (${pendingCount} pending)`
       );
       return;
     }
@@ -2555,19 +2563,10 @@ export class TownDO extends DurableObject<Env> {
       agents.updateAgentStatus(this.sql, triageAgent.id, 'working');
     } else {
       agents.unhookBead(this.sql, triageAgent.id);
+      // Failing the batch bead triggers cooldown: the guard at the top of
+      // this method skips dispatch while a failed batch bead's updated_at
+      // is within DISPATCH_COOLDOWN_MS.
       beadOps.updateBeadStatus(this.sql, triageBead.bead_id, 'failed', triageAgent.id);
-      // Apply dispatch cooldown so the next alarm tick doesn't immediately
-      // retry. Setting last_activity_at = now() makes the agent invisible
-      // to schedulePendingWork for DISPATCH_COOLDOWN_MS (2 min).
-      query(
-        this.sql,
-        /* sql */ `
-          UPDATE ${agent_metadata}
-          SET ${agent_metadata.columns.last_activity_at} = ?
-          WHERE ${agent_metadata.bead_id} = ?
-        `,
-        [now(), triageAgent.id]
-      );
       console.error(`${TOWN_LOG} maybeDispatchTriageAgent: triage agent failed to start`);
     }
   }

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -585,8 +585,10 @@ export function detectCrashLoops(sql: SqlStorage): void {
 
   // Exclude triage agents from crash loop detection — their failures must
   // not create new triage requests, which would feed the feedback loop.
-  // An agent is considered a triage agent if its current hooked bead has
-  // the gt:triage or gt:triage-request label (both start with "gt:triage").
+  // We check whether the *failed bead itself* carries a triage label
+  // (gt:triage or gt:triage-request). This is stable even after unhook
+  // clears current_hook_bead_id, because the bead_event.bead_id still
+  // points to the triage batch bead that was failed.
   const TRIAGE_LABEL_ANY = `%"gt:triage%`;
 
   const rows = CrashRow.array().parse([
@@ -600,11 +602,9 @@ export function detectCrashLoops(sql: SqlStorage): void {
           AND be.agent_id IS NOT NULL
           AND be.created_at > ?
           AND NOT EXISTS (
-            SELECT 1 FROM ${agent_metadata}
-            INNER JOIN ${beads} AS hooked
-              ON ${agent_metadata.current_hook_bead_id} = hooked.${beads.columns.bead_id}
-            WHERE ${agent_metadata.bead_id} = be.agent_id
-              AND hooked.${beads.columns.labels} LIKE ?
+            SELECT 1 FROM ${beads} AS failed_bead
+            WHERE failed_bead.${beads.columns.bead_id} = be.bead_id
+              AND failed_bead.${beads.columns.labels} LIKE ?
           )
         GROUP BY be.agent_id
         HAVING fail_count >= ?

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -107,11 +107,10 @@ export function createTriageRequest(
     if (existing.length > 0) return;
   }
 
-  // Global cap: skip if there are already too many open triage requests.
-  // Prevents unbounded accumulation during feedback loops from patrol's
-  // automatic detections. Escalations are exempt — they are agent/user
-  // initiated and silently dropping them would leave the escalation bead
-  // open with no automated follow-up.
+  // Global cap: skip if there are already too many open *automatic* triage
+  // requests (patrol-generated). Escalations are exempt from both the gate
+  // and the count — they are agent/user initiated and silently dropping
+  // them would leave the escalation bead with no automated follow-up.
   if (params.triageType !== 'escalation') {
     const openCountRows = [
       ...query(
@@ -121,6 +120,7 @@ export function createTriageRequest(
           WHERE ${beads.type} = 'issue'
             AND ${beads.labels} LIKE ?
             AND ${beads.status} = 'open'
+            AND json_extract(${beads.metadata}, '$.triage_type') != 'escalation'
         `,
         [TRIAGE_LABEL_LIKE]
       ),
@@ -590,10 +590,12 @@ export function detectCrashLoops(sql: SqlStorage): void {
 
   // Exclude triage agents from crash loop detection — their failures must
   // not create new triage requests, which would feed the feedback loop.
-  // We check whether the *failed bead itself* carries a triage label
-  // (gt:triage or gt:triage-request). This is stable even after unhook
-  // clears current_hook_bead_id, because the bead_event.bead_id still
-  // points to the triage batch bead that was failed.
+  // Two complementary checks:
+  //  1. The failed bead itself carries a triage label (covers triage batch
+  //     bead failures, stable after unhook clears current_hook_bead_id).
+  //  2. The agent is currently hooked to a triage-labeled bead (covers
+  //     resolveTriage actions like CLOSE_BEAD that fail ordinary beads
+  //     while the triage agent is still working its batch).
   const TRIAGE_LABEL_ANY = `%"gt:triage%`;
 
   const rows = CrashRow.array().parse([
@@ -611,10 +613,17 @@ export function detectCrashLoops(sql: SqlStorage): void {
             WHERE failed_bead.${beads.columns.bead_id} = be.bead_id
               AND failed_bead.${beads.columns.labels} LIKE ?
           )
+          AND NOT EXISTS (
+            SELECT 1 FROM ${agent_metadata}
+            INNER JOIN ${beads} AS hooked
+              ON ${agent_metadata.current_hook_bead_id} = hooked.${beads.columns.bead_id}
+            WHERE ${agent_metadata.bead_id} = be.agent_id
+              AND hooked.${beads.columns.labels} LIKE ?
+          )
         GROUP BY be.agent_id
         HAVING fail_count >= ?
       `,
-      [windowCutoff, TRIAGE_LABEL_ANY, CRASH_LOOP_THRESHOLD]
+      [windowCutoff, TRIAGE_LABEL_ANY, TRIAGE_LABEL_ANY, CRASH_LOOP_THRESHOLD]
     ),
   ]);
 

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -108,25 +108,30 @@ export function createTriageRequest(
   }
 
   // Global cap: skip if there are already too many open triage requests.
-  // Prevents unbounded accumulation during feedback loops.
-  const openCountRows = [
-    ...query(
-      sql,
-      /* sql */ `
-        SELECT COUNT(*) AS cnt FROM ${beads}
-        WHERE ${beads.type} = 'issue'
-          AND ${beads.labels} LIKE ?
-          AND ${beads.status} = 'open'
-      `,
-      [TRIAGE_LABEL_LIKE]
-    ),
-  ];
-  const openCount = Number(z.object({ cnt: z.number() }).parse(openCountRows[0]).cnt);
-  if (openCount >= MAX_OPEN_TRIAGE_REQUESTS) {
-    console.warn(
-      `${LOG} createTriageRequest: global cap reached (${openCount} open), skipping type=${params.triageType}`
-    );
-    return;
+  // Prevents unbounded accumulation during feedback loops from patrol's
+  // automatic detections. Escalations are exempt — they are agent/user
+  // initiated and silently dropping them would leave the escalation bead
+  // open with no automated follow-up.
+  if (params.triageType !== 'escalation') {
+    const openCountRows = [
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT COUNT(*) AS cnt FROM ${beads}
+          WHERE ${beads.type} = 'issue'
+            AND ${beads.labels} LIKE ?
+            AND ${beads.status} = 'open'
+        `,
+        [TRIAGE_LABEL_LIKE]
+      ),
+    ];
+    const openCount = Number(z.object({ cnt: z.number() }).parse(openCountRows[0]).cnt);
+    if (openCount >= MAX_OPEN_TRIAGE_REQUESTS) {
+      console.warn(
+        `${LOG} createTriageRequest: global cap reached (${openCount} open), skipping type=${params.triageType}`
+      );
+      return;
+    }
   }
 
   const metadata: TriageRequestMetadata = {

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -48,7 +48,7 @@ export type BeadFilter = {
 
 // -- Agents (now beads + agent_metadata) --
 
-export const AgentRole = z.enum(['polecat', 'refinery', 'mayor', 'triage']);
+export const AgentRole = z.enum(['polecat', 'refinery', 'mayor']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 export const AgentStatus = z.enum(['idle', 'working', 'stalled', 'dead']);


### PR DESCRIPTION
## Summary

Follow-up to #988, which merged the initial triage feedback loop fix. This PR addresses review feedback and additional edge cases found during code review:

- **Batch-bead-based dispatch cooldown**: Replaced the ineffective `last_activity_at` update with a guard that checks for recently-failed `gt:triage` batch beads (`updated_at > cooldownCutoff`), giving a real `DISPATCH_COOLDOWN_MS` backoff between retry attempts.
- **Stable crash-loop exclusion**: Fixed `detectCrashLoops` to use two complementary `NOT EXISTS` checks — one on the failed bead's labels (stable after unhook) and one on the agent's current hook — preventing both triage batch bead failures and triage resolution actions (e.g. `CLOSE_BEAD`) from triggering crash-loop detection.
- **Escalation-aware global cap**: Exempted escalation-type triage requests from the `MAX_OPEN_TRIAGE_REQUESTS` gate and count, so escalation backlog doesn't suppress patrol's automatic detections and low-severity escalations always get triage follow-up.
- **Remove `triage` from public `AgentRole` enum**: The triage role is only a container dispatch-time signal — keeping it in the public enum would let external API callers create agents that skip repo clone.

## Verification

- [x] `pnpm typecheck` — passes

## Visual Changes

N/A

## Reviewer Notes

- The original triage loop fix (lightweight workspace, `triage` role dispatch, global cap, crash-loop exclusion) was merged in #988. This PR only contains the fixes for issues identified during review of #997.
- The crash-loop `NOT EXISTS` uses two clauses: the first (bead labels) is stable post-unhook; the second (current hook) covers the `resolveTriage` CLOSE_BEAD path where an ordinary bead is failed by the triage agent.