### PR TITLE
refactor(kiloclaw): rename restartGateway to restartMachine

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2903,10 +2903,10 @@ describe('auto-destroy stale provisioned instances', () => {
 });
 
 // ============================================================================
-// restartGateway image tag override
+// restartMachine image tag override
 // ============================================================================
 
-describe('restartGateway image tag override', () => {
+describe('restartMachine image tag override', () => {
   beforeEach(() => {
     (flyClient.stopMachineAndWait as Mock).mockResolvedValue(undefined);
     (flyClient.updateMachine as Mock).mockResolvedValue(undefined);
@@ -2921,7 +2921,7 @@ describe('restartGateway image tag override', () => {
     const { instance, storage } = createInstance();
     await seedRunning(storage, { trackedImageTag: 'old-tag-123' });
 
-    const result = await instance.restartGateway();
+    const result = await instance.restartMachine();
 
     expect(result.success).toBe(true);
     expect(resolveLatestVersion).not.toHaveBeenCalled();
@@ -2944,7 +2944,7 @@ describe('restartGateway image tag override', () => {
       publishedAt: new Date().toISOString(),
     });
 
-    const result = await instance.restartGateway({ imageTag: 'latest' });
+    const result = await instance.restartMachine({ imageTag: 'latest' });
 
     expect(result.success).toBe(true);
     expect(resolveLatestVersion).toHaveBeenCalledOnce();
@@ -2959,7 +2959,7 @@ describe('restartGateway image tag override', () => {
 
     (resolveLatestVersion as Mock).mockResolvedValueOnce(null);
 
-    const result = await instance.restartGateway({ imageTag: 'latest' });
+    const result = await instance.restartMachine({ imageTag: 'latest' });
 
     expect(result.success).toBe(true);
     expect(resolveLatestVersion).toHaveBeenCalledOnce();
@@ -2975,7 +2975,7 @@ describe('restartGateway image tag override', () => {
       imageVariant: 'default',
     });
 
-    const result = await instance.restartGateway({ imageTag: '2026.2.25-abc123' });
+    const result = await instance.restartMachine({ imageTag: '2026.2.25-abc123' });
 
     expect(result.success).toBe(true);
     expect(resolveLatestVersion).not.toHaveBeenCalled();

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -929,9 +929,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return gateway.patchConfigOnMachine(this.s, this.env, patch);
   }
 
-  // ── Restart gateway (user-facing) ──────────────────────────────────
+  // ── Restart machine (user-facing) ──────────────────────────────────
 
-  async restartGateway(options?: {
+  async restartMachine(options?: {
     imageTag?: string;
   }): Promise<{ success: boolean; error?: string }> {
     await this.loadState();
@@ -946,7 +946,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         : `pin-to-tag:${options.imageTag}`
       : 'redeploy-same-image';
     console.log(
-      '[DO] restartGateway:',
+      '[DO] restartMachine:',
       action,
       '| current trackedImageTag:',
       this.s.trackedImageTag
@@ -998,13 +998,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       } catch (stopErr) {
         const isTimeout = stopErr instanceof fly.FlyApiError && stopErr.status === 408;
         if (!isTimeout) throw stopErr;
-        console.warn('[DO] restartGateway: stop timed out, will update in-place:', stopErr.message);
+        console.warn('[DO] restartMachine: stop timed out, will update in-place:', stopErr.message);
       }
 
       const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
       const guest = guestFromSize(this.s.machineSize);
       const imageTag = resolveImageTag(this.s, this.env);
-      console.log('[DO] restartGateway: deploying with imageTag:', imageTag);
+      console.log('[DO] restartMachine: deploying with imageTag:', imageTag);
       const identity = {
         userId: this.s.userId ?? '',
         sandboxId: this.s.sandboxId ?? '',

--- a/kiloclaw/src/routes/api.ts
+++ b/kiloclaw/src/routes/api.ts
@@ -37,7 +37,33 @@ adminApi.post('/storage/sync', async c => {
   );
 });
 
-// POST /api/admin/gateway/restart - Restart the Fly Machine via the DO
+// POST /api/admin/machine/restart - Restart the Fly Machine via the DO
+adminApi.post('/machine/restart', async c => {
+  const stub = resolveStub(c);
+  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const rawTag = typeof body.imageTag === 'string' ? body.imageTag : undefined;
+
+  if (rawTag && !isValidImageTag(rawTag)) {
+    return c.json({ success: false, error: 'Invalid image tag format' }, 400);
+  }
+
+  const imageTag = rawTag;
+  const result = await stub.restartMachine(imageTag ? { imageTag } : undefined);
+
+  if (result.success) {
+    return c.json({
+      success: true,
+      message: imageTag
+        ? `Machine restarting with image tag: ${imageTag}...`
+        : 'Machine restarting with updated configuration...',
+    });
+  } else {
+    return c.json({ success: false, error: result.error }, 500);
+  }
+});
+
+// TODO: Remove after frontend rollout to /api/admin/machine/restart
+// POST /api/admin/gateway/restart - Backward-compat alias for machine restart
 adminApi.post('/gateway/restart', async c => {
   const stub = resolveStub(c);
   const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
@@ -48,7 +74,7 @@ adminApi.post('/gateway/restart', async c => {
   }
 
   const imageTag = rawTag;
-  const result = await stub.restartGateway(imageTag ? { imageTag } : undefined);
+  const result = await stub.restartMachine(imageTag ? { imageTag } : undefined);
 
   if (result.success) {
     return c.json({

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -113,7 +113,7 @@ export function InstanceControls({
           size="sm"
           variant="outline"
           className="border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
-          disabled={!isRunning || mutations.restartGateway.isPending || isDestroying}
+          disabled={!isRunning || mutations.restartMachine.isPending || isDestroying}
           onClick={() => {
             posthog?.capture('claw_redeploy_prompted', { instance_status: status.status });
             setRedeployMode('redeploy');
@@ -166,7 +166,7 @@ export function InstanceControls({
       <Dialog
         open={confirmRedeploy}
         onOpenChange={open => {
-          if (mutations.restartGateway.isPending) return;
+          if (mutations.restartMachine.isPending) return;
           if (!open) posthog?.capture('claw_redeploy_cancelled');
           setConfirmRedeploy(open);
         }}
@@ -210,7 +210,7 @@ export function InstanceControls({
             <Button
               variant="outline"
               onClick={() => setConfirmRedeploy(false)}
-              disabled={mutations.restartGateway.isPending}
+              disabled={mutations.restartMachine.isPending}
             >
               Cancel
             </Button>
@@ -222,12 +222,10 @@ export function InstanceControls({
                   instance_status: status.status,
                   redeploy_mode: redeployMode,
                 });
-                mutations.restartGateway.mutate(imageTag ? { imageTag } : undefined, {
+                mutations.restartMachine.mutate(imageTag ? { imageTag } : undefined, {
                   onSuccess: () => {
                     toast.success(
-                      redeployMode === 'upgrade'
-                        ? 'Upgrading to latest image'
-                        : 'Gateway restarting'
+                      redeployMode === 'upgrade' ? 'Upgrading to latest image' : 'Redeploying'
                     );
                     setConfirmRedeploy(false);
                     onRedeploySuccess?.();
@@ -235,9 +233,9 @@ export function InstanceControls({
                   onError: err => toast.error(err.message),
                 });
               }}
-              disabled={mutations.restartGateway.isPending}
+              disabled={mutations.restartMachine.isPending}
             >
-              {mutations.restartGateway.isPending ? (
+              {mutations.restartMachine.isPending ? (
                 <>
                   {redeployMode === 'redeploy' ? 'Redeploying' : 'Upgrading'}
                   <AnimatedDots />

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -123,8 +123,8 @@ export function useKiloClawMutations() {
         },
       })
     ),
-    restartGateway: useMutation(
-      trpc.kiloclaw.restartGateway.mutationOptions({
+    restartMachine: useMutation(
+      trpc.kiloclaw.restartMachine.mutationOptions({
         onSuccess: async () => {
           await invalidateStatus();
           await queryClient.invalidateQueries({

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { KILOCLAW_API_URL } from '@/lib/config.server';
 import { KiloClawApiError } from './kiloclaw-internal-client';
-import type { UserConfigResponse, PlatformStatusResponse, RestartGatewayResponse } from './types';
+import type { UserConfigResponse, PlatformStatusResponse, RestartMachineResponse } from './types';
 
 /**
  * KiloClaw worker client for user-facing routes.
@@ -50,8 +50,8 @@ export class KiloClawUserClient {
     return this.request('/api/kiloclaw/status');
   }
 
-  async restartGateway(options?: { imageTag?: string }): Promise<RestartGatewayResponse> {
-    return this.request('/api/admin/gateway/restart', {
+  async restartMachine(options?: { imageTag?: string }): Promise<RestartMachineResponse> {
+    return this.request('/api/admin/machine/restart', {
       method: 'POST',
       body: options?.imageTag ? JSON.stringify({ imageTag: options.imageTag }) : undefined,
     });

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -188,8 +188,8 @@ export type DoctorResponse = {
   output: string;
 };
 
-/** Response from POST /api/admin/gateway/restart */
-export type RestartGatewayResponse = {
+/** Response from POST /api/admin/machine/restart */
+export type RestartMachineResponse = {
   success: boolean;
   message?: string;
   error?: string;

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -379,7 +379,7 @@ export const kiloclawRouter = createTRPCRouter({
     return client.getConfig();
   }),
 
-  restartGateway: baseProcedure
+  restartMachine: baseProcedure
     .input(
       z
         .object({
@@ -398,7 +398,7 @@ export const kiloclawRouter = createTRPCRouter({
       const client = new KiloClawUserClient(
         generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
       );
-      return client.restartGateway(input?.imageTag ? { imageTag: input.imageTag } : undefined);
+      return client.restartMachine(input?.imageTag ? { imageTag: input.imageTag } : undefined);
     }),
 
   listPairingRequests: baseProcedure


### PR DESCRIPTION
## Summary

The DO method `restartGateway` performs a full Fly Machine restart (stop → update config/image/env → start), not a gateway process restart. This was confusing because a separate `restartGatewayProcess()` method exists that actually restarts the gateway process inside the running machine. This PR renames the machine-level restart to `restartMachine` across the full stack:

- **KiloClaw DO** (`index.ts`): Method `restartGateway` → `restartMachine`, updated log messages.
- **KiloClaw routes** (`api.ts`): Added new `/api/admin/machine/restart` route; kept old `/gateway/restart` as backward-compat alias (both call `stub.restartMachine()`).
- **Next.js client** (`kiloclaw-user-client.ts`): Method and URL updated to `/api/admin/machine/restart`.
- **tRPC router** (`kiloclaw-router.ts`): Mutation renamed `restartGateway` → `restartMachine`.
- **React hook** (`useKiloClaw.ts`): Property renamed accordingly.
- **UI** (`InstanceControls.tsx`): All references updated; toast changed from `'Gateway restarting'` → `'Redeploying'`.
- **Types** (`types.ts`): `RestartGatewayResponse` → `RestartMachineResponse`.

**Not changed** (names are already accurate): `restartGatewayProcess()`, `gatewayRestart` admin tRPC mutation, platform gateway process routes.

### Rollout plan (two phases)

This ships in two phases since the kiloclaw worker and Next.js frontend deploy independently:

1. **Phase 1 (this PR):** Deploy kiloclaw worker first — it registers both `/api/admin/machine/restart` (new) and `/api/admin/gateway/restart` (backward-compat alias), so existing UI versions continue to work.
2. **Phase 2 (this PR):** Deploy the Next.js frontend — it now hits the new `/api/admin/machine/restart` endpoint.
3. **Follow-up cleanup:** Once no old frontend versions are active, remove the old `/gateway/restart` route from kiloclaw (marked with a `// TODO` comment).

## Verification

- [x] `pnpm typecheck && pnpm test && pnpm lint` in `kiloclaw/` — 537 tests passed, 0 errors
- [x] `pnpm typecheck` for full monorepo — all 29 workspace projects pass
- [x] Grep confirmed no stale `restartGateway` references remain (only `restartGatewayProcess` which is intentionally unchanged)
- [ ] _Additional verification by reviewer_
 - hit restart and upgrade button and saw it hit the new url

## Visual Changes



## Reviewer Notes

- **Deploy order matters**: Deploy kiloclaw worker first (has both routes), then Next.js. The old route is kept alive so old frontend versions don't break during rollout.
- The old `/gateway/restart` route has a `// TODO: Remove after frontend rollout` comment for later cleanup once all frontends are on the new path.
- The toast text change from `'Gateway restarting'` to `'Redeploying'` aligns with the button label ("Redeploy or Upgrade") and dialog copy that already say "machine".