### PR TITLE
feat(admin): add user-scoped Gastown admin panel

### DIFF
--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -430,8 +430,9 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
   let request = originalRequest;
   let workdir: string;
 
-  if (request.role === 'mayor') {
-    // Mayor doesn't need a repo clone — just a git-initialized directory
+  if (request.role === 'mayor' || request.lightweight) {
+    // Mayor and lightweight agents (e.g. triage) don't need a repo clone —
+    // just a git-initialized directory so kilo serve has a valid git root.
     workdir = await createMayorWorkspace(request.rigId);
 
     // On fresh containers the browse worktrees won't exist yet. Set them

--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -333,24 +333,23 @@ async function verifyGitCredentials(
 }
 
 /**
- * Create a minimal git-initialized workspace for the mayor agent.
- * The mayor doesn't need a real repo clone — it's a conversational
- * orchestrator that delegates work via tools. But kilo serve requires
- * a git repo in the working directory.
+ * Create a minimal git-initialized workspace for a reasoning-only agent
+ * (e.g. triage) that doesn't need a real repo clone.
+ * kilo serve requires a git repo in the working directory, so we init
+ * a bare local repo with an empty initial commit.
  */
-async function createMayorWorkspace(rigId: string): Promise<string> {
+async function createLightweightWorkspace(label: string, rigId: string): Promise<string> {
   const { mkdir: mkdirAsync } = await import('node:fs/promises');
   const { existsSync } = await import('node:fs');
   const path = await import('node:path');
-  // Validate rigId to prevent path traversal (rigId is synthetic: "mayor-<townId>")
+  // Validate to prevent path traversal
   // eslint-disable-next-line no-control-regex
   if (!rigId || /\.\.[/\\]|[/\\]\.\.|^\.\.$/.test(rigId) || /[\x00-\x1f]/.test(rigId)) {
-    throw new Error(`Invalid rigId for mayor workspace: ${rigId}`);
+    throw new Error(`Invalid rigId for lightweight workspace: ${rigId}`);
   }
-  const dir = path.resolve('/workspace/rigs', rigId, 'mayor-workspace');
+  const dir = path.resolve('/workspace/rigs', rigId, `${label}-workspace`);
   await mkdirAsync(dir, { recursive: true });
 
-  // Initialize a bare git repo if not already present
   if (!existsSync(`${dir}/.git`)) {
     const init = Bun.spawn(['git', 'init'], { cwd: dir, stdout: 'pipe', stderr: 'pipe' });
     await init.exited;
@@ -360,10 +359,20 @@ async function createMayorWorkspace(rigId: string): Promise<string> {
       stderr: 'pipe',
     });
     await commit.exited;
-    console.log(`Created mayor workspace at ${dir}`);
+    console.log(`Created ${label} workspace at ${dir}`);
   }
 
   return dir;
+}
+
+/**
+ * Create a minimal git-initialized workspace for the mayor agent.
+ * The mayor doesn't need a real repo clone — it's a conversational
+ * orchestrator that delegates work via tools. But kilo serve requires
+ * a git repo in the working directory.
+ */
+async function createMayorWorkspace(rigId: string): Promise<string> {
+  return createLightweightWorkspace('mayor', rigId);
 }
 
 /**
@@ -420,7 +429,7 @@ async function writeMayorSystemPromptToAgentsMd(
 
 /**
  * Run the full agent startup sequence:
- * 1. Clone/fetch the rig's git repo (or create minimal workspace for mayor)
+ * 1. Clone/fetch the rig's git repo (or create minimal workspace for mayor/triage)
  * 2. Create an isolated worktree for the agent's branch
  * 3. Configure git credentials for push/fetch
  * 4. Start a kilo serve instance for the worktree (or reuse existing)
@@ -430,9 +439,12 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
   let request = originalRequest;
   let workdir: string;
 
-  if (request.role === 'mayor' || request.lightweight) {
-    // Mayor and lightweight agents (e.g. triage) don't need a repo clone —
-    // just a git-initialized directory so kilo serve has a valid git root.
+  if (request.role === 'triage' || request.lightweight) {
+    // Triage/lightweight agents are pure reasoning — no code changes, no git needed.
+    // Use a lightweight workspace to avoid clone failures feeding the loop.
+    workdir = await createLightweightWorkspace('triage', request.rigId);
+  } else if (request.role === 'mayor') {
+    // Mayor doesn't need a repo clone — just a git-initialized directory
     workdir = await createMayorWorkspace(request.rigId);
 
     // On fresh containers the browse worktrees won't exist yet. Set them

--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -333,23 +333,24 @@ async function verifyGitCredentials(
 }
 
 /**
- * Create a minimal git-initialized workspace for a reasoning-only agent
- * (e.g. triage) that doesn't need a real repo clone.
- * kilo serve requires a git repo in the working directory, so we init
- * a bare local repo with an empty initial commit.
+ * Create a minimal git-initialized workspace for the mayor agent.
+ * The mayor doesn't need a real repo clone — it's a conversational
+ * orchestrator that delegates work via tools. But kilo serve requires
+ * a git repo in the working directory.
  */
-async function createLightweightWorkspace(label: string, rigId: string): Promise<string> {
+async function createMayorWorkspace(rigId: string): Promise<string> {
   const { mkdir: mkdirAsync } = await import('node:fs/promises');
   const { existsSync } = await import('node:fs');
   const path = await import('node:path');
-  // Validate to prevent path traversal
+  // Validate rigId to prevent path traversal (rigId is synthetic: "mayor-<townId>")
   // eslint-disable-next-line no-control-regex
   if (!rigId || /\.\.[/\\]|[/\\]\.\.|^\.\.$/.test(rigId) || /[\x00-\x1f]/.test(rigId)) {
-    throw new Error(`Invalid rigId for lightweight workspace: ${rigId}`);
+    throw new Error(`Invalid rigId for mayor workspace: ${rigId}`);
   }
-  const dir = path.resolve('/workspace/rigs', rigId, `${label}-workspace`);
+  const dir = path.resolve('/workspace/rigs', rigId, 'mayor-workspace');
   await mkdirAsync(dir, { recursive: true });
 
+  // Initialize a bare git repo if not already present
   if (!existsSync(`${dir}/.git`)) {
     const init = Bun.spawn(['git', 'init'], { cwd: dir, stdout: 'pipe', stderr: 'pipe' });
     await init.exited;
@@ -359,20 +360,10 @@ async function createLightweightWorkspace(label: string, rigId: string): Promise
       stderr: 'pipe',
     });
     await commit.exited;
-    console.log(`Created ${label} workspace at ${dir}`);
+    console.log(`Created mayor workspace at ${dir}`);
   }
 
   return dir;
-}
-
-/**
- * Create a minimal git-initialized workspace for the mayor agent.
- * The mayor doesn't need a real repo clone — it's a conversational
- * orchestrator that delegates work via tools. But kilo serve requires
- * a git repo in the working directory.
- */
-async function createMayorWorkspace(rigId: string): Promise<string> {
-  return createLightweightWorkspace('mayor', rigId);
 }
 
 /**
@@ -429,7 +420,7 @@ async function writeMayorSystemPromptToAgentsMd(
 
 /**
  * Run the full agent startup sequence:
- * 1. Clone/fetch the rig's git repo (or create minimal workspace for mayor/triage)
+ * 1. Clone/fetch the rig's git repo (or create minimal workspace for mayor)
  * 2. Create an isolated worktree for the agent's branch
  * 3. Configure git credentials for push/fetch
  * 4. Start a kilo serve instance for the worktree (or reuse existing)
@@ -439,11 +430,7 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
   let request = originalRequest;
   let workdir: string;
 
-  if (request.role === 'triage') {
-    // Triage agents are pure reasoning — no code changes, no git needed.
-    // Use a lightweight workspace to avoid clone failures feeding the loop.
-    workdir = await createLightweightWorkspace('triage', request.rigId);
-  } else if (request.role === 'mayor') {
+  if (request.role === 'mayor') {
     // Mayor doesn't need a repo clone — just a git-initialized directory
     workdir = await createMayorWorkspace(request.rigId);
 

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -27,6 +27,8 @@ export const StartAgentRequest = z.object({
   platformIntegrationId: z.string().optional(),
   /** Git ref to branch from (e.g. convoy feature branch). Falls back to HEAD if absent. */
   startPoint: z.string().optional(),
+  /** Skip repo clone — use a lightweight git-init-only workspace (for reasoning-only agents like triage). */
+  lightweight: z.boolean().optional(),
   /** Rig list for mayor agents — used to set up browse worktrees on fresh containers. */
   rigs: z
     .array(

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // ── Agent roles (mirrors worker types) ──────────────────────────────────
 
-export const AgentRole = z.enum(['mayor', 'polecat', 'refinery', 'triage']);
+export const AgentRole = z.enum(['mayor', 'polecat', 'refinery']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 // ── Control server request/response schemas ─────────────────────────────

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // ── Agent roles (mirrors worker types) ──────────────────────────────────
 
-export const AgentRole = z.enum(['mayor', 'polecat', 'refinery']);
+export const AgentRole = z.enum(['mayor', 'polecat', 'refinery', 'triage']);
 export type AgentRole = z.infer<typeof AgentRole>;
 
 // ── Control server request/response schemas ─────────────────────────────

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2652,6 +2652,7 @@ export class TownDO extends DurableObject<Env> {
       townConfig,
       systemPromptOverride: systemPrompt,
       platformIntegrationId: rigConfig.platformIntegrationId,
+      lightweight: true,
     });
 
     if (started) {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2640,9 +2640,7 @@ export class TownDO extends DurableObject<Env> {
       userId: rigConfig.userId,
       agentId: triageAgent.id,
       agentName: triageAgent.name,
-      // Use 'triage' role so the container skips the git clone entirely.
-      // Triage work is purely reasoning — no code changes needed.
-      role: 'triage',
+      role: 'polecat',
       identity: triageAgent.identity,
       beadId: triageBead.bead_id,
       beadTitle: triageBead.title,

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -230,7 +230,7 @@ export function updateBeadStatus(
  * recount closed beads and update convoy_metadata. Auto-lands the
  * convoy when all tracked beads are closed.
  */
-export function updateConvoyProgress(sql: SqlStorage, beadId: string, timestamp: string): void {
+function updateConvoyProgress(sql: SqlStorage, beadId: string, timestamp: string): void {
   const convoyRows = [
     ...query(
       sql,
@@ -671,18 +671,11 @@ export function getConvoyDependencyEdges(
 }
 
 /**
- * Find the convoy a bead belongs to (if any).
- *
- * Two cases:
- * 1. Normal source bead: tracked by a convoy via bead_dependencies
- *    (bead_id = sourceBeadId, depends_on_bead_id = convoyId, type = 'tracks').
- *    Returns the convoy bead_id.
- * 2. The bead IS the convoy (e.g. for the final landing MR where processConvoyLandings
- *    passes the convoy bead_id as the source). Returns beadId itself.
+ * Find the convoy a bead belongs to (if any) via 'tracks' dependencies.
+ * Returns the convoy bead_id or null.
  */
 export function getConvoyForBead(sql: SqlStorage, beadId: string): string | null {
-  // Case 1: bead is tracked by a convoy
-  const trackRows = [
+  const rows = [
     ...query(
       sql,
       /* sql */ `
@@ -694,24 +687,8 @@ export function getConvoyForBead(sql: SqlStorage, beadId: string): string | null
       [beadId]
     ),
   ];
-  if (trackRows.length > 0) {
-    return z.object({ depends_on_bead_id: z.string() }).parse(trackRows[0]).depends_on_bead_id;
-  }
-
-  // Case 2: bead is itself a convoy (has convoy_metadata)
-  const metaRows = [
-    ...query(
-      sql,
-      /* sql */ `
-        SELECT 1 FROM ${convoy_metadata}
-        WHERE ${convoy_metadata.bead_id} = ?
-      `,
-      [beadId]
-    ),
-  ];
-  if (metaRows.length > 0) return beadId;
-
-  return null;
+  if (rows.length === 0) return null;
+  return z.object({ depends_on_bead_id: z.string() }).parse(rows[0]).depends_on_bead_id;
 }
 
 /**

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -230,7 +230,7 @@ export function updateBeadStatus(
  * recount closed beads and update convoy_metadata. Auto-lands the
  * convoy when all tracked beads are closed.
  */
-function updateConvoyProgress(sql: SqlStorage, beadId: string, timestamp: string): void {
+export function updateConvoyProgress(sql: SqlStorage, beadId: string, timestamp: string): void {
   const convoyRows = [
     ...query(
       sql,

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -240,6 +240,8 @@ export async function startAgentInContainer(
     platformIntegrationId?: string;
     /** For convoy beads: the convoy's feature branch to branch from instead of defaultBranch. */
     convoyFeatureBranch?: string;
+    /** Skip repo clone — use a lightweight workspace (for reasoning-only agents like triage). */
+    lightweight?: boolean;
     /** All rigs in the town (mayor only) — used to set up browse worktrees on fresh containers. */
     rigs?: Array<{
       rigId: string;
@@ -346,6 +348,7 @@ export async function startAgentInContainer(
         // For convoy agents, start from the convoy's feature branch so the
         // worktree includes all previously merged convoy work.
         startPoint: params.convoyFeatureBranch ? `origin/${params.convoyFeatureBranch}` : undefined,
+        lightweight: params.lightweight,
         rigs: params.rigs,
       }),
     });

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -18,7 +18,6 @@ import {
   getBead,
   closeBead,
   updateBeadStatus,
-  updateConvoyProgress,
   createBead,
   getConvoyForBead,
   getConvoyFeatureBranch,
@@ -274,17 +273,7 @@ export function completeReviewWithResult(
   });
 
   if (input.status === 'merged') {
-    const mergeTimestamp = now();
     closeBead(sql, entry.bead_id, entry.agent_id);
-
-    // Explicitly trigger convoy progress for the source bead after the MR closes.
-    // closeBead → updateBeadStatus → updateConvoyProgress, but only if the source
-    // bead's status actually changes. If the polecat already closed the source bead
-    // before submitting to the review queue, the guard in updateBeadStatus short-
-    // circuits and updateConvoyProgress is never called. Calling it here directly
-    // ensures the convoy recounts after the MR bead is now closed (not in-flight),
-    // so the source bead passes the NOT EXISTS guard and counts toward closedCount.
-    updateConvoyProgress(sql, entry.bead_id, mergeTimestamp);
 
     // If this was a convoy landing MR, also set landed_at on the convoy metadata
     const sourceBead = getBead(sql, entry.bead_id);

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -18,6 +18,7 @@ import {
   getBead,
   closeBead,
   updateBeadStatus,
+  updateConvoyProgress,
   createBead,
   getConvoyForBead,
   getConvoyFeatureBranch,
@@ -273,7 +274,14 @@ export function completeReviewWithResult(
   });
 
   if (input.status === 'merged') {
+    const mergeTimestamp = now();
     closeBead(sql, entry.bead_id, entry.agent_id);
+
+    // closeBead → updateBeadStatus short-circuits when completeReview already
+    // set the status to 'closed' via direct SQL, so updateConvoyProgress is
+    // never reached transitively. Call it explicitly to ensure the convoy
+    // recounts after the MR bead is closed.
+    updateConvoyProgress(sql, entry.bead_id, mergeTimestamp);
 
     // If this was a convoy landing MR, also set landed_at on the convoy metadata
     const sourceBead = getBead(sql, entry.bead_id);

--- a/cloudflare-gastown/src/trpc/init.ts
+++ b/cloudflare-gastown/src/trpc/init.ts
@@ -36,3 +36,15 @@ export const gastownProcedure = procedure.use(async ({ ctx, next }) => {
   }
   return next({ ctx });
 });
+
+/**
+ * Admin-only procedure — requires `isAdmin` on the JWT. Used for admin
+ * panel endpoints that bypass per-user ownership checks (e.g. town-wide
+ * bead/agent listing for support diagnostics).
+ */
+export const adminProcedure = procedure.use(async ({ ctx, next }) => {
+  if (!ctx.isAdmin) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Admin access required' });
+  }
+  return next({ ctx });
+});

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -688,6 +688,14 @@ export const gastownRouter = router({
         limit: input.limit,
       });
     }),
+
+  adminGetBead: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
+    .output(RpcBeadOutput.nullable())
+    .query(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.getBeadAsync(input.beadId);
+    }),
 });
 
 export type GastownRouter = typeof gastownRouter;

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/await-thenable -- DO RPC stubs return Rpc.Promisified which is thenable at runtime */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
-import { router, gastownProcedure } from './init';
+import { router, gastownProcedure, adminProcedure } from './init';
 import { getTownDOStub } from '../dos/Town.do';
 import { getTownContainerStub } from '../dos/TownContainer.do';
 import { getGastownUserStub } from '../dos/GastownUser.do';
@@ -597,6 +597,68 @@ export const gastownRouter = router({
       if (!convoy) return null;
       const status = await townStub.getConvoyStatus(input.convoyId);
       return status ?? { ...convoy, beads: [] };
+    }),
+
+  // ── Admin-only routes (bypass ownership checks) ──────────────────────
+
+  adminListBeads: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'closed', 'failed']).optional(),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+        limit: z.number().int().positive().max(500).default(200),
+      })
+    )
+    .output(z.array(RpcBeadOutput))
+    .query(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.listBeads({
+        status: input.status,
+        type: input.type,
+        limit: input.limit,
+      });
+    }),
+
+  adminListAgents: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(z.array(RpcAgentOutput))
+    .query(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.listAgents({});
+    }),
+
+  adminForceRestartContainer: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const containerStub = getTownContainerStub(ctx.env, input.townId);
+      await containerStub.destroy();
+    }),
+
+  adminForceResetAgent: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), agentId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.unhookBead(input.agentId);
+      await townStub.updateAgentStatus(input.agentId, 'idle');
+    }),
+
+  adminForceCloseBead: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
+    .output(RpcBeadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.closeBead(input.beadId, 'admin');
+    }),
+
+  adminForceFailBead: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
+    .output(RpcBeadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.updateBeadStatus(input.beadId, 'failed', 'admin');
     }),
 });
 

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -660,6 +660,34 @@ export const gastownRouter = router({
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.updateBeadStatus(input.beadId, 'failed', 'admin');
     }),
+
+  adminGetAlarmStatus: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(RpcAlarmStatusOutput)
+    .query(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.setTownId(input.townId);
+      return townStub.getAlarmStatus();
+    }),
+
+  adminGetTownEvents: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        beadId: z.string().uuid().optional(),
+        since: z.string().optional(),
+        limit: z.number().int().positive().max(500).default(100),
+      })
+    )
+    .output(z.array(RpcBeadEventOutput))
+    .query(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.listBeadEvents({
+        beadId: input.beadId,
+        since: input.since,
+        limit: input.limit,
+      });
+    }),
 });
 
 export type GastownRouter = typeof gastownRouter;

--- a/src/app/admin/components/AppSidebar.tsx
+++ b/src/app/admin/components/AppSidebar.tsx
@@ -22,6 +22,7 @@ import {
   Upload,
   Bell,
   Server,
+  Network,
 } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import type { Session } from 'next-auth';
@@ -143,6 +144,11 @@ const productEngineeringItems: MenuItem[] = [
     title: () => 'Managed Indexing',
     url: '/admin/code-indexing',
     icon: () => <Database />,
+  },
+  {
+    title: () => 'Gastown',
+    url: '/admin/gastown',
+    icon: () => <Network />,
   },
 ];
 

--- a/src/app/admin/components/UserAdmin/UserAdminDashboard.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminDashboard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/breadcrumb';
 import { UserAdminOrganizations } from '@/app/admin/components/UserAdmin/UserAdminOrganizations';
 import { UserAdminKiloPass } from '@/app/admin/components/UserAdmin/UserAdminKiloPass';
+import { UserAdminGastown } from '@/app/admin/components/UserAdmin/UserAdminGastown';
 
 export function UserAdminDashboard({ ...user }: UserDetailProps) {
   const breadcrumbs = (
@@ -59,6 +60,8 @@ export function UserAdminDashboard({ ...user }: UserDetailProps) {
           <UserAdminInvoices stripe_customer_id={user.stripe_customer_id} />
           <UserAdminReferrals kilo_user_id={user.id} />
         </div>
+
+        <UserAdminGastown userId={user.id} />
       </div>
     </AdminPage>
   );

--- a/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { formatDate } from '@/lib/admin-utils';
+import { toast } from 'sonner';
+import { ExternalLink, RotateCcw } from 'lucide-react';
+
+type HealthDotProps = { status: 'green' | 'yellow' | 'red' | 'unknown' };
+
+function HealthDot({ status }: HealthDotProps) {
+  const colors = {
+    green: 'bg-green-500',
+    yellow: 'bg-yellow-400',
+    red: 'bg-red-500',
+    unknown: 'bg-gray-400',
+  };
+  const labels = {
+    green: 'Healthy',
+    yellow: 'Degraded',
+    red: 'Critical',
+    unknown: 'Unknown',
+  };
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className={`inline-block h-2.5 w-2.5 rounded-full ${colors[status]}`} />
+      <span className="text-muted-foreground text-xs">{labels[status]}</span>
+    </span>
+  );
+}
+
+function deriveHealthStatus(
+  health: {
+    agents: { working: number; stalled: number; dead: number };
+    beads: { failed: number };
+    patrol: { guppEscalations: number; stalledAgents: number };
+  } | null
+): 'green' | 'yellow' | 'red' | 'unknown' {
+  if (!health) return 'unknown';
+  const { agents, beads, patrol } = health;
+  if (agents.dead > 0 || patrol.guppEscalations > 0) return 'red';
+  if (agents.stalled > 0 || beads.failed > 0 || patrol.stalledAgents > 0) return 'yellow';
+  return 'green';
+}
+
+function TownRow({ town, userId }: { town: { id: string; name: string; created_at: string }; userId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const healthQuery = useQuery({
+    ...trpc.admin.gastown.getTownHealth.queryOptions({ townId: town.id }),
+    retry: false,
+  });
+
+  const restartMutation = useMutation(
+    trpc.admin.gastown.forceRestartContainer.mutationOptions({
+      onSuccess: () => {
+        toast.success(`Container restart requested for town ${town.name}`);
+        void queryClient.invalidateQueries(
+          trpc.admin.gastown.getTownHealth.queryOptions({ townId: town.id })
+        );
+      },
+      onError: err => {
+        toast.error(`Failed to restart container: ${err.message}`);
+      },
+    })
+  );
+
+  const health = healthQuery.data ?? null;
+  const healthStatus = deriveHealthStatus(health);
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="font-medium">{town.name}</div>
+        <div className="text-muted-foreground font-mono text-xs">{town.id}</div>
+      </TableCell>
+      <TableCell>
+        {healthQuery.isLoading ? (
+          <span className="text-muted-foreground text-xs">Loading…</span>
+        ) : (
+          <HealthDot status={healthStatus} />
+        )}
+      </TableCell>
+      <TableCell className="text-sm">
+        {health ? (
+          <span className="text-muted-foreground">
+            {health.agents.working} working / {health.agents.idle} idle
+          </span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-sm">
+        {health ? (
+          <span className="text-muted-foreground">
+            {health.beads.open + health.beads.inProgress} open
+          </span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-sm">
+        {formatDate(town.created_at)}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/admin/gastown/towns/${town.id}`}>
+              <ExternalLink className="mr-1 h-3 w-3" />
+              Inspect
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={restartMutation.isPending}
+            onClick={() => restartMutation.mutate({ townId: town.id })}
+          >
+            <RotateCcw className="mr-1 h-3 w-3" />
+            {restartMutation.isPending ? 'Restarting…' : 'Force Restart'}
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function UserAdminGastown({ userId }: { userId: string }) {
+  const trpc = useTRPC();
+
+  const townsQuery = useQuery({
+    ...trpc.admin.gastown.getUserTowns.queryOptions({ userId }),
+    retry: false,
+  });
+
+  const rigsQuery = useQuery({
+    ...trpc.admin.gastown.getUserRigs.queryOptions({ userId }),
+    retry: false,
+  });
+
+  return (
+    <Card className="col-span-1 lg:col-span-4">
+      <CardHeader>
+        <CardTitle>Gastown</CardTitle>
+        <CardDescription>Towns and rigs owned by this user</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Towns */}
+        <div>
+          <h4 className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+            Towns
+          </h4>
+          {townsQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading towns…</p>
+          )}
+          {townsQuery.error && (
+            <p className="text-sm text-red-400">Failed to load towns</p>
+          )}
+          {townsQuery.data && townsQuery.data.length === 0 && (
+            <p className="text-muted-foreground text-sm">No towns found</p>
+          )}
+          {townsQuery.data && townsQuery.data.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Town</TableHead>
+                  <TableHead>Health</TableHead>
+                  <TableHead>Agents</TableHead>
+                  <TableHead>Beads</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {townsQuery.data.map(town => (
+                  <TownRow key={town.id} town={town} userId={userId} />
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+
+        {/* Rigs */}
+        <div>
+          <h4 className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+            Rigs
+          </h4>
+          {rigsQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading rigs…</p>
+          )}
+          {rigsQuery.error && (
+            <p className="text-sm text-red-400">Failed to load rigs</p>
+          )}
+          {rigsQuery.data && rigsQuery.data.length === 0 && (
+            <p className="text-muted-foreground text-sm">No rigs found</p>
+          )}
+          {rigsQuery.data && rigsQuery.data.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Rig Name</TableHead>
+                  <TableHead>Git URL</TableHead>
+                  <TableHead>Integration</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rigsQuery.data.map(rig => (
+                  <TableRow key={rig.id}>
+                    <TableCell>
+                      <div className="font-medium">{rig.name}</div>
+                      <div className="text-muted-foreground font-mono text-xs">{rig.id}</div>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-muted-foreground font-mono text-xs break-all">
+                        {rig.git_url}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      {rig.platform_integration_id ? (
+                        <Badge variant="outline" className="border-green-500/30 text-green-400">
+                          Linked
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-muted-foreground">
+                          Not linked
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDate(rig.created_at)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
@@ -55,7 +55,7 @@ function deriveHealthStatus(
   return 'green';
 }
 
-function TownRow({ town, userId }: { town: { id: string; name: string; created_at: string }; userId: string }) {
+function TownRow({ town }: { town: { id: string; name: string; created_at: string } }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
@@ -112,9 +112,7 @@ function TownRow({ town, userId }: { town: { id: string; name: string; created_a
           <span className="text-muted-foreground">—</span>
         )}
       </TableCell>
-      <TableCell className="text-muted-foreground text-sm">
-        {formatDate(town.created_at)}
-      </TableCell>
+      <TableCell className="text-muted-foreground text-sm">{formatDate(town.created_at)}</TableCell>
       <TableCell>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" asChild>
@@ -160,15 +158,11 @@ export function UserAdminGastown({ userId }: { userId: string }) {
       <CardContent className="space-y-6">
         {/* Towns */}
         <div>
-          <h4 className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+          <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
             Towns
           </h4>
-          {townsQuery.isLoading && (
-            <p className="text-muted-foreground text-sm">Loading towns…</p>
-          )}
-          {townsQuery.error && (
-            <p className="text-sm text-red-400">Failed to load towns</p>
-          )}
+          {townsQuery.isLoading && <p className="text-muted-foreground text-sm">Loading towns…</p>}
+          {townsQuery.error && <p className="text-sm text-red-400">Failed to load towns</p>}
           {townsQuery.data && townsQuery.data.length === 0 && (
             <p className="text-muted-foreground text-sm">No towns found</p>
           )}
@@ -186,7 +180,7 @@ export function UserAdminGastown({ userId }: { userId: string }) {
               </TableHeader>
               <TableBody>
                 {townsQuery.data.map(town => (
-                  <TownRow key={town.id} town={town} userId={userId} />
+                  <TownRow key={town.id} town={town} />
                 ))}
               </TableBody>
             </Table>
@@ -195,15 +189,11 @@ export function UserAdminGastown({ userId }: { userId: string }) {
 
         {/* Rigs */}
         <div>
-          <h4 className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+          <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
             Rigs
           </h4>
-          {rigsQuery.isLoading && (
-            <p className="text-muted-foreground text-sm">Loading rigs…</p>
-          )}
-          {rigsQuery.error && (
-            <p className="text-sm text-red-400">Failed to load rigs</p>
-          )}
+          {rigsQuery.isLoading && <p className="text-muted-foreground text-sm">Loading rigs…</p>}
+          {rigsQuery.error && <p className="text-sm text-red-400">Failed to load rigs</p>}
           {rigsQuery.data && rigsQuery.data.length === 0 && (
             <p className="text-muted-foreground text-sm">No rigs found</p>
           )}

--- a/src/app/admin/gastown/page.tsx
+++ b/src/app/admin/gastown/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+import { getUserFromAuth } from '@/lib/user.server';
+
+export default async function GastownIndexPage() {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) {
+    redirect('/admin/unauthorized');
+  }
+
+  // Gastown data is scoped to a user — navigate to a user first.
+  redirect('/admin/users');
+}

--- a/src/app/admin/gastown/towns/[townId]/AgentsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/AgentsTab.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+
+const AGENT_STATUS_COLORS: Record<string, string> = {
+  working: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  idle: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  dead: 'bg-red-500/10 text-red-400 border-red-500/20',
+  stalled: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+};
+
+export function AgentsTab({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const [agentToReset, setAgentToReset] = useState<{ id: string; name: string } | null>(null);
+
+  const agentsQuery = useQuery(trpc.admin.gastown.listAgents.queryOptions({ townId }));
+
+  const forceResetMutation = useMutation(
+    trpc.admin.gastown.forceResetAgent.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listAgents.queryFilter({ townId }));
+        setAgentToReset(null);
+      },
+    })
+  );
+
+  const agents = agentsQuery.data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Agents</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {agentsQuery.isLoading && (
+          <p className="text-muted-foreground py-8 text-center text-sm">Loading agents…</p>
+        )}
+        {agentsQuery.isError && (
+          <p className="py-8 text-center text-sm text-red-400">
+            Failed to load agents: {agentsQuery.error.message}
+          </p>
+        )}
+        {!agentsQuery.isLoading && agents.length === 0 && (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            No agents found. (Town-wide listing requires bead 0 admin endpoints.)
+          </p>
+        )}
+        {agents.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Agent</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Role</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Status</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Hooked Bead</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Dispatches</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Last Active</th>
+                  <th className="text-muted-foreground pb-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agents.map(agent => (
+                  <tr key={agent.id} className="hover:bg-muted/40 border-b transition-colors">
+                    <td className="py-2 pr-4">
+                      <Link
+                        href={`/admin/gastown/towns/${townId}/agents/${agent.id}`}
+                        className="hover:text-foreground text-blue-400 transition-colors"
+                      >
+                        <div className="font-medium">{agent.name}</div>
+                        <div className="text-muted-foreground font-mono text-xs">
+                          {agent.id.slice(0, 8)}…
+                        </div>
+                      </Link>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span className="font-mono text-xs">{agent.role}</span>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Badge
+                        variant="outline"
+                        className={AGENT_STATUS_COLORS[agent.status] ?? ''}
+                      >
+                        {agent.status}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4">
+                      {agent.current_hook_bead_id ? (
+                        <Link
+                          href={`/admin/gastown/towns/${townId}/beads/${agent.current_hook_bead_id}`}
+                          className="text-muted-foreground hover:text-foreground font-mono text-xs transition-colors"
+                        >
+                          {agent.current_hook_bead_id.slice(0, 8)}…
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </td>
+                    <td className="text-muted-foreground py-2 pr-4 text-center text-xs">
+                      {agent.dispatch_attempts}
+                    </td>
+                    <td className="text-muted-foreground py-2 pr-4 text-xs">
+                      {agent.last_activity_at
+                        ? formatDistanceToNow(new Date(agent.last_activity_at), {
+                            addSuffix: true,
+                          })
+                        : '—'}
+                    </td>
+                    <td className="py-2 text-right">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        onClick={() => setAgentToReset({ id: agent.id, name: agent.name })}
+                      >
+                        Force Reset
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={!!agentToReset} onOpenChange={() => setAgentToReset(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Force Reset Agent</DialogTitle>
+            <DialogDescription>
+              This will reset agent{' '}
+              <span className="font-semibold">{agentToReset?.name}</span> to idle status and unhook
+              any hooked bead. This action is logged in the audit trail.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setAgentToReset(null)}
+              disabled={forceResetMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() =>
+                agentToReset &&
+                forceResetMutation.mutate({ townId, agentId: agentToReset.id })
+              }
+              disabled={forceResetMutation.isPending}
+            >
+              {forceResetMutation.isPending ? 'Resetting…' : 'Force Reset'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/AgentsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/AgentsTab.tsx
@@ -64,7 +64,7 @@ export function AgentsTab({ townId }: { townId: string }) {
         )}
         {!agentsQuery.isLoading && agents.length === 0 && (
           <p className="text-muted-foreground py-8 text-center text-sm">
-            No agents found. (Town-wide listing requires bead 0 admin endpoints.)
+            No agents found in this town.
           </p>
         )}
         {agents.length > 0 && (

--- a/src/app/admin/gastown/towns/[townId]/AgentsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/AgentsTab.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
 import {
   Dialog,
   DialogContent,
@@ -37,6 +38,10 @@ export function AgentsTab({ townId }: { townId: string }) {
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.admin.gastown.listAgents.queryFilter({ townId }));
         setAgentToReset(null);
+        toast.success('Agent reset successfully');
+      },
+      onError: err => {
+        toast.error(`Failed to reset agent: ${err.message}`);
       },
     })
   );
@@ -94,10 +99,7 @@ export function AgentsTab({ townId }: { townId: string }) {
                       <span className="font-mono text-xs">{agent.role}</span>
                     </td>
                     <td className="py-2 pr-4">
-                      <Badge
-                        variant="outline"
-                        className={AGENT_STATUS_COLORS[agent.status] ?? ''}
-                      >
+                      <Badge variant="outline" className={AGENT_STATUS_COLORS[agent.status] ?? ''}>
                         {agent.status}
                       </Badge>
                     </td>
@@ -146,9 +148,8 @@ export function AgentsTab({ townId }: { townId: string }) {
           <DialogHeader>
             <DialogTitle>Force Reset Agent</DialogTitle>
             <DialogDescription>
-              This will reset agent{' '}
-              <span className="font-semibold">{agentToReset?.name}</span> to idle status and unhook
-              any hooked bead. This action is logged in the audit trail.
+              This will reset agent <span className="font-semibold">{agentToReset?.name}</span> to
+              idle status and unhook any hooked bead. This action is logged in the audit trail.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -162,8 +163,7 @@ export function AgentsTab({ townId }: { townId: string }) {
             <Button
               variant="destructive"
               onClick={() =>
-                agentToReset &&
-                forceResetMutation.mutate({ townId, agentId: agentToReset.id })
+                agentToReset && forceResetMutation.mutate({ townId, agentId: agentToReset.id })
               }
               disabled={forceResetMutation.isPending}
             >

--- a/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -166,7 +166,7 @@ export function BeadsTab({ townId }: { townId: string }) {
         )}
         {!beadsQuery.isLoading && beads.length === 0 && (
           <p className="text-muted-foreground py-8 text-center text-sm">
-            No beads found. (Town-wide listing requires bead 0 admin endpoints.)
+            No beads found matching the current filters.
           </p>
         )}
         {beads.length > 0 && (

--- a/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -198,14 +198,7 @@ export function BeadsTab({ townId }: { townId: string }) {
                       <span className="font-mono text-xs">{bead.type}</span>
                     </td>
                     <td className="py-2 pr-4">
-                      <Badge
-                        variant="outline"
-                        className={
-                          (beadStatuses as readonly string[]).includes(bead.status)
-                            ? STATUS_COLORS[bead.status as BeadStatus]
-                            : ''
-                        }
-                      >
+                      <Badge variant="outline" className={STATUS_COLORS[bead.status]}>
                         {bead.status}
                       </Badge>
                     </td>

--- a/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+
+type BeadStatus = 'open' | 'in_progress' | 'closed' | 'failed';
+type BeadType =
+  | 'issue'
+  | 'message'
+  | 'escalation'
+  | 'merge_request'
+  | 'convoy'
+  | 'molecule'
+  | 'agent';
+
+const STATUS_COLORS: Record<BeadStatus, string> = {
+  open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  closed: 'bg-green-500/10 text-green-400 border-green-500/20',
+  failed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+type ConfirmAction = {
+  type: 'close' | 'fail';
+  beadId: string;
+  title: string;
+};
+
+export function BeadsTab({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const [statusFilter, setStatusFilter] = useState<BeadStatus | 'all'>('all');
+  const [typeFilter, setTypeFilter] = useState<BeadType | 'all'>('all');
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+
+  const beadsQuery = useQuery(
+    trpc.admin.gastown.listBeads.queryOptions({
+      townId,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      type: typeFilter === 'all' ? undefined : typeFilter,
+    })
+  );
+
+  const forceCloseMutation = useMutation(
+    trpc.admin.gastown.forceCloseBead.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        setConfirmAction(null);
+      },
+    })
+  );
+
+  const forceFailMutation = useMutation(
+    trpc.admin.gastown.forceFailBead.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        setConfirmAction(null);
+      },
+    })
+  );
+
+  const handleConfirm = () => {
+    if (!confirmAction) return;
+    if (confirmAction.type === 'close') {
+      forceCloseMutation.mutate({ townId, beadId: confirmAction.beadId });
+    } else {
+      forceFailMutation.mutate({ townId, beadId: confirmAction.beadId });
+    }
+  };
+
+  const beads = beadsQuery.data ?? [];
+  const isPending = forceCloseMutation.isPending || forceFailMutation.isPending;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Beads</CardTitle>
+          <div className="flex gap-2">
+            <Select
+              value={statusFilter}
+              onValueChange={v => setStatusFilter(v as BeadStatus | 'all')}
+            >
+              <SelectTrigger className="w-36">
+                <SelectValue placeholder="All statuses" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                <SelectItem value="open">Open</SelectItem>
+                <SelectItem value="in_progress">In Progress</SelectItem>
+                <SelectItem value="closed">Closed</SelectItem>
+                <SelectItem value="failed">Failed</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select value={typeFilter} onValueChange={v => setTypeFilter(v as BeadType | 'all')}>
+              <SelectTrigger className="w-36">
+                <SelectValue placeholder="All types" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All types</SelectItem>
+                <SelectItem value="issue">Issue</SelectItem>
+                <SelectItem value="merge_request">Merge Request</SelectItem>
+                <SelectItem value="convoy">Convoy</SelectItem>
+                <SelectItem value="escalation">Escalation</SelectItem>
+                <SelectItem value="message">Message</SelectItem>
+                <SelectItem value="molecule">Molecule</SelectItem>
+                <SelectItem value="agent">Agent</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {beadsQuery.isLoading && (
+          <p className="text-muted-foreground py-8 text-center text-sm">Loading beads…</p>
+        )}
+        {beadsQuery.isError && (
+          <p className="py-8 text-center text-sm text-red-400">
+            Failed to load beads: {beadsQuery.error.message}
+          </p>
+        )}
+        {!beadsQuery.isLoading && beads.length === 0 && (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            No beads found. (Town-wide listing requires bead 0 admin endpoints.)
+          </p>
+        )}
+        {beads.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Type</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Status</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Agent</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Created</th>
+                  <th className="text-muted-foreground pb-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {beads.map(bead => (
+                  <tr key={bead.bead_id} className="hover:bg-muted/40 border-b transition-colors">
+                    <td className="py-2 pr-4">
+                      <Link
+                        href={`/admin/gastown/towns/${townId}/beads/${bead.bead_id}`}
+                        className="hover:text-foreground text-blue-400 transition-colors"
+                      >
+                        <span className="font-mono text-xs">{bead.bead_id.slice(0, 8)}…</span>
+                        {bead.title && (
+                          <span className="ml-2 max-w-64 truncate">{bead.title}</span>
+                        )}
+                      </Link>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span className="font-mono text-xs">{bead.type}</span>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Badge
+                        variant="outline"
+                        className={STATUS_COLORS[bead.status as BeadStatus] ?? ''}
+                      >
+                        {bead.status}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4">
+                      {bead.assignee_agent_bead_id ? (
+                        <Link
+                          href={`/admin/gastown/towns/${townId}/agents/${bead.assignee_agent_bead_id}`}
+                          className="text-muted-foreground hover:text-foreground font-mono text-xs transition-colors"
+                        >
+                          {bead.assignee_agent_bead_id.slice(0, 8)}…
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </td>
+                    <td className="text-muted-foreground py-2 pr-4 text-xs">
+                      {formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}
+                    </td>
+                    <td className="py-2 text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          disabled={bead.status === 'closed' || bead.status === 'failed'}
+                          onClick={() =>
+                            setConfirmAction({
+                              type: 'close',
+                              beadId: bead.bead_id,
+                              title: bead.title,
+                            })
+                          }
+                        >
+                          Force Close
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+                          disabled={bead.status === 'closed' || bead.status === 'failed'}
+                          onClick={() =>
+                            setConfirmAction({
+                              type: 'fail',
+                              beadId: bead.bead_id,
+                              title: bead.title,
+                            })
+                          }
+                        >
+                          Force Fail
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={!!confirmAction} onOpenChange={() => setConfirmAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {confirmAction?.type === 'close' ? 'Force Close Bead' : 'Force Fail Bead'}
+            </DialogTitle>
+            <DialogDescription>
+              This will{' '}
+              {confirmAction?.type === 'close' ? 'force-close' : 'force-fail'} bead{' '}
+              <span className="font-mono">{confirmAction?.beadId.slice(0, 8)}…</span>
+              {confirmAction?.title ? ` (${confirmAction.title})` : ''}. This action is logged in
+              the audit trail.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant={confirmAction?.type === 'fail' ? 'destructive' : 'default'}
+              onClick={handleConfirm}
+              disabled={isPending}
+            >
+              {isPending
+                ? 'Processing…'
+                : confirmAction?.type === 'close'
+                  ? 'Force Close'
+                  : 'Force Fail'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,15 +25,19 @@ import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 
-type BeadStatus = 'open' | 'in_progress' | 'closed' | 'failed';
-type BeadType =
-  | 'issue'
-  | 'message'
-  | 'escalation'
-  | 'merge_request'
-  | 'convoy'
-  | 'molecule'
-  | 'agent';
+const beadStatuses = ['open', 'in_progress', 'closed', 'failed'] as const;
+type BeadStatus = (typeof beadStatuses)[number];
+
+const beadTypes = [
+  'issue',
+  'message',
+  'escalation',
+  'merge_request',
+  'convoy',
+  'molecule',
+  'agent',
+] as const;
+type BeadType = (typeof beadTypes)[number];
 
 const STATUS_COLORS: Record<BeadStatus, string> = {
   open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
@@ -68,6 +73,10 @@ export function BeadsTab({ townId }: { townId: string }) {
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
         setConfirmAction(null);
+        toast.success('Bead closed successfully');
+      },
+      onError: err => {
+        toast.error(`Failed to close bead: ${err.message}`);
       },
     })
   );
@@ -77,6 +86,10 @@ export function BeadsTab({ townId }: { townId: string }) {
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
         setConfirmAction(null);
+        toast.success('Bead marked as failed');
+      },
+      onError: err => {
+        toast.error(`Failed to fail bead: ${err.message}`);
       },
     })
   );
@@ -101,7 +114,10 @@ export function BeadsTab({ townId }: { townId: string }) {
           <div className="flex gap-2">
             <Select
               value={statusFilter}
-              onValueChange={v => setStatusFilter(v as BeadStatus | 'all')}
+              onValueChange={v => {
+                if (v === 'all' || (beadStatuses as readonly string[]).includes(v))
+                  setStatusFilter(v as BeadStatus | 'all');
+              }}
             >
               <SelectTrigger className="w-36">
                 <SelectValue placeholder="All statuses" />
@@ -115,7 +131,13 @@ export function BeadsTab({ townId }: { townId: string }) {
               </SelectContent>
             </Select>
 
-            <Select value={typeFilter} onValueChange={v => setTypeFilter(v as BeadType | 'all')}>
+            <Select
+              value={typeFilter}
+              onValueChange={v => {
+                if (v === 'all' || (beadTypes as readonly string[]).includes(v))
+                  setTypeFilter(v as BeadType | 'all');
+              }}
+            >
               <SelectTrigger className="w-36">
                 <SelectValue placeholder="All types" />
               </SelectTrigger>
@@ -169,9 +191,7 @@ export function BeadsTab({ townId }: { townId: string }) {
                         className="hover:text-foreground text-blue-400 transition-colors"
                       >
                         <span className="font-mono text-xs">{bead.bead_id.slice(0, 8)}…</span>
-                        {bead.title && (
-                          <span className="ml-2 max-w-64 truncate">{bead.title}</span>
-                        )}
+                        {bead.title && <span className="ml-2 max-w-64 truncate">{bead.title}</span>}
                       </Link>
                     </td>
                     <td className="py-2 pr-4">
@@ -180,7 +200,11 @@ export function BeadsTab({ townId }: { townId: string }) {
                     <td className="py-2 pr-4">
                       <Badge
                         variant="outline"
-                        className={STATUS_COLORS[bead.status as BeadStatus] ?? ''}
+                        className={
+                          (beadStatuses as readonly string[]).includes(bead.status)
+                            ? STATUS_COLORS[bead.status as BeadStatus]
+                            : ''
+                        }
                       >
                         {bead.status}
                       </Badge>
@@ -249,8 +273,7 @@ export function BeadsTab({ townId }: { townId: string }) {
               {confirmAction?.type === 'close' ? 'Force Close Bead' : 'Force Fail Bead'}
             </DialogTitle>
             <DialogDescription>
-              This will{' '}
-              {confirmAction?.type === 'close' ? 'force-close' : 'force-fail'} bead{' '}
+              This will {confirmAction?.type === 'close' ? 'force-close' : 'force-fail'} bead{' '}
               <span className="font-mono">{confirmAction?.beadId.slice(0, 8)}…</span>
               {confirmAction?.title ? ` (${confirmAction.title})` : ''}. This action is logged in
               the audit trail.

--- a/src/app/admin/gastown/towns/[townId]/ConfigTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ConfigTab.tsx
@@ -49,9 +49,9 @@ export function ConfigTab({ townId }: { townId: string }) {
 
   const saveField = (field: string) => {
     if (field === 'default_model') {
-      updateConfigMutation.mutate({ townId, update: { default_model: editValue || undefined } });
+      updateConfigMutation.mutate({ townId, update: { default_model: editValue || null } });
     } else if (field === 'small_model') {
-      updateConfigMutation.mutate({ townId, update: { small_model: editValue || undefined } });
+      updateConfigMutation.mutate({ townId, update: { small_model: editValue || null } });
     } else if (field === 'max_polecats_per_rig') {
       const num = parseInt(editValue, 10);
       if (!isNaN(num) && num > 0) {

--- a/src/app/admin/gastown/towns/[townId]/ConfigTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ConfigTab.tsx
@@ -1,0 +1,387 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { formatDistanceToNow } from 'date-fns';
+
+export function ConfigTab({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const configQuery = useQuery(trpc.admin.gastown.getTownConfig.queryOptions({ townId }));
+  const credEventsQuery = useQuery(
+    trpc.admin.gastown.listCredentialEvents.queryOptions({ townId })
+  );
+
+  const updateConfigMutation = useMutation(
+    trpc.admin.gastown.updateTownConfig.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(
+          trpc.admin.gastown.getTownConfig.queryFilter({ townId })
+        );
+        setEditingField(null);
+      },
+    })
+  );
+
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+
+  const config = configQuery.data;
+  const credEvents = credEventsQuery.data ?? [];
+
+  const startEdit = (field: string, currentValue: string) => {
+    setEditingField(field);
+    setEditValue(currentValue);
+  };
+
+  const saveField = (field: string) => {
+    if (field === 'default_model') {
+      updateConfigMutation.mutate({ townId, update: { default_model: editValue || undefined } });
+    } else if (field === 'small_model') {
+      updateConfigMutation.mutate({ townId, update: { small_model: editValue || undefined } });
+    } else if (field === 'max_polecats_per_rig') {
+      const num = parseInt(editValue, 10);
+      if (!isNaN(num) && num > 0) {
+        updateConfigMutation.mutate({ townId, update: { max_polecats_per_rig: num } });
+      }
+    } else if (field === 'merge_strategy') {
+      updateConfigMutation.mutate({
+        townId,
+        update: { merge_strategy: editValue as 'direct' | 'pr' },
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Town Config */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Town Config</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {configQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading config…</p>
+          )}
+          {configQuery.isError && (
+            <p className="text-sm text-red-400">
+              Failed to load config: {configQuery.error.message}
+            </p>
+          )}
+          {config && (
+            <div className="space-y-4">
+              {/* Merge Strategy */}
+              <div className="flex items-center justify-between gap-4 border-b pb-3">
+                <div>
+                  <Label className="text-sm font-medium">Merge Strategy</Label>
+                  <p className="text-muted-foreground text-xs">How branches are merged</p>
+                </div>
+                {editingField === 'merge_strategy' ? (
+                  <div className="flex items-center gap-2">
+                    <Select value={editValue} onValueChange={setEditValue}>
+                      <SelectTrigger className="w-28">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="direct">direct</SelectItem>
+                        <SelectItem value="pr">pr</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      size="sm"
+                      onClick={() => saveField('merge_strategy')}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingField(null)}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-sm">{config.merge_strategy}</span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs"
+                      onClick={() => startEdit('merge_strategy', config.merge_strategy)}
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {/* Default Model */}
+              <div className="flex items-center justify-between gap-4 border-b pb-3">
+                <div>
+                  <Label className="text-sm font-medium">Default Model</Label>
+                  <p className="text-muted-foreground text-xs">Primary AI model for agents</p>
+                </div>
+                {editingField === 'default_model' ? (
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={editValue}
+                      onChange={e => setEditValue(e.target.value)}
+                      className="w-64"
+                      placeholder="e.g. anthropic/claude-sonnet-4"
+                    />
+                    <Button
+                      size="sm"
+                      onClick={() => saveField('default_model')}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingField(null)}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground font-mono text-sm">
+                      {config.default_model ?? '—'}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs"
+                      onClick={() => startEdit('default_model', config.default_model ?? '')}
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {/* Small Model */}
+              <div className="flex items-center justify-between gap-4 border-b pb-3">
+                <div>
+                  <Label className="text-sm font-medium">Small Model</Label>
+                  <p className="text-muted-foreground text-xs">Lightweight model for simple tasks</p>
+                </div>
+                {editingField === 'small_model' ? (
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={editValue}
+                      onChange={e => setEditValue(e.target.value)}
+                      className="w-64"
+                      placeholder="e.g. anthropic/claude-haiku"
+                    />
+                    <Button
+                      size="sm"
+                      onClick={() => saveField('small_model')}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingField(null)}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground font-mono text-sm">
+                      {config.small_model ?? '—'}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs"
+                      onClick={() => startEdit('small_model', config.small_model ?? '')}
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {/* Max Polecats */}
+              <div className="flex items-center justify-between gap-4 border-b pb-3">
+                <div>
+                  <Label className="text-sm font-medium">Max Polecats per Rig</Label>
+                  <p className="text-muted-foreground text-xs">
+                    Concurrency limit per rig
+                  </p>
+                </div>
+                {editingField === 'max_polecats_per_rig' ? (
+                  <div className="flex items-center gap-2">
+                    <Input
+                      type="number"
+                      value={editValue}
+                      onChange={e => setEditValue(e.target.value)}
+                      className="w-24"
+                      min={1}
+                    />
+                    <Button
+                      size="sm"
+                      onClick={() => saveField('max_polecats_per_rig')}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingField(null)}
+                      disabled={updateConfigMutation.isPending}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground font-mono text-sm">
+                      {config.max_polecats_per_rig ?? '—'}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs"
+                      onClick={() =>
+                        startEdit(
+                          'max_polecats_per_rig',
+                          String(config.max_polecats_per_rig ?? '')
+                        )
+                      }
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {/* Refinery Config */}
+              {config.refinery && (
+                <div className="border-b pb-3">
+                  <Label className="text-sm font-medium">Refinery</Label>
+                  <div className="mt-2 space-y-1 font-mono text-xs">
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-40">Auto Merge:</span>
+                      <span>{String(config.refinery.auto_merge)}</span>
+                    </div>
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-40">Require Clean Merge:</span>
+                      <span>{String(config.refinery.require_clean_merge)}</span>
+                    </div>
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-40">Gates:</span>
+                      <span>{config.refinery.gates.join(', ') || '—'}</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Git Auth */}
+              <div className="pb-3">
+                <Label className="text-sm font-medium">Git Auth</Label>
+                <div className="mt-2 space-y-1 font-mono text-xs">
+                  {config.git_auth.platform_integration_id && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-48">Platform Integration:</span>
+                      <span>{config.git_auth.platform_integration_id.slice(0, 16)}…</span>
+                    </div>
+                  )}
+                  {config.git_auth.github_token && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-48">GitHub Token:</span>
+                      <span className="text-muted-foreground">••••••••</span>
+                    </div>
+                  )}
+                  {config.git_auth.gitlab_token && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-48">GitLab Token:</span>
+                      <span className="text-muted-foreground">••••••••</span>
+                    </div>
+                  )}
+                  {config.git_auth.gitlab_instance_url && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground w-48">GitLab Instance URL:</span>
+                      <span>{config.git_auth.gitlab_instance_url}</span>
+                    </div>
+                  )}
+                  {!config.git_auth.github_token &&
+                    !config.git_auth.gitlab_token &&
+                    !config.git_auth.platform_integration_id && (
+                      <span className="text-muted-foreground">No git auth configured</span>
+                    )}
+                </div>
+              </div>
+
+              {updateConfigMutation.isError && (
+                <p className="text-sm text-red-400">
+                  Failed to update config: {updateConfigMutation.error.message}
+                </p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Credential Events */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Credential Events</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {credEventsQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading credential events…</p>
+          )}
+          {!credEventsQuery.isLoading && credEvents.length === 0 && (
+            <p className="text-muted-foreground text-sm">
+              No credential events. (Requires bead 0 admin endpoints.)
+            </p>
+          )}
+          {credEvents.length > 0 && (
+            <div className="space-y-2">
+              {credEvents.map(event => (
+                <div key={event.id} className="flex items-start justify-between gap-4 text-sm">
+                  <div>
+                    <span className="font-mono text-xs">{event.event_type}</span>
+                    {event.rig_id && (
+                      <span className="text-muted-foreground ml-2 font-mono text-xs">
+                        rig: {event.rig_id.slice(0, 8)}…
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/ConfigTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ConfigTab.tsx
@@ -58,10 +58,11 @@ export function ConfigTab({ townId }: { townId: string }) {
         updateConfigMutation.mutate({ townId, update: { max_polecats_per_rig: num } });
       }
     } else if (field === 'merge_strategy') {
-      updateConfigMutation.mutate({
-        townId,
-        update: { merge_strategy: editValue as 'direct' | 'pr' },
-      });
+      const validStrategies = ['direct', 'pr'] as const;
+      const strategy = validStrategies.find(s => s === editValue);
+      if (strategy) {
+        updateConfigMutation.mutate({ townId, update: { merge_strategy: strategy } });
+      }
     }
   };
 
@@ -182,7 +183,9 @@ export function ConfigTab({ townId }: { townId: string }) {
               <div className="flex items-center justify-between gap-4 border-b pb-3">
                 <div>
                   <Label className="text-sm font-medium">Small Model</Label>
-                  <p className="text-muted-foreground text-xs">Lightweight model for simple tasks</p>
+                  <p className="text-muted-foreground text-xs">
+                    Lightweight model for simple tasks
+                  </p>
                 </div>
                 {editingField === 'small_model' ? (
                   <div className="flex items-center gap-2">
@@ -229,9 +232,7 @@ export function ConfigTab({ townId }: { townId: string }) {
               <div className="flex items-center justify-between gap-4 border-b pb-3">
                 <div>
                   <Label className="text-sm font-medium">Max Polecats per Rig</Label>
-                  <p className="text-muted-foreground text-xs">
-                    Concurrency limit per rig
-                  </p>
+                  <p className="text-muted-foreground text-xs">Concurrency limit per rig</p>
                 </div>
                 {editingField === 'max_polecats_per_rig' ? (
                   <div className="flex items-center gap-2">
@@ -268,10 +269,7 @@ export function ConfigTab({ townId }: { townId: string }) {
                       variant="outline"
                       className="h-7 text-xs"
                       onClick={() =>
-                        startEdit(
-                          'max_polecats_per_rig',
-                          String(config.max_polecats_per_rig ?? '')
-                        )
+                        startEdit('max_polecats_per_rig', String(config.max_polecats_per_rig ?? ''))
                       }
                     >
                       Edit

--- a/src/app/admin/gastown/towns/[townId]/ContainerTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ContainerTab.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { formatDistanceToNow } from 'date-fns';
+
+export function ContainerTab({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+
+  const [showRestartDialog, setShowRestartDialog] = useState(false);
+
+  const healthQuery = useQuery(trpc.admin.gastown.getTownHealth.queryOptions({ townId }));
+  const eventsQuery = useQuery(trpc.admin.gastown.listContainerEvents.queryOptions({ townId }));
+  const configQuery = useQuery(trpc.admin.gastown.getTownConfig.queryOptions({ townId }));
+
+  const forceRestartMutation = useMutation(
+    trpc.admin.gastown.forceRestartContainer.mutationOptions({
+      onSuccess: () => {
+        setShowRestartDialog(false);
+      },
+    })
+  );
+
+  const health = healthQuery.data;
+  const containerEvents = eventsQuery.data ?? [];
+  const envVars = configQuery.data?.env_vars ?? {};
+
+  // Derive container health status from the alarm status snapshot
+  let containerStatus: 'running' | 'stopped' | 'unknown' = 'unknown';
+  if (health) {
+    const hasDeadAgents = health.agents.dead > 0;
+    const hasWorkingAgents = health.agents.working > 0;
+    if (hasWorkingAgents) {
+      containerStatus = 'running';
+    } else if (hasDeadAgents) {
+      containerStatus = 'stopped';
+    } else {
+      containerStatus = 'running'; // idle but alive
+    }
+  }
+
+  const healthBadgeClass =
+    containerStatus === 'running'
+      ? 'bg-green-500/10 text-green-400 border-green-500/20'
+      : containerStatus === 'stopped'
+        ? 'bg-red-500/10 text-red-400 border-red-500/20'
+        : 'bg-gray-500/10 text-gray-400 border-gray-500/20';
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Health & Actions */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Container Health</CardTitle>
+            <Button
+              variant="outline"
+              className="border-red-500/30 text-red-400 hover:bg-red-500/10"
+              onClick={() => setShowRestartDialog(true)}
+            >
+              Force Restart Container
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {healthQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading health status…</p>
+          )}
+          {!healthQuery.isLoading && (
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center gap-3">
+                <span className="text-muted-foreground text-sm">Status:</span>
+                <Badge variant="outline" className={healthBadgeClass}>
+                  {containerStatus}
+                </Badge>
+              </div>
+              {health && (
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-muted-foreground text-xs">Working Agents</div>
+                    <div className="mt-1 text-2xl font-semibold">{health.agents.working}</div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-muted-foreground text-xs">Idle Agents</div>
+                    <div className="mt-1 text-2xl font-semibold">{health.agents.idle}</div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-muted-foreground text-xs">Dead Agents</div>
+                    <div className="mt-1 text-2xl font-semibold text-red-400">
+                      {health.agents.dead}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-muted-foreground text-xs">Open Beads</div>
+                    <div className="mt-1 text-2xl font-semibold">{health.beads.open}</div>
+                  </div>
+                </div>
+              )}
+              {health && (
+                <div>
+                  <div className="text-muted-foreground mb-1 text-xs">Alarm interval</div>
+                  <div className="text-sm">{health.alarm.intervalLabel}</div>
+                  {health.alarm.nextFireAt && (
+                    <div className="text-muted-foreground text-xs">
+                      Next:{' '}
+                      {formatDistanceToNow(new Date(health.alarm.nextFireAt), { addSuffix: true })}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Recent Events */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Container Events</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {eventsQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading events…</p>
+          )}
+          {!eventsQuery.isLoading && containerEvents.length === 0 && (
+            <p className="text-muted-foreground text-sm">
+              No container events. (Requires bead 0 admin endpoints.)
+            </p>
+          )}
+          {containerEvents.length > 0 && (
+            <div className="space-y-2">
+              {containerEvents.map(event => (
+                <div key={event.id} className="flex items-start justify-between gap-4 text-sm">
+                  <div>
+                    <span className="font-mono text-xs">{event.event_type}</span>
+                    {event.data && Object.keys(event.data).length > 0 && (
+                      <pre className="text-muted-foreground mt-1 font-mono text-xs whitespace-pre-wrap">
+                        {JSON.stringify(event.data, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Environment Variables */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Environment Variables</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {configQuery.isLoading && (
+            <p className="text-muted-foreground text-sm">Loading config…</p>
+          )}
+          {!configQuery.isLoading && Object.keys(envVars).length === 0 && (
+            <p className="text-muted-foreground text-sm">No environment variables configured.</p>
+          )}
+          {Object.keys(envVars).length > 0 && (
+            <div className="space-y-1">
+              {Object.keys(envVars)
+                .sort()
+                .map(key => (
+                  <div key={key} className="flex items-center gap-4 font-mono text-sm">
+                    <span className="text-foreground min-w-48">{key}</span>
+                    <span className="text-muted-foreground">••••••••</span>
+                  </div>
+                ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={showRestartDialog} onOpenChange={setShowRestartDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Force Restart Container</DialogTitle>
+            <DialogDescription>
+              This will force-restart the Gastown container for this town. All running agents will
+              be interrupted. This action is logged in the audit trail.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowRestartDialog(false)}
+              disabled={forceRestartMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => forceRestartMutation.mutate({ townId })}
+              disabled={forceRestartMutation.isPending}
+            >
+              {forceRestartMutation.isPending ? 'Restarting…' : 'Force Restart'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/ContainerTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ContainerTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -29,6 +30,10 @@ export function ContainerTab({ townId }: { townId: string }) {
     trpc.admin.gastown.forceRestartContainer.mutationOptions({
       onSuccess: () => {
         setShowRestartDialog(false);
+        toast.success('Container restart requested');
+      },
+      onError: err => {
+        toast.error(`Failed to restart container: ${err.message}`);
       },
     })
   );
@@ -78,7 +83,12 @@ export function ContainerTab({ townId }: { townId: string }) {
           {healthQuery.isLoading && (
             <p className="text-muted-foreground text-sm">Loading health status…</p>
           )}
-          {!healthQuery.isLoading && (
+          {healthQuery.isError && (
+            <p className="text-sm text-red-400">
+              Failed to load container health: {healthQuery.error.message}
+            </p>
+          )}
+          {!healthQuery.isLoading && !healthQuery.isError && (
             <div className="flex flex-col gap-4">
               <div className="flex items-center gap-3">
                 <span className="text-muted-foreground text-sm">Status:</span>

--- a/src/app/admin/gastown/towns/[townId]/EventsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/EventsTab.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { formatDistanceToNow, format } from 'date-fns';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+type SortDir = 'asc' | 'desc';
+
+export function EventsTab({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [beadFilter, setBeadFilter] = useState('');
+  const [agentFilter, setAgentFilter] = useState('');
+  const [limit, setLimit] = useState(100);
+
+  const eventsQuery = useQuery(
+    trpc.admin.gastown.getBeadEvents.queryOptions({ townId, limit })
+  );
+
+  const events = eventsQuery.data ?? [];
+
+  const filtered = events.filter(e => {
+    if (beadFilter && !e.bead_id.toLowerCase().includes(beadFilter.toLowerCase())) return false;
+    if (agentFilter && e.agent_id && !e.agent_id.toLowerCase().includes(agentFilter.toLowerCase()))
+      return false;
+    return true;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    const diff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    return sortDir === 'desc' ? -diff : diff;
+  });
+
+  const toggleSort = () => setSortDir(d => (d === 'desc' ? 'asc' : 'desc'));
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle>Events Timeline</CardTitle>
+          <div className="flex flex-wrap items-center gap-2">
+            <Input
+              placeholder="Filter by bead ID…"
+              value={beadFilter}
+              onChange={e => setBeadFilter(e.target.value)}
+              className="h-8 w-48 text-xs"
+            />
+            <Input
+              placeholder="Filter by agent ID…"
+              value={agentFilter}
+              onChange={e => setAgentFilter(e.target.value)}
+              className="h-8 w-48 text-xs"
+            />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {eventsQuery.isLoading && (
+          <p className="text-muted-foreground py-8 text-center text-sm">Loading events…</p>
+        )}
+        {eventsQuery.isError && (
+          <p className="py-8 text-center text-sm text-red-400">
+            Failed to load events: {eventsQuery.error.message}
+          </p>
+        )}
+        {!eventsQuery.isLoading && sorted.length === 0 && (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            {events.length === 0
+              ? 'No events found for this town.'
+              : 'No events match the current filters.'}
+          </p>
+        )}
+        {sorted.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-muted-foreground pb-2 text-left font-medium">
+                    <button
+                      className="flex items-center gap-1 hover:text-foreground transition-colors"
+                      onClick={toggleSort}
+                    >
+                      Time
+                      {sortDir === 'desc' ? (
+                        <ChevronDown className="h-3 w-3" />
+                      ) : (
+                        <ChevronUp className="h-3 w-3" />
+                      )}
+                    </button>
+                  </th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Event</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Agent</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Change</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map(event => (
+                  <tr
+                    key={event.bead_event_id}
+                    className="hover:bg-muted/40 border-b transition-colors"
+                  >
+                    <td className="text-muted-foreground py-2 pr-4 text-xs">
+                      <span title={format(new Date(event.created_at), 'PPpp')}>
+                        {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
+                        {event.event_type}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Link
+                        href={`/admin/gastown/towns/${townId}/beads/${event.bead_id}`}
+                        className="hover:text-foreground font-mono text-xs text-blue-400 transition-colors"
+                      >
+                        {event.bead_id.slice(0, 8)}…
+                      </Link>
+                      {event.rig_name && (
+                        <span className="text-muted-foreground ml-1 text-xs">
+                          ({event.rig_name})
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4">
+                      {event.agent_id ? (
+                        <Link
+                          href={`/admin/gastown/towns/${townId}/agents/${event.agent_id}`}
+                          className="hover:text-foreground font-mono text-xs text-blue-400 transition-colors"
+                        >
+                          {event.agent_id.slice(0, 8)}…
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </td>
+                    <td className="py-2 text-xs">
+                      {(event.old_value ?? event.new_value) ? (
+                        <div className="flex items-center gap-1">
+                          {event.old_value && (
+                            <span className="rounded bg-red-500/10 px-1 py-0.5 font-mono text-red-400 line-through">
+                              {event.old_value.length > 30
+                                ? `${event.old_value.slice(0, 30)}…`
+                                : event.old_value}
+                            </span>
+                          )}
+                          {event.old_value && event.new_value && (
+                            <span className="text-muted-foreground">→</span>
+                          )}
+                          {event.new_value && (
+                            <span className="rounded bg-green-500/10 px-1 py-0.5 font-mono text-green-400">
+                              {event.new_value.length > 30
+                                ? `${event.new_value.slice(0, 30)}…`
+                                : event.new_value}
+                            </span>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {events.length >= limit && (
+          <div className="mt-4 flex justify-center">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setLimit(l => l + 100)}
+              disabled={eventsQuery.isFetching}
+            >
+              {eventsQuery.isFetching ? 'Loading…' : `Load more (showing ${events.length})`}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/EventsTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/EventsTab.tsx
@@ -20,9 +20,7 @@ export function EventsTab({ townId }: { townId: string }) {
   const [agentFilter, setAgentFilter] = useState('');
   const [limit, setLimit] = useState(100);
 
-  const eventsQuery = useQuery(
-    trpc.admin.gastown.getBeadEvents.queryOptions({ townId, limit })
-  );
+  const eventsQuery = useQuery(trpc.admin.gastown.getBeadEvents.queryOptions({ townId, limit }));
 
   const events = eventsQuery.data ?? [];
 
@@ -84,7 +82,7 @@ export function EventsTab({ townId }: { townId: string }) {
                 <tr className="border-b">
                   <th className="text-muted-foreground pb-2 text-left font-medium">
                     <button
-                      className="flex items-center gap-1 hover:text-foreground transition-colors"
+                      className="hover:text-foreground flex items-center gap-1 transition-colors"
                       onClick={toggleSort}
                     >
                       Time

--- a/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
+import { ExternalLink } from 'lucide-react';
+
+const STATUS_COLORS: Record<string, string> = {
+  open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  closed: 'bg-green-500/10 text-green-400 border-green-500/20',
+  failed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+type EntryToRetry = { id: string; title: string };
+
+export function ReviewQueueTab({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const [entryToRetry, setEntryToRetry] = useState<EntryToRetry | null>(null);
+
+  // Fetch in-progress merge request beads as the review queue
+  const inProgressQuery = useQuery(
+    trpc.admin.gastown.listBeads.queryOptions({
+      townId,
+      type: 'merge_request',
+      status: 'in_progress',
+    })
+  );
+
+  const openQuery = useQuery(
+    trpc.admin.gastown.listBeads.queryOptions({
+      townId,
+      type: 'merge_request',
+      status: 'open',
+    })
+  );
+
+  const forceRetryMutation = useMutation(
+    trpc.admin.gastown.forceRetryReview.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        setEntryToRetry(null);
+      },
+    })
+  );
+
+  const queueEntries = [...(inProgressQuery.data ?? []), ...(openQuery.data ?? [])];
+  const isLoading = inProgressQuery.isLoading || openQuery.isLoading;
+  const isError = inProgressQuery.isError || openQuery.isError;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Review Queue</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            Loading review queue…
+          </p>
+        )}
+        {isError && (
+          <p className="py-8 text-center text-sm text-red-400">Failed to load review queue.</p>
+        )}
+        {!isLoading && queueEntries.length === 0 && (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            No active review queue entries. (Town-wide listing requires bead 0 admin endpoints.)
+          </p>
+        )}
+        {queueEntries.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">PR URL</th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">
+                    Assigned Agent
+                  </th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">
+                    Time in Queue
+                  </th>
+                  <th className="text-muted-foreground pb-2 text-left font-medium">Status</th>
+                  <th className="text-muted-foreground pb-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {queueEntries.map(entry => {
+                  const prUrl =
+                    typeof entry.metadata['pr_url'] === 'string' ? entry.metadata['pr_url'] : null;
+                  return (
+                    <tr
+                      key={entry.bead_id}
+                      className="hover:bg-muted/40 border-b transition-colors"
+                    >
+                      <td className="py-2 pr-4">
+                        <Link
+                          href={`/admin/gastown/towns/${townId}/beads/${entry.bead_id}`}
+                          className="hover:text-foreground text-blue-400 transition-colors"
+                        >
+                          <div className="max-w-64 truncate">{entry.title}</div>
+                          <div className="text-muted-foreground font-mono text-xs">
+                            {entry.bead_id.slice(0, 8)}…
+                          </div>
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-4">
+                        {prUrl ? (
+                          <a
+                            href={prUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1 text-blue-400 hover:underline"
+                          >
+                            <span className="max-w-40 truncate text-xs">{prUrl}</span>
+                            <ExternalLink className="h-3 w-3 shrink-0" />
+                          </a>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">—</span>
+                        )}
+                      </td>
+                      <td className="py-2 pr-4">
+                        {entry.assignee_agent_bead_id ? (
+                          <Link
+                            href={`/admin/gastown/towns/${townId}/agents/${entry.assignee_agent_bead_id}`}
+                            className="text-muted-foreground hover:text-foreground font-mono text-xs transition-colors"
+                          >
+                            {entry.assignee_agent_bead_id.slice(0, 8)}…
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">—</span>
+                        )}
+                      </td>
+                      <td className="text-muted-foreground py-2 pr-4 text-xs">
+                        {formatDistanceToNow(new Date(entry.created_at), { addSuffix: false })}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <Badge
+                          variant="outline"
+                          className={STATUS_COLORS[entry.status] ?? ''}
+                        >
+                          {entry.status}
+                        </Badge>
+                      </td>
+                      <td className="py-2 text-right">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() =>
+                            setEntryToRetry({ id: entry.bead_id, title: entry.title })
+                          }
+                        >
+                          Force Retry
+                        </Button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={!!entryToRetry} onOpenChange={() => setEntryToRetry(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Force Retry Review</DialogTitle>
+            <DialogDescription>
+              This will force-retry the review for{' '}
+              <span className="font-semibold">{entryToRetry?.title}</span>. This action is logged
+              in the audit trail.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setEntryToRetry(null)}
+              disabled={forceRetryMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() =>
+                entryToRetry &&
+                forceRetryMutation.mutate({ townId, entryId: entryToRetry.id })
+              }
+              disabled={forceRetryMutation.isPending}
+            >
+              {forceRetryMutation.isPending ? 'Retrying…' : 'Force Retry'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
@@ -165,7 +165,8 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
                           size="sm"
                           variant="outline"
                           className="h-7 text-xs"
-                          onClick={() => setEntryToRetry({ id: entry.bead_id, title: entry.title })}
+                          disabled
+                          title="Review retry not yet implemented"
                         >
                           Force Retry
                         </Button>

--- a/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -55,6 +56,10 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
         setEntryToRetry(null);
+        toast.success('Review retry requested');
+      },
+      onError: err => {
+        toast.error(`Failed to retry review: ${err.message}`);
       },
     })
   );
@@ -70,9 +75,7 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
       </CardHeader>
       <CardContent>
         {isLoading && (
-          <p className="text-muted-foreground py-8 text-center text-sm">
-            Loading review queue…
-          </p>
+          <p className="text-muted-foreground py-8 text-center text-sm">Loading review queue…</p>
         )}
         {isError && (
           <p className="py-8 text-center text-sm text-red-400">Failed to load review queue.</p>
@@ -102,7 +105,10 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
               <tbody>
                 {queueEntries.map(entry => {
                   const prUrl =
-                    typeof entry.metadata['pr_url'] === 'string' ? entry.metadata['pr_url'] : null;
+                    typeof entry.metadata['pr_url'] === 'string' &&
+                    /^https?:\/\//.test(entry.metadata['pr_url'])
+                      ? entry.metadata['pr_url']
+                      : null;
                   return (
                     <tr
                       key={entry.bead_id}
@@ -150,10 +156,7 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
                         {formatDistanceToNow(new Date(entry.created_at), { addSuffix: false })}
                       </td>
                       <td className="py-2 pr-4">
-                        <Badge
-                          variant="outline"
-                          className={STATUS_COLORS[entry.status] ?? ''}
-                        >
+                        <Badge variant="outline" className={STATUS_COLORS[entry.status] ?? ''}>
                           {entry.status}
                         </Badge>
                       </td>
@@ -162,9 +165,7 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
                           size="sm"
                           variant="outline"
                           className="h-7 text-xs"
-                          onClick={() =>
-                            setEntryToRetry({ id: entry.bead_id, title: entry.title })
-                          }
+                          onClick={() => setEntryToRetry({ id: entry.bead_id, title: entry.title })}
                         >
                           Force Retry
                         </Button>
@@ -184,8 +185,8 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
             <DialogTitle>Force Retry Review</DialogTitle>
             <DialogDescription>
               This will force-retry the review for{' '}
-              <span className="font-semibold">{entryToRetry?.title}</span>. This action is logged
-              in the audit trail.
+              <span className="font-semibold">{entryToRetry?.title}</span>. This action is logged in
+              the audit trail.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -198,8 +199,7 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
             </Button>
             <Button
               onClick={() =>
-                entryToRetry &&
-                forceRetryMutation.mutate({ townId, entryId: entryToRetry.id })
+                entryToRetry && forceRetryMutation.mutate({ townId, entryId: entryToRetry.id })
               }
               disabled={forceRetryMutation.isPending}
             >

--- a/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
+++ b/src/app/admin/gastown/towns/[townId]/ReviewQueueTab.tsx
@@ -82,7 +82,7 @@ export function ReviewQueueTab({ townId }: { townId: string }) {
         )}
         {!isLoading && queueEntries.length === 0 && (
           <p className="text-muted-foreground py-8 text-center text-sm">
-            No active review queue entries. (Town-wide listing requires bead 0 admin endpoints.)
+            No active review queue entries.
           </p>
         )}
         {queueEntries.length > 0 && (

--- a/src/app/admin/gastown/towns/[townId]/TownInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/TownInspectorDashboard.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useCallback } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { BeadsTab } from './BeadsTab';
+import { AgentsTab } from './AgentsTab';
+import { ReviewQueueTab } from './ReviewQueueTab';
+import { ContainerTab } from './ContainerTab';
+import { ConfigTab } from './ConfigTab';
+import { EventsTab } from './EventsTab';
+import Link from 'next/link';
+
+const VALID_TABS = ['beads', 'agents', 'review', 'container', 'config', 'events'] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+function isValidTab(value: string | null): value is Tab {
+  return value !== null && (VALID_TABS as readonly string[]).includes(value);
+}
+
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
+export function TownInspectorDashboard({ townId }: { townId: string }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const tabParam = searchParams.get('tab');
+  const activeTab: Tab = isValidTab(tabParam) ? tabParam : 'beads';
+
+  const onTabChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === 'beads') {
+        params.delete('tab');
+      } else {
+        params.set('tab', value);
+      }
+      const qs = params.toString();
+      router.replace(`${pathname}${qs ? `?${qs}` : ''}`, { scroll: false });
+    },
+    [searchParams, router, pathname]
+  );
+
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Town Inspector</h1>
+          <p className="text-muted-foreground font-mono text-sm">{townId}</p>
+        </div>
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/admin/gastown/towns/${townId}/audit`}>Audit Log</Link>
+        </Button>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={onTabChange}>
+        <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+          <TabsTrigger value="beads" className={tabTriggerClass}>
+            Beads
+          </TabsTrigger>
+          <TabsTrigger value="agents" className={tabTriggerClass}>
+            Agents
+          </TabsTrigger>
+          <TabsTrigger value="review" className={tabTriggerClass}>
+            Review Queue
+          </TabsTrigger>
+          <TabsTrigger value="container" className={tabTriggerClass}>
+            Container
+          </TabsTrigger>
+          <TabsTrigger value="config" className={tabTriggerClass}>
+            Config
+          </TabsTrigger>
+          <TabsTrigger value="events" className={tabTriggerClass}>
+            Events
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="beads" className="mt-4">
+          <BeadsTab townId={townId} />
+        </TabsContent>
+        <TabsContent value="agents" className="mt-4">
+          <AgentsTab townId={townId} />
+        </TabsContent>
+        <TabsContent value="review" className="mt-4">
+          <ReviewQueueTab townId={townId} />
+        </TabsContent>
+        <TabsContent value="container" className="mt-4">
+          <ContainerTab townId={townId} />
+        </TabsContent>
+        <TabsContent value="config" className="mt-4">
+          <ConfigTab townId={townId} />
+        </TabsContent>
+        <TabsContent value="events" className="mt-4">
+          <EventsTab townId={townId} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/agents/[agentId]/AgentInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/agents/[agentId]/AgentInspectorDashboard.tsx
@@ -1,0 +1,523 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import Link from 'next/link';
+import { formatDistanceToNow, format } from 'date-fns';
+import { ArrowLeft, ChevronDown, ChevronUp } from 'lucide-react';
+
+const AGENT_STATUS_COLORS: Record<string, string> = {
+  working: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  idle: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  dead: 'bg-red-500/10 text-red-400 border-red-500/20',
+  stalled: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+};
+
+
+type SortDir = 'asc' | 'desc';
+
+export function AgentInspectorDashboard({
+  townId,
+  agentId,
+}: {
+  townId: string;
+  agentId: string;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [eventSearch, setEventSearch] = useState('');
+  const [eventSortDir, setEventSortDir] = useState<SortDir>('desc');
+  const [eventLimit, setEventLimit] = useState(500);
+
+  // Fetch agent from list
+  const agentsQuery = useQuery(trpc.admin.gastown.listAgents.queryOptions({ townId }));
+  const agent = (agentsQuery.data ?? []).find(a => a.id === agentId) ?? null;
+
+  const agentEventsQuery = useQuery(
+    trpc.admin.gastown.getAgentEvents.queryOptions({ townId, agentId, limit: eventLimit })
+  );
+
+  const beadEventsQuery = useQuery(
+    trpc.admin.gastown.getBeadEvents.queryOptions({ townId, limit: 500 })
+  );
+
+  const dispatchAttemptsQuery = useQuery(
+    trpc.admin.gastown.listDispatchAttempts.queryOptions({ townId, agentId })
+  );
+
+  const forceResetMutation = useMutation(
+    trpc.admin.gastown.forceResetAgent.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listAgents.queryFilter({ townId }));
+        setConfirmReset(false);
+      },
+    })
+  );
+
+  const agentEvents = agentEventsQuery.data ?? [];
+  const allBeadEvents = beadEventsQuery.data ?? [];
+  const dispatchAttempts = dispatchAttemptsQuery.data ?? [];
+
+  // Events related to this agent from bead events
+  const agentBeadEvents = allBeadEvents.filter(e => e.agent_id === agentId);
+
+  // Deduplicated bead IDs that this agent was ever hooked to
+  const hookedBeadIds = Array.from(new Set(agentBeadEvents.map(e => e.bead_id)));
+
+  // Filtered + sorted agent events
+  const filteredAgentEvents = agentEvents
+    .filter(e => {
+      if (!eventSearch) return true;
+      const ev = e as Record<string, unknown>;
+      return JSON.stringify(ev).toLowerCase().includes(eventSearch.toLowerCase());
+    })
+    .sort((a, b) => {
+      const ea = a as Record<string, unknown>;
+      const eb = b as Record<string, unknown>;
+      const ta = new Date(ea['created_at'] as string).getTime();
+      const tb = new Date(eb['created_at'] as string).getTime();
+      return eventSortDir === 'desc' ? tb - ta : ta - tb;
+    });
+
+  return (
+    <div className="flex w-full flex-col gap-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <Link
+            href={`/admin/gastown/towns/${townId}?tab=agents`}
+            className="text-muted-foreground hover:text-foreground mb-2 flex items-center gap-1 text-sm transition-colors"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Back to Town Inspector
+          </Link>
+          <h1 className="text-2xl font-semibold">Agent Inspector</h1>
+          <p className="text-muted-foreground font-mono text-sm">{agentId}</p>
+        </div>
+        {agent && (
+          <Badge variant="outline" className={AGENT_STATUS_COLORS[agent.status] ?? ''}>
+            {agent.status}
+          </Badge>
+        )}
+      </div>
+
+      {agentsQuery.isLoading && (
+        <p className="text-muted-foreground py-8 text-center text-sm">Loading agent…</p>
+      )}
+
+      {agent && (
+        <>
+          {/* Agent overview */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Overview</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm md:grid-cols-3">
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Name
+                  </dt>
+                  <dd className="font-semibold">{agent.name}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Role
+                  </dt>
+                  <dd className="font-mono">{agent.role}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Identity
+                  </dt>
+                  <dd className="font-mono text-xs">{agent.identity}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Dispatch Attempts
+                  </dt>
+                  <dd>{agent.dispatch_attempts}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Last Active
+                  </dt>
+                  <dd>
+                    {agent.last_activity_at
+                      ? formatDistanceToNow(new Date(agent.last_activity_at), {
+                          addSuffix: true,
+                        })
+                      : '—'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Created
+                  </dt>
+                  <dd title={format(new Date(agent.created_at), 'PPpp')}>
+                    {formatDistanceToNow(new Date(agent.created_at), { addSuffix: true })}
+                  </dd>
+                </div>
+                {agent.current_hook_bead_id && (
+                  <div>
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Current Hooked Bead
+                    </dt>
+                    <dd>
+                      <Link
+                        href={`/admin/gastown/towns/${townId}/beads/${agent.current_hook_bead_id}`}
+                        className="font-mono text-xs text-blue-400 hover:underline"
+                      >
+                        {agent.current_hook_bead_id.slice(0, 8)}…
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+                {agent.rig_id && (
+                  <div>
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Rig
+                    </dt>
+                    <dd className="font-mono text-xs">{agent.rig_id.slice(0, 8)}…</dd>
+                  </div>
+                )}
+              </dl>
+            </CardContent>
+          </Card>
+
+          {/* Admin Actions */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Admin Actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-red-500/30 text-red-400 hover:bg-red-500/10"
+                onClick={() => setConfirmReset(true)}
+              >
+                Force Reset Agent
+              </Button>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {/* Current/Past Hooked Beads */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Hooked Beads</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {beadEventsQuery.isLoading && (
+            <p className="text-muted-foreground py-4 text-center text-sm">Loading…</p>
+          )}
+          {!beadEventsQuery.isLoading && hookedBeadIds.length === 0 && (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              No bead history found for this agent.
+            </p>
+          )}
+          {hookedBeadIds.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Events</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">
+                      Last Event
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {hookedBeadIds.map(bid => {
+                    const beadEvs = agentBeadEvents.filter(e => e.bead_id === bid);
+                    const latest = beadEvs.reduce((a, b) =>
+                      new Date(a.created_at) > new Date(b.created_at) ? a : b
+                    );
+                    return (
+                      <tr key={bid} className="hover:bg-muted/40 border-b transition-colors">
+                        <td className="py-2 pr-4">
+                          <Link
+                            href={`/admin/gastown/towns/${townId}/beads/${bid}`}
+                            className="font-mono text-xs text-blue-400 hover:underline"
+                          >
+                            {bid.slice(0, 8)}…
+                          </Link>
+                        </td>
+                        <td className="text-muted-foreground py-2 pr-4 text-center text-xs">
+                          {beadEvs.length}
+                        </td>
+                        <td
+                          className="text-muted-foreground py-2 text-xs"
+                          title={format(new Date(latest.created_at), 'PPpp')}
+                        >
+                          {formatDistanceToNow(new Date(latest.created_at), {
+                            addSuffix: true,
+                          })}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Status Timeline */}
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle>Status Timeline</CardTitle>
+            <div className="flex items-center gap-2">
+              <Input
+                placeholder="Search events…"
+                value={eventSearch}
+                onChange={e => setEventSearch(e.target.value)}
+                className="h-8 w-48 text-xs"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1 text-xs"
+                onClick={() => setEventSortDir(d => (d === 'desc' ? 'asc' : 'desc'))}
+              >
+                Time
+                {eventSortDir === 'desc' ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronUp className="h-3 w-3" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {agentEventsQuery.isLoading && (
+            <p className="text-muted-foreground py-4 text-center text-sm">Loading events…</p>
+          )}
+          {!agentEventsQuery.isLoading && filteredAgentEvents.length === 0 && (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              {agentEvents.length === 0
+                ? 'No agent events found. (Requires bead 0 admin endpoints.)'
+                : 'No events match the current search.'}
+            </p>
+          )}
+          {filteredAgentEvents.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Time</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Event</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Change</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredAgentEvents.map((rawEvent, idx) => {
+                    const ev = rawEvent as Record<string, unknown>;
+                    const eventId = String(ev['id'] ?? ev['agent_event_id'] ?? idx);
+                    const createdAt = String(ev['created_at'] ?? '');
+                    const eventType = String(ev['event_type'] ?? '');
+                    const oldValue = ev['old_value'] as string | null | undefined;
+                    const newValue = ev['new_value'] as string | null | undefined;
+                    return (
+                      <tr
+                        key={eventId}
+                        className="hover:bg-muted/40 border-b transition-colors"
+                      >
+                        <td
+                          className="text-muted-foreground py-2 pr-4 text-xs"
+                          title={createdAt ? format(new Date(createdAt), 'PPpp') : ''}
+                        >
+                          {createdAt
+                            ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+                            : '—'}
+                        </td>
+                        <td className="py-2 pr-4">
+                          <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
+                            {eventType}
+                          </span>
+                        </td>
+                        <td className="py-2 text-xs">
+                          {(oldValue ?? newValue) ? (
+                            <div className="flex flex-wrap items-center gap-1">
+                              {oldValue && (
+                                <span className="rounded bg-red-500/10 px-1 py-0.5 font-mono text-red-400 line-through">
+                                  {String(oldValue).length > 40
+                                    ? `${String(oldValue).slice(0, 40)}…`
+                                    : String(oldValue)}
+                                </span>
+                              )}
+                              {oldValue && newValue && (
+                                <span className="text-muted-foreground">→</span>
+                              )}
+                              {newValue && (
+                                <span className="rounded bg-green-500/10 px-1 py-0.5 font-mono text-green-400">
+                                  {String(newValue).length > 40
+                                    ? `${String(newValue).slice(0, 40)}…`
+                                    : String(newValue)}
+                                </span>
+                              )}
+                            </div>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {agentEvents.length >= eventLimit && (
+            <div className="mt-4 flex justify-center">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setEventLimit(l => l + 500)}
+                disabled={agentEventsQuery.isFetching}
+              >
+                {agentEventsQuery.isFetching
+                  ? 'Loading…'
+                  : `Load more (showing ${agentEvents.length})`}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Dispatch Attempts */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Dispatch Attempt History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {dispatchAttemptsQuery.isLoading && (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              Loading dispatch attempts…
+            </p>
+          )}
+          {!dispatchAttemptsQuery.isLoading && dispatchAttempts.length === 0 && (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              No dispatch attempts found.
+            </p>
+          )}
+          {dispatchAttempts.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Time</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Result</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Error</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dispatchAttempts.map(attempt => (
+                    <tr
+                      key={attempt.id}
+                      className="hover:bg-muted/40 border-b transition-colors"
+                    >
+                      <td
+                        className="text-muted-foreground py-2 pr-4 text-xs"
+                        title={format(new Date(attempt.attempted_at), 'PPpp')}
+                      >
+                        {formatDistanceToNow(new Date(attempt.attempted_at), {
+                          addSuffix: true,
+                        })}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <Badge
+                          variant="outline"
+                          className={
+                            attempt.success
+                              ? 'border-green-500/20 bg-green-500/10 text-green-400'
+                              : 'border-red-500/20 bg-red-500/10 text-red-400'
+                          }
+                        >
+                          {attempt.success ? 'Success' : 'Failed'}
+                        </Badge>
+                      </td>
+                      <td className="py-2 pr-4">
+                        {attempt.bead_id ? (
+                          <Link
+                            href={`/admin/gastown/towns/${townId}/beads/${attempt.bead_id}`}
+                            className="font-mono text-xs text-blue-400 hover:underline"
+                          >
+                            {attempt.bead_id.slice(0, 8)}…
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">—</span>
+                        )}
+                      </td>
+                      <td className="max-w-xs py-2 text-xs text-red-400">
+                        {attempt.error_message ? (
+                          <span title={attempt.error_message}>
+                            {attempt.error_message.length > 80
+                              ? `${attempt.error_message.slice(0, 80)}…`
+                              : attempt.error_message}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Confirm Reset AlertDialog */}
+      <AlertDialog open={confirmReset} onOpenChange={setConfirmReset}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Force Reset Agent</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will reset agent{' '}
+              <span className="font-semibold">{agent?.name ?? agentId.slice(0, 8)}</span>{' '}
+              to idle status and unhook any hooked bead. This action is logged in the audit trail.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={forceResetMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => forceResetMutation.mutate({ townId, agentId })}
+              disabled={forceResetMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {forceResetMutation.isPending ? 'Resetting…' : 'Force Reset'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+
+    </div>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/agents/[agentId]/AgentInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/agents/[agentId]/AgentInspectorDashboard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -28,16 +29,23 @@ const AGENT_STATUS_COLORS: Record<string, string> = {
   stalled: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
 };
 
-
 type SortDir = 'asc' | 'desc';
 
-export function AgentInspectorDashboard({
-  townId,
-  agentId,
-}: {
-  townId: string;
-  agentId: string;
-}) {
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function safeTimestamp(value: unknown): number {
+  if (typeof value !== 'string') return 0;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+export function AgentInspectorDashboard({ townId, agentId }: { townId: string; agentId: string }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
@@ -67,6 +75,10 @@ export function AgentInspectorDashboard({
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.admin.gastown.listAgents.queryFilter({ townId }));
         setConfirmReset(false);
+        toast.success('Agent reset successfully');
+      },
+      onError: err => {
+        toast.error(`Failed to reset agent: ${err.message}`);
       },
     })
   );
@@ -85,14 +97,11 @@ export function AgentInspectorDashboard({
   const filteredAgentEvents = agentEvents
     .filter(e => {
       if (!eventSearch) return true;
-      const ev = e as Record<string, unknown>;
-      return JSON.stringify(ev).toLowerCase().includes(eventSearch.toLowerCase());
+      return JSON.stringify(e).toLowerCase().includes(eventSearch.toLowerCase());
     })
     .sort((a, b) => {
-      const ea = a as Record<string, unknown>;
-      const eb = b as Record<string, unknown>;
-      const ta = new Date(ea['created_at'] as string).getTime();
-      const tb = new Date(eb['created_at'] as string).getTime();
+      const ta = safeTimestamp(toRecord(a)['created_at']);
+      const tb = safeTimestamp(toRecord(b)['created_at']);
       return eventSortDir === 'desc' ? tb - ta : ta - tb;
     });
 
@@ -132,31 +141,31 @@ export function AgentInspectorDashboard({
             <CardContent>
               <dl className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm md:grid-cols-3">
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Name
                   </dt>
                   <dd className="font-semibold">{agent.name}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Role
                   </dt>
                   <dd className="font-mono">{agent.role}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Identity
                   </dt>
                   <dd className="font-mono text-xs">{agent.identity}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Dispatch Attempts
                   </dt>
                   <dd>{agent.dispatch_attempts}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Last Active
                   </dt>
                   <dd>
@@ -168,7 +177,7 @@ export function AgentInspectorDashboard({
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Created
                   </dt>
                   <dd title={format(new Date(agent.created_at), 'PPpp')}>
@@ -177,7 +186,7 @@ export function AgentInspectorDashboard({
                 </div>
                 {agent.current_hook_bead_id && (
                   <div>
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Current Hooked Bead
                     </dt>
                     <dd>
@@ -192,7 +201,7 @@ export function AgentInspectorDashboard({
                 )}
                 {agent.rig_id && (
                   <div>
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Rig
                     </dt>
                     <dd className="font-mono text-xs">{agent.rig_id.slice(0, 8)}…</dd>
@@ -242,9 +251,7 @@ export function AgentInspectorDashboard({
                   <tr className="border-b">
                     <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
                     <th className="text-muted-foreground pb-2 text-left font-medium">Events</th>
-                    <th className="text-muted-foreground pb-2 text-left font-medium">
-                      Last Event
-                    </th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Last Event</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -335,17 +342,15 @@ export function AgentInspectorDashboard({
                 </thead>
                 <tbody>
                   {filteredAgentEvents.map((rawEvent, idx) => {
-                    const ev = rawEvent as Record<string, unknown>;
-                    const eventId = String(ev['id'] ?? ev['agent_event_id'] ?? idx);
-                    const createdAt = String(ev['created_at'] ?? '');
-                    const eventType = String(ev['event_type'] ?? '');
-                    const oldValue = ev['old_value'] as string | null | undefined;
-                    const newValue = ev['new_value'] as string | null | undefined;
+                    const ev = toRecord(rawEvent);
+                    const eventId =
+                      safeString(ev['id']) || safeString(ev['agent_event_id']) || String(idx);
+                    const createdAt = safeString(ev['created_at']);
+                    const eventType = safeString(ev['event_type']);
+                    const oldValue = typeof ev['old_value'] === 'string' ? ev['old_value'] : null;
+                    const newValue = typeof ev['new_value'] === 'string' ? ev['new_value'] : null;
                     return (
-                      <tr
-                        key={eventId}
-                        className="hover:bg-muted/40 border-b transition-colors"
-                      >
+                      <tr key={eventId} className="hover:bg-muted/40 border-b transition-colors">
                         <td
                           className="text-muted-foreground py-2 pr-4 text-xs"
                           title={createdAt ? format(new Date(createdAt), 'PPpp') : ''}
@@ -437,10 +442,7 @@ export function AgentInspectorDashboard({
                 </thead>
                 <tbody>
                   {dispatchAttempts.map(attempt => (
-                    <tr
-                      key={attempt.id}
-                      className="hover:bg-muted/40 border-b transition-colors"
-                    >
+                    <tr key={attempt.id} className="hover:bg-muted/40 border-b transition-colors">
                       <td
                         className="text-muted-foreground py-2 pr-4 text-xs"
                         title={format(new Date(attempt.attempted_at), 'PPpp')}
@@ -500,8 +502,8 @@ export function AgentInspectorDashboard({
             <AlertDialogTitle>Force Reset Agent</AlertDialogTitle>
             <AlertDialogDescription>
               This will reset agent{' '}
-              <span className="font-semibold">{agent?.name ?? agentId.slice(0, 8)}</span>{' '}
-              to idle status and unhook any hooked bead. This action is logged in the audit trail.
+              <span className="font-semibold">{agent?.name ?? agentId.slice(0, 8)}</span> to idle
+              status and unhook any hooked bead. This action is logged in the audit trail.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -516,8 +518,6 @@ export function AgentInspectorDashboard({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-
     </div>
   );
 }

--- a/src/app/admin/gastown/towns/[townId]/agents/[agentId]/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/agents/[agentId]/page.tsx
@@ -1,0 +1,40 @@
+import AdminPage from '@/app/admin/components/AdminPage';
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { AgentInspectorDashboard } from './AgentInspectorDashboard';
+
+export default async function AgentInspectorPage({
+  params,
+}: {
+  params: Promise<{ townId: string; agentId: string }>;
+}) {
+  const { townId, agentId } = await params;
+
+  const breadcrumbs = (
+    <>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbLink href={`/admin/gastown/towns/${townId}`}>
+          Town {townId.slice(0, 8)}…
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage>Agent {agentId.slice(0, 8)}…</BreadcrumbPage>
+      </BreadcrumbItem>
+    </>
+  );
+
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <AgentInspectorDashboard townId={townId} agentId={agentId} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/audit/AuditLogDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/audit/AuditLogDashboard.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import Link from 'next/link';
+import { formatDistanceToNow, format } from 'date-fns';
+import { ArrowLeft, ChevronDown, ChevronUp } from 'lucide-react';
+
+type SortDir = 'asc' | 'desc';
+
+export function AuditLogDashboard({ townId }: { townId: string }) {
+  const trpc = useTRPC();
+
+  const [search, setSearch] = useState('');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const auditQuery = useQuery(trpc.admin.gastown.listAuditLog.queryOptions({ townId }));
+  const entries = auditQuery.data ?? [];
+
+  const filtered = entries.filter(entry => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      entry.admin_user_id.toLowerCase().includes(q) ||
+      entry.action.toLowerCase().includes(q) ||
+      (entry.target_type ?? '').toLowerCase().includes(q) ||
+      (entry.target_id ?? '').toLowerCase().includes(q)
+    );
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    const diff =
+      new Date(a.performed_at).getTime() - new Date(b.performed_at).getTime();
+    return sortDir === 'desc' ? -diff : diff;
+  });
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-y-6">
+      {/* Header */}
+      <div>
+        <Link
+          href={`/admin/gastown/towns/${townId}`}
+          className="text-muted-foreground hover:text-foreground mb-2 flex items-center gap-1 text-sm transition-colors"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Back to Town Inspector
+        </Link>
+        <h1 className="text-2xl font-semibold">Audit Log</h1>
+        <p className="text-muted-foreground font-mono text-sm">{townId}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle>Admin Actions</CardTitle>
+            <Input
+              placeholder="Search by action, user, target…"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="h-8 w-64 text-xs"
+            />
+          </div>
+        </CardHeader>
+        <CardContent>
+          {auditQuery.isLoading && (
+            <p className="text-muted-foreground py-8 text-center text-sm">
+              Loading audit log…
+            </p>
+          )}
+          {auditQuery.isError && (
+            <p className="py-8 text-center text-sm text-red-400">
+              Failed to load audit log: {auditQuery.error.message}
+            </p>
+          )}
+          {!auditQuery.isLoading && sorted.length === 0 && (
+            <p className="text-muted-foreground py-8 text-center text-sm">
+              {entries.length === 0
+                ? 'No audit log entries found. (Requires bead 0 admin endpoints.)'
+                : 'No entries match the current search.'}
+            </p>
+          )}
+          {sorted.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-muted-foreground pb-2 text-left font-medium">
+                      <button
+                        className="hover:text-foreground flex items-center gap-1 transition-colors"
+                        onClick={() => setSortDir(d => (d === 'desc' ? 'asc' : 'desc'))}
+                      >
+                        Time
+                        {sortDir === 'desc' ? (
+                          <ChevronDown className="h-3 w-3" />
+                        ) : (
+                          <ChevronUp className="h-3 w-3" />
+                        )}
+                      </button>
+                    </th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Admin</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Action</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">
+                      Target Type
+                    </th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">
+                      Target ID
+                    </th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map(entry => {
+                    const isExpanded = expandedIds.has(entry.id);
+                    const hasDetail =
+                      entry.detail != null && Object.keys(entry.detail).length > 0;
+                    return (
+                      <React.Fragment key={entry.id}>
+                        <tr
+                          className="hover:bg-muted/40 border-b transition-colors"
+                        >
+                          <td
+                            className="text-muted-foreground py-2 pr-4 text-xs"
+                            title={format(new Date(entry.performed_at), 'PPpp')}
+                          >
+                            {formatDistanceToNow(new Date(entry.performed_at), {
+                              addSuffix: true,
+                            })}
+                          </td>
+                          <td className="py-2 pr-4">
+                            <span className="font-mono text-xs">{entry.admin_user_id}</span>
+                          </td>
+                          <td className="py-2 pr-4">
+                            <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
+                              {entry.action}
+                            </span>
+                          </td>
+                          <td className="text-muted-foreground py-2 pr-4 font-mono text-xs">
+                            {entry.target_type ?? '—'}
+                          </td>
+                          <td className="py-2 pr-4">
+                            {entry.target_id ? (
+                              <TargetLink
+                                townId={townId}
+                                targetType={entry.target_type}
+                                targetId={entry.target_id}
+                              />
+                            ) : (
+                              <span className="text-muted-foreground text-xs">—</span>
+                            )}
+                          </td>
+                          <td className="py-2">
+                            {hasDetail ? (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-6 px-2 text-xs"
+                                onClick={() => toggleExpand(entry.id)}
+                              >
+                                {isExpanded ? 'Hide' : 'Show'}
+                              </Button>
+                            ) : (
+                              <span className="text-muted-foreground text-xs">—</span>
+                            )}
+                          </td>
+                        </tr>
+                        {isExpanded && hasDetail && (
+                          <tr className="border-b">
+                            <td colSpan={6} className="bg-muted/20 py-2 pl-4 pr-4">
+                              <pre className="overflow-x-auto rounded bg-gray-900/50 p-3 font-mono text-xs text-gray-300">
+                                {JSON.stringify(entry.detail, null, 2)}
+                              </pre>
+                            </td>
+                          </tr>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function TargetLink({
+  townId,
+  targetType,
+  targetId,
+}: {
+  townId: string;
+  targetType: string | null;
+  targetId: string;
+}) {
+  if (targetType === 'bead') {
+    return (
+      <Link
+        href={`/admin/gastown/towns/${townId}/beads/${targetId}`}
+        className="font-mono text-xs text-blue-400 hover:underline"
+      >
+        {targetId.slice(0, 8)}…
+      </Link>
+    );
+  }
+  if (targetType === 'agent') {
+    return (
+      <Link
+        href={`/admin/gastown/towns/${townId}/agents/${targetId}`}
+        className="font-mono text-xs text-blue-400 hover:underline"
+      >
+        {targetId.slice(0, 8)}…
+      </Link>
+    );
+  }
+  return <span className="font-mono text-xs">{targetId.slice(0, 8)}…</span>;
+}

--- a/src/app/admin/gastown/towns/[townId]/audit/AuditLogDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/audit/AuditLogDashboard.tsx
@@ -34,8 +34,7 @@ export function AuditLogDashboard({ townId }: { townId: string }) {
   });
 
   const sorted = [...filtered].sort((a, b) => {
-    const diff =
-      new Date(a.performed_at).getTime() - new Date(b.performed_at).getTime();
+    const diff = new Date(a.performed_at).getTime() - new Date(b.performed_at).getTime();
     return sortDir === 'desc' ? -diff : diff;
   });
 
@@ -80,9 +79,7 @@ export function AuditLogDashboard({ townId }: { townId: string }) {
         </CardHeader>
         <CardContent>
           {auditQuery.isLoading && (
-            <p className="text-muted-foreground py-8 text-center text-sm">
-              Loading audit log…
-            </p>
+            <p className="text-muted-foreground py-8 text-center text-sm">Loading audit log…</p>
           )}
           {auditQuery.isError && (
             <p className="py-8 text-center text-sm text-red-400">
@@ -119,22 +116,17 @@ export function AuditLogDashboard({ townId }: { townId: string }) {
                     <th className="text-muted-foreground pb-2 text-left font-medium">
                       Target Type
                     </th>
-                    <th className="text-muted-foreground pb-2 text-left font-medium">
-                      Target ID
-                    </th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Target ID</th>
                     <th className="text-muted-foreground pb-2 text-left font-medium">Detail</th>
                   </tr>
                 </thead>
                 <tbody>
                   {sorted.map(entry => {
                     const isExpanded = expandedIds.has(entry.id);
-                    const hasDetail =
-                      entry.detail != null && Object.keys(entry.detail).length > 0;
+                    const hasDetail = entry.detail != null && Object.keys(entry.detail).length > 0;
                     return (
                       <React.Fragment key={entry.id}>
-                        <tr
-                          className="hover:bg-muted/40 border-b transition-colors"
-                        >
+                        <tr className="hover:bg-muted/40 border-b transition-colors">
                           <td
                             className="text-muted-foreground py-2 pr-4 text-xs"
                             title={format(new Date(entry.performed_at), 'PPpp')}
@@ -182,7 +174,7 @@ export function AuditLogDashboard({ townId }: { townId: string }) {
                         </tr>
                         {isExpanded && hasDetail && (
                           <tr className="border-b">
-                            <td colSpan={6} className="bg-muted/20 py-2 pl-4 pr-4">
+                            <td colSpan={6} className="bg-muted/20 py-2 pr-4 pl-4">
                               <pre className="overflow-x-auto rounded bg-gray-900/50 p-3 font-mono text-xs text-gray-300">
                                 {JSON.stringify(entry.detail, null, 2)}
                               </pre>

--- a/src/app/admin/gastown/towns/[townId]/audit/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/audit/page.tsx
@@ -7,11 +7,7 @@ import {
 } from '@/components/ui/breadcrumb';
 import { AuditLogDashboard } from './AuditLogDashboard';
 
-export default async function AuditLogPage({
-  params,
-}: {
-  params: Promise<{ townId: string }>;
-}) {
+export default async function AuditLogPage({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = await params;
 
   const breadcrumbs = (

--- a/src/app/admin/gastown/towns/[townId]/audit/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/audit/page.tsx
@@ -1,0 +1,40 @@
+import AdminPage from '@/app/admin/components/AdminPage';
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { AuditLogDashboard } from './AuditLogDashboard';
+
+export default async function AuditLogPage({
+  params,
+}: {
+  params: Promise<{ townId: string }>;
+}) {
+  const { townId } = await params;
+
+  const breadcrumbs = (
+    <>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbLink href={`/admin/gastown/towns/${townId}`}>
+          Town {townId.slice(0, 8)}…
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage>Audit Log</BreadcrumbPage>
+      </BreadcrumbItem>
+    </>
+  );
+
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <AuditLogDashboard townId={townId} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -119,7 +119,10 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
   const events = (eventsQuery.data ?? []).filter(e => e.bead_id === beadId);
   const dispatchAttempts = dispatchAttemptsQuery.data ?? [];
 
-  // Dependency graph: beads whose metadata references this beadId
+  // Dependency graph: reads from metadata.depends_on as a temporary fallback.
+  // The canonical source is the bead_dependencies table, but that requires a
+  // dedicated admin endpoint (bead 0). Once available, switch to querying
+  // bead_dependencies for accurate blocker/convoy/tracks edges.
   const getMetaDeps = (meta: Record<string, unknown>): string[] => {
     const raw = meta['depends_on'];
     return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -1,0 +1,634 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import Link from 'next/link';
+import { formatDistanceToNow, format } from 'date-fns';
+import { ArrowLeft } from 'lucide-react';
+
+const STATUS_COLORS: Record<string, string> = {
+  open: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  in_progress: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  closed: 'bg-green-500/10 text-green-400 border-green-500/20',
+  failed: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+type ConfirmActionType = 'close' | 'fail' | 'reset_agent';
+
+type ConfirmAction = {
+  type: ConfirmActionType;
+  label: string;
+  description: string;
+};
+
+export function BeadInspectorDashboard({
+  townId,
+  beadId,
+}: {
+  townId: string;
+  beadId: string;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+
+  // Fetch all beads — used both for finding this bead and computing dependency graph.
+  // listBeads returns [] until bead-0 admin endpoints are merged.
+  const allBeadsQuery = useQuery(
+    trpc.admin.gastown.listBeads.queryOptions({ townId })
+  );
+  const allBeads = allBeadsQuery.data ?? [];
+  const bead = allBeads.find(b => b.bead_id === beadId) ?? null;
+
+  const eventsQuery = useQuery(
+    trpc.admin.gastown.getBeadEvents.queryOptions({ townId, beadId, limit: 500 })
+  );
+
+  const dispatchAttemptsQuery = useQuery(
+    trpc.admin.gastown.listDispatchAttempts.queryOptions({ townId, beadId })
+  );
+
+  const invalidateAll = () => {
+    void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+    void queryClient.invalidateQueries(trpc.admin.gastown.getBeadEvents.queryFilter({ townId }));
+  };
+
+  const forceCloseMutation = useMutation(
+    trpc.admin.gastown.forceCloseBead.mutationOptions({
+      onSuccess: () => {
+        invalidateAll();
+        setConfirmAction(null);
+      },
+    })
+  );
+
+  const forceFailMutation = useMutation(
+    trpc.admin.gastown.forceFailBead.mutationOptions({
+      onSuccess: () => {
+        invalidateAll();
+        setConfirmAction(null);
+      },
+    })
+  );
+
+  const forceResetAgentMutation = useMutation(
+    trpc.admin.gastown.forceResetAgent.mutationOptions({
+      onSuccess: () => {
+        invalidateAll();
+        setConfirmAction(null);
+      },
+    })
+  );
+
+  const handleConfirm = () => {
+    if (!confirmAction) return;
+    if (confirmAction.type === 'close') {
+      forceCloseMutation.mutate({ townId, beadId });
+    } else if (confirmAction.type === 'fail') {
+      forceFailMutation.mutate({ townId, beadId });
+    } else if (confirmAction.type === 'reset_agent' && bead?.assignee_agent_bead_id) {
+      forceResetAgentMutation.mutate({ townId, agentId: bead.assignee_agent_bead_id });
+    }
+  };
+
+  const isMutating =
+    forceCloseMutation.isPending || forceFailMutation.isPending || forceResetAgentMutation.isPending;
+
+  // Filter events to only those for this bead (server doesn't filter by beadId yet)
+  const events = (eventsQuery.data ?? []).filter(e => e.bead_id === beadId);
+  const dispatchAttempts = dispatchAttemptsQuery.data ?? [];
+
+  // Dependency graph: beads whose metadata references this beadId
+  // Beads that this bead depends on: look at bead.metadata.depends_on
+  const thisBeadDeps = bead != null
+    ? ((bead.metadata as Record<string, unknown>)['depends_on'] as string[] | undefined) ?? []
+    : [];
+  const dependsOnBeads = allBeads.filter(b => thisBeadDeps.includes(b.bead_id));
+
+  // Beads that depend on this bead: look for other beads whose metadata.depends_on includes beadId
+  const dependentBeads = allBeads.filter(b => {
+    const meta = b.metadata as Record<string, unknown>;
+    const deps = meta['depends_on'] as string[] | undefined;
+    return Array.isArray(deps) && deps.includes(beadId);
+  });
+
+  // Agent history from events (deduplicated)
+  const agentHistory = Array.from(
+    new Map(
+      events
+        .filter(e => e.agent_id != null)
+        .map(e => [e.agent_id, e])
+    ).values()
+  );
+
+  // Convoy membership
+  const convoyId =
+    bead != null
+      ? ((bead.metadata as Record<string, unknown>)['convoy_id'] as string | undefined)
+      : undefined;
+  const convoyBead = convoyId ? allBeads.find(b => b.bead_id === convoyId) : undefined;
+
+  return (
+    <div className="flex w-full flex-col gap-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <Link
+            href={`/admin/gastown/towns/${townId}?tab=beads`}
+            className="text-muted-foreground hover:text-foreground mb-2 flex items-center gap-1 text-sm transition-colors"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Back to Town Inspector
+          </Link>
+          <h1 className="text-2xl font-semibold">Bead Inspector</h1>
+          <p className="text-muted-foreground font-mono text-sm">{beadId}</p>
+        </div>
+        {bead && (
+          <Badge variant="outline" className={STATUS_COLORS[bead.status] ?? ''}>
+            {bead.status}
+          </Badge>
+        )}
+      </div>
+
+      {allBeadsQuery.isLoading && (
+        <p className="text-muted-foreground py-8 text-center text-sm">Loading bead…</p>
+      )}
+      {allBeadsQuery.isError && (
+        <p className="py-8 text-center text-sm text-red-400">
+          Failed to load bead: {allBeadsQuery.error.message}
+        </p>
+      )}
+
+      {bead && (
+        <>
+          {/* Bead summary */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Overview</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm md:grid-cols-3">
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Type
+                  </dt>
+                  <dd className="font-mono">{bead.type}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Priority
+                  </dt>
+                  <dd className="font-mono">{bead.priority}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    Created
+                  </dt>
+                  <dd title={format(new Date(bead.created_at), 'PPpp')}>
+                    {formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}
+                  </dd>
+                </div>
+                {bead.closed_at && (
+                  <div>
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Closed
+                    </dt>
+                    <dd title={format(new Date(bead.closed_at), 'PPpp')}>
+                      {formatDistanceToNow(new Date(bead.closed_at), { addSuffix: true })}
+                    </dd>
+                  </div>
+                )}
+                {bead.assignee_agent_bead_id && (
+                  <div>
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Assigned Agent
+                    </dt>
+                    <dd>
+                      <Link
+                        href={`/admin/gastown/towns/${townId}/agents/${bead.assignee_agent_bead_id}`}
+                        className="font-mono text-blue-400 hover:underline"
+                      >
+                        {bead.assignee_agent_bead_id.slice(0, 8)}…
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+                {bead.rig_id && (
+                  <div>
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Rig
+                    </dt>
+                    <dd className="font-mono text-xs">{bead.rig_id.slice(0, 8)}…</dd>
+                  </div>
+                )}
+                {bead.labels.length > 0 && (
+                  <div className="col-span-2 md:col-span-3">
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Labels
+                    </dt>
+                    <dd className="mt-1 flex flex-wrap gap-1">
+                      {bead.labels.map(label => (
+                        <Badge key={label} variant="outline" className="font-mono text-xs">
+                          {label}
+                        </Badge>
+                      ))}
+                    </dd>
+                  </div>
+                )}
+                {bead.title && (
+                  <div className="col-span-2 md:col-span-3">
+                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                      Title
+                    </dt>
+                    <dd>{bead.title}</dd>
+                  </div>
+                )}
+              </dl>
+            </CardContent>
+          </Card>
+
+          {/* Admin Actions */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Admin Actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={bead.status === 'closed' || bead.status === 'failed'}
+                  onClick={() =>
+                    setConfirmAction({
+                      type: 'close',
+                      label: 'Force Close Bead',
+                      description: `This will force-close bead ${beadId.slice(0, 8)}…. This action is logged in the audit trail.`,
+                    })
+                  }
+                >
+                  Force Close Bead
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-red-500/30 text-red-400 hover:bg-red-500/10"
+                  disabled={bead.status === 'closed' || bead.status === 'failed'}
+                  onClick={() =>
+                    setConfirmAction({
+                      type: 'fail',
+                      label: 'Force Fail Bead',
+                      description: `This will force-fail bead ${beadId.slice(0, 8)}…. This action is logged in the audit trail.`,
+                    })
+                  }
+                >
+                  Force Fail Bead
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!bead.assignee_agent_bead_id}
+                  onClick={() =>
+                    setConfirmAction({
+                      type: 'reset_agent',
+                      label: 'Force Reset Assigned Agent',
+                      description: `This will reset the currently assigned agent (${bead.assignee_agent_bead_id?.slice(0, 8)}…) to idle. This action is logged in the audit trail.`,
+                    })
+                  }
+                >
+                  Force Reset Assigned Agent
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {/* State History Timeline */}
+      <Card>
+        <CardHeader>
+          <CardTitle>State History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {eventsQuery.isLoading && (
+            <p className="text-muted-foreground py-4 text-center text-sm">Loading events…</p>
+          )}
+          {eventsQuery.isError && (
+            <p className="py-4 text-center text-sm text-red-400">
+              Failed to load events: {eventsQuery.error.message}
+            </p>
+          )}
+          {!eventsQuery.isLoading && events.length === 0 && (
+            <p className="text-muted-foreground py-4 text-center text-sm">No events found.</p>
+          )}
+          {events.length > 0 && (
+            <div className="relative ml-2 flex flex-col gap-0">
+              {[...events]
+                .sort(
+                  (a, b) =>
+                    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+                )
+                .map((event, idx) => (
+                  <div key={event.bead_event_id} className="flex gap-4">
+                    {/* Timeline line + dot */}
+                    <div className="flex flex-col items-center">
+                      <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-gray-400" />
+                      {idx < events.length - 1 && (
+                        <div className="w-px flex-1 bg-gray-700" />
+                      )}
+                    </div>
+                    <div className="pb-4">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
+                          {event.event_type}
+                        </span>
+                        {event.agent_id && (
+                          <Link
+                            href={`/admin/gastown/towns/${townId}/agents/${event.agent_id}`}
+                            className="font-mono text-xs text-blue-400 hover:underline"
+                          >
+                            agent {event.agent_id.slice(0, 8)}…
+                          </Link>
+                        )}
+                        <span
+                          className="text-muted-foreground text-xs"
+                          title={format(new Date(event.created_at), 'PPpp')}
+                        >
+                          {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                        </span>
+                      </div>
+                      {(event.old_value ?? event.new_value) && (
+                        <div className="mt-1 flex flex-wrap items-center gap-1 text-xs">
+                          {event.old_value && (
+                            <span className="rounded bg-red-500/10 px-1 py-0.5 font-mono text-red-400 line-through">
+                              {event.old_value}
+                            </span>
+                          )}
+                          {event.old_value && event.new_value && (
+                            <span className="text-muted-foreground">→</span>
+                          )}
+                          {event.new_value && (
+                            <span className="rounded bg-green-500/10 px-1 py-0.5 font-mono text-green-400">
+                              {event.new_value}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Assigned Agent History */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Assigned Agent History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {agentHistory.length === 0 ? (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              No agent assignments found in event history.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Agent</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Event</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {agentHistory.map(event => (
+                    <tr key={event.bead_event_id} className="hover:bg-muted/40 border-b transition-colors">
+                      <td className="py-2 pr-4">
+                        <Link
+                          href={`/admin/gastown/towns/${townId}/agents/${event.agent_id}`}
+                          className="font-mono text-xs text-blue-400 hover:underline"
+                        >
+                          {event.agent_id?.slice(0, 8)}…
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-4">
+                        <span className="rounded bg-gray-500/10 px-1.5 py-0.5 font-mono text-xs">
+                          {event.event_type}
+                        </span>
+                      </td>
+                      <td
+                        className="text-muted-foreground py-2 text-xs"
+                        title={format(new Date(event.created_at), 'PPpp')}
+                      >
+                        {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Dependency Graph */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Dependencies</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {convoyBead && (
+            <div>
+              <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+                Convoy
+              </p>
+              <Link
+                href={`/admin/gastown/towns/${townId}/beads/${convoyBead.bead_id}`}
+                className="text-sm text-blue-400 hover:underline"
+              >
+                <span className="font-mono text-xs">{convoyBead.bead_id.slice(0, 8)}…</span>
+                {convoyBead.title && <span className="ml-2">{convoyBead.title}</span>}
+              </Link>
+            </div>
+          )}
+
+          <div>
+            <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+              Depends On
+            </p>
+            {dependsOnBeads.length === 0 ? (
+              <p className="text-muted-foreground text-sm">None</p>
+            ) : (
+              <ul className="space-y-1">
+                {dependsOnBeads.map(b => (
+                  <li key={b.bead_id}>
+                    <Link
+                      href={`/admin/gastown/towns/${townId}/beads/${b.bead_id}`}
+                      className="text-sm text-blue-400 hover:underline"
+                    >
+                      <span className="font-mono text-xs">{b.bead_id.slice(0, 8)}…</span>
+                      {b.title && <span className="ml-2">{b.title}</span>}
+                    </Link>
+                    <Badge
+                      variant="outline"
+                      className={`ml-2 text-xs ${STATUS_COLORS[b.status] ?? ''}`}
+                    >
+                      {b.status}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+              Depended On By
+            </p>
+            {dependentBeads.length === 0 ? (
+              <p className="text-muted-foreground text-sm">None</p>
+            ) : (
+              <ul className="space-y-1">
+                {dependentBeads.map(b => (
+                  <li key={b.bead_id}>
+                    <Link
+                      href={`/admin/gastown/towns/${townId}/beads/${b.bead_id}`}
+                      className="text-sm text-blue-400 hover:underline"
+                    >
+                      <span className="font-mono text-xs">{b.bead_id.slice(0, 8)}…</span>
+                      {b.title && <span className="ml-2">{b.title}</span>}
+                    </Link>
+                    <Badge
+                      variant="outline"
+                      className={`ml-2 text-xs ${STATUS_COLORS[b.status] ?? ''}`}
+                    >
+                      {b.status}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Dispatch Attempts */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Dispatch Attempts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {dispatchAttemptsQuery.isLoading && (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              Loading dispatch attempts…
+            </p>
+          )}
+          {!dispatchAttemptsQuery.isLoading && dispatchAttempts.length === 0 && (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              No dispatch attempts found.
+            </p>
+          )}
+          {dispatchAttempts.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Time</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Result</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Agent</th>
+                    <th className="text-muted-foreground pb-2 text-left font-medium">Error</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dispatchAttempts.map(attempt => (
+                    <tr
+                      key={attempt.id}
+                      className="hover:bg-muted/40 border-b transition-colors"
+                    >
+                      <td
+                        className="text-muted-foreground py-2 pr-4 text-xs"
+                        title={format(new Date(attempt.attempted_at), 'PPpp')}
+                      >
+                        {formatDistanceToNow(new Date(attempt.attempted_at), {
+                          addSuffix: true,
+                        })}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <Badge
+                          variant="outline"
+                          className={
+                            attempt.success
+                              ? 'border-green-500/20 bg-green-500/10 text-green-400'
+                              : 'border-red-500/20 bg-red-500/10 text-red-400'
+                          }
+                        >
+                          {attempt.success ? 'Success' : 'Failed'}
+                        </Badge>
+                      </td>
+                      <td className="py-2 pr-4">
+                        {attempt.agent_id ? (
+                          <Link
+                            href={`/admin/gastown/towns/${townId}/agents/${attempt.agent_id}`}
+                            className="font-mono text-xs text-blue-400 hover:underline"
+                          >
+                            {attempt.agent_id.slice(0, 8)}…
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">—</span>
+                        )}
+                      </td>
+                      <td className="py-2 text-xs text-red-400">
+                        {attempt.error_message ?? (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Confirm AlertDialog */}
+      <AlertDialog open={!!confirmAction} onOpenChange={() => setConfirmAction(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirmAction?.label}</AlertDialogTitle>
+            <AlertDialogDescription>{confirmAction?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isMutating}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirm}
+              disabled={isMutating}
+              className={
+                confirmAction?.type === 'fail'
+                  ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                  : ''
+              }
+            >
+              {isMutating ? 'Processing…' : confirmAction?.label}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -42,7 +42,6 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
 
   // Fetch all beads — used both for finding this bead and computing dependency graph.
-  // listBeads returns [] until bead-0 admin endpoints are merged.
   const allBeadsQuery = useQuery(trpc.admin.gastown.listBeads.queryOptions({ townId }));
   const allBeads = allBeadsQuery.data ?? [];
   const bead = allBeads.find(b => b.bead_id === beadId) ?? null;

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -35,22 +36,14 @@ type ConfirmAction = {
   description: string;
 };
 
-export function BeadInspectorDashboard({
-  townId,
-  beadId,
-}: {
-  townId: string;
-  beadId: string;
-}) {
+export function BeadInspectorDashboard({ townId, beadId }: { townId: string; beadId: string }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
 
   // Fetch all beads — used both for finding this bead and computing dependency graph.
   // listBeads returns [] until bead-0 admin endpoints are merged.
-  const allBeadsQuery = useQuery(
-    trpc.admin.gastown.listBeads.queryOptions({ townId })
-  );
+  const allBeadsQuery = useQuery(trpc.admin.gastown.listBeads.queryOptions({ townId }));
   const allBeads = allBeadsQuery.data ?? [];
   const bead = allBeads.find(b => b.bead_id === beadId) ?? null;
 
@@ -72,6 +65,10 @@ export function BeadInspectorDashboard({
       onSuccess: () => {
         invalidateAll();
         setConfirmAction(null);
+        toast.success('Bead closed successfully');
+      },
+      onError: err => {
+        toast.error(`Failed to close bead: ${err.message}`);
       },
     })
   );
@@ -81,6 +78,10 @@ export function BeadInspectorDashboard({
       onSuccess: () => {
         invalidateAll();
         setConfirmAction(null);
+        toast.success('Bead marked as failed');
+      },
+      onError: err => {
+        toast.error(`Failed to fail bead: ${err.message}`);
       },
     })
   );
@@ -90,6 +91,10 @@ export function BeadInspectorDashboard({
       onSuccess: () => {
         invalidateAll();
         setConfirmAction(null);
+        toast.success('Agent reset successfully');
+      },
+      onError: err => {
+        toast.error(`Failed to reset agent: ${err.message}`);
       },
     })
   );
@@ -106,40 +111,34 @@ export function BeadInspectorDashboard({
   };
 
   const isMutating =
-    forceCloseMutation.isPending || forceFailMutation.isPending || forceResetAgentMutation.isPending;
+    forceCloseMutation.isPending ||
+    forceFailMutation.isPending ||
+    forceResetAgentMutation.isPending;
 
   // Filter events to only those for this bead (server doesn't filter by beadId yet)
   const events = (eventsQuery.data ?? []).filter(e => e.bead_id === beadId);
   const dispatchAttempts = dispatchAttemptsQuery.data ?? [];
 
   // Dependency graph: beads whose metadata references this beadId
-  // Beads that this bead depends on: look at bead.metadata.depends_on
-  const thisBeadDeps = bead != null
-    ? ((bead.metadata as Record<string, unknown>)['depends_on'] as string[] | undefined) ?? []
-    : [];
+  const getMetaDeps = (meta: Record<string, unknown>): string[] => {
+    const raw = meta['depends_on'];
+    return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
+  };
+
+  const thisBeadDeps = bead != null ? getMetaDeps(bead.metadata) : [];
   const dependsOnBeads = allBeads.filter(b => thisBeadDeps.includes(b.bead_id));
 
-  // Beads that depend on this bead: look for other beads whose metadata.depends_on includes beadId
-  const dependentBeads = allBeads.filter(b => {
-    const meta = b.metadata as Record<string, unknown>;
-    const deps = meta['depends_on'] as string[] | undefined;
-    return Array.isArray(deps) && deps.includes(beadId);
-  });
+  // Beads that depend on this bead
+  const dependentBeads = allBeads.filter(b => getMetaDeps(b.metadata).includes(beadId));
 
   // Agent history from events (deduplicated)
   const agentHistory = Array.from(
-    new Map(
-      events
-        .filter(e => e.agent_id != null)
-        .map(e => [e.agent_id, e])
-    ).values()
+    new Map(events.filter(e => e.agent_id != null).map(e => [e.agent_id, e])).values()
   );
 
   // Convoy membership
-  const convoyId =
-    bead != null
-      ? ((bead.metadata as Record<string, unknown>)['convoy_id'] as string | undefined)
-      : undefined;
+  const rawConvoyId = bead != null ? bead.metadata['convoy_id'] : undefined;
+  const convoyId = typeof rawConvoyId === 'string' ? rawConvoyId : undefined;
   const convoyBead = convoyId ? allBeads.find(b => b.bead_id === convoyId) : undefined;
 
   return (
@@ -183,19 +182,19 @@ export function BeadInspectorDashboard({
             <CardContent>
               <dl className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm md:grid-cols-3">
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Type
                   </dt>
                   <dd className="font-mono">{bead.type}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Priority
                   </dt>
                   <dd className="font-mono">{bead.priority}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                     Created
                   </dt>
                   <dd title={format(new Date(bead.created_at), 'PPpp')}>
@@ -204,7 +203,7 @@ export function BeadInspectorDashboard({
                 </div>
                 {bead.closed_at && (
                   <div>
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Closed
                     </dt>
                     <dd title={format(new Date(bead.closed_at), 'PPpp')}>
@@ -214,7 +213,7 @@ export function BeadInspectorDashboard({
                 )}
                 {bead.assignee_agent_bead_id && (
                   <div>
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Assigned Agent
                     </dt>
                     <dd>
@@ -229,7 +228,7 @@ export function BeadInspectorDashboard({
                 )}
                 {bead.rig_id && (
                   <div>
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Rig
                     </dt>
                     <dd className="font-mono text-xs">{bead.rig_id.slice(0, 8)}…</dd>
@@ -237,7 +236,7 @@ export function BeadInspectorDashboard({
                 )}
                 {bead.labels.length > 0 && (
                   <div className="col-span-2 md:col-span-3">
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Labels
                     </dt>
                     <dd className="mt-1 flex flex-wrap gap-1">
@@ -251,7 +250,7 @@ export function BeadInspectorDashboard({
                 )}
                 {bead.title && (
                   <div className="col-span-2 md:col-span-3">
-                    <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                    <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                       Title
                     </dt>
                     <dd>{bead.title}</dd>
@@ -337,18 +336,13 @@ export function BeadInspectorDashboard({
           {events.length > 0 && (
             <div className="relative ml-2 flex flex-col gap-0">
               {[...events]
-                .sort(
-                  (a, b) =>
-                    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-                )
+                .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
                 .map((event, idx) => (
                   <div key={event.bead_event_id} className="flex gap-4">
                     {/* Timeline line + dot */}
                     <div className="flex flex-col items-center">
                       <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-gray-400" />
-                      {idx < events.length - 1 && (
-                        <div className="w-px flex-1 bg-gray-700" />
-                      )}
+                      {idx < events.length - 1 && <div className="w-px flex-1 bg-gray-700" />}
                     </div>
                     <div className="pb-4">
                       <div className="flex flex-wrap items-center gap-2">
@@ -417,7 +411,10 @@ export function BeadInspectorDashboard({
                 </thead>
                 <tbody>
                   {agentHistory.map(event => (
-                    <tr key={event.bead_event_id} className="hover:bg-muted/40 border-b transition-colors">
+                    <tr
+                      key={event.bead_event_id}
+                      className="hover:bg-muted/40 border-b transition-colors"
+                    >
                       <td className="py-2 pr-4">
                         <Link
                           href={`/admin/gastown/towns/${townId}/agents/${event.agent_id}`}
@@ -454,7 +451,7 @@ export function BeadInspectorDashboard({
         <CardContent className="space-y-4">
           {convoyBead && (
             <div>
-              <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+              <p className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
                 Convoy
               </p>
               <Link
@@ -468,7 +465,7 @@ export function BeadInspectorDashboard({
           )}
 
           <div>
-            <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+            <p className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
               Depends On
             </p>
             {dependsOnBeads.length === 0 ? (
@@ -497,7 +494,7 @@ export function BeadInspectorDashboard({
           </div>
 
           <div>
-            <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+            <p className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
               Depended On By
             </p>
             {dependentBeads.length === 0 ? (
@@ -556,10 +553,7 @@ export function BeadInspectorDashboard({
                 </thead>
                 <tbody>
                   {dispatchAttempts.map(attempt => (
-                    <tr
-                      key={attempt.id}
-                      className="hover:bg-muted/40 border-b transition-colors"
-                    >
+                    <tr key={attempt.id} className="hover:bg-muted/40 border-b transition-colors">
                       <td
                         className="text-muted-foreground py-2 pr-4 text-xs"
                         title={format(new Date(attempt.attempted_at), 'PPpp')}
@@ -593,9 +587,7 @@ export function BeadInspectorDashboard({
                         )}
                       </td>
                       <td className="py-2 text-xs text-red-400">
-                        {attempt.error_message ?? (
-                          <span className="text-muted-foreground">—</span>
-                        )}
+                        {attempt.error_message ?? <span className="text-muted-foreground">—</span>}
                       </td>
                     </tr>
                   ))}

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/BeadInspectorDashboard.tsx
@@ -41,10 +41,13 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
   const queryClient = useQueryClient();
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
 
-  // Fetch all beads — used both for finding this bead and computing dependency graph.
+  // Fetch the specific bead by ID (not limited by pagination).
+  const beadQuery = useQuery(trpc.admin.gastown.getBead.queryOptions({ townId, beadId }));
+  const bead = beadQuery.data ?? null;
+
+  // Fetch all beads for computing the dependency graph.
   const allBeadsQuery = useQuery(trpc.admin.gastown.listBeads.queryOptions({ townId }));
   const allBeads = allBeadsQuery.data ?? [];
-  const bead = allBeads.find(b => b.bead_id === beadId) ?? null;
 
   const eventsQuery = useQuery(
     trpc.admin.gastown.getBeadEvents.queryOptions({ townId, beadId, limit: 500 })
@@ -55,6 +58,7 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
   );
 
   const invalidateAll = () => {
+    void queryClient.invalidateQueries(trpc.admin.gastown.getBead.queryFilter({ townId, beadId }));
     void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
     void queryClient.invalidateQueries(trpc.admin.gastown.getBeadEvents.queryFilter({ townId }));
   };
@@ -114,7 +118,7 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
     forceFailMutation.isPending ||
     forceResetAgentMutation.isPending;
 
-  // Filter events to only those for this bead (server doesn't filter by beadId yet)
+  // Filter events to only those for this bead
   const events = (eventsQuery.data ?? []).filter(e => e.bead_id === beadId);
   const dispatchAttempts = dispatchAttemptsQuery.data ?? [];
 
@@ -165,12 +169,12 @@ export function BeadInspectorDashboard({ townId, beadId }: { townId: string; bea
         )}
       </div>
 
-      {allBeadsQuery.isLoading && (
+      {beadQuery.isLoading && (
         <p className="text-muted-foreground py-8 text-center text-sm">Loading bead…</p>
       )}
-      {allBeadsQuery.isError && (
+      {beadQuery.isError && (
         <p className="py-8 text-center text-sm text-red-400">
-          Failed to load bead: {allBeadsQuery.error.message}
+          Failed to load bead: {beadQuery.error.message}
         </p>
       )}
 

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/page.tsx
@@ -1,0 +1,40 @@
+import AdminPage from '@/app/admin/components/AdminPage';
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { BeadInspectorDashboard } from './BeadInspectorDashboard';
+
+export default async function BeadInspectorPage({
+  params,
+}: {
+  params: Promise<{ townId: string; beadId: string }>;
+}) {
+  const { townId, beadId } = await params;
+
+  const breadcrumbs = (
+    <>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbLink href={`/admin/gastown/towns/${townId}`}>
+          Town {townId.slice(0, 8)}…
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage>Bead {beadId.slice(0, 8)}…</BreadcrumbPage>
+      </BreadcrumbItem>
+    </>
+  );
+
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <BeadInspectorDashboard townId={townId} beadId={beadId} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/gastown/towns/[townId]/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/page.tsx
@@ -1,0 +1,34 @@
+import AdminPage from '@/app/admin/components/AdminPage';
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { TownInspectorDashboard } from './TownInspectorDashboard';
+
+export default async function TownInspectorPage({
+  params,
+}: {
+  params: Promise<{ townId: string }>;
+}) {
+  const { townId } = await params;
+
+  const breadcrumbs = (
+    <>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage>Town {townId.slice(0, 8)}…</BreadcrumbPage>
+      </BreadcrumbItem>
+    </>
+  );
+
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <TownInspectorDashboard townId={townId} />
+    </AdminPage>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -7,6 +7,7 @@
 import * as React from 'react';
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogFooter,
@@ -41,7 +42,9 @@ type AlertDialogCancelProps = React.ComponentPropsWithoutRef<typeof Button>;
 
 const AlertDialogCancel = React.forwardRef<HTMLButtonElement, AlertDialogCancelProps>(
   ({ className, ...props }, ref) => (
-    <Button ref={ref} variant="outline" className={cn('mt-2 sm:mt-0', className)} {...props} />
+    <DialogClose asChild>
+      <Button ref={ref} variant="outline" className={cn('mt-2 sm:mt-0', className)} {...props} />
+    </DialogClose>
   )
 );
 AlertDialogCancel.displayName = 'AlertDialogCancel';

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+// AlertDialog built on top of the existing Dialog primitive.
+// Mirrors the shadcn/ui AlertDialog API surface so callers can use the standard
+// AlertDialog, AlertDialogContent, AlertDialogHeader, etc. naming.
+
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const AlertDialog = Dialog;
+
+// AlertDialogContent hides the default close button so users must use Cancel/Action
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogContent>,
+  React.ComponentPropsWithoutRef<typeof DialogContent>
+>(({ className, ...props }, ref) => (
+  <DialogContent
+    ref={ref}
+    showCloseButton={false}
+    className={cn('sm:max-w-md', className)}
+    {...props}
+  />
+));
+AlertDialogContent.displayName = 'AlertDialogContent';
+
+const AlertDialogHeader = DialogHeader;
+const AlertDialogFooter = DialogFooter;
+const AlertDialogTitle = DialogTitle;
+const AlertDialogDescription = DialogDescription;
+
+type AlertDialogCancelProps = React.ComponentPropsWithoutRef<typeof Button>;
+
+const AlertDialogCancel = React.forwardRef<HTMLButtonElement, AlertDialogCancelProps>(
+  ({ className, ...props }, ref) => (
+    <Button ref={ref} variant="outline" className={cn('mt-2 sm:mt-0', className)} {...props} />
+  )
+);
+AlertDialogCancel.displayName = 'AlertDialogCancel';
+
+type AlertDialogActionProps = React.ComponentPropsWithoutRef<typeof Button>;
+
+const AlertDialogAction = React.forwardRef<HTMLButtonElement, AlertDialogActionProps>(
+  ({ className, ...props }, ref) => <Button ref={ref} className={className} {...props} />
+);
+AlertDialogAction.displayName = 'AlertDialogAction';
+
+export {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  AlertDialogAction,
+};

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -24,6 +24,7 @@ import { adminAIAttributionRouter } from '@/routers/admin-ai-attribution-router'
 import { ossSponsorshipRouter } from '@/routers/admin/oss-sponsorship-router';
 import { bulkUserCreditsRouter } from '@/routers/admin/bulk-user-credits-router';
 import { emailTestingRouter } from '@/routers/admin/email-testing-router';
+import { adminGastownRouter } from '@/routers/admin/gastown-router';
 import { adminWebhookTriggersRouter } from '@/routers/admin-webhook-triggers-router';
 import { adminAlertingRouter } from '@/routers/admin-alerting-router';
 import { adminBotRequestsRouter } from '@/routers/admin-bot-requests-router';
@@ -1094,4 +1095,5 @@ export const adminRouter = createTRPCRouter({
   bulkUserCredits: bulkUserCreditsRouter,
   emailTesting: emailTestingRouter,
   botRequests: adminBotRequestsRouter,
+  gastown: adminGastownRouter,
 });

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -392,9 +392,7 @@ export const adminGastownRouter = createTRPCRouter({
 
   /**
    * Get the alarm status snapshot for a town.
-   * Calls the tRPC gastown.getAlarmStatus with admin JWT.
-   * Requires admin-bypass support on the Gastown worker (bead 0) since
-   * verifyTownOwnership is checked per town.
+   * Calls the admin-bypass gastown.adminGetAlarmStatus endpoint.
    */
   getTownHealth: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
@@ -402,7 +400,7 @@ export const adminGastownRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       return gastownTrpcGet(
         ctx.user,
-        'gastown.getAlarmStatus',
+        'gastown.adminGetAlarmStatus',
         { townId: input.townId },
         AlarmStatusRecord
       );
@@ -453,8 +451,8 @@ export const adminGastownRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       const result = await gastownTrpcGet(
         ctx.user,
-        'gastown.getTownEvents',
-        { townId: input.townId, since: input.since, limit: input.limit },
+        'gastown.adminGetTownEvents',
+        { townId: input.townId, beadId: input.beadId, since: input.since, limit: input.limit },
         z.array(BeadEventRecord)
       );
       return result ?? [];

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -1,0 +1,683 @@
+import 'server-only';
+
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+import {
+  GASTOWN_SERVICE_URL,
+  GASTOWN_CF_ACCESS_CLIENT_ID,
+  GASTOWN_CF_ACCESS_CLIENT_SECRET,
+} from '@/lib/config.server';
+import { generateApiToken } from '@/lib/tokens';
+import type { User } from '@kilocode/db/schema';
+
+// ── Zod schemas matching Gastown API response shapes ─────────────────────────
+
+const UserTownRecord = z.object({
+  id: z.string(),
+  name: z.string(),
+  owner_user_id: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const UserRigRecord = z.object({
+  id: z.string(),
+  town_id: z.string(),
+  name: z.string(),
+  git_url: z.string(),
+  default_branch: z.string(),
+  platform_integration_id: z.string().nullable().optional().default(null),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const BeadRecord = z.object({
+  bead_id: z.string(),
+  type: z.enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent']),
+  status: z.enum(['open', 'in_progress', 'closed', 'failed']),
+  title: z.string(),
+  body: z.string().nullable(),
+  rig_id: z.string().nullable(),
+  parent_bead_id: z.string().nullable(),
+  assignee_agent_bead_id: z.string().nullable(),
+  priority: z.enum(['low', 'medium', 'high', 'critical']),
+  labels: z.array(z.string()),
+  metadata: z.record(z.string(), z.unknown()),
+  created_by: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  closed_at: z.string().nullable(),
+});
+
+const AgentRecord = z.object({
+  id: z.string(),
+  rig_id: z.string().nullable(),
+  role: z.string(),
+  name: z.string(),
+  identity: z.string(),
+  status: z.string(),
+  current_hook_bead_id: z.string().nullable(),
+  dispatch_attempts: z.number().default(0),
+  last_activity_at: z.string().nullable(),
+  checkpoint: z.unknown().optional(),
+  created_at: z.string(),
+});
+
+const BeadEventRecord = z.object({
+  bead_event_id: z.string(),
+  bead_id: z.string(),
+  agent_id: z.string().nullable(),
+  event_type: z.string(),
+  old_value: z.string().nullable(),
+  new_value: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+  rig_id: z.string().optional(),
+  rig_name: z.string().optional(),
+});
+
+const AlarmStatusRecord = z.object({
+  alarm: z.object({
+    nextFireAt: z.string().nullable(),
+    intervalMs: z.number(),
+    intervalLabel: z.string(),
+  }),
+  agents: z.object({
+    working: z.number(),
+    idle: z.number(),
+    stalled: z.number(),
+    dead: z.number(),
+    total: z.number(),
+  }),
+  beads: z.object({
+    open: z.number(),
+    inProgress: z.number(),
+    failed: z.number(),
+    triageRequests: z.number(),
+  }),
+  patrol: z.object({
+    guppWarnings: z.number(),
+    guppEscalations: z.number(),
+    stalledAgents: z.number(),
+    orphanedHooks: z.number(),
+  }),
+  recentEvents: z.array(
+    z.object({
+      time: z.string(),
+      type: z.string(),
+      message: z.string(),
+    })
+  ),
+});
+
+const TownConfigRecord = z.object({
+  env_vars: z.record(z.string(), z.string()),
+  git_auth: z.object({
+    github_token: z.string().optional(),
+    gitlab_token: z.string().optional(),
+    gitlab_instance_url: z.string().optional(),
+    platform_integration_id: z.string().optional(),
+  }),
+  owner_user_id: z.string().optional(),
+  kilocode_token: z.string().optional(),
+  default_model: z.string().optional(),
+  small_model: z.string().optional(),
+  max_polecats_per_rig: z.number().optional(),
+  merge_strategy: z.enum(['direct', 'pr']),
+  refinery: z
+    .object({
+      gates: z.array(z.string()),
+      auto_merge: z.boolean(),
+      require_clean_merge: z.boolean(),
+    })
+    .optional(),
+  alarm_interval_active: z.number().optional(),
+  alarm_interval_idle: z.number().optional(),
+  container: z.object({ sleep_after_minutes: z.number().optional() }).optional(),
+});
+
+const ConvoyDetailRecord = z.object({
+  id: z.string(),
+  title: z.string(),
+  status: z.enum(['active', 'landed']),
+  total_beads: z.number(),
+  closed_beads: z.number(),
+  created_by: z.string().nullable(),
+  created_at: z.string(),
+  landed_at: z.string().nullable(),
+  feature_branch: z.string().nullable(),
+  merge_mode: z.string().nullable(),
+  beads: z.array(
+    z.object({
+      bead_id: z.string(),
+      title: z.string(),
+      status: z.string(),
+      rig_id: z.string().nullable(),
+      assignee_agent_name: z.string().nullable(),
+    })
+  ),
+  dependency_edges: z.array(
+    z.object({
+      bead_id: z.string(),
+      depends_on_bead_id: z.string(),
+    })
+  ),
+});
+
+// These schemas are for TownDO methods added in bead 0.
+// Procedures using them return empty arrays until bead 0 is merged.
+
+const DispatchAttemptRecord = z.object({
+  id: z.string(),
+  bead_id: z.string().nullable(),
+  agent_id: z.string().nullable(),
+  attempted_at: z.string(),
+  success: z.boolean(),
+  error_message: z.string().nullable(),
+});
+
+const ContainerEventRecord = z.object({
+  id: z.string(),
+  event_type: z.string(),
+  data: z.record(z.string(), z.unknown()).optional(),
+  created_at: z.string(),
+});
+
+const CredentialEventRecord = z.object({
+  id: z.string(),
+  rig_id: z.string().nullable(),
+  event_type: z.string(),
+  data: z.record(z.string(), z.unknown()).optional(),
+  created_at: z.string(),
+});
+
+const AdminAuditLogRecord = z.object({
+  id: z.string(),
+  admin_user_id: z.string(),
+  action: z.string(),
+  target_type: z.string().nullable(),
+  target_id: z.string().nullable(),
+  detail: z.record(z.string(), z.unknown()).optional(),
+  performed_at: z.string(),
+});
+
+// ── Gastown HTTP client ───────────────────────────────────────────────────────
+
+/**
+ * Build auth headers for server-side calls to the Gastown worker.
+ * Uses the admin user's Kilo JWT (isAdmin: true, gastownAccess: true)
+ * plus CF Access service token headers for production.
+ */
+function buildAdminHeaders(adminUser: User): Record<string, string> {
+  const token = generateApiToken(
+    adminUser,
+    { isAdmin: true, gastownAccess: true },
+    { expiresIn: 60 } // 1-minute lifetime — server-side only
+  );
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  if (GASTOWN_CF_ACCESS_CLIENT_ID && GASTOWN_CF_ACCESS_CLIENT_SECRET) {
+    headers['CF-Access-Client-Id'] = GASTOWN_CF_ACCESS_CLIENT_ID;
+    headers['CF-Access-Client-Secret'] = GASTOWN_CF_ACCESS_CLIENT_SECRET;
+  }
+
+  return headers;
+}
+
+type GastownSuccessResponse<T> = { success: true; data: T };
+type GastownErrorResponse = { success: false; error: string };
+type GastownApiResponse<T> = GastownSuccessResponse<T> | GastownErrorResponse;
+
+function isGastownSuccess<T>(res: GastownApiResponse<T>): res is GastownSuccessResponse<T> {
+  return res.success === true;
+}
+
+/** GET request to the Gastown worker, parsing the response with the given schema. */
+async function gastownGet<T>(adminUser: User, path: string, schema: z.ZodType<T>): Promise<T> {
+  const response = await fetch(`${GASTOWN_SERVICE_URL}${path}`, {
+    method: 'GET',
+    headers: buildAdminHeaders(adminUser),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new TRPCError({
+      code: response.status === 404 ? 'NOT_FOUND' : 'INTERNAL_SERVER_ERROR',
+      message: `Gastown ${response.status}: ${body.slice(0, 200)}`,
+    });
+  }
+
+  const raw = (await response.json()) as GastownApiResponse<unknown>;
+  if (!isGastownSuccess(raw)) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Gastown error: ${raw.error}` });
+  }
+  return schema.parse(raw.data);
+}
+
+/** PATCH request to the Gastown worker. */
+async function gastownPatch<T>(
+  adminUser: User,
+  path: string,
+  body: unknown,
+  schema: z.ZodType<T>
+): Promise<T> {
+  const response = await fetch(`${GASTOWN_SERVICE_URL}${path}`, {
+    method: 'PATCH',
+    headers: buildAdminHeaders(adminUser),
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text().catch(() => '');
+    throw new TRPCError({
+      code: response.status === 404 ? 'NOT_FOUND' : 'INTERNAL_SERVER_ERROR',
+      message: `Gastown ${response.status}: ${responseBody.slice(0, 200)}`,
+    });
+  }
+
+  const raw = (await response.json()) as GastownApiResponse<unknown>;
+  if (!isGastownSuccess(raw)) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Gastown error: ${raw.error}` });
+  }
+  return schema.parse(raw.data);
+}
+
+/**
+ * Call the Gastown worker's tRPC endpoint (GET query) and return the result.
+ * The admin JWT has isAdmin=true which satisfies gastownProcedure.
+ * Note: procedures that call verifyTownOwnership will fail for towns not owned
+ * by the admin user — those procedures need admin-bypass support in the worker.
+ */
+async function gastownTrpcGet<T>(
+  adminUser: User,
+  procedure: string,
+  input: unknown,
+  schema: z.ZodType<T>
+): Promise<T | null> {
+  const headers = buildAdminHeaders(adminUser);
+  const url = `${GASTOWN_SERVICE_URL}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`;
+  const response = await fetch(url, { headers });
+  if (!response.ok) return null;
+
+  const raw: unknown = await response.json();
+  const resultSchema = z.object({ result: z.object({ data: schema }) });
+  const parsed = resultSchema.safeParse(raw);
+  return parsed.success ? parsed.data.result.data : null;
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+export const adminGastownRouter = createTRPCRouter({
+  // ── User → Towns ─────────────────────────────────────────────────────────
+
+  /**
+   * List all towns owned by a given user.
+   * Calls: GET /api/users/:userId/towns (kiloAuthMiddleware, no ownership check)
+   */
+  getUserTowns: adminProcedure
+    .input(z.object({ userId: z.string().uuid() }))
+    .output(z.array(UserTownRecord))
+    .query(({ input, ctx }) => {
+      return gastownGet(ctx.user, `/api/users/${input.userId}/towns`, z.array(UserTownRecord));
+    }),
+
+  /**
+   * List all rigs for all towns owned by a given user.
+   * Calls: GET /api/users/:userId/towns/:townId/rigs for each town.
+   */
+  getUserRigs: adminProcedure
+    .input(z.object({ userId: z.string().uuid() }))
+    .output(z.array(UserRigRecord))
+    .query(async ({ input, ctx }) => {
+      const towns = await gastownGet(
+        ctx.user,
+        `/api/users/${input.userId}/towns`,
+        z.array(UserTownRecord)
+      );
+
+      const rigLists = await Promise.all(
+        towns.map(town =>
+          gastownGet(
+            ctx.user,
+            `/api/users/${input.userId}/towns/${town.id}/rigs`,
+            z.array(UserRigRecord)
+          ).catch((): z.infer<typeof UserRigRecord>[] => [])
+        )
+      );
+
+      return rigLists.flat();
+    }),
+
+  // ── Town inspection ───────────────────────────────────────────────────────
+
+  /**
+   * Get the alarm status snapshot for a town.
+   * Calls the tRPC gastown.getAlarmStatus with admin JWT.
+   * Requires admin-bypass support on the Gastown worker (bead 0) since
+   * verifyTownOwnership is checked per town.
+   */
+  getTownHealth: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(AlarmStatusRecord.nullable())
+    .query(async ({ input, ctx }) => {
+      return gastownTrpcGet(
+        ctx.user,
+        'gastown.getAlarmStatus',
+        { townId: input.townId },
+        AlarmStatusRecord
+      );
+    }),
+
+  /**
+   * List all beads in a town, with optional filters.
+   * The user-facing tRPC listBeads requires a rigId and verifies ownership.
+   * Admin-level town-wide listing requires bead 0 admin endpoints on the worker.
+   * Until then, callers can use getUserRigs + per-rig listBeads via the tRPC client.
+   */
+  listBeads: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'closed', 'failed']).optional(),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+        rigId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.array(BeadRecord))
+    .query(async ({ input, ctx }) => {
+      if (!input.rigId) {
+        // Town-wide listing requires admin-bypass endpoint (bead 0).
+        return [];
+      }
+      // Per-rig listing via tRPC listBeads (requires rig ownership — will fail for other users' rigs).
+      const result = await gastownTrpcGet(
+        ctx.user,
+        'gastown.listBeads',
+        { rigId: input.rigId, status: input.status },
+        z.array(BeadRecord)
+      );
+      return result ?? [];
+    }),
+
+  /**
+   * Get bead events for a town or specific bead.
+   * Calls tRPC gastown.getTownEvents (requires town ownership).
+   */
+  getBeadEvents: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        beadId: z.string().uuid().optional(),
+        since: z.string().optional(),
+        limit: z.number().int().positive().max(500).default(100),
+      })
+    )
+    .output(z.array(BeadEventRecord))
+    .query(async ({ input, ctx }) => {
+      const result = await gastownTrpcGet(
+        ctx.user,
+        'gastown.getTownEvents',
+        { townId: input.townId, since: input.since, limit: input.limit },
+        z.array(BeadEventRecord)
+      );
+      return result ?? [];
+    }),
+
+  /**
+   * List all agents in a town.
+   * The user-facing tRPC listAgents requires rigId and ownership verification.
+   * Admin-level town-wide listing requires bead 0 admin endpoints.
+   */
+  listAgents: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        rigId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.array(AgentRecord))
+    .query(async ({ input, ctx }) => {
+      if (!input.rigId) {
+        // Town-wide listing requires admin-bypass endpoint (bead 0).
+        return [];
+      }
+      const result = await gastownTrpcGet(
+        ctx.user,
+        'gastown.listAgents',
+        { rigId: input.rigId },
+        z.array(AgentRecord)
+      );
+      return result ?? [];
+    }),
+
+  /**
+   * Get agent events from the AgentDO.
+   * The HTTP endpoint for agent events uses agent JWT auth.
+   * Admin access requires bead 0 admin bypass endpoint.
+   */
+  getAgentEvents: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        agentId: z.string().uuid(),
+        afterId: z.number().int().optional(),
+        limit: z.number().int().positive().max(500).default(100),
+      })
+    )
+    .output(z.array(z.unknown()))
+    .query(async ({ input }) => {
+      // Requires admin-bypass endpoint on the Gastown worker (bead 0).
+      void input;
+      return [];
+    }),
+
+  /**
+   * List dispatch attempts for a town, optionally filtered by bead or agent.
+   * Requires bead 0 (TownDO.listDispatchAttempts).
+   */
+  listDispatchAttempts: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        beadId: z.string().uuid().optional(),
+        agentId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.array(DispatchAttemptRecord))
+    .query(async ({ input }) => {
+      void input;
+      return [];
+    }),
+
+  /**
+   * List container events for a town.
+   * Requires bead 0 (TownDO.listContainerEvents).
+   */
+  listContainerEvents: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        since: z.string().optional(),
+      })
+    )
+    .output(z.array(ContainerEventRecord))
+    .query(async ({ input }) => {
+      void input;
+      return [];
+    }),
+
+  /**
+   * List credential events for a town, optionally filtered by rig.
+   * Requires bead 0 (TownDO.listCredentialEvents).
+   */
+  listCredentialEvents: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        rigId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.array(CredentialEventRecord))
+    .query(async ({ input }) => {
+      void input;
+      return [];
+    }),
+
+  /**
+   * List the admin audit log for a town.
+   * Requires bead 0 (TownDO.listAdminAuditLog).
+   */
+  listAuditLog: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(z.array(AdminAuditLogRecord))
+    .query(async ({ input }) => {
+      void input;
+      return [];
+    }),
+
+  /**
+   * Get the town config.
+   * Calls: GET /api/towns/:townId/config (kiloAuthMiddleware, no ownership check).
+   */
+  getTownConfig: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(TownConfigRecord)
+    .query(({ input, ctx }) => {
+      return gastownGet(ctx.user, `/api/towns/${input.townId}/config`, TownConfigRecord);
+    }),
+
+  /**
+   * Get convoy status (convoy + tracked beads) for a specific convoyId.
+   * Calls tRPC gastown.listConvoys and filters by convoyId.
+   * Requires admin-bypass support for verifyTownOwnership (bead 0).
+   */
+  getConvoyStatus: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), convoyId: z.string().uuid() }))
+    .output(ConvoyDetailRecord.nullable())
+    .query(async ({ input, ctx }) => {
+      const convoys = await gastownTrpcGet(
+        ctx.user,
+        'gastown.listConvoys',
+        { townId: input.townId },
+        z.array(ConvoyDetailRecord)
+      );
+      if (!convoys) return null;
+      return convoys.find(c => c.id === input.convoyId) ?? null;
+    }),
+
+  /**
+   * List all convoys in a town.
+   * Calls tRPC gastown.listConvoys (requires admin-bypass for verifyTownOwnership).
+   */
+  listConvoys: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(z.array(ConvoyDetailRecord))
+    .query(async ({ input, ctx }) => {
+      const result = await gastownTrpcGet(
+        ctx.user,
+        'gastown.listConvoys',
+        { townId: input.townId },
+        z.array(ConvoyDetailRecord)
+      );
+      return result ?? [];
+    }),
+
+  // ── Admin interventions ───────────────────────────────────────────────────
+  // All write to audit log via TownDO.logAdminAction() (added in bead 0).
+  // These throw METHOD_NOT_SUPPORTED until bead 0 adds admin intervention
+  // endpoints to the Gastown worker.
+
+  /** Force-reset an agent: sets status to idle and unhooks the bead. */
+  forceResetAgent: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), agentId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      void input;
+      throw new TRPCError({
+        code: 'METHOD_NOT_SUPPORTED',
+        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+      });
+    }),
+
+  /** Force-close a bead. */
+  forceCloseBead: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      void input;
+      throw new TRPCError({
+        code: 'METHOD_NOT_SUPPORTED',
+        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+      });
+    }),
+
+  /** Force-fail a bead. */
+  forceFailBead: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      void input;
+      throw new TRPCError({
+        code: 'METHOD_NOT_SUPPORTED',
+        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+      });
+    }),
+
+  /** Force-restart the town container. */
+  forceRestartContainer: adminProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      void input;
+      throw new TRPCError({
+        code: 'METHOD_NOT_SUPPORTED',
+        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+      });
+    }),
+
+  /** Force-retry a stalled review queue entry. */
+  forceRetryReview: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), entryId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      void input;
+      throw new TRPCError({
+        code: 'METHOD_NOT_SUPPORTED',
+        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+      });
+    }),
+
+  /** Force-refresh git credentials for a rig. */
+  forceRefreshCredentials: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), rigId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      void input;
+      throw new TRPCError({
+        code: 'METHOD_NOT_SUPPORTED',
+        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+      });
+    }),
+
+  /**
+   * Admin-level town config update.
+   * Calls: PATCH /api/towns/:townId/config (kiloAuthMiddleware, no ownership check).
+   */
+  updateTownConfig: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        update: TownConfigRecord.partial(),
+      })
+    )
+    .output(TownConfigRecord)
+    .mutation(({ input, ctx }) => {
+      return gastownPatch(
+        ctx.user,
+        `/api/towns/${input.townId}/config`,
+        input.update,
+        TownConfigRecord
+      );
+    }),
+});

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -121,8 +121,8 @@ const TownConfigRecord = z.object({
   }),
   owner_user_id: z.string().optional(),
   kilocode_token: z.string().optional(),
-  default_model: z.string().optional(),
-  small_model: z.string().optional(),
+  default_model: z.string().nullable().optional(),
+  small_model: z.string().nullable().optional(),
   max_polecats_per_rig: z.number().optional(),
   merge_strategy: z.enum(['direct', 'pr']),
   refinery: z

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -233,7 +233,6 @@ const GastownApiResponseSchema = z.union([
   z.object({ success: z.literal(true), data: z.unknown() }),
   z.object({ success: z.literal(false), error: z.string() }),
 ]);
-type GastownApiResponse = z.infer<typeof GastownApiResponseSchema>;
 
 /** GET request to the Gastown worker, parsing the response with the given schema. */
 async function gastownGet<T>(adminUser: User, path: string, schema: z.ZodType<T>): Promise<T> {

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -312,6 +312,40 @@ async function gastownTrpcGet<T>(
   return parsed.success ? parsed.data.result.data : null;
 }
 
+/**
+ * Call a Gastown worker tRPC mutation (POST) and return the result.
+ * Returns null on failure.
+ */
+async function gastownTrpcMutate<T>(
+  adminUser: User,
+  procedure: string,
+  input: unknown,
+  schema: z.ZodType<T>
+): Promise<T | null> {
+  const headers = buildAdminHeaders(adminUser);
+  const url = `${GASTOWN_SERVICE_URL}/trpc/${procedure}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    console.error(
+      `[admin/gastown] tRPC mutate ${procedure} failed: ${response.status} ${body.slice(0, 200)}`
+    );
+    throw new TRPCError({
+      code: response.status === 404 ? 'NOT_FOUND' : 'INTERNAL_SERVER_ERROR',
+      message: `Gastown tRPC ${procedure} failed: ${response.status}`,
+    });
+  }
+
+  const raw: unknown = await response.json();
+  const resultSchema = z.object({ result: z.object({ data: schema }) });
+  const parsed = resultSchema.safeParse(raw);
+  return parsed.success ? parsed.data.result.data : null;
+}
+
 // ── Router ────────────────────────────────────────────────────────────────────
 
 export const adminGastownRouter = createTRPCRouter({
@@ -389,20 +423,15 @@ export const adminGastownRouter = createTRPCRouter({
         type: z
           .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
           .optional(),
-        rigId: z.string().uuid().optional(),
+        limit: z.number().int().positive().max(500).default(200),
       })
     )
     .output(z.array(BeadRecord))
     .query(async ({ input, ctx }) => {
-      if (!input.rigId) {
-        // Town-wide listing requires admin-bypass endpoint (bead 0).
-        return [];
-      }
-      // Per-rig listing via tRPC listBeads (requires rig ownership — will fail for other users' rigs).
       const result = await gastownTrpcGet(
         ctx.user,
-        'gastown.listBeads',
-        { rigId: input.rigId, status: input.status },
+        'gastown.adminListBeads',
+        { townId: input.townId, status: input.status, type: input.type, limit: input.limit },
         z.array(BeadRecord)
       );
       return result ?? [];
@@ -438,22 +467,13 @@ export const adminGastownRouter = createTRPCRouter({
    * Admin-level town-wide listing requires bead 0 admin endpoints.
    */
   listAgents: adminProcedure
-    .input(
-      z.object({
-        townId: z.string().uuid(),
-        rigId: z.string().uuid().optional(),
-      })
-    )
+    .input(z.object({ townId: z.string().uuid() }))
     .output(z.array(AgentRecord))
     .query(async ({ input, ctx }) => {
-      if (!input.rigId) {
-        // Town-wide listing requires admin-bypass endpoint (bead 0).
-        return [];
-      }
       const result = await gastownTrpcGet(
         ctx.user,
-        'gastown.listAgents',
-        { rigId: input.rigId },
+        'gastown.adminListAgents',
+        { townId: input.townId },
         z.array(AgentRecord)
       );
       return result ?? [];
@@ -592,73 +612,70 @@ export const adminGastownRouter = createTRPCRouter({
     }),
 
   // ── Admin interventions ───────────────────────────────────────────────────
-  // All write to audit log via TownDO.logAdminAction() (added in bead 0).
-  // These throw METHOD_NOT_SUPPORTED until bead 0 adds admin intervention
-  // endpoints to the Gastown worker.
 
-  /** Force-reset an agent: sets status to idle and unhooks the bead. */
   forceResetAgent: adminProcedure
     .input(z.object({ townId: z.string().uuid(), agentId: z.string().uuid() }))
-    .mutation(async ({ input }) => {
-      void input;
-      throw new TRPCError({
-        code: 'METHOD_NOT_SUPPORTED',
-        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
-      });
+    .mutation(async ({ input, ctx }) => {
+      await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminForceResetAgent',
+        { townId: input.townId, agentId: input.agentId },
+        z.void().or(z.null())
+      );
     }),
 
-  /** Force-close a bead. */
   forceCloseBead: adminProcedure
     .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
-    .mutation(async ({ input }) => {
-      void input;
-      throw new TRPCError({
-        code: 'METHOD_NOT_SUPPORTED',
-        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
-      });
+    .mutation(async ({ input, ctx }) => {
+      await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminForceCloseBead',
+        { townId: input.townId, beadId: input.beadId },
+        BeadRecord
+      );
     }),
 
-  /** Force-fail a bead. */
   forceFailBead: adminProcedure
     .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
-    .mutation(async ({ input }) => {
-      void input;
-      throw new TRPCError({
-        code: 'METHOD_NOT_SUPPORTED',
-        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
-      });
+    .mutation(async ({ input, ctx }) => {
+      await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminForceFailBead',
+        { townId: input.townId, beadId: input.beadId },
+        BeadRecord
+      );
     }),
 
-  /** Force-restart the town container. */
   forceRestartContainer: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
-    .mutation(async ({ input }) => {
-      void input;
-      throw new TRPCError({
-        code: 'METHOD_NOT_SUPPORTED',
-        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
-      });
+    .mutation(async ({ input, ctx }) => {
+      await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminForceRestartContainer',
+        { townId: input.townId },
+        z.void().or(z.null())
+      );
     }),
 
-  /** Force-retry a stalled review queue entry. */
+  /** Force-retry a stalled review queue entry. Not yet implemented on the worker. */
   forceRetryReview: adminProcedure
     .input(z.object({ townId: z.string().uuid(), entryId: z.string().uuid() }))
     .mutation(async ({ input }) => {
       void input;
       throw new TRPCError({
         code: 'METHOD_NOT_SUPPORTED',
-        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+        message: 'Review retry requires manual re-submission — not yet implemented.',
       });
     }),
 
-  /** Force-refresh git credentials for a rig. */
+  /** Force-refresh git credentials for a rig. Not yet implemented on the worker. */
   forceRefreshCredentials: adminProcedure
     .input(z.object({ townId: z.string().uuid(), rigId: z.string().uuid() }))
     .mutation(async ({ input }) => {
       void input;
       throw new TRPCError({
         code: 'METHOD_NOT_SUPPORTED',
-        message: 'Requires bead 0 admin intervention endpoints on the Gastown worker.',
+        message: 'Credential refresh not yet implemented.',
       });
     }),
 

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -229,13 +229,11 @@ function buildAdminHeaders(adminUser: User): Record<string, string> {
   return headers;
 }
 
-type GastownSuccessResponse<T> = { success: true; data: T };
-type GastownErrorResponse = { success: false; error: string };
-type GastownApiResponse<T> = GastownSuccessResponse<T> | GastownErrorResponse;
-
-function isGastownSuccess<T>(res: GastownApiResponse<T>): res is GastownSuccessResponse<T> {
-  return res.success === true;
-}
+const GastownApiResponseSchema = z.union([
+  z.object({ success: z.literal(true), data: z.unknown() }),
+  z.object({ success: z.literal(false), error: z.string() }),
+]);
+type GastownApiResponse = z.infer<typeof GastownApiResponseSchema>;
 
 /** GET request to the Gastown worker, parsing the response with the given schema. */
 async function gastownGet<T>(adminUser: User, path: string, schema: z.ZodType<T>): Promise<T> {
@@ -252,8 +250,8 @@ async function gastownGet<T>(adminUser: User, path: string, schema: z.ZodType<T>
     });
   }
 
-  const raw = (await response.json()) as GastownApiResponse<unknown>;
-  if (!isGastownSuccess(raw)) {
+  const raw = GastownApiResponseSchema.parse(await response.json());
+  if (!raw.success) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Gastown error: ${raw.error}` });
   }
   return schema.parse(raw.data);
@@ -280,8 +278,8 @@ async function gastownPatch<T>(
     });
   }
 
-  const raw = (await response.json()) as GastownApiResponse<unknown>;
-  if (!isGastownSuccess(raw)) {
+  const raw = GastownApiResponseSchema.parse(await response.json());
+  if (!raw.success) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Gastown error: ${raw.error}` });
   }
   return schema.parse(raw.data);
@@ -302,7 +300,11 @@ async function gastownTrpcGet<T>(
   const headers = buildAdminHeaders(adminUser);
   const url = `${GASTOWN_SERVICE_URL}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`;
   const response = await fetch(url, { headers });
-  if (!response.ok) return null;
+  if (!response.ok) {
+    if (response.status === 404) return null;
+    console.error(`[admin/gastown] tRPC proxy ${procedure} failed: ${response.status}`);
+    return null;
+  }
 
   const raw: unknown = await response.json();
   const resultSchema = z.object({ result: z.object({ data: schema }) });

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -434,9 +434,20 @@ export const adminGastownRouter = createTRPCRouter({
       return result ?? [];
     }),
 
+  getBead: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadId: z.string().uuid() }))
+    .output(BeadRecord.nullable())
+    .query(async ({ input, ctx }) => {
+      return gastownTrpcGet(
+        ctx.user,
+        'gastown.adminGetBead',
+        { townId: input.townId, beadId: input.beadId },
+        BeadRecord
+      );
+    }),
+
   /**
    * Get bead events for a town or specific bead.
-   * Calls tRPC gastown.getTownEvents (requires town ownership).
    */
   getBeadEvents: adminProcedure
     .input(


### PR DESCRIPTION
## Summary

Adds a user-scoped Gastown admin panel for diagnosing and intervening in user issues across towns, beads, and agents. The architecture follows a proxy pattern: the Next.js admin dashboard calls tRPC endpoints that authenticate to the Gastown Cloudflare Worker via short-lived admin JWTs + CF Access service tokens.

Key additions:
- **User → Gastown section** on the existing admin user detail page (`UserAdminGastown.tsx`), showing all towns with traffic-light health indicators (green/yellow/red based on dead agents, stalled work, failed beads) and rigs with integration status
- **Town Inspector** (`/admin/gastown/towns/[townId]`) with 6 tabs: Beads, Agents, Review Queue, Container, Config, Events — each filterable/sortable with admin intervention buttons (force-close, force-fail, force-reset, force-restart)
- **Bead Inspector** deep-dive with full event timeline, dependency graph, and agent assignment history
- **Agent Inspector** deep-dive with SDK event stream, dispatch history, and status timeline
- **Audit Log** page for tracking all admin interventions on a town
- **tRPC backend** (`gastown-router.ts`) with working read endpoints for towns, rigs, beads, agents, config, convoys, and health — plus stubbed write endpoints awaiting bead-0 admin-bypass routes on the Gastown worker
- **Gastown worker changes**: triage agents now use the standard `polecat` role and real repo workspaces instead of the former lightweight/fake workspace path, eliminating the `createLightweightWorkspace` abstraction

Closes #897

## Verification

- [x] Merge conflicts resolved manually (patrol.ts triage cap logic retained from main, admin-router.ts imports merged)
- [ ] `pnpm typecheck` — not yet run (new files depend on Gastown worker types that may not resolve in the monorepo typecheck without the worker running)
- [ ] Manual testing — admin panel endpoints depend on running Gastown worker infrastructure

## Visual Changes

<img width="1706" height="1234" alt="image" src="https://github.com/user-attachments/assets/d993c0e5-d4a9-416f-994f-843d64e9186a" />

<img width="1706" height="1234" alt="image" src="https://github.com/user-attachments/assets/a8f57405-5151-4518-b782-4368db651c64" />

<img width="1706" height="1234" alt="image" src="https://github.com/user-attachments/assets/5f8abe8f-17af-424f-88d4-7af09c9184bf" />

<img width="1706" height="1234" alt="image" src="https://github.com/user-attachments/assets/1945ed81-d326-437c-af6c-e62d21dfbcab" />


## Reviewer Notes

- Many tRPC endpoints in `gastown-router.ts` are **stubs** returning empty arrays or throwing `METHOD_NOT_SUPPORTED`. These are scaffolded ahead of bead-0 admin-bypass endpoints on the Gastown worker. The frontend is wired up to handle empty/error states gracefully.
- The patrol.ts conflict resolution kept main's refined triage cap logic (escalation exemption, two-check crash loop exclusion) over the feature branch's simplification, since main's version is more recent and more correct.
- The `alert-dialog.tsx` shadcn component was added as a new UI primitive for confirmation dialogs on destructive admin actions.