### PR TITLE
chore(kiloclaw): remove deprecated /gateway/restart route

### DIFF
--- a/kiloclaw/src/routes/api.ts
+++ b/kiloclaw/src/routes/api.ts
@@ -62,32 +62,6 @@ adminApi.post('/machine/restart', async c => {
   }
 });
 
-// TODO: Remove after frontend rollout to /api/admin/machine/restart
-// POST /api/admin/gateway/restart - Backward-compat alias for machine restart
-adminApi.post('/gateway/restart', async c => {
-  const stub = resolveStub(c);
-  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
-  const rawTag = typeof body.imageTag === 'string' ? body.imageTag : undefined;
-
-  if (rawTag && !isValidImageTag(rawTag)) {
-    return c.json({ success: false, error: 'Invalid image tag format' }, 400);
-  }
-
-  const imageTag = rawTag;
-  const result = await stub.restartMachine(imageTag ? { imageTag } : undefined);
-
-  if (result.success) {
-    return c.json({
-      success: true,
-      message: imageTag
-        ? `Machine restarting with image tag: ${imageTag}...`
-        : 'Machine restarting with updated configuration...',
-    });
-  } else {
-    return c.json({ success: false, error: result.error }, 500);
-  }
-});
-
 // Mount admin API routes under /admin
 api.route('/admin', adminApi);
 


### PR DESCRIPTION
## Summary

Removes the backward-compat `/api/admin/gateway/restart` route from the kiloclaw worker. This was kept temporarily during the `restartGateway` → `restartMachine` rename (#1038) so that old frontend versions could still reach the machine restart endpoint. Now that #1038 has been deployed and all frontends use `/api/admin/machine/restart`, the old alias is no longer needed.

Single file change: 26 lines deleted from `kiloclaw/src/routes/api.ts`.

## Verification

- [x] `pnpm typecheck` in `kiloclaw/` — pass
- [x] `pnpm test` in `kiloclaw/` — 537 tests passed
- [x] `pnpm lint` in `kiloclaw/` — pass
- [ ] _Additional verification by reviewer_

## Visual Changes

N/A

## Reviewer Notes

- This is the cleanup step planned in #1038. The route was marked with `// TODO: Remove after frontend rollout to /api/admin/machine/restart`.
- No frontend changes — the frontend was already updated to use `/machine/restart` in #1038.
- Only the kiloclaw worker is affected.