### PR TITLE
feat(admin): add machine start/stop controls to kiloclaw instance detail

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -394,6 +394,36 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
   };
 
+  const machineControlsEnabled = data?.destroyed_at === null && !!data?.workerStatus?.flyMachineId;
+
+  const invalidateMachineQueries = () => {
+    void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
+  };
+
+  const { mutateAsync: machineStart, isPending: isMachineStarting } = useMutation(
+    trpc.admin.kiloclawInstances.machineStart.mutationOptions({
+      onSuccess: () => {
+        toast.success('Machine start requested');
+        invalidateMachineQueries();
+      },
+      onError: err => {
+        toast.error(`Failed to start machine: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: machineStop, isPending: isMachineStopping } = useMutation(
+    trpc.admin.kiloclawInstances.machineStop.mutationOptions({
+      onSuccess: () => {
+        toast.success('Machine stop requested');
+        invalidateMachineQueries();
+      },
+      onError: err => {
+        toast.error(`Failed to stop machine: ${err.message}`);
+      },
+    })
+  );
+
   const { mutateAsync: gatewayStart, isPending: isGatewayStarting } = useMutation(
     trpc.admin.kiloclawInstances.gatewayStart.mutationOptions({
       onSuccess: () => {
@@ -494,6 +524,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   }
 
   const isActive = data.destroyed_at === null;
+  const machineActionPending = isMachineStarting || isMachineStopping;
   const gatewayActionPending =
     isGatewayStarting ||
     isGatewayStopping ||
@@ -789,6 +820,51 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             ) : null}
           </CardContent>
         </Card>
+
+        {/* Machine Controls */}
+        {isActive && machineControlsEnabled && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <CardTitle>Machine Controls</CardTitle>
+                  <CardDescription>Start or stop the Fly machine</CardDescription>
+                </div>
+                <StatusBadge status={data.workerStatus?.status ?? null} />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={machineActionPending}
+                  onClick={() => void machineStart({ userId: data.user_id })}
+                >
+                  {isMachineStarting ? (
+                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="mr-1 h-4 w-4" />
+                  )}
+                  Start Machine
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={machineActionPending}
+                  onClick={() => void machineStop({ userId: data.user_id })}
+                >
+                  {isMachineStopping ? (
+                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Square className="mr-1 h-4 w-4" />
+                  )}
+                  Stop Machine
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Gateway Process (controller) */}
         {isActive && (

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -448,6 +448,28 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     }
   }),
 
+  machineStart: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
+    const fallbackMessage = 'Failed to start machine';
+    try {
+      const client = new KiloClawInternalClient();
+      return await client.start(input.userId);
+    } catch (err) {
+      console.error('Failed to start machine for user:', input.userId, err);
+      throwKiloclawAdminError(err, fallbackMessage);
+    }
+  }),
+
+  machineStop: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
+    const fallbackMessage = 'Failed to stop machine';
+    try {
+      const client = new KiloClawInternalClient();
+      return await client.stop(input.userId);
+    } catch (err) {
+      console.error('Failed to stop machine for user:', input.userId, err);
+      throwKiloclawAdminError(err, fallbackMessage);
+    }
+  }),
+
   destroy: adminProcedure.input(DestroyInstanceSchema).mutation(async ({ input, ctx }) => {
     const [instance] = await db
       .select({


### PR DESCRIPTION
## Summary

Adds machine-level Start/Stop buttons to the KiloClaw admin instance detail page (`/admin/kiloclaw/[id]`). These call the kiloclaw worker's existing `POST /api/platform/start` and `POST /api/platform/stop` endpoints via two new admin tRPC mutations (`machineStart`, `machineStop`).

The buttons are always clickable regardless of the DO's reported machine state. This is intentional — the primary use case is admin recovery when the Durable Object state and the actual Fly machine state have drifted out of sync, so we need to be able to force a start or stop even if the DO thinks the machine is already in that state.

The existing Gateway Process card controls the openclaw process *inside* the machine; this new Machine Controls card operates on the Fly machine itself.

## Verification

- [x] `pnpm typecheck` — passed (only pre-existing errors in `email-mailgun.ts` unrelated to this change)
- [ ] Manual verification of UI and machine start/stop behavior

## Visual Changes

| Before | After |
| ------ | ----- |
| No machine controls on instance detail page | New "Machine Controls" card with Start/Stop buttons and status badge, between Live Worker Status and Gateway Process cards |

## Reviewer Notes

- The two new tRPC mutations follow the exact same pattern as the existing `gatewayStart`/`gatewayStop` mutations (same input schema, error handling, logging).
- Buttons are only disabled during in-flight requests — no state-based gating — per the requirement to always allow forcing start/stop for recovery scenarios.
- The card only renders when the instance is active and has a `flyMachineId` (same guard as the gateway controls card).