### PR TITLE
fix(kiloclaw): reverse region list on capacity recovery

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2128,7 +2128,7 @@ describe('start: volume region validation', () => {
 // ============================================================================
 
 describe('start: 412 insufficient resources recovery', () => {
-  it('fresh provision (never started): deletes volume and creates fresh with deprioritized regions', async () => {
+  it('fresh provision (never started): deletes volume and creates fresh with reversed regions', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, { flyMachineId: null, lastStartedAt: null });
 
@@ -2150,16 +2150,15 @@ describe('start: 412 insufficient resources recovery', () => {
 
     // Old volume was deleted
     expect(flyClient.deleteVolume).toHaveBeenCalledWith(expect.anything(), 'vol-1');
-    // New volume created via fallback with deprioritized regions and compute hint
+    // New volume created via fallback with reversed regions and compute hint
     const regions412Call = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
     expect(regions412Call[1]).toEqual(
       expect.objectContaining({
         compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }) as unknown,
       })
     );
-    // Regions are shuffled, so just check the set (deprioritize is a no-op here
-    // because 'iad' is not in FLY_REGION='us,eu')
-    expect((regions412Call[2] as string[]).sort()).toEqual(['eu', 'us']);
+    // Regions are reversed from FLY_REGION='us,eu' so EU is tried first on recovery
+    expect(regions412Call[2]).toEqual(['eu', 'us']);
     // source_volume_id should NOT be set for fresh provision
     const createVolumeCall = (flyClient.createVolumeWithFallback as Mock).mock
       .calls[0][1] as Record<string, unknown>;
@@ -2197,7 +2196,7 @@ describe('start: 412 insufficient resources recovery', () => {
 
     await instance.start('user-1');
 
-    // Volume was forked (source_volume_id set) with compute hint and deprioritized regions
+    // Volume was forked (source_volume_id set) with compute hint and reversed regions
     const regionsForkCall = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
     expect(regionsForkCall[1]).toEqual(
       expect.objectContaining({
@@ -2205,8 +2204,8 @@ describe('start: 412 insufficient resources recovery', () => {
         compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }) as unknown,
       })
     );
-    // Regions are shuffled — check the set
-    expect((regionsForkCall[2] as string[]).sort()).toEqual(['eu', 'us']);
+    // Regions are reversed from FLY_REGION='us,eu' so EU is tried first on recovery
+    expect(regionsForkCall[2]).toEqual(['eu', 'us']);
     // Old volume was deleted
     expect(flyClient.deleteVolume).toHaveBeenCalledWith(expect.anything(), 'vol-1');
     // Machine was retried
@@ -2270,8 +2269,8 @@ describe('start: 412 insufficient resources recovery', () => {
         compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }) as unknown,
       })
     );
-    // Regions are shuffled then deprioritized — check the set
-    expect((regionsUpdateCall[2] as string[]).sort()).toEqual(['eu', 'us']);
+    // Regions are reversed from FLY_REGION='us,eu' so EU is tried first on recovery
+    expect(regionsUpdateCall[2]).toEqual(['eu', 'us']);
     // New machine was created
     expect(storage._store.get('flyMachineId')).toBe('machine-new');
     expect(storage._store.get('flyVolumeId')).toBe('vol-new');

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_FLY_REGION,
   STALE_PROVISION_THRESHOLD_MS,
 } from '../../config';
-import { parseRegions, shuffleRegions, deprioritizeRegion } from '../regions';
+import { parseRegions, shuffleRegions } from '../regions';
 import { guestFromSize, volumeNameFromSandboxId } from '../machine-config';
 import type { InstanceMutableState } from './types';
 import { storageUpdate } from './state';
@@ -65,8 +65,7 @@ export async function replaceStrandedVolume(
   const oldVolumeId = state.flyVolumeId;
   const oldRegion = state.flyRegion;
   const hasUserData = state.lastStartedAt !== null;
-  const allRegions = shuffleRegions(parseRegions(env.FLY_REGION ?? DEFAULT_FLY_REGION));
-  const regions = deprioritizeRegion(allRegions, oldRegion);
+  const regions = parseRegions(env.FLY_REGION ?? DEFAULT_FLY_REGION).reverse();
   const compute = guestFromSize(state.machineSize);
 
   // Destroy existing machine if any — it's stuck on the constrained host.

--- a/kiloclaw/src/routes/api.ts
+++ b/kiloclaw/src/routes/api.ts
@@ -62,32 +62,6 @@ adminApi.post('/machine/restart', async c => {
   }
 });
 
-// TODO: Remove after frontend rollout to /api/admin/machine/restart
-// POST /api/admin/gateway/restart - Backward-compat alias for machine restart
-adminApi.post('/gateway/restart', async c => {
-  const stub = resolveStub(c);
-  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
-  const rawTag = typeof body.imageTag === 'string' ? body.imageTag : undefined;
-
-  if (rawTag && !isValidImageTag(rawTag)) {
-    return c.json({ success: false, error: 'Invalid image tag format' }, 400);
-  }
-
-  const imageTag = rawTag;
-  const result = await stub.restartMachine(imageTag ? { imageTag } : undefined);
-
-  if (result.success) {
-    return c.json({
-      success: true,
-      message: imageTag
-        ? `Machine restarting with image tag: ${imageTag}...`
-        : 'Machine restarting with updated configuration...',
-    });
-  } else {
-    return c.json({ success: false, error: result.error }, 500);
-  }
-});
-
 // Mount admin API routes under /admin
 api.route('/admin', adminApi);
 

--- a/kiloclaw/src/routes/api.ts
+++ b/kiloclaw/src/routes/api.ts
@@ -62,6 +62,32 @@ adminApi.post('/machine/restart', async c => {
   }
 });
 
+// TODO: Remove after frontend rollout to /api/admin/machine/restart
+// POST /api/admin/gateway/restart - Backward-compat alias for machine restart
+adminApi.post('/gateway/restart', async c => {
+  const stub = resolveStub(c);
+  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const rawTag = typeof body.imageTag === 'string' ? body.imageTag : undefined;
+
+  if (rawTag && !isValidImageTag(rawTag)) {
+    return c.json({ success: false, error: 'Invalid image tag format' }, 400);
+  }
+
+  const imageTag = rawTag;
+  const result = await stub.restartMachine(imageTag ? { imageTag } : undefined);
+
+  if (result.success) {
+    return c.json({
+      success: true,
+      message: imageTag
+        ? `Machine restarting with image tag: ${imageTag}...`
+        : 'Machine restarting with updated configuration...',
+    });
+  } else {
+    return c.json({ success: false, error: result.error }, 500);
+  }
+});
+
 // Mount admin API routes under /admin
 api.route('/admin', adminApi);
 


### PR DESCRIPTION
## Summary

- **Fix capacity recovery region fallback**: `replaceStrandedVolume` used `deprioritizeRegion` to push the failed region to the back of the list, but this compared the concrete Fly region (e.g. `ord`) against meta-regions (`us`, `eu`) — which never matched. The recovery volume landed back in the same exhausted region, causing the retry `createNewMachine` to fail with the same capacity error. Axiom logs confirmed a **76% failure rate** (136/178) on capacity recovery attempts, with replacement volumes landing in `ord` 113/178 times. Fix: reverse the configured region list on recovery so the opposite geographic region is always tried first.

## Verification

- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — 537 tests pass (28 test files)
- [x] Verified via Axiom log analysis that the capacity recovery was firing but replacement volumes were landing back in the same region (`ord` 113/178 times)
- [ ] Additional verification after deploy

## Visual Changes

N/A

## Reviewer Notes

- The `deprioritizeRegion` function and its tests are kept (still exported) but no longer used in the recovery path. It could be cleaned up separately if desired.
- Initial provision and `ensureVolume` still use `shuffleRegions` for randomized first-attempt region selection — only the capacity recovery path is changed to deterministic reverse order.
- With `FLY_REGION=us,eu`, recovery now always tries `[eu, us]`, ensuring the replacement volume targets the opposite continent first.