### PR TITLE
refactor(kiloclaw): rename onChannelsChanged/dirtyChannels to onSecretsChanged/dirtySecrets

### DIFF
--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -48,13 +48,13 @@ export function ClawDashboard({ status }: { status: KiloClawDashboardStatus | un
   const { data: isServiceDegraded } = useKiloClawServiceDegraded();
   const { data: earlybirdStatus } = useQuery(trpc.kiloclaw.getEarlybirdStatus.queryOptions());
 
-  const [dirtyChannels, setDirtyChannels] = useState<Set<string>>(new Set());
+  const [dirtySecrets, setDirtySecrets] = useState<Set<string>>(new Set());
 
-  const onChannelsChanged = useCallback((channelType: string) => {
-    setDirtyChannels(prev => new Set([...prev, channelType]));
+  const onSecretsChanged = useCallback((entryId: string) => {
+    setDirtySecrets(prev => new Set([...prev, entryId]));
   }, []);
   const onRedeploySuccess = useCallback(() => {
-    setDirtyChannels(new Set());
+    setDirtySecrets(new Set());
   }, []);
 
   return (
@@ -134,8 +134,8 @@ export function ClawDashboard({ status }: { status: KiloClawDashboardStatus | un
                   <SettingsTab
                     status={instanceStatus}
                     mutations={mutations}
-                    onChannelsChanged={onChannelsChanged}
-                    dirtyChannels={dirtyChannels}
+                    onSecretsChanged={onSecretsChanged}
+                    dirtySecrets={dirtySecrets}
                   />
                 </TabsContent>
               </CardContent>

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -29,13 +29,13 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 export function SettingsTab({
   status,
   mutations,
-  onChannelsChanged,
-  dirtyChannels,
+  onSecretsChanged,
+  dirtySecrets,
 }: {
   status: KiloClawDashboardStatus;
   mutations: ClawMutations;
-  onChannelsChanged?: (channelType: string) => void;
-  dirtyChannels: Set<string>;
+  onSecretsChanged?: (entryId: string) => void;
+  dirtySecrets: Set<string>;
 }) {
   const posthog = usePostHog();
   const { data: config } = useKiloClawConfig();
@@ -280,8 +280,8 @@ export function SettingsTab({
               entry={entry}
               configured={configuredSecrets[entry.id] ?? false}
               mutations={mutations}
-              onSecretsChanged={onChannelsChanged}
-              isDirty={dirtyChannels.has(entry.id)}
+              onSecretsChanged={onSecretsChanged}
+              isDirty={dirtySecrets.has(entry.id)}
             />
           ))}
         </div>


### PR DESCRIPTION


<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Renames the `onChannelsChanged`/`dirtyChannels` prop and state pair to `onSecretsChanged`/`dirtySecrets` across   `ClawDashboard.tsx` and `SettingsTab.tsx`. Also renames the callback parameter from `channelType` to `entryId` to match what     it actually tracks (catalog entry IDs, not channel types).       

This fixes a naming mismatch introduced during the catalog migration — `SettingsTab` was receiving `onChannelsChanged` from   its parent but passing it as `onSecretsChanged` to `SecretEntrySection`. P1 cleanup item from the [secret-catalog-registry   plan](plans/secret-catalog-registry.md).


## Verification

- TypeScript typecheck passes (no type changes, just renames)
- Prettier formatting passes
- Grep confirms zero remaining references to `onChannelsChanged` or `dirtyChannels` in `src/`


## Visual Changes

N/A

## Reviewer Notes


- **2 files, 12 lines changed** — mechanical rename, no logic changes
- The UI-visible "Channels" heading and `DetailTile` label are intentionally unchanged. Those describe the current secret   category shown to users and will be revisited when non-channel categories (tools, providers) are added
- `SecretEntrySection` already used `onSecretsChanged` as its prop name — this rename just makes the parent chain consistent
