### PR TITLE
feat(billing): restrict Rewardful commissions to KiloClaw purchases

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -117,7 +117,7 @@ export default function RootLayout({
         {process.env.NEXT_PUBLIC_REWARDFUL_ID && (
           <>
             <Script id="rewardful-queue" strategy="beforeInteractive">
-              {`(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q||[]).push(arguments)}})(window,'rewardful');rewardful('ready',function(){if(Rewardful.referral){document.cookie='rewardful_referral='+encodeURIComponent(Rewardful.referral)+';path=/;max-age=7776000;SameSite=Lax'+(location.protocol==='https:'?';Secure':'')}});`}
+              {`(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q||[]).push(arguments)}})(window,'rewardful');rewardful('ready',function(){if(Rewardful.referral){document.cookie='rewardful_referral='+encodeURIComponent(Rewardful.referral)+';path=/;max-age=5184000;SameSite=Lax'+(location.protocol==='https:'?';Secure':'')}});`}
             </Script>
             <Script
               strategy="beforeInteractive"

--- a/src/lib/organizations/organization-auto-top-up.ts
+++ b/src/lib/organizations/organization-auto-top-up.ts
@@ -65,6 +65,7 @@ export async function createOrgAutoTopUpSetupCheckoutSession(
         kiloUserId,
         organizationId,
         amountCents: String(amountCents),
+        rewardful: 'false',
       },
       setup_future_usage: 'off_session',
     },

--- a/src/lib/organizations/organization-auto-top-up.ts
+++ b/src/lib/organizations/organization-auto-top-up.ts
@@ -48,6 +48,9 @@ export async function createOrgAutoTopUpSetupCheckoutSession(
     ],
     invoice_creation: {
       enabled: true,
+      invoice_data: {
+        metadata: { rewardful: 'false' },
+      },
     },
     customer_update: {
       name: 'auto',
@@ -65,7 +68,6 @@ export async function createOrgAutoTopUpSetupCheckoutSession(
         kiloUserId,
         organizationId,
         amountCents: String(amountCents),
-        rewardful: 'false',
       },
       setup_future_usage: 'off_session',
     },

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -77,7 +77,6 @@ export type StripeTopupMetadata = {
   type?: string;
   kiloUserId?: User['id'];
   organizationId?: Organization['id'] | null;
-  rewardful?: string;
 };
 
 export async function detachAllPaymentMethods(user: User) {
@@ -924,6 +923,9 @@ export async function createAutoTopUpSetupCheckoutSession(
     ],
     invoice_creation: {
       enabled: true,
+      invoice_data: {
+        metadata: { rewardful: 'false' },
+      },
     },
     customer_update: {
       name: 'auto',
@@ -940,7 +942,6 @@ export async function createAutoTopUpSetupCheckoutSession(
         type: 'auto-topup-setup',
         kiloUserId,
         amountCents: String(amountCents),
-        rewardful: 'false',
       },
       // KEY CONFIGURATION: This saves the payment method for future off-session charges
       setup_future_usage: 'off_session',
@@ -993,6 +994,9 @@ export async function getStripeTopUpCheckoutUrl(
     line_items: line_items,
     invoice_creation: {
       enabled: true,
+      invoice_data: {
+        metadata: { rewardful: 'false' },
+      },
     },
     customer_update: {
       name: 'auto',
@@ -1009,7 +1013,6 @@ export async function getStripeTopUpCheckoutUrl(
         type: 'stripe-checkout-topup',
         kiloUserId,
         organizationId: organizationId ?? null,
-        rewardful: 'false',
       } satisfies StripeTopupMetadata,
     },
     saved_payment_method_options: {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -77,6 +77,7 @@ export type StripeTopupMetadata = {
   type?: string;
   kiloUserId?: User['id'];
   organizationId?: Organization['id'] | null;
+  rewardful?: string;
 };
 
 export async function detachAllPaymentMethods(user: User) {
@@ -939,6 +940,7 @@ export async function createAutoTopUpSetupCheckoutSession(
         type: 'auto-topup-setup',
         kiloUserId,
         amountCents: String(amountCents),
+        rewardful: 'false',
       },
       // KEY CONFIGURATION: This saves the payment method for future off-session charges
       setup_future_usage: 'off_session',
@@ -1007,6 +1009,7 @@ export async function getStripeTopUpCheckoutUrl(
         type: 'stripe-checkout-topup',
         kiloUserId,
         organizationId: organizationId ?? null,
+        rewardful: 'false',
       } satisfies StripeTopupMetadata,
     },
     saved_payment_method_options: {
@@ -1106,7 +1109,7 @@ export async function getStripeSeatsCheckoutUrl(
         isSubscription: 'yes',
       },
       subscription_data: {
-        metadata: subscriptionMetadata,
+        metadata: { ...subscriptionMetadata, rewardful: 'false' },
       },
     });
 

--- a/src/routers/kilo-pass-router.test.ts
+++ b/src/routers/kilo-pass-router.test.ts
@@ -1471,6 +1471,7 @@ describe('kiloPassRouter', () => {
               kiloUserId: user.id,
               tier: 'tier_49',
               cadence: 'yearly',
+              rewardful: 'false',
             },
           },
           metadata: {

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -954,6 +954,7 @@ export const kiloPassRouter = createTRPCRouter({
             kiloUserId: ctx.user.id,
             tier,
             cadence,
+            rewardful: 'false',
           },
         },
         metadata: {


### PR DESCRIPTION
## Summary

Restricts Rewardful affiliate commissions to KiloClaw purchases only by adding `rewardful: 'false'` to Stripe metadata on all non-KiloClaw checkout sessions. Also fixes the referral cookie `max-age` to 60 days (5184000s) to match the affiliate program T&Cs.

Changes:
- **Cookie duration**: `max-age` corrected from 90 days to 60 days in the Rewardful inline script (`layout.tsx`)
- **Commission suppression**: Added `rewardful: 'false'` to `payment_intent_data.metadata` (payment-mode) or `subscription_data.metadata` (subscription-mode) on 5 checkout flows: credit top-ups, auto top-up setup, org auto top-up setup, org seat subscriptions, and Kilo Pass subscriptions
- **KiloClaw earlybird checkout is unchanged** — commissions apply there as intended
- Added `rewardful` as an optional field to `StripeTopupMetadata` to satisfy the existing `satisfies` check

## Verification

- [x] `pnpm typecheck` — passes

## Visual Changes

N/A

## Reviewer Notes

- Per [Rewardful docs](https://support.rewardful.com/en/articles/4821-how-can-i-skip-paying-a-commission-for-certain-payments), `rewardful: 'false'` in Stripe metadata on Customer, Subscription, Invoice, or Charge causes Rewardful to skip commission. For payment-mode checkouts, `payment_intent_data.metadata` flows to the Charge; for subscription-mode, `subscription_data.metadata` flows to both Subscription and Invoices.
- The `client_reference_id` is still passed on all checkouts (including non-KiloClaw ones) so Rewardful can link the customer to the affiliate for attribution tracking — the metadata flag only suppresses the commission payout.