### PR TITLE
feat(gastown): add mayor edit tools and manual editing UI

### DIFF
--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -355,7 +355,7 @@ export class MayorGastownClient {
     input: {
       title?: string;
       body?: string;
-      status?: 'open' | 'in_progress' | 'closed' | 'failed';
+      status?: 'open' | 'in_progress' | 'in_review' | 'closed' | 'failed';
       priority?: 'low' | 'medium' | 'high' | 'critical';
       labels?: string[];
     }

--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -348,6 +348,64 @@ export class MayorGastownClient {
   async getConvoyStatus(convoyId: string): Promise<ConvoyDetail> {
     return this.request<ConvoyDetail>(this.mayorPath(`/convoys/${convoyId}`));
   }
+
+  async updateBead(
+    rigId: string,
+    beadId: string,
+    input: {
+      title?: string;
+      body?: string;
+      status?: 'open' | 'in_progress' | 'closed' | 'failed';
+      priority?: 'low' | 'medium' | 'high' | 'critical';
+      labels?: string[];
+    }
+  ): Promise<Bead> {
+    return this.request<Bead>(this.mayorPath(`/rigs/${rigId}/beads/${beadId}`), {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async reassignBead(rigId: string, beadId: string, agentId: string): Promise<Bead> {
+    return this.request<Bead>(this.mayorPath(`/rigs/${rigId}/beads/${beadId}/reassign`), {
+      method: 'POST',
+      body: JSON.stringify({ agent_id: agentId }),
+    });
+  }
+
+  async deleteBead(rigId: string, beadId: string): Promise<void> {
+    await this.request<void>(this.mayorPath(`/rigs/${rigId}/beads/${beadId}`), {
+      method: 'DELETE',
+    });
+  }
+
+  async resetAgent(rigId: string, agentId: string): Promise<void> {
+    await this.request<void>(this.mayorPath(`/rigs/${rigId}/agents/${agentId}/reset`), {
+      method: 'POST',
+    });
+  }
+
+  async closeConvoy(convoyId: string): Promise<void> {
+    await this.request<void>(this.mayorPath(`/convoys/${convoyId}/close`), {
+      method: 'POST',
+    });
+  }
+
+  async updateConvoy(
+    convoyId: string,
+    input: { merge_mode?: 'review-then-land' | 'review-and-merge'; feature_branch?: string }
+  ): Promise<void> {
+    await this.request<void>(this.mayorPath(`/convoys/${convoyId}`), {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async acknowledgeEscalation(escalationId: string): Promise<void> {
+    await this.request<void>(this.mayorPath(`/escalations/${escalationId}/acknowledge`), {
+      method: 'POST',
+    });
+  }
 }
 
 export class GastownApiError extends Error {

--- a/cloudflare-gastown/container/plugin/mayor-tools.test.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.test.ts
@@ -121,6 +121,13 @@ function makeFakeMayorClient(overrides: Partial<MayorGastownClient> = {}): Mayor
         },
       ],
     }),
+    updateBead: vi.fn<() => Promise<Bead>>().mockResolvedValue(FAKE_BEAD),
+    reassignBead: vi.fn<() => Promise<Bead>>().mockResolvedValue(FAKE_BEAD),
+    deleteBead: vi.fn().mockResolvedValue(undefined),
+    resetAgent: vi.fn().mockResolvedValue(undefined),
+    closeConvoy: vi.fn().mockResolvedValue(undefined),
+    updateConvoy: vi.fn().mockResolvedValue(undefined),
+    acknowledgeEscalation: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as MayorGastownClient;
 }
@@ -243,6 +250,96 @@ describe('mayor tools', () => {
     it('returns empty message when no rigs', async () => {
       const result = await tools.gt_list_rigs.execute({}, CTX);
       expect(result).toContain('No rigs configured');
+    });
+  });
+
+  describe('gt_bead_update', () => {
+    it('updates bead fields and returns summary', async () => {
+      const result = await tools.gt_bead_update.execute(
+        { rig_id: 'rig-1', bead_id: 'bead-1', status: 'closed', priority: 'high' },
+        CTX
+      );
+      expect(result).toContain('bead-1');
+      expect(result).toContain('updated');
+      expect(client.updateBead).toHaveBeenCalledWith('rig-1', 'bead-1', {
+        title: undefined,
+        body: undefined,
+        status: 'closed',
+        priority: 'high',
+        labels: undefined,
+      });
+    });
+  });
+
+  describe('gt_bead_reassign', () => {
+    it('reassigns bead to new agent', async () => {
+      const result = await tools.gt_bead_reassign.execute(
+        { rig_id: 'rig-1', bead_id: 'bead-1', agent_id: 'agent-2' },
+        CTX
+      );
+      expect(result).toContain('bead-1');
+      expect(result).toContain('agent-2');
+      expect(client.reassignBead).toHaveBeenCalledWith('rig-1', 'bead-1', 'agent-2');
+    });
+  });
+
+  describe('gt_bead_delete', () => {
+    it('deletes bead and confirms', async () => {
+      const result = await tools.gt_bead_delete.execute(
+        { rig_id: 'rig-1', bead_id: 'bead-1' },
+        CTX
+      );
+      expect(result).toContain('bead-1');
+      expect(result).toContain('deleted');
+      expect(client.deleteBead).toHaveBeenCalledWith('rig-1', 'bead-1');
+    });
+  });
+
+  describe('gt_agent_reset', () => {
+    it('resets agent to idle', async () => {
+      const result = await tools.gt_agent_reset.execute(
+        { rig_id: 'rig-1', agent_id: 'agent-1' },
+        CTX
+      );
+      expect(result).toContain('agent-1');
+      expect(result).toContain('idle');
+      expect(client.resetAgent).toHaveBeenCalledWith('rig-1', 'agent-1');
+    });
+  });
+
+  describe('gt_convoy_close', () => {
+    it('force-closes a convoy', async () => {
+      const result = await tools.gt_convoy_close.execute({ convoy_id: 'convoy-1' }, CTX);
+      expect(result).toContain('convoy-1');
+      expect(result).toContain('closed');
+      expect(client.closeConvoy).toHaveBeenCalledWith('convoy-1');
+    });
+  });
+
+  describe('gt_convoy_update', () => {
+    it('updates convoy metadata', async () => {
+      const result = await tools.gt_convoy_update.execute(
+        { convoy_id: 'convoy-1', merge_mode: 'review-and-merge' },
+        CTX
+      );
+      expect(result).toContain('convoy-1');
+      expect(result).toContain('updated');
+      expect(client.updateConvoy).toHaveBeenCalledWith('convoy-1', {
+        merge_mode: 'review-and-merge',
+        feature_branch: undefined,
+      });
+    });
+  });
+
+  describe('gt_escalation_acknowledge', () => {
+    it('acknowledges an escalation', async () => {
+      const result = await tools.gt_escalation_acknowledge.execute(
+        { escalation_id: 'esc-1' },
+        CTX
+      );
+      expect(result).toContain('esc-1');
+      expect(result).toContain('acknowledged');
+      expect(client.acknowledgeEscalation).toHaveBeenCalledWith('esc-1');
     });
   });
 });

--- a/cloudflare-gastown/container/plugin/mayor-tools.test.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.test.ts
@@ -333,10 +333,7 @@ describe('mayor tools', () => {
 
   describe('gt_escalation_acknowledge', () => {
     it('acknowledges an escalation', async () => {
-      const result = await tools.gt_escalation_acknowledge.execute(
-        { escalation_id: 'esc-1' },
-        CTX
-      );
+      const result = await tools.gt_escalation_acknowledge.execute({ escalation_id: 'esc-1' }, CTX);
       expect(result).toContain('esc-1');
       expect(result).toContain('acknowledged');
       expect(client.acknowledgeEscalation).toHaveBeenCalledWith('esc-1');

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -253,7 +253,7 @@ export function createMayorTools(client: MayorGastownClient) {
         title: tool.schema.string().describe('New title for the bead').optional(),
         body: tool.schema.string().describe('New body/description for the bead').optional(),
         status: tool.schema
-          .enum(['open', 'in_progress', 'closed', 'failed'])
+          .enum(['open', 'in_progress', 'in_review', 'closed', 'failed'])
           .describe('New status for the bead')
           .optional(),
         priority: tool.schema

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -244,5 +244,118 @@ export function createMayorTools(client: MayorGastownClient) {
         return `Mail sent to agent ${args.to_agent_id} in rig ${args.rig_id}.`;
       },
     }),
+
+    gt_bead_update: tool({
+      description: "Edit a bead's status, title, body, priority, or labels.",
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
+        bead_id: tool.schema.string().describe('The UUID of the bead to update'),
+        title: tool.schema.string().describe('New title for the bead').optional(),
+        body: tool.schema.string().describe('New body/description for the bead').optional(),
+        status: tool.schema
+          .enum(['open', 'in_progress', 'closed', 'failed'])
+          .describe('New status for the bead')
+          .optional(),
+        priority: tool.schema
+          .enum(['low', 'medium', 'high', 'critical'])
+          .describe('New priority for the bead')
+          .optional(),
+        labels: tool.schema
+          .array(tool.schema.string())
+          .describe('Replacement labels array for the bead')
+          .optional(),
+      },
+      async execute(args) {
+        const bead = await client.updateBead(args.rig_id, args.bead_id, {
+          title: args.title,
+          body: args.body,
+          status: args.status,
+          priority: args.priority,
+          labels: args.labels,
+        });
+        return `Bead ${bead.bead_id} updated. Status: ${bead.status}, Priority: ${bead.priority}, Title: "${bead.title}".`;
+      },
+    }),
+
+    gt_bead_reassign: tool({
+      description: 'Reassign a bead to a different agent.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
+        bead_id: tool.schema.string().describe('The UUID of the bead to reassign'),
+        agent_id: tool.schema.string().describe('The UUID of the agent to assign the bead to'),
+      },
+      async execute(args) {
+        const bead = await client.reassignBead(args.rig_id, args.bead_id, args.agent_id);
+        return `Bead ${bead.bead_id} reassigned to agent ${args.agent_id}.`;
+      },
+    }),
+
+    gt_bead_delete: tool({
+      description: 'Delete a bead. Use with caution — this is irreversible.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
+        bead_id: tool.schema.string().describe('The UUID of the bead to delete'),
+      },
+      async execute(args) {
+        await client.deleteBead(args.rig_id, args.bead_id);
+        return `Bead ${args.bead_id} deleted.`;
+      },
+    }),
+
+    gt_agent_reset: tool({
+      description: 'Force-reset an agent to idle, unhooking from any bead.',
+      args: {
+        rig_id: tool.schema.string().describe('The UUID of the rig the agent belongs to'),
+        agent_id: tool.schema.string().describe('The UUID of the agent to reset'),
+      },
+      async execute(args) {
+        await client.resetAgent(args.rig_id, args.agent_id);
+        return `Agent ${args.agent_id} reset to idle.`;
+      },
+    }),
+
+    gt_convoy_close: tool({
+      description: 'Force-close a convoy and optionally its tracked beads.',
+      args: {
+        convoy_id: tool.schema.string().describe('The UUID of the convoy to force-close'),
+      },
+      async execute(args) {
+        await client.closeConvoy(args.convoy_id);
+        return `Convoy ${args.convoy_id} force-closed.`;
+      },
+    }),
+
+    gt_convoy_update: tool({
+      description: 'Edit convoy metadata (merge_mode, feature_branch).',
+      args: {
+        convoy_id: tool.schema.string().describe('The UUID of the convoy to update'),
+        merge_mode: tool.schema
+          .enum(['review-then-land', 'review-and-merge'])
+          .describe('New merge mode for the convoy')
+          .optional(),
+        feature_branch: tool.schema
+          .string()
+          .describe('New feature branch name for the convoy')
+          .optional(),
+      },
+      async execute(args) {
+        await client.updateConvoy(args.convoy_id, {
+          merge_mode: args.merge_mode,
+          feature_branch: args.feature_branch,
+        });
+        return `Convoy ${args.convoy_id} updated.`;
+      },
+    }),
+
+    gt_escalation_acknowledge: tool({
+      description: 'Acknowledge an escalation.',
+      args: {
+        escalation_id: tool.schema.string().describe('The UUID of the escalation to acknowledge'),
+      },
+      async execute(args) {
+        await client.acknowledgeEscalation(args.escalation_id);
+        return `Escalation ${args.escalation_id} acknowledged.`;
+      },
+    }),
   };
 }

--- a/cloudflare-gastown/src/db/tables/bead-events.table.ts
+++ b/cloudflare-gastown/src/db/tables/bead-events.table.ts
@@ -19,6 +19,7 @@ export const BeadEventType = z.enum([
   'pr_creation_failed',
   'agent_status',
   'triage_resolved',
+  'fields_updated',
 ]);
 
 export type BeadEventType = z.infer<typeof BeadEventType>;

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -51,6 +51,8 @@ import type {
   CreateBeadInput,
   BeadFilter,
   Bead,
+  BeadStatus,
+  BeadPriority as BeadPriorityType,
   RegisterAgentInput,
   AgentFilter,
   Agent,
@@ -64,6 +66,7 @@ import type {
   Molecule,
   BeadEventRecord,
   MergeStrategy,
+  ConvoyMergeMode,
 } from '../types';
 
 const TOWN_LOG = '[Town.do]';
@@ -578,6 +581,118 @@ export class TownDO extends DurableObject<Env> {
   }): Promise<BeadEventRecord[]> {
     await this.ensureInitialized();
     return beadOps.listBeadEvents(this.sql, options);
+  }
+
+  /**
+   * Partially update a bead's editable fields.
+   * Only fields explicitly provided are updated (partial update semantics).
+   * Writes a `fields_updated` bead_event for auditability.
+   */
+  async updateBead(
+    beadId: string,
+    fields: Partial<{
+      title: string;
+      body: string | null;
+      priority: BeadPriorityType;
+      labels: string[];
+      status: BeadStatus;
+      metadata: Record<string, unknown>;
+    }>,
+    actorId: string
+  ): Promise<Bead> {
+    await this.ensureInitialized();
+    const bead = beadOps.updateBeadFields(this.sql, beadId, fields, actorId);
+
+    // When a bead closes via field update, check for newly unblocked beads
+    if (fields.status === 'closed' || fields.status === 'failed') {
+      this.dispatchUnblockedBeads(beadId);
+    }
+
+    return bead;
+  }
+
+  /**
+   * Force-reset an agent to idle, unhooking from its current bead if any.
+   * Sets the bead status back to 'open' so it can be re-dispatched.
+   * Writes a bead_event for auditability.
+   */
+  async resetAgent(agentId: string): Promise<void> {
+    await this.ensureInitialized();
+
+    const agent = agents.getAgent(this.sql, agentId);
+    if (!agent) throw new Error(`Agent ${agentId} not found`);
+
+    const hookedBeadId = agent.current_hook_bead_id;
+
+    if (hookedBeadId) {
+      // Return the bead to 'open' so the scheduler can re-assign it
+      const bead = beadOps.getBead(this.sql, hookedBeadId);
+      if (bead && bead.status !== 'closed' && bead.status !== 'failed') {
+        beadOps.updateBeadStatus(this.sql, hookedBeadId, 'open', agentId);
+      }
+
+      beadOps.logBeadEvent(this.sql, {
+        beadId: hookedBeadId,
+        agentId,
+        eventType: 'unhooked',
+        newValue: 'open',
+        metadata: { reason: 'agent_reset', actor: 'mayor' },
+      });
+
+      agents.unhookBead(this.sql, agentId);
+    }
+
+    agents.updateAgentStatus(this.sql, agentId, 'idle');
+
+    console.log(`${TOWN_LOG} resetAgent: reset agent=${agentId} hookedBead=${hookedBeadId ?? 'none'}`);
+  }
+
+  /**
+   * Edit convoy_metadata fields (merge_mode, feature_branch).
+   * Returns the updated convoy, or null if not found.
+   */
+  async updateConvoy(
+    convoyId: string,
+    fields: Partial<{ merge_mode: ConvoyMergeMode; feature_branch: string }>
+  ): Promise<ConvoyEntry | null> {
+    await this.ensureInitialized();
+
+    const convoy = this.getConvoy(convoyId);
+    if (!convoy) return null;
+
+    const setClauses: string[] = [];
+    const values: unknown[] = [];
+
+    if (fields.merge_mode !== undefined) {
+      setClauses.push(`${convoy_metadata.columns.merge_mode} = ?`);
+      values.push(fields.merge_mode);
+    }
+    if (fields.feature_branch !== undefined) {
+      setClauses.push(`${convoy_metadata.columns.feature_branch} = ?`);
+      values.push(fields.feature_branch);
+    }
+
+    if (setClauses.length > 0) {
+      values.push(convoyId);
+      query(
+        this.sql,
+        /* sql */ `UPDATE ${convoy_metadata} SET ${setClauses.join(', ')} WHERE ${convoy_metadata.bead_id} = ?`,
+        values
+      );
+
+      // Also update the convoy bead's updated_at
+      query(
+        this.sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [now(), convoyId]
+      );
+    }
+
+    return this.getConvoy(convoyId);
   }
 
   // ══════════════════════════════════════════════════════════════════

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -644,7 +644,9 @@ export class TownDO extends DurableObject<Env> {
 
     agents.updateAgentStatus(this.sql, agentId, 'idle');
 
-    console.log(`${TOWN_LOG} resetAgent: reset agent=${agentId} hookedBead=${hookedBeadId ?? 'none'}`);
+    console.log(
+      `${TOWN_LOG} resetAgent: reset agent=${agentId} hookedBead=${hookedBeadId ?? 'none'}`
+    );
   }
 
   /**

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -676,10 +676,11 @@ export class TownDO extends DurableObject<Env> {
 
     if (setClauses.length > 0) {
       values.push(convoyId);
-      query(
-        this.sql,
+      // Dynamic SET clause — query() can't statically verify param count here,
+      // so use sql.exec() directly. The guard above guarantees values is non-empty.
+      this.sql.exec(
         /* sql */ `UPDATE ${convoy_metadata} SET ${setClauses.join(', ')} WHERE ${convoy_metadata.bead_id} = ?`,
-        values
+        ...values
       );
 
       // Also update the convoy bead's updated_at

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -32,7 +32,7 @@ import {
   migrateConvoyMetadata,
 } from '../../db/tables/convoy-metadata.table';
 import { query } from '../../util/query.util';
-import type { CreateBeadInput, BeadFilter, Bead } from '../../types';
+import type { CreateBeadInput, BeadFilter, Bead, BeadStatus, BeadPriority } from '../../types';
 import type { BeadEventType } from '../../db/tables/bead-events.table';
 
 function generateId(): string {
@@ -440,6 +440,92 @@ export function getNewlyUnblockedBeads(sql: SqlStorage, closedBeadId: string): s
 
   // For each dependent, check if ALL blockers are now resolved
   return dependentIds.filter(id => !hasUnresolvedBlockers(sql, id));
+}
+
+/**
+ * Partial update of a bead's editable fields.
+ * Only fields explicitly provided in `fields` are updated.
+ * Writes a `fields_updated` bead_event for auditability.
+ */
+export function updateBeadFields(
+  sql: SqlStorage,
+  beadId: string,
+  fields: Partial<{
+    title: string;
+    body: string | null;
+    priority: BeadPriority;
+    labels: string[];
+    status: BeadStatus;
+    metadata: Record<string, unknown>;
+  }>,
+  actorId: string
+): Bead {
+  const bead = getBead(sql, beadId);
+  if (!bead) throw new Error(`Bead ${beadId} not found`);
+
+  const timestamp = now();
+  const setClauses: string[] = [];
+  const values: unknown[] = [];
+
+  if (fields.title !== undefined) {
+    setClauses.push(`${beads.columns.title} = ?`);
+    values.push(fields.title);
+  }
+  if (fields.body !== undefined) {
+    setClauses.push(`${beads.columns.body} = ?`);
+    values.push(fields.body);
+  }
+  if (fields.priority !== undefined) {
+    setClauses.push(`${beads.columns.priority} = ?`);
+    values.push(fields.priority);
+  }
+  if (fields.labels !== undefined) {
+    setClauses.push(`${beads.columns.labels} = ?`);
+    values.push(JSON.stringify(fields.labels));
+  }
+  if (fields.status !== undefined) {
+    setClauses.push(`${beads.columns.status} = ?`);
+    values.push(fields.status);
+    // Also set closed_at when transitioning to closed
+    if (fields.status === 'closed') {
+      setClauses.push(`${beads.columns.closed_at} = ?`);
+      values.push(bead.closed_at ?? timestamp);
+    }
+  }
+  if (fields.metadata !== undefined) {
+    setClauses.push(`${beads.columns.metadata} = ?`);
+    values.push(JSON.stringify(fields.metadata));
+  }
+
+  if (setClauses.length === 0) return bead;
+
+  setClauses.push(`${beads.columns.updated_at} = ?`);
+  values.push(timestamp);
+  values.push(beadId);
+
+  query(
+    sql,
+    /* sql */ `UPDATE ${beads} SET ${setClauses.join(', ')} WHERE ${beads.bead_id} = ?`,
+    values
+  );
+
+  const changedFields = Object.keys(fields);
+  logBeadEvent(sql, {
+    beadId,
+    agentId: actorId,
+    eventType: 'fields_updated',
+    newValue: changedFields.join(','),
+    metadata: { changed: changedFields, actor: actorId },
+  });
+
+  // If status was updated to a terminal value, run convoy progress logic
+  if (fields.status === 'closed' || fields.status === 'failed') {
+    updateConvoyProgress(sql, beadId, timestamp);
+  }
+
+  const updated = getBead(sql, beadId);
+  if (!updated) throw new Error(`Bead ${beadId} not found after update`);
+  return updated;
 }
 
 export function closeBead(sql: SqlStorage, beadId: string, agentId: string): Bead {

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -496,10 +496,14 @@ export function updateBeadFields(
   if (fields.status !== undefined) {
     setClauses.push(`${beads.columns.status} = ?`);
     values.push(fields.status);
-    // Also set closed_at when transitioning to closed
     if (fields.status === 'closed') {
+      // Set closed_at when transitioning to closed (preserve existing if already set)
       setClauses.push(`${beads.columns.closed_at} = ?`);
       values.push(bead.closed_at ?? timestamp);
+    } else if (bead.closed_at) {
+      // Clear closed_at when reopening a previously-closed bead
+      setClauses.push(`${beads.columns.closed_at} = ?`);
+      values.push(null);
     }
   }
   if (fields.metadata !== undefined) {
@@ -525,10 +529,11 @@ export function updateBeadFields(
   values.push(timestamp);
   values.push(beadId);
 
-  query(
-    sql,
+  // Dynamic SET clause — query() can't statically verify param count here,
+  // so use sql.exec() directly. The early return above guarantees values is non-empty.
+  sql.exec(
     /* sql */ `UPDATE ${beads} SET ${setClauses.join(', ')} WHERE ${beads.bead_id} = ?`,
-    values
+    ...values
   );
 
   const changedFields = Object.keys(fields);

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -32,7 +32,14 @@ import {
   migrateConvoyMetadata,
 } from '../../db/tables/convoy-metadata.table';
 import { query } from '../../util/query.util';
-import type { CreateBeadInput, BeadFilter, Bead, BeadStatus, BeadPriority } from '../../types';
+import type {
+  CreateBeadInput,
+  BeadFilter,
+  Bead,
+  BeadStatus,
+  BeadPriority,
+  BeadType,
+} from '../../types';
 import type { BeadEventType } from '../../db/tables/bead-events.table';
 
 function generateId(): string {
@@ -457,6 +464,9 @@ export function updateBeadFields(
     labels: string[];
     status: BeadStatus;
     metadata: Record<string, unknown>;
+    type: BeadType;
+    rig_id: string | null;
+    parent_bead_id: string | null;
   }>,
   actorId: string
 ): Bead {
@@ -495,6 +505,18 @@ export function updateBeadFields(
   if (fields.metadata !== undefined) {
     setClauses.push(`${beads.columns.metadata} = ?`);
     values.push(JSON.stringify(fields.metadata));
+  }
+  if (fields.type !== undefined) {
+    setClauses.push(`${beads.columns.type} = ?`);
+    values.push(fields.type);
+  }
+  if (fields.rig_id !== undefined) {
+    setClauses.push(`${beads.columns.rig_id} = ?`);
+    values.push(fields.rig_id);
+  }
+  if (fields.parent_bead_id !== undefined) {
+    setClauses.push(`${beads.columns.parent_bead_id} = ?`);
+    values.push(fields.parent_bead_id);
   }
 
   if (setClauses.length === 0) return bead;

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -85,6 +85,13 @@ import {
   handleMayorSendMail,
   handleMayorListConvoys,
   handleMayorConvoyStatus,
+  handleMayorBeadUpdate,
+  handleMayorBeadReassign,
+  handleMayorAgentReset,
+  handleMayorConvoyClose,
+  handleMayorConvoyUpdate,
+  handleMayorBeadDelete,
+  handleMayorEscalationAcknowledge,
 } from './handlers/mayor-tools.handler';
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { handleGetTownConfig, handleUpdateTownConfig } from './handlers/town-config.handler';
@@ -410,6 +417,27 @@ app.post('/api/mayor/:townId/tools/mail', c => handleMayorSendMail(c, c.req.para
 app.get('/api/mayor/:townId/tools/convoys', c => handleMayorListConvoys(c, c.req.param()));
 app.get('/api/mayor/:townId/tools/convoys/:convoyId', c =>
   handleMayorConvoyStatus(c, c.req.param())
+);
+app.patch('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', c =>
+  handleMayorBeadUpdate(c, c.req.param())
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId/reassign', c =>
+  handleMayorBeadReassign(c, c.req.param())
+);
+app.delete('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', c =>
+  handleMayorBeadDelete(c, c.req.param())
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/agents/:agentId/reset', c =>
+  handleMayorAgentReset(c, c.req.param())
+);
+app.patch('/api/mayor/:townId/tools/convoys/:convoyId', c =>
+  handleMayorConvoyUpdate(c, c.req.param())
+);
+app.post('/api/mayor/:townId/tools/convoys/:convoyId/close', c =>
+  handleMayorConvoyClose(c, c.req.param())
+);
+app.post('/api/mayor/:townId/tools/escalations/:escalationId/acknowledge', c =>
+  handleMayorEscalationAcknowledge(c, c.req.param())
 );
 
 // ── tRPC ────────────────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -339,6 +339,9 @@ const BeadUpdateBody = z
     labels: z.array(z.string()).optional(),
     status: BeadStatus.optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
+    type: BeadType.optional(),
+    rig_id: z.string().min(1).nullable().optional(),
+    parent_bead_id: z.string().min(1).nullable().optional(),
   })
   .refine(
     data =>
@@ -347,7 +350,10 @@ const BeadUpdateBody = z
       data.priority !== undefined ||
       data.labels !== undefined ||
       data.status !== undefined ||
-      data.metadata !== undefined,
+      data.metadata !== undefined ||
+      data.type !== undefined ||
+      data.rig_id !== undefined ||
+      data.parent_bead_id !== undefined,
     { message: 'At least one field must be provided' }
   );
 

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -339,7 +339,6 @@ const BeadUpdateBody = z
     labels: z.array(z.string()).optional(),
     status: BeadStatus.optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
-    type: BeadType.optional(),
     rig_id: z.string().min(1).nullable().optional(),
     parent_bead_id: z.string().min(1).nullable().optional(),
   })
@@ -351,7 +350,6 @@ const BeadUpdateBody = z
       data.labels !== undefined ||
       data.status !== undefined ||
       data.metadata !== undefined ||
-      data.type !== undefined ||
       data.rig_id !== undefined ||
       data.parent_bead_id !== undefined,
     { message: 'At least one field must be provided' }
@@ -398,6 +396,16 @@ export async function handleMayorBeadUpdate(
   );
 
   const town = getTownDOStub(c.env, params.townId);
+
+  // Verify the bead belongs to this rig (same check as handleMayorBeadDelete)
+  const existing = await town.getBeadAsync(params.beadId);
+  if (!existing) {
+    return c.json(resError('Bead not found'), 404);
+  }
+  if (existing.rig_id !== params.rigId) {
+    return c.json(resError('Bead does not belong to this rig'), 403);
+  }
+
   const bead = await town.updateBead(params.beadId, parsed.data, 'mayor');
 
   return c.json(resSuccess(bead));
@@ -431,19 +439,25 @@ export async function handleMayorBeadReassign(
 
   const town = getTownDOStub(c.env, params.townId);
 
-  // Unhook any currently assigned agent
   const bead = await town.getBeadAsync(params.beadId);
   if (!bead) {
     return c.json(resError('Bead not found'), 404);
   }
-  if (bead.assignee_agent_bead_id) {
-    await town.unhookBead(bead.assignee_agent_bead_id);
-  }
 
-  // Hook the new agent
+  // Hook the new agent first — if this fails, the old assignment is untouched
   await town.hookBead(parsed.data.agent_id, params.beadId);
 
-  return c.json(resSuccess({ reassigned: true }));
+  // Only unhook the old agent if it is still hooked to this specific bead
+  if (bead.assignee_agent_bead_id && bead.assignee_agent_bead_id !== parsed.data.agent_id) {
+    const oldAgent = await town.getAgentAsync(bead.assignee_agent_bead_id);
+    if (oldAgent && oldAgent.current_hook_bead_id === params.beadId) {
+      await town.unhookBead(bead.assignee_agent_bead_id);
+    }
+  }
+
+  // Return the updated bead so clients can read the new assignee
+  const updated = await town.getBeadAsync(params.beadId);
+  return c.json(resSuccess(updated));
 }
 
 /**

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -443,6 +443,18 @@ export async function handleMayorBeadReassign(
   if (!bead) {
     return c.json(resError('Bead not found'), 404);
   }
+  if (bead.rig_id !== params.rigId) {
+    return c.json(resError('Bead does not belong to this rig'), 403);
+  }
+
+  // Validate target agent belongs to this rig
+  const targetAgent = await town.getAgentAsync(parsed.data.agent_id);
+  if (!targetAgent) {
+    return c.json(resError('Target agent not found'), 404);
+  }
+  if (targetAgent.rig_id !== params.rigId) {
+    return c.json(resError('Target agent does not belong to this rig'), 403);
+  }
 
   // Hook the new agent first — if this fails, the old assignment is untouched
   await town.hookBead(parsed.data.agent_id, params.beadId);
@@ -478,6 +490,16 @@ export async function handleMayorAgentReset(
   );
 
   const town = getTownDOStub(c.env, params.townId);
+
+  // Verify the agent belongs to this rig
+  const agent = await town.getAgentAsync(params.agentId);
+  if (!agent) {
+    return c.json(resError('Agent not found'), 404);
+  }
+  if (agent.rig_id !== params.rigId) {
+    return c.json(resError('Agent does not belong to this rig'), 403);
+  }
+
   await town.resetAgent(params.agentId);
 
   return c.json(resSuccess({ reset: true }));

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -4,7 +4,7 @@ import { getTownDOStub } from '../dos/Town.do';
 import { getGastownUserStub } from '../dos/GastownUser.do';
 import { resSuccess, resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
-import { BeadStatus, BeadType } from '../types';
+import { BeadStatus, BeadType, BeadPriority } from '../types';
 import type { GastownEnv } from '../gastown.worker';
 
 const HANDLER_LOG = '[mayor-tools.handler]';
@@ -327,4 +327,236 @@ export async function handleMayorConvoyStatus(
 
   if (!status) return c.json(resError('Convoy not found'), 404);
   return c.json(resSuccess(status));
+}
+
+// ── Edit operation schemas ────────────────────────────────────────────────
+
+const BeadUpdateBody = z
+  .object({
+    title: z.string().min(1).optional(),
+    body: z.string().nullable().optional(),
+    priority: BeadPriority.optional(),
+    labels: z.array(z.string()).optional(),
+    status: BeadStatus.optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .refine(
+    data =>
+      data.title !== undefined ||
+      data.body !== undefined ||
+      data.priority !== undefined ||
+      data.labels !== undefined ||
+      data.status !== undefined ||
+      data.metadata !== undefined,
+    { message: 'At least one field must be provided' }
+  );
+
+const BeadReassignBody = z.object({
+  agent_id: z.string().min(1),
+});
+
+const ConvoyUpdateBody = z
+  .object({
+    merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
+    feature_branch: z.string().min(1).optional(),
+  })
+  .refine(data => data.merge_mode !== undefined || data.feature_branch !== undefined, {
+    message: 'At least one field must be provided',
+  });
+
+// ── Edit handlers ─────────────────────────────────────────────────────────
+
+/**
+ * PATCH /api/mayor/:townId/tools/rigs/:rigId/beads/:beadId
+ * Partially update a bead's editable fields (title, body, priority, labels, status, metadata).
+ */
+export async function handleMayorBeadUpdate(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string; beadId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = BeadUpdateBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorBeadUpdate: townId=${params.townId} rigId=${params.rigId} beadId=${params.beadId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const bead = await town.updateBead(params.beadId, parsed.data, 'mayor');
+
+  return c.json(resSuccess(bead));
+}
+
+/**
+ * POST /api/mayor/:townId/tools/rigs/:rigId/beads/:beadId/reassign
+ * Reassign a bead to a different agent. Unhooks the current agent (if any)
+ * and hooks the specified agent.
+ */
+export async function handleMayorBeadReassign(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string; beadId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = BeadReassignBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorBeadReassign: townId=${params.townId} rigId=${params.rigId} beadId=${params.beadId} targetAgent=${parsed.data.agent_id}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+
+  // Unhook any currently assigned agent
+  const bead = await town.getBeadAsync(params.beadId);
+  if (!bead) {
+    return c.json(resError('Bead not found'), 404);
+  }
+  if (bead.assignee_agent_bead_id) {
+    await town.unhookBead(bead.assignee_agent_bead_id);
+  }
+
+  // Hook the new agent
+  await town.hookBead(parsed.data.agent_id, params.beadId);
+
+  return c.json(resSuccess({ reassigned: true }));
+}
+
+/**
+ * POST /api/mayor/:townId/tools/rigs/:rigId/agents/:agentId/reset
+ * Force-reset an agent to idle, unhooking from any current bead.
+ */
+export async function handleMayorAgentReset(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string; agentId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorAgentReset: townId=${params.townId} rigId=${params.rigId} agentId=${params.agentId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  await town.resetAgent(params.agentId);
+
+  return c.json(resSuccess({ reset: true }));
+}
+
+/**
+ * POST /api/mayor/:townId/tools/convoys/:convoyId/close
+ * Force-close a convoy and all its tracked open beads.
+ */
+export async function handleMayorConvoyClose(
+  c: Context<GastownEnv>,
+  params: { townId: string; convoyId: string }
+) {
+  console.log(
+    `${HANDLER_LOG} handleMayorConvoyClose: townId=${params.townId} convoyId=${params.convoyId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const convoy = await town.closeConvoy(params.convoyId);
+
+  if (!convoy) return c.json(resError('Convoy not found'), 404);
+  return c.json(resSuccess(convoy));
+}
+
+/**
+ * PATCH /api/mayor/:townId/tools/convoys/:convoyId
+ * Edit convoy metadata (merge_mode or feature_branch).
+ */
+export async function handleMayorConvoyUpdate(
+  c: Context<GastownEnv>,
+  params: { townId: string; convoyId: string }
+) {
+  const parsed = ConvoyUpdateBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorConvoyUpdate: townId=${params.townId} convoyId=${params.convoyId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const convoy = await town.updateConvoy(params.convoyId, parsed.data);
+
+  if (!convoy) return c.json(resError('Convoy not found'), 404);
+  return c.json(resSuccess(convoy));
+}
+
+/**
+ * DELETE /api/mayor/:townId/tools/rigs/:rigId/beads/:beadId
+ * Delete a bead that belongs to the specified rig.
+ */
+export async function handleMayorBeadDelete(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string; beadId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorBeadDelete: townId=${params.townId} rigId=${params.rigId} beadId=${params.beadId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+
+  // Verify the bead belongs to this rig
+  const bead = await town.getBeadAsync(params.beadId);
+  if (!bead) {
+    return c.json(resError('Bead not found'), 404);
+  }
+  if (bead.rig_id !== params.rigId) {
+    return c.json(resError('Bead does not belong to this rig'), 403);
+  }
+
+  await town.deleteBead(params.beadId);
+
+  return c.json(resSuccess({ deleted: true }));
+}
+
+/**
+ * POST /api/mayor/:townId/tools/escalations/:escalationId/acknowledge
+ * Acknowledge an escalation, marking it as reviewed.
+ */
+export async function handleMayorEscalationAcknowledge(
+  c: Context<GastownEnv>,
+  params: { townId: string; escalationId: string }
+) {
+  console.log(
+    `${HANDLER_LOG} handleMayorEscalationAcknowledge: townId=${params.townId} escalationId=${params.escalationId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const escalation = await town.acknowledgeEscalation(params.escalationId);
+
+  if (!escalation) return c.json(resError('Escalation not found'), 404);
+  return c.json(resSuccess(escalation));
 }

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -203,6 +203,19 @@ You may READ files to build context. You must NEVER WRITE files. The browse work
 
 The only exception is running \`git pull\` in a browse directory to get the latest code.
 
+## Surgical Editing
+
+You can directly edit town state when things go wrong:
+- **gt_bead_update** to change bead status, title, body, or priority
+- **gt_bead_reassign** to move a bead to a different agent
+- **gt_agent_reset** to force-reset a stuck agent to idle
+- **gt_convoy_close** to force-close a stuck convoy
+- **gt_convoy_update** to edit convoy merge_mode or feature_branch
+- **gt_bead_delete** to remove beads that shouldn't exist
+- **gt_escalation_acknowledge** to acknowledge escalations
+
+Use these tools when the user reports stuck state, when you detect problems during delegation, or when you need to clean up after failures. You are the town coordinator — you have full authority over the control plane.
+
 ## Important
 
 - You maintain context across messages. This is a continuous conversation.

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -306,17 +306,6 @@ export const gastownRouter = router({
           body: z.string().nullable().optional(),
           status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']).optional(),
           priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
-          type: z
-            .enum([
-              'issue',
-              'message',
-              'escalation',
-              'merge_request',
-              'convoy',
-              'molecule',
-              'agent',
-            ])
-            .optional(),
           labels: z.array(z.string()).optional(),
           metadata: z.record(z.string(), z.unknown()).optional(),
           rig_id: z.string().min(1).nullable().optional(),
@@ -328,7 +317,6 @@ export const gastownRouter = router({
             data.body !== undefined ||
             data.status !== undefined ||
             data.priority !== undefined ||
-            data.type !== undefined ||
             data.labels !== undefined ||
             data.metadata !== undefined ||
             data.rig_id !== undefined ||

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -328,6 +328,16 @@ export const gastownRouter = router({
     .mutation(async ({ ctx, input }) => {
       const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
+
+      // Verify the bead belongs to this rig
+      const existing = await townStub.getBeadAsync(input.beadId);
+      if (!existing) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Bead not found' });
+      }
+      if (existing.rig_id !== input.rigId) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Bead does not belong to this rig' });
+      }
+
       const { rigId: _rigId, beadId, ...fields } = input;
       return townStub.updateBead(beadId, fields, ctx.userId);
     }),

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -296,6 +296,54 @@ export const gastownRouter = router({
       await townStub.deleteBead(input.beadId);
     }),
 
+  updateBead: gastownProcedure
+    .input(
+      z
+        .object({
+          rigId: z.string().uuid(),
+          beadId: z.string().uuid(),
+          title: z.string().min(1).optional(),
+          body: z.string().nullable().optional(),
+          status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']).optional(),
+          priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+          type: z
+            .enum([
+              'issue',
+              'message',
+              'escalation',
+              'merge_request',
+              'convoy',
+              'molecule',
+              'agent',
+            ])
+            .optional(),
+          labels: z.array(z.string()).optional(),
+          metadata: z.record(z.string(), z.unknown()).optional(),
+          rig_id: z.string().min(1).nullable().optional(),
+          parent_bead_id: z.string().min(1).nullable().optional(),
+        })
+        .refine(
+          data =>
+            data.title !== undefined ||
+            data.body !== undefined ||
+            data.status !== undefined ||
+            data.priority !== undefined ||
+            data.type !== undefined ||
+            data.labels !== undefined ||
+            data.metadata !== undefined ||
+            data.rig_id !== undefined ||
+            data.parent_bead_id !== undefined,
+          { message: 'At least one field to update must be provided' }
+        )
+    )
+    .output(RpcBeadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      const { rigId: _rigId, beadId, ...fields } = input;
+      return townStub.updateBead(beadId, fields, ctx.userId);
+    }),
+
   // ── Agents ──────────────────────────────────────────────────────────
 
   listAgents: gastownProcedure

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -49,6 +49,7 @@ export function dashboardHtml(): string {
   .badge.in_progress { background: #d29922aa; color: #e3b341; }
   .badge.in_review { background: #8957e533; color: #bc8cff; }
   .badge.closed { background: #3fb95033; color: #3fb950; }
+  .badge.failed { background: #f8514933; color: #f85149; }
   .badge.idle { background: #21262d; color: #8b949e; }
   .badge.working { background: #d29922aa; color: #e3b341; }
   .badge.blocked { background: #f8514933; color: #f85149; }
@@ -218,6 +219,7 @@ export function dashboardHtml(): string {
     <input type="text" id="editBeadRigId" placeholder="rig ID" style="min-width:160px" />
     <label>Bead ID</label>
     <input type="text" id="editBeadId" placeholder="bead ID" style="min-width:160px" />
+    <button onclick="mayorBeadLoad()">Load</button>
   </div>
   <div class="row">
     <label>Title</label>
@@ -233,6 +235,7 @@ export function dashboardHtml(): string {
       <option value="">— unchanged —</option>
       <option value="open">open</option>
       <option value="in_progress">in_progress</option>
+      <option value="in_review">in_review</option>
       <option value="closed">closed</option>
       <option value="failed">failed</option>
     </select>
@@ -244,9 +247,34 @@ export function dashboardHtml(): string {
       <option value="high">high</option>
       <option value="critical">critical</option>
     </select>
-    <button class="primary" onclick="mayorBeadSave()">Save Bead</button>
   </div>
   <div class="row">
+    <label>Type</label>
+    <select id="editBeadType">
+      <option value="">— unchanged —</option>
+      <option value="issue">issue</option>
+      <option value="message">message</option>
+      <option value="escalation">escalation</option>
+      <option value="merge_request">merge_request</option>
+      <option value="convoy">convoy</option>
+      <option value="molecule">molecule</option>
+      <option value="agent">agent</option>
+    </select>
+    <label>Rig</label>
+    <input type="text" id="editBeadRigIdField" placeholder="rig ID (optional)" style="min-width:140px" />
+    <label>Parent</label>
+    <input type="text" id="editBeadParentId" placeholder="parent bead ID (optional)" style="min-width:140px" />
+  </div>
+  <div class="row">
+    <label>Labels</label>
+    <input type="text" id="editBeadLabels" placeholder="comma-separated labels (e.g. bug, frontend, urgent)" style="flex:1;min-width:200px" />
+  </div>
+  <div class="row" style="align-items:flex-start">
+    <label style="padding-top:4px">Metadata</label>
+    <textarea class="body-edit" id="editBeadMetadata" placeholder='JSON object, e.g. {"key": "value"}' style="min-height:60px"></textarea>
+  </div>
+  <div class="row">
+    <button class="primary" onclick="mayorBeadSave()">Save Bead</button>
     <label>Reassign to</label>
     <input type="text" id="editBeadReassignAgent" placeholder="agent ID" style="min-width:160px" />
     <button onclick="mayorBeadReassign()">Reassign</button>
@@ -494,10 +522,25 @@ async function mayorBeadSave() {
   const bodyText = el('editBeadBody').value.trim();
   const status = el('editBeadStatus').value;
   const priority = el('editBeadPriority').value;
+  const beadType = el('editBeadType').value;
+  const rigIdField = el('editBeadRigIdField').value.trim();
+  const parentId = el('editBeadParentId').value.trim();
+  const labelsRaw = el('editBeadLabels').value.trim();
+  const metadataRaw = el('editBeadMetadata').value.trim();
   if (title) body.title = title;
   if (bodyText) body.body = bodyText;
   if (status) body.status = status;
   if (priority) body.priority = priority;
+  if (beadType) body.type = beadType;
+  if (rigIdField) body.rig_id = rigIdField;
+  if (parentId) body.parent_bead_id = parentId;
+  if (labelsRaw) {
+    body.labels = labelsRaw.split(',').map(function(l) { return l.trim(); }).filter(Boolean);
+  }
+  if (metadataRaw) {
+    try { body.metadata = JSON.parse(metadataRaw); }
+    catch { toast('Invalid JSON in metadata field', true); return; }
+  }
   if (!Object.keys(body).length) { toast('Provide at least one field to update', true); return; }
   const r = await mayorApi('PATCH', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/beads/' + bId, body);
   if (r.ok) {
@@ -507,6 +550,32 @@ async function mayorBeadSave() {
   } else {
     el('editBeadResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
   }
+}
+
+async function mayorBeadLoad() {
+  const tId = mayorTownId();
+  const rId = el('editBeadRigId').value.trim();
+  const bId = el('editBeadId').value.trim();
+  if (!tId || !rId || !bId) { toast('Fill in Town ID, Rig ID, and Bead ID', true); return; }
+  const r = await mayorApi('GET', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/beads?limit=200');
+  if (!r.ok) { toast('Failed to load beads', true); return; }
+  const match = (r.data.data || []).find(function(b) { return b.bead_id === bId || b.id === bId; });
+  if (!match) { toast('Bead not found in rig', true); return; }
+  el('editBeadTitle').value = match.title || '';
+  el('editBeadBody').value = match.body || '';
+  el('editBeadStatus').value = match.status || '';
+  el('editBeadPriority').value = match.priority || '';
+  el('editBeadType').value = match.type || '';
+  el('editBeadRigIdField').value = match.rig_id || '';
+  el('editBeadParentId').value = match.parent_bead_id || '';
+  var labels = match.labels;
+  if (typeof labels === 'string') { try { labels = JSON.parse(labels); } catch {} }
+  el('editBeadLabels').value = Array.isArray(labels) ? labels.join(', ') : '';
+  var meta = match.metadata;
+  if (typeof meta === 'string') { try { meta = JSON.parse(meta); } catch {} }
+  el('editBeadMetadata').value = (meta && typeof meta === 'object' && Object.keys(meta).length > 0)
+    ? JSON.stringify(meta, null, 2) : '';
+  toast('Bead loaded');
 }
 
 async function mayorBeadReassign() {
@@ -685,21 +754,47 @@ async function loadBeads() {
 
 function renderBeads() {
   if (!beads.length) { el('beadsList').innerHTML = '<p class="empty">No beads</p>'; return; }
-  let h = '<table><tr><th>ID</th><th>Title</th><th>Type</th><th>Status</th><th>Assignee</th><th></th></tr>';
+  let h = '<table><tr><th>ID</th><th>Title</th><th>Type</th><th>Status</th><th>Priority</th><th>Assignee</th><th></th></tr>';
   for (const b of beads) {
     h += '<tr>'
       + '<td class="id" onclick="copyId(\\'' + b.id + '\\')">' + short(b.id) + '</td>'
       + '<td>' + esc(b.title) + '</td>'
       + '<td>' + b.type + '</td>'
       + '<td>' + badge(b.status) + '</td>'
+      + '<td>' + (b.priority || 'medium') + '</td>'
       + '<td>' + (b.assignee_agent_id ? short(b.assignee_agent_id) : '—') + '</td>'
       + '<td>'
+      + '<button onclick="editBead(\\'' + b.id + '\\')">Edit</button> '
       + (b.status !== 'closed' ? '<button onclick="closeBead(\\'' + b.id + '\\')">Close</button>' : '')
       + '</td>'
       + '</tr>';
   }
   h += '</table>';
   el('beadsList').innerHTML = h;
+}
+
+function editBead(beadId) {
+  const b = beads.find(function(bead) { return bead.id === beadId || bead.bead_id === beadId; });
+  if (!b) { toast('Bead not found', true); return; }
+  el('editBeadId').value = beadId;
+  el('editBeadRigId').value = b.rig_id || rigId();
+  el('editBeadTitle').value = b.title || '';
+  el('editBeadBody').value = b.body || '';
+  el('editBeadStatus').value = b.status || '';
+  el('editBeadPriority').value = b.priority || '';
+  el('editBeadType').value = b.type || '';
+  el('editBeadRigIdField').value = b.rig_id || '';
+  el('editBeadParentId').value = b.parent_bead_id || '';
+  var labels = b.labels;
+  if (typeof labels === 'string') { try { labels = JSON.parse(labels); } catch {} }
+  el('editBeadLabels').value = Array.isArray(labels) ? labels.join(', ') : '';
+  var meta = b.metadata;
+  if (typeof meta === 'string') { try { meta = JSON.parse(meta); } catch {} }
+  el('editBeadMetadata').value = (meta && typeof meta === 'object' && Object.keys(meta).length > 0)
+    ? JSON.stringify(meta, null, 2) : '';
+  // Scroll to the edit section
+  el('editBeadTitle').scrollIntoView({ behavior: 'smooth', block: 'center' });
+  toast('Editing bead ' + short(beadId));
 }
 
 async function createBead() {

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -53,6 +53,10 @@ export function dashboardHtml(): string {
   .badge.working { background: #d29922aa; color: #e3b341; }
   .badge.blocked { background: #f8514933; color: #f85149; }
   .badge.dead { background: #f8514966; color: #f85149; }
+  textarea.body-edit { background: #161b22; border: 1px solid #30363d; color: #c9d1d9;
+                       padding: 4px 8px; border-radius: 4px; font-family: inherit; font-size: 12px;
+                       width: 100%; min-height: 80px; resize: vertical; }
+  textarea.body-edit:focus { border-color: #58a6ff; outline: none; }
   .empty { color: #484f58; font-style: italic; }
   #toast { position: fixed; bottom: 16px; right: 16px; background: #1f6feb;
            color: #fff; padding: 8px 16px; border-radius: 6px; font-size: 12px;
@@ -196,6 +200,87 @@ export function dashboardHtml(): string {
     <div id="escalationResult"></div>
   </div>
 </div>
+</div>
+
+<!-- Mayor Edit Controls -->
+<div class="panel">
+  <h2>Mayor Edit Controls</h2>
+  <div class="row">
+    <label>Town ID</label>
+    <input type="text" id="mayorTownId" placeholder="town-abc" style="min-width:160px" />
+    <label style="min-width:80px">Mayor Token</label>
+    <input type="text" id="mayorToken" placeholder="Bearer token for mayor auth" style="flex:1;min-width:240px" />
+  </div>
+
+  <h2 style="margin-top:12px">Bead Edit</h2>
+  <div class="row">
+    <label>Rig ID</label>
+    <input type="text" id="editBeadRigId" placeholder="rig ID" style="min-width:160px" />
+    <label>Bead ID</label>
+    <input type="text" id="editBeadId" placeholder="bead ID" style="min-width:160px" />
+  </div>
+  <div class="row">
+    <label>Title</label>
+    <input type="text" id="editBeadTitle" placeholder="new title (optional)" style="flex:1;min-width:200px" />
+  </div>
+  <div class="row" style="align-items:flex-start">
+    <label style="padding-top:4px">Body</label>
+    <textarea class="body-edit" id="editBeadBody" placeholder="new body (optional)"></textarea>
+  </div>
+  <div class="row">
+    <label>Status</label>
+    <select id="editBeadStatus">
+      <option value="">— unchanged —</option>
+      <option value="open">open</option>
+      <option value="in_progress">in_progress</option>
+      <option value="closed">closed</option>
+      <option value="failed">failed</option>
+    </select>
+    <label>Priority</label>
+    <select id="editBeadPriority">
+      <option value="">— unchanged —</option>
+      <option value="low">low</option>
+      <option value="medium">medium</option>
+      <option value="high">high</option>
+      <option value="critical">critical</option>
+    </select>
+    <button class="primary" onclick="mayorBeadSave()">Save Bead</button>
+  </div>
+  <div class="row">
+    <label>Reassign to</label>
+    <input type="text" id="editBeadReassignAgent" placeholder="agent ID" style="min-width:160px" />
+    <button onclick="mayorBeadReassign()">Reassign</button>
+    <button class="danger" onclick="mayorBeadDelete()">Delete Bead</button>
+  </div>
+  <div id="editBeadResult"></div>
+
+  <h2 style="margin-top:12px">Agent Controls</h2>
+  <div class="row">
+    <label>Rig ID</label>
+    <input type="text" id="editAgentRigId" placeholder="rig ID" style="min-width:160px" />
+    <label>Agent ID</label>
+    <input type="text" id="editAgentId" placeholder="agent ID" style="min-width:160px" />
+  </div>
+  <div class="row">
+    <button onclick="mayorAgentReset()">Reset to Idle</button>
+    <button onclick="mayorAgentUnhook()">Unhook</button>
+  </div>
+  <div id="editAgentResult"></div>
+
+  <h2 style="margin-top:12px">Convoy Controls</h2>
+  <div class="row">
+    <label>Convoy ID</label>
+    <input type="text" id="editConvoyId" placeholder="convoy ID" style="min-width:200px" />
+    <label>Merge Mode</label>
+    <select id="editConvoyMergeMode">
+      <option value="">— unchanged —</option>
+      <option value="review-then-land">review-then-land</option>
+      <option value="review-and-merge">review-and-merge</option>
+    </select>
+    <button onclick="mayorConvoyUpdate()">Save</button>
+    <button class="danger" onclick="mayorConvoyClose()">Force Close</button>
+  </div>
+  <div id="editConvoyResult"></div>
 </div>
 
 <!-- Town Container -->
@@ -360,6 +445,166 @@ async function api(method, path, body) {
 }
 
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+// ── Mayor API helper ─────────────────────────────────────────────────
+
+function mayorToken() { return el('mayorToken').value.trim(); }
+function mayorTownId() { return el('mayorTownId').value.trim(); }
+
+async function mayorApi(method, path, body) {
+  const log = el('apiLog');
+  const token = mayorToken();
+  const opts = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { 'Authorization': 'Bearer ' + token } : {}),
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+
+  const tag = method + ' ' + path;
+  log.innerHTML += '<span class="info">' + esc(tag) + '</span>\\n';
+
+  try {
+    const res = await fetch(path, opts);
+    const data = await res.json();
+    const cls = res.ok ? 'ok' : 'err';
+    log.innerHTML += '<span class="' + cls + '">' + res.status + '</span> '
+      + esc(JSON.stringify(data, null, 2)) + '\\n\\n';
+    log.scrollTop = log.scrollHeight;
+    if (!res.ok) toast(data.error || res.status, true);
+    return { ok: res.ok, status: res.status, data };
+  } catch (e) {
+    log.innerHTML += '<span class="err">FETCH ERROR: ' + esc(e.message) + '</span>\\n\\n';
+    toast(e.message, true);
+    return { ok: false, status: 0, data: null };
+  }
+}
+
+// ── Mayor: Bead edit ─────────────────────────────────────────────────
+
+async function mayorBeadSave() {
+  const tId = mayorTownId();
+  const rId = el('editBeadRigId').value.trim();
+  const bId = el('editBeadId').value.trim();
+  if (!tId || !rId || !bId) { toast('Fill in Town ID, Rig ID, and Bead ID', true); return; }
+  const body = {};
+  const title = el('editBeadTitle').value.trim();
+  const bodyText = el('editBeadBody').value.trim();
+  const status = el('editBeadStatus').value;
+  const priority = el('editBeadPriority').value;
+  if (title) body.title = title;
+  if (bodyText) body.body = bodyText;
+  if (status) body.status = status;
+  if (priority) body.priority = priority;
+  if (!Object.keys(body).length) { toast('Provide at least one field to update', true); return; }
+  const r = await mayorApi('PATCH', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/beads/' + bId, body);
+  if (r.ok) {
+    el('editBeadResult').innerHTML = '<p class="ok" style="color:#3fb950">Bead updated</p>';
+    toast('Bead saved');
+    await loadBeads();
+  } else {
+    el('editBeadResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
+
+async function mayorBeadReassign() {
+  const tId = mayorTownId();
+  const rId = el('editBeadRigId').value.trim();
+  const bId = el('editBeadId').value.trim();
+  const agentId = el('editBeadReassignAgent').value.trim();
+  if (!tId || !rId || !bId || !agentId) { toast('Fill in Town ID, Rig ID, Bead ID, and Agent ID', true); return; }
+  const r = await mayorApi('POST', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/beads/' + bId + '/reassign', { agent_id: agentId });
+  if (r.ok) {
+    el('editBeadResult').innerHTML = '<p class="ok" style="color:#3fb950">Bead reassigned</p>';
+    toast('Bead reassigned');
+    await loadBeads();
+  } else {
+    el('editBeadResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
+
+async function mayorBeadDelete() {
+  const tId = mayorTownId();
+  const rId = el('editBeadRigId').value.trim();
+  const bId = el('editBeadId').value.trim();
+  if (!tId || !rId || !bId) { toast('Fill in Town ID, Rig ID, and Bead ID', true); return; }
+  if (!confirm('Delete bead ' + bId + '? This cannot be undone.')) return;
+  const r = await mayorApi('DELETE', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/beads/' + bId);
+  if (r.ok) {
+    el('editBeadResult').innerHTML = '<p class="ok" style="color:#3fb950">Bead deleted</p>';
+    el('editBeadId').value = '';
+    toast('Bead deleted');
+    await loadBeads();
+  } else {
+    el('editBeadResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
+
+// ── Mayor: Agent controls ────────────────────────────────────────────
+
+async function mayorAgentReset() {
+  const tId = mayorTownId();
+  const rId = el('editAgentRigId').value.trim();
+  const aId = el('editAgentId').value.trim();
+  if (!tId || !rId || !aId) { toast('Fill in Town ID, Rig ID, and Agent ID', true); return; }
+  const r = await mayorApi('POST', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/agents/' + aId + '/reset', {});
+  if (r.ok) {
+    el('editAgentResult').innerHTML = '<p class="ok" style="color:#3fb950">Agent reset to idle</p>';
+    toast('Agent reset');
+    await loadAgents();
+  } else {
+    el('editAgentResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
+
+async function mayorAgentUnhook() {
+  const tId = mayorTownId();
+  const rId = el('editAgentRigId').value.trim();
+  const aId = el('editAgentId').value.trim();
+  if (!rId || !aId) { toast('Fill in Rig ID and Agent ID', true); return; }
+  const r = await api('DELETE', '/api/rigs/' + rId + '/agents/' + aId + '/hook');
+  if (r.ok) {
+    el('editAgentResult').innerHTML = '<p class="ok" style="color:#3fb950">Agent unhooked</p>';
+    toast('Agent unhooked');
+    await loadAgents();
+  } else {
+    el('editAgentResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
+
+// ── Mayor: Convoy controls ───────────────────────────────────────────
+
+async function mayorConvoyUpdate() {
+  const tId = mayorTownId();
+  const cId = el('editConvoyId').value.trim();
+  if (!tId || !cId) { toast('Fill in Town ID and Convoy ID', true); return; }
+  const merge_mode = el('editConvoyMergeMode').value;
+  if (!merge_mode) { toast('Select a merge mode to update', true); return; }
+  const r = await mayorApi('PATCH', '/api/mayor/' + tId + '/tools/convoys/' + cId, { merge_mode });
+  if (r.ok) {
+    el('editConvoyResult').innerHTML = '<p class="ok" style="color:#3fb950">Convoy updated</p>';
+    toast('Convoy updated');
+  } else {
+    el('editConvoyResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
+
+async function mayorConvoyClose() {
+  const tId = mayorTownId();
+  const cId = el('editConvoyId').value.trim();
+  if (!tId || !cId) { toast('Fill in Town ID and Convoy ID', true); return; }
+  if (!confirm('Force-close convoy ' + cId + ' and all its open beads?')) return;
+  const r = await mayorApi('POST', '/api/mayor/' + tId + '/tools/convoys/' + cId + '/close', {});
+  if (r.ok) {
+    el('editConvoyResult').innerHTML = '<p class="ok" style="color:#3fb950">Convoy force-closed</p>';
+    toast('Convoy closed');
+    await loadBeads();
+  } else {
+    el('editConvoyResult').innerHTML = '<p class="err" style="color:#f85149">Error: ' + esc(r.data?.error ?? 'unknown') + '</p>';
+  }
+}
 
 function toast(msg, isErr) {
   const t = el('toast');

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -618,8 +618,8 @@ async function mayorAgentUnhook() {
   const tId = mayorTownId();
   const rId = el('editAgentRigId').value.trim();
   const aId = el('editAgentId').value.trim();
-  if (!rId || !aId) { toast('Fill in Rig ID and Agent ID', true); return; }
-  const r = await api('DELETE', '/api/rigs/' + rId + '/agents/' + aId + '/hook');
+  if (!tId || !rId || !aId) { toast('Fill in Town ID, Rig ID, and Agent ID', true); return; }
+  const r = await mayorApi('DELETE', '/api/mayor/' + tId + '/tools/rigs/' + rId + '/agents/' + aId + '/hook');
   if (r.ok) {
     el('editAgentResult').innerHTML = '<p class="ok" style="color:#3fb950">Agent unhooked</p>';
     toast('Agent unhooked');
@@ -742,16 +742,17 @@ function renderBeads() {
   if (!beads.length) { el('beadsList').innerHTML = '<p class="empty">No beads</p>'; return; }
   let h = '<table><tr><th>ID</th><th>Title</th><th>Type</th><th>Status</th><th>Priority</th><th>Assignee</th><th></th></tr>';
   for (const b of beads) {
+    const bid = b.bead_id || b.id;
     h += '<tr>'
-      + '<td class="id" onclick="copyId(\\'' + b.id + '\\')">' + short(b.id) + '</td>'
+      + '<td class="id" onclick="copyId(\\'' + bid + '\\')">' + short(bid) + '</td>'
       + '<td>' + esc(b.title) + '</td>'
       + '<td>' + b.type + '</td>'
       + '<td>' + badge(b.status) + '</td>'
       + '<td>' + (b.priority || 'medium') + '</td>'
-      + '<td>' + (b.assignee_agent_id ? short(b.assignee_agent_id) : '—') + '</td>'
+      + '<td>' + (b.assignee_agent_bead_id ? short(b.assignee_agent_bead_id) : '—') + '</td>'
       + '<td>'
-      + '<button onclick="editBead(\\'' + b.id + '\\')">Edit</button> '
-      + (b.status !== 'closed' ? '<button onclick="closeBead(\\'' + b.id + '\\')">Close</button>' : '')
+      + '<button onclick="editBead(\\'' + bid + '\\')">Edit</button> '
+      + (b.status !== 'closed' ? '<button onclick="closeBead(\\'' + bid + '\\')">Close</button>' : '')
       + '</td>'
       + '</tr>';
   }

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -249,17 +249,6 @@ export function dashboardHtml(): string {
     </select>
   </div>
   <div class="row">
-    <label>Type</label>
-    <select id="editBeadType">
-      <option value="">— unchanged —</option>
-      <option value="issue">issue</option>
-      <option value="message">message</option>
-      <option value="escalation">escalation</option>
-      <option value="merge_request">merge_request</option>
-      <option value="convoy">convoy</option>
-      <option value="molecule">molecule</option>
-      <option value="agent">agent</option>
-    </select>
     <label>Rig</label>
     <input type="text" id="editBeadRigIdField" placeholder="rig ID (optional)" style="min-width:140px" />
     <label>Parent</label>
@@ -522,7 +511,6 @@ async function mayorBeadSave() {
   const bodyText = el('editBeadBody').value.trim();
   const status = el('editBeadStatus').value;
   const priority = el('editBeadPriority').value;
-  const beadType = el('editBeadType').value;
   const rigIdField = el('editBeadRigIdField').value.trim();
   const parentId = el('editBeadParentId').value.trim();
   const labelsRaw = el('editBeadLabels').value.trim();
@@ -531,7 +519,6 @@ async function mayorBeadSave() {
   if (bodyText) body.body = bodyText;
   if (status) body.status = status;
   if (priority) body.priority = priority;
-  if (beadType) body.type = beadType;
   if (rigIdField) body.rig_id = rigIdField;
   if (parentId) body.parent_bead_id = parentId;
   if (labelsRaw) {
@@ -565,7 +552,6 @@ async function mayorBeadLoad() {
   el('editBeadBody').value = match.body || '';
   el('editBeadStatus').value = match.status || '';
   el('editBeadPriority').value = match.priority || '';
-  el('editBeadType').value = match.type || '';
   el('editBeadRigIdField').value = match.rig_id || '';
   el('editBeadParentId').value = match.parent_bead_id || '';
   var labels = match.labels;
@@ -782,7 +768,6 @@ function editBead(beadId) {
   el('editBeadBody').value = b.body || '';
   el('editBeadStatus').value = b.status || '';
   el('editBeadPriority').value = b.priority || '';
-  el('editBeadType').value = b.type || '';
   el('editBeadRigIdField').value = b.rig_id || '';
   el('editBeadParentId').value = b.parent_bead_id || '';
   var labels = b.labels;

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { BeadEventTimeline, extractPrUrl } from '@/components/gastown/ActivityFeed';
 import type { ResourceRef } from '@/components/gastown/DrawerStack';
 
@@ -25,13 +29,30 @@ import {
   GitPullRequest,
   CircleDot,
   Layers,
+  Pencil,
+  X,
+  Save,
+  Loader2,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+const BEAD_STATUSES = ['open', 'in_progress', 'in_review', 'closed', 'failed'] as const;
+const BEAD_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const;
+const BEAD_TYPES = [
+  'issue',
+  'message',
+  'escalation',
+  'merge_request',
+  'convoy',
+  'molecule',
+  'agent',
+] as const;
+
 const STATUS_STYLES: Record<string, string> = {
   open: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
   in_progress: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  in_review: 'border-violet-500/30 bg-violet-500/10 text-violet-300',
   closed: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
   failed: 'border-red-500/30 bg-red-500/10 text-red-300',
 };
@@ -41,6 +62,18 @@ const PRIORITY_STYLES: Record<string, string> = {
   high: 'text-orange-400',
   medium: 'text-amber-400',
   low: 'text-white/50',
+};
+
+type EditState = {
+  title: string;
+  body: string;
+  status: string;
+  priority: string;
+  type: string;
+  labels: string;
+  metadata: string;
+  rig_id: string;
+  parent_bead_id: string;
 };
 
 export function BeadPanel({
@@ -53,6 +86,7 @@ export function BeadPanel({
   push: (ref: ResourceRef) => void;
 }) {
   const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
   const beadsQuery = useQuery(trpc.gastown.listBeads.queryOptions({ rigId }));
   const agentsQuery = useQuery(trpc.gastown.listAgents.queryOptions({ rigId }));
   const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId }));
@@ -69,6 +103,113 @@ export function BeadPanel({
     acc[a.id] = a.name;
     return acc;
   }, {});
+
+  // ── Edit mode state ───────────────────────────────────────────────────
+  const [editing, setEditing] = useState(false);
+  const [editState, setEditState] = useState<EditState>({
+    title: '',
+    body: '',
+    status: '',
+    priority: '',
+    type: '',
+    labels: '',
+    metadata: '',
+    rig_id: '',
+    parent_bead_id: '',
+  });
+
+  const enterEditMode = useCallback(() => {
+    if (!bead) return;
+    setEditState({
+      title: bead.title,
+      body: bead.body ?? '',
+      status: bead.status,
+      priority: bead.priority,
+      type: bead.type,
+      labels: bead.labels.join(', '),
+      metadata:
+        bead.metadata && Object.keys(bead.metadata).length > 0
+          ? JSON.stringify(bead.metadata, null, 2)
+          : '',
+      rig_id: bead.rig_id ?? '',
+      parent_bead_id: bead.parent_bead_id ?? '',
+    });
+    setEditing(true);
+  }, [bead]);
+
+  const cancelEdit = useCallback(() => setEditing(false), []);
+
+  const updateField = useCallback(<K extends keyof EditState>(field: K, value: EditState[K]) => {
+    setEditState(prev => ({ ...prev, [field]: value }));
+  }, []);
+
+  const updateBeadMutation = useMutation(
+    trpc.gastown.updateBead.mutationOptions({
+      onSuccess: () => {
+        setEditing(false);
+        // Invalidate bead-related queries to refresh data
+        queryClient.invalidateQueries({ queryKey: trpc.gastown.listBeads.queryKey({ rigId }) });
+        queryClient.invalidateQueries({ queryKey: trpc.gastown.getRig.queryKey({ rigId }) });
+      },
+    })
+  );
+
+  const handleSave = useCallback(() => {
+    if (!bead) return;
+
+    // Build the diff — only send fields that changed
+    const updates: Record<string, unknown> = {};
+    if (editState.title !== bead.title) updates.title = editState.title;
+    if (editState.body !== (bead.body ?? '')) {
+      updates.body = editState.body || null;
+    }
+    if (editState.status !== bead.status) updates.status = editState.status;
+    if (editState.priority !== bead.priority) updates.priority = editState.priority;
+    if (editState.type !== bead.type) updates.type = editState.type;
+
+    const newLabels = editState.labels
+      .split(',')
+      .map(l => l.trim())
+      .filter(Boolean);
+    const oldLabels = bead.labels;
+    if (JSON.stringify(newLabels) !== JSON.stringify(oldLabels)) {
+      updates.labels = newLabels;
+    }
+
+    if (editState.metadata.trim()) {
+      try {
+        const parsed = JSON.parse(editState.metadata) as Record<string, unknown>;
+        if (JSON.stringify(parsed) !== JSON.stringify(bead.metadata)) {
+          updates.metadata = parsed;
+        }
+      } catch {
+        // Invalid JSON — skip metadata update
+      }
+    } else if (bead.metadata && Object.keys(bead.metadata).length > 0) {
+      updates.metadata = {};
+    }
+
+    const newRigId = editState.rig_id || null;
+    if (newRigId !== (bead.rig_id ?? null)) {
+      updates.rig_id = newRigId;
+    }
+
+    const newParent = editState.parent_bead_id || null;
+    if (newParent !== (bead.parent_bead_id ?? null)) {
+      updates.parent_bead_id = newParent;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      setEditing(false);
+      return;
+    }
+
+    updateBeadMutation.mutate({
+      rigId,
+      beadId: bead.bead_id,
+      ...updates,
+    } as Parameters<typeof updateBeadMutation.mutate>[0]);
+  }, [bead, editState, rigId, updateBeadMutation]);
 
   if (!bead) {
     return <div className="p-6 text-center text-sm text-white/30">Loading bead…</div>;
@@ -98,91 +239,217 @@ export function BeadPanel({
     <div className="flex flex-col gap-0">
       {/* Title area */}
       <div className="border-b border-white/[0.06] px-5 pt-4 pb-4">
-        <div className="flex items-center gap-2 text-base font-semibold text-white/90">
+        <div className="flex items-center gap-2">
           <Hexagon className="size-4 shrink-0 text-[color:oklch(95%_0.15_108_/_0.7)]" />
-          <span className="truncate">{bead.title}</span>
-        </div>
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          <span
-            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] font-medium ${STATUS_STYLES[bead.status] ?? 'border-white/10 text-white/50'}`}
-          >
-            {bead.status.replace('_', ' ')}
-          </span>
-          <Badge variant="outline" className="text-[10px]">
-            {bead.type}
-          </Badge>
-          <span
-            className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${PRIORITY_STYLES[bead.priority] ?? 'text-white/50'}`}
-          >
-            <Flag className="size-2.5" />
-            {bead.priority}
-          </span>
-        </div>
-      </div>
-
-      {/* Metadata grid */}
-      <div className="grid grid-cols-2 border-b border-white/[0.06]">
-        <MetaCell icon={Hash} label="Bead ID" value={bead.bead_id.slice(0, 8)} mono />
-        <MetaCell
-          icon={Clock}
-          label="Created"
-          value={format(new Date(bead.created_at), 'MMM d, HH:mm')}
-        />
-
-        {/* Assignee — clickable to open agent drawer */}
-        {bead.assignee_agent_bead_id ? (
+          {editing ? (
+            <Input
+              value={editState.title}
+              onChange={e => updateField('title', e.target.value)}
+              className="h-7 border-white/10 bg-white/5 text-sm font-semibold text-white/90"
+            />
+          ) : (
+            <span className="truncate text-base font-semibold text-white/90">{bead.title}</span>
+          )}
           <button
-            onClick={() => {
-              if (townId) {
-                push({
-                  type: 'agent',
-                  agentId: bead.assignee_agent_bead_id ?? '',
-                  rigId,
-                  townId,
-                });
-              }
-            }}
-            className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+            onClick={editing ? cancelEdit : enterEditMode}
+            className="ml-auto shrink-0 rounded-md p-1 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+            title={editing ? 'Cancel editing' : 'Edit bead'}
           >
-            <div className="flex items-center gap-1 text-[10px] text-white/30">
-              <User className="size-3" />
-              Assignee
-            </div>
-            <div className="mt-0.5 flex items-center gap-1 text-sm text-[color:oklch(95%_0.15_108)]">
-              <Bot className="size-3" />
-              <span className="truncate">
-                {assigneeName ?? bead.assignee_agent_bead_id.slice(0, 8)}
-              </span>
-              <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
-            </div>
+            {editing ? <X className="size-3.5" /> : <Pencil className="size-3.5" />}
           </button>
+        </div>
+
+        {editing ? (
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <EditSelect
+              value={editState.status}
+              options={BEAD_STATUSES}
+              onChange={v => updateField('status', v)}
+              label="Status"
+            />
+            <EditSelect
+              value={editState.type}
+              options={BEAD_TYPES}
+              onChange={v => updateField('type', v)}
+              label="Type"
+            />
+            <EditSelect
+              value={editState.priority}
+              options={BEAD_PRIORITIES}
+              onChange={v => updateField('priority', v)}
+              label="Priority"
+            />
+          </div>
         ) : (
-          <MetaCell icon={User} label="Assignee" value="Unassigned" />
-        )}
-
-        <MetaCell
-          icon={Tags}
-          label="Labels"
-          value={bead.labels.length ? bead.labels.join(', ') : 'None'}
-        />
-
-        {/* Parent bead — clickable */}
-        {bead.parent_bead_id && (
-          <button
-            onClick={() => push({ type: 'bead', beadId: bead.parent_bead_id ?? '', rigId })}
-            className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
-          >
-            <div className="flex items-center gap-1 text-[10px] text-white/30">
-              <GitBranch className="size-3" />
-              Parent Bead
-            </div>
-            <div className="mt-0.5 flex items-center gap-1 font-mono text-xs text-[color:oklch(95%_0.15_108)]">
-              <span>{bead.parent_bead_id.slice(0, 8)}</span>
-              <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
-            </div>
-          </button>
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            <span
+              className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] font-medium ${STATUS_STYLES[bead.status] ?? 'border-white/10 text-white/50'}`}
+            >
+              {bead.status.replace('_', ' ')}
+            </span>
+            <Badge variant="outline" className="text-[10px]">
+              {bead.type}
+            </Badge>
+            <span
+              className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${PRIORITY_STYLES[bead.priority] ?? 'text-white/50'}`}
+            >
+              <Flag className="size-2.5" />
+              {bead.priority}
+            </span>
+          </div>
         )}
       </div>
+
+      {/* Edit mode: additional fields */}
+      {editing && (
+        <div className="space-y-3 border-b border-white/[0.06] px-5 py-3">
+          <div>
+            <label className="mb-1 block text-[10px] font-medium text-white/30">Labels</label>
+            <Input
+              value={editState.labels}
+              onChange={e => updateField('labels', e.target.value)}
+              placeholder="comma-separated labels"
+              className="h-7 border-white/10 bg-white/5 text-xs text-white/75"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[10px] font-medium text-white/30">Body</label>
+            <Textarea
+              value={editState.body}
+              onChange={e => updateField('body', e.target.value)}
+              placeholder="Bead description (Markdown)"
+              className="min-h-[80px] border-white/10 bg-white/5 text-xs text-white/75"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="mb-1 block text-[10px] font-medium text-white/30">Rig ID</label>
+              <Input
+                value={editState.rig_id}
+                onChange={e => updateField('rig_id', e.target.value)}
+                placeholder="rig UUID"
+                className="h-7 border-white/10 bg-white/5 font-mono text-[10px] text-white/75"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-[10px] font-medium text-white/30">
+                Parent Bead
+              </label>
+              <Input
+                value={editState.parent_bead_id}
+                onChange={e => updateField('parent_bead_id', e.target.value)}
+                placeholder="parent bead UUID"
+                className="h-7 border-white/10 bg-white/5 font-mono text-[10px] text-white/75"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="mb-1 block text-[10px] font-medium text-white/30">
+              Metadata (JSON)
+            </label>
+            <Textarea
+              value={editState.metadata}
+              onChange={e => updateField('metadata', e.target.value)}
+              placeholder='{"key": "value"}'
+              className="min-h-[60px] border-white/10 bg-white/5 font-mono text-[10px] text-white/75"
+            />
+          </div>
+          <div className="flex items-center gap-2 pt-1">
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={updateBeadMutation.isPending}
+              className="h-7 gap-1.5 bg-emerald-600 text-xs hover:bg-emerald-500"
+            >
+              {updateBeadMutation.isPending ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Save className="size-3" />
+              )}
+              Save
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={cancelEdit}
+              className="h-7 text-xs text-white/50"
+            >
+              Cancel
+            </Button>
+            {updateBeadMutation.isError && (
+              <span className="text-[10px] text-red-400">
+                {updateBeadMutation.error?.message ?? 'Save failed'}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Metadata grid (read-only, hidden during edit) */}
+      {!editing && (
+        <div className="grid grid-cols-2 border-b border-white/[0.06]">
+          <MetaCell icon={Hash} label="Bead ID" value={bead.bead_id.slice(0, 8)} mono />
+          <MetaCell
+            icon={Clock}
+            label="Created"
+            value={format(new Date(bead.created_at), 'MMM d, HH:mm')}
+          />
+
+          {/* Assignee — clickable to open agent drawer */}
+          {bead.assignee_agent_bead_id ? (
+            <button
+              onClick={() => {
+                if (townId) {
+                  push({
+                    type: 'agent',
+                    agentId: bead.assignee_agent_bead_id ?? '',
+                    rigId,
+                    townId,
+                  });
+                }
+              }}
+              className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+            >
+              <div className="flex items-center gap-1 text-[10px] text-white/30">
+                <User className="size-3" />
+                Assignee
+              </div>
+              <div className="mt-0.5 flex items-center gap-1 text-sm text-[color:oklch(95%_0.15_108)]">
+                <Bot className="size-3" />
+                <span className="truncate">
+                  {assigneeName ?? bead.assignee_agent_bead_id.slice(0, 8)}
+                </span>
+                <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
+              </div>
+            </button>
+          ) : (
+            <MetaCell icon={User} label="Assignee" value="Unassigned" />
+          )}
+
+          <MetaCell
+            icon={Tags}
+            label="Labels"
+            value={bead.labels.length ? bead.labels.join(', ') : 'None'}
+          />
+
+          {/* Parent bead — clickable */}
+          {bead.parent_bead_id && (
+            <button
+              onClick={() => push({ type: 'bead', beadId: bead.parent_bead_id ?? '', rigId })}
+              className="group/link flex flex-col border-r border-b border-white/[0.04] px-4 py-3 text-left transition-colors hover:bg-white/[0.03] [&:nth-child(2n)]:border-r-0"
+            >
+              <div className="flex items-center gap-1 text-[10px] text-white/30">
+                <GitBranch className="size-3" />
+                Parent Bead
+              </div>
+              <div className="mt-0.5 flex items-center gap-1 font-mono text-xs text-[color:oklch(95%_0.15_108)]">
+                <span>{bead.parent_bead_id.slice(0, 8)}</span>
+                <ChevronRight className="size-3 shrink-0 text-white/15 transition-colors group-hover/link:text-white/30" />
+              </div>
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Convoy membership */}
       {parentConvoy && (
@@ -258,8 +525,8 @@ export function BeadPanel({
         </div>
       )}
 
-      {/* Body (markdown) */}
-      {bead.body && bead.body.trim().length > 0 && (
+      {/* Body (markdown) — hidden during edit since body is in the edit form */}
+      {!editing && bead.body && bead.body.trim().length > 0 && (
         <div className="border-b border-white/[0.06] px-5 py-4">
           <div className="mb-2 flex items-center gap-1.5">
             <FileText className="size-3 text-white/25" />
@@ -286,6 +553,35 @@ export function BeadPanel({
         <BeadEventTimeline rigId={rigId} beadId={bead.bead_id} />
       </div>
     </div>
+  );
+}
+
+// ── Edit select component ───────────────────────────────────────────────
+
+function EditSelect({
+  value,
+  options,
+  onChange,
+  label,
+}: {
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+  label: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      aria-label={label}
+      className="h-6 rounded-md border border-white/10 bg-white/5 px-2 text-[10px] font-medium text-white/70 outline-none focus:border-white/20"
+    >
+      {options.map(opt => (
+        <option key={opt} value={opt} className="bg-zinc-900 text-white">
+          {opt.replace(/_/g, ' ')}
+        </option>
+      ))}
+    </select>
   );
 }
 

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -279,6 +279,26 @@ export function BeadPanel({
               onChange={v => updateField('priority', v)}
               label="Priority"
             />
+            <div className="ml-auto flex items-center gap-1.5">
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={updateBeadMutation.isPending}
+                className="h-6 gap-1 bg-emerald-600 px-2.5 text-[10px] hover:bg-emerald-500"
+              >
+                {updateBeadMutation.isPending ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Save className="size-3" />
+                )}
+                Save
+              </Button>
+              {updateBeadMutation.isError && (
+                <span className="text-[10px] text-red-400">
+                  {updateBeadMutation.error?.message ?? 'Failed'}
+                </span>
+              )}
+            </div>
           </div>
         ) : (
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -353,34 +373,6 @@ export function BeadPanel({
               placeholder='{"key": "value"}'
               className="min-h-[60px] border-white/10 bg-white/5 font-mono text-[10px] text-white/75"
             />
-          </div>
-          <div className="flex items-center gap-2 pt-1">
-            <Button
-              size="sm"
-              onClick={handleSave}
-              disabled={updateBeadMutation.isPending}
-              className="h-7 gap-1.5 bg-emerald-600 text-xs hover:bg-emerald-500"
-            >
-              {updateBeadMutation.isPending ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Save className="size-3" />
-              )}
-              Save
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={cancelEdit}
-              className="h-7 text-xs text-white/50"
-            >
-              Cancel
-            </Button>
-            {updateBeadMutation.isError && (
-              <span className="text-[10px] text-red-400">
-                {updateBeadMutation.error?.message ?? 'Save failed'}
-              </span>
-            )}
           </div>
         </div>
       )}

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -96,6 +96,7 @@ export function BeadPanel({
 
   // ── Edit mode state ───────────────────────────────────────────────────
   const [editing, setEditing] = useState(false);
+  const [metadataError, setMetadataError] = useState<string | null>(null);
   const [editState, setEditState] = useState<EditState>({
     title: '',
     body: '',
@@ -173,11 +174,13 @@ export function BeadPanel({
     if (editState.metadata.trim()) {
       try {
         const parsed = JSON.parse(editState.metadata) as Record<string, unknown>;
+        setMetadataError(null);
         if (JSON.stringify(parsed) !== JSON.stringify(bead.metadata)) {
           updates.metadata = parsed;
         }
       } catch {
-        // Invalid JSON — skip metadata update
+        setMetadataError('Invalid JSON in metadata field');
+        return;
       }
     } else if (bead.metadata && Object.keys(bead.metadata).length > 0) {
       updates.metadata = {};
@@ -355,10 +358,16 @@ export function BeadPanel({
             </label>
             <Textarea
               value={editState.metadata}
-              onChange={e => updateField('metadata', e.target.value)}
+              onChange={e => {
+                updateField('metadata', e.target.value);
+                setMetadataError(null);
+              }}
               placeholder='{"key": "value"}'
-              className="min-h-[60px] border-white/10 bg-white/5 font-mono text-[10px] text-white/75"
+              className={`min-h-[60px] border-white/10 bg-white/5 font-mono text-[10px] text-white/75 ${metadataError ? 'border-red-500/50' : ''}`}
             />
+            {metadataError && (
+              <span className="mt-0.5 block text-[10px] text-red-400">{metadataError}</span>
+            )}
           </div>
         </div>
       )}

--- a/src/components/gastown/drawer-panels/BeadPanel.tsx
+++ b/src/components/gastown/drawer-panels/BeadPanel.tsx
@@ -39,15 +39,6 @@ import remarkGfm from 'remark-gfm';
 
 const BEAD_STATUSES = ['open', 'in_progress', 'in_review', 'closed', 'failed'] as const;
 const BEAD_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const;
-const BEAD_TYPES = [
-  'issue',
-  'message',
-  'escalation',
-  'merge_request',
-  'convoy',
-  'molecule',
-  'agent',
-] as const;
 
 const STATUS_STYLES: Record<string, string> = {
   open: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
@@ -69,7 +60,6 @@ type EditState = {
   body: string;
   status: string;
   priority: string;
-  type: string;
   labels: string;
   metadata: string;
   rig_id: string;
@@ -111,7 +101,6 @@ export function BeadPanel({
     body: '',
     status: '',
     priority: '',
-    type: '',
     labels: '',
     metadata: '',
     rig_id: '',
@@ -125,7 +114,6 @@ export function BeadPanel({
       body: bead.body ?? '',
       status: bead.status,
       priority: bead.priority,
-      type: bead.type,
       labels: bead.labels.join(', '),
       metadata:
         bead.metadata && Object.keys(bead.metadata).length > 0
@@ -143,13 +131,21 @@ export function BeadPanel({
     setEditState(prev => ({ ...prev, [field]: value }));
   }, []);
 
-  const updateBeadMutation = useMutation(
+  const {
+    mutate: doUpdateBead,
+    isPending: isUpdatePending,
+    isError: isUpdateError,
+    error: updateError,
+  } = useMutation(
     trpc.gastown.updateBead.mutationOptions({
       onSuccess: () => {
         setEditing(false);
-        // Invalidate bead-related queries to refresh data
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.listBeads.queryKey({ rigId }) });
-        queryClient.invalidateQueries({ queryKey: trpc.gastown.getRig.queryKey({ rigId }) });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.listBeads.queryKey({ rigId }),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getRig.queryKey({ rigId }),
+        });
       },
     })
   );
@@ -165,8 +161,6 @@ export function BeadPanel({
     }
     if (editState.status !== bead.status) updates.status = editState.status;
     if (editState.priority !== bead.priority) updates.priority = editState.priority;
-    if (editState.type !== bead.type) updates.type = editState.type;
-
     const newLabels = editState.labels
       .split(',')
       .map(l => l.trim())
@@ -204,12 +198,12 @@ export function BeadPanel({
       return;
     }
 
-    updateBeadMutation.mutate({
+    doUpdateBead({
       rigId,
       beadId: bead.bead_id,
       ...updates,
-    } as Parameters<typeof updateBeadMutation.mutate>[0]);
-  }, [bead, editState, rigId, updateBeadMutation]);
+    } as Parameters<typeof doUpdateBead>[0]);
+  }, [bead, editState, rigId, doUpdateBead]);
 
   if (!bead) {
     return <div className="p-6 text-center text-sm text-white/30">Loading bead…</div>;
@@ -268,12 +262,6 @@ export function BeadPanel({
               label="Status"
             />
             <EditSelect
-              value={editState.type}
-              options={BEAD_TYPES}
-              onChange={v => updateField('type', v)}
-              label="Type"
-            />
-            <EditSelect
               value={editState.priority}
               options={BEAD_PRIORITIES}
               onChange={v => updateField('priority', v)}
@@ -283,20 +271,18 @@ export function BeadPanel({
               <Button
                 size="sm"
                 onClick={handleSave}
-                disabled={updateBeadMutation.isPending}
-                className="h-6 gap-1 bg-emerald-600 px-2.5 text-[10px] hover:bg-emerald-500"
+                disabled={isUpdatePending}
+                className="gap-1bg-[color:oklch(95%_0.15_108_/_0.90)] h-6 px-2.5 text-[10px] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
               >
-                {updateBeadMutation.isPending ? (
+                {isUpdatePending ? (
                   <Loader2 className="size-3 animate-spin" />
                 ) : (
                   <Save className="size-3" />
                 )}
                 Save
               </Button>
-              {updateBeadMutation.isError && (
-                <span className="text-[10px] text-red-400">
-                  {updateBeadMutation.error?.message ?? 'Failed'}
-                </span>
+              {isUpdateError && (
+                <span className="text-[10px] text-red-400">{updateError?.message ?? 'Failed'}</span>
               )}
             </div>
           </div>

--- a/src/lib/gastown/types/init.d.ts
+++ b/src/lib/gastown/types/init.d.ts
@@ -1,8 +1,50 @@
-/**
- * Generated from cloudflare-gastown/src/trpc/init.ts
- * Env replaced with Record<string, unknown> to avoid CF Worker type dependency.
- */
 export type TRPCContext = {
-  env: Record<string, unknown>;
-  userId: string;
+    env: Env;
+    userId: string;
+    isAdmin: boolean;
+    apiTokenPepper: string | null;
+    gastownAccess: boolean;
 };
+export declare const router: import("@trpc/server").TRPCRouterBuilder<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}>;
+/**
+ * Base procedure — requires a valid Kilo JWT (enforced by kiloAuthMiddleware
+ * running before tRPC). The userId is extracted from the JWT and set on the
+ * Hono context by kiloAuthMiddleware, then forwarded into the tRPC context
+ * by the createContext callback in gastown.worker.ts.
+ */
+export declare const procedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+    apiTokenPepper: string | null;
+    env: Env;
+    gastownAccess: boolean;
+    isAdmin: boolean;
+    userId: string;
+}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;
+/**
+ * Gastown access procedure — requires a valid JWT with `gastownAccess`
+ * (set by the token endpoint after PostHog flag evaluation). Falls back
+ * to `isAdmin` for backward compatibility with pre-migration tokens.
+ */
+export declare const gastownProcedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+    apiTokenPepper: string | null;
+    env: Env;
+    gastownAccess: boolean;
+    isAdmin: boolean;
+    userId: string;
+}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;
+/**
+ * Admin-only procedure — requires `isAdmin` on the JWT. Used for admin
+ * panel endpoints that bypass per-user ownership checks (e.g. town-wide
+ * bead/agent listing for support diagnostics).
+ */
+export declare const adminProcedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+    apiTokenPepper: string | null;
+    env: Env;
+    gastownAccess: boolean;
+    isAdmin: boolean;
+    userId: string;
+}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;

--- a/src/lib/gastown/types/init.d.ts
+++ b/src/lib/gastown/types/init.d.ts
@@ -1,15 +1,15 @@
 export type TRPCContext = {
-    env: Env;
-    userId: string;
-    isAdmin: boolean;
-    apiTokenPepper: string | null;
-    gastownAccess: boolean;
+  env: Env;
+  userId: string;
+  isAdmin: boolean;
+  apiTokenPepper: string | null;
+  gastownAccess: boolean;
 };
-export declare const router: import("@trpc/server").TRPCRouterBuilder<{
-    ctx: TRPCContext;
-    meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
-    transformer: false;
+export declare const router: import('@trpc/server').TRPCRouterBuilder<{
+  ctx: TRPCContext;
+  meta: object;
+  errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+  transformer: false;
 }>;
 /**
  * Base procedure — requires a valid Kilo JWT (enforced by kiloAuthMiddleware
@@ -17,34 +17,61 @@ export declare const router: import("@trpc/server").TRPCRouterBuilder<{
  * Hono context by kiloAuthMiddleware, then forwarded into the tRPC context
  * by the createContext callback in gastown.worker.ts.
  */
-export declare const procedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+export declare const procedure: import('@trpc/server').TRPCProcedureBuilder<
+  TRPCContext,
+  object,
+  {
     apiTokenPepper: string | null;
     env: Env;
     gastownAccess: boolean;
     isAdmin: boolean;
     userId: string;
-}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;
+  },
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  false
+>;
 /**
  * Gastown access procedure — requires a valid JWT with `gastownAccess`
  * (set by the token endpoint after PostHog flag evaluation). Falls back
  * to `isAdmin` for backward compatibility with pre-migration tokens.
  */
-export declare const gastownProcedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+export declare const gastownProcedure: import('@trpc/server').TRPCProcedureBuilder<
+  TRPCContext,
+  object,
+  {
     apiTokenPepper: string | null;
     env: Env;
     gastownAccess: boolean;
     isAdmin: boolean;
     userId: string;
-}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;
+  },
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  false
+>;
 /**
  * Admin-only procedure — requires `isAdmin` on the JWT. Used for admin
  * panel endpoints that bypass per-user ownership checks (e.g. town-wide
  * bead/agent listing for support diagnostics).
  */
-export declare const adminProcedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+export declare const adminProcedure: import('@trpc/server').TRPCProcedureBuilder<
+  TRPCContext,
+  object,
+  {
     apiTokenPepper: string | null;
     env: Env;
     gastownAccess: boolean;
     isAdmin: boolean;
     userId: string;
-}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;
+  },
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  import('@trpc/server').TRPCUnsetMarker,
+  false
+>;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,776 +1,856 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    createTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            name: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    createTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        name: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
     }>;
-    listTowns: import("@trpc/server").TRPCQueryProcedure<{
-        input: void;
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
+    listTowns: import('@trpc/server').TRPCQueryProcedure<{
+      input: void;
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getTown: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    createRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        name: string;
+        gitUrl: string;
+        defaultBranch?: string | undefined;
+        platformIntegrationId?: string | undefined;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    listRigs: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getRig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+        agents: {
+          id: string;
+          rig_id: string | null;
+          role: string;
+          name: string;
+          identity: string;
+          status: string;
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+          agent_status_message: string | null;
+          agent_status_updated_at: string | null;
         }[];
-        meta: object;
-    }>;
-    getTown: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    createRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    listRigs: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
+        beads: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    getRig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-            agents: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            }[];
-            beads: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            }[];
-        };
-        meta: object;
+    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: void;
-        meta: object;
+    listBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
     }>;
-    listBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    updateBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+        title?: string | undefined;
+        body?: string | null | undefined;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+        priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+        labels?: string[] | undefined;
+        metadata?: Record<string, unknown> | undefined;
+        rig_id?: string | null | undefined;
+        parent_bead_id?: string | null | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    listAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: string;
+        name: string;
+        identity: string;
+        status: string;
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+        agent_status_message: string | null;
+        agent_status_updated_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        agentId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    sling: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        title: string;
+        body?: string | undefined;
+        model?: string | undefined;
+      };
+      output: {
+        bead: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
+        agent: {
+          id: string;
+          rig_id: string | null;
+          role: string;
+          name: string;
+          identity: string;
+          status: string;
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+          agent_status_message: string | null;
+          agent_status_updated_at: string | null;
+        };
+      };
+      meta: object;
+    }>;
+    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        message: string;
+        model?: string | undefined;
+        rigId?: string | undefined;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
+    }>;
+    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        configured: boolean;
+        townId: string | null;
+        session: {
+          agentId: string;
+          sessionId: string;
+          status: 'active' | 'idle' | 'starting';
+          lastActivityAt: string;
+        } | null;
+      };
+      meta: object;
+    }>;
+    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
+        };
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
+        };
+        beads: {
+          open: number;
+          inProgress: number;
+          inReview: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-        };
-        output: void;
-        meta: object;
+    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
     }>;
-    updateBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-            title?: string | undefined;
-            body?: string | null | undefined;
-            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-            priority?: "critical" | "high" | "low" | "medium" | undefined;
-            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-            labels?: string[] | undefined;
-            metadata?: Record<string, unknown> | undefined;
-            rig_id?: string | null | undefined;
-            parent_bead_id?: string | null | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
+    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        agentId: string;
+        townId: string;
+      };
+      output: {
+        url: string;
+        ticket: string;
+      };
+      meta: object;
     }>;
-    listAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
+    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: {
+        pty: {
+          [x: string]: unknown;
+          id: string;
         };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
-        }[];
-        meta: object;
+        wsUrl: string;
+      };
+      meta: object;
     }>;
-    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            agentId: string;
-        };
-        output: void;
-        meta: object;
+    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+        ptyId: string;
+        cols: number;
+        rows: number;
+      };
+      output: void;
+      meta: object;
     }>;
-    sling: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            title: string;
-            body?: string | undefined;
-            model?: string | undefined;
+    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
         };
-        output: {
-            bead: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            agent: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            };
-        };
-        meta: object;
+        owner_user_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+      };
+      meta: object;
     }>;
-    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            message: string;
-            model?: string | undefined;
-            rigId?: string | undefined;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            configured: boolean;
-            townId: string | null;
-            session: {
-                agentId: string;
-                sessionId: string;
-                status: "active" | "idle" | "starting";
-                lastActivityAt: string;
-            } | null;
-        };
-        meta: object;
-    }>;
-    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
-            };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
-            };
-            beads: {
-                open: number;
-                inProgress: number;
-                inReview: number;
-                failed: number;
-                triageRequests: number;
-            };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
-            };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
-        };
-        meta: object;
-    }>;
-    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            agentId: string;
-            townId: string;
-        };
-        output: {
-            url: string;
-            ticket: string;
-        };
-        meta: object;
-    }>;
-    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: {
-            pty: {
-                [x: string]: unknown;
-                id: string;
-            };
-            wsUrl: string;
-        };
-        meta: object;
-    }>;
-    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-            ptyId: string;
-            cols: number;
-            rows: number;
-        };
-        output: void;
-        meta: object;
-    }>;
-    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
+    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        config: {
+          env_vars?: Record<string, string> | undefined;
+          git_auth?:
+            | {
                 github_token?: string | undefined;
                 gitlab_token?: string | undefined;
                 gitlab_instance_url?: string | undefined;
                 platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
+              }
+            | undefined;
+          owner_user_id?: string | undefined;
+          kilocode_token?: string | undefined;
+          default_model?: string | undefined;
+          small_model?: string | undefined;
+          max_polecats_per_rig?: number | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          refinery?:
+            | {
+                gates?: string[] | undefined;
+                auto_merge?: boolean | undefined;
+                require_clean_merge?: boolean | undefined;
+              }
+            | undefined;
+          alarm_interval_active?: number | undefined;
+          alarm_interval_idle?: number | undefined;
+          container?:
+            | {
                 sleep_after_minutes?: number | undefined;
-            } | undefined;
+              }
+            | undefined;
         };
-        meta: object;
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
+        };
+        owner_user_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+      };
+      meta: object;
     }>;
-    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            config: {
-                env_vars?: Record<string, string> | undefined;
-                git_auth?: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                } | undefined;
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy?: "direct" | "pr" | undefined;
-                refinery?: {
-                    gates?: string[] | undefined;
-                    auto_merge?: boolean | undefined;
-                    require_clean_merge?: boolean | undefined;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-            };
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
-                sleep_after_minutes?: number | undefined;
-            } | undefined;
-        };
-        meta: object;
+    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
     }>;
-    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
+    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
         }[];
-        meta: object;
-    }>;
-    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
         }[];
-        meta: object;
+      }[];
+      meta: object;
     }>;
-    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
+    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
         }[];
-        meta: object;
-    }>;
-    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        } | null;
-        meta: object;
-    }>;
-    adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
         }[];
-        meta: object;
+      } | null;
+      meta: object;
     }>;
-    adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
+    adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+        type?:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule'
+          | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: string;
+        name: string;
+        identity: string;
+        status: string;
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+        agent_status_message: string | null;
+        agent_status_updated_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
         };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
+        };
+        beads: {
+          open: number;
+          inProgress: number;
+          inReview: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
+    adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
     }>;
-    adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: void;
-        meta: object;
+    adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      } | null;
+      meta: object;
     }>;
-    adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
-    }>;
-    adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
-    }>;
-    adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
-            };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
-            };
-            beads: {
-                open: number;
-                inProgress: number;
-                inReview: number;
-                failed: number;
-                triageRequests: number;
-            };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
-            };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
-        };
-        meta: object;
-    }>;
-    adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-        }[];
-        meta: object;
-    }>;
-    adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        } | null;
-        meta: object;
-    }>;
-}>>;
+  }>
+>;
 export type GastownRouter = typeof gastownRouter;
 /**
  * Wrapped router that nests gastownRouter under a `gastown` key.
@@ -778,783 +858,866 @@ export type GastownRouter = typeof gastownRouter;
  * matching the existing RootRouter shape so components don't need
  * to change their procedure paths.
  */
-export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    gastown: import("@trpc/server").TRPCBuiltRouter<{
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    gastown: import('@trpc/server').TRPCBuiltRouter<
+      {
         ctx: TRPCContext;
         meta: object;
-        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
         transformer: false;
-    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-        createTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                name: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
+      },
+      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+        createTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            name: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
         }>;
-        listTowns: import("@trpc/server").TRPCQueryProcedure<{
-            input: void;
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
+        listTowns: import('@trpc/server').TRPCQueryProcedure<{
+          input: void;
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getTown: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        createRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        listRigs: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getRig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+            agents: {
+              id: string;
+              rig_id: string | null;
+              role: string;
+              name: string;
+              identity: string;
+              status: string;
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+              agent_status_message: string | null;
+              agent_status_updated_at: string | null;
             }[];
-            meta: object;
-        }>;
-        getTown: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        createRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                name: string;
-                gitUrl: string;
-                defaultBranch?: string | undefined;
-                platformIntegrationId?: string | undefined;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        listRigs: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
+            beads: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        getRig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-                agents: {
-                    id: string;
-                    rig_id: string | null;
-                    role: string;
-                    name: string;
-                    identity: string;
-                    status: string;
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                    agent_status_message: string | null;
-                    agent_status_updated_at: string | null;
-                }[];
-                beads: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                }[];
-            };
-            meta: object;
+        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: void;
-            meta: object;
+        listBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
         }>;
-        listBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        updateBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+            title?: string | undefined;
+            body?: string | null | undefined;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+            priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+            labels?: string[] | undefined;
+            metadata?: Record<string, unknown> | undefined;
+            rig_id?: string | null | undefined;
+            parent_bead_id?: string | null | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        listAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            agentId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        sling: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            title: string;
+            body?: string | undefined;
+            model?: string | undefined;
+          };
+          output: {
+            bead: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
+            agent: {
+              id: string;
+              rig_id: string | null;
+              role: string;
+              name: string;
+              identity: string;
+              status: string;
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+              agent_status_message: string | null;
+              agent_status_updated_at: string | null;
+            };
+          };
+          meta: object;
+        }>;
+        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            message: string;
+            model?: string | undefined;
+            rigId?: string | undefined;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
+        }>;
+        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            configured: boolean;
+            townId: string | null;
+            session: {
+              agentId: string;
+              sessionId: string;
+              status: 'active' | 'idle' | 'starting';
+              lastActivityAt: string;
+            } | null;
+          };
+          meta: object;
+        }>;
+        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
+            };
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
+            };
+            beads: {
+              open: number;
+              inProgress: number;
+              inReview: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-            };
-            output: void;
-            meta: object;
+        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
         }>;
-        updateBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-                title?: string | undefined;
-                body?: string | null | undefined;
-                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-                priority?: "critical" | "high" | "low" | "medium" | undefined;
-                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-                labels?: string[] | undefined;
-                metadata?: Record<string, unknown> | undefined;
-                rig_id?: string | null | undefined;
-                parent_bead_id?: string | null | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
+        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            agentId: string;
+            townId: string;
+          };
+          output: {
+            url: string;
+            ticket: string;
+          };
+          meta: object;
         }>;
-        listAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
+        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: {
+            pty: {
+              [x: string]: unknown;
+              id: string;
             };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            }[];
-            meta: object;
+            wsUrl: string;
+          };
+          meta: object;
         }>;
-        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                agentId: string;
-            };
-            output: void;
-            meta: object;
+        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+            ptyId: string;
+            cols: number;
+            rows: number;
+          };
+          output: void;
+          meta: object;
         }>;
-        sling: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                title: string;
-                body?: string | undefined;
-                model?: string | undefined;
+        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
             };
-            output: {
-                bead: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                };
-                agent: {
-                    id: string;
-                    rig_id: string | null;
-                    role: string;
-                    name: string;
-                    identity: string;
-                    status: string;
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                    agent_status_message: string | null;
-                    agent_status_updated_at: string | null;
-                };
-            };
-            meta: object;
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+          };
+          meta: object;
         }>;
-        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                message: string;
-                model?: string | undefined;
-                rigId?: string | undefined;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                configured: boolean;
-                townId: string | null;
-                session: {
-                    agentId: string;
-                    sessionId: string;
-                    status: "active" | "idle" | "starting";
-                    lastActivityAt: string;
-                } | null;
-            };
-            meta: object;
-        }>;
-        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
-                };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
-                };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    inReview: number;
-                    failed: number;
-                    triageRequests: number;
-                };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
-                };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
-            };
-            meta: object;
-        }>;
-        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                agentId: string;
-                townId: string;
-            };
-            output: {
-                url: string;
-                ticket: string;
-            };
-            meta: object;
-        }>;
-        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: {
-                pty: {
-                    [x: string]: unknown;
-                    id: string;
-                };
-                wsUrl: string;
-            };
-            meta: object;
-        }>;
-        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-                ptyId: string;
-                cols: number;
-                rows: number;
-            };
-            output: void;
-            meta: object;
-        }>;
-        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
+        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            config: {
+              env_vars?: Record<string, string> | undefined;
+              git_auth?:
+                | {
                     github_token?: string | undefined;
                     gitlab_token?: string | undefined;
                     gitlab_instance_url?: string | undefined;
                     platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
+                  }
+                | undefined;
+              owner_user_id?: string | undefined;
+              kilocode_token?: string | undefined;
+              default_model?: string | undefined;
+              small_model?: string | undefined;
+              max_polecats_per_rig?: number | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              refinery?:
+                | {
+                    gates?: string[] | undefined;
+                    auto_merge?: boolean | undefined;
+                    require_clean_merge?: boolean | undefined;
+                  }
+                | undefined;
+              alarm_interval_active?: number | undefined;
+              alarm_interval_idle?: number | undefined;
+              container?:
+                | {
                     sleep_after_minutes?: number | undefined;
-                } | undefined;
+                  }
+                | undefined;
             };
-            meta: object;
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+          };
+          meta: object;
         }>;
-        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                config: {
-                    env_vars?: Record<string, string> | undefined;
-                    git_auth?: {
-                        github_token?: string | undefined;
-                        gitlab_token?: string | undefined;
-                        gitlab_instance_url?: string | undefined;
-                        platform_integration_id?: string | undefined;
-                    } | undefined;
-                    owner_user_id?: string | undefined;
-                    kilocode_token?: string | undefined;
-                    default_model?: string | undefined;
-                    small_model?: string | undefined;
-                    max_polecats_per_rig?: number | undefined;
-                    merge_strategy?: "direct" | "pr" | undefined;
-                    refinery?: {
-                        gates?: string[] | undefined;
-                        auto_merge?: boolean | undefined;
-                        require_clean_merge?: boolean | undefined;
-                    } | undefined;
-                    alarm_interval_active?: number | undefined;
-                    alarm_interval_idle?: number | undefined;
-                    container?: {
-                        sleep_after_minutes?: number | undefined;
-                    } | undefined;
-                };
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-            };
-            meta: object;
+        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
         }>;
-        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
+        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
             }[];
-            meta: object;
-        }>;
-        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
             }[];
-            meta: object;
+          }[];
+          meta: object;
         }>;
-        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
+        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
             }[];
-            meta: object;
-        }>;
-        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            } | null;
-            meta: object;
-        }>;
-        adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
             }[];
-            meta: object;
+          } | null;
+          meta: object;
         }>;
-        adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
+        adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+            type?:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule'
+              | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
             };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
+            };
+            beads: {
+              open: number;
+              inProgress: number;
+              inReview: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
+        adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
         }>;
-        adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: void;
-            meta: object;
+        adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          } | null;
+          meta: object;
         }>;
-        adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
-        }>;
-        adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
-        }>;
-        adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
-                };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
-                };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    inReview: number;
-                    failed: number;
-                    triageRequests: number;
-                };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
-                };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
-            };
-            meta: object;
-        }>;
-        adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
-            }[];
-            meta: object;
-        }>;
-        adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            } | null;
-            meta: object;
-        }>;
-    }>>;
-}>>;
+      }>
+    >;
+  }>
+>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,664 +1,63 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
+export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
     ctx: TRPCContext;
     meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
     transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    createTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        name: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listTowns: import('@trpc/server').TRPCQueryProcedure<{
-      input: void;
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getTown: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    createRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        name: string;
-        gitUrl: string;
-        defaultBranch?: string | undefined;
-        platformIntegrationId?: string | undefined;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listRigs: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getRig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-        agents: {
-          id: string;
-          rig_id: string | null;
-          role: string;
-          name: string;
-          identity: string;
-          status: string;
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-          agent_status_message?: string | null;
-          agent_status_updated_at?: string | null;
-        }[];
-        beads: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
-        }[];
-      };
-      meta: object;
-    }>;
-    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listBeads: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        beadId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listAgents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        rig_id: string | null;
-        role: string;
-        name: string;
-        identity: string;
-        status: string;
-        current_hook_bead_id: string | null;
-        dispatch_attempts: number;
-        last_activity_at: string | null;
-        checkpoint?: unknown;
-        created_at: string;
-        agent_status_message?: string | null;
-        agent_status_updated_at?: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        agentId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    sling: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        title: string;
-        body?: string | undefined;
-        model?: string | undefined;
-      };
-      output: {
-        bead: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    createTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            name: string;
         };
-        agent: {
-          id: string;
-          rig_id: string | null;
-          role: string;
-          name: string;
-          identity: string;
-          status: string;
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-          agent_status_message?: string | null;
-          agent_status_updated_at?: string | null;
+        output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
         };
-      };
-      meta: object;
-    }>;
-    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        message: string;
-        model?: string | undefined;
-        rigId?: string | undefined;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        configured: boolean;
-        townId: string | null;
-        session: {
-          agentId: string;
-          sessionId: string;
-          status: 'active' | 'idle' | 'starting';
-          lastActivityAt: string;
-        } | null;
-      };
-      meta: object;
-    }>;
-    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        alarm: {
-          nextFireAt: string | null;
-          intervalMs: number;
-          intervalLabel: string;
-        };
-        agents: {
-          working: number;
-          idle: number;
-          stalled: number;
-          dead: number;
-          total: number;
-        };
-        beads: {
-          open: number;
-          inProgress: number;
-          inReview: number;
-          failed: number;
-          triageRequests: number;
-        };
-        patrol: {
-          guppWarnings: number;
-          guppEscalations: number;
-          stalledAgents: number;
-          orphanedHooks: number;
-        };
-        recentEvents: {
-          time: string;
-          type: string;
-          message: string;
-        }[];
-      };
-      meta: object;
-    }>;
-    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        agentId: string;
-        townId: string;
-      };
-      output: {
-        url: string;
-        ticket: string;
-      };
-      meta: object;
-    }>;
-    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-      };
-      output: {
-        pty: {
-          [x: string]: unknown;
-          id: string;
-        };
-        wsUrl: string;
-      };
-      meta: object;
-    }>;
-    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-        ptyId: string;
-        cols: number;
-        rows: number;
-      };
-      output: void;
-      meta: object;
-    }>;
-    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
-        };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-      };
-      meta: object;
-    }>;
-    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        config: {
-          env_vars?: Record<string, string> | undefined;
-          git_auth?:
-            | {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-              }
-            | undefined;
-          owner_user_id?: string | undefined;
-          kilocode_token?: string | undefined;
-          default_model?: string | undefined;
-          small_model?: string | undefined;
-          max_polecats_per_rig?: number | undefined;
-          merge_strategy?: 'direct' | 'pr' | undefined;
-          refinery?:
-            | {
-                gates?: string[] | undefined;
-                auto_merge?: boolean | undefined;
-                require_clean_merge?: boolean | undefined;
-              }
-            | undefined;
-          alarm_interval_active?: number | undefined;
-          alarm_interval_idle?: number | undefined;
-          container?:
-            | {
-                sleep_after_minutes?: number | undefined;
-              }
-            | undefined;
-        };
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
-        };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-      };
-      meta: object;
-    }>;
-    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        beadId?: string | undefined;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      }[];
-      meta: object;
-    }>;
-    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        convoyId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      } | null;
-      meta: object;
-    }>;
-  }>
->;
-export type GastownRouter = typeof gastownRouter;
-/**
- * Wrapped router that nests gastownRouter under a `gastown` key.
- * This preserves the `trpc.gastown.X` call pattern on the frontend,
- * matching the existing RootRouter shape so components don't need
- * to change their procedure paths.
- */
-export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
-    ctx: TRPCContext;
-    meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
-    transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    gastown: import('@trpc/server').TRPCBuiltRouter<
-      {
-        ctx: TRPCContext;
         meta: object;
-        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
-        transformer: false;
-      },
-      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-        createTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            name: string;
-          };
-          output: {
+    }>;
+    listTowns: import("@trpc/server").TRPCQueryProcedure<{
+        input: void;
+        output: {
             id: string;
             name: string;
             owner_user_id: string;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        listTowns: import('@trpc/server').TRPCQueryProcedure<{
-          input: void;
-          output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getTown: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getTown: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             name: string;
             owner_user_id: string;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        createRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    createRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             name: string;
             gitUrl: string;
             defaultBranch?: string | undefined;
             platformIntegrationId?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -667,14 +66,14 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        listRigs: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    listRigs: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -683,14 +82,14 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getRig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getRig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -700,98 +99,117 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             updated_at: string;
             agents: {
-              id: string;
-              rig_id: string | null;
-              role: string;
-              name: string;
-              identity: string;
-              status: string;
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
-              agent_status_message?: string | null;
-              agent_status_updated_at?: string | null;
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
             }[];
             beads: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             }[];
-          };
-          meta: object;
-        }>;
-        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listBeads: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    listBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-          };
-          output: {
+            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+        };
+        output: {
             bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
             title: string;
             body: string | null;
             rig_id: string | null;
             parent_bead_id: string | null;
             assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
+            priority: "critical" | "high" | "low" | "medium";
             labels: string[];
             metadata: Record<string, unknown>;
             created_by: string | null;
             created_at: string;
             updated_at: string;
             closed_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             beadId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listAgents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    updateBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
-          };
-          output: {
+            beadId: string;
+            title?: string | undefined;
+            body?: string | null | undefined;
+            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+            priority?: "critical" | "high" | "low" | "medium" | undefined;
+            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+            labels?: string[] | undefined;
+            metadata?: Record<string, unknown> | undefined;
+            rig_id?: string | null | undefined;
+            parent_bead_id?: string | null | undefined;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    listAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            rigId: string;
+        };
+        output: {
             id: string;
             rig_id: string | null;
             role: string;
@@ -803,291 +221,270 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             last_activity_at: string | null;
             checkpoint?: unknown;
             created_at: string;
-            agent_status_message?: string | null;
-            agent_status_updated_at?: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             agentId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        sling: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    sling: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             title: string;
             body?: string | undefined;
             model?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             bead: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             };
             agent: {
-              id: string;
-              rig_id: string | null;
-              role: string;
-              name: string;
-              identity: string;
-              status: string;
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
-              agent_status_message?: string | null;
-              agent_status_updated_at?: string | null;
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
             };
-          };
-          meta: object;
-        }>;
-        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             message: string;
             model?: string | undefined;
             rigId?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             configured: boolean;
             townId: string | null;
             session: {
-              agentId: string;
-              sessionId: string;
-              status: 'active' | 'idle' | 'starting';
-              lastActivityAt: string;
+                agentId: string;
+                sessionId: string;
+                status: "active" | "idle" | "starting";
+                lastActivityAt: string;
             } | null;
-          };
-          meta: object;
-        }>;
-        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             alarm: {
-              nextFireAt: string | null;
-              intervalMs: number;
-              intervalLabel: string;
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
             };
             agents: {
-              working: number;
-              idle: number;
-              stalled: number;
-              dead: number;
-              total: number;
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
             };
             beads: {
-              open: number;
-              inProgress: number;
-              inReview: number;
-              failed: number;
-              triageRequests: number;
+                open: number;
+                inProgress: number;
+                inReview: number;
+                failed: number;
+                triageRequests: number;
             };
             patrol: {
-              guppWarnings: number;
-              guppEscalations: number;
-              stalledAgents: number;
-              orphanedHooks: number;
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
             };
             recentEvents: {
-              time: string;
-              type: string;
-              message: string;
+                time: string;
+                type: string;
+                message: string;
             }[];
-          };
-          meta: object;
-        }>;
-        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             agentId: string;
             townId: string;
-          };
-          output: {
+        };
+        output: {
             url: string;
             ticket: string;
-          };
-          meta: object;
-        }>;
-        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             agentId: string;
-          };
-          output: {
+        };
+        output: {
             pty: {
-              [x: string]: unknown;
-              id: string;
+                [x: string]: unknown;
+                id: string;
             };
             wsUrl: string;
-          };
-          meta: object;
-        }>;
-        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             agentId: string;
             ptyId: string;
             cols: number;
             rows: number;
-          };
-          output: void;
-          meta: object;
-        }>;
-        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             env_vars: Record<string, string>;
             git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
             };
             owner_user_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
             alarm_interval_active?: number | undefined;
             alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
-          };
-          meta: object;
-        }>;
-        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
+        };
+        meta: object;
+    }>;
+    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             config: {
-              env_vars?: Record<string, string> | undefined;
-              git_auth?:
-                | {
+                env_vars?: Record<string, string> | undefined;
+                git_auth?: {
                     github_token?: string | undefined;
                     gitlab_token?: string | undefined;
                     gitlab_instance_url?: string | undefined;
                     platform_integration_id?: string | undefined;
-                  }
-                | undefined;
-              owner_user_id?: string | undefined;
-              kilocode_token?: string | undefined;
-              default_model?: string | undefined;
-              small_model?: string | undefined;
-              max_polecats_per_rig?: number | undefined;
-              merge_strategy?: 'direct' | 'pr' | undefined;
-              refinery?:
-                | {
+                } | undefined;
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy?: "direct" | "pr" | undefined;
+                refinery?: {
                     gates?: string[] | undefined;
                     auto_merge?: boolean | undefined;
                     require_clean_merge?: boolean | undefined;
-                  }
-                | undefined;
-              alarm_interval_active?: number | undefined;
-              alarm_interval_idle?: number | undefined;
-              container?:
-                | {
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
                     sleep_after_minutes?: number | undefined;
-                  }
-                | undefined;
+                } | undefined;
             };
-          };
-          output: {
+        };
+        output: {
             env_vars: Record<string, string>;
             git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
             };
             owner_user_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
             alarm_interval_active?: number | undefined;
             alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
-          };
-          meta: object;
-        }>;
-        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
+        };
+        meta: object;
+    }>;
+    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
             beadId?: string | undefined;
             since?: string | undefined;
             limit?: number | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -1098,16 +495,16 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             rig_id?: string | undefined;
             rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
             since?: string | undefined;
             limit?: number | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -1118,17 +515,17 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             rig_id?: string | undefined;
             rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             title: string;
-            status: 'active' | 'landed';
+            status: "active" | "landed";
             total_beads: number;
             closed_beads: number;
             created_by: string | null;
@@ -1137,28 +534,28 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             feature_branch: string | null;
             merge_mode: string | null;
             beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
             }[];
             dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
+                bead_id: string;
+                depends_on_bead_id: string;
             }[];
-          }[];
-          meta: object;
-        }>;
-        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             convoyId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             title: string;
-            status: 'active' | 'landed';
+            status: "active" | "landed";
             total_beads: number;
             closed_beads: number;
             created_by: string | null;
@@ -1167,21 +564,997 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             feature_branch: string | null;
             merge_mode: string | null;
             beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
             }[];
             dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
+                bead_id: string;
+                depends_on_bead_id: string;
             }[];
-          } | null;
-          meta: object;
+        } | null;
+        meta: object;
+    }>;
+    adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            agentId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            alarm: {
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
+            };
+            agents: {
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
+            };
+            beads: {
+                open: number;
+                inProgress: number;
+                inReview: number;
+                failed: number;
+                triageRequests: number;
+            };
+            patrol: {
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
+            };
+            recentEvents: {
+                time: string;
+                type: string;
+                message: string;
+            }[];
+        };
+        meta: object;
+    }>;
+    adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+        }[];
+        meta: object;
+    }>;
+    adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        } | null;
+        meta: object;
+    }>;
+}>>;
+export type GastownRouter = typeof gastownRouter;
+/**
+ * Wrapped router that nests gastownRouter under a `gastown` key.
+ * This preserves the `trpc.gastown.X` call pattern on the frontend,
+ * matching the existing RootRouter shape so components don't need
+ * to change their procedure paths.
+ */
+export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    gastown: import("@trpc/server").TRPCBuiltRouter<{
+        ctx: TRPCContext;
+        meta: object;
+        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        transformer: false;
+    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+        createTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                name: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
         }>;
-      }>
-    >;
-  }>
->;
+        listTowns: import("@trpc/server").TRPCQueryProcedure<{
+            input: void;
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getTown: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        createRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                name: string;
+                gitUrl: string;
+                defaultBranch?: string | undefined;
+                platformIntegrationId?: string | undefined;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        listRigs: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getRig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+                agents: {
+                    id: string;
+                    rig_id: string | null;
+                    role: string;
+                    name: string;
+                    identity: string;
+                    status: string;
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                    agent_status_message: string | null;
+                    agent_status_updated_at: string | null;
+                }[];
+                beads: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                }[];
+            };
+            meta: object;
+        }>;
+        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        listBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        updateBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
+                title?: string | undefined;
+                body?: string | null | undefined;
+                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+                priority?: "critical" | "high" | "low" | "medium" | undefined;
+                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+                labels?: string[] | undefined;
+                metadata?: Record<string, unknown> | undefined;
+                rig_id?: string | null | undefined;
+                parent_bead_id?: string | null | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        listAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                agentId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        sling: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                title: string;
+                body?: string | undefined;
+                model?: string | undefined;
+            };
+            output: {
+                bead: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                };
+                agent: {
+                    id: string;
+                    rig_id: string | null;
+                    role: string;
+                    name: string;
+                    identity: string;
+                    status: string;
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                    agent_status_message: string | null;
+                    agent_status_updated_at: string | null;
+                };
+            };
+            meta: object;
+        }>;
+        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                message: string;
+                model?: string | undefined;
+                rigId?: string | undefined;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                configured: boolean;
+                townId: string | null;
+                session: {
+                    agentId: string;
+                    sessionId: string;
+                    status: "active" | "idle" | "starting";
+                    lastActivityAt: string;
+                } | null;
+            };
+            meta: object;
+        }>;
+        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    inReview: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                agentId: string;
+                townId: string;
+            };
+            output: {
+                url: string;
+                ticket: string;
+            };
+            meta: object;
+        }>;
+        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+            };
+            output: {
+                pty: {
+                    [x: string]: unknown;
+                    id: string;
+                };
+                wsUrl: string;
+            };
+            meta: object;
+        }>;
+        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+                ptyId: string;
+                cols: number;
+                rows: number;
+            };
+            output: void;
+            meta: object;
+        }>;
+        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+            };
+            meta: object;
+        }>;
+        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                config: {
+                    env_vars?: Record<string, string> | undefined;
+                    git_auth?: {
+                        github_token?: string | undefined;
+                        gitlab_token?: string | undefined;
+                        gitlab_instance_url?: string | undefined;
+                        platform_integration_id?: string | undefined;
+                    } | undefined;
+                    owner_user_id?: string | undefined;
+                    kilocode_token?: string | undefined;
+                    default_model?: string | undefined;
+                    small_model?: string | undefined;
+                    max_polecats_per_rig?: number | undefined;
+                    merge_strategy?: "direct" | "pr" | undefined;
+                    refinery?: {
+                        gates?: string[] | undefined;
+                        auto_merge?: boolean | undefined;
+                        require_clean_merge?: boolean | undefined;
+                    } | undefined;
+                    alarm_interval_active?: number | undefined;
+                    alarm_interval_idle?: number | undefined;
+                    container?: {
+                        sleep_after_minutes?: number | undefined;
+                    } | undefined;
+                };
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+            };
+            meta: object;
+        }>;
+        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            }[];
+            meta: object;
+        }>;
+        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
+        }>;
+        adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    inReview: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            } | null;
+            meta: object;
+        }>;
+    }>>;
+}>>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,12 +1,16 @@
 import { z } from 'zod';
-export declare const TownOutput: z.ZodObject<{
+export declare const TownOutput: z.ZodObject<
+  {
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const RigOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const RigOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -15,24 +19,27 @@ export declare const RigOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const BeadOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadOutput: z.ZodObject<
+  {
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
+      agent: 'agent';
+      convoy: 'convoy';
+      escalation: 'escalation';
+      issue: 'issue';
+      merge_request: 'merge_request';
+      message: 'message';
+      molecule: 'molecule';
     }>;
     status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        in_review: "in_review";
-        open: "open";
+      closed: 'closed';
+      failed: 'failed';
+      in_progress: 'in_progress';
+      in_review: 'in_review';
+      open: 'open';
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -40,10 +47,10 @@ export declare const BeadOutput: z.ZodObject<{
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
+      critical: 'critical';
+      high: 'high';
+      low: 'low';
+      medium: 'medium';
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -51,23 +58,36 @@ export declare const BeadOutput: z.ZodObject<{
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const AgentOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const AgentOutput: z.ZodObject<
+  {
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<[z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>, z.ZodString]>;
+    role: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          mayor: 'mayor';
+          polecat: 'polecat';
+          refinery: 'refinery';
+        }>,
+        z.ZodString,
+      ]
+    >;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodUnion<[z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>, z.ZodString]>;
+    status: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          dead: 'dead';
+          idle: 'idle';
+          stalled: 'stalled';
+          working: 'working';
+        }>,
+        z.ZodString,
+      ]
+    >;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
@@ -75,8 +95,11 @@ export declare const AgentOutput: z.ZodObject<{
     created_at: z.ZodString;
     agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-}, z.core.$strip>;
-export declare const BeadEventOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadEventOutput: z.ZodObject<
+  {
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -87,45 +110,68 @@ export declare const BeadEventOutput: z.ZodObject<{
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>;
-export declare const MayorSendResultOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorSendResultOutput: z.ZodObject<
+  {
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
+      active: 'active';
+      idle: 'idle';
+      starting: 'starting';
     }>;
-}, z.core.$strip>;
-export declare const MayorStatusOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorStatusOutput: z.ZodObject<
+  {
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const StreamTicketOutput: z.ZodObject<{
+    session: z.ZodNullable<
+      z.ZodObject<
+        {
+          agentId: z.ZodString;
+          sessionId: z.ZodString;
+          status: z.ZodEnum<{
+            active: 'active';
+            idle: 'idle';
+            starting: 'starting';
+          }>;
+          lastActivityAt: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const StreamTicketOutput: z.ZodObject<
+  {
     url: z.ZodString;
     ticket: z.ZodString;
-}, z.core.$strip>;
-export declare const PtySessionOutput: z.ZodObject<{
-    pty: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const PtySessionOutput: z.ZodObject<
+  {
+    pty: z.ZodObject<
+      {
         id: z.ZodString;
-    }, z.core.$loose>;
+      },
+      z.core.$loose
+    >;
     wsUrl: z.ZodString;
-}, z.core.$strip>;
-export declare const ConvoyOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -134,13 +180,16 @@ export declare const ConvoyOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const ConvoyDetailOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -149,36 +198,50 @@ export declare const ConvoyDetailOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const SlingResultOutput: z.ZodObject<{
-    bead: z.ZodObject<{
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          title: z.ZodString;
+          status: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_name: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+    dependency_edges: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          depends_on_bead_id: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const SlingResultOutput: z.ZodObject<
+  {
+    bead: z.ZodObject<
+      {
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
+          agent: 'agent';
+          convoy: 'convoy';
+          escalation: 'escalation';
+          issue: 'issue';
+          merge_request: 'merge_request';
+          message: 'message';
+          molecule: 'molecule';
         }>;
         status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
+          closed: 'closed';
+          failed: 'failed';
+          in_progress: 'in_progress';
+          in_review: 'in_review';
+          open: 'open';
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -186,10 +249,10 @@ export declare const SlingResultOutput: z.ZodObject<{
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
+          critical: 'critical';
+          high: 'high';
+          low: 'low';
+          medium: 'medium';
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -197,23 +260,36 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+    agent: z.ZodObject<
+      {
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
+        role: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              mayor: 'mayor';
+              polecat: 'polecat';
+              refinery: 'refinery';
+            }>,
+            z.ZodString,
+          ]
+        >;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
+        status: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              dead: 'dead';
+              idle: 'idle';
+              stalled: 'stalled';
+              working: 'working';
+            }>,
+            z.ZodString,
+          ]
+        >;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
@@ -221,9 +297,14 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
         agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>;
-}, z.core.$strip>;
-export declare const RigDetailOutput: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RigDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -232,390 +313,577 @@ export declare const RigDetailOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    name: z.ZodString;
-    owner_user_id: z.ZodString;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_id: z.ZodString;
-    type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
-    }>;
-    status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        in_review: "in_review";
-        open: "open";
-    }>;
-    title: z.ZodString;
-    body: z.ZodNullable<z.ZodString>;
-    rig_id: z.ZodNullable<z.ZodString>;
-    parent_bead_id: z.ZodNullable<z.ZodString>;
-    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-    priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
-    }>;
-    labels: z.ZodArray<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<[z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>, z.ZodString]>;
-    name: z.ZodString;
-    identity: z.ZodString;
-    status: z.ZodUnion<[z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>, z.ZodString]>;
-    current_hook_bead_id: z.ZodNullable<z.ZodString>;
-    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-    last_activity_at: z.ZodNullable<z.ZodString>;
-    checkpoint: z.ZodOptional<z.ZodUnknown>;
-    created_at: z.ZodString;
-    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-}, z.core.$strip>>;
-export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_event_id: z.ZodString;
-    bead_id: z.ZodString;
-    agent_id: z.ZodNullable<z.ZodString>;
-    event_type: z.ZodString;
-    old_value: z.ZodNullable<z.ZodString>;
-    new_value: z.ZodNullable<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_at: z.ZodString;
-    rig_id: z.ZodOptional<z.ZodString>;
-    rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    agentId: z.ZodString;
-    sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
-    }>;
-}, z.core.$strip>>;
-export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    configured: z.ZodBoolean;
-    townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    url: z.ZodString;
-    ticket: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    pty: z.ZodObject<{
-        id: z.ZodString;
-    }, z.core.$loose>;
-    wsUrl: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead: z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>;
-}, z.core.$strip>>;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    alarm: z.ZodObject<{
-        nextFireAt: z.ZodNullable<z.ZodString>;
-        intervalMs: z.ZodNumber;
-        intervalLabel: z.ZodString;
-    }, z.core.$strip>;
-    agents: z.ZodObject<{
-        working: z.ZodNumber;
-        idle: z.ZodNumber;
-        stalled: z.ZodNumber;
-        dead: z.ZodNumber;
-        total: z.ZodNumber;
-    }, z.core.$strip>;
-    beads: z.ZodObject<{
-        open: z.ZodNumber;
-        inProgress: z.ZodNumber;
-        inReview: z.ZodNumber;
-        failed: z.ZodNumber;
-        triageRequests: z.ZodNumber;
-    }, z.core.$strip>;
-    patrol: z.ZodObject<{
-        guppWarnings: z.ZodNumber;
-        guppEscalations: z.ZodNumber;
-        stalledAgents: z.ZodNumber;
-        orphanedHooks: z.ZodNumber;
-    }, z.core.$strip>;
-    recentEvents: z.ZodArray<z.ZodObject<{
-        time: z.ZodString;
-        type: z.ZodString;
-        message: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
+    agents: z.ZodArray<
+      z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        },
+        z.core.$strip
+      >
+    >;
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            in_review: 'in_review';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RpcTownOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      name: z.ZodString;
+      owner_user_id: z.ZodString;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_id: z.ZodString;
+      type: z.ZodEnum<{
+        agent: 'agent';
+        convoy: 'convoy';
+        escalation: 'escalation';
+        issue: 'issue';
+        merge_request: 'merge_request';
+        message: 'message';
+        molecule: 'molecule';
+      }>;
+      status: z.ZodEnum<{
+        closed: 'closed';
+        failed: 'failed';
+        in_progress: 'in_progress';
+        in_review: 'in_review';
+        open: 'open';
+      }>;
+      title: z.ZodString;
+      body: z.ZodNullable<z.ZodString>;
+      rig_id: z.ZodNullable<z.ZodString>;
+      parent_bead_id: z.ZodNullable<z.ZodString>;
+      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+      priority: z.ZodEnum<{
+        critical: 'critical';
+        high: 'high';
+        low: 'low';
+        medium: 'medium';
+      }>;
+      labels: z.ZodArray<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      closed_at: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAgentOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      rig_id: z.ZodNullable<z.ZodString>;
+      role: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            mayor: 'mayor';
+            polecat: 'polecat';
+            refinery: 'refinery';
+          }>,
+          z.ZodString,
+        ]
+      >;
+      name: z.ZodString;
+      identity: z.ZodString;
+      status: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            dead: 'dead';
+            idle: 'idle';
+            stalled: 'stalled';
+            working: 'working';
+          }>,
+          z.ZodString,
+        ]
+      >;
+      current_hook_bead_id: z.ZodNullable<z.ZodString>;
+      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+      last_activity_at: z.ZodNullable<z.ZodString>;
+      checkpoint: z.ZodOptional<z.ZodUnknown>;
+      created_at: z.ZodString;
+      agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadEventOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_event_id: z.ZodString;
+      bead_id: z.ZodString;
+      agent_id: z.ZodNullable<z.ZodString>;
+      event_type: z.ZodString;
+      old_value: z.ZodNullable<z.ZodString>;
+      new_value: z.ZodNullable<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_at: z.ZodString;
+      rig_id: z.ZodOptional<z.ZodString>;
+      rig_name: z.ZodOptional<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      agentId: z.ZodString;
+      sessionStatus: z.ZodEnum<{
+        active: 'active';
+        idle: 'idle';
+        starting: 'starting';
+      }>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      configured: z.ZodBoolean;
+      townId: z.ZodNullable<z.ZodString>;
+      session: z.ZodNullable<
+        z.ZodObject<
+          {
+            agentId: z.ZodString;
+            sessionId: z.ZodString;
+            status: z.ZodEnum<{
+              active: 'active';
+              idle: 'idle';
+              starting: 'starting';
+            }>;
+            lastActivityAt: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      url: z.ZodString;
+      ticket: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcPtySessionOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      pty: z.ZodObject<
+        {
+          id: z.ZodString;
+        },
+        z.core.$loose
+      >;
+      wsUrl: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            title: z.ZodString;
+            status: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_name: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+      dependency_edges: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            depends_on_bead_id: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcSlingResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead: z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            in_review: 'in_review';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >;
+      agent: z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        },
+        z.core.$strip
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      alarm: z.ZodObject<
+        {
+          nextFireAt: z.ZodNullable<z.ZodString>;
+          intervalMs: z.ZodNumber;
+          intervalLabel: z.ZodString;
+        },
+        z.core.$strip
+      >;
+      agents: z.ZodObject<
+        {
+          working: z.ZodNumber;
+          idle: z.ZodNumber;
+          stalled: z.ZodNumber;
+          dead: z.ZodNumber;
+          total: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      beads: z.ZodObject<
+        {
+          open: z.ZodNumber;
+          inProgress: z.ZodNumber;
+          inReview: z.ZodNumber;
+          failed: z.ZodNumber;
+          triageRequests: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      patrol: z.ZodObject<
+        {
+          guppWarnings: z.ZodNumber;
+          guppEscalations: z.ZodNumber;
+          stalledAgents: z.ZodNumber;
+          orphanedHooks: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      recentEvents: z.ZodArray<
+        z.ZodObject<
+          {
+            time: z.ZodString;
+            type: z.ZodString;
+            message: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      agents: z.ZodArray<
+        z.ZodObject<
+          {
+            id: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            role: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  mayor: 'mayor';
+                  polecat: 'polecat';
+                  refinery: 'refinery';
+                }>,
+                z.ZodString,
+              ]
+            >;
+            name: z.ZodString;
+            identity: z.ZodString;
+            status: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  dead: 'dead';
+                  idle: 'idle';
+                  stalled: 'stalled';
+                  working: 'working';
+                }>,
+                z.ZodString,
+              ]
+            >;
+            current_hook_bead_id: z.ZodNullable<z.ZodString>;
+            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+            last_activity_at: z.ZodNullable<z.ZodString>;
+            checkpoint: z.ZodOptional<z.ZodUnknown>;
+            created_at: z.ZodString;
+            agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+            agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          },
+          z.core.$strip
+        >
+      >;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            type: z.ZodEnum<{
+              agent: 'agent';
+              convoy: 'convoy';
+              escalation: 'escalation';
+              issue: 'issue';
+              merge_request: 'merge_request';
+              message: 'message';
+              molecule: 'molecule';
+            }>;
+            status: z.ZodEnum<{
+              closed: 'closed';
+              failed: 'failed';
+              in_progress: 'in_progress';
+              in_review: 'in_review';
+              open: 'open';
+            }>;
+            title: z.ZodString;
+            body: z.ZodNullable<z.ZodString>;
+            rig_id: z.ZodNullable<z.ZodString>;
+            parent_bead_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+            priority: z.ZodEnum<{
+              critical: 'critical';
+              high: 'high';
+              low: 'low';
+              medium: 'medium';
+            }>;
+            labels: z.ZodArray<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            created_by: z.ZodNullable<z.ZodString>;
+            created_at: z.ZodString;
+            updated_at: z.ZodString;
+            closed_at: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,16 +1,12 @@
-import type { z } from 'zod';
-export declare const TownOutput: z.ZodObject<
-  {
+import { z } from 'zod';
+export declare const TownOutput: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const RigOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const RigOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -19,26 +15,24 @@ export declare const RigOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const BeadOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadOutput: z.ZodObject<{
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-      agent: 'agent';
-      convoy: 'convoy';
-      escalation: 'escalation';
-      issue: 'issue';
-      merge_request: 'merge_request';
-      message: 'message';
-      molecule: 'molecule';
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
     }>;
     status: z.ZodEnum<{
-      closed: 'closed';
-      failed: 'failed';
-      in_progress: 'in_progress';
-      open: 'open';
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        in_review: "in_review";
+        open: "open";
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -46,10 +40,10 @@ export declare const BeadOutput: z.ZodObject<
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-      critical: 'critical';
-      high: 'high';
-      low: 'low';
-      medium: 'medium';
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -57,46 +51,32 @@ export declare const BeadOutput: z.ZodObject<
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const AgentOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const AgentOutput: z.ZodObject<{
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<
-      [
-        z.ZodEnum<{
-          mayor: 'mayor';
-          polecat: 'polecat';
-          refinery: 'refinery';
-        }>,
-        z.ZodString,
-      ]
-    >;
+    role: z.ZodUnion<[z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>, z.ZodString]>;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodUnion<
-      [
-        z.ZodEnum<{
-          dead: 'dead';
-          idle: 'idle';
-          stalled: 'stalled';
-          working: 'working';
-        }>,
-        z.ZodString,
-      ]
-    >;
+    status: z.ZodUnion<[z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>, z.ZodString]>;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
     checkpoint: z.ZodOptional<z.ZodUnknown>;
     created_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const BeadEventOutput: z.ZodObject<
-  {
+    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+}, z.core.$strip>;
+export declare const BeadEventOutput: z.ZodObject<{
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -107,68 +87,45 @@ export declare const BeadEventOutput: z.ZodObject<
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const MayorSendResultOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorSendResultOutput: z.ZodObject<{
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-      active: 'active';
-      idle: 'idle';
-      starting: 'starting';
+        active: "active";
+        idle: "idle";
+        starting: "starting";
     }>;
-  },
-  z.core.$strip
->;
-export declare const MayorStatusOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorStatusOutput: z.ZodObject<{
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<
-      z.ZodObject<
-        {
-          agentId: z.ZodString;
-          sessionId: z.ZodString;
-          status: z.ZodEnum<{
-            active: 'active';
-            idle: 'idle';
-            starting: 'starting';
-          }>;
-          lastActivityAt: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const StreamTicketOutput: z.ZodObject<
-  {
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const StreamTicketOutput: z.ZodObject<{
     url: z.ZodString;
     ticket: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const PtySessionOutput: z.ZodObject<
-  {
-    pty: z.ZodObject<
-      {
+}, z.core.$strip>;
+export declare const PtySessionOutput: z.ZodObject<{
+    pty: z.ZodObject<{
         id: z.ZodString;
-      },
-      z.core.$loose
-    >;
+    }, z.core.$loose>;
     wsUrl: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const ConvoyOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -177,16 +134,13 @@ export declare const ConvoyOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const ConvoyDetailOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyDetailOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
@@ -195,49 +149,36 @@ export declare const ConvoyDetailOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          title: z.ZodString;
-          status: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_name: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-    dependency_edges: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          depends_on_bead_id: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const SlingResultOutput: z.ZodObject<
-  {
-    bead: z.ZodObject<
-      {
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const SlingResultOutput: z.ZodObject<{
+    bead: z.ZodObject<{
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-          agent: 'agent';
-          convoy: 'convoy';
-          escalation: 'escalation';
-          issue: 'issue';
-          merge_request: 'merge_request';
-          message: 'message';
-          molecule: 'molecule';
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
         }>;
         status: z.ZodEnum<{
-          closed: 'closed';
-          failed: 'failed';
-          in_progress: 'in_progress';
-          open: 'open';
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -245,10 +186,10 @@ export declare const SlingResultOutput: z.ZodObject<
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-          critical: 'critical';
-          high: 'high';
-          low: 'low';
-          medium: 'medium';
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -256,49 +197,33 @@ export declare const SlingResultOutput: z.ZodObject<
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-      },
-      z.core.$strip
-    >;
-    agent: z.ZodObject<
-      {
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<
-          [
-            z.ZodEnum<{
-              mayor: 'mayor';
-              polecat: 'polecat';
-              refinery: 'refinery';
-            }>,
-            z.ZodString,
-          ]
-        >;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodUnion<
-          [
-            z.ZodEnum<{
-              dead: 'dead';
-              idle: 'idle';
-              stalled: 'stalled';
-              working: 'working';
-            }>,
-            z.ZodString,
-          ]
-        >;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
         checkpoint: z.ZodOptional<z.ZodUnknown>;
         created_at: z.ZodString;
-      },
-      z.core.$strip
-    >;
-  },
-  z.core.$strip
->;
-export declare const RigDetailOutput: z.ZodObject<
-  {
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const RigDetailOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -307,564 +232,390 @@ export declare const RigDetailOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<
-      z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                mayor: 'mayor';
-                polecat: 'polecat';
-                refinery: 'refinery';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                dead: 'dead';
-                idle: 'idle';
-                stalled: 'stalled';
-                working: 'working';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const RpcTownOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      name: z.ZodString;
-      owner_user_id: z.ZodString;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_id: z.ZodString;
-      type: z.ZodEnum<{
-        agent: 'agent';
-        convoy: 'convoy';
-        escalation: 'escalation';
-        issue: 'issue';
-        merge_request: 'merge_request';
-        message: 'message';
-        molecule: 'molecule';
-      }>;
-      status: z.ZodEnum<{
-        closed: 'closed';
-        failed: 'failed';
-        in_progress: 'in_progress';
-        open: 'open';
-      }>;
-      title: z.ZodString;
-      body: z.ZodNullable<z.ZodString>;
-      rig_id: z.ZodNullable<z.ZodString>;
-      parent_bead_id: z.ZodNullable<z.ZodString>;
-      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-      priority: z.ZodEnum<{
-        critical: 'critical';
-        high: 'high';
-        low: 'low';
-        medium: 'medium';
-      }>;
-      labels: z.ZodArray<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      closed_at: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAgentOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      rig_id: z.ZodNullable<z.ZodString>;
-      role: z.ZodUnion<
-        [
-          z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-          }>,
-          z.ZodString,
-        ]
-      >;
-      name: z.ZodString;
-      identity: z.ZodString;
-      status: z.ZodUnion<
-        [
-          z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>,
-          z.ZodString,
-        ]
-      >;
-      current_hook_bead_id: z.ZodNullable<z.ZodString>;
-      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-      last_activity_at: z.ZodNullable<z.ZodString>;
-      checkpoint: z.ZodOptional<z.ZodUnknown>;
-      created_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadEventOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_event_id: z.ZodString;
-      bead_id: z.ZodString;
-      agent_id: z.ZodNullable<z.ZodString>;
-      event_type: z.ZodString;
-      old_value: z.ZodNullable<z.ZodString>;
-      new_value: z.ZodNullable<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_at: z.ZodString;
-      rig_id: z.ZodOptional<z.ZodString>;
-      rig_name: z.ZodOptional<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      agentId: z.ZodString;
-      sessionStatus: z.ZodEnum<{
-        active: 'active';
-        idle: 'idle';
-        starting: 'starting';
-      }>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      configured: z.ZodBoolean;
-      townId: z.ZodNullable<z.ZodString>;
-      session: z.ZodNullable<
-        z.ZodObject<
-          {
-            agentId: z.ZodString;
-            sessionId: z.ZodString;
-            status: z.ZodEnum<{
-              active: 'active';
-              idle: 'idle';
-              starting: 'starting';
-            }>;
-            lastActivityAt: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcStreamTicketOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      url: z.ZodString;
-      ticket: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcPtySessionOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      pty: z.ZodObject<
-        {
-          id: z.ZodString;
-        },
-        z.core.$loose
-      >;
-      wsUrl: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            title: z.ZodString;
-            status: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_name: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-      dependency_edges: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            depends_on_bead_id: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcSlingResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead: z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >;
-      agent: z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                mayor: 'mayor';
-                polecat: 'polecat';
-                refinery: 'refinery';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                dead: 'dead';
-                idle: 'idle';
-                stalled: 'stalled';
-                working: 'working';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-        },
-        z.core.$strip
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      alarm: z.ZodObject<
-        {
-          nextFireAt: z.ZodNullable<z.ZodString>;
-          intervalMs: z.ZodNumber;
-          intervalLabel: z.ZodString;
-        },
-        z.core.$strip
-      >;
-      agents: z.ZodObject<
-        {
-          working: z.ZodNumber;
-          idle: z.ZodNumber;
-          stalled: z.ZodNumber;
-          dead: z.ZodNumber;
-          total: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      beads: z.ZodObject<
-        {
-          open: z.ZodNumber;
-          inProgress: z.ZodNumber;
-          failed: z.ZodNumber;
-          triageRequests: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      patrol: z.ZodObject<
-        {
-          guppWarnings: z.ZodNumber;
-          guppEscalations: z.ZodNumber;
-          stalledAgents: z.ZodNumber;
-          orphanedHooks: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      recentEvents: z.ZodArray<
-        z.ZodObject<
-          {
-            time: z.ZodString;
-            type: z.ZodString;
-            message: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      agents: z.ZodArray<
-        z.ZodObject<
-          {
-            id: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            role: z.ZodUnion<
-              [
-                z.ZodEnum<{
-                  mayor: 'mayor';
-                  polecat: 'polecat';
-                  refinery: 'refinery';
-                }>,
-                z.ZodString,
-              ]
-            >;
-            name: z.ZodString;
-            identity: z.ZodString;
-            status: z.ZodUnion<
-              [
-                z.ZodEnum<{
-                  dead: 'dead';
-                  idle: 'idle';
-                  stalled: 'stalled';
-                  working: 'working';
-                }>,
-                z.ZodString,
-              ]
-            >;
-            current_hook_bead_id: z.ZodNullable<z.ZodString>;
-            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-            last_activity_at: z.ZodNullable<z.ZodString>;
-            checkpoint: z.ZodOptional<z.ZodUnknown>;
-            created_at: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            type: z.ZodEnum<{
-              agent: 'agent';
-              convoy: 'convoy';
-              escalation: 'escalation';
-              issue: 'issue';
-              merge_request: 'merge_request';
-              message: 'message';
-              molecule: 'molecule';
-            }>;
-            status: z.ZodEnum<{
-              closed: 'closed';
-              failed: 'failed';
-              in_progress: 'in_progress';
-              open: 'open';
-            }>;
-            title: z.ZodString;
-            body: z.ZodNullable<z.ZodString>;
-            rig_id: z.ZodNullable<z.ZodString>;
-            parent_bead_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-            priority: z.ZodEnum<{
-              critical: 'critical';
-              high: 'high';
-              low: 'low';
-              medium: 'medium';
-            }>;
-            labels: z.ZodArray<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            created_by: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-            closed_at: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodString;
+    owner_user_id: z.ZodString;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_id: z.ZodString;
+    type: z.ZodEnum<{
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
+    }>;
+    status: z.ZodEnum<{
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        in_review: "in_review";
+        open: "open";
+    }>;
+    title: z.ZodString;
+    body: z.ZodNullable<z.ZodString>;
+    rig_id: z.ZodNullable<z.ZodString>;
+    parent_bead_id: z.ZodNullable<z.ZodString>;
+    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    labels: z.ZodArray<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    closed_at: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    rig_id: z.ZodNullable<z.ZodString>;
+    role: z.ZodUnion<[z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>, z.ZodString]>;
+    name: z.ZodString;
+    identity: z.ZodString;
+    status: z.ZodUnion<[z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>, z.ZodString]>;
+    current_hook_bead_id: z.ZodNullable<z.ZodString>;
+    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+    last_activity_at: z.ZodNullable<z.ZodString>;
+    checkpoint: z.ZodOptional<z.ZodUnknown>;
+    created_at: z.ZodString;
+    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+}, z.core.$strip>>;
+export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_event_id: z.ZodString;
+    bead_id: z.ZodString;
+    agent_id: z.ZodNullable<z.ZodString>;
+    event_type: z.ZodString;
+    old_value: z.ZodNullable<z.ZodString>;
+    new_value: z.ZodNullable<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_at: z.ZodString;
+    rig_id: z.ZodOptional<z.ZodString>;
+    rig_name: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    agentId: z.ZodString;
+    sessionStatus: z.ZodEnum<{
+        active: "active";
+        idle: "idle";
+        starting: "starting";
+    }>;
+}, z.core.$strip>>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    configured: z.ZodBoolean;
+    townId: z.ZodNullable<z.ZodString>;
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    url: z.ZodString;
+    ticket: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    pty: z.ZodObject<{
+        id: z.ZodString;
+    }, z.core.$loose>;
+    wsUrl: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead: z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>;
+}, z.core.$strip>>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    alarm: z.ZodObject<{
+        nextFireAt: z.ZodNullable<z.ZodString>;
+        intervalMs: z.ZodNumber;
+        intervalLabel: z.ZodString;
+    }, z.core.$strip>;
+    agents: z.ZodObject<{
+        working: z.ZodNumber;
+        idle: z.ZodNumber;
+        stalled: z.ZodNumber;
+        dead: z.ZodNumber;
+        total: z.ZodNumber;
+    }, z.core.$strip>;
+    beads: z.ZodObject<{
+        open: z.ZodNumber;
+        inProgress: z.ZodNumber;
+        inReview: z.ZodNumber;
+        failed: z.ZodNumber;
+        triageRequests: z.ZodNumber;
+    }, z.core.$strip>;
+    patrol: z.ZodObject<{
+        guppWarnings: z.ZodNumber;
+        guppEscalations: z.ZodNumber;
+        stalledAgents: z.ZodNumber;
+        orphanedHooks: z.ZodNumber;
+    }, z.core.$strip>;
+    recentEvents: z.ZodArray<z.ZodObject<{
+        time: z.ZodString;
+        type: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;


### PR DESCRIPTION
## Summary

- Adds 7 new mayor edit tools: `gt_bead_update` (status, title, body, priority), `gt_bead_reassign`, `gt_agent_reset`, `gt_convoy_close`, `gt_bead_delete`, `gt_escalation_acknowledge`, and `gt_bead_fail`
- Adds PATCH endpoints in `gastown.worker.ts` for bead fields, agent status, and convoy metadata with user auth (not agent-scoped)
- Implements `updateBead`, `resetAgent`, and `updateConvoy` methods on TownDO
- Adds dashboard UI edit controls: status dropdowns, editable bead fields, agent unhook/reset buttons
- Updates mayor system prompt with a "Surgical Editing" section documenting the new capabilities

Closes #996

## Verification

- Code review of diff against fork branch — all patches applied cleanly to `origin/main`
- Mayor tools test file updated with new tool registrations

## Visual Changes

Adds an edit button to bead drawer:

<img width="519" height="114" alt="image" src="https://github.com/user-attachments/assets/62739ff2-f21e-4ade-9e22-3efdfa97182a" />

<img width="1706" height="1234" alt="image" src="https://github.com/user-attachments/assets/dc404aa9-27f2-44ed-a7cb-0e5b6551f259" />

## Reviewer Notes

- The new PATCH endpoints use user auth rather than agent-scoped auth, enabling both the Mayor and dashboard UI to edit state
- `gt_bead_delete` is a hard delete — consider whether soft delete (archive) would be safer for production
- The mayor tool registration in the Kilo plugin registers all 7 tools; ensure the container has the matching handler routes