### PR TITLE
bug(OpenClaw version) Fix openclaw version parsing

### DIFF
--- a/kiloclaw/controller/src/routes/health.test.ts
+++ b/kiloclaw/controller/src/routes/health.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import { registerHealthRoute } from './health';
+import { registerHealthRoute, parseOpenclawVersion } from './health';
 import type { Supervisor } from '../supervisor';
 
 const MOCK_STATS = {
@@ -22,6 +22,43 @@ function createMockSupervisor(): Supervisor {
     getStats: () => MOCK_STATS,
   };
 }
+
+describe('parseOpenclawVersion', () => {
+  it('parses full output with commit hash', () => {
+    expect(parseOpenclawVersion('OpenClaw 2026.3.8 (3caab92)')).toEqual({
+      version: '2026.3.8',
+      commit: '3caab92',
+    });
+  });
+
+  it('parses output without commit hash', () => {
+    expect(parseOpenclawVersion('OpenClaw 2026.3.8')).toEqual({
+      version: '2026.3.8',
+      commit: null,
+    });
+  });
+
+  it('parses bare calver', () => {
+    expect(parseOpenclawVersion('2026.3.8')).toEqual({
+      version: '2026.3.8',
+      commit: null,
+    });
+  });
+
+  it('returns null version for unrecognised output', () => {
+    expect(parseOpenclawVersion('something unexpected')).toEqual({
+      version: null,
+      commit: null,
+    });
+  });
+
+  it('returns null version for empty string', () => {
+    expect(parseOpenclawVersion('')).toEqual({
+      version: null,
+      commit: null,
+    });
+  });
+});
 
 describe('GET /_kilo/health', () => {
   it('returns 200 with minimal payload', async () => {

--- a/kiloclaw/controller/src/routes/health.ts
+++ b/kiloclaw/controller/src/routes/health.ts
@@ -12,8 +12,19 @@ import { getBearerToken } from './gateway';
  * This is acceptable: the UI shows a "Modified" badge by comparing image vs running
  * version, and spawning a subprocess on every request is not worth the cost.
  */
-let openclawVersionPromise: Promise<string | null> | undefined;
-function getOpenclawVersion(): Promise<string | null> {
+/** Parsed result from `openclaw --version` (e.g. "OpenClaw 2026.3.8 (3caab92)"). */
+type OpenclawVersionInfo = { version: string | null; commit: string | null };
+
+const OPENCLAW_VERSION_RE = /(\d{4}\.\d{1,2}\.\d{1,2})(?:\s+\(([0-9a-f]+)\))?/;
+
+function parseOpenclawVersion(raw: string): OpenclawVersionInfo {
+  const match = raw.match(OPENCLAW_VERSION_RE);
+  if (!match) return { version: raw, commit: null };
+  return { version: match[1], commit: match[2] ?? null };
+}
+
+let openclawVersionPromise: Promise<OpenclawVersionInfo> | undefined;
+function getOpenclawVersion(): Promise<OpenclawVersionInfo> {
   if (!openclawVersionPromise) {
     openclawVersionPromise = new Promise(resolve => {
       execFile(
@@ -21,7 +32,11 @@ function getOpenclawVersion(): Promise<string | null> {
         ['HOME=/root', 'openclaw', '--version'],
         { timeout: 5000 },
         (err, stdout) => {
-          resolve(err ? null : stdout.toString().trim());
+          if (err) {
+            resolve({ version: null, commit: null });
+          } else {
+            resolve(parseOpenclawVersion(stdout.toString().trim()));
+          }
         }
       );
     });
@@ -53,10 +68,12 @@ export function registerHealthRoute(
       }
     }
 
+    const openclaw = await getOpenclawVersion();
     return c.json({
       version: CONTROLLER_VERSION,
       commit: CONTROLLER_COMMIT,
-      openclawVersion: await getOpenclawVersion(),
+      openclawVersion: openclaw.version,
+      openclawCommit: openclaw.commit,
       gateway: supervisor.getStats(),
     });
   });

--- a/kiloclaw/controller/src/routes/health.ts
+++ b/kiloclaw/controller/src/routes/health.ts
@@ -5,6 +5,17 @@ import type { Supervisor } from '../supervisor';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from '../version';
 import { getBearerToken } from './gateway';
 
+/** Parsed result from `openclaw --version` (e.g. "OpenClaw 2026.3.8 (3caab92)"). */
+type OpenclawVersionInfo = { version: string | null; commit: string | null };
+
+const OPENCLAW_VERSION_RE = /(\d{4}\.\d{1,2}\.\d{1,2})(?:\s+\(([0-9a-f]+)\))?/;
+
+export function parseOpenclawVersion(raw: string): OpenclawVersionInfo {
+  const match = raw.match(OPENCLAW_VERSION_RE);
+  if (!match) return { version: null, commit: null };
+  return { version: match[1], commit: match[2] ?? null };
+}
+
 /**
  * Resolve the installed openclaw version once and cache it for the process lifetime.
  * If the user upgrades openclaw while the controller is running, the cached value
@@ -12,17 +23,6 @@ import { getBearerToken } from './gateway';
  * This is acceptable: the UI shows a "Modified" badge by comparing image vs running
  * version, and spawning a subprocess on every request is not worth the cost.
  */
-/** Parsed result from `openclaw --version` (e.g. "OpenClaw 2026.3.8 (3caab92)"). */
-type OpenclawVersionInfo = { version: string | null; commit: string | null };
-
-const OPENCLAW_VERSION_RE = /(\d{4}\.\d{1,2}\.\d{1,2})(?:\s+\(([0-9a-f]+)\))?/;
-
-function parseOpenclawVersion(raw: string): OpenclawVersionInfo {
-  const match = raw.match(OPENCLAW_VERSION_RE);
-  if (!match) return { version: raw, commit: null };
-  return { version: match[1], commit: match[2] ?? null };
-}
-
 let openclawVersionPromise: Promise<OpenclawVersionInfo> | undefined;
 function getOpenclawVersion(): Promise<OpenclawVersionInfo> {
   if (!openclawVersionPromise) {

--- a/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -42,6 +42,7 @@ export const ControllerVersionResponseSchema = z.object({
   commit: z.string(),
   // optional() for backward compat with older controllers that don't include this field
   openclawVersion: z.string().nullable().optional(),
+  openclawCommit: z.string().nullable().optional(),
 });
 
 export class GatewayControllerError extends Error {

--- a/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -40,7 +40,7 @@ export const ConfigRestoreResponseSchema = z.object({
 export const ControllerVersionResponseSchema = z.object({
   version: z.string(),
   commit: z.string(),
-  // optional() for backward compat with older controllers that don't include this field
+  // optional() for backward compat with older controllers that don't include these fields
   openclawVersion: z.string().nullable().optional(),
   openclawCommit: z.string().nullable().optional(),
 });

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -172,9 +172,22 @@ export function SettingsTab({
               <div>
                 <p className="text-muted-foreground mb-1.5 text-xs">Running Version</p>
                 <div className="flex items-center gap-2">
-                  <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
-                    {runningVersion ?? '—'}
-                  </code>
+                  {runningVersion ? (
+                    <code className="bg-muted text-foreground rounded px-2 py-1 text-sm font-medium">
+                      {runningVersion}
+                    </code>
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <code className="bg-muted text-muted-foreground cursor-help rounded px-2 py-1 text-sm font-medium">
+                          —
+                        </code>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Unable to determine the running OpenClaw version</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
                   {needsImageUpgrade && (
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -224,6 +224,7 @@ export type ControllerVersionResponse = {
   version: string | null;
   commit: string | null;
   openclawVersion?: string | null;
+  openclawCommit?: string | null;
 };
 
 /** Combined status + gateway token returned by tRPC getStatus */

--- a/src/lib/kiloclaw/version.test.ts
+++ b/src/lib/kiloclaw/version.test.ts
@@ -1,0 +1,59 @@
+import { cleanVersion, calverAtLeast } from './version';
+
+describe('cleanVersion', () => {
+  // Null / undefined / empty
+  it('returns null for null', () => expect(cleanVersion(null)).toBeNull());
+  it('returns null for undefined', () => expect(cleanVersion(undefined)).toBeNull());
+  it('returns null for empty string', () => expect(cleanVersion('')).toBeNull());
+
+  // Plain calver (new controller output)
+  it('passes through a bare calver', () => expect(cleanVersion('2026.3.8')).toBe('2026.3.8'));
+
+  // Surrounding quotes (bun build --define)
+  it('strips double quotes', () => expect(cleanVersion('"2026.3.8"')).toBe('2026.3.8'));
+  it('strips single quotes', () => expect(cleanVersion("'2026.3.8'")).toBe('2026.3.8'));
+
+  // Full openclaw --version output (older controllers)
+  it('extracts calver from "OpenClaw 2026.3.8 (3caab92)"', () =>
+    expect(cleanVersion('OpenClaw 2026.3.8 (3caab92)')).toBe('2026.3.8'));
+  it('extracts calver from "OpenClaw 2026.3.8" without hash', () =>
+    expect(cleanVersion('OpenClaw 2026.3.8')).toBe('2026.3.8'));
+  it('extracts calver from quoted full string', () =>
+    expect(cleanVersion('"OpenClaw 2026.3.8 (abc1234)"')).toBe('2026.3.8'));
+
+  // No calver found — returns raw string as fallback
+  it('returns raw string when no calver pattern matches', () =>
+    expect(cleanVersion('unknown')).toBe('unknown'));
+  it('returns null for whitespace-only after quote stripping', () =>
+    expect(cleanVersion('""')).toBeNull());
+
+  // :latest sentinel (used by hasVersionInfo check)
+  it('passes through :latest unchanged', () => expect(cleanVersion(':latest')).toBe(':latest'));
+});
+
+describe('calverAtLeast', () => {
+  it('returns false for null', () => expect(calverAtLeast(null, '2026.1.1')).toBe(false));
+  it('returns false for undefined', () => expect(calverAtLeast(undefined, '2026.1.1')).toBe(false));
+  it('returns false for empty string', () => expect(calverAtLeast('', '2026.1.1')).toBe(false));
+
+  it('returns true when equal', () => expect(calverAtLeast('2026.2.26', '2026.2.26')).toBe(true));
+  it('returns true when greater (patch)', () =>
+    expect(calverAtLeast('2026.2.27', '2026.2.26')).toBe(true));
+  it('returns true when greater (minor)', () =>
+    expect(calverAtLeast('2026.3.1', '2026.2.26')).toBe(true));
+  it('returns true when greater (major)', () =>
+    expect(calverAtLeast('2027.1.1', '2026.2.26')).toBe(true));
+
+  it('returns false when less (patch)', () =>
+    expect(calverAtLeast('2026.2.25', '2026.2.26')).toBe(false));
+  it('returns false when less (minor)', () =>
+    expect(calverAtLeast('2026.1.30', '2026.2.26')).toBe(false));
+  it('returns false when less (major)', () =>
+    expect(calverAtLeast('2025.12.31', '2026.2.26')).toBe(false));
+
+  // Malformed input — fails closed
+  it('returns false for non-numeric version', () =>
+    expect(calverAtLeast('abc.def.ghi', '2026.1.1')).toBe(false));
+  it('returns false for non-numeric minVersion segment', () =>
+    expect(calverAtLeast('2026.1.1', 'abc.1.1')).toBe(false));
+});

--- a/src/lib/kiloclaw/version.ts
+++ b/src/lib/kiloclaw/version.ts
@@ -1,6 +1,20 @@
-/** Strip surrounding quotes; bun build --define can wrap values in extra quotes. */
+/**
+ * Normalise a version string to a bare calver (e.g. "2026.3.8").
+ *
+ * Handles:
+ *  - Surrounding quotes from bun build --define: `"2026.3.8"` → `2026.3.8`
+ *  - Full `openclaw --version` output from older controllers:
+ *    `OpenClaw 2026.3.8 (3caab92)` → `2026.3.8`
+ *  - Plain calver (new controllers already strip): `2026.3.8` → `2026.3.8`
+ */
 export function cleanVersion(version: string | null | undefined): string | null {
-  return version?.replace(/^["']|["']$/g, '') || null;
+  if (!version) return null;
+  // Strip surrounding quotes
+  const v = version.replace(/^["']|["']$/g, '');
+  // Extract bare calver if the string contains one (handles prefixed/suffixed formats)
+  const match = v.match(/(\d{4}\.\d{1,2}\.\d{1,2})/);
+  if (match) return match[1];
+  return v || null;
 }
 
 /** Returns true if calver `version` is >= `minVersion` (e.g. "2026.2.26"). Fails closed on malformed input. */


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
openclaw --version changed its output format from 2026.3.8 to OpenClaw   2026.3.8 (3caab92). This caused a false "Modified" badge in the OpenClaw   Version section because the running version string no longer matched the bare   calver stored as the image version.

  The fix parses the version at the controller (source) into structured fields   (openclawVersion + openclawCommit), with cleanVersion() as a   belt-and-suspenders fallback for older controllers that haven't been   redeployed yet.

## Verification

- health.test.ts — 11/11 passed (5 new for parseOpenclawVersion)
- kiloclaw-instance.test.ts — 144/144 passed
- version.test.ts — 24/24 passed (new file covering cleanVersion +   calverAtLeast)
- Typecheck — all packages pass
- Lint — all packages pass
- Format — clean (2 pre-existing warnings on unrelated markdown files)

## Visual Changes

- Running Version now displays the bare calver (2026.3.8) instead of the full   openclaw --version output
- Modified badge no longer appears when running and image versions match
- When running version is null (unrecognised format or error), the dash (—)   now has a tooltip: "Unable to determine the running OpenClaw version"
- openclawCommit hash is available in the API response for future use (e.g.   advanced view, SBOM display)


## Reviewer Notes

- The OPENCLAW_VERSION_RE in health.ts and catalog-registration.ts look   similar but serve different purposes — one parses the full output, the other   validates bare calver format with anchors. Intentionally not deduplicated.
- parseOpenclawVersion returns { version: null, commit: null } on unrecognised    input rather than passing through the raw string — fail-safe over fail-open.
- cleanVersion() and types.ts changes were already merged to main via a prior   commit (17347003). This PR adds the controller-side parsing, the SettingsTab   tooltip, and test coverage.
