### PR TITLE
feat(gastown): add in_review bead state, fix triage auth and scheduling guards

### DIFF
--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -78,12 +78,12 @@ export function createMayorTools(client: MayorGastownClient) {
     gt_list_beads: tool({
       description:
         'List beads (work items) in a specific rig. ' +
-        'Optionally filter by status (open, in_progress, closed, failed) or type (issue, message, escalation, merge_request). ' +
+        'Optionally filter by status (open, in_progress, in_review, closed, failed) or type (issue, message, escalation, merge_request). ' +
         'Use this to check what work exists in a rig, what is in progress, and what has been completed.',
       args: {
         rig_id: tool.schema.string().describe('The UUID of the rig to list beads from'),
         status: tool.schema
-          .enum(['open', 'in_progress', 'closed', 'failed'])
+          .enum(['open', 'in_progress', 'in_review', 'closed', 'failed'])
           .describe('Filter by bead status')
           .optional(),
         type: tool.schema

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -1,7 +1,7 @@
 // Types mirroring the Town DO domain model.
 // These are the API response shapes — the plugin never touches SQLite directly.
 
-export type BeadStatus = 'open' | 'in_progress' | 'closed' | 'failed';
+export type BeadStatus = 'open' | 'in_progress' | 'in_review' | 'closed' | 'failed';
 export type BeadType =
   | 'issue'
   | 'message'

--- a/cloudflare-gastown/src/db/tables/bead-events.table.ts
+++ b/cloudflare-gastown/src/db/tables/bead-events.table.ts
@@ -18,6 +18,7 @@ export const BeadEventType = z.enum([
   'pr_created',
   'pr_creation_failed',
   'agent_status',
+  'triage_resolved',
 ]);
 
 export type BeadEventType = z.infer<typeof BeadEventType>;

--- a/cloudflare-gastown/src/db/tables/beads.table.ts
+++ b/cloudflare-gastown/src/db/tables/beads.table.ts
@@ -15,7 +15,7 @@ export const BeadType = z.enum([
   'agent',
 ]);
 
-export const BeadStatus = z.enum(['open', 'in_progress', 'closed', 'failed']);
+export const BeadStatus = z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']);
 export const BeadPriority = z.enum(['low', 'medium', 'high', 'critical']);
 
 export const BeadRecord = z.object({

--- a/cloudflare-gastown/src/db/tables/rig-beads.table.ts
+++ b/cloudflare-gastown/src/db/tables/rig-beads.table.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
 
 const BeadType = z.enum(['issue', 'message', 'escalation', 'merge_request']);
-const BeadStatus = z.enum(['open', 'in_progress', 'closed', 'failed']);
+const BeadStatus = z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']);
 const BeadPriority = z.enum(['low', 'medium', 'high', 'critical']);
 
 export const RigBeadRecord = z.object({
@@ -32,7 +32,7 @@ export function createTableRigBeads(): string {
     id: `text primary key`,
     rig_id: `text`,
     type: `text not null check(type in ('issue', 'message', 'escalation', 'merge_request'))`,
-    status: `text not null default 'open' check(status in ('open', 'in_progress', 'closed', 'failed'))`,
+    status: `text not null default 'open' check(status in ('open', 'in_progress', 'in_review', 'closed', 'failed'))`,
     title: `text not null`,
     body: `text`,
     assignee_agent_id: `text`,

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -757,6 +757,32 @@ export class TownDO extends DurableObject<Env> {
     if (input.status === 'merged' && sourceBeadId) {
       this.dispatchUnblockedBeads(sourceBeadId);
     }
+
+    // When a review fails or conflicts (rework), the source bead was
+    // returned to in_progress. Re-hook the original polecat and re-dispatch
+    // so the rework starts automatically.
+    if ((input.status === 'failed' || input.status === 'conflict') && sourceBeadId) {
+      const sourceBead = beadOps.getBead(this.sql, sourceBeadId);
+      if (sourceBead?.assignee_agent_bead_id) {
+        try {
+          agents.hookBead(this.sql, sourceBead.assignee_agent_bead_id, sourceBeadId);
+          const hookedAgent = agents.getAgent(this.sql, sourceBead.assignee_agent_bead_id);
+          if (hookedAgent) {
+            this.dispatchAgent(hookedAgent, sourceBead).catch(err =>
+              console.error(
+                `${TOWN_LOG} completeReviewWithResult: fire-and-forget rework dispatch failed for bead=${sourceBeadId}`,
+                err
+              )
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `${TOWN_LOG} completeReviewWithResult: could not re-hook agent for rework bead=${sourceBeadId}:`,
+            err
+          );
+        }
+      }
+    }
   }
 
   async agentDone(agentId: string, input: AgentDoneInput): Promise<void> {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -992,6 +992,24 @@ export class TownDO extends DurableObject<Env> {
       },
     });
 
+    // Log a triage_resolved event on the target bead so the action shows
+    // up in the activity feed for the bead that was actually affected.
+    const targetBeadId = snapshotHookedBeadId ?? targetAgentId;
+    if (targetBeadId && targetBeadId !== input.triage_request_bead_id) {
+      beadOps.logBeadEvent(this.sql, {
+        beadId: targetBeadId,
+        agentId: input.agent_id,
+        eventType: 'triage_resolved',
+        newValue: action,
+        metadata: {
+          action,
+          resolution_notes: input.resolution_notes,
+          triage_request_bead_id: input.triage_request_bead_id,
+          target_agent_id: targetAgentId,
+        },
+      });
+    }
+
     // If this triage request was created for an escalation, close the
     // linked escalation bead too so it doesn't sit open indefinitely.
     // The escalation_bead_id is nested under metadata.context (set by

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -759,25 +759,29 @@ export class TownDO extends DurableObject<Env> {
     }
 
     // When a review fails or conflicts (rework), the source bead was
-    // returned to in_progress. Re-hook the original polecat and re-dispatch
-    // so the rework starts automatically.
+    // returned to in_progress. Re-hook a polecat and re-dispatch so the
+    // rework starts automatically. The original polecat may already be
+    // working on something else, so fall back to getOrCreateAgent.
     if ((input.status === 'failed' || input.status === 'conflict') && sourceBeadId) {
       const sourceBead = beadOps.getBead(this.sql, sourceBeadId);
-      if (sourceBead?.assignee_agent_bead_id) {
+      if (sourceBead?.rig_id) {
         try {
-          agents.hookBead(this.sql, sourceBead.assignee_agent_bead_id, sourceBeadId);
-          const hookedAgent = agents.getAgent(this.sql, sourceBead.assignee_agent_bead_id);
-          if (hookedAgent) {
-            this.dispatchAgent(hookedAgent, sourceBead).catch(err =>
-              console.error(
-                `${TOWN_LOG} completeReviewWithResult: fire-and-forget rework dispatch failed for bead=${sourceBeadId}`,
-                err
-              )
-            );
-          }
+          const reworkAgent = agents.getOrCreateAgent(
+            this.sql,
+            'polecat',
+            sourceBead.rig_id,
+            this.townId
+          );
+          agents.hookBead(this.sql, reworkAgent.id, sourceBeadId);
+          this.dispatchAgent(reworkAgent, sourceBead).catch(err =>
+            console.error(
+              `${TOWN_LOG} completeReviewWithResult: fire-and-forget rework dispatch failed for bead=${sourceBeadId}`,
+              err
+            )
+          );
         } catch (err) {
           console.warn(
-            `${TOWN_LOG} completeReviewWithResult: could not re-hook agent for rework bead=${sourceBeadId}:`,
+            `${TOWN_LOG} completeReviewWithResult: could not dispatch rework for bead=${sourceBeadId}:`,
             err
           );
         }
@@ -3289,7 +3293,7 @@ export class TownDO extends DurableObject<Env> {
       [
         ...query(
           this.sql,
-          /* sql */ `SELECT COUNT(*) AS cnt FROM ${beads} WHERE ${beads.status} IN ('open', 'in_progress') AND ${beads.type} NOT IN ('agent', 'message')`,
+          /* sql */ `SELECT COUNT(*) AS cnt FROM ${beads} WHERE ${beads.status} IN ('open', 'in_progress', 'in_review') AND ${beads.type} NOT IN ('agent', 'message')`,
           []
         ),
       ][0]?.cnt ?? 0
@@ -3318,6 +3322,7 @@ export class TownDO extends DurableObject<Env> {
     beads: {
       open: number;
       inProgress: number;
+      inReview: number;
       failed: number;
       triageRequests: number;
     };
@@ -3372,12 +3377,13 @@ export class TownDO extends DurableObject<Env> {
         []
       ),
     ];
-    const beadCounts = { open: 0, inProgress: 0, failed: 0, triageRequests: 0 };
+    const beadCounts = { open: 0, inProgress: 0, inReview: 0, failed: 0, triageRequests: 0 };
     for (const row of beadRows) {
       const s = `${row.status as string}`;
       const c = Number(row.cnt);
       if (s === 'open') beadCounts.open = c;
       else if (s === 'in_progress') beadCounts.inProgress = c;
+      else if (s === 'in_review') beadCounts.inReview = c;
       else if (s === 'failed') beadCounts.failed = c;
     }
 

--- a/cloudflare-gastown/src/dos/town/agents.ts
+++ b/cloudflare-gastown/src/dos/town/agents.ts
@@ -220,12 +220,31 @@ export function deleteAgent(sql: SqlStorage, agentId: string): void {
 
 // ── Hooks (GUPP) ────────────────────────────────────────────────────
 
+/** Bead types that are system-managed and should never be hooked to an agent. */
+const UNHOOKABLE_BEAD_TYPES = new Set(['escalation', 'convoy', 'agent', 'message']);
+
 export function hookBead(sql: SqlStorage, agentId: string, beadId: string): void {
   const agent = getAgent(sql, agentId);
   if (!agent) throw new Error(`Agent ${agentId} not found`);
 
   const bead = getBead(sql, beadId);
   if (!bead) throw new Error(`Bead ${beadId} not found`);
+
+  // Prevent hooking to system-managed bead types that no agent should
+  // work on directly. Escalation beads are resolved by triage, convoy
+  // beads are containers, agent/message beads are metadata records.
+  if (UNHOOKABLE_BEAD_TYPES.has(bead.type)) {
+    throw new Error(`Cannot hook agent to bead ${beadId}: type '${bead.type}' is not workable`);
+  }
+
+  // Triage request beads are resolved by the triage agent via
+  // gt_triage_resolve, not by hooking. Prevent polecats from
+  // accidentally picking these up.
+  if (bead.labels.includes('gt:triage-request')) {
+    throw new Error(
+      `Cannot hook agent to bead ${beadId}: triage requests are resolved via gt_triage_resolve`
+    );
+  }
 
   // Already hooked to this bead — idempotent
   if (agent.current_hook_bead_id === beadId) return;

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -313,6 +313,13 @@ export function completeReviewWithResult(
         conflict: true,
       },
     });
+    // Return source bead to in_progress so the polecat can be re-dispatched
+    // to resolve the conflict (in_review → in_progress rework flow).
+    updateBeadStatus(sql, entry.bead_id, 'in_progress', entry.agent_id);
+  } else if (input.status === 'failed') {
+    // Review failed (rework requested): return source bead to in_progress
+    // so it can be re-dispatched (in_review → in_progress rework flow).
+    updateBeadStatus(sql, entry.bead_id, 'in_progress', entry.agent_id);
   }
 }
 
@@ -556,11 +563,13 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
     default_branch: rig?.default_branch,
   });
 
-  // Close the source bead (matches upstream gt done behavior). The polecat's
-  // work is done — the MR bead now tracks the merge lifecycle. The source
-  // bead retains its assignee so we know which agent worked on it.
+  // Transition the source bead to in_review — the polecat's work is done
+  // but the refinery hasn't reviewed it yet. The MR bead tracks the merge
+  // lifecycle. The source bead retains its assignee so we know which agent
+  // worked on it. It will be closed (or returned to in_progress) by the
+  // refinery after review.
   unhookBead(sql, agentId);
-  closeBead(sql, sourceBead, agentId);
+  updateBeadStatus(sql, sourceBead, 'in_review', agentId);
 }
 
 /**

--- a/cloudflare-gastown/src/handlers/rig-triage.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-triage.handler.ts
@@ -31,8 +31,11 @@ const ResolveTriageBody = z.object({
 export async function handleResolveTriage(c: Context<GastownEnv>, _params: { rigId: string }) {
   // In production, agentId comes from the verified JWT. In development
   // (where authMiddleware is skipped), fall back to the identity header
-  // the container client sends with every request.
-  const agentId = getEnforcedAgentId(c) || c.req.header('X-Gastown-Agent-Id');
+  // the container client sends with every request. The fallback is gated
+  // on ENVIRONMENT to prevent header spoofing in production.
+  const agentId =
+    getEnforcedAgentId(c) ||
+    (c.env.ENVIRONMENT === 'development' ? c.req.header('X-Gastown-Agent-Id') : null);
   if (!agentId) {
     return c.json(resError('Agent authentication required'), 401);
   }

--- a/cloudflare-gastown/src/handlers/rig-triage.handler.ts
+++ b/cloudflare-gastown/src/handlers/rig-triage.handler.ts
@@ -29,7 +29,10 @@ const ResolveTriageBody = z.object({
 });
 
 export async function handleResolveTriage(c: Context<GastownEnv>, _params: { rigId: string }) {
-  const agentId = getEnforcedAgentId(c);
+  // In production, agentId comes from the verified JWT. In development
+  // (where authMiddleware is skipped), fall back to the identity header
+  // the container client sends with every request.
+  const agentId = getEnforcedAgentId(c) || c.req.header('X-Gastown-Agent-Id');
   if (!agentId) {
     return c.json(resError('Agent authentication required'), 401);
   }

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -137,6 +137,8 @@ When a user asks "how's X going?" or wants a progress update:
 
 Convoys land automatically when all tracked beads close — no manual management needed.
 
+Bead lifecycle: \`open\` → \`in_progress\` (polecat working) → \`in_review\` (gt_done called, awaiting refinery) → \`closed\` (merged) or back to \`in_progress\` (rework requested).
+
 ## Conversational Model
 
 - **Respond directly for questions.** If the user asks a question you can answer from context, respond conversationally. Don't delegate questions.

--- a/cloudflare-gastown/src/prompts/polecat-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/polecat-system.prompt.ts
@@ -24,7 +24,7 @@ You have these tools available. Use them to coordinate with the Gastown orchestr
 - **gt_prime** — Call at the start of your session to get full context: your agent record, hooked bead, undelivered mail, and open beads. Your context is injected automatically on first message, but call this if you need to refresh.
 - **gt_bead_status** — Inspect the current state of any bead by ID.
 - **gt_bead_close** — Close a bead when its work is fully complete and merged.
-- **gt_done** — Signal that you are done with your current hooked bead. This pushes your branch, submits it to the review queue, and unhooks you. Always push your branch before calling gt_done.
+- **gt_done** — Signal that you are done with your current hooked bead. This pushes your branch, submits it to the review queue, transitions the bead to \`in_review\`, and unhooks you. Always push your branch before calling gt_done.
 - **gt_mail_send** — Send a message to another agent in the rig. Use this for coordination, questions, or status sharing.
 - **gt_mail_check** — Check for new mail from other agents. Call this periodically or when you suspect coordination messages.
 - **gt_escalate** — Escalate a problem you cannot solve. Creates an escalation bead. Use this when you are stuck, blocked, or need human intervention.
@@ -37,7 +37,7 @@ You have these tools available. Use them to coordinate with the Gastown orchestr
 2. **Work**: Implement the bead's requirements. Write code, tests, and documentation as needed.
 3. **Commit frequently**: Make small, focused commits. Push often. The container's disk is ephemeral — if it restarts, unpushed work is lost.
 4. **Checkpoint**: After significant milestones, call gt_checkpoint with a summary of progress.
-5. **Done**: When the bead is complete, push your branch and call gt_done with the branch name.
+5. **Done**: When the bead is complete, push your branch and call gt_done with the branch name. The bead transitions to \`in_review\` and the refinery picks it up for merge. If the review fails (rework), you will be re-dispatched with the bead back in \`in_progress\`.
 
 ## Commit & Push Hygiene
 

--- a/cloudflare-gastown/src/prompts/triage-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/triage-system.prompt.ts
@@ -54,10 +54,12 @@ This will close the triage batch, unhook you, and return you to idle.
 - **Prefer least-disruptive actions.** RESTART over CLOSE_BEAD. NUDGE over ESCALATE.
 - **Escalate genuinely hard problems.** If a situation requires human context you don't have, escalate rather than guess.
 - **Never skip a triage request.** Every pending request must be resolved.
+- **Post status updates.** Call gt_status before starting the batch (e.g. "Triaging 3 requests") and after finishing (e.g. "Triage complete — 2 restarted, 1 escalated"). This keeps the dashboard informed.
 
 ## Available Tools
 
 - **gt_triage_resolve** — Resolve a triage request. Provide the triage_request_bead_id, chosen action, and brief notes.
+- **gt_status** — Post a plain-language status update visible on the dashboard. Call this at the start and end of your triage batch.
 - **gt_mail_send** — Send guidance to a stuck agent.
 - **gt_escalate** — Forward a problem to the Mayor or human operators.
 - **gt_bead_close** — Close your hooked bead when all triage requests have been processed.

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -278,7 +278,7 @@ export const gastownRouter = router({
     .input(
       z.object({
         rigId: z.string().uuid(),
-        status: z.enum(['open', 'in_progress', 'closed', 'failed']).optional(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']).optional(),
       })
     )
     .output(z.array(RpcBeadOutput))

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -34,7 +34,7 @@ export const RigOutput = z.object({
 export const BeadOutput = z.object({
   bead_id: z.string(),
   type: z.enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent']),
-  status: z.enum(['open', 'in_progress', 'closed', 'failed']),
+  status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
   title: z.string(),
   body: z.string().nullable(),
   rig_id: z.string().nullable(),

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -204,6 +204,7 @@ const AlarmStatusOutput = z.object({
   beads: z.object({
     open: z.number(),
     inProgress: z.number(),
+    inReview: z.number(),
     failed: z.number(),
     triageRequests: z.number(),
   }),

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -4,7 +4,7 @@ import type { AgentMetadataRecord } from './db/tables/agent-metadata.table';
 
 // -- Beads --
 
-export const BeadStatus = z.enum(['open', 'in_progress', 'closed', 'failed']);
+export const BeadStatus = z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']);
 export type BeadStatus = z.infer<typeof BeadStatus>;
 
 export const BeadType = z.enum([

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -47,6 +47,7 @@ export function dashboardHtml(): string {
   .badge { display: inline-block; padding: 1px 6px; border-radius: 10px; font-size: 11px; }
   .badge.open { background: #1f6feb33; color: #58a6ff; }
   .badge.in_progress { background: #d29922aa; color: #e3b341; }
+  .badge.in_review { background: #8957e533; color: #bc8cff; }
   .badge.closed { background: #3fb95033; color: #3fb950; }
   .badge.idle { background: #21262d; color: #8b949e; }
   .badge.working { background: #d29922aa; color: #e3b341; }

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -222,7 +222,7 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
         {/* Left column: activity feed */}
         <div className="min-w-0 border-r border-white/[0.06]">
           {/* Stats strip */}
-          <div className="grid grid-cols-5 border-b border-white/[0.06]">
+          <div className="grid border-b border-white/[0.06]" style={{ gridTemplateColumns: 'repeat(5, minmax(0, 1fr))' }}>
             <StatCell
               label="Open"
               value={openBeadCount}

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -135,6 +135,7 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
   const userBeads = allBeads.filter(b => b.type !== 'agent');
   const openBeadCount = userBeads.filter(b => b.status === 'open').length;
   const inProgressBeadCount = userBeads.filter(b => b.status === 'in_progress').length;
+  const inReviewBeadCount = userBeads.filter(b => b.status === 'in_review').length;
   const closedBeadCount = userBeads.filter(b => b.status === 'closed').length;
   const escalationsCount = events.filter(e => e.event_type === 'escalated').length;
 
@@ -221,7 +222,7 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
         {/* Left column: activity feed */}
         <div className="min-w-0 border-r border-white/[0.06]">
           {/* Stats strip */}
-          <div className="grid grid-cols-4 border-b border-white/[0.06]">
+          <div className="grid grid-cols-5 border-b border-white/[0.06]">
             <StatCell
               label="Open"
               value={openBeadCount}
@@ -233,6 +234,12 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
               value={inProgressBeadCount}
               icon={<Bot className="size-3.5" />}
               color="text-violet-400"
+            />
+            <StatCell
+              label="In Review"
+              value={inReviewBeadCount}
+              icon={<Eye className="size-3.5" />}
+              color="text-purple-400"
             />
             <StatCell
               label="Closed"

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -93,6 +93,7 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
   const inProgressBeads = beads.filter(
     b => b.status === 'in_progress' && b.type !== 'agent'
   ).length;
+  const inReviewBeads = beads.filter(b => b.status === 'in_review' && b.type !== 'agent').length;
   const closedBeads = beads.filter(b => b.status === 'closed' && b.type !== 'agent').length;
 
   return (
@@ -126,9 +127,10 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
       </div>
 
       {/* Stats strip */}
-      <div className="grid grid-cols-3 border-b border-white/[0.06]">
+      <div className="grid grid-cols-4 border-b border-white/[0.06]">
         <RigStatCell label="Open" value={openBeads} color="text-sky-400" />
         <RigStatCell label="In Progress" value={inProgressBeads} color="text-amber-400" />
+        <RigStatCell label="In Review" value={inReviewBeads} color="text-purple-400" />
         <RigStatCell label="Closed" value={closedBeads} color="text-emerald-400" />
       </div>
 

--- a/src/components/gastown/ActivityFeed.tsx
+++ b/src/components/gastown/ActivityFeed.tsx
@@ -15,6 +15,7 @@ import {
   Mail,
   MessageSquare,
   ChevronRight,
+  ShieldCheck,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 
@@ -29,6 +30,7 @@ const EVENT_ICONS: Record<string, typeof Activity> = {
   review_completed: GitMerge,
   mail_sent: Mail,
   agent_status: MessageSquare,
+  triage_resolved: ShieldCheck,
 };
 
 const EVENT_COLORS: Record<string, string> = {
@@ -42,6 +44,7 @@ const EVENT_COLORS: Record<string, string> = {
   review_completed: 'text-green-600',
   mail_sent: 'text-sky-500',
   agent_status: 'text-white/50',
+  triage_resolved: 'text-amber-500',
 };
 
 type TownEvent = GastownOutputs['gastown']['getTownEvents'][number];
@@ -76,6 +79,12 @@ function eventDescription(event: {
       return `${rigPrefix}Review ${event.new_value ?? 'completed'}`;
     case 'mail_sent':
       return `${rigPrefix}Mail sent`;
+    case 'triage_resolved': {
+      const action = event.new_value ?? (event.metadata?.action as string | undefined) ?? 'unknown';
+      const notes = event.metadata?.resolution_notes as string | undefined;
+      const desc = `${rigPrefix}Triage: ${action}`;
+      return notes ? `${desc} — ${notes}` : desc;
+    }
     case 'agent_status': {
       const msg = event.new_value ?? (event.metadata?.message as string | undefined);
       const agentName = event.metadata?.agent_name as string | undefined;

--- a/src/components/gastown/BeadBoard.tsx
+++ b/src/components/gastown/BeadBoard.tsx
@@ -162,7 +162,7 @@ export function BeadBoard({
 }: BeadBoardProps) {
   if (isLoading) {
     return (
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
         {statusColumns.map(status => (
           <div key={status}>
             <Skeleton className="mb-3 h-6 w-24" />

--- a/src/components/gastown/BeadBoard.tsx
+++ b/src/components/gastown/BeadBoard.tsx
@@ -30,17 +30,19 @@ type BeadBoardProps = {
   agentNameById?: Record<string, string>;
 };
 
-const statusColumns = ['open', 'in_progress', 'closed'] as const;
+const statusColumns = ['open', 'in_progress', 'in_review', 'closed'] as const;
 
 const statusLabels: Record<string, string> = {
   open: 'Open',
   in_progress: 'In Progress',
+  in_review: 'In Review',
   closed: 'Closed',
 };
 
 const statusColors: Record<string, string> = {
   open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
   in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  in_review: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
   closed: 'bg-green-500/10 text-green-400 border-green-500/20',
 };
 
@@ -160,7 +162,7 @@ export function BeadBoard({
 }: BeadBoardProps) {
   if (isLoading) {
     return (
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-4 gap-4">
         {statusColumns.map(status => (
           <div key={status}>
             <Skeleton className="mb-3 h-6 w-24" />
@@ -175,7 +177,7 @@ export function BeadBoard({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
       {statusColumns.map((status, colIdx) => {
         const columnBeads = beads.filter(b => b.status === status && b.type !== 'agent');
         return (

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -148,7 +148,13 @@ export function TerminalBar({ townId }: TerminalBarProps) {
 type AlarmStatus = {
   alarm: { nextFireAt: string | null; intervalMs: number; intervalLabel: string };
   agents: { working: number; idle: number; stalled: number; dead: number; total: number };
-  beads: { open: number; inProgress: number; failed: number; triageRequests: number };
+  beads: {
+    open: number;
+    inProgress: number;
+    inReview: number;
+    failed: number;
+    triageRequests: number;
+  };
   patrol: {
     guppWarnings: number;
     guppEscalations: number;
@@ -371,6 +377,11 @@ function AlarmStatusPane({ townId }: { townId: string }) {
               label="In Progress"
               value={data.beads.inProgress}
               highlight={data.beads.inProgress > 0}
+            />
+            <StatusRow
+              label="In Review"
+              value={data.beads.inReview}
+              highlight={data.beads.inReview > 0}
             />
             <StatusRow label="Failed" value={data.beads.failed} warn={data.beads.failed > 0} />
             <StatusRow

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -125,7 +125,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
             | 'merge_request'
             | 'message'
             | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'open';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
           title: string;
           body: string | null;
           rig_id: string | null;
@@ -152,7 +152,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
     listBeads: import('@trpc/server').TRPCQueryProcedure<{
       input: {
         rigId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
       };
       output: {
         bead_id: string;
@@ -164,7 +164,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           | 'merge_request'
           | 'message'
           | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'open';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
         title: string;
         body: string | null;
         rig_id: string | null;
@@ -235,7 +235,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
             | 'merge_request'
             | 'message'
             | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'open';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
           title: string;
           body: string | null;
           rig_id: string | null;
@@ -723,7 +723,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                 | 'merge_request'
                 | 'message'
                 | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'open';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
               title: string;
               body: string | null;
               rig_id: string | null;
@@ -750,7 +750,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
         listBeads: import('@trpc/server').TRPCQueryProcedure<{
           input: {
             rigId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
           };
           output: {
             bead_id: string;
@@ -762,7 +762,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               | 'merge_request'
               | 'message'
               | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'open';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
             title: string;
             body: string | null;
             rig_id: string | null;
@@ -833,7 +833,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                 | 'merge_request'
                 | 'message'
                 | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'open';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
               title: string;
               body: string | null;
               rig_id: string | null;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -316,6 +316,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         beads: {
           open: number;
           inProgress: number;
+          inReview: number;
           failed: number;
           triageRequests: number;
         };
@@ -914,6 +915,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             beads: {
               open: number;
               inProgress: number;
+              inReview: number;
               failed: number;
               triageRequests: number;
             };


### PR DESCRIPTION
## Summary

- **`in_review` bead state:** Beads now transition from `in_progress` to `in_review` when a polecat calls `gt_done`, rather than going straight to `closed`. The refinery review then closes the bead on merge or returns it to `in_progress` for rework. Wired through all layers: DB schemas, Zod enums, SQL CHECK constraints, tRPC schemas, generated `router.d.ts` types, container plugin `BeadStatus` type, and mayor `gt_list_beads` tool.
- **Rework re-dispatch:** On review failure or conflict, a polecat is assigned via `getOrCreateAgent` (not the original, which may already be busy) and dispatched to rework the bead automatically.
- **Triage handler 401 fix:** `handleResolveTriage` returned 401 in development because `authMiddleware` is skipped and `getEnforcedAgentId` returned null. Fixed with an `ENVIRONMENT === 'development'`-gated fallback to the `X-Gastown-Agent-Id` header.
- **Scheduling guard:** `hookBead` now rejects system-managed bead types (`escalation`, `convoy`, `agent`, `message`) and `gt:triage-request` beads, preventing polecats from accidentally being assigned to them.
- **Activity feed:** Added `triage_resolved` bead event type with ShieldCheck icon (amber) so triage actions appear on affected beads' timelines. Updated triage system prompt to encourage `gt_status` calls for dashboard visibility.
- **Dashboard stats:** `in_review` is now counted in `healthCheck()` pending beads, `getAlarmStatus()` bead counts (new `inReview` field), rig detail stats, town overview stats, and the TerminalBar status pane.
- **UI:** BeadBoard has 4 columns (Open, In Progress, In Review, Closed) with responsive loading skeleton. Town overview stats strip uses 5 columns with inline grid-template-columns. Purple theming for In Review throughout.

Closes #895

## Verification

- [x] `pnpm typecheck` passes across all 28 workspace projects
- [x] Rebase onto main — no conflicts
- [x] All 6 code review threads addressed and resolved

## Visual Changes

| Before | After |
| ------ | ----- |
| BeadBoard: 3 columns (Open, In Progress, Closed) | BeadBoard: 4 columns (Open, In Progress, In Review, Closed) |
| Rig stats: 3 cells | Rig stats: 4 cells (added In Review, purple) |
| Town stats: 4 cells | Town stats: 5 cells (added In Review with Eye icon) |
| TerminalBar beads: Open, In Progress, Failed, Triage | TerminalBar beads: Open, In Progress, In Review, Failed, Triage |
| Activity feed: no triage events | Activity feed: triage_resolved with ShieldCheck icon (amber) |

## Reviewer Notes

- No data migration needed — cloud Gastown hasn't deployed to production.
- The rework re-dispatch uses `getOrCreateAgent` to avoid stranding when the original polecat has moved on to other work.
- The triage auth fallback is explicitly gated on `ENVIRONMENT === 'development'` — production always uses the verified JWT identity.
- `hookBead` guard covers the HTTP API entry point (`POST /agents/:agentId/hook`) which was the only external vector for hooking agents to wrong bead types.