### PR TITLE
fix(ui): persist selected usage view across refreshes

### DIFF
--- a/apps/web/src/app/(app)/usage/page.tsx
+++ b/apps/web/src/app/(app)/usage/page.tsx
@@ -19,7 +19,7 @@ import {
   formatLargeNumber,
 } from '@/lib/utils';
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { StreakCalendar } from '@/components/profile/StreakCalendar';
 import { UsageWarning } from '@/components/usage/UsageWarning';
 import type { UsageTableColumn, UsageTableRow } from '@/components/usage/UsageTableBase';
@@ -29,6 +29,7 @@ import { PageLayout } from '@/components/PageLayout';
 import { useTRPC } from '@/lib/trpc/utils';
 
 type Period = 'week' | 'month' | 'year' | 'all';
+type GroupBy = 'day' | 'model';
 
 type UsageData = {
   date: string;
@@ -148,10 +149,26 @@ const PERIOD_LABELS: Record<Period, string> = {
 
 export default function UsagePage() {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const trpc = useTRPC();
-  const [groupByModel, setGroupByModel] = useState(false);
+  const groupByParam = searchParams.get('groupBy');
+  const groupBy: GroupBy = groupByParam === 'model' ? 'model' : 'day';
+  const groupByModel = groupBy === 'model';
   const [viewType, setViewType] = useState<string>('personal');
   const [period, setPeriod] = useState<Period>('week');
+
+  const handleGroupByChange = (nextGroupBy: GroupBy) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextGroupBy === 'day') {
+      params.delete('groupBy');
+    } else {
+      params.set('groupBy', nextGroupBy);
+    }
+
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  };
 
   const {
     data: usageData,
@@ -569,14 +586,14 @@ export default function UsagePage() {
             <Button
               variant={groupByModel ? 'outline' : 'default'}
               size="sm"
-              onClick={() => setGroupByModel(false)}
+              onClick={() => handleGroupByChange('day')}
             >
               By Day
             </Button>
             <Button
               variant={groupByModel ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setGroupByModel(true)}
+              onClick={() => handleGroupByChange('model')}
             >
               By Model & Day
             </Button>

--- a/apps/web/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
+++ b/apps/web/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   useOrganizationUsageDetails,
   useOrganizationUsageTimeseries,
@@ -59,6 +60,7 @@ const METRIC_KEY_TO_FILTER_METRIC: Record<string, OrganizationUsageMetric> = {
   outputTokens: 'output_tokens',
   users: 'active_users',
 };
+type GroupBy = 'day' | 'model';
 
 export function OrganizationUsageDetailsPage({ organizationId }: { organizationId: string }) {
   return (
@@ -69,15 +71,33 @@ export function OrganizationUsageDetailsPage({ organizationId }: { organizationI
 }
 
 export function OrganizationUsageDetails({ organizationId }: { organizationId: string }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
   // State management
   const [timePeriod, setTimePeriod] = useState<TimePeriod>('week');
-  const [groupByModel, setGroupByModel] = useState(false);
+  const groupByParam = searchParams.get('groupBy');
+  const groupBy: GroupBy = groupByParam === 'model' ? 'model' : 'day';
+  const groupByModel = groupBy === 'model';
   const [selectedMetric, setSelectedMetric] = useState('cost');
   const [chartSplitBy, setChartSplitBy] = useState<ChartSplitBy>({
     provider: false,
     model: false,
     tokenType: false,
   });
+
+  const handleGroupByChange = (nextGroupBy: GroupBy) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextGroupBy === 'day') {
+      params.delete('groupBy');
+    } else {
+      params.set('groupBy', nextGroupBy);
+    }
+
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  };
 
   // Context and session
   const { data: session } = useSession();
@@ -374,14 +394,14 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
                     <Button
                       variant={groupByModel ? 'outline' : 'default'}
                       size="sm"
-                      onClick={() => setGroupByModel(false)}
+                      onClick={() => handleGroupByChange('day')}
                     >
                       By Day
                     </Button>
                     <Button
                       variant={groupByModel ? 'default' : 'outline'}
                       size="sm"
-                      onClick={() => setGroupByModel(true)}
+                      onClick={() => handleGroupByChange('model')}
                     >
                       By Model & Day
                     </Button>


### PR DESCRIPTION
## Summary

Currently the Usage page will always reset to the "By Day" view when a user refreshes the page. This change persists the user's selected view by using a query parameter, so that "By Model & Day" can have a permanent URL.

## Verification

- Login and go to the Usage page
- Select "By Day & Model"
- Refresh the page
- Ensure that "By Day & Model" is still the active view after refresh

<img width="1320" height="826" alt="image" src="https://github.com/user-attachments/assets/365c2d67-8b3e-4534-b315-06dccc52a416" />

## Visual Changes

N/A