### PR TITLE
feat(admin): show cancelled rate and cancellation reasons on dashboard

### DIFF
--- a/src/app/admin/api/code-reviews/hooks.ts
+++ b/src/app/admin/api/code-reviews/hooks.ts
@@ -36,6 +36,14 @@ export function useCodeReviewPerformanceStats(params: FilterParams) {
   });
 }
 
+export function useCodeReviewCancellationAnalysis(params: FilterParams) {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.admin.codeReviews.getCancellationAnalysis.queryOptions(params),
+    enabled: Boolean(params.startDate && params.endDate),
+  });
+}
+
 export function useCodeReviewErrorAnalysis(params: FilterParams) {
   const trpc = useTRPC();
   return useQuery({

--- a/src/app/admin/code-reviews/page.tsx
+++ b/src/app/admin/code-reviews/page.tsx
@@ -6,6 +6,7 @@ import AdminPage from '@/app/admin/components/AdminPage';
 import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
 import { CodeReviewStats } from '@/app/admin/components/CodeReviewStats';
 import { CodeReviewDailyChart } from '@/app/admin/components/CodeReviewDailyChart';
+import { CodeReviewCancellationAnalysis } from '@/app/admin/components/CodeReviewCancellationAnalysis';
 import { CodeReviewErrorAnalysis } from '@/app/admin/components/CodeReviewErrorAnalysis';
 import { CodeReviewPerformanceChart } from '@/app/admin/components/CodeReviewPerformanceChart';
 import { CodeReviewUserSegmentation } from '@/app/admin/components/CodeReviewUserSegmentation';
@@ -16,6 +17,7 @@ import {
   useCodeReviewOverviewStats,
   useCodeReviewDailyStats,
   useCodeReviewPerformanceStats,
+  useCodeReviewCancellationAnalysis,
   useCodeReviewErrorAnalysis,
   useCodeReviewUserSegmentation,
   useSearchUsers,
@@ -105,6 +107,7 @@ export default function CodeReviewsPage() {
   const overviewQuery = useCodeReviewOverviewStats(filterParams);
   const dailyQuery = useCodeReviewDailyStats(filterParams);
   const performanceQuery = useCodeReviewPerformanceStats(filterParams);
+  const cancellationQuery = useCodeReviewCancellationAnalysis(filterParams);
   const errorQuery = useCodeReviewErrorAnalysis(filterParams);
   const segmentationQuery = useCodeReviewUserSegmentation(filterParams);
 
@@ -112,9 +115,17 @@ export default function CodeReviewsPage() {
     void overviewQuery.refetch();
     void dailyQuery.refetch();
     void performanceQuery.refetch();
+    void cancellationQuery.refetch();
     void errorQuery.refetch();
     void segmentationQuery.refetch();
-  }, [overviewQuery, dailyQuery, performanceQuery, errorQuery, segmentationQuery]);
+  }, [
+    overviewQuery,
+    dailyQuery,
+    performanceQuery,
+    cancellationQuery,
+    errorQuery,
+    segmentationQuery,
+  ]);
 
   // Handle selecting a user from search
   const handleSelectUser = (user: SelectedUser) => {
@@ -179,6 +190,7 @@ export default function CodeReviewsPage() {
     overviewQuery.isFetching ||
     dailyQuery.isFetching ||
     performanceQuery.isFetching ||
+    cancellationQuery.isFetching ||
     errorQuery.isFetching ||
     segmentationQuery.isFetching;
 
@@ -448,6 +460,11 @@ export default function CodeReviewsPage() {
               />
             )}
 
+            {/* Cancellation Reasons */}
+            {cancellationQuery.data && (
+              <CodeReviewCancellationAnalysis data={cancellationQuery.data} />
+            )}
+
             {/* Error Analysis */}
             {errorQuery.data && <CodeReviewErrorAnalysis data={errorQuery.data} />}
           </>
@@ -457,6 +474,7 @@ export default function CodeReviewsPage() {
         {(overviewQuery.error ||
           dailyQuery.error ||
           performanceQuery.error ||
+          cancellationQuery.error ||
           errorQuery.error ||
           segmentationQuery.error) && (
           <div className="rounded-lg border border-red-200 bg-red-50 p-4">
@@ -465,6 +483,7 @@ export default function CodeReviewsPage() {
               {overviewQuery.error?.message ||
                 dailyQuery.error?.message ||
                 performanceQuery.error?.message ||
+                cancellationQuery.error?.message ||
                 errorQuery.error?.message ||
                 segmentationQuery.error?.message ||
                 'Unknown error'}

--- a/src/app/admin/components/CodeReviewCancellationAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewCancellationAnalysis.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatDate } from '@/lib/admin-utils';
+
+type CancellationReason = {
+  reason: string;
+  count: number;
+  firstOccurrence: string;
+  lastOccurrence: string;
+};
+
+const REASON_COLORS: Record<string, string> = {
+  'Superseded by new commit': 'bg-blue-500',
+  'No credits (billing)': 'bg-yellow-500',
+  'Stream timeout': 'bg-orange-500',
+  'Explicitly cancelled': 'bg-slate-500',
+  'Process killed': 'bg-red-500',
+  'User interrupted': 'bg-purple-500',
+  'No reason provided': 'bg-gray-400',
+  Other: 'bg-gray-500',
+};
+
+export function CodeReviewCancellationAnalysis({ data }: { data: CancellationReason[] }) {
+  const totalCancelled = data.reduce((sum, r) => sum + r.count, 0);
+  const maxCount = Math.max(...data.map(r => r.count), 1);
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Cancellation Reasons</CardTitle>
+          <CardDescription>No cancellations in selected period</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            No cancelled reviews found in this time range.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cancellation Reasons</CardTitle>
+        <CardDescription>{totalCancelled.toLocaleString()} total cancellations</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {data.map(row => {
+          const pct = totalCancelled > 0 ? (row.count / totalCancelled) * 100 : 0;
+          const barWidth = (row.count / maxCount) * 100;
+          const colorClass = REASON_COLORS[row.reason] ?? 'bg-gray-500';
+          return (
+            <div key={row.reason} className="flex items-center gap-3">
+              <span className="w-52 shrink-0 truncate text-right text-xs font-medium">
+                {row.reason}
+              </span>
+              <div className="bg-muted relative h-5 flex-1 overflow-hidden rounded">
+                <div
+                  className={`${colorClass} absolute inset-y-0 left-0 rounded transition-all`}
+                  style={{ width: `${barWidth}%` }}
+                />
+              </div>
+              <span className="text-muted-foreground w-32 shrink-0 text-right text-xs">
+                {row.count.toLocaleString()} ({pct.toFixed(1)}%)
+              </span>
+              <span className="text-muted-foreground w-28 shrink-0 text-right text-xs">
+                {formatDate(row.lastOccurrence)}
+              </span>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/components/CodeReviewStats.tsx
+++ b/src/app/admin/components/CodeReviewStats.tsx
@@ -19,6 +19,7 @@ type StatsData = {
   inProgressCount: number;
   successRate: number;
   failureRate: number;
+  cancelledRate: number;
   avgDurationSeconds: number;
   versionBreakdown?: VersionBreakdownRow[];
 };
@@ -40,7 +41,7 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
   const showVersionBreakdown = byVersion.size > 0;
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-6">
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium">Total Reviews</CardTitle>
@@ -109,6 +110,16 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
               })}
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Cancelled Rate</CardTitle>
+          <CardDescription>{data.cancelledCount.toLocaleString()} cancelled</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-3xl font-bold text-yellow-500">{data.cancelledRate.toFixed(1)}%</div>
         </CardContent>
       </Card>
 

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -244,12 +244,12 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     ].filter(Boolean) as SQL[];
 
     const cancellationReasonExpr = sql<string>`CASE
-      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%superseded%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Superseded%' THEN 'Superseded by new commit'
-      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%paid model%' OR ${cloud_agent_code_reviews.error_message} LIKE '%add credits%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Add credits%' THEN 'No credits (billing)'
-      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%Stream timeout%' OR ${cloud_agent_code_reviews.error_message} LIKE '%stream timeout%' THEN 'Stream timeout'
-      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%cancelled%' OR ${cloud_agent_code_reviews.error_message} LIKE '%canceled%' THEN 'Explicitly cancelled'
-      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%Killed%' OR ${cloud_agent_code_reviews.error_message} LIKE '%SIGKILL%' OR ${cloud_agent_code_reviews.error_message} LIKE '%SIGTERM%' THEN 'Process killed'
-      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%Interrupted%' THEN 'User interrupted'
+      WHEN ${cloud_agent_code_reviews.error_message} ILIKE '%superseded%' THEN 'Superseded by new commit'
+      WHEN ${cloud_agent_code_reviews.error_message} ILIKE '%paid model%' OR ${cloud_agent_code_reviews.error_message} ILIKE '%add credits%' THEN 'No credits (billing)'
+      WHEN ${cloud_agent_code_reviews.error_message} ILIKE '%stream timeout%' THEN 'Stream timeout'
+      WHEN ${cloud_agent_code_reviews.error_message} ILIKE '%cancelled%' OR ${cloud_agent_code_reviews.error_message} ILIKE '%canceled%' THEN 'Explicitly cancelled'
+      WHEN ${cloud_agent_code_reviews.error_message} ILIKE '%killed%' OR ${cloud_agent_code_reviews.error_message} ILIKE '%sigkill%' OR ${cloud_agent_code_reviews.error_message} ILIKE '%sigterm%' THEN 'Process killed'
+      WHEN ${cloud_agent_code_reviews.error_message} ILIKE '%interrupted%' THEN 'User interrupted'
       WHEN ${cloud_agent_code_reviews.error_message} IS NULL THEN 'No reason provided'
       ELSE 'Other'
     END`;

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -173,8 +173,9 @@ export const adminCodeReviewsRouter = createTRPCRouter({
       // Success rate = completed / terminal states
       successRate: terminalCount > 0 ? (completedCount / terminalCount) * 100 : 0,
       // Failure rate = (failed + interrupted) / terminal states
-      // Note: cancelled and insufficient credits are neutral (not success, not failure)
       failureRate: terminalCount > 0 ? ((failedCount + interruptedCount) / terminalCount) * 100 : 0,
+      // Cancelled rate = cancelled / terminal states (the remainder to reach 100%)
+      cancelledRate: terminalCount > 0 ? (cancelledCount / terminalCount) * 100 : 0,
       avgDurationSeconds: Number(stats.avg_duration_seconds) || 0,
       versionBreakdown: versionBreakdown?.map(row => ({
         agentVersion: row.agent_version,

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -229,6 +229,51 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     }));
   }),
 
+  // Get cancellation reasons analysis
+  getCancellationAnalysis: adminProcedure.input(FilterSchema).query(async ({ input }) => {
+    const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;
+    const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+    const agentVersionFilter = buildAgentVersionFilter(agentVersion);
+
+    const conditions = [
+      eq(cloud_agent_code_reviews.status, 'cancelled'),
+      gte(cloud_agent_code_reviews.created_at, startDate),
+      lt(cloud_agent_code_reviews.created_at, endDate),
+      ownershipFilter,
+      agentVersionFilter,
+    ].filter(Boolean) as SQL[];
+
+    const cancellationReasonExpr = sql<string>`CASE
+      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%superseded%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Superseded%' THEN 'Superseded by new commit'
+      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%paid model%' OR ${cloud_agent_code_reviews.error_message} LIKE '%add credits%' OR ${cloud_agent_code_reviews.error_message} LIKE '%Add credits%' THEN 'No credits (billing)'
+      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%Stream timeout%' OR ${cloud_agent_code_reviews.error_message} LIKE '%stream timeout%' THEN 'Stream timeout'
+      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%cancelled%' OR ${cloud_agent_code_reviews.error_message} LIKE '%canceled%' THEN 'Explicitly cancelled'
+      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%Killed%' OR ${cloud_agent_code_reviews.error_message} LIKE '%SIGKILL%' OR ${cloud_agent_code_reviews.error_message} LIKE '%SIGTERM%' THEN 'Process killed'
+      WHEN ${cloud_agent_code_reviews.error_message} LIKE '%Interrupted%' THEN 'User interrupted'
+      WHEN ${cloud_agent_code_reviews.error_message} IS NULL THEN 'No reason provided'
+      ELSE 'Other'
+    END`;
+
+    const reasons = await db
+      .select({
+        reason: cancellationReasonExpr,
+        count: sql<number>`COUNT(*)`,
+        first_occurrence: sql<string>`MIN(${cloud_agent_code_reviews.created_at})::text`,
+        last_occurrence: sql<string>`MAX(${cloud_agent_code_reviews.created_at})::text`,
+      })
+      .from(cloud_agent_code_reviews)
+      .where(and(...conditions))
+      .groupBy(cancellationReasonExpr)
+      .orderBy(desc(sql`COUNT(*)`));
+
+    return reasons.map(row => ({
+      reason: row.reason,
+      count: Number(row.count) || 0,
+      firstOccurrence: row.first_occurrence,
+      lastOccurrence: row.last_occurrence,
+    }));
+  }),
+
   // Get error analysis (excludes "Insufficient credits" billing errors from the list)
   getErrorAnalysis: adminProcedure.input(FilterSchema).query(async ({ input }) => {
     const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;


### PR DESCRIPTION
## Summary

- The code review dashboard showed success rate (47%) and failure rate (11%) that didn't add up to 100%. The missing ~42% was cancelled reviews sitting in the denominator but not shown anywhere.
- Added a yellow **Cancelled Rate** KPI card so all three rates visibly sum to 100%.
- Added a new **Cancellation Reasons** bar chart (above error analysis) that breaks down why reviews were cancelled: superseded by new commit, no credits, stream timeout, user-cancelled, etc.

## Verification

- [x] `pnpm typecheck` passes with no errors
- [x] Queried prod DB (read-only) to confirm cancellation reason categorization matches real data

## Visual Changes

The KPI row now has 6 cards instead of 5, with a yellow "Cancelled Rate" card between Failure Rate and Avg Duration)

<img width="2253" height="960" alt="Screenshot 2026-03-11 at 17 59 26" src="https://github.com/user-attachments/assets/7a9f58fd-4337-4b25-bc39-73f63f81d446" />

## Reviewer Notes

- The V1 cancellation rate is ~42% vs V2's ~15%. The main drivers are billing-blocked reviews (users without credits on paid models) and stream timeouts — both V1-specific issues.
- The cancellation reason SQL uses `CASE WHEN` pattern matching on `error_message` since there's no dedicated `cancellation_reason` column.