### PR TITLE
chore(nix): add vercel, fly, cloudflared to dev env and fix NixOS TLS certs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765838191,
-        "narHash": "sha256-m5KWt1nOm76ILk/JSCxBM4MfK3rYY7Wq9/TZIIeGnT8=",
+        "lastModified": 1772822230,
+        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6f52ebd45e5925c188d1a20119978aa4ffd5ef6",
+        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,22 @@
             wrangler
             nodePackages.vercel
             flyctl
+            cloudflared
           ];
+
+          env = {
+            # Node.js TLS: extra CA certificates for the wrangler Node.js process.
+            NODE_EXTRA_CA_CERTS = "/etc/ssl/certs/ca-certificates.crt";
+          };
+
+          shellHook = ''
+            # workerd's BoringSSL calls SSL_CTX_set_default_verify_paths(), which reads
+            # SSL_CERT_FILE and falls back to the compiled-in /etc/ssl/cert.pem.
+            # NixOS doesn't create /etc/ssl/cert.pem, so force-export SSL_CERT_FILE here.
+            # We use shellHook (not env) because nixpkgs stdenv also sets SSL_CERT_FILE
+            # internally, which silently wins over the env attribute.
+            export SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+          '';
         };
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             postgresql_18
             wrangler
             nodePackages.vercel
+            flyctl
           ];
         };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,8 @@
 
           env = {
             # Node.js TLS: extra CA certificates for the wrangler Node.js process.
-            NODE_EXTRA_CA_CERTS = "/etc/ssl/certs/ca-certificates.crt";
+            # Use the Nix-managed CA bundle so this works on both Linux and macOS.
+            NODE_EXTRA_CA_CERTS = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
           };
 
           shellHook = ''
@@ -51,7 +52,11 @@
             # NixOS doesn't create /etc/ssl/cert.pem, so force-export SSL_CERT_FILE here.
             # We use shellHook (not env) because nixpkgs stdenv also sets SSL_CERT_FILE
             # internally, which silently wins over the env attribute.
-            export SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+            # Guard to Linux only: macOS ships its own trust store and the hard-coded
+            # /etc/ssl/certs/ca-certificates.crt path does not exist there.
+            ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ''}
           '';
         };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -5,33 +5,43 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
   };
 
-  outputs = { self, nixpkgs, ... }: let
-    systems = [ "aarch64-darwin" "x86_64-linux" ];
-
-    forAllSystems = nixpkgs.lib.genAttrs systems;
-
-    mkDevShell = system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-      };
-    in pkgs.mkShell {
-      name = "kilo-code-backend";
-
-      packages = with pkgs; [
-        git
-        git-lfs
-        nodejs_22
-        corepack_22
-        dotenvx
-        _1password-cli
-        postgresql_18
-        wrangler
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-linux"
       ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      mkDevShell =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+        in
+        pkgs.mkShell {
+          name = "kilo-code-backend";
+
+          packages = with pkgs; [
+            git
+            git-lfs
+            nodejs_22
+            corepack_22
+            dotenvx
+            _1password-cli
+            postgresql_18
+            wrangler
+            nodePackages.vercel
+          ];
+        };
+    in
+    {
+      devShells = forAllSystems (system: {
+        default = mkDevShell system;
+      });
     };
-  in {
-    devShells = forAllSystems (system: {
-      default = mkDevShell system;
-    });
-  };
 }


### PR DESCRIPTION
## Summary

- Adds \`vercel\`, \`flyctl\`, and \`cloudflared\` to the Nix dev shell packages
- Fixes TLS certificate resolution on NixOS for both Node.js (\`NODE_EXTRA_CA_CERTS\`) and workerd/wrangler (\`SSL_CERT_FILE\` via \`shellHook\`)
- Reformats \`flake.nix\` for improved readability (consistent indentation/style)
- Bumps \`flake.lock\` to latest \`nixos-25.11\` nixpkgs revision

## Verification

- Nix flake evaluated locally on NixOS (\`nix develop\`)
- \`wrangler\` and \`vercel\` CLI commands work without TLS errors after the cert fix

## Visual Changes

N/A

## Reviewer Notes

The \`SSL_CERT_FILE\` fix is set via \`shellHook\` rather than \`env\` because nixpkgs stdenv internally sets \`SSL_CERT_FILE\`, which silently overrides the \`env\` attribute. Using \`shellHook\` ensures our value wins at shell entry time.