### PR TITLE
feat(billing): integrate Rewardful affiliate tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter, Roboto_Mono, JetBrains_Mono } from 'next/font/google';
+import Script from 'next/script';
 import './globals.css';
 import { PostHogProvider } from '../components/PostHogProvider';
 import { Providers } from '../components/Providers';
@@ -111,6 +112,18 @@ export default function RootLayout({
 
         {process.env.NEXT_PUBLIC_GTM_ID && (
           <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
+        )}
+
+        {process.env.NEXT_PUBLIC_REWARDFUL_ID && (
+          <>
+            <Script id="rewardful-queue">
+              {`(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q||[]).push(arguments)}})(window,'rewardful');rewardful('ready',function(){if(Rewardful.referral){document.cookie='rewardful_referral='+encodeURIComponent(Rewardful.referral)+';path=/;max-age=7776000;SameSite=Lax'+(location.protocol==='https:'?';Secure':'')}});`}
+            </Script>
+            <Script
+              src="https://r.wdfl.co/rw.js"
+              data-rewardful={process.env.NEXT_PUBLIC_REWARDFUL_ID}
+            />
+          </>
         )}
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -116,10 +116,11 @@ export default function RootLayout({
 
         {process.env.NEXT_PUBLIC_REWARDFUL_ID && (
           <>
-            <Script id="rewardful-queue">
+            <Script id="rewardful-queue" strategy="beforeInteractive">
               {`(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q||[]).push(arguments)}})(window,'rewardful');rewardful('ready',function(){if(Rewardful.referral){document.cookie='rewardful_referral='+encodeURIComponent(Rewardful.referral)+';path=/;max-age=7776000;SameSite=Lax'+(location.protocol==='https:'?';Secure':'')}});`}
             </Script>
             <Script
+              strategy="beforeInteractive"
               src="https://r.wdfl.co/rw.js"
               data-rewardful={process.env.NEXT_PUBLIC_REWARDFUL_ID}
             />

--- a/src/lib/organizations/organization-auto-top-up.ts
+++ b/src/lib/organizations/organization-auto-top-up.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_ORG_AUTO_TOP_UP_AMOUNT_CENTS,
 } from '@/lib/autoTopUpConstants';
 import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { getRewardfulReferral } from '@/lib/rewardful';
 
 export async function isOrgAutoTopUpFeatureEnabled(organizationId: string): Promise<boolean> {
   return (
@@ -25,10 +26,12 @@ export async function createOrgAutoTopUpSetupCheckoutSession(
   amountCents: number = DEFAULT_ORG_AUTO_TOP_UP_AMOUNT_CENTS
 ): Promise<string | null> {
   const amountDollars = amountCents / 100;
+  const rewardfulReferral = await getRewardfulReferral();
 
   const checkoutSession = await client.checkout.sessions.create({
     mode: 'payment',
     customer: stripeCustomerId,
+    ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
     billing_address_collection: 'required',
     line_items: [
       {

--- a/src/lib/rewardful.ts
+++ b/src/lib/rewardful.ts
@@ -1,0 +1,16 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+
+const REWARDFUL_COOKIE = 'rewardful_referral';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Reads the Rewardful referral ID (a UUID) from the cookie set by the client-side rw.js script. */
+export async function getRewardfulReferral(): Promise<string | undefined> {
+  try {
+    const jar = await cookies();
+    const value = jar.get(REWARDFUL_COOKIE)?.value;
+    return value && UUID_RE.test(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/rewardful.ts
+++ b/src/lib/rewardful.ts
@@ -10,7 +10,8 @@ export async function getRewardfulReferral(): Promise<string | undefined> {
     const jar = await cookies();
     const value = jar.get(REWARDFUL_COOKIE)?.value;
     return value && UUID_RE.test(value) ? value : undefined;
-  } catch {
+  } catch (error) {
+    console.warn('Failed to read rewardful referral cookie', error);
     return undefined;
   }
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -53,6 +53,7 @@ import {
 } from '@/lib/config.server';
 import type { OrganizationPlan } from '@/lib/organizations/organization-types';
 import { successResult } from '@/lib/maybe-result';
+import { getRewardfulReferral } from '@/lib/rewardful';
 
 if (!APP_URL) throw new Error('APP_URL constant is not set');
 
@@ -900,10 +901,12 @@ export async function createAutoTopUpSetupCheckoutSession(
   amountCents: number = 5000
 ): Promise<string | null> {
   const amountDollars = amountCents / 100;
+  const rewardfulReferral = await getRewardfulReferral();
 
   const checkoutSession = await client.checkout.sessions.create({
     mode: 'payment',
     customer: stripeCustomerId,
+    ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
     billing_address_collection: 'required',
     line_items: [
       {
@@ -978,9 +981,12 @@ export async function getStripeTopUpCheckoutUrl(
     cancelUrl = `${APP_URL}/organizations/${organizationId}?${TOPUP_CANCELED_QUERY_STRING_KEY}=true`;
   }
 
+  const rewardfulReferral = await getRewardfulReferral();
+
   const checkoutSession = await client.checkout.sessions.create({
     mode: 'payment',
     customer: stripeCustomerId,
+    ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
     billing_address_collection: 'required',
     line_items: line_items,
     invoice_creation: {
@@ -1077,10 +1083,12 @@ export async function getStripeSeatsCheckoutUrl(
     ];
 
     const successUrl = `${process.env.NEXTAUTH_URL}/payments/subscriptions/success?organizationId=${organizationId}&${STRIPE_SUB_QUERY_STRING_KEY}={CHECKOUT_SESSION_ID}`;
+    const rewardfulReferral = await getRewardfulReferral();
 
     const checkoutSession = await client.checkout.sessions.create({
       mode: 'subscription',
       customer: stripeCustomerId,
+      ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
       allow_promotion_codes: true,
       billing_address_collection: 'required',
       line_items: line_items,

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -38,6 +38,7 @@ import {
 import { fromMicrodollars } from '@/lib/utils';
 import type Stripe from 'stripe';
 import { dayjs } from '@/lib/kilo-pass/dayjs';
+import { getRewardfulReferral } from '@/lib/rewardful';
 
 const KiloPassTierSchema = z.enum(KiloPassTier);
 
@@ -928,10 +929,12 @@ export const kiloPassRouter = createTRPCRouter({
       }
 
       const priceId = getStripePriceIdForKiloPass({ tier, cadence });
+      const rewardfulReferral = await getRewardfulReferral();
 
       const session = await stripe.checkout.sessions.create({
         mode: 'subscription',
         customer: stripeCustomerId,
+        ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
         allow_promotion_codes: true,
         billing_address_collection: 'required',
         line_items: [{ price: priceId, quantity: 1 }],

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -34,6 +34,7 @@ import {
 } from '@/lib/kiloclaw/instance-registry';
 import { client as stripe } from '@/lib/stripe-client';
 import { APP_URL } from '@/lib/constants';
+import { getRewardfulReferral } from '@/lib/rewardful';
 
 const kilocodeDefaultModelSchema = z
   .string()
@@ -504,9 +505,12 @@ export const kiloclawRouter = createTRPCRouter({
         });
       }
 
+      const rewardfulReferral = await getRewardfulReferral();
+
       const session = await stripe.checkout.sessions.create({
         mode: 'payment',
         customer: stripeCustomerId,
+        ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
         billing_address_collection: 'required',
         line_items: [{ price: STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID, quantity: 1 }],
         ...(STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID


### PR DESCRIPTION
## Summary

Integrates Rewardful affiliate/referral tracking into all Stripe checkout session creation points. Two-part approach:

1. **Client-side** (`layout.tsx`): Loads the Rewardful `rw.js` script (gated on `NEXT_PUBLIC_REWARDFUL_ID` env var). On ready, it writes the referral UUID into a `rewardful_referral` cookie.
2. **Server-side** (`src/lib/rewardful.ts`): A helper reads and UUID-validates the cookie, and every Stripe `checkout.sessions.create` call now passes `client_reference_id` when a referral is present.

Affected checkout flows: credit top-ups, auto top-up setup, org auto top-up setup, seat subscriptions, Kilo Pass subscriptions, and KiloClaw early-bird purchases.

## Verification

- [x] `pnpm typecheck` — passes

## Visual Changes

N/A

## Reviewer Notes

- The Rewardful script is a no-op unless `NEXT_PUBLIC_REWARDFUL_ID` is set — zero impact on existing environments.
- `getRewardfulReferral()` validates the cookie value is a UUID and swallows errors if `cookies()` is unavailable (e.g. during static generation), so it never blocks a checkout.
- The cookie has a 90-day `max-age`, matching Rewardful's default attribution window. The `Secure` flag is added conditionally (HTTPS only) so it works on localhost dev too.