### PR TITLE
Feat(version) Fix openclaw version update indicator

### DIFF
--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -7,9 +7,14 @@ import { toast } from 'sonner';
 import { useOpenRouterModels } from '@/app/api/openrouter/hooks';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
-import { calverAtLeast, cleanVersion } from '@/lib/kiloclaw/version';
+import { calverAtLeast, cleanVersion, getRunningVersionBadge } from '@/lib/kiloclaw/version';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { useControllerVersion, useKiloClawConfig, useKiloClawMyPin } from '@/hooks/useKiloClaw';
+import {
+  useControllerVersion,
+  useKiloClawConfig,
+  useKiloClawLatestVersion,
+  useKiloClawMyPin,
+} from '@/hooks/useKiloClaw';
 import { useDefaultModelSelection } from '../hooks/useDefaultModelSelection';
 import { getSettingsModelOptions } from './modelSupport';
 
@@ -47,10 +52,12 @@ export function SettingsTab({
     isError: isControllerVersionError,
   } = useControllerVersion(isRunning);
   const { data: myPin } = useKiloClawMyPin();
+  const { data: latestVersion } = useKiloClawLatestVersion();
   const [confirmDestroy, setConfirmDestroy] = useState(false);
   const [confirmRestore, setConfirmRestore] = useState(false);
   const trackedVersion = cleanVersion(status.openclawVersion);
   const runningVersion = cleanVersion(controllerVersion?.openclawVersion);
+  const latestAvailableVersion = cleanVersion(latestVersion?.openclawVersion);
   const hasModelSelectionError = isRunning && isControllerVersionError;
   const modelSelectionError = hasModelSelectionError
     ? 'Failed to load the running OpenClaw version. Retry before changing the default model.'
@@ -122,7 +129,14 @@ export function SettingsTab({
   // Old image: the DO returns null when the controller lacks /_kilo/version,
   // and the platform route converts that to { version: null, commit: null }.
   const needsImageUpgrade = isRunning && controllerVersion && !controllerVersion.version;
-  const versionMismatch = trackedVersion && runningVersion && trackedVersion !== runningVersion;
+  // User self-updated OpenClaw on-machine — running version differs from what the image shipped with
+  const isModified = getRunningVersionBadge(runningVersion, trackedVersion) === 'modified';
+  // A newer image exists in the catalog with a newer OpenClaw version — user should redeploy
+  const updateAvailable =
+    !!trackedVersion &&
+    !!latestAvailableVersion &&
+    latestAvailableVersion !== trackedVersion &&
+    calverAtLeast(latestAvailableVersion, trackedVersion);
   const isPinned = !!myPin;
 
   // Show version section when running with a tracked version — even if running version is unknown yet
@@ -181,20 +195,38 @@ export function SettingsTab({
                       </TooltipContent>
                     </Tooltip>
                   )}
-                  {versionMismatch && (
+                  {updateAvailable && (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Badge
                           variant="outline"
-                          className="border-amber-500/30 bg-amber-500/15 text-amber-400"
+                          className="border-orange-500/30 bg-orange-500/15 text-orange-400"
+                        >
+                          Update available
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          A newer OpenClaw version ({latestAvailableVersion}) is available —
+                          redeploy to upgrade
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {isModified && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant="outline"
+                          className="border-zinc-500/30 bg-zinc-500/15 text-zinc-400"
                         >
                           Modified
                         </Badge>
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>
-                          OpenClaw was updated on this machine independently of the image —
-                          redeploying will revert to the image version ({trackedVersion})
+                          OpenClaw was self-updated on this machine — redeploying will revert to the
+                          image version ({trackedVersion})
                         </p>
                       </TooltipContent>
                     </Tooltip>
@@ -214,11 +246,18 @@ export function SettingsTab({
                 </code>
               </div>
             </div>
-            {versionMismatch && (
+            {updateAvailable && (
               <p className="text-muted-foreground mt-2 text-xs">
                 {isPinned
-                  ? `Redeploying will replace the running version with your pinned image version (${trackedVersion}).`
-                  : `Redeploying will replace the running version with the image version (${trackedVersion}).`}
+                  ? `A newer OpenClaw version (${latestAvailableVersion}) is available. You are pinned to an older image — update your pin to redeploy with the latest.`
+                  : `A newer OpenClaw version (${latestAvailableVersion}) is available. Redeploy to upgrade.`}
+              </p>
+            )}
+            {isModified && (
+              <p className="text-muted-foreground mt-2 text-xs">
+                {isPinned
+                  ? `OpenClaw was self-updated on this machine. Redeploying will revert to your pinned image version (${trackedVersion}).`
+                  : `OpenClaw was self-updated on this machine. Redeploying will revert to the image version (${trackedVersion}).`}
               </p>
             )}
           </div>

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -132,13 +132,19 @@ export function SettingsTab({
   // User self-updated OpenClaw on-machine — running version differs from what the image shipped with
   const isModified = getRunningVersionBadge(runningVersion, trackedVersion) === 'modified';
   // A newer image exists in the catalog with a newer OpenClaw version — user should redeploy.
-  // Suppress when the user already self-updated past the catalog version (redeploying would downgrade).
-  const updateAvailable =
+  // Suppress when the user already self-updated past the catalog version (redeploying would downgrade),
+  // or when the running version is non-calver and we can't determine ordering.
+  const catalogNewerThanImage =
     !!trackedVersion &&
     !!latestAvailableVersion &&
     latestAvailableVersion !== trackedVersion &&
-    calverAtLeast(latestAvailableVersion, trackedVersion) &&
-    (!runningVersion || !calverAtLeast(runningVersion, latestAvailableVersion));
+    calverAtLeast(latestAvailableVersion, trackedVersion);
+  const updateAvailable =
+    catalogNewerThanImage &&
+    (!isModified ||
+      (!!runningVersion &&
+        calverAtLeast(latestAvailableVersion, runningVersion) &&
+        latestAvailableVersion !== runningVersion));
   const isPinned = !!myPin;
 
   // Show version section when running with a tracked version — even if running version is unknown yet

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -131,12 +131,14 @@ export function SettingsTab({
   const needsImageUpgrade = isRunning && controllerVersion && !controllerVersion.version;
   // User self-updated OpenClaw on-machine — running version differs from what the image shipped with
   const isModified = getRunningVersionBadge(runningVersion, trackedVersion) === 'modified';
-  // A newer image exists in the catalog with a newer OpenClaw version — user should redeploy
+  // A newer image exists in the catalog with a newer OpenClaw version — user should redeploy.
+  // Suppress when the user already self-updated past the catalog version (redeploying would downgrade).
   const updateAvailable =
     !!trackedVersion &&
     !!latestAvailableVersion &&
     latestAvailableVersion !== trackedVersion &&
-    calverAtLeast(latestAvailableVersion, trackedVersion);
+    calverAtLeast(latestAvailableVersion, trackedVersion) &&
+    (!runningVersion || !calverAtLeast(runningVersion, latestAvailableVersion));
   const isPinned = !!myPin;
 
   // Show version section when running with a tracked version — even if running version is unknown yet

--- a/src/lib/kiloclaw/version.test.ts
+++ b/src/lib/kiloclaw/version.test.ts
@@ -1,4 +1,4 @@
-import { cleanVersion, calverAtLeast } from './version';
+import { cleanVersion, calverAtLeast, getRunningVersionBadge } from './version';
 
 describe('cleanVersion', () => {
   // Null / undefined / empty
@@ -56,4 +56,36 @@ describe('calverAtLeast', () => {
     expect(calverAtLeast('abc.def.ghi', '2026.1.1')).toBe(false));
   it('returns false for non-numeric minVersion segment', () =>
     expect(calverAtLeast('2026.1.1', 'abc.1.1')).toBe(false));
+});
+
+describe('getRunningVersionBadge', () => {
+  // No data
+  it('returns null when running version is null', () =>
+    expect(getRunningVersionBadge(null, '2026.3.8')).toBeNull());
+  it('returns null when image version is null', () =>
+    expect(getRunningVersionBadge('2026.3.8', null)).toBeNull());
+  it('returns null when both are null', () =>
+    expect(getRunningVersionBadge(null, null)).toBeNull());
+
+  // Versions match — no badge needed
+  it('returns null when running equals image', () =>
+    expect(getRunningVersionBadge('2026.3.8', '2026.3.8')).toBeNull());
+
+  // Any difference means user self-updated on-machine
+  it('returns modified when running is newer (patch)', () =>
+    expect(getRunningVersionBadge('2026.3.9', '2026.3.8')).toBe('modified'));
+  it('returns modified when running is newer (minor)', () =>
+    expect(getRunningVersionBadge('2026.4.1', '2026.3.8')).toBe('modified'));
+  it('returns modified when running is older (patch)', () =>
+    expect(getRunningVersionBadge('2026.3.7', '2026.3.8')).toBe('modified'));
+  it('returns modified when running is older (minor)', () =>
+    expect(getRunningVersionBadge('2026.2.1', '2026.3.8')).toBe('modified'));
+  it('returns modified for non-calver strings that differ', () =>
+    expect(getRunningVersionBadge('custom-build', 'release-build')).toBe('modified'));
+
+  // Version string normalisation works end-to-end
+  it('handles quoted version strings', () =>
+    expect(getRunningVersionBadge('"2026.3.9"', '2026.3.8')).toBe('modified'));
+  it('handles full openclaw --version output', () =>
+    expect(getRunningVersionBadge('OpenClaw 2026.3.9 (abc1234)', '2026.3.8')).toBe('modified'));
 });

--- a/src/lib/kiloclaw/version.ts
+++ b/src/lib/kiloclaw/version.ts
@@ -17,6 +17,21 @@ export function cleanVersion(version: string | null | undefined): string | null 
   return v || null;
 }
 
+/**
+ * Returns `'modified'` when the running OpenClaw version differs from the image version,
+ * indicating the user has self-updated OpenClaw on their machine.
+ * Returns `null` when the versions match or there is insufficient data to compare.
+ */
+export function getRunningVersionBadge(
+  runningVersion: string | null | undefined,
+  imageVersion: string | null | undefined
+): 'modified' | null {
+  const running = cleanVersion(runningVersion);
+  const image = cleanVersion(imageVersion);
+  if (!running || !image || running === image) return null;
+  return 'modified';
+}
+
 /** Returns true if calver `version` is >= `minVersion` (e.g. "2026.2.26"). Fails closed on malformed input. */
 export function calverAtLeast(version: string | null | undefined, minVersion: string): boolean {
   const parts = parseCalver(version);


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
- Add two independent version badge indicators to the KiloClaw settings screen                                     
- "Update available" (orange badge) — shown when the catalog contains a newer OpenClaw image version than what the    user deployed with                                                                                                 
- "Modified" (gray badge) — shown when the running OpenClaw version differs from the image version, indicating the    user self-updated on-machine                                                                                       
- Both badges can appear simultaneously                                                                            
- New getRunningVersionBadge() utility with full test coverage                                                     
- Wires in useKiloClawLatestVersion() hook to fetch the latest available version from the catalog 


## Verification

- Provision an instance — no badges should appear when running == image and image is latest
- Publish a newer image to the catalog without redeploying — "Update available" orange badge should appear
- Self-update OpenClaw on-machine to a different version — "Modified" gray badge should appear
- Self-update on-machine AND have a newer catalog image — both badges should appear simultaneously
- Pin to a version and verify pinned-specific copy appears in the helper text
- Verify tooltips render correctly for both badges
- Run pnpm jest src/lib/kiloclaw/version.test.ts — all 35 tests pass
- Run pnpm run typecheck — passes clean

## Visual Changes
- New orange badge ("Update available") next to Running Version — with tooltip: "A newer OpenClaw version (X) is   available — redeploy to upgrade"
- New gray badge ("Modified") next to Running Version — with tooltip: "OpenClaw was self-updated on this machine —   redeploying will revert to the image version (X)"
- Helper text below version info — context-aware copy that differs based on whether the user has a version pin   active
- Removed the old amber "Modified" badge that conflated both states into a single versionMismatch check


<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->
<img width="1122" height="179" alt="Screenshot 2026-03-11 at 4 07 13 PM" src="https://github.com/user-attachments/assets/80349510-3204-4eca-893b-001e48d6b1e2" />
<img width="1114" height="174" alt="Screenshot 2026-03-11 at 4 07 33 PM" src="https://github.com/user-attachments/assets/b7cca417-4d5e-4c69-9bbd-2b967bdec819" />

## Reviewer Notes

- getRunningVersionBadge was simplified to return 'modified' | null — the previous behind/ahead/mismatch   distinction was unnecessary because users only self-upgrade (never downgrade), so any running != image difference   means "modified"
- "Update available" is a separate concern: it compares the image version (what the user deployed with) against the    latest catalog version, not the running version
- The useKiloClawLatestVersion hook already existed (used elsewhere) — just newly consumed in SettingsTab
- calverAtLeast is reused for the catalog comparison; no new comparison logic needed
