### PR TITLE
feat(git-token-service): add GitLab token support with OAuth refresh

### DIFF
--- a/cloudflare-git-token-service/src/gitlab-lookup-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-lookup-service.ts
@@ -7,12 +7,6 @@ import {
 } from '@kilocode/db/schema';
 import { eq, and, isNull, isNotNull, sql } from 'drizzle-orm';
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function isValidUuid(value: string): boolean {
-  return UUID_REGEX.test(value);
-}
-
 export type GitLabLookupParams = {
   userId: string;
   orgId?: string;
@@ -77,7 +71,7 @@ export class GitLabLookupService {
       return { success: false, reason: 'database_not_configured' };
     }
 
-    if (params.orgId !== undefined && !isValidUuid(params.orgId)) {
+    if (params.orgId !== undefined && !z.string().uuid().safeParse(params.orgId).success) {
       return { success: false, reason: 'invalid_org_id' };
     }
 

--- a/cloudflare-git-token-service/src/gitlab-lookup-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-lookup-service.ts
@@ -119,7 +119,7 @@ export class GitLabLookupService {
     }
 
     const row = rows[0];
-    const metadata = GitLabMetadataSchema.parse(row.metadata);
+    const metadata = GitLabMetadataSchema.parse(row.metadata ?? {});
 
     return {
       success: true,

--- a/cloudflare-git-token-service/src/gitlab-lookup-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-lookup-service.ts
@@ -5,7 +5,7 @@ import {
   organization_memberships,
   kilocode_users,
 } from '@kilocode/db/schema';
-import { eq, and, isNull, isNotNull, or, sql } from 'drizzle-orm';
+import { eq, and, isNull, isNotNull, sql } from 'drizzle-orm';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -41,15 +41,17 @@ type GitLabLookupFailure = {
 
 export type GitLabLookupResult = GitLabLookupSuccess | GitLabLookupFailure;
 
-const GitLabMetadataSchema = z.object({
-  access_token: z.string().optional(),
-  refresh_token: z.string().optional(),
-  token_expires_at: z.string().optional(),
-  gitlab_instance_url: z.string().optional(),
-  client_id: z.string().optional(),
-  client_secret: z.string().optional(),
-  auth_type: z.enum(['oauth', 'pat']).optional(),
-});
+const GitLabMetadataSchema = z
+  .object({
+    access_token: z.string().optional(),
+    refresh_token: z.string().optional(),
+    token_expires_at: z.string().optional(),
+    gitlab_instance_url: z.string().optional(),
+    client_id: z.string().optional(),
+    client_secret: z.string().optional(),
+    auth_type: z.enum(['oauth', 'pat']).optional(),
+  })
+  .passthrough();
 
 export class GitLabLookupService {
   private db: WorkerDb | null = null;
@@ -105,24 +107,16 @@ export class GitLabLookupService {
         and(
           eq(platform_integrations.platform, 'gitlab'),
           eq(platform_integrations.integration_status, 'active'),
-          or(
-            and(
-              isNotNull(platform_integrations.owned_by_organization_id),
-              eq(
-                platform_integrations.owned_by_organization_id,
-                sql`${params.orgId ?? null}::uuid`
-              ),
-              isNotNull(organization_memberships.id)
-            ),
-            and(
-              isNotNull(platform_integrations.owned_by_user_id),
-              eq(platform_integrations.owned_by_user_id, params.userId)
-            )
-          )
+          params.orgId
+            ? and(
+                eq(platform_integrations.owned_by_organization_id, sql`${params.orgId}::uuid`),
+                isNotNull(organization_memberships.id)
+              )
+            : and(
+                isNotNull(platform_integrations.owned_by_user_id),
+                eq(platform_integrations.owned_by_user_id, params.userId)
+              )
         )
-      )
-      .orderBy(
-        sql`CASE WHEN ${platform_integrations.owned_by_organization_id} IS NOT NULL THEN 0 ELSE 1 END`
       )
       .limit(1);
 

--- a/cloudflare-git-token-service/src/gitlab-lookup-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-lookup-service.ts
@@ -1,0 +1,142 @@
+import * as z from 'zod';
+import { getWorkerDb, type WorkerDb } from '@kilocode/db/client';
+import {
+  platform_integrations,
+  organization_memberships,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import { eq, and, isNull, isNotNull, or, sql } from 'drizzle-orm';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+export type GitLabLookupParams = {
+  userId: string;
+  orgId?: string;
+};
+
+export type GitLabIntegrationMetadata = {
+  access_token?: string;
+  refresh_token?: string;
+  token_expires_at?: string;
+  gitlab_instance_url?: string;
+  client_id?: string;
+  client_secret?: string;
+  auth_type?: 'oauth' | 'pat';
+};
+
+type GitLabLookupSuccess = {
+  success: true;
+  integrationId: string;
+  metadata: GitLabIntegrationMetadata;
+};
+
+type GitLabLookupFailure = {
+  success: false;
+  reason: 'database_not_configured' | 'no_integration_found' | 'invalid_org_id';
+};
+
+export type GitLabLookupResult = GitLabLookupSuccess | GitLabLookupFailure;
+
+const GitLabMetadataSchema = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  token_expires_at: z.string().optional(),
+  gitlab_instance_url: z.string().optional(),
+  client_id: z.string().optional(),
+  client_secret: z.string().optional(),
+  auth_type: z.enum(['oauth', 'pat']).optional(),
+});
+
+export class GitLabLookupService {
+  private db: WorkerDb | null = null;
+
+  constructor(private env: CloudflareEnv) {}
+
+  isConfigured(): boolean {
+    return Boolean(this.env.HYPERDRIVE);
+  }
+
+  private getDb(): WorkerDb {
+    if (!this.db) {
+      if (!this.env.HYPERDRIVE) {
+        throw new Error('Hyperdrive not configured');
+      }
+      this.db = getWorkerDb(this.env.HYPERDRIVE.connectionString, { statement_timeout: 10_000 });
+    }
+    return this.db;
+  }
+
+  async findGitLabIntegration(params: GitLabLookupParams): Promise<GitLabLookupResult> {
+    if (!this.isConfigured()) {
+      return { success: false, reason: 'database_not_configured' };
+    }
+
+    if (params.orgId !== undefined && !isValidUuid(params.orgId)) {
+      return { success: false, reason: 'invalid_org_id' };
+    }
+
+    const db = this.getDb();
+
+    const rows = await db
+      .select({
+        id: platform_integrations.id,
+        metadata: platform_integrations.metadata,
+      })
+      .from(platform_integrations)
+      .leftJoin(
+        organization_memberships,
+        and(
+          eq(
+            platform_integrations.owned_by_organization_id,
+            organization_memberships.organization_id
+          ),
+          eq(organization_memberships.kilo_user_id, params.userId)
+        )
+      )
+      .innerJoin(
+        kilocode_users,
+        and(eq(kilocode_users.id, params.userId), isNull(kilocode_users.blocked_reason))
+      )
+      .where(
+        and(
+          eq(platform_integrations.platform, 'gitlab'),
+          eq(platform_integrations.integration_status, 'active'),
+          or(
+            and(
+              isNotNull(platform_integrations.owned_by_organization_id),
+              eq(
+                platform_integrations.owned_by_organization_id,
+                sql`${params.orgId ?? null}::uuid`
+              ),
+              isNotNull(organization_memberships.id)
+            ),
+            and(
+              isNotNull(platform_integrations.owned_by_user_id),
+              eq(platform_integrations.owned_by_user_id, params.userId)
+            )
+          )
+        )
+      )
+      .orderBy(
+        sql`CASE WHEN ${platform_integrations.owned_by_organization_id} IS NOT NULL THEN 0 ELSE 1 END`
+      )
+      .limit(1);
+
+    if (rows.length === 0) {
+      return { success: false, reason: 'no_integration_found' };
+    }
+
+    const row = rows[0];
+    const metadata = GitLabMetadataSchema.parse(row.metadata);
+
+    return {
+      success: true,
+      integrationId: row.id,
+      metadata,
+    };
+  }
+}

--- a/cloudflare-git-token-service/src/gitlab-token-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-token-service.ts
@@ -59,7 +59,7 @@ export class GitLabTokenService {
       return { success: true, token: metadata.access_token, instanceUrl };
     }
 
-    if (isTokenExpired(metadata.token_expires_at)) {
+    if (metadata.token_expires_at && isTokenExpired(metadata.token_expires_at)) {
       if (!metadata.refresh_token) {
         return { success: false, reason: 'token_expired_no_refresh' };
       }

--- a/cloudflare-git-token-service/src/gitlab-token-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-token-service.ts
@@ -1,0 +1,161 @@
+import { getWorkerDb, type WorkerDb } from '@kilocode/db/client';
+import { platform_integrations } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import * as z from 'zod';
+import type { GitLabIntegrationMetadata } from './gitlab-lookup-service.js';
+
+const GitLabOAuthTokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  token_type: z.string(),
+  expires_in: z.number(),
+  created_at: z.number(),
+  scope: z.string(),
+});
+
+type GitLabOAuthTokenResponse = z.infer<typeof GitLabOAuthTokenResponseSchema>;
+
+export type GitLabTokenSuccess = {
+  success: true;
+  token: string;
+  instanceUrl: string;
+};
+
+export type GitLabTokenFailure = {
+  success: false;
+  reason: 'no_token' | 'token_refresh_failed' | 'token_expired_no_refresh';
+};
+
+export type GitLabTokenResult = GitLabTokenSuccess | GitLabTokenFailure;
+
+function isTokenExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) return true;
+  const expiryTime = new Date(expiresAt).getTime();
+  const bufferMs = 5 * 60 * 1000;
+  return Date.now() >= expiryTime - bufferMs;
+}
+
+function calculateTokenExpiry(createdAt: number, expiresIn: number): string {
+  const expiresAtMs = (createdAt + expiresIn) * 1000;
+  return new Date(expiresAtMs).toISOString();
+}
+
+export class GitLabTokenService {
+  private db: WorkerDb | null = null;
+
+  constructor(private env: CloudflareEnv) {}
+
+  async getToken(
+    integrationId: string,
+    metadata: GitLabIntegrationMetadata
+  ): Promise<GitLabTokenResult> {
+    const instanceUrl = metadata.gitlab_instance_url || 'https://gitlab.com';
+
+    if (!metadata.access_token) {
+      return { success: false, reason: 'no_token' };
+    }
+
+    if (metadata.auth_type === 'pat') {
+      return { success: true, token: metadata.access_token, instanceUrl };
+    }
+
+    if (isTokenExpired(metadata.token_expires_at)) {
+      if (!metadata.refresh_token) {
+        return { success: false, reason: 'token_expired_no_refresh' };
+      }
+
+      const clientId = metadata.client_id || this.env.GITLAB_OAUTH_CLIENT_ID;
+      const clientSecret = metadata.client_secret || this.env.GITLAB_OAUTH_CLIENT_SECRET;
+
+      if (!clientId || !clientSecret) {
+        console.error('GitLab OAuth credentials not configured');
+        return { success: false, reason: 'token_refresh_failed' };
+      }
+
+      const refreshResult = await this.refreshToken(
+        metadata.refresh_token,
+        instanceUrl,
+        clientId,
+        clientSecret
+      );
+
+      if (!refreshResult) {
+        return { success: false, reason: 'token_refresh_failed' };
+      }
+
+      await this.updateIntegrationMetadata(integrationId, metadata, refreshResult);
+
+      return { success: true, token: refreshResult.access_token, instanceUrl };
+    }
+
+    return { success: true, token: metadata.access_token, instanceUrl };
+  }
+
+  private async refreshToken(
+    refreshToken: string,
+    instanceUrl: string,
+    clientId: string,
+    clientSecret: string
+  ): Promise<GitLabOAuthTokenResponse | null> {
+    try {
+      const response = await fetch(`${instanceUrl}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_id: clientId,
+          client_secret: clientSecret,
+          refresh_token: refreshToken,
+          grant_type: 'refresh_token',
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        console.error('GitLab OAuth token refresh failed:', { status: response.status, error });
+        return null;
+      }
+
+      const parsed = GitLabOAuthTokenResponseSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        console.error('Unexpected GitLab token response shape:', parsed.error);
+        return null;
+      }
+      return parsed.data;
+    } catch (error) {
+      console.error('GitLab OAuth token refresh error:', error);
+      return null;
+    }
+  }
+
+  private async updateIntegrationMetadata(
+    integrationId: string,
+    existingMetadata: GitLabIntegrationMetadata,
+    tokens: GitLabOAuthTokenResponse
+  ): Promise<void> {
+    const db = this.getDb();
+    const newExpiresAt = calculateTokenExpiry(tokens.created_at, tokens.expires_in);
+
+    await db
+      .update(platform_integrations)
+      .set({
+        metadata: {
+          ...existingMetadata,
+          access_token: tokens.access_token,
+          refresh_token: tokens.refresh_token,
+          token_expires_at: newExpiresAt,
+        },
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(platform_integrations.id, integrationId));
+  }
+
+  private getDb(): WorkerDb {
+    if (!this.db) {
+      if (!this.env.HYPERDRIVE) {
+        throw new Error('Hyperdrive not configured');
+      }
+      this.db = getWorkerDb(this.env.HYPERDRIVE.connectionString, { statement_timeout: 10_000 });
+    }
+    return this.db;
+  }
+}

--- a/cloudflare-git-token-service/src/gitlab-token-service.ts
+++ b/cloudflare-git-token-service/src/gitlab-token-service.ts
@@ -64,8 +64,8 @@ export class GitLabTokenService {
         return { success: false, reason: 'token_expired_no_refresh' };
       }
 
-      const clientId = metadata.client_id || this.env.GITLAB_OAUTH_CLIENT_ID;
-      const clientSecret = metadata.client_secret || this.env.GITLAB_OAUTH_CLIENT_SECRET;
+      const clientId = metadata.client_id || this.env.GITLAB_CLIENT_ID;
+      const clientSecret = metadata.client_secret || this.env.GITLAB_CLIENT_SECRET;
 
       if (!clientId || !clientSecret) {
         console.error('GitLab OAuth credentials not configured');

--- a/cloudflare-git-token-service/src/index.ts
+++ b/cloudflare-git-token-service/src/index.ts
@@ -1,5 +1,7 @@
 import { WorkerEntrypoint } from 'cloudflare:workers';
 import { GitHubTokenService, type GitHubAppType } from './github-token-service.js';
+import { GitLabLookupService } from './gitlab-lookup-service.js';
+import { GitLabTokenService } from './gitlab-token-service.js';
 import { InstallationLookupService } from './installation-lookup-service.js';
 
 export type GetTokenForRepoParams = {
@@ -27,14 +29,42 @@ export type GetTokenForRepoFailure = {
 
 export type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
 
+export type GetGitLabTokenParams = {
+  userId: string;
+  orgId?: string;
+};
+
+export type GetGitLabTokenSuccess = {
+  success: true;
+  token: string;
+  instanceUrl: string;
+};
+
+export type GetGitLabTokenFailure = {
+  success: false;
+  reason:
+    | 'database_not_configured'
+    | 'no_integration_found'
+    | 'invalid_org_id'
+    | 'no_token'
+    | 'token_refresh_failed'
+    | 'token_expired_no_refresh';
+};
+
+export type GetGitLabTokenResult = GetGitLabTokenSuccess | GetGitLabTokenFailure;
+
 export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
   private githubService: GitHubTokenService;
   private installationLookupService: InstallationLookupService;
+  private gitlabLookupService: GitLabLookupService;
+  private gitlabTokenService: GitLabTokenService;
 
   constructor(ctx: ExecutionContext, env: CloudflareEnv) {
     super(ctx, env);
     this.githubService = new GitHubTokenService(env);
     this.installationLookupService = new InstallationLookupService(env);
+    this.gitlabLookupService = new GitLabLookupService(env);
+    this.gitlabTokenService = new GitLabTokenService(env);
   }
 
   /**
@@ -82,6 +112,24 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
    */
   async getToken(installationId: string, appType: GitHubAppType = 'standard'): Promise<string> {
     return this.githubService.getToken(installationId, appType);
+  }
+
+  /**
+   * Get a GitLab token for the user/org.
+   *
+   * Looks up the GitLab integration and returns a valid access token,
+   * refreshing OAuth tokens if needed.
+   *
+   * @param params - The user and optional org context
+   * @returns Token and instance URL, or a failure reason
+   */
+  async getGitLabToken(params: GetGitLabTokenParams): Promise<GetGitLabTokenResult> {
+    const integration = await this.gitlabLookupService.findGitLabIntegration(params);
+    if (!integration.success) {
+      return integration;
+    }
+
+    return this.gitlabTokenService.getToken(integration.integrationId, integration.metadata);
   }
 }
 

--- a/cloudflare-git-token-service/src/installation-lookup-service.ts
+++ b/cloudflare-git-token-service/src/installation-lookup-service.ts
@@ -13,12 +13,6 @@ export type FindInstallationParams = {
   orgId?: string;
 };
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function isValidUuid(value: string): boolean {
-  return UUID_REGEX.test(value);
-}
-
 const InstallationLookupResultSchema = z.object({
   platform_installation_id: z.string(),
   platform_account_login: z.string(),
@@ -77,7 +71,7 @@ export class InstallationLookupService {
     }
 
     // Validate orgId is a valid UUID if provided, to prevent database errors
-    if (params.orgId !== undefined && !isValidUuid(params.orgId)) {
+    if (params.orgId !== undefined && !z.string().uuid().safeParse(params.orgId).success) {
       return { success: false, reason: 'invalid_org_id' };
     }
 

--- a/cloudflare-git-token-service/test/test-worker.ts
+++ b/cloudflare-git-token-service/test/test-worker.ts
@@ -11,11 +11,14 @@
  * Endpoints:
  *   POST /getTokenForRepo - { githubRepo, userId, orgId? }
  *   POST /getToken - { installationId, appType? }
+ *   POST /getGitLabToken - { userId, orgId? }
  */
 import type {
   GitTokenRPCEntrypoint,
   GetTokenForRepoParams,
   GetTokenForRepoResult,
+  GetGitLabTokenParams,
+  GetGitLabTokenResult,
 } from '../src/index.js';
 import type { GitHubAppType } from '../src/github-token-service.js';
 
@@ -46,12 +49,22 @@ export default {
         return Response.json({ success: true, data: { token } });
       }
 
+      if (url.pathname === '/getGitLabToken' && request.method === 'POST') {
+        const body = (await request.json()) as GetGitLabTokenParams;
+        const result: GetGitLabTokenResult = await env.GIT_TOKEN_SERVICE.getGitLabToken(body);
+        if (!result.success) {
+          return Response.json(result, { status: 404 });
+        }
+        return Response.json(result);
+      }
+
       return Response.json(
         {
           error: 'Not Found',
           endpoints: [
             'POST /getTokenForRepo - { githubRepo, userId, orgId? }',
             'POST /getToken - { installationId, appType? }',
+            'POST /getGitLabToken - { userId, orgId? }',
           ],
         },
         { status: 404 }

--- a/cloudflare-git-token-service/worker-configuration.d.ts
+++ b/cloudflare-git-token-service/worker-configuration.d.ts
@@ -12,16 +12,16 @@ declare namespace Cloudflare {
     GITHUB_APP_PRIVATE_KEY: string;
     GITHUB_LITE_APP_ID: string;
     GITHUB_LITE_APP_PRIVATE_KEY: string;
-    GITLAB_OAUTH_CLIENT_ID?: string;
-    GITLAB_OAUTH_CLIENT_SECRET?: string;
+    GITLAB_CLIENT_ID?: string;
+    GITLAB_CLIENT_SECRET?: string;
   }
   interface Env {
     GITHUB_APP_ID: string;
     GITHUB_APP_PRIVATE_KEY: string;
     GITHUB_LITE_APP_ID: string;
     GITHUB_LITE_APP_PRIVATE_KEY: string;
-    GITLAB_OAUTH_CLIENT_ID?: string;
-    GITLAB_OAUTH_CLIENT_SECRET?: string;
+    GITLAB_CLIENT_ID?: string;
+    GITLAB_CLIENT_SECRET?: string;
     TOKEN_CACHE: KVNamespace;
     HYPERDRIVE: Hyperdrive;
   }

--- a/cloudflare-git-token-service/worker-configuration.d.ts
+++ b/cloudflare-git-token-service/worker-configuration.d.ts
@@ -12,12 +12,16 @@ declare namespace Cloudflare {
     GITHUB_APP_PRIVATE_KEY: string;
     GITHUB_LITE_APP_ID: string;
     GITHUB_LITE_APP_PRIVATE_KEY: string;
+    GITLAB_OAUTH_CLIENT_ID?: string;
+    GITLAB_OAUTH_CLIENT_SECRET?: string;
   }
   interface Env {
     GITHUB_APP_ID: string;
     GITHUB_APP_PRIVATE_KEY: string;
     GITHUB_LITE_APP_ID: string;
     GITHUB_LITE_APP_PRIVATE_KEY: string;
+    GITLAB_OAUTH_CLIENT_ID?: string;
+    GITLAB_OAUTH_CLIENT_SECRET?: string;
     TOKEN_CACHE: KVNamespace;
     HYPERDRIVE: Hyperdrive;
   }

--- a/cloudflare-git-token-service/wrangler.test.jsonc
+++ b/cloudflare-git-token-service/wrangler.test.jsonc
@@ -5,7 +5,7 @@
   "compatibility_date": "2025-09-15",
   "compatibility_flags": ["nodejs_compat"],
   "dev": {
-    "port": 8795,
+    "port": 8796,
   },
   // Service binding to the git-token-service-dev worker
   // The test worker calls git-token-service via RPC over this binding

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -222,7 +222,10 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
         {/* Left column: activity feed */}
         <div className="min-w-0 border-r border-white/[0.06]">
           {/* Stats strip */}
-          <div className="grid border-b border-white/[0.06]" style={{ gridTemplateColumns: 'repeat(5, minmax(0, 1fr))' }}>
+          <div
+            className="grid border-b border-white/[0.06]"
+            style={{ gridTemplateColumns: 'repeat(5, minmax(0, 1fr))' }}
+          >
             <StatCell
               label="Open"
               value={openBeadCount}


### PR DESCRIPTION
## Summary

- Add `getGitLabToken` RPC method to `cloudflare-git-token-service`, enabling callers to retrieve GitLab access tokens the same way they already use `getTokenForRepo`/`getToken` for GitHub.
- New `GitLabLookupService` queries `platform_integrations` for active GitLab integrations by user/org ID, joining `organization_memberships` for org-scoped lookups and `kilocode_users` to enforce blocked-user checks. Org integrations are prioritized over personal ones.
- New `GitLabTokenService` handles token retrieval: PAT tokens are returned directly, OAuth tokens are checked for expiry (with a 5-minute buffer) and automatically refreshed via GitLab's `/oauth/token` endpoint. Refreshed tokens are written back to `platform_integrations.metadata`.
- OAuth client credentials are sourced per-integration from `metadata.client_id`/`client_secret` (for self-hosted instances) with fallback to `GITLAB_OAUTH_CLIENT_ID`/`GITLAB_OAUTH_CLIENT_SECRET` env vars (for gitlab.com).
- No KV caching — Hyperdrive queries are fast enough, and caching would risk serving stale tokens after reconnection or refresh.
- Exports typed result types (`GetGitLabTokenParams`, `GetGitLabTokenResult`) for consuming service bindings.
- Test worker updated with `POST /getGitLabToken` endpoint for manual testing.

## Verification

- [x] `pnpm typecheck` — pass (all 28 workspace projects)
- [x] `pnpm --filter cloudflare-git-token-service lint` — pass (no errors)
- [x]  verified manually locally

## Visual Changes

N/A

## Reviewer Notes

- This PR is scoped to `cloudflare-git-token-service` only. Consumers (`cloud-agent-next`, `cloudflare-gastown`) will integrate via service binding in follow-up PRs.
- OAuth refresh race condition is accepted: if two workers refresh simultaneously, GitLab rotates the refresh token so the second refresh fails. The first writer wins; callers can retry.