### PR TITLE
feat(cloud-agent-next): disable question tool for cloud-agent sessions

### DIFF
--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -1000,7 +1000,9 @@ describe('WrapperClient', () => {
       });
 
       expect(session.startProcess).toHaveBeenCalledWith(
-        "WRAPPER_PORT=5000 KILO_SERVER_PORT=4600 WORKSPACE_PATH=/workspace/test bun run './wrapper'\\''s folder/wrapper.js; touch /tmp/pwned' --agent-session test-session",
+        expect.stringMatching(
+          /^WRAPPER_PORT=5000 KILO_SERVER_PORT=4600 WORKSPACE_PATH=\/workspace\/test WRAPPER_LOG_PATH=\/tmp\/kilocode-wrapper-test-session-\d+\.log bun run '\.\/wrapper'\\''s folder\/wrapper\.js; touch \/tmp\/pwned' --agent-session test-session$/
+        ),
         expect.objectContaining({ cwd: '/workspace/test' })
       );
     });

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -1303,7 +1303,7 @@ describe('SessionService', () => {
       };
     };
 
-    it.each([undefined, 'app-builder'])(
+    it.each([undefined])(
       'should NOT include question:deny for interactive platform %s',
       async createdOnPlatform => {
         const { sandbox, sandboxCreateSession } = setupForPlatformTest();
@@ -1334,6 +1334,7 @@ describe('SessionService', () => {
 
     it.each([
       'cloud-agent',
+      'app-builder',
       'slack',
       'security-agent',
       'webhook',

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -1303,7 +1303,7 @@ describe('SessionService', () => {
       };
     };
 
-    it.each([undefined, 'cloud-agent', 'app-builder'])(
+    it.each([undefined, 'app-builder'])(
       'should NOT include question:deny for interactive platform %s',
       async createdOnPlatform => {
         const { sandbox, sandboxCreateSession } = setupForPlatformTest();
@@ -1332,34 +1332,39 @@ describe('SessionService', () => {
       }
     );
 
-    it.each(['slack', 'security-agent', 'webhook', 'code-review', 'auto-triage', 'autofix'])(
-      'should include question:deny for non-interactive platform %s',
-      async createdOnPlatform => {
-        const { sandbox, sandboxCreateSession } = setupForPlatformTest();
-        const sessionId: SessionId = 'agent_noninteractive_test';
-        mockedSetupWorkspace.mockResolvedValue({
-          workspacePath: `/workspace/org/user/sessions/${sessionId}`,
-          sessionHome: `/home/${sessionId}`,
-        });
+    it.each([
+      'cloud-agent',
+      'slack',
+      'security-agent',
+      'webhook',
+      'code-review',
+      'auto-triage',
+      'autofix',
+    ])('should include question:deny for non-interactive platform %s', async createdOnPlatform => {
+      const { sandbox, sandboxCreateSession } = setupForPlatformTest();
+      const sessionId: SessionId = 'agent_noninteractive_test';
+      mockedSetupWorkspace.mockResolvedValue({
+        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
+        sessionHome: `/home/${sessionId}`,
+      });
 
-        const service = new SessionService();
-        await service.initiate({
-          sandbox,
-          sandboxId: 'org__user',
-          orgId: 'org',
-          userId: 'user',
-          sessionId,
-          kilocodeToken: 'token',
-          kilocodeModel: 'test-model',
-          githubRepo: 'acme/repo',
-          env: mockEnv,
-          createdOnPlatform,
-        });
+      const service = new SessionService();
+      await service.initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        githubRepo: 'acme/repo',
+        env: mockEnv,
+        createdOnPlatform,
+      });
 
-        const config = getConfigContent(sandboxCreateSession);
-        expect(config.permission.question).toBe('deny');
-      }
-    );
+      const config = getConfigContent(sandboxCreateSession);
+      expect(config.permission.question).toBe('deny');
+    });
 
     it('should include read-only command guard policy for code-review sessions', async () => {
       const { sandbox, sandboxCreateSession } = setupForPlatformTest();

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -578,7 +578,7 @@ export class SessionService {
     if (env.KILO_OPENROUTER_BASE) {
       providerOptions.baseURL = env.KILO_OPENROUTER_BASE;
     }
-    const isInteractive = !createdOnPlatform || createdOnPlatform === 'app-builder';
+    const isInteractive = !createdOnPlatform;
     const commandGuardPolicy = getCommandGuardPolicy(createdOnPlatform);
 
     const permission: Record<string, unknown> = {

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -578,10 +578,7 @@ export class SessionService {
     if (env.KILO_OPENROUTER_BASE) {
       providerOptions.baseURL = env.KILO_OPENROUTER_BASE;
     }
-    const isInteractive =
-      !createdOnPlatform ||
-      createdOnPlatform === 'cloud-agent' ||
-      createdOnPlatform === 'app-builder';
+    const isInteractive = !createdOnPlatform || createdOnPlatform === 'app-builder';
     const commandGuardPolicy = getCommandGuardPolicy(createdOnPlatform);
 
     const permission: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

Temporarily disable the question tool for `cloud-agent` and `app-builder` sessions. If a user doesn't answer a question before the sandbox expires, the Kilo server rejects the late reply and the UI ends up in a broken state. Until that underlying issue is resolved, this change adds `question: 'deny'` to the permission config for these sessions, matching the behavior already in place for `slack`, `webhook`, and other non-interactive platforms.

Also fixes a pre-existing broken test in `wrapper-client.test.ts` where the shell-quote assertion didn't account for the `WRAPPER_LOG_PATH` env var added to the wrapper startup command.

## Verification

- [x] `pnpm run test` — 650 passed, 0 failures
- [x] Confirmed question permission tests pass for all platforms: `cloud-agent` and `app-builder` now get `question:deny`, only `undefined` (no platform) remains interactive
- [ ] _Additional verification (typecheck, deploy, etc.)_

## Visual Changes

N/A

## Reviewer Notes

- This is a temporary measure. The question tool should be re-enabled once the sandbox-expiry / stale-answer rejection issue is fixed.
- The only production logic change is simplifying the `isInteractive` condition in `session-service.ts:581` to `!createdOnPlatform` — only sessions with no platform set retain the question tool.
- The existing question event plumbing (WebSocket events, tRPC handlers, frontend UI) is untouched — it will simply never fire for `cloud-agent` or `app-builder` sessions.
- The wrapper test fix uses `expect.stringMatching(...)` with a regex to handle the non-deterministic `Date.now()` timestamp in `WRAPPER_LOG_PATH`.