### PR TITLE
feat(kiloclaw): seed TOOLS.md into new instances on first boot

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-03-10-v59-uv-pip-global-prefix
+# Build cache bust: 2026-03-11-v60-tools-md
 RUN echo "9"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
@@ -120,6 +120,10 @@ RUN ls -l /usr/local/bin/start-openclaw.sh \
 
 # Copy custom skills
 COPY skills/ /root/clawd/skills/
+
+# Stage TOOLS.md outside /root so it survives the Fly Volume mount.
+# start-openclaw.sh copies it to /root/.openclaw/workspace/TOOLS.md on first boot.
+COPY container/TOOLS.md /usr/local/share/kiloclaw/TOOLS.md
 
 # Expose the gateway port
 EXPOSE 18789

--- a/kiloclaw/container/TOOLS.md
+++ b/kiloclaw/container/TOOLS.md
@@ -1,0 +1,7 @@
+# Environment
+
+- OS: Debian Bookworm (slim)
+- `go` and `apt` are present and available
+- Volume mounted at /root, backed up by snapshots — prefer to install there
+- The openclaw process is managed by a supervisor process
+- Do not modify /root/.kilo

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -139,6 +139,12 @@ else
 fi
 export KILOCLAW_FRESH_INSTALL
 
+# Seed TOOLS.md on first provision only — the bot may update it at runtime.
+if [ "$KILOCLAW_FRESH_INSTALL" = "true" ]; then
+    mkdir -p /root/.openclaw/workspace
+    cp /usr/local/share/kiloclaw/TOOLS.md /root/.openclaw/workspace/TOOLS.md
+fi
+
 # ============================================================
 # INSTANCE FEATURE FLAGS
 # ============================================================


### PR DESCRIPTION
## Summary

Provision a `TOOLS.md` into fresh clawdbot containers so the bot understands its operating environment from the start. The file describes the OS (Debian Bookworm slim), available tooling (`go`, `apt`), volume layout, supervisor, and protected paths — matching the spec in #976.

The template lives in `kiloclaw/container/TOOLS.md` in the repo and is staged at `/usr/local/share/kiloclaw/TOOLS.md` in the Docker image (outside the `/root` Fly Volume mount point so it survives the shadow). `start-openclaw.sh` copies it to `/root/.openclaw/workspace/TOOLS.md` only on fresh installs (`KILOCLAW_FRESH_INSTALL=true`), so bot-made edits are preserved across restarts.

Closes #976

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm --filter kiloclaw test` — 532 tests passed

## Visual Changes

N/A

## Reviewer Notes

- Only new instances get the file; existing instances are unaffected. If we later want to update the file for existing instances, that would need a separate migration mechanism.