### PR TITLE
feat(kiloclaw): add pip/uv global install dir with instance feature flags 

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -77,6 +77,11 @@ RUN GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@v0.11.0 \
     && GOBIN=/usr/local/bin go install github.com/steipete/gifgrep/cmd/gifgrep@v0.2.3 \
     && go clean -cache -modcache
 
+# Install uv (Python package manager, available at runtime).
+# Install to /usr/local/bin so the binary survives the Fly Volume mount at /root.
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && uv --version
+
 # Install pinned Bun (build-time only) and compile the controller bundle.
 ARG BUN_VERSION=1.2.4
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
@@ -102,8 +107,8 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-03-10-v58-instance-feature-flags-npm-global-prefix
-RUN echo "8"
+# Build cache bust: 2026-03-10-v59-uv-pip-global-prefix
+RUN echo "9"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js

--- a/kiloclaw/docs/instance-features.md
+++ b/kiloclaw/docs/instance-features.md
@@ -24,6 +24,8 @@ DO (source of truth) → buildEnvVars() → config.env → Fly machine → start
 | Feature name        | Env var                      | Description                                                                                                                                                                                                          |
 | ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `npm-global-prefix` | `KILOCLAW_NPM_GLOBAL_PREFIX` | Redirects `npm install -g` to `/root/.npm-global` (persistent volume) instead of `/usr/local` (image layer, lost on restart). Both `NPM_CONFIG_PREFIX` and `PATH` are exported conditionally in `start-openclaw.sh`. |
+| `pip-global-prefix` | `KILOCLAW_PIP_GLOBAL_PREFIX` | Redirects `pip install --user` to `/root/.pip-global` (persistent volume) via `PYTHONUSERBASE`. PATH is appended conditionally in `start-openclaw.sh`.                                                               |
+| `uv-global-prefix`  | `KILOCLAW_UV_GLOBAL_PREFIX`  | Configures `uv` tool/cache directories on the persistent volume (`/root/.uv`). Sets `UV_TOOL_DIR`, `UV_TOOL_BIN_DIR`, and `UV_CACHE_DIR`. PATH is appended conditionally in `start-openclaw.sh`.                     |
 
 ## Adding a new flag
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2434,7 +2434,7 @@ describe('provision: instance feature flags', () => {
     await instance.provision('user-1', {});
 
     const features = storage._store.get('instanceFeatures') as string[];
-    expect(features).toEqual(['npm-global-prefix']);
+    expect(features).toEqual(['npm-global-prefix', 'pip-global-prefix', 'uv-global-prefix']);
   });
 
   it('preserves existing features on re-provision (does not reset to defaults)', async () => {

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -24,6 +24,8 @@ export type UserConfig = {
  */
 export const FEATURE_TO_ENV_VAR: Record<string, string> = {
   'npm-global-prefix': 'KILOCLAW_NPM_GLOBAL_PREFIX',
+  'pip-global-prefix': 'KILOCLAW_PIP_GLOBAL_PREFIX',
+  'uv-global-prefix': 'KILOCLAW_UV_GLOBAL_PREFIX',
 };
 
 /**

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -162,4 +162,8 @@ export type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Existing instances keep their persisted (possibly empty) feature set.
  * See kiloclaw/docs/instance-features.md for details.
  */
-export const DEFAULT_INSTANCE_FEATURES: readonly string[] = ['npm-global-prefix'];
+export const DEFAULT_INSTANCE_FEATURES: readonly string[] = [
+  'npm-global-prefix',
+  'pip-global-prefix',
+  'uv-global-prefix',
+];

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -160,6 +160,38 @@ else
     echo "npm global prefix: using default"
 fi
 
+# Feature: pip-global-prefix
+# Redirect pip install --user to the persistent volume so packages
+# survive restarts. Uses /root/.pip-global instead of /root/.local.
+if [ "${KILOCLAW_PIP_GLOBAL_PREFIX:-}" = "true" ]; then
+    if mkdir -p /root/.pip-global/bin; then
+        export PYTHONUSERBASE="/root/.pip-global"
+        export PATH="$PATH:/root/.pip-global/bin"
+        echo "pip global prefix set to /root/.pip-global"
+    else
+        echo "WARNING: failed to create pip-global directory, using default prefix"
+    fi
+else
+    echo "pip global prefix: using default"
+fi
+
+# Feature: uv-global-prefix
+# Configure uv tool/cache directories on the persistent volume so
+# uv tool install packages survive restarts.
+if [ "${KILOCLAW_UV_GLOBAL_PREFIX:-}" = "true" ]; then
+    if mkdir -p /root/.uv/tools /root/.uv/bin /root/.uv/cache; then
+        export UV_TOOL_DIR="/root/.uv/tools"
+        export UV_TOOL_BIN_DIR="/root/.uv/bin"
+        export UV_CACHE_DIR="/root/.uv/cache"
+        export PATH="$PATH:/root/.uv/bin"
+        echo "uv global prefix set to /root/.uv"
+    else
+        echo "WARNING: failed to create uv directories, using defaults"
+    fi
+else
+    echo "uv global prefix: using default"
+fi
+
 # ============================================================
 # PATCH CONFIG (channels, gateway auth, exec policy)
 # ============================================================

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -12,6 +12,20 @@ export type ChangelogEntry = {
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-03-10',
+    description:
+      'New instances now redirect pip and uv package installs to the persistent volume so packages survive restarts. pip uses /root/.pip-global via PYTHONUSERBASE; uv uses /root/.uv for tools and cache. uv is now pre-installed in the base image. Only applies to newly provisioned instances.',
+    category: 'feature',
+    deployHint: null,
+  },
+  {
+    date: '2026-03-10',
+    description:
+      'New instances now redirect npm global installs to the persistent volume (/root/.npm-global) so packages installed via `npm install -g` survive restarts. Only applies to newly provisioned instances.',
+    category: 'feature',
+    deployHint: null,
+  },
+  {
+    date: '2026-03-10',
     description: 'Updated OpenClaw to 2026.3.8.',
     category: 'feature',
     deployHint: 'redeploy_suggested',


### PR DESCRIPTION
## Summary
feat(kiloclaw): add pip/uv global install dir with instance feature flags 
- Add `pip-global-prefix` and `uv-global-prefix` instance feature flags so pip/uv packages survive restarts on new instances
- Install `uv` in the base image (to `/usr/local/bin` so it survives the Fly Volume mount at `/root`)
- Set `PYTHONUSERBASE=/root/.pip-global` for pip and `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR`/`UV_CACHE_DIR` under `/root/.uv` for uv
- PATH appended (not prepended) to prevent user-installed packages from shadowing pinned image binaries during bootstrap
- Only applies to newly provisioned instances — existing instances are completely unaffected


<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification
- All 523 kiloclaw tests pass
- Prettier clean
- Built dev image and deployed to `dev-6d7b34449cb91dc1074c`
- Confirmed `uv` is installed and available (`uv 0.10.9`)
- Confirmed existing instance only has `KILOCLAW_NPM_GLOBAL_PREFIX=true` (no pip/uv flags) — proving existing instances are   unaffected
- New flags require destroy + re-provision to activate (by design)


## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->
N/A


## Reviewer Notes
- This follows the exact same pattern established in #993 (instance feature flags + npm-global-prefix)
- `uv` is installed to `/usr/local/bin` (not `/root/.local/bin`) because the Fly Volume mount at `/root` would shadow the   image layer binary
- PATH is appended, not prepended — a security fix from #993 review to prevent user-writable bin dirs from shadowing   bootstrap binaries like `node` or `openclaw`
- pip and uv are separate flags because they're independent tools with separate config mechanisms (`PYTHONUSERBASE` vs   `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR`/`UV_CACHE_DIR`)
- `deployHint: null` on changelog entries because these only affect new provisions, not existing instances

