### PR TITLE
feat(gastown): add staged convoys for plan-review-iterate workflow

### DIFF
--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -7,6 +7,7 @@ import type {
   BeadType,
   Convoy,
   ConvoyDetail,
+  ConvoyStartResult,
   GastownEnv,
   Mail,
   MayorGastownEnv,
@@ -334,10 +335,18 @@ export class MayorGastownClient {
     tasks: Array<{ title: string; body?: string; depends_on?: number[] }>;
     merge_mode?: 'review-then-land' | 'review-and-merge';
     parallel?: boolean;
+    staged?: boolean;
   }): Promise<SlingBatchResult> {
     return this.request<SlingBatchResult>(this.mayorPath('/sling-batch'), {
       method: 'POST',
       body: JSON.stringify(input),
+    });
+  }
+
+  async startConvoy(convoyId: string): Promise<ConvoyStartResult> {
+    return this.request<ConvoyStartResult>(this.mayorPath(`/convoys/${convoyId}/start`), {
+      method: 'POST',
+      body: JSON.stringify({}),
     });
   }
 

--- a/cloudflare-gastown/container/plugin/mayor-tools.test.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.test.ts
@@ -376,11 +376,11 @@ describe('mayor tools', () => {
           beads: [
             {
               bead: { ...FAKE_BEAD, bead_id: 'bead-1', title: 'Task 1' },
-              agent: { ...FAKE_AGENT, id: 'agent-1', name: 'Toast' },
+              agent: null,
             },
             {
               bead: { ...FAKE_BEAD, bead_id: 'bead-2', title: 'Task 2' },
-              agent: { ...FAKE_AGENT, id: 'agent-2', name: 'Muffin' },
+              agent: null,
             },
           ],
         }),
@@ -396,6 +396,7 @@ describe('mayor tools', () => {
       expect(result).toContain('Convoy staged:');
       expect(result).toContain('convoy-staged-1');
       expect(result).toContain('gt_convoy_start');
+      expect(result).toContain('unassigned, pending gt_convoy_start');
       expect(client.slingBatch).toHaveBeenCalledWith(expect.objectContaining({ staged: true }));
     });
   });

--- a/cloudflare-gastown/container/plugin/mayor-tools.test.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.test.ts
@@ -72,7 +72,7 @@ const FAKE_CONVOY: Convoy = {
 const FAKE_STAGED_CONVOY: Convoy = {
   id: 'convoy-staged-1',
   title: 'Big Refactor',
-  status: 'staged',
+  status: 'active',
   staged: true,
   total_beads: 2,
   closed_beads: 0,

--- a/cloudflare-gastown/container/plugin/mayor-tools.test.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.test.ts
@@ -5,6 +5,7 @@ import type {
   Bead,
   Convoy,
   ConvoyDetail,
+  ConvoyStartResult,
   Rig,
   SlingBatchResult,
   SlingResult,
@@ -60,8 +61,21 @@ const FAKE_CONVOY: Convoy = {
   id: 'convoy-1',
   title: 'JWT Authentication',
   status: 'active',
+  staged: false,
   total_beads: 3,
   closed_beads: 1,
+  created_by: null,
+  created_at: '2026-03-05T00:00:00Z',
+  landed_at: null,
+};
+
+const FAKE_STAGED_CONVOY: Convoy = {
+  id: 'convoy-staged-1',
+  title: 'Big Refactor',
+  status: 'staged',
+  staged: true,
+  total_beads: 2,
+  closed_beads: 0,
   created_by: null,
   created_at: '2026-03-05T00:00:00Z',
   landed_at: null,
@@ -95,8 +109,22 @@ function makeFakeMayorClient(overrides: Partial<MayorGastownClient> = {}): Mayor
       ],
     }),
     listConvoys: vi.fn<() => Promise<Convoy[]>>().mockResolvedValue([FAKE_CONVOY]),
+    startConvoy: vi.fn<() => Promise<ConvoyStartResult>>().mockResolvedValue({
+      convoy: { ...FAKE_STAGED_CONVOY, status: 'active', staged: false },
+      beads: [
+        {
+          bead: { ...FAKE_BEAD, bead_id: 'bead-1', title: 'Task 1' },
+          agent: { ...FAKE_AGENT, id: 'agent-1', name: 'Toast' },
+        },
+        {
+          bead: { ...FAKE_BEAD, bead_id: 'bead-2', title: 'Task 2' },
+          agent: { ...FAKE_AGENT, id: 'agent-2', name: 'Muffin' },
+        },
+      ],
+    }),
     getConvoyStatus: vi.fn<() => Promise<ConvoyDetail>>().mockResolvedValue({
       ...FAKE_CONVOY,
+      staged: false,
       beads: [
         {
           bead_id: 'bead-1',
@@ -337,6 +365,47 @@ describe('mayor tools', () => {
       expect(result).toContain('esc-1');
       expect(result).toContain('acknowledged');
       expect(client.acknowledgeEscalation).toHaveBeenCalledWith('esc-1');
+    });
+  });
+
+  describe('gt_sling_batch staged', () => {
+    it('passes staged=true to client and reports convoy as staged', async () => {
+      client = makeFakeMayorClient({
+        slingBatch: vi.fn<() => Promise<SlingBatchResult>>().mockResolvedValue({
+          convoy: FAKE_STAGED_CONVOY,
+          beads: [
+            {
+              bead: { ...FAKE_BEAD, bead_id: 'bead-1', title: 'Task 1' },
+              agent: { ...FAKE_AGENT, id: 'agent-1', name: 'Toast' },
+            },
+            {
+              bead: { ...FAKE_BEAD, bead_id: 'bead-2', title: 'Task 2' },
+              agent: { ...FAKE_AGENT, id: 'agent-2', name: 'Muffin' },
+            },
+          ],
+        }),
+      });
+      tools = createMayorTools(client);
+
+      const tasks = [{ title: 'Task 1' }, { title: 'Task 2', depends_on: [0] }];
+      const result = await tools.gt_sling_batch.execute(
+        { rig_id: 'rig-1', convoy_title: 'Big Refactor', tasks, staged: true },
+        CTX
+      );
+
+      expect(result).toContain('Convoy staged:');
+      expect(result).toContain('convoy-staged-1');
+      expect(result).toContain('gt_convoy_start');
+      expect(client.slingBatch).toHaveBeenCalledWith(expect.objectContaining({ staged: true }));
+    });
+  });
+
+  describe('gt_convoy_start', () => {
+    it('starts a staged convoy and reports bead count', async () => {
+      const result = await tools.gt_convoy_start.execute({ convoy_id: 'convoy-staged-1' }, CTX);
+      expect(result).toContain('Convoy started');
+      expect(result).toContain('2 bead(s)');
+      expect(client.startConvoy).toHaveBeenCalledWith('convoy-staged-1');
     });
   });
 });

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -198,7 +198,7 @@ export function createMayorTools(client: MayorGastownClient) {
               : `  ${i + 1}. "${b.bead.title}" (unassigned, pending gt_convoy_start)`
         );
         const mode = args.merge_mode ?? 'review-then-land';
-        const staged = args.staged === true;
+        const staged = result.convoy.staged;
         return [
           `Convoy ${staged ? 'staged' : 'created'}: "${result.convoy.title}" (${result.convoy.id})`,
           `Merge mode: ${mode}`,

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -189,8 +189,13 @@ export function createMayorTools(client: MayorGastownClient) {
         });
 
         const beadLines = result.beads.map(
-          (b: { bead: { title: string }; agent: { name: string; id: string } }, i: number) =>
-            `  ${i + 1}. "${b.bead.title}" → ${b.agent.name} (${b.agent.id})`
+          (
+            b: { bead: { title: string }; agent: { name: string; id: string } | null },
+            i: number
+          ) =>
+            b.agent
+              ? `  ${i + 1}. "${b.bead.title}" → ${b.agent.name} (${b.agent.id})`
+              : `  ${i + 1}. "${b.bead.title}" (unassigned, pending gt_convoy_start)`
         );
         const mode = args.merge_mode ?? 'review-then-land';
         const staged = args.staged === true;

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -169,6 +169,14 @@ export function createMayorTools(client: MayorGastownClient) {
               'that need ordering, which causes merge conflicts and failures.'
           )
           .optional(),
+        staged: tool.schema
+          .boolean()
+          .describe(
+            'If true, creates the convoy plan without dispatching agents. ' +
+              'The user can review and edit before calling gt_convoy_start to begin execution. ' +
+              'Default: false (dispatch immediately).'
+          )
+          .optional(),
       },
       async execute(args) {
         const result = await client.slingBatch({
@@ -177,6 +185,7 @@ export function createMayorTools(client: MayorGastownClient) {
           tasks: args.tasks,
           merge_mode: args.merge_mode,
           parallel: args.parallel,
+          staged: args.staged,
         });
 
         const beadLines = result.beads.map(
@@ -184,14 +193,17 @@ export function createMayorTools(client: MayorGastownClient) {
             `  ${i + 1}. "${b.bead.title}" → ${b.agent.name} (${b.agent.id})`
         );
         const mode = args.merge_mode ?? 'review-then-land';
+        const staged = args.staged === true;
         return [
-          `Convoy created: "${result.convoy.title}" (${result.convoy.id})`,
+          `Convoy ${staged ? 'staged' : 'created'}: "${result.convoy.title}" (${result.convoy.id})`,
           `Merge mode: ${mode}`,
           `Tracking ${result.convoy.total_beads} beads:`,
           ...beadLines,
-          mode === 'review-then-land'
-            ? `Beads will be reviewed and merged into the convoy feature branch. A final PR/merge to main occurs when all beads are done.`
-            : `Each bead will go through the full review + merge/PR cycle independently.`,
+          staged
+            ? `Convoy is staged — agents have NOT been dispatched. Call gt_convoy_start with convoy_id "${result.convoy.id}" when ready to begin execution.`
+            : mode === 'review-then-land'
+              ? `Beads will be reviewed and merged into the convoy feature branch. A final PR/merge to main occurs when all beads are done.`
+              : `Each bead will go through the full review + merge/PR cycle independently.`,
         ].join('\n');
       },
     }),
@@ -220,6 +232,21 @@ export function createMayorTools(client: MayorGastownClient) {
       async execute(args) {
         const status = await client.getConvoyStatus(args.convoy_id);
         return JSON.stringify(status, null, 2);
+      },
+    }),
+
+    gt_convoy_start: tool({
+      description:
+        'Start a staged convoy. Transitions the convoy from staged (planned but not executing) ' +
+        'to active: hooks agents to all tracked beads and begins dispatch. ' +
+        'Call this when the user approves a staged plan and says to start it.',
+      args: {
+        convoy_id: tool.schema.string().describe('The UUID of the staged convoy to start'),
+      },
+      async execute(args) {
+        const result = await client.startConvoy(args.convoy_id);
+        const beadCount = result.beads?.length ?? 0;
+        return `Convoy started. ${beadCount} bead(s) dispatched to agents.`;
       },
     }),
 

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -97,12 +97,19 @@ export type SlingBatchResult = {
 export type Convoy = {
   id: string;
   title: string;
-  status: 'active' | 'landed';
+  status: 'active' | 'staged' | 'landed';
+  staged: boolean;
   total_beads: number;
   closed_beads: number;
   created_by: string | null;
   created_at: string;
   landed_at: string | null;
+};
+
+// Result returned by POST /convoys/:id/start
+export type ConvoyStartResult = {
+  convoy: Convoy;
+  beads: Array<{ bead: Bead; agent: Agent }>;
 };
 
 // Detailed convoy status with per-bead breakdown

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -88,9 +88,10 @@ export type SlingResult = {
 };
 
 // Sling batch result (convoy + beads + agents)
+// agent is null for staged convoys (agents aren't assigned until gt_convoy_start)
 export type SlingBatchResult = {
   convoy: Convoy;
-  beads: Array<{ bead: Bead; agent: Agent }>;
+  beads: Array<{ bead: Bead; agent: Agent | null }>;
 };
 
 // Convoy summary (returned by list and status endpoints)

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -95,10 +95,12 @@ export type SlingBatchResult = {
 };
 
 // Convoy summary (returned by list and status endpoints)
+// Staging is tracked by the `staged` boolean, not the status field.
+// status tracks the convoy lifecycle: active (in progress) or landed (complete).
 export type Convoy = {
   id: string;
   title: string;
-  status: 'active' | 'staged' | 'landed';
+  status: 'active' | 'landed';
   staged: boolean;
   total_beads: number;
   closed_beads: number;

--- a/cloudflare-gastown/src/db/tables/convoy-metadata.table.ts
+++ b/cloudflare-gastown/src/db/tables/convoy-metadata.table.ts
@@ -19,6 +19,8 @@ export const ConvoyMetadataRecord = z.object({
    *   individually, like standalone beads.
    */
   merge_mode: ConvoyMergeMode.nullable(),
+  /** 1 = staged (planned, agents not dispatched), 0 = active (SQLite boolean) */
+  staged: z.number().int().default(0),
 });
 
 export type ConvoyMetadataRecord = z.output<typeof ConvoyMetadataRecord>;
@@ -32,7 +34,8 @@ export function createTableConvoyMetadata(): string {
     closed_beads: `integer not null default 0`,
     landed_at: `text`,
     feature_branch: `text`,
-    merge_mode: `text`,
+    merge_mode: `text check(merge_mode in ('review-then-land', 'review-and-merge'))`,
+    staged: `integer not null default 0`,
   });
 }
 
@@ -40,6 +43,7 @@ export function createTableConvoyMetadata(): string {
 export function migrateConvoyMetadata(): string[] {
   return [
     `ALTER TABLE convoy_metadata ADD COLUMN feature_branch text`,
-    `ALTER TABLE convoy_metadata ADD COLUMN merge_mode text`,
+    `ALTER TABLE convoy_metadata ADD COLUMN merge_mode text check(merge_mode in ('review-then-land', 'review-and-merge'))`,
+    `ALTER TABLE convoy_metadata ADD COLUMN staged integer not null default 0`,
   ];
 }

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2069,17 +2069,6 @@ export class TownDO extends DurableObject<Env> {
     if (!convoy) throw new Error(`Convoy not found: ${convoyId}`);
     if (!convoy.staged) throw new Error(`Convoy is not staged: ${convoyId}`);
 
-    // Mark convoy as active
-    query(
-      this.sql,
-      /* sql */ `
-        UPDATE ${convoy_metadata}
-        SET ${convoy_metadata.columns.staged} = 0
-        WHERE ${convoy_metadata.bead_id} = ?
-      `,
-      [convoyId]
-    );
-
     // Find all beads tracked by this convoy
     const trackedRows = [
       ...query(
@@ -2127,6 +2116,18 @@ export class TownDO extends DurableObject<Env> {
 
       results.push({ bead: updatedBead, agent: hookedAgent });
     }
+
+    // Clear the staged flag only after all agents are successfully hooked.
+    // If the loop above throws, the convoy stays staged so the caller can retry.
+    query(
+      this.sql,
+      /* sql */ `
+        UPDATE ${convoy_metadata}
+        SET ${convoy_metadata.columns.staged} = 0
+        WHERE ${convoy_metadata.bead_id} = ?
+      `,
+      [convoyId]
+    );
 
     await this.armAlarmIfNeeded();
 

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1855,6 +1855,10 @@ export class TownDO extends DurableObject<Env> {
   }): Promise<{ convoy: ConvoyEntry; beads: Array<{ bead: Bead; agent: Agent | null }> }> {
     await this.ensureInitialized();
 
+    // Resolve staged: explicit request wins, otherwise fall back to town config default.
+    const townConfig = await this.getTownConfig();
+    const isStaged = input.staged ?? townConfig.staged_convoys_default;
+
     const convoyId = generateId();
     const timestamp = now();
 
@@ -1944,7 +1948,7 @@ export class TownDO extends DurableObject<Env> {
 
     const mergeMode = input.merge_mode ?? 'review-then-land';
 
-    const stagedValue = input.staged ? 1 : 0;
+    const stagedValue = isStaged ? 1 : 0;
 
     query(
       this.sql,
@@ -2008,7 +2012,7 @@ export class TownDO extends DurableObject<Env> {
       }
     }
 
-    if (input.staged) {
+    if (isStaged) {
       // Staged mode: collect beads without hooking agents or dispatching.
       for (const beadId of beadIds) {
         const bead = beadOps.getBead(this.sql, beadId);

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -171,6 +171,7 @@ type ConvoyEntry = {
   id: string;
   title: string;
   status: 'active' | 'landed';
+  staged: boolean;
   total_beads: number;
   closed_beads: number;
   created_by: string | null;
@@ -185,6 +186,7 @@ function toConvoy(row: ConvoyBeadRecord): ConvoyEntry {
     id: row.bead_id,
     title: row.title,
     status: row.status === 'closed' ? 'landed' : 'active',
+    staged: row.staged === 1,
     total_beads: row.total_beads,
     closed_beads: row.closed_beads,
     created_by: row.created_by,
@@ -199,7 +201,7 @@ const CONVOY_JOIN = /* sql */ `
   SELECT ${beads}.*,
          ${convoy_metadata.total_beads}, ${convoy_metadata.closed_beads},
          ${convoy_metadata.landed_at}, ${convoy_metadata.feature_branch},
-         ${convoy_metadata.merge_mode}
+         ${convoy_metadata.merge_mode}, ${convoy_metadata.staged}
   FROM ${beads}
   INNER JOIN ${convoy_metadata} ON ${beads.bead_id} = ${convoy_metadata.bead_id}
 `;
@@ -1849,7 +1851,8 @@ export class TownDO extends DurableObject<Env> {
     convoyTitle: string;
     tasks: Array<{ title: string; body?: string; depends_on?: number[] }>;
     merge_mode?: 'review-then-land' | 'review-and-merge';
-  }): Promise<{ convoy: ConvoyEntry; beads: Array<{ bead: Bead; agent: Agent }> }> {
+    staged?: boolean;
+  }): Promise<{ convoy: ConvoyEntry; beads: Array<{ bead: Bead; agent: Agent | null }> }> {
     await this.ensureInitialized();
 
     const convoyId = generateId();
@@ -1941,21 +1944,24 @@ export class TownDO extends DurableObject<Env> {
 
     const mergeMode = input.merge_mode ?? 'review-then-land';
 
+    const stagedValue = input.staged ? 1 : 0;
+
     query(
       this.sql,
       /* sql */ `
         INSERT INTO ${convoy_metadata} (
           ${convoy_metadata.columns.bead_id}, ${convoy_metadata.columns.total_beads},
           ${convoy_metadata.columns.closed_beads}, ${convoy_metadata.columns.landed_at},
-          ${convoy_metadata.columns.feature_branch}, ${convoy_metadata.columns.merge_mode}
-        ) VALUES (?, ?, ?, ?, ?, ?)
+          ${convoy_metadata.columns.feature_branch}, ${convoy_metadata.columns.merge_mode},
+          ${convoy_metadata.columns.staged}
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
       `,
-      [convoyId, input.tasks.length, 0, null, featureBranch, mergeMode]
+      [convoyId, input.tasks.length, 0, null, featureBranch, mergeMode, stagedValue]
     );
 
     // 2. Create all beads and track their IDs (needed for depends_on resolution)
     const beadIds: string[] = [];
-    const results: Array<{ bead: Bead; agent: Agent }> = [];
+    const results: Array<{ bead: Bead; agent: Agent | null }> = [];
 
     for (const task of input.tasks) {
       const createdBead = beadOps.createBead(this.sql, {
@@ -2002,24 +2008,109 @@ export class TownDO extends DurableObject<Env> {
       }
     }
 
-    // 4. For each bead: assign a polecat, but only dispatch if unblocked
-    for (let i = 0; i < beadIds.length; i++) {
-      const beadId = beadIds[i];
-      const agent = agents.getOrCreateAgent(this.sql, 'polecat', input.rigId, this.townId);
-      agents.hookBead(this.sql, agent.id, beadId);
+    if (input.staged) {
+      // Staged mode: collect beads without hooking agents or dispatching.
+      for (const beadId of beadIds) {
+        const bead = beadOps.getBead(this.sql, beadId);
+        if (!bead) continue;
+        results.push({ bead, agent: null });
+      }
+    } else {
+      // 4. For each bead: assign a polecat, but only dispatch if unblocked
+      for (let i = 0; i < beadIds.length; i++) {
+        const beadId = beadIds[i];
+        const agent = agents.getOrCreateAgent(this.sql, 'polecat', input.rigId, this.townId);
+        agents.hookBead(this.sql, agent.id, beadId);
 
+        const bead = beadOps.getBead(this.sql, beadId);
+        const hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
+        if (!bead) continue;
+
+        // Only dispatch beads with no unresolved blockers
+        if (!beadOps.hasUnresolvedBlockers(this.sql, beadId)) {
+          this.dispatchAgent(hookedAgent, bead).catch(err =>
+            console.error(`${TOWN_LOG} slingConvoy: fire-and-forget dispatchAgent failed:`, err)
+          );
+        } else {
+          console.log(
+            `${TOWN_LOG} slingConvoy: bead=${beadId} blocked, deferring dispatch until deps close`
+          );
+        }
+
+        results.push({ bead, agent: hookedAgent });
+      }
+
+      await this.armAlarmIfNeeded();
+    }
+
+    const convoy = this.getConvoy(convoyId);
+    if (!convoy) throw new Error('Failed to create convoy');
+    return { convoy, beads: results };
+  }
+
+  /**
+   * Transition a staged convoy to active: hook agents and begin dispatch.
+   */
+  async startConvoy(
+    convoyId: string
+  ): Promise<{ convoy: ConvoyEntry; beads: Array<{ bead: Bead; agent: Agent }> }> {
+    await this.ensureInitialized();
+
+    const convoy = this.getConvoy(convoyId);
+    if (!convoy) throw new Error(`Convoy not found: ${convoyId}`);
+    if (!convoy.staged) throw new Error(`Convoy is not staged: ${convoyId}`);
+
+    // Mark convoy as active
+    query(
+      this.sql,
+      /* sql */ `
+        UPDATE ${convoy_metadata}
+        SET ${convoy_metadata.columns.staged} = 0
+        WHERE ${convoy_metadata.bead_id} = ?
+      `,
+      [convoyId]
+    );
+
+    // Find all beads tracked by this convoy
+    const trackedRows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${bead_dependencies.bead_id}
+          FROM ${bead_dependencies}
+          WHERE ${bead_dependencies.depends_on_bead_id} = ?
+            AND ${bead_dependencies.dependency_type} = 'tracks'
+        `,
+        [convoyId]
+      ),
+    ];
+
+    const BeadIdRow = z.object({ bead_id: z.string() });
+    const trackedBeadIds = BeadIdRow.array()
+      .parse(trackedRows)
+      .map(r => r.bead_id);
+
+    const results: Array<{ bead: Bead; agent: Agent }> = [];
+
+    for (const beadId of trackedBeadIds) {
       const bead = beadOps.getBead(this.sql, beadId);
-      const hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
       if (!bead) continue;
 
-      // Only dispatch beads with no unresolved blockers
+      const rigId = bead.rig_id;
+      if (!rigId) continue;
+
+      const agent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
+      agents.hookBead(this.sql, agent.id, beadId);
+
+      const hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
+
       if (!beadOps.hasUnresolvedBlockers(this.sql, beadId)) {
         this.dispatchAgent(hookedAgent, bead).catch(err =>
-          console.error(`${TOWN_LOG} slingConvoy: fire-and-forget dispatchAgent failed:`, err)
+          console.error(`${TOWN_LOG} startConvoy: fire-and-forget dispatchAgent failed:`, err)
         );
       } else {
         console.log(
-          `${TOWN_LOG} slingConvoy: bead=${beadId} blocked, deferring dispatch until deps close`
+          `${TOWN_LOG} startConvoy: bead=${beadId} blocked, deferring dispatch until deps close`
         );
       }
 
@@ -2028,14 +2119,14 @@ export class TownDO extends DurableObject<Env> {
 
     await this.armAlarmIfNeeded();
 
-    const convoy = this.getConvoy(convoyId);
-    if (!convoy) throw new Error('Failed to create convoy');
+    const updatedConvoy = this.getConvoy(convoyId);
+    if (!updatedConvoy) throw new Error(`Failed to re-fetch convoy after start: ${convoyId}`);
     this.emitEvent({
       event: 'convoy.created',
       townId: this.townId,
       convoyId,
     });
-    return { convoy, beads: results };
+    return { convoy: updatedConvoy, beads: results };
   }
 
   /**

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2107,9 +2107,11 @@ export class TownDO extends DurableObject<Env> {
       agents.hookBead(this.sql, agent.id, beadId);
 
       const hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
+      // Re-read bead after hookBead so assignee_agent_bead_id is up to date
+      const updatedBead = beadOps.getBead(this.sql, beadId) ?? bead;
 
       if (!beadOps.hasUnresolvedBlockers(this.sql, beadId)) {
-        this.dispatchAgent(hookedAgent, bead).catch(err =>
+        this.dispatchAgent(hookedAgent, updatedBead).catch(err =>
           console.error(`${TOWN_LOG} startConvoy: fire-and-forget dispatchAgent failed:`, err)
         );
       } else {
@@ -2118,7 +2120,7 @@ export class TownDO extends DurableObject<Env> {
         );
       }
 
-      results.push({ bead, agent: hookedAgent });
+      results.push({ bead: updatedBead, agent: hookedAgent });
     }
 
     await this.armAlarmIfNeeded();
@@ -2126,7 +2128,7 @@ export class TownDO extends DurableObject<Env> {
     const updatedConvoy = this.getConvoy(convoyId);
     if (!updatedConvoy) throw new Error(`Failed to re-fetch convoy after start: ${convoyId}`);
     this.emitEvent({
-      event: 'convoy.created',
+      event: 'convoy.started',
       townId: this.townId,
       convoyId,
     });

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2097,11 +2097,25 @@ export class TownDO extends DurableObject<Env> {
       const rigId = bead.rig_id;
       if (!rigId) continue;
 
-      const agent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
-      agents.hookBead(this.sql, agent.id, beadId);
+      // Skip beads already hooked from a prior partial attempt (retry-safe).
+      let hookedAgent: Agent;
+      if (bead.assignee_agent_bead_id) {
+        const existing = agents.getAgent(this.sql, bead.assignee_agent_bead_id);
+        if (existing) {
+          hookedAgent = existing;
+        } else {
+          // Orphaned assignee reference — re-hook with a fresh agent
+          const agent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
+          agents.hookBead(this.sql, agent.id, beadId);
+          hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
+        }
+      } else {
+        const agent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
+        agents.hookBead(this.sql, agent.id, beadId);
+        hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
+      }
 
-      const hookedAgent = agents.getAgent(this.sql, agent.id) ?? agent;
-      // Re-read bead after hookBead so assignee_agent_bead_id is up to date
+      // Re-read bead after potential hookBead so assignee_agent_bead_id is up to date
       const updatedBead = beadOps.getBead(this.sql, beadId) ?? bead;
 
       if (!beadOps.hasUnresolvedBlockers(this.sql, beadId)) {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2049,6 +2049,11 @@ export class TownDO extends DurableObject<Env> {
 
     const convoy = this.getConvoy(convoyId);
     if (!convoy) throw new Error('Failed to create convoy');
+    this.emitEvent({
+      event: 'convoy.created',
+      townId: this.townId,
+      convoyId,
+    });
     return { convoy, beads: results };
   }
 

--- a/cloudflare-gastown/src/dos/town/patrol.ts
+++ b/cloudflare-gastown/src/dos/town/patrol.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { beads, BeadRecord as BeadRecordSchema } from '../../db/tables/beads.table';
 import { agent_metadata, AgentMetadataRecord } from '../../db/tables/agent-metadata.table';
 import { bead_dependencies } from '../../db/tables/bead-dependencies.table';
+import { convoy_metadata } from '../../db/tables/convoy-metadata.table';
 import { query } from '../../util/query.util';
 import { sendMail } from './mail';
 import { deleteAgent, getOrCreateAgent, hookBead, unhookBead } from './agents';
@@ -501,8 +502,10 @@ export function detectStaleHooks(sql: SqlStorage): void {
 }
 
 /**
- * Feed stranded convoys: find active convoys that have open beads with
- * no assigned agent. Auto-sling by assigning idle polecats.
+ * Feed stranded convoys: find active (non-staged) convoys that have open
+ * beads with no assigned agent. Auto-sling by assigning idle polecats.
+ * Staged convoys are excluded — their beads remain unassigned until
+ * the convoy is explicitly started via startConvoy().
  */
 export function feedStrandedConvoys(sql: SqlStorage, townId: string): void {
   // Find open issue beads that:
@@ -524,9 +527,11 @@ export function feedStrandedConvoys(sql: SqlStorage, townId: string): void {
         FROM ${bead_dependencies}
         INNER JOIN ${beads} ON ${bead_dependencies.bead_id} = ${beads.bead_id}
         INNER JOIN ${beads} AS convoy ON ${bead_dependencies.depends_on_bead_id} = convoy.${beads.columns.bead_id}
+        INNER JOIN ${convoy_metadata} ON ${convoy_metadata.bead_id} = convoy.${beads.columns.bead_id}
         WHERE ${bead_dependencies.dependency_type} = 'tracks'
           AND convoy.${beads.columns.type} = 'convoy'
           AND convoy.${beads.columns.status} = 'open'
+          AND ${convoy_metadata.staged} = 0
           AND ${beads.status} = 'open'
           AND ${beads.type} = 'issue'
           AND ${beads.assignee_agent_bead_id} IS NULL

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -95,6 +95,7 @@ import {
   handleMayorConvoyUpdate,
   handleMayorBeadDelete,
   handleMayorEscalationAcknowledge,
+  handleMayorConvoyStart,
 } from './handlers/mayor-tools.handler';
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
@@ -655,6 +656,9 @@ app.post('/api/mayor/:townId/tools/escalations/:escalationId/acknowledge', c =>
   instrumented(c, 'POST /api/mayor/:townId/tools/escalations/:escalationId/acknowledge', () =>
     handleMayorEscalationAcknowledge(c, c.req.param())
   )
+);
+app.post('/api/mayor/:townId/tools/convoys/:convoyId/start', c =>
+  handleMayorConvoyStart(c, c.req.param())
 );
 
 // ── tRPC ────────────────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -618,7 +618,7 @@ export async function handleMayorConvoyStart(
   );
 
   const town = getTownDOStub(c.env, params.townId);
-  let result: Awaited<ReturnType<typeof town.startConvoy>>;
+  let result: { convoy: { id: string }; beads: unknown[] };
   try {
     result = await town.startConvoy(params.convoyId);
   } catch (err) {

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -35,6 +35,7 @@ const MayorSlingBatchBody = z
     merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
     /** Set to true only when ALL tasks are genuinely independent (no shared files, no shared state). */
     parallel: z.boolean().optional(),
+    staged: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     // Require dependency graph unless explicitly opted out with parallel: true.
@@ -288,6 +289,7 @@ export async function handleMayorSlingBatch(c: Context<GastownEnv>, params: { to
     convoyTitle: parsed.data.convoy_title,
     tasks: parsed.data.tasks,
     merge_mode: parsed.data.merge_mode,
+    staged: parsed.data.staged,
   });
 
   console.log(
@@ -601,4 +603,35 @@ export async function handleMayorEscalationAcknowledge(
 
   if (!escalation) return c.json(resError('Escalation not found'), 404);
   return c.json(resSuccess(escalation));
+}
+
+/**
+ * POST /api/mayor/:townId/tools/convoys/:convoyId/start
+ * Transition a staged convoy to active: hook agents and begin dispatch.
+ */
+export async function handleMayorConvoyStart(
+  c: Context<GastownEnv>,
+  params: { townId: string; convoyId: string }
+) {
+  console.log(
+    `${HANDLER_LOG} handleMayorConvoyStart: townId=${params.townId} convoyId=${params.convoyId}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  let result: Awaited<ReturnType<typeof town.startConvoy>>;
+  try {
+    result = await town.startConvoy(params.convoyId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('not found') || message.includes('not staged')) {
+      return c.json(resError('Convoy not found or not staged'), 404);
+    }
+    throw err;
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorConvoyStart: completed, convoy=${result.convoy.id} beads=${result.beads.length}`
+  );
+
+  return c.json(resSuccess(result));
 }

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -26,9 +26,11 @@ Your #1 purpose is to turn user requests into actionable work items. Every time 
 You have these tools for cross-rig coordination:
 
 - **gt_sling** — Delegate a single task to a polecat in a specific rig. Use for one-off tasks.
-- **gt_sling_batch** — YOUR MOST IMPORTANT TOOL. Sling multiple beads as a tracked convoy. Use this when breaking work into parallel sub-tasks. Creates all beads at once, groups them into a convoy for progress tracking, and dispatches polecats automatically. Accepts an optional \`merge_mode\`:
+  - **gt_sling_batch** — YOUR MOST IMPORTANT TOOL. Sling multiple beads as a tracked convoy. Use this when breaking work into parallel sub-tasks. Creates all beads at once, groups them into a convoy for progress tracking, and dispatches polecats automatically. Accepts an optional \`merge_mode\`:
   - **"review-then-land"** (default): Each bead is reviewed by the refinery and merged into the convoy's feature branch. Only at the very end does a PR or merge to main occur. Best for tightly coupled tasks that build on each other.
   - **"review-and-merge"**: Each bead goes through the full review + merge/PR cycle independently. Best for loosely coupled tasks where each can land on its own.
+  - Accepts an optional \`staged\` boolean. When \`staged: true\`, creates the convoy and beads without dispatching agents — a plan for review. See the Staged Convoys section below.
+- **gt_convoy_start** — Start a staged convoy. Transitions it from staged (planned, no agents) to active: hooks agents to all tracked beads and begins dispatch. Call this when the user approves a staged plan.
 - **gt_list_rigs** — List all rigs in your town. Returns rig ID, name, git URL, and default branch. Call this first when you need to know what repositories are available.
 - **gt_list_beads** — List beads (work items) in a rig. Filter by status or type. Use this to check progress, find open work, or review completed tasks.
 - **gt_list_agents** — List agents in a rig. Shows who is working, idle, or stuck. Use this to understand workforce capacity.
@@ -221,6 +223,24 @@ Use these tools when the user reports stuck state, when you detect problems duri
 - You maintain context across messages. This is a continuous conversation.
 - Never fabricate rig IDs or agent IDs. Always use gt_list_rigs to discover real IDs.
 - If no rigs exist, tell the user they need to create one first.
-- If a task spans multiple rigs, create separate slings for each rig.
-- ALWAYS sling when the user requests work. Describing what you would do without actually slinging is a failure mode. Prefer gt_sling_batch for multi-task requests.`;
+  - If a task spans multiple rigs, create separate slings for each rig.
+  - ALWAYS sling when the user requests work. Describing what you would do without actually slinging is a failure mode. Prefer gt_sling_batch for multi-task requests.
+
+## Staged Convoys
+
+When the user asks you to plan or prepare work (but not start it immediately),
+use gt_sling_batch with staged=true. This creates the convoy and beads without
+dispatching agents — it's a plan for review.
+
+After creating a staged convoy, tell the user:
+- The convoy title and number of beads
+- A brief description of the plan
+- That they can review the beads and say "start it" or "go" when ready
+
+When the user says "go", "start it", "kick it off", or similar for a staged
+convoy, call gt_convoy_start with the convoy_id.
+
+For large convoys (>5 beads) where the decomposition is non-obvious, consider
+using staged=true by default to give the user a chance to review before agents
+start spending compute.`;
 }

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -628,6 +628,20 @@ export const gastownRouter = router({
       return townStub.listConvoysDetailed();
     }),
 
+  getConvoy: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        convoyId: z.string().uuid(),
+      })
+    )
+    .output(RpcConvoyDetailOutput.nullable())
+    .query(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.getConvoyStatus(input.convoyId);
+    }),
+
   closeConvoy: gastownProcedure
     .input(
       z.object({

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -645,6 +645,22 @@ export const gastownRouter = router({
       return status ?? { ...convoy, beads: [] };
     }),
 
+  startConvoy: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        convoyId: z.string().uuid(),
+      })
+    )
+    .output(RpcConvoyDetailOutput.nullable())
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId);
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.startConvoy(input.convoyId);
+      const status = await townStub.getConvoyStatus(input.convoyId);
+      return status ?? null;
+    }),
+
   // ── Admin-only routes (bypass ownership checks) ──────────────────────
 
   adminListBeads: adminProcedure

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -118,6 +118,7 @@ export const ConvoyOutput = z.object({
   id: z.string(),
   title: z.string(),
   status: z.enum(['active', 'landed']),
+  staged: z.boolean(),
   total_beads: z.number(),
   closed_beads: z.number(),
   created_by: z.string().nullable(),

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -245,6 +245,9 @@ export const TownConfigSchema = z.object({
       sleep_after_minutes: z.number().int().min(5).max(120).optional(),
     })
     .optional(),
+
+  /** When true, all convoys are created as staged by default (agents not dispatched until started). */
+  staged_convoys_default: z.boolean().default(false),
 });
 
 export type TownConfig = z.infer<typeof TownConfigSchema>;
@@ -285,6 +288,7 @@ export const TownConfigUpdateSchema = z.object({
       sleep_after_minutes: z.number().int().min(5).max(120).optional(),
     })
     .optional(),
+  staged_convoys_default: z.boolean().optional(),
 });
 export type TownConfigUpdate = z.infer<typeof TownConfigUpdateSchema>;
 

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -371,7 +371,7 @@ export function dashboardHtml(): string {
     <label>Town ID</label>
     <input type="text" id="convoyTownId" placeholder="town-abc" style="min-width:160px" />
     <label style="margin-left:8px">Mayor Token</label>
-    <input type="text" id="mayorToken" placeholder="mayor token" style="min-width:200px" />
+    <input type="text" id="convoyMayorToken" placeholder="mayor token" style="min-width:200px" />
     <button class="primary" onclick="loadConvoys()">Load Convoys</button>
   </div>
   <div id="convoysList"></div>
@@ -1077,13 +1077,13 @@ async function containerSendMessage() {
 async function loadConvoys() {
   const convoyTownId = el('convoyTownId').value.trim();
   if (!convoyTownId) { toast('Set a Town ID first', true); return; }
-  const mayorToken = el('mayorToken').value.trim();
+  const token = el('convoyMayorToken').value.trim();
   const log = el('apiLog');
   const path = '/api/mayor/' + convoyTownId + '/tools/convoys';
   log.innerHTML += '<span class="info">GET ' + esc(path) + '</span>\\n';
   try {
     const res = await fetch(path, {
-      headers: { 'Authorization': 'Bearer ' + mayorToken, 'Content-Type': 'application/json' },
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
     });
     const data = await res.json();
     const cls = res.ok ? 'ok' : 'err';
@@ -1124,14 +1124,14 @@ function renderConvoys(convoys, convoyTownId) {
 }
 
 async function startConvoy(convoyId, convoyTownId) {
-  const mayorToken = el('mayorToken').value.trim();
+  const token = el('convoyMayorToken').value.trim();
   const log = el('apiLog');
   const path = '/api/mayor/' + convoyTownId + '/tools/convoys/' + convoyId + '/start';
   log.innerHTML += '<span class="info">POST ' + esc(path) + '</span>\\n';
   try {
     const res = await fetch(path, {
       method: 'POST',
-      headers: { 'Authorization': 'Bearer ' + mayorToken, 'Content-Type': 'application/json' },
+      headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },
       body: '{}',
     });
     const data = await res.json();

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -58,6 +58,7 @@ export function dashboardHtml(): string {
                        padding: 4px 8px; border-radius: 4px; font-family: inherit; font-size: 12px;
                        width: 100%; min-height: 80px; resize: vertical; }
   textarea.body-edit:focus { border-color: #58a6ff; outline: none; }
+  .badge.staged { background: #21262d; color: #8b949e; border: 1px dashed #30363d; }
   .empty { color: #484f58; font-style: italic; }
   #toast { position: fixed; bottom: 16px; right: 16px; background: #1f6feb;
            color: #fff; padding: 8px 16px; border-radius: 6px; font-size: 12px;
@@ -361,6 +362,19 @@ export function dashboardHtml(): string {
     <button class="primary" onclick="containerSendMessage()">Send Message</button>
   </div>
   <div id="containerResult"></div>
+</div>
+
+<!-- Convoys -->
+<div class="panel">
+  <h2>Convoys</h2>
+  <div class="row">
+    <label>Town ID</label>
+    <input type="text" id="convoyTownId" placeholder="town-abc" style="min-width:160px" />
+    <label style="margin-left:8px">Mayor Token</label>
+    <input type="text" id="mayorToken" placeholder="mayor token" style="min-width:200px" />
+    <button class="primary" onclick="loadConvoys()">Load Convoys</button>
+  </div>
+  <div id="convoysList"></div>
 </div>
 
 <!-- Log -->
@@ -1056,6 +1070,85 @@ async function containerSendMessage() {
   if (!agentId || !prompt) { toast('Enter agent ID and message', true); return; }
   const r = await containerApi('POST', '/agents/' + agentId + '/message', { prompt });
   if (r.ok) { el('cMessage').value = ''; toast('Message sent'); }
+}
+
+// ── Convoys ──────────────────────────────────────────────────────────
+
+async function loadConvoys() {
+  const convoyTownId = el('convoyTownId').value.trim();
+  if (!convoyTownId) { toast('Set a Town ID first', true); return; }
+  const mayorToken = el('mayorToken').value.trim();
+  const log = el('apiLog');
+  const path = '/api/mayor/' + convoyTownId + '/tools/convoys';
+  log.innerHTML += '<span class="info">GET ' + esc(path) + '</span>\\n';
+  try {
+    const res = await fetch(path, {
+      headers: { 'Authorization': 'Bearer ' + mayorToken, 'Content-Type': 'application/json' },
+    });
+    const data = await res.json();
+    const cls = res.ok ? 'ok' : 'err';
+    log.innerHTML += '<span class="' + cls + '">' + res.status + '</span> '
+      + esc(JSON.stringify(data, null, 2)) + '\\n\\n';
+    log.scrollTop = log.scrollHeight;
+    if (!res.ok) { toast(data.error || res.status, true); return; }
+    renderConvoys(data.data || [], convoyTownId);
+  } catch (e) {
+    log.innerHTML += '<span class="err">FETCH ERROR: ' + esc(e.message) + '</span>\\n\\n';
+    toast(e.message, true);
+  }
+}
+
+function renderConvoys(convoys, convoyTownId) {
+  if (!convoys.length) { el('convoysList').innerHTML = '<p class="empty">No convoys</p>'; return; }
+  let h = '<table><tr><th>ID</th><th>Title</th><th>Status</th><th>Beads</th><th></th></tr>';
+  for (const c of convoys) {
+    const isStaged = c.staged === true;
+    const statusBadge = isStaged
+      ? '<span class="badge staged">STAGED</span>'
+      : '<span class="badge ' + (c.status || 'open') + '">' + (c.status || 'open') + '</span>';
+    const progress = (c.closed_beads != null && c.total_beads != null)
+      ? c.closed_beads + '/' + c.total_beads
+      : '—';
+    h += '<tr>'
+      + '<td class="id" onclick="copyId(\\'' + c.convoy_id + '\\')">' + short(c.convoy_id) + '</td>'
+      + '<td>' + esc(c.title || '—') + '</td>'
+      + '<td>' + statusBadge + '</td>'
+      + '<td>' + progress + '</td>'
+      + '<td>'
+      + (isStaged ? '<button class="primary" onclick="startConvoy(\\'' + c.convoy_id + '\\', \\'' + convoyTownId + '\\')">Start Convoy</button>' : '')
+      + '</td>'
+      + '</tr>';
+  }
+  h += '</table>';
+  el('convoysList').innerHTML = h;
+}
+
+async function startConvoy(convoyId, convoyTownId) {
+  const mayorToken = el('mayorToken').value.trim();
+  const log = el('apiLog');
+  const path = '/api/mayor/' + convoyTownId + '/tools/convoys/' + convoyId + '/start';
+  log.innerHTML += '<span class="info">POST ' + esc(path) + '</span>\\n';
+  try {
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + mayorToken, 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const data = await res.json();
+    const cls = res.ok ? 'ok' : 'err';
+    log.innerHTML += '<span class="' + cls + '">' + res.status + '</span> '
+      + esc(JSON.stringify(data, null, 2)) + '\\n\\n';
+    log.scrollTop = log.scrollHeight;
+    if (data.success) {
+      toast('Convoy ' + convoyId.slice(0, 8) + ' started');
+      loadConvoys();
+    } else {
+      toast('Error: ' + (data.error || 'unknown'), true);
+    }
+  } catch (e) {
+    log.innerHTML += '<span class="err">FETCH ERROR: ' + esc(e.message) + '</span>\\n\\n';
+    toast(e.message, true);
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/ui/dashboard.ui.ts
+++ b/cloudflare-gastown/src/ui/dashboard.ui.ts
@@ -1110,12 +1110,12 @@ function renderConvoys(convoys, convoyTownId) {
       ? c.closed_beads + '/' + c.total_beads
       : '—';
     h += '<tr>'
-      + '<td class="id" onclick="copyId(\\'' + c.convoy_id + '\\')">' + short(c.convoy_id) + '</td>'
+      + '<td class="id" onclick="copyId(\\'' + c.id + '\\')">' + short(c.id) + '</td>'
       + '<td>' + esc(c.title || '—') + '</td>'
       + '<td>' + statusBadge + '</td>'
       + '<td>' + progress + '</td>'
       + '<td>'
-      + (isStaged ? '<button class="primary" onclick="startConvoy(\\'' + c.convoy_id + '\\', \\'' + convoyTownId + '\\')">Start Convoy</button>' : '')
+      + (isStaged ? '<button class="primary" onclick="startConvoy(\\'' + c.id + '\\', \\'' + convoyTownId + '\\')">Start Convoy</button>' : '')
       + '</td>'
       + '</tr>';
   }

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -108,6 +108,17 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
       onError: err => toast.error(err.message),
     })
   );
+  const startConvoyMutation = useMutation(
+    trpc.gastown.startConvoy.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.listConvoys.queryKey({ townId }),
+        });
+        toast.success('Convoy started');
+      },
+      onError: err => toast.error(err.message),
+    })
+  );
 
   const rigs = rigsQuery.data ?? [];
   const events = townEventsQuery.data ?? [];
@@ -335,7 +346,9 @@ export function TownOverviewPageClient({ townId }: TownOverviewPageClientProps) 
                   onSelectBead={(beadId, rigId) => {
                     if (rigId) openDrawer({ type: 'bead', beadId, rigId });
                   }}
+                  onSelectConvoy={convoyId => openDrawer({ type: 'convoy', convoyId, townId })}
                   onCloseConvoy={convoyId => closeConvoyMutation.mutate({ townId, convoyId })}
+                  onStartConvoy={convoyId => startConvoyMutation.mutate({ townId, convoyId })}
                 />
               </div>
             </div>

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -77,6 +77,17 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
       onError: err => toast.error(err.message),
     })
   );
+  const startConvoyMutation = useMutation(
+    trpc.gastown.startConvoy.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.listConvoys.queryKey({ townId }),
+        });
+        toast.success('Convoy started');
+      },
+      onError: err => toast.error(err.message),
+    })
+  );
 
   const beads = beadsQuery.data ?? [];
   const agents = agentsQuery.data ?? [];
@@ -160,7 +171,9 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
               onSelectBead={(beadId, beadRigId) =>
                 openDrawer({ type: 'bead', beadId, rigId: beadRigId ?? rigId })
               }
+              onSelectConvoy={convoyId => openDrawer({ type: 'convoy', convoyId, townId })}
               onCloseConvoy={convoyId => closeConvoyMutation.mutate({ townId, convoyId })}
+              onStartConvoy={convoyId => startConvoyMutation.mutate({ townId, convoyId })}
             />
           </div>
         </div>

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -21,6 +21,7 @@ import {
   Bot,
   Shield,
   Variable,
+  Layers,
 } from 'lucide-react';
 import { motion } from 'motion/react';
 
@@ -33,6 +34,7 @@ const SECTIONS = [
   { id: 'git-auth', label: 'Git Authentication', icon: GitBranch },
   { id: 'env-vars', label: 'Environment Variables', icon: Variable },
   { id: 'agent-defaults', label: 'Agent Defaults', icon: Bot },
+  { id: 'convoys', label: 'Convoys', icon: Layers },
   { id: 'merge-strategy', label: 'Merge Strategy', icon: GitPullRequest },
   { id: 'refinery', label: 'Refinery', icon: Shield },
 ] as const;
@@ -101,6 +103,7 @@ export function TownSettingsPageClient({ townId }: Props) {
   const [refineryGates, setRefineryGates] = useState<string[]>([]);
   const [autoMerge, setAutoMerge] = useState(true);
   const [mergeStrategy, setMergeStrategy] = useState<'direct' | 'pr'>('direct');
+  const [stagedConvoysDefault, setStagedConvoysDefault] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [showTokens, setShowTokens] = useState(false);
 
@@ -116,6 +119,7 @@ export function TownSettingsPageClient({ townId }: Props) {
     setRefineryGates(cfg.refinery?.gates ?? []);
     setAutoMerge(cfg.refinery?.auto_merge ?? true);
     setMergeStrategy(cfg.merge_strategy === 'pr' ? 'pr' : 'direct');
+    setStagedConvoysDefault(cfg.staged_convoys_default ?? false);
     setInitialized(true);
   }
 
@@ -141,6 +145,7 @@ export function TownSettingsPageClient({ townId }: Props) {
         ...(defaultModel ? { default_model: defaultModel } : {}),
         ...(maxPolecats ? { max_polecats_per_rig: maxPolecats } : {}),
         merge_strategy: mergeStrategy,
+        staged_convoys_default: stagedConvoysDefault,
         refinery: {
           gates: refineryGates.filter(g => g.trim()),
           auto_merge: autoMerge,
@@ -360,13 +365,37 @@ export function TownSettingsPageClient({ townId }: Props) {
                 </div>
               </SettingsSection>
 
+              {/* ── Convoys ──────────────────────────────────────── */}
+              <SettingsSection
+                id="convoys"
+                title="Convoys"
+                description="Settings for convoy (batch task) behavior."
+                icon={Layers}
+                index={3}
+              >
+                <div className="flex items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                  <Switch
+                    checked={stagedConvoysDefault}
+                    onCheckedChange={setStagedConvoysDefault}
+                  />
+                  <div>
+                    <Label className="text-sm text-white/70">Stage convoys by default</Label>
+                    <p className="text-[11px] text-white/30">
+                      When enabled, new convoys are created in staged mode — agents are not
+                      dispatched until the convoy is explicitly started. This gives the mayor a
+                      chance to review and adjust the plan before execution begins.
+                    </p>
+                  </div>
+                </div>
+              </SettingsSection>
+
               {/* ── Merge Strategy ──────────────────────────────────── */}
               <SettingsSection
                 id="merge-strategy"
                 title="Merge Strategy"
                 description="How agent work lands in the default branch. Per-rig overrides coming soon."
                 icon={GitPullRequest}
-                index={3}
+                index={4}
               >
                 <div className="space-y-3">
                   <MergeStrategyOption
@@ -390,7 +419,7 @@ export function TownSettingsPageClient({ townId }: Props) {
                 title="Refinery"
                 description="Quality gates run before merging polecat branches into the default branch."
                 icon={Shield}
-                index={4}
+                index={5}
                 action={
                   <button
                     onClick={addRefineryGate}

--- a/src/components/gastown/ConvoyTimeline.tsx
+++ b/src/components/gastown/ConvoyTimeline.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
-import { CheckCircle, GitBranch, Loader2, X, ArrowRight } from 'lucide-react';
+import { CheckCircle, GitBranch, Loader2, X, ArrowRight, Play } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 
 type ConvoyDetail = GastownOutputs['gastown']['listConvoys'][number];
@@ -13,7 +13,9 @@ export type ConvoyTimelineProps = {
   convoys: ConvoyDetail[];
   collapsed?: boolean;
   onSelectBead?: (beadId: string, rigId: string | null) => void;
+  onSelectConvoy?: (convoyId: string) => void;
   onCloseConvoy?: (convoyId: string) => void;
+  onStartConvoy?: (convoyId: string) => void;
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -105,7 +107,9 @@ export function ConvoyTimeline({
   convoys,
   collapsed = false,
   onSelectBead,
+  onSelectConvoy,
   onCloseConvoy,
+  onStartConvoy,
 }: ConvoyTimelineProps) {
   if (convoys.length === 0) {
     return null;
@@ -125,7 +129,9 @@ export function ConvoyTimeline({
               key={convoy.id}
               convoy={convoy}
               onSelectBead={onSelectBead}
+              onSelectConvoy={onSelectConvoy ? () => onSelectConvoy(convoy.id) : undefined}
               onClose={onCloseConvoy ? () => onCloseConvoy(convoy.id) : undefined}
+              onStart={convoy.staged && onStartConvoy ? () => onStartConvoy(convoy.id) : undefined}
             />
           ))}
         </motion.div>
@@ -137,13 +143,18 @@ export function ConvoyTimeline({
 function ConvoyCard({
   convoy,
   onSelectBead,
+  onSelectConvoy,
   onClose,
+  onStart,
 }: {
   convoy: ConvoyDetail;
   onSelectBead?: (beadId: string, rigId: string | null) => void;
+  onSelectConvoy?: () => void;
   onClose?: () => void;
+  onStart?: () => void;
 }) {
   const [confirming, setConfirming] = useState(false);
+  const isStaged = 'staged' in convoy && convoy.staged === true;
   const progress = convoy.total_beads > 0 ? convoy.closed_beads / convoy.total_beads : 0;
 
   const waves = useMemo(
@@ -154,19 +165,24 @@ function ConvoyCard({
   const hasDag = (convoy.dependency_edges ?? []).length > 0;
 
   return (
-    <div className="min-w-0 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+    <div
+      className={`min-w-0 rounded-lg border p-3 ${isStaged ? 'border-dashed border-amber-500/30 bg-amber-500/[0.03]' : 'border-white/[0.06] bg-white/[0.02]'}`}
+    >
       {/* Convoy header */}
       <div className="mb-2 flex items-center justify-between">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="shrink-0 rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-medium text-violet-400">
-            CONVOY
-          </span>
           <span
-            className="min-w-0 shrink truncate text-xs font-medium text-white/70"
+            className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium ${isStaged ? 'border border-dashed border-amber-500/40 bg-amber-500/15 text-amber-400' : 'bg-violet-500/15 text-violet-400'}`}
+          >
+            {isStaged ? 'STAGED' : 'CONVOY'}
+          </span>
+          <button
+            onClick={onSelectConvoy}
+            className="min-w-0 shrink truncate text-xs font-medium text-white/70 transition-colors hover:text-white/90"
             title={convoy.title}
           >
             {convoy.title}
-          </span>
+          </button>
           {convoy.feature_branch && (
             <span
               className="flex min-w-0 shrink items-center gap-1 text-[9px] text-white/25"
@@ -178,6 +194,16 @@ function ConvoyCard({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {onStart && (
+            <button
+              onClick={onStart}
+              className="flex items-center gap-1 rounded bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-medium text-amber-400 transition-colors hover:bg-amber-500/30"
+              title="Start convoy — dispatch agents"
+            >
+              <Play className="size-2.5" />
+              Start
+            </button>
+          )}
           <span className="font-mono text-[10px] text-white/30">
             {convoy.closed_beads}/{convoy.total_beads}
           </span>

--- a/src/components/gastown/DrawerStack.tsx
+++ b/src/components/gastown/DrawerStack.tsx
@@ -10,7 +10,8 @@ import type { TownEvent } from './ActivityFeed';
 export type ResourceRef =
   | { type: 'bead'; beadId: string; rigId: string }
   | { type: 'agent'; agentId: string; rigId: string; townId?: string }
-  | { type: 'event'; event: TownEvent };
+  | { type: 'event'; event: TownEvent }
+  | { type: 'convoy'; convoyId: string; townId: string };
 
 type DrawerStackEntry = {
   key: string;

--- a/src/components/gastown/DrawerStackContent.tsx
+++ b/src/components/gastown/DrawerStackContent.tsx
@@ -5,6 +5,7 @@ import type { ResourceRef } from './DrawerStack';
 import { BeadPanel } from './drawer-panels/BeadPanel';
 import { AgentPanel } from './drawer-panels/AgentPanel';
 import { EventPanel } from './drawer-panels/EventPanel';
+import { ConvoyPanel } from './drawer-panels/ConvoyPanel';
 
 /**
  * Dispatch function that maps a ResourceRef to the right panel component.
@@ -29,5 +30,9 @@ export function renderDrawerContent(
       );
     case 'event':
       return <EventPanel event={resource.event} push={helpers.push} />;
+    case 'convoy':
+      return (
+        <ConvoyPanel convoyId={resource.convoyId} townId={resource.townId} push={helpers.push} />
+      );
   }
 }

--- a/src/components/gastown/drawer-panels/ConvoyPanel.tsx
+++ b/src/components/gastown/drawer-panels/ConvoyPanel.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { ResourceRef } from '@/components/gastown/DrawerStack';
+
+import { format } from 'date-fns';
+import {
+  Layers,
+  GitBranch,
+  Clock,
+  Play,
+  CheckCircle,
+  Loader2,
+  ArrowRight,
+  Hexagon,
+  Hash,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+type ConvoyBead = {
+  bead_id: string;
+  title: string;
+  status: string;
+  rig_id: string | null;
+  assignee_agent_name: string | null;
+};
+
+type DependencyEdge = {
+  bead_id: string;
+  depends_on_bead_id: string;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  open: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
+  in_progress: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  closed: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  failed: 'border-red-500/30 bg-red-500/10 text-red-300',
+};
+
+const STATUS_DOT_COLORS: Record<string, string> = {
+  open: 'bg-sky-400',
+  in_progress: 'bg-amber-400',
+  closed: 'bg-emerald-400',
+  failed: 'bg-red-400',
+};
+
+/**
+ * Topological wave grouping via Kahn's algorithm.
+ * Wave 0 = no incoming edges, Wave N = all blockers in prior waves.
+ */
+function computeWaves(beadList: ConvoyBead[], edges: DependencyEdge[]): ConvoyBead[][] {
+  const beadIds = new Set(beadList.map(b => b.bead_id));
+  const inDegree = new Map<string, number>();
+  const blockedBy = new Map<string, string[]>();
+  for (const b of beadList) {
+    inDegree.set(b.bead_id, 0);
+    blockedBy.set(b.bead_id, []);
+  }
+  for (const edge of edges) {
+    if (!beadIds.has(edge.bead_id) || !beadIds.has(edge.depends_on_bead_id)) continue;
+    inDegree.set(edge.bead_id, (inDegree.get(edge.bead_id) ?? 0) + 1);
+    blockedBy.get(edge.bead_id)?.push(edge.depends_on_bead_id);
+  }
+
+  const beadById = new Map(beadList.map(b => [b.bead_id, b]));
+  const waves: ConvoyBead[][] = [];
+  const remaining = new Set(beadIds);
+
+  while (remaining.size > 0) {
+    const wave: ConvoyBead[] = [];
+    for (const id of remaining) {
+      if ((inDegree.get(id) ?? 0) === 0) {
+        const bead = beadById.get(id);
+        if (bead) wave.push(bead);
+      }
+    }
+    if (wave.length === 0) {
+      const rest: ConvoyBead[] = [];
+      for (const id of remaining) {
+        const bead = beadById.get(id);
+        if (bead) rest.push(bead);
+      }
+      waves.push(rest);
+      break;
+    }
+    waves.push(wave);
+    for (const bead of wave) remaining.delete(bead.bead_id);
+    for (const id of remaining) {
+      const blockers = blockedBy.get(id) ?? [];
+      let newDeg = 0;
+      for (const dep of blockers) {
+        if (remaining.has(dep)) newDeg++;
+      }
+      inDegree.set(id, newDeg);
+    }
+  }
+  return waves;
+}
+
+export function ConvoyPanel({
+  convoyId,
+  townId,
+  push,
+}: {
+  convoyId: string;
+  townId: string;
+  push: (ref: ResourceRef) => void;
+}) {
+  const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
+
+  const convoysQuery = useQuery({
+    ...trpc.gastown.listConvoys.queryOptions({ townId }),
+    refetchInterval: 5_000,
+  });
+
+  const convoy = (convoysQuery.data ?? []).find(c => c.id === convoyId);
+
+  const startConvoyMutation = useMutation(
+    trpc.gastown.startConvoy.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.listConvoys.queryKey({ townId }),
+        });
+        toast.success('Convoy started');
+      },
+      onError: err => toast.error(err.message),
+    })
+  );
+
+  const waves = useMemo(
+    () => computeWaves(convoy?.beads ?? [], convoy?.dependency_edges ?? []),
+    [convoy?.beads, convoy?.dependency_edges]
+  );
+
+  if (convoysQuery.isLoading) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <Loader2 className="size-5 animate-spin text-white/20" />
+      </div>
+    );
+  }
+
+  if (!convoy) {
+    return <div className="p-6 text-center text-sm text-white/30">Convoy not found</div>;
+  }
+
+  const progress = convoy.total_beads > 0 ? convoy.closed_beads / convoy.total_beads : 0;
+  const hasDag = (convoy.dependency_edges ?? []).length > 0;
+
+  return (
+    <div className="flex flex-col gap-0">
+      {/* Header */}
+      <div className="border-b border-white/[0.06] px-5 py-4">
+        <div className="mb-2 flex items-center gap-2">
+          <Layers className="size-4 text-violet-400" />
+          <span className="text-xs font-medium tracking-wide text-white/40 uppercase">Convoy</span>
+          {convoy.staged && (
+            <Badge
+              variant="outline"
+              className="border-dashed border-amber-500/40 bg-amber-500/10 text-[9px] text-amber-300"
+            >
+              STAGED
+            </Badge>
+          )}
+          {!convoy.staged && convoy.status === 'active' && (
+            <Badge
+              variant="outline"
+              className="border-emerald-500/30 bg-emerald-500/10 text-[9px] text-emerald-300"
+            >
+              ACTIVE
+            </Badge>
+          )}
+          {convoy.status === 'landed' && (
+            <Badge
+              variant="outline"
+              className="border-violet-500/30 bg-violet-500/10 text-[9px] text-violet-300"
+            >
+              LANDED
+            </Badge>
+          )}
+        </div>
+        <h2 className="text-base font-semibold text-white/80">{convoy.title}</h2>
+      </div>
+
+      {/* Staged banner + start button */}
+      {convoy.staged && (
+        <div className="border-b border-amber-500/20 bg-amber-500/[0.04] px-5 py-3">
+          <div className="mb-2 text-xs text-amber-300/70">
+            This convoy is staged — agents have not been dispatched yet. Start the convoy when
+            you&apos;re ready to begin execution.
+          </div>
+          <Button
+            size="sm"
+            onClick={() => startConvoyMutation.mutate({ townId, convoyId })}
+            disabled={startConvoyMutation.isPending}
+            className="bg-amber-500/20 text-amber-300 hover:bg-amber-500/30"
+          >
+            {startConvoyMutation.isPending ? (
+              <Loader2 className="mr-1.5 size-3 animate-spin" />
+            ) : (
+              <Play className="mr-1.5 size-3" />
+            )}
+            Start Convoy
+          </Button>
+        </div>
+      )}
+
+      {/* Progress */}
+      <div className="border-b border-white/[0.06] px-5 py-3">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-[10px] text-white/40">Progress</span>
+          <span className="font-mono text-[10px] text-white/30">
+            {convoy.closed_beads}/{convoy.total_beads}
+          </span>
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+          <div
+            className="h-full rounded-full bg-emerald-500/60 transition-all duration-500"
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Metadata grid */}
+      <div className="grid grid-cols-2 gap-px border-b border-white/[0.06] bg-white/[0.02]">
+        <MetaCell
+          icon={<Hash className="size-3" />}
+          label="ID"
+          value={convoy.id.slice(0, 8)}
+          mono
+        />
+        <MetaCell
+          icon={<Clock className="size-3" />}
+          label="Created"
+          value={format(new Date(convoy.created_at), 'MMM d, HH:mm')}
+        />
+        {convoy.feature_branch && (
+          <MetaCell
+            icon={<GitBranch className="size-3" />}
+            label="Branch"
+            value={convoy.feature_branch}
+            mono
+            colSpan2
+          />
+        )}
+        {convoy.merge_mode && (
+          <MetaCell
+            icon={<Layers className="size-3" />}
+            label="Merge Mode"
+            value={convoy.merge_mode}
+            colSpan2
+          />
+        )}
+      </div>
+
+      {/* DAG: Bead list with wave structure */}
+      <div className="px-5 py-3">
+        <div className="mb-2 flex items-center gap-2">
+          <Hexagon className="size-3 text-white/25" />
+          <span className="text-[10px] font-medium tracking-wide text-white/40 uppercase">
+            Beads ({convoy.beads.length})
+          </span>
+        </div>
+
+        {hasDag ? (
+          <div className="space-y-2">
+            {waves.map((wave, waveIdx) => (
+              <div key={waveIdx}>
+                {waveIdx > 0 && (
+                  <div className="my-1.5 flex items-center gap-2 px-1">
+                    <ArrowRight className="size-3 text-white/15" />
+                    <span className="text-[9px] text-white/20">wave {waveIdx + 1}</span>
+                    <div className="h-px flex-1 bg-white/[0.04]" />
+                  </div>
+                )}
+                <div className="space-y-0.5">
+                  {wave.map(bead => (
+                    <BeadRow key={bead.bead_id} bead={bead} push={push} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-0.5">
+            {convoy.beads.map(bead => (
+              <BeadRow key={bead.bead_id} bead={bead} push={push} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BeadRow({ bead, push }: { bead: ConvoyBead; push: (ref: ResourceRef) => void }) {
+  return (
+    <button
+      onClick={() => {
+        if (bead.rig_id) push({ type: 'bead', beadId: bead.bead_id, rigId: bead.rig_id });
+      }}
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-white/[0.04]"
+    >
+      {bead.status === 'closed' ? (
+        <CheckCircle className="size-3.5 shrink-0 text-emerald-400" />
+      ) : bead.status === 'in_progress' ? (
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-amber-400" />
+      ) : (
+        <span
+          className={`size-2.5 shrink-0 rounded-full ${STATUS_DOT_COLORS[bead.status] ?? 'bg-white/20'}`}
+        />
+      )}
+      <span className="min-w-0 flex-1 truncate text-xs text-white/70">{bead.title}</span>
+      <Badge
+        variant="outline"
+        className={`shrink-0 text-[9px] ${STATUS_STYLES[bead.status] ?? 'border-white/10 text-white/30'}`}
+      >
+        {bead.status}
+      </Badge>
+      {bead.assignee_agent_name && (
+        <span className="shrink-0 text-[10px] text-white/25">{bead.assignee_agent_name}</span>
+      )}
+    </button>
+  );
+}
+
+function MetaCell({
+  icon,
+  label,
+  value,
+  mono,
+  colSpan2,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  mono?: boolean;
+  colSpan2?: boolean;
+}) {
+  return (
+    <div className={`flex items-center gap-2 px-4 py-2.5 ${colSpan2 ? 'col-span-2' : ''}`}>
+      <span className="text-white/20">{icon}</span>
+      <div className="min-w-0 flex-1">
+        <div className="text-[9px] text-white/30">{label}</div>
+        <div className={`truncate text-xs text-white/60 ${mono ? 'font-mono' : ''}`} title={value}>
+          {value}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/gastown/drawer-panels/ConvoyPanel.tsx
+++ b/src/components/gastown/drawer-panels/ConvoyPanel.tsx
@@ -113,16 +113,19 @@ export function ConvoyPanel({
   const trpc = useGastownTRPC();
   const queryClient = useQueryClient();
 
-  const convoysQuery = useQuery({
-    ...trpc.gastown.listConvoys.queryOptions({ townId }),
+  const convoyQuery = useQuery({
+    ...trpc.gastown.getConvoy.queryOptions({ townId, convoyId }),
     refetchInterval: 5_000,
   });
 
-  const convoy = (convoysQuery.data ?? []).find(c => c.id === convoyId);
+  const convoy = convoyQuery.data ?? null;
 
   const startConvoyMutation = useMutation(
     trpc.gastown.startConvoy.mutationOptions({
       onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getConvoy.queryKey({ townId, convoyId }),
+        });
         void queryClient.invalidateQueries({
           queryKey: trpc.gastown.listConvoys.queryKey({ townId }),
         });
@@ -137,7 +140,7 @@ export function ConvoyPanel({
     [convoy?.beads, convoy?.dependency_edges]
   );
 
-  if (convoysQuery.isLoading) {
+  if (convoyQuery.isLoading) {
     return (
       <div className="flex h-40 items-center justify-center">
         <Loader2 className="size-5 animate-spin text-white/20" />

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,811 +1,923 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    createTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            name: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    createTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        name: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
     }>;
-    listTowns: import("@trpc/server").TRPCQueryProcedure<{
-        input: void;
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
+    listTowns: import('@trpc/server').TRPCQueryProcedure<{
+      input: void;
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getTown: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    createRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        name: string;
+        gitUrl: string;
+        defaultBranch?: string | undefined;
+        platformIntegrationId?: string | undefined;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    listRigs: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getRig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+        agents: {
+          id: string;
+          rig_id: string | null;
+          role: string;
+          name: string;
+          identity: string;
+          status: string;
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+          agent_status_message: string | null;
+          agent_status_updated_at: string | null;
         }[];
-        meta: object;
-    }>;
-    getTown: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    createRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    listRigs: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
+        beads: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    getRig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-            agents: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            }[];
-            beads: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            }[];
-        };
-        meta: object;
+    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: void;
-        meta: object;
+    listBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
     }>;
-    listBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    updateBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+        title?: string | undefined;
+        body?: string | null | undefined;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+        priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+        labels?: string[] | undefined;
+        metadata?: Record<string, unknown> | undefined;
+        rig_id?: string | null | undefined;
+        parent_bead_id?: string | null | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    listAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: string;
+        name: string;
+        identity: string;
+        status: string;
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+        agent_status_message: string | null;
+        agent_status_updated_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        agentId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    sling: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        title: string;
+        body?: string | undefined;
+        model?: string | undefined;
+      };
+      output: {
+        bead: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
+        agent: {
+          id: string;
+          rig_id: string | null;
+          role: string;
+          name: string;
+          identity: string;
+          status: string;
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+          agent_status_message: string | null;
+          agent_status_updated_at: string | null;
+        };
+      };
+      meta: object;
+    }>;
+    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        message: string;
+        model?: string | undefined;
+        rigId?: string | undefined;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
+    }>;
+    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        configured: boolean;
+        townId: string | null;
+        session: {
+          agentId: string;
+          sessionId: string;
+          status: 'active' | 'idle' | 'starting';
+          lastActivityAt: string;
+        } | null;
+      };
+      meta: object;
+    }>;
+    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
+        };
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
+        };
+        beads: {
+          open: number;
+          inProgress: number;
+          inReview: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-        };
-        output: void;
-        meta: object;
+    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
     }>;
-    updateBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-            title?: string | undefined;
-            body?: string | null | undefined;
-            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-            priority?: "critical" | "high" | "low" | "medium" | undefined;
-            labels?: string[] | undefined;
-            metadata?: Record<string, unknown> | undefined;
-            rig_id?: string | null | undefined;
-            parent_bead_id?: string | null | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
+    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        agentId: string;
+        townId: string;
+      };
+      output: {
+        url: string;
+        ticket: string;
+      };
+      meta: object;
     }>;
-    listAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
+    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: {
+        pty: {
+          [x: string]: unknown;
+          id: string;
         };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
-        }[];
-        meta: object;
+        wsUrl: string;
+      };
+      meta: object;
     }>;
-    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            agentId: string;
-        };
-        output: void;
-        meta: object;
+    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+        ptyId: string;
+        cols: number;
+        rows: number;
+      };
+      output: void;
+      meta: object;
     }>;
-    sling: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            title: string;
-            body?: string | undefined;
-            model?: string | undefined;
+    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
         };
-        output: {
-            bead: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            agent: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            };
-        };
-        meta: object;
+        owner_user_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+        staged_convoys_default: boolean;
+      };
+      meta: object;
     }>;
-    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            message: string;
-            model?: string | undefined;
-            rigId?: string | undefined;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            configured: boolean;
-            townId: string | null;
-            session: {
-                agentId: string;
-                sessionId: string;
-                status: "active" | "idle" | "starting";
-                lastActivityAt: string;
-            } | null;
-        };
-        meta: object;
-    }>;
-    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
-            };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
-            };
-            beads: {
-                open: number;
-                inProgress: number;
-                inReview: number;
-                failed: number;
-                triageRequests: number;
-            };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
-            };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
-        };
-        meta: object;
-    }>;
-    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            agentId: string;
-            townId: string;
-        };
-        output: {
-            url: string;
-            ticket: string;
-        };
-        meta: object;
-    }>;
-    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: {
-            pty: {
-                [x: string]: unknown;
-                id: string;
-            };
-            wsUrl: string;
-        };
-        meta: object;
-    }>;
-    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-            ptyId: string;
-            cols: number;
-            rows: number;
-        };
-        output: void;
-        meta: object;
-    }>;
-    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
+    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        config: {
+          env_vars?: Record<string, string> | undefined;
+          git_auth?:
+            | {
                 github_token?: string | undefined;
                 gitlab_token?: string | undefined;
                 gitlab_instance_url?: string | undefined;
                 platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
+              }
+            | undefined;
+          owner_user_id?: string | undefined;
+          kilocode_token?: string | undefined;
+          default_model?: string | undefined;
+          small_model?: string | undefined;
+          max_polecats_per_rig?: number | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          refinery?:
+            | {
+                gates?: string[] | undefined;
+                auto_merge?: boolean | undefined;
+                require_clean_merge?: boolean | undefined;
+              }
+            | undefined;
+          alarm_interval_active?: number | undefined;
+          alarm_interval_idle?: number | undefined;
+          container?:
+            | {
                 sleep_after_minutes?: number | undefined;
-            } | undefined;
-            staged_convoys_default: boolean;
+              }
+            | undefined;
+          staged_convoys_default?: boolean | undefined;
         };
-        meta: object;
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
+        };
+        owner_user_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+        staged_convoys_default: boolean;
+      };
+      meta: object;
     }>;
-    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            config: {
-                env_vars?: Record<string, string> | undefined;
-                git_auth?: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                } | undefined;
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy?: "direct" | "pr" | undefined;
-                refinery?: {
-                    gates?: string[] | undefined;
-                    auto_merge?: boolean | undefined;
-                    require_clean_merge?: boolean | undefined;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-                staged_convoys_default?: boolean | undefined;
-            };
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
-                sleep_after_minutes?: number | undefined;
-            } | undefined;
-            staged_convoys_default: boolean;
-        };
-        meta: object;
+    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
     }>;
-    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
+    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
         }[];
-        meta: object;
-    }>;
-    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
         }[];
-        meta: object;
+      }[];
+      meta: object;
     }>;
-    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
+    getConvoy: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
         }[];
-        meta: object;
-    }>;
-    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        } | null;
-        meta: object;
-    }>;
-    startConvoy: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        } | null;
-        meta: object;
-    }>;
-    adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
         }[];
-        meta: object;
+      } | null;
+      meta: object;
     }>;
-    adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
+    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
         }[];
-        meta: object;
-    }>;
-    adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
-    }>;
-    adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
-    }>;
-    adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
-            };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
-            };
-            beads: {
-                open: number;
-                inProgress: number;
-                inReview: number;
-                failed: number;
-                triageRequests: number;
-            };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
-            };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
-        };
-        meta: object;
-    }>;
-    adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
         }[];
-        meta: object;
+      } | null;
+      meta: object;
     }>;
-    adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
+    startConvoy: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
+        }[];
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      } | null;
+      meta: object;
+    }>;
+    adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+        type?:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule'
+          | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: string;
+        name: string;
+        identity: string;
+        status: string;
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+        agent_status_message: string | null;
+        agent_status_updated_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
         };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        } | null;
-        meta: object;
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
+        };
+        beads: {
+          open: number;
+          inProgress: number;
+          inReview: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
+        }[];
+      };
+      meta: object;
     }>;
-}>>;
+    adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      } | null;
+      meta: object;
+    }>;
+  }>
+>;
 export type GastownRouter = typeof gastownRouter;
 /**
  * Wrapped router that nests gastownRouter under a `gastown` key.
@@ -813,818 +925,933 @@ export type GastownRouter = typeof gastownRouter;
  * matching the existing RootRouter shape so components don't need
  * to change their procedure paths.
  */
-export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    gastown: import("@trpc/server").TRPCBuiltRouter<{
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    gastown: import('@trpc/server').TRPCBuiltRouter<
+      {
         ctx: TRPCContext;
         meta: object;
-        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
         transformer: false;
-    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-        createTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                name: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
+      },
+      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+        createTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            name: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
         }>;
-        listTowns: import("@trpc/server").TRPCQueryProcedure<{
-            input: void;
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
+        listTowns: import('@trpc/server').TRPCQueryProcedure<{
+          input: void;
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getTown: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        createRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        listRigs: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getRig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+            agents: {
+              id: string;
+              rig_id: string | null;
+              role: string;
+              name: string;
+              identity: string;
+              status: string;
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+              agent_status_message: string | null;
+              agent_status_updated_at: string | null;
             }[];
-            meta: object;
-        }>;
-        getTown: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        createRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                name: string;
-                gitUrl: string;
-                defaultBranch?: string | undefined;
-                platformIntegrationId?: string | undefined;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        listRigs: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
+            beads: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        getRig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-                agents: {
-                    id: string;
-                    rig_id: string | null;
-                    role: string;
-                    name: string;
-                    identity: string;
-                    status: string;
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                    agent_status_message: string | null;
-                    agent_status_updated_at: string | null;
-                }[];
-                beads: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                }[];
-            };
-            meta: object;
+        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: void;
-            meta: object;
+        listBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
         }>;
-        listBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        updateBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+            title?: string | undefined;
+            body?: string | null | undefined;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+            priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+            labels?: string[] | undefined;
+            metadata?: Record<string, unknown> | undefined;
+            rig_id?: string | null | undefined;
+            parent_bead_id?: string | null | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        listAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            agentId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        sling: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            title: string;
+            body?: string | undefined;
+            model?: string | undefined;
+          };
+          output: {
+            bead: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
+            agent: {
+              id: string;
+              rig_id: string | null;
+              role: string;
+              name: string;
+              identity: string;
+              status: string;
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+              agent_status_message: string | null;
+              agent_status_updated_at: string | null;
+            };
+          };
+          meta: object;
+        }>;
+        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            message: string;
+            model?: string | undefined;
+            rigId?: string | undefined;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
+        }>;
+        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            configured: boolean;
+            townId: string | null;
+            session: {
+              agentId: string;
+              sessionId: string;
+              status: 'active' | 'idle' | 'starting';
+              lastActivityAt: string;
+            } | null;
+          };
+          meta: object;
+        }>;
+        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
+            };
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
+            };
+            beads: {
+              open: number;
+              inProgress: number;
+              inReview: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-            };
-            output: void;
-            meta: object;
+        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
         }>;
-        updateBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-                title?: string | undefined;
-                body?: string | null | undefined;
-                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-                priority?: "critical" | "high" | "low" | "medium" | undefined;
-                labels?: string[] | undefined;
-                metadata?: Record<string, unknown> | undefined;
-                rig_id?: string | null | undefined;
-                parent_bead_id?: string | null | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
+        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            agentId: string;
+            townId: string;
+          };
+          output: {
+            url: string;
+            ticket: string;
+          };
+          meta: object;
         }>;
-        listAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
+        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: {
+            pty: {
+              [x: string]: unknown;
+              id: string;
             };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            }[];
-            meta: object;
+            wsUrl: string;
+          };
+          meta: object;
         }>;
-        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                agentId: string;
-            };
-            output: void;
-            meta: object;
+        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+            ptyId: string;
+            cols: number;
+            rows: number;
+          };
+          output: void;
+          meta: object;
         }>;
-        sling: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                title: string;
-                body?: string | undefined;
-                model?: string | undefined;
+        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
             };
-            output: {
-                bead: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                };
-                agent: {
-                    id: string;
-                    rig_id: string | null;
-                    role: string;
-                    name: string;
-                    identity: string;
-                    status: string;
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                    agent_status_message: string | null;
-                    agent_status_updated_at: string | null;
-                };
-            };
-            meta: object;
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+            staged_convoys_default: boolean;
+          };
+          meta: object;
         }>;
-        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                message: string;
-                model?: string | undefined;
-                rigId?: string | undefined;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                configured: boolean;
-                townId: string | null;
-                session: {
-                    agentId: string;
-                    sessionId: string;
-                    status: "active" | "idle" | "starting";
-                    lastActivityAt: string;
-                } | null;
-            };
-            meta: object;
-        }>;
-        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
-                };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
-                };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    inReview: number;
-                    failed: number;
-                    triageRequests: number;
-                };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
-                };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
-            };
-            meta: object;
-        }>;
-        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                agentId: string;
-                townId: string;
-            };
-            output: {
-                url: string;
-                ticket: string;
-            };
-            meta: object;
-        }>;
-        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: {
-                pty: {
-                    [x: string]: unknown;
-                    id: string;
-                };
-                wsUrl: string;
-            };
-            meta: object;
-        }>;
-        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-                ptyId: string;
-                cols: number;
-                rows: number;
-            };
-            output: void;
-            meta: object;
-        }>;
-        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
+        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            config: {
+              env_vars?: Record<string, string> | undefined;
+              git_auth?:
+                | {
                     github_token?: string | undefined;
                     gitlab_token?: string | undefined;
                     gitlab_instance_url?: string | undefined;
                     platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
+                  }
+                | undefined;
+              owner_user_id?: string | undefined;
+              kilocode_token?: string | undefined;
+              default_model?: string | undefined;
+              small_model?: string | undefined;
+              max_polecats_per_rig?: number | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              refinery?:
+                | {
+                    gates?: string[] | undefined;
+                    auto_merge?: boolean | undefined;
+                    require_clean_merge?: boolean | undefined;
+                  }
+                | undefined;
+              alarm_interval_active?: number | undefined;
+              alarm_interval_idle?: number | undefined;
+              container?:
+                | {
                     sleep_after_minutes?: number | undefined;
-                } | undefined;
-                staged_convoys_default: boolean;
+                  }
+                | undefined;
+              staged_convoys_default?: boolean | undefined;
             };
-            meta: object;
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+            staged_convoys_default: boolean;
+          };
+          meta: object;
         }>;
-        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                config: {
-                    env_vars?: Record<string, string> | undefined;
-                    git_auth?: {
-                        github_token?: string | undefined;
-                        gitlab_token?: string | undefined;
-                        gitlab_instance_url?: string | undefined;
-                        platform_integration_id?: string | undefined;
-                    } | undefined;
-                    owner_user_id?: string | undefined;
-                    kilocode_token?: string | undefined;
-                    default_model?: string | undefined;
-                    small_model?: string | undefined;
-                    max_polecats_per_rig?: number | undefined;
-                    merge_strategy?: "direct" | "pr" | undefined;
-                    refinery?: {
-                        gates?: string[] | undefined;
-                        auto_merge?: boolean | undefined;
-                        require_clean_merge?: boolean | undefined;
-                    } | undefined;
-                    alarm_interval_active?: number | undefined;
-                    alarm_interval_idle?: number | undefined;
-                    container?: {
-                        sleep_after_minutes?: number | undefined;
-                    } | undefined;
-                    staged_convoys_default?: boolean | undefined;
-                };
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-                staged_convoys_default: boolean;
-            };
-            meta: object;
+        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
         }>;
-        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
+        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
             }[];
-            meta: object;
-        }>;
-        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
             }[];
-            meta: object;
+          }[];
+          meta: object;
         }>;
-        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
+        getConvoy: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
             }[];
-            meta: object;
-        }>;
-        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            } | null;
-            meta: object;
-        }>;
-        startConvoy: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            } | null;
-            meta: object;
-        }>;
-        adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
             }[];
-            meta: object;
+          } | null;
+          meta: object;
         }>;
-        adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
+        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
             }[];
-            meta: object;
-        }>;
-        adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
-        }>;
-        adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
-        }>;
-        adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
-                };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
-                };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    inReview: number;
-                    failed: number;
-                    triageRequests: number;
-                };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
-                };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
-            };
-            meta: object;
-        }>;
-        adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
             }[];
-            meta: object;
+          } | null;
+          meta: object;
         }>;
-        adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
+        startConvoy: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          } | null;
+          meta: object;
+        }>;
+        adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+            type?:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule'
+              | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
             };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            } | null;
-            meta: object;
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
+            };
+            beads: {
+              open: number;
+              inProgress: number;
+              inReview: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
+            }[];
+          };
+          meta: object;
         }>;
-    }>>;
-}>>;
+        adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          } | null;
+          meta: object;
+        }>;
+      }>
+    >;
+  }>
+>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -417,6 +417,7 @@ export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
             container?: {
                 sleep_after_minutes?: number | undefined;
             } | undefined;
+            staged_convoys_default: boolean;
         };
         meta: object;
     }>;
@@ -447,6 +448,7 @@ export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
                 container?: {
                     sleep_after_minutes?: number | undefined;
                 } | undefined;
+                staged_convoys_default?: boolean | undefined;
             };
         };
         output: {
@@ -473,6 +475,7 @@ export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
             container?: {
                 sleep_after_minutes?: number | undefined;
             } | undefined;
+            staged_convoys_default: boolean;
         };
         meta: object;
     }>;
@@ -1234,6 +1237,7 @@ export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRoute
                 container?: {
                     sleep_after_minutes?: number | undefined;
                 } | undefined;
+                staged_convoys_default: boolean;
             };
             meta: object;
         }>;
@@ -1264,6 +1268,7 @@ export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRoute
                     container?: {
                         sleep_after_minutes?: number | undefined;
                     } | undefined;
+                    staged_convoys_default?: boolean | undefined;
                 };
             };
             output: {
@@ -1290,6 +1295,7 @@ export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRoute
                 container?: {
                     sleep_after_minutes?: number | undefined;
                 } | undefined;
+                staged_convoys_default: boolean;
             };
             meta: object;
         }>;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,856 +1,808 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
+export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
     ctx: TRPCContext;
     meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
     transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    createTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        name: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    createTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            name: string;
+        };
+        output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
     }>;
-    listTowns: import('@trpc/server').TRPCQueryProcedure<{
-      input: void;
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getTown: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    createRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        name: string;
-        gitUrl: string;
-        defaultBranch?: string | undefined;
-        platformIntegrationId?: string | undefined;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listRigs: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getRig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-        agents: {
-          id: string;
-          rig_id: string | null;
-          role: string;
-          name: string;
-          identity: string;
-          status: string;
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-          agent_status_message: string | null;
-          agent_status_updated_at: string | null;
+    listTowns: import("@trpc/server").TRPCQueryProcedure<{
+        input: void;
+        output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
         }[];
-        beads: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
+        meta: object;
+    }>;
+    getTown: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    createRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+        };
+        output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    listRigs: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
         }[];
-      };
-      meta: object;
+        meta: object;
     }>;
-    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listBeads: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        beadId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    updateBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        beadId: string;
-        title?: string | undefined;
-        body?: string | null | undefined;
-        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-        priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
-        labels?: string[] | undefined;
-        metadata?: Record<string, unknown> | undefined;
-        rig_id?: string | null | undefined;
-        parent_bead_id?: string | null | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      };
-      meta: object;
-    }>;
-    listAgents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        rig_id: string | null;
-        role: string;
-        name: string;
-        identity: string;
-        status: string;
-        current_hook_bead_id: string | null;
-        dispatch_attempts: number;
-        last_activity_at: string | null;
-        checkpoint?: unknown;
-        created_at: string;
-        agent_status_message: string | null;
-        agent_status_updated_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        agentId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    sling: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        title: string;
-        body?: string | undefined;
-        model?: string | undefined;
-      };
-      output: {
-        bead: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
+    getRig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            rigId: string;
         };
-        agent: {
-          id: string;
-          rig_id: string | null;
-          role: string;
-          name: string;
-          identity: string;
-          status: string;
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-          agent_status_message: string | null;
-          agent_status_updated_at: string | null;
+        output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+            agents: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            }[];
+            beads: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
         };
-      };
-      meta: object;
+        meta: object;
     }>;
-    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        message: string;
-        model?: string | undefined;
-        rigId?: string | undefined;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
+    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            rigId: string;
+        };
+        output: void;
+        meta: object;
     }>;
-    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        configured: boolean;
-        townId: string | null;
-        session: {
-          agentId: string;
-          sessionId: string;
-          status: 'active' | 'idle' | 'starting';
-          lastActivityAt: string;
-        } | null;
-      };
-      meta: object;
-    }>;
-    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        alarm: {
-          nextFireAt: string | null;
-          intervalMs: number;
-          intervalLabel: string;
+    listBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            rigId: string;
+            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
         };
-        agents: {
-          working: number;
-          idle: number;
-          stalled: number;
-          dead: number;
-          total: number;
-        };
-        beads: {
-          open: number;
-          inProgress: number;
-          inReview: number;
-          failed: number;
-          triageRequests: number;
-        };
-        patrol: {
-          guppWarnings: number;
-          guppEscalations: number;
-          stalledAgents: number;
-          orphanedHooks: number;
-        };
-        recentEvents: {
-          time: string;
-          type: string;
-          message: string;
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
         }[];
-      };
-      meta: object;
+        meta: object;
     }>;
-    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        agentId: string;
-        townId: string;
-      };
-      output: {
-        url: string;
-        ticket: string;
-      };
-      meta: object;
-    }>;
-    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-      };
-      output: {
-        pty: {
-          [x: string]: unknown;
-          id: string;
+    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            rigId: string;
+            beadId: string;
         };
-        wsUrl: string;
-      };
-      meta: object;
+        output: void;
+        meta: object;
     }>;
-    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-        ptyId: string;
-        cols: number;
-        rows: number;
-      };
-      output: void;
-      meta: object;
-    }>;
-    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
+    updateBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            rigId: string;
+            beadId: string;
+            title?: string | undefined;
+            body?: string | null | undefined;
+            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+            priority?: "critical" | "high" | "low" | "medium" | undefined;
+            labels?: string[] | undefined;
+            metadata?: Record<string, unknown> | undefined;
+            rig_id?: string | null | undefined;
+            parent_bead_id?: string | null | undefined;
         };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-      };
-      meta: object;
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
     }>;
-    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        config: {
-          env_vars?: Record<string, string> | undefined;
-          git_auth?:
-            | {
+    listAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            rigId: string;
+        };
+        output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            rigId: string;
+            agentId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    sling: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            rigId: string;
+            title: string;
+            body?: string | undefined;
+            model?: string | undefined;
+        };
+        output: {
+            bead: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            agent: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            };
+        };
+        meta: object;
+    }>;
+    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            message: string;
+            model?: string | undefined;
+            rigId?: string | undefined;
+        };
+        output: {
+            agentId: string;
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            configured: boolean;
+            townId: string | null;
+            session: {
+                agentId: string;
+                sessionId: string;
+                status: "active" | "idle" | "starting";
+                lastActivityAt: string;
+            } | null;
+        };
+        meta: object;
+    }>;
+    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            alarm: {
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
+            };
+            agents: {
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
+            };
+            beads: {
+                open: number;
+                inProgress: number;
+                inReview: number;
+                failed: number;
+                triageRequests: number;
+            };
+            patrol: {
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
+            };
+            recentEvents: {
+                time: string;
+                type: string;
+                message: string;
+            }[];
+        };
+        meta: object;
+    }>;
+    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            agentId: string;
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            agentId: string;
+            townId: string;
+        };
+        output: {
+            url: string;
+            ticket: string;
+        };
+        meta: object;
+    }>;
+    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            agentId: string;
+        };
+        output: {
+            pty: {
+                [x: string]: unknown;
+                id: string;
+            };
+            wsUrl: string;
+        };
+        meta: object;
+    }>;
+    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            agentId: string;
+            ptyId: string;
+            cols: number;
+            rows: number;
+        };
+        output: void;
+        meta: object;
+    }>;
+    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            env_vars: Record<string, string>;
+            git_auth: {
                 github_token?: string | undefined;
                 gitlab_token?: string | undefined;
                 gitlab_instance_url?: string | undefined;
                 platform_integration_id?: string | undefined;
-              }
-            | undefined;
-          owner_user_id?: string | undefined;
-          kilocode_token?: string | undefined;
-          default_model?: string | undefined;
-          small_model?: string | undefined;
-          max_polecats_per_rig?: number | undefined;
-          merge_strategy?: 'direct' | 'pr' | undefined;
-          refinery?:
-            | {
-                gates?: string[] | undefined;
-                auto_merge?: boolean | undefined;
-                require_clean_merge?: boolean | undefined;
-              }
-            | undefined;
-          alarm_interval_active?: number | undefined;
-          alarm_interval_idle?: number | undefined;
-          container?:
-            | {
+            };
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?: {
                 sleep_after_minutes?: number | undefined;
-              }
-            | undefined;
+            } | undefined;
         };
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
+        meta: object;
+    }>;
+    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            config: {
+                env_vars?: Record<string, string> | undefined;
+                git_auth?: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                } | undefined;
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy?: "direct" | "pr" | undefined;
+                refinery?: {
+                    gates?: string[] | undefined;
+                    auto_merge?: boolean | undefined;
+                    require_clean_merge?: boolean | undefined;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+            };
         };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-      };
-      meta: object;
+        output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
+        };
+        meta: object;
     }>;
-    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        beadId?: string | undefined;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
+    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            rigId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
         }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      }[];
-      meta: object;
+        meta: object;
     }>;
-    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        convoyId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      } | null;
-      meta: object;
-    }>;
-    adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
-        type?:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule'
-          | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        rig_id: string | null;
-        role: string;
-        name: string;
-        identity: string;
-        status: string;
-        current_hook_bead_id: string | null;
-        dispatch_attempts: number;
-        last_activity_at: string | null;
-        checkpoint?: unknown;
-        created_at: string;
-        agent_status_message: string | null;
-        agent_status_updated_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        beadId: string;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      };
-      meta: object;
-    }>;
-    adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        beadId: string;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      };
-      meta: object;
-    }>;
-    adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        alarm: {
-          nextFireAt: string | null;
-          intervalMs: number;
-          intervalLabel: string;
+    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            since?: string | undefined;
+            limit?: number | undefined;
         };
-        agents: {
-          working: number;
-          idle: number;
-          stalled: number;
-          dead: number;
-          total: number;
-        };
-        beads: {
-          open: number;
-          inProgress: number;
-          inReview: number;
-          failed: number;
-          triageRequests: number;
-        };
-        patrol: {
-          guppWarnings: number;
-          guppEscalations: number;
-          stalledAgents: number;
-          orphanedHooks: number;
-        };
-        recentEvents: {
-          time: string;
-          type: string;
-          message: string;
+        output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
         }[];
-      };
-      meta: object;
+        meta: object;
     }>;
-    adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        beadId?: string | undefined;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
+    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        }[];
+        meta: object;
     }>;
-    adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        beadId: string;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      } | null;
-      meta: object;
+    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            convoyId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        } | null;
+        meta: object;
     }>;
-  }>
->;
+    startConvoy: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            convoyId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        } | null;
+        meta: object;
+    }>;
+    adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            agentId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            alarm: {
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
+            };
+            agents: {
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
+            };
+            beads: {
+                open: number;
+                inProgress: number;
+                inReview: number;
+                failed: number;
+                triageRequests: number;
+            };
+            patrol: {
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
+            };
+            recentEvents: {
+                time: string;
+                type: string;
+                message: string;
+            }[];
+        };
+        meta: object;
+    }>;
+    adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+        }[];
+        meta: object;
+    }>;
+    adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        } | null;
+        meta: object;
+    }>;
+}>>;
 export type GastownRouter = typeof gastownRouter;
 /**
  * Wrapped router that nests gastownRouter under a `gastown` key.
@@ -858,866 +810,815 @@ export type GastownRouter = typeof gastownRouter;
  * matching the existing RootRouter shape so components don't need
  * to change their procedure paths.
  */
-export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
+export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
     ctx: TRPCContext;
     meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
     transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    gastown: import('@trpc/server').TRPCBuiltRouter<
-      {
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    gastown: import("@trpc/server").TRPCBuiltRouter<{
         ctx: TRPCContext;
         meta: object;
-        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
         transformer: false;
-      },
-      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-        createTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            name: string;
-          };
-          output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-          };
-          meta: object;
+    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+        createTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                name: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
         }>;
-        listTowns: import('@trpc/server').TRPCQueryProcedure<{
-          input: void;
-          output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getTown: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-          };
-          meta: object;
-        }>;
-        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        createRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-          };
-          output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-          };
-          meta: object;
-        }>;
-        listRigs: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getRig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            rigId: string;
-          };
-          output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-            agents: {
-              id: string;
-              rig_id: string | null;
-              role: string;
-              name: string;
-              identity: string;
-              status: string;
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
-              agent_status_message: string | null;
-              agent_status_updated_at: string | null;
+        listTowns: import("@trpc/server").TRPCQueryProcedure<{
+            input: void;
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
             }[];
-            beads: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+            meta: object;
+        }>;
+        getTown: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        createRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                name: string;
+                gitUrl: string;
+                defaultBranch?: string | undefined;
+                platformIntegrationId?: string | undefined;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        listRigs: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
             }[];
-          };
-          meta: object;
+            meta: object;
         }>;
-        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            rigId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listBeads: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            rigId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            rigId: string;
-            beadId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        updateBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            rigId: string;
-            beadId: string;
-            title?: string | undefined;
-            body?: string | null | undefined;
-            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-            priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
-            labels?: string[] | undefined;
-            metadata?: Record<string, unknown> | undefined;
-            rig_id?: string | null | undefined;
-            parent_bead_id?: string | null | undefined;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          };
-          meta: object;
-        }>;
-        listAgents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            rigId: string;
-          };
-          output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            rigId: string;
-            agentId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        sling: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            rigId: string;
-            title: string;
-            body?: string | undefined;
-            model?: string | undefined;
-          };
-          output: {
-            bead: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+        getRig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
             };
-            agent: {
-              id: string;
-              rig_id: string | null;
-              role: string;
-              name: string;
-              identity: string;
-              status: string;
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
-              agent_status_message: string | null;
-              agent_status_updated_at: string | null;
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+                agents: {
+                    id: string;
+                    rig_id: string | null;
+                    role: string;
+                    name: string;
+                    identity: string;
+                    status: string;
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                    agent_status_message: string | null;
+                    agent_status_updated_at: string | null;
+                }[];
+                beads: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                }[];
             };
-          };
-          meta: object;
+            meta: object;
         }>;
-        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            message: string;
-            model?: string | undefined;
-            rigId?: string | undefined;
-          };
-          output: {
-            agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
+        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: void;
+            meta: object;
         }>;
-        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            configured: boolean;
-            townId: string | null;
-            session: {
-              agentId: string;
-              sessionId: string;
-              status: 'active' | 'idle' | 'starting';
-              lastActivityAt: string;
-            } | null;
-          };
-          meta: object;
-        }>;
-        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            alarm: {
-              nextFireAt: string | null;
-              intervalMs: number;
-              intervalLabel: string;
+        listBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
             };
-            agents: {
-              working: number;
-              idle: number;
-              stalled: number;
-              dead: number;
-              total: number;
-            };
-            beads: {
-              open: number;
-              inProgress: number;
-              inReview: number;
-              failed: number;
-              triageRequests: number;
-            };
-            patrol: {
-              guppWarnings: number;
-              guppEscalations: number;
-              stalledAgents: number;
-              orphanedHooks: number;
-            };
-            recentEvents: {
-              time: string;
-              type: string;
-              message: string;
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             }[];
-          };
-          meta: object;
+            meta: object;
         }>;
-        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            agentId: string;
-            townId: string;
-          };
-          output: {
-            url: string;
-            ticket: string;
-          };
-          meta: object;
-        }>;
-        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            agentId: string;
-          };
-          output: {
-            pty: {
-              [x: string]: unknown;
-              id: string;
+        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
             };
-            wsUrl: string;
-          };
-          meta: object;
+            output: void;
+            meta: object;
         }>;
-        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            agentId: string;
-            ptyId: string;
-            cols: number;
-            rows: number;
-          };
-          output: void;
-          meta: object;
-        }>;
-        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+        updateBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
+                title?: string | undefined;
+                body?: string | null | undefined;
+                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+                priority?: "critical" | "high" | "low" | "medium" | undefined;
+                labels?: string[] | undefined;
+                metadata?: Record<string, unknown> | undefined;
+                rig_id?: string | null | undefined;
+                parent_bead_id?: string | null | undefined;
             };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
-          };
-          meta: object;
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
         }>;
-        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            config: {
-              env_vars?: Record<string, string> | undefined;
-              git_auth?:
-                | {
+        listAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                agentId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        sling: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                title: string;
+                body?: string | undefined;
+                model?: string | undefined;
+            };
+            output: {
+                bead: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                };
+                agent: {
+                    id: string;
+                    rig_id: string | null;
+                    role: string;
+                    name: string;
+                    identity: string;
+                    status: string;
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                    agent_status_message: string | null;
+                    agent_status_updated_at: string | null;
+                };
+            };
+            meta: object;
+        }>;
+        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                message: string;
+                model?: string | undefined;
+                rigId?: string | undefined;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                configured: boolean;
+                townId: string | null;
+                session: {
+                    agentId: string;
+                    sessionId: string;
+                    status: "active" | "idle" | "starting";
+                    lastActivityAt: string;
+                } | null;
+            };
+            meta: object;
+        }>;
+        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    inReview: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                agentId: string;
+                townId: string;
+            };
+            output: {
+                url: string;
+                ticket: string;
+            };
+            meta: object;
+        }>;
+        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+            };
+            output: {
+                pty: {
+                    [x: string]: unknown;
+                    id: string;
+                };
+                wsUrl: string;
+            };
+            meta: object;
+        }>;
+        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+                ptyId: string;
+                cols: number;
+                rows: number;
+            };
+            output: void;
+            meta: object;
+        }>;
+        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
                     github_token?: string | undefined;
                     gitlab_token?: string | undefined;
                     gitlab_instance_url?: string | undefined;
                     platform_integration_id?: string | undefined;
-                  }
-                | undefined;
-              owner_user_id?: string | undefined;
-              kilocode_token?: string | undefined;
-              default_model?: string | undefined;
-              small_model?: string | undefined;
-              max_polecats_per_rig?: number | undefined;
-              merge_strategy?: 'direct' | 'pr' | undefined;
-              refinery?:
-                | {
-                    gates?: string[] | undefined;
-                    auto_merge?: boolean | undefined;
-                    require_clean_merge?: boolean | undefined;
-                  }
-                | undefined;
-              alarm_interval_active?: number | undefined;
-              alarm_interval_idle?: number | undefined;
-              container?:
-                | {
+                };
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
                     sleep_after_minutes?: number | undefined;
-                  }
-                | undefined;
+                } | undefined;
             };
-          };
-          output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+            meta: object;
+        }>;
+        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                config: {
+                    env_vars?: Record<string, string> | undefined;
+                    git_auth?: {
+                        github_token?: string | undefined;
+                        gitlab_token?: string | undefined;
+                        gitlab_instance_url?: string | undefined;
+                        platform_integration_id?: string | undefined;
+                    } | undefined;
+                    owner_user_id?: string | undefined;
+                    kilocode_token?: string | undefined;
+                    default_model?: string | undefined;
+                    small_model?: string | undefined;
+                    max_polecats_per_rig?: number | undefined;
+                    merge_strategy?: "direct" | "pr" | undefined;
+                    refinery?: {
+                        gates?: string[] | undefined;
+                        auto_merge?: boolean | undefined;
+                        require_clean_merge?: boolean | undefined;
+                    } | undefined;
+                    alarm_interval_active?: number | undefined;
+                    alarm_interval_idle?: number | undefined;
+                    container?: {
+                        sleep_after_minutes?: number | undefined;
+                    } | undefined;
+                };
             };
-            owner_user_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
-          };
-          meta: object;
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+            };
+            meta: object;
         }>;
-        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            rigId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-          };
-          output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            since?: string | undefined;
-            limit?: number | undefined;
-          };
-          output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            id: string;
-            title: string;
-            status: 'active' | 'landed';
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
+        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
             }[];
-            dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
-            }[];
-          }[];
-          meta: object;
+            meta: object;
         }>;
-        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            convoyId: string;
-          };
-          output: {
-            id: string;
-            title: string;
-            status: 'active' | 'landed';
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
-            }[];
-          } | null;
-          meta: object;
-        }>;
-        adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
-            type?:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule'
-              | undefined;
-            limit?: number | undefined;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            agentId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            beadId: string;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          };
-          meta: object;
-        }>;
-        adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            beadId: string;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          };
-          meta: object;
-        }>;
-        adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            alarm: {
-              nextFireAt: string | null;
-              intervalMs: number;
-              intervalLabel: string;
+        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                since?: string | undefined;
+                limit?: number | undefined;
             };
-            agents: {
-              working: number;
-              idle: number;
-              stalled: number;
-              dead: number;
-              total: number;
-            };
-            beads: {
-              open: number;
-              inProgress: number;
-              inReview: number;
-              failed: number;
-              triageRequests: number;
-            };
-            patrol: {
-              guppWarnings: number;
-              guppEscalations: number;
-              stalledAgents: number;
-              orphanedHooks: number;
-            };
-            recentEvents: {
-              time: string;
-              type: string;
-              message: string;
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
             }[];
-          };
-          meta: object;
+            meta: object;
         }>;
-        adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-          };
-          output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-          }[];
-          meta: object;
+        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                staged: boolean;
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            }[];
+            meta: object;
         }>;
-        adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            beadId: string;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          } | null;
-          meta: object;
+        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                staged: boolean;
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
         }>;
-      }>
-    >;
-  }>
->;
+        startConvoy: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                staged: boolean;
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
+        }>;
+        adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    inReview: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            } | null;
+            meta: object;
+        }>;
+    }>>;
+}>>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,16 +1,12 @@
-import { z } from 'zod';
-export declare const TownOutput: z.ZodObject<
-  {
+import type { z } from 'zod';
+export declare const TownOutput: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const RigOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const RigOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -19,27 +15,24 @@ export declare const RigOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const BeadOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadOutput: z.ZodObject<{
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-      agent: 'agent';
-      convoy: 'convoy';
-      escalation: 'escalation';
-      issue: 'issue';
-      merge_request: 'merge_request';
-      message: 'message';
-      molecule: 'molecule';
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
     }>;
     status: z.ZodEnum<{
-      closed: 'closed';
-      failed: 'failed';
-      in_progress: 'in_progress';
-      in_review: 'in_review';
-      open: 'open';
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        in_review: "in_review";
+        open: "open";
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -47,10 +40,10 @@ export declare const BeadOutput: z.ZodObject<
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-      critical: 'critical';
-      high: 'high';
-      low: 'low';
-      medium: 'medium';
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -58,36 +51,23 @@ export declare const BeadOutput: z.ZodObject<
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const AgentOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const AgentOutput: z.ZodObject<{
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<
-      [
-        z.ZodEnum<{
-          mayor: 'mayor';
-          polecat: 'polecat';
-          refinery: 'refinery';
-        }>,
-        z.ZodString,
-      ]
-    >;
+    role: z.ZodUnion<[z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>, z.ZodString]>;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodUnion<
-      [
-        z.ZodEnum<{
-          dead: 'dead';
-          idle: 'idle';
-          stalled: 'stalled';
-          working: 'working';
-        }>,
-        z.ZodString,
-      ]
-    >;
+    status: z.ZodUnion<[z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>, z.ZodString]>;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
@@ -95,11 +75,8 @@ export declare const AgentOutput: z.ZodObject<
     created_at: z.ZodString;
     agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-  },
-  z.core.$strip
->;
-export declare const BeadEventOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadEventOutput: z.ZodObject<{
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -110,69 +87,47 @@ export declare const BeadEventOutput: z.ZodObject<
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const MayorSendResultOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorSendResultOutput: z.ZodObject<{
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-      active: 'active';
-      idle: 'idle';
-      starting: 'starting';
+        active: "active";
+        idle: "idle";
+        starting: "starting";
     }>;
-  },
-  z.core.$strip
->;
-export declare const MayorStatusOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorStatusOutput: z.ZodObject<{
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<
-      z.ZodObject<
-        {
-          agentId: z.ZodString;
-          sessionId: z.ZodString;
-          status: z.ZodEnum<{
-            active: 'active';
-            idle: 'idle';
-            starting: 'starting';
-          }>;
-          lastActivityAt: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const StreamTicketOutput: z.ZodObject<
-  {
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const StreamTicketOutput: z.ZodObject<{
     url: z.ZodString;
     ticket: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const PtySessionOutput: z.ZodObject<
-  {
-    pty: z.ZodObject<
-      {
+}, z.core.$strip>;
+export declare const PtySessionOutput: z.ZodObject<{
+    pty: z.ZodObject<{
         id: z.ZodString;
-      },
-      z.core.$loose
-    >;
+    }, z.core.$loose>;
     wsUrl: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const ConvoyOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
+    staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
     created_by: z.ZodNullable<z.ZodString>;
@@ -180,17 +135,15 @@ export declare const ConvoyOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const ConvoyDetailOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyDetailOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
+    staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
     closed_beads: z.ZodNumber;
     created_by: z.ZodNullable<z.ZodString>;
@@ -198,50 +151,36 @@ export declare const ConvoyDetailOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          title: z.ZodString;
-          status: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_name: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-    dependency_edges: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          depends_on_bead_id: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const SlingResultOutput: z.ZodObject<
-  {
-    bead: z.ZodObject<
-      {
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const SlingResultOutput: z.ZodObject<{
+    bead: z.ZodObject<{
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-          agent: 'agent';
-          convoy: 'convoy';
-          escalation: 'escalation';
-          issue: 'issue';
-          merge_request: 'merge_request';
-          message: 'message';
-          molecule: 'molecule';
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
         }>;
         status: z.ZodEnum<{
-          closed: 'closed';
-          failed: 'failed';
-          in_progress: 'in_progress';
-          in_review: 'in_review';
-          open: 'open';
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -249,10 +188,10 @@ export declare const SlingResultOutput: z.ZodObject<
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-          critical: 'critical';
-          high: 'high';
-          low: 'low';
-          medium: 'medium';
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -260,36 +199,23 @@ export declare const SlingResultOutput: z.ZodObject<
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-      },
-      z.core.$strip
-    >;
-    agent: z.ZodObject<
-      {
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<
-          [
-            z.ZodEnum<{
-              mayor: 'mayor';
-              polecat: 'polecat';
-              refinery: 'refinery';
-            }>,
-            z.ZodString,
-          ]
-        >;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodUnion<
-          [
-            z.ZodEnum<{
-              dead: 'dead';
-              idle: 'idle';
-              stalled: 'stalled';
-              working: 'working';
-            }>,
-            z.ZodString,
-          ]
-        >;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
@@ -297,14 +223,9 @@ export declare const SlingResultOutput: z.ZodObject<
         created_at: z.ZodString;
         agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
         agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      },
-      z.core.$strip
-    >;
-  },
-  z.core.$strip
->;
-export declare const RigDetailOutput: z.ZodObject<
-  {
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const RigDetailOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -313,577 +234,392 @@ export declare const RigDetailOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<
-      z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                mayor: 'mayor';
-                polecat: 'polecat';
-                refinery: 'refinery';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                dead: 'dead';
-                idle: 'idle';
-                stalled: 'stalled';
-                working: 'working';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        },
-        z.core.$strip
-      >
-    >;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            in_review: 'in_review';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const RpcTownOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      name: z.ZodString;
-      owner_user_id: z.ZodString;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_id: z.ZodString;
-      type: z.ZodEnum<{
-        agent: 'agent';
-        convoy: 'convoy';
-        escalation: 'escalation';
-        issue: 'issue';
-        merge_request: 'merge_request';
-        message: 'message';
-        molecule: 'molecule';
-      }>;
-      status: z.ZodEnum<{
-        closed: 'closed';
-        failed: 'failed';
-        in_progress: 'in_progress';
-        in_review: 'in_review';
-        open: 'open';
-      }>;
-      title: z.ZodString;
-      body: z.ZodNullable<z.ZodString>;
-      rig_id: z.ZodNullable<z.ZodString>;
-      parent_bead_id: z.ZodNullable<z.ZodString>;
-      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-      priority: z.ZodEnum<{
-        critical: 'critical';
-        high: 'high';
-        low: 'low';
-        medium: 'medium';
-      }>;
-      labels: z.ZodArray<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      closed_at: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAgentOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      rig_id: z.ZodNullable<z.ZodString>;
-      role: z.ZodUnion<
-        [
-          z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-          }>,
-          z.ZodString,
-        ]
-      >;
-      name: z.ZodString;
-      identity: z.ZodString;
-      status: z.ZodUnion<
-        [
-          z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>,
-          z.ZodString,
-        ]
-      >;
-      current_hook_bead_id: z.ZodNullable<z.ZodString>;
-      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-      last_activity_at: z.ZodNullable<z.ZodString>;
-      checkpoint: z.ZodOptional<z.ZodUnknown>;
-      created_at: z.ZodString;
-      agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadEventOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_event_id: z.ZodString;
-      bead_id: z.ZodString;
-      agent_id: z.ZodNullable<z.ZodString>;
-      event_type: z.ZodString;
-      old_value: z.ZodNullable<z.ZodString>;
-      new_value: z.ZodNullable<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_at: z.ZodString;
-      rig_id: z.ZodOptional<z.ZodString>;
-      rig_name: z.ZodOptional<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      agentId: z.ZodString;
-      sessionStatus: z.ZodEnum<{
-        active: 'active';
-        idle: 'idle';
-        starting: 'starting';
-      }>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      configured: z.ZodBoolean;
-      townId: z.ZodNullable<z.ZodString>;
-      session: z.ZodNullable<
-        z.ZodObject<
-          {
-            agentId: z.ZodString;
-            sessionId: z.ZodString;
-            status: z.ZodEnum<{
-              active: 'active';
-              idle: 'idle';
-              starting: 'starting';
-            }>;
-            lastActivityAt: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcStreamTicketOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      url: z.ZodString;
-      ticket: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcPtySessionOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      pty: z.ZodObject<
-        {
-          id: z.ZodString;
-        },
-        z.core.$loose
-      >;
-      wsUrl: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            title: z.ZodString;
-            status: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_name: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-      dependency_edges: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            depends_on_bead_id: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcSlingResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead: z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            in_review: 'in_review';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >;
-      agent: z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                mayor: 'mayor';
-                polecat: 'polecat';
-                refinery: 'refinery';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                dead: 'dead';
-                idle: 'idle';
-                stalled: 'stalled';
-                working: 'working';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        },
-        z.core.$strip
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      alarm: z.ZodObject<
-        {
-          nextFireAt: z.ZodNullable<z.ZodString>;
-          intervalMs: z.ZodNumber;
-          intervalLabel: z.ZodString;
-        },
-        z.core.$strip
-      >;
-      agents: z.ZodObject<
-        {
-          working: z.ZodNumber;
-          idle: z.ZodNumber;
-          stalled: z.ZodNumber;
-          dead: z.ZodNumber;
-          total: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      beads: z.ZodObject<
-        {
-          open: z.ZodNumber;
-          inProgress: z.ZodNumber;
-          inReview: z.ZodNumber;
-          failed: z.ZodNumber;
-          triageRequests: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      patrol: z.ZodObject<
-        {
-          guppWarnings: z.ZodNumber;
-          guppEscalations: z.ZodNumber;
-          stalledAgents: z.ZodNumber;
-          orphanedHooks: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      recentEvents: z.ZodArray<
-        z.ZodObject<
-          {
-            time: z.ZodString;
-            type: z.ZodString;
-            message: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      agents: z.ZodArray<
-        z.ZodObject<
-          {
-            id: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            role: z.ZodUnion<
-              [
-                z.ZodEnum<{
-                  mayor: 'mayor';
-                  polecat: 'polecat';
-                  refinery: 'refinery';
-                }>,
-                z.ZodString,
-              ]
-            >;
-            name: z.ZodString;
-            identity: z.ZodString;
-            status: z.ZodUnion<
-              [
-                z.ZodEnum<{
-                  dead: 'dead';
-                  idle: 'idle';
-                  stalled: 'stalled';
-                  working: 'working';
-                }>,
-                z.ZodString,
-              ]
-            >;
-            current_hook_bead_id: z.ZodNullable<z.ZodString>;
-            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-            last_activity_at: z.ZodNullable<z.ZodString>;
-            checkpoint: z.ZodOptional<z.ZodUnknown>;
-            created_at: z.ZodString;
-            agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-            agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-          },
-          z.core.$strip
-        >
-      >;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            type: z.ZodEnum<{
-              agent: 'agent';
-              convoy: 'convoy';
-              escalation: 'escalation';
-              issue: 'issue';
-              merge_request: 'merge_request';
-              message: 'message';
-              molecule: 'molecule';
-            }>;
-            status: z.ZodEnum<{
-              closed: 'closed';
-              failed: 'failed';
-              in_progress: 'in_progress';
-              in_review: 'in_review';
-              open: 'open';
-            }>;
-            title: z.ZodString;
-            body: z.ZodNullable<z.ZodString>;
-            rig_id: z.ZodNullable<z.ZodString>;
-            parent_bead_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-            priority: z.ZodEnum<{
-              critical: 'critical';
-              high: 'high';
-              low: 'low';
-              medium: 'medium';
-            }>;
-            labels: z.ZodArray<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            created_by: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-            closed_at: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodString;
+    owner_user_id: z.ZodString;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_id: z.ZodString;
+    type: z.ZodEnum<{
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
+    }>;
+    status: z.ZodEnum<{
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        in_review: "in_review";
+        open: "open";
+    }>;
+    title: z.ZodString;
+    body: z.ZodNullable<z.ZodString>;
+    rig_id: z.ZodNullable<z.ZodString>;
+    parent_bead_id: z.ZodNullable<z.ZodString>;
+    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    labels: z.ZodArray<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    closed_at: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    rig_id: z.ZodNullable<z.ZodString>;
+    role: z.ZodUnion<[z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>, z.ZodString]>;
+    name: z.ZodString;
+    identity: z.ZodString;
+    status: z.ZodUnion<[z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>, z.ZodString]>;
+    current_hook_bead_id: z.ZodNullable<z.ZodString>;
+    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+    last_activity_at: z.ZodNullable<z.ZodString>;
+    checkpoint: z.ZodOptional<z.ZodUnknown>;
+    created_at: z.ZodString;
+    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+}, z.core.$strip>>;
+export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_event_id: z.ZodString;
+    bead_id: z.ZodString;
+    agent_id: z.ZodNullable<z.ZodString>;
+    event_type: z.ZodString;
+    old_value: z.ZodNullable<z.ZodString>;
+    new_value: z.ZodNullable<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_at: z.ZodString;
+    rig_id: z.ZodOptional<z.ZodString>;
+    rig_name: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    agentId: z.ZodString;
+    sessionStatus: z.ZodEnum<{
+        active: "active";
+        idle: "idle";
+        starting: "starting";
+    }>;
+}, z.core.$strip>>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    configured: z.ZodBoolean;
+    townId: z.ZodNullable<z.ZodString>;
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    url: z.ZodString;
+    ticket: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    pty: z.ZodObject<{
+        id: z.ZodString;
+    }, z.core.$loose>;
+    wsUrl: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    staged: z.ZodBoolean;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    staged: z.ZodBoolean;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead: z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>;
+}, z.core.$strip>>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    alarm: z.ZodObject<{
+        nextFireAt: z.ZodNullable<z.ZodString>;
+        intervalMs: z.ZodNumber;
+        intervalLabel: z.ZodString;
+    }, z.core.$strip>;
+    agents: z.ZodObject<{
+        working: z.ZodNumber;
+        idle: z.ZodNumber;
+        stalled: z.ZodNumber;
+        dead: z.ZodNumber;
+        total: z.ZodNumber;
+    }, z.core.$strip>;
+    beads: z.ZodObject<{
+        open: z.ZodNumber;
+        inProgress: z.ZodNumber;
+        inReview: z.ZodNumber;
+        failed: z.ZodNumber;
+        triageRequests: z.ZodNumber;
+    }, z.core.$strip>;
+    patrol: z.ZodObject<{
+        guppWarnings: z.ZodNumber;
+        guppEscalations: z.ZodNumber;
+        stalledAgents: z.ZodNumber;
+        orphanedHooks: z.ZodNumber;
+    }, z.core.$strip>;
+    recentEvents: z.ZodArray<z.ZodObject<{
+        time: z.ZodString;
+        type: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,12 +1,16 @@
 import type { z } from 'zod';
-export declare const TownOutput: z.ZodObject<{
+export declare const TownOutput: z.ZodObject<
+  {
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const RigOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const RigOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -15,24 +19,27 @@ export declare const RigOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const BeadOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadOutput: z.ZodObject<
+  {
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
+      agent: 'agent';
+      convoy: 'convoy';
+      escalation: 'escalation';
+      issue: 'issue';
+      merge_request: 'merge_request';
+      message: 'message';
+      molecule: 'molecule';
     }>;
     status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        in_review: "in_review";
-        open: "open";
+      closed: 'closed';
+      failed: 'failed';
+      in_progress: 'in_progress';
+      in_review: 'in_review';
+      open: 'open';
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -40,10 +47,10 @@ export declare const BeadOutput: z.ZodObject<{
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
+      critical: 'critical';
+      high: 'high';
+      low: 'low';
+      medium: 'medium';
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -51,23 +58,36 @@ export declare const BeadOutput: z.ZodObject<{
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const AgentOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const AgentOutput: z.ZodObject<
+  {
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<[z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>, z.ZodString]>;
+    role: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          mayor: 'mayor';
+          polecat: 'polecat';
+          refinery: 'refinery';
+        }>,
+        z.ZodString,
+      ]
+    >;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodUnion<[z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>, z.ZodString]>;
+    status: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          dead: 'dead';
+          idle: 'idle';
+          stalled: 'stalled';
+          working: 'working';
+        }>,
+        z.ZodString,
+      ]
+    >;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
@@ -75,8 +95,11 @@ export declare const AgentOutput: z.ZodObject<{
     created_at: z.ZodString;
     agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-}, z.core.$strip>;
-export declare const BeadEventOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadEventOutput: z.ZodObject<
+  {
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -87,45 +110,68 @@ export declare const BeadEventOutput: z.ZodObject<{
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>;
-export declare const MayorSendResultOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorSendResultOutput: z.ZodObject<
+  {
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
+      active: 'active';
+      idle: 'idle';
+      starting: 'starting';
     }>;
-}, z.core.$strip>;
-export declare const MayorStatusOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorStatusOutput: z.ZodObject<
+  {
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const StreamTicketOutput: z.ZodObject<{
+    session: z.ZodNullable<
+      z.ZodObject<
+        {
+          agentId: z.ZodString;
+          sessionId: z.ZodString;
+          status: z.ZodEnum<{
+            active: 'active';
+            idle: 'idle';
+            starting: 'starting';
+          }>;
+          lastActivityAt: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const StreamTicketOutput: z.ZodObject<
+  {
     url: z.ZodString;
     ticket: z.ZodString;
-}, z.core.$strip>;
-export declare const PtySessionOutput: z.ZodObject<{
-    pty: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const PtySessionOutput: z.ZodObject<
+  {
+    pty: z.ZodObject<
+      {
         id: z.ZodString;
-    }, z.core.$loose>;
+      },
+      z.core.$loose
+    >;
     wsUrl: z.ZodString;
-}, z.core.$strip>;
-export declare const ConvoyOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
@@ -135,13 +181,16 @@ export declare const ConvoyOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const ConvoyDetailOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
@@ -151,36 +200,50 @@ export declare const ConvoyDetailOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const SlingResultOutput: z.ZodObject<{
-    bead: z.ZodObject<{
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          title: z.ZodString;
+          status: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_name: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+    dependency_edges: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          depends_on_bead_id: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const SlingResultOutput: z.ZodObject<
+  {
+    bead: z.ZodObject<
+      {
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
+          agent: 'agent';
+          convoy: 'convoy';
+          escalation: 'escalation';
+          issue: 'issue';
+          merge_request: 'merge_request';
+          message: 'message';
+          molecule: 'molecule';
         }>;
         status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
+          closed: 'closed';
+          failed: 'failed';
+          in_progress: 'in_progress';
+          in_review: 'in_review';
+          open: 'open';
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -188,10 +251,10 @@ export declare const SlingResultOutput: z.ZodObject<{
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
+          critical: 'critical';
+          high: 'high';
+          low: 'low';
+          medium: 'medium';
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -199,23 +262,36 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+    agent: z.ZodObject<
+      {
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
+        role: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              mayor: 'mayor';
+              polecat: 'polecat';
+              refinery: 'refinery';
+            }>,
+            z.ZodString,
+          ]
+        >;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
+        status: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              dead: 'dead';
+              idle: 'idle';
+              stalled: 'stalled';
+              working: 'working';
+            }>,
+            z.ZodString,
+          ]
+        >;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
@@ -223,9 +299,14 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
         agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>;
-}, z.core.$strip>;
-export declare const RigDetailOutput: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RigDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -234,392 +315,579 @@ export declare const RigDetailOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    name: z.ZodString;
-    owner_user_id: z.ZodString;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_id: z.ZodString;
-    type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
-    }>;
-    status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        in_review: "in_review";
-        open: "open";
-    }>;
-    title: z.ZodString;
-    body: z.ZodNullable<z.ZodString>;
-    rig_id: z.ZodNullable<z.ZodString>;
-    parent_bead_id: z.ZodNullable<z.ZodString>;
-    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-    priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
-    }>;
-    labels: z.ZodArray<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<[z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>, z.ZodString]>;
-    name: z.ZodString;
-    identity: z.ZodString;
-    status: z.ZodUnion<[z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>, z.ZodString]>;
-    current_hook_bead_id: z.ZodNullable<z.ZodString>;
-    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-    last_activity_at: z.ZodNullable<z.ZodString>;
-    checkpoint: z.ZodOptional<z.ZodUnknown>;
-    created_at: z.ZodString;
-    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-}, z.core.$strip>>;
-export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_event_id: z.ZodString;
-    bead_id: z.ZodString;
-    agent_id: z.ZodNullable<z.ZodString>;
-    event_type: z.ZodString;
-    old_value: z.ZodNullable<z.ZodString>;
-    new_value: z.ZodNullable<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_at: z.ZodString;
-    rig_id: z.ZodOptional<z.ZodString>;
-    rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    agentId: z.ZodString;
-    sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
-    }>;
-}, z.core.$strip>>;
-export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    configured: z.ZodBoolean;
-    townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    url: z.ZodString;
-    ticket: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    pty: z.ZodObject<{
-        id: z.ZodString;
-    }, z.core.$loose>;
-    wsUrl: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    staged: z.ZodBoolean;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    staged: z.ZodBoolean;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead: z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>;
-}, z.core.$strip>>;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    alarm: z.ZodObject<{
-        nextFireAt: z.ZodNullable<z.ZodString>;
-        intervalMs: z.ZodNumber;
-        intervalLabel: z.ZodString;
-    }, z.core.$strip>;
-    agents: z.ZodObject<{
-        working: z.ZodNumber;
-        idle: z.ZodNumber;
-        stalled: z.ZodNumber;
-        dead: z.ZodNumber;
-        total: z.ZodNumber;
-    }, z.core.$strip>;
-    beads: z.ZodObject<{
-        open: z.ZodNumber;
-        inProgress: z.ZodNumber;
-        inReview: z.ZodNumber;
-        failed: z.ZodNumber;
-        triageRequests: z.ZodNumber;
-    }, z.core.$strip>;
-    patrol: z.ZodObject<{
-        guppWarnings: z.ZodNumber;
-        guppEscalations: z.ZodNumber;
-        stalledAgents: z.ZodNumber;
-        orphanedHooks: z.ZodNumber;
-    }, z.core.$strip>;
-    recentEvents: z.ZodArray<z.ZodObject<{
-        time: z.ZodString;
-        type: z.ZodString;
-        message: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
+    agents: z.ZodArray<
+      z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        },
+        z.core.$strip
+      >
+    >;
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            in_review: 'in_review';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RpcTownOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      name: z.ZodString;
+      owner_user_id: z.ZodString;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_id: z.ZodString;
+      type: z.ZodEnum<{
+        agent: 'agent';
+        convoy: 'convoy';
+        escalation: 'escalation';
+        issue: 'issue';
+        merge_request: 'merge_request';
+        message: 'message';
+        molecule: 'molecule';
+      }>;
+      status: z.ZodEnum<{
+        closed: 'closed';
+        failed: 'failed';
+        in_progress: 'in_progress';
+        in_review: 'in_review';
+        open: 'open';
+      }>;
+      title: z.ZodString;
+      body: z.ZodNullable<z.ZodString>;
+      rig_id: z.ZodNullable<z.ZodString>;
+      parent_bead_id: z.ZodNullable<z.ZodString>;
+      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+      priority: z.ZodEnum<{
+        critical: 'critical';
+        high: 'high';
+        low: 'low';
+        medium: 'medium';
+      }>;
+      labels: z.ZodArray<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      closed_at: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAgentOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      rig_id: z.ZodNullable<z.ZodString>;
+      role: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            mayor: 'mayor';
+            polecat: 'polecat';
+            refinery: 'refinery';
+          }>,
+          z.ZodString,
+        ]
+      >;
+      name: z.ZodString;
+      identity: z.ZodString;
+      status: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            dead: 'dead';
+            idle: 'idle';
+            stalled: 'stalled';
+            working: 'working';
+          }>,
+          z.ZodString,
+        ]
+      >;
+      current_hook_bead_id: z.ZodNullable<z.ZodString>;
+      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+      last_activity_at: z.ZodNullable<z.ZodString>;
+      checkpoint: z.ZodOptional<z.ZodUnknown>;
+      created_at: z.ZodString;
+      agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadEventOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_event_id: z.ZodString;
+      bead_id: z.ZodString;
+      agent_id: z.ZodNullable<z.ZodString>;
+      event_type: z.ZodString;
+      old_value: z.ZodNullable<z.ZodString>;
+      new_value: z.ZodNullable<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_at: z.ZodString;
+      rig_id: z.ZodOptional<z.ZodString>;
+      rig_name: z.ZodOptional<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      agentId: z.ZodString;
+      sessionStatus: z.ZodEnum<{
+        active: 'active';
+        idle: 'idle';
+        starting: 'starting';
+      }>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      configured: z.ZodBoolean;
+      townId: z.ZodNullable<z.ZodString>;
+      session: z.ZodNullable<
+        z.ZodObject<
+          {
+            agentId: z.ZodString;
+            sessionId: z.ZodString;
+            status: z.ZodEnum<{
+              active: 'active';
+              idle: 'idle';
+              starting: 'starting';
+            }>;
+            lastActivityAt: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      url: z.ZodString;
+      ticket: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcPtySessionOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      pty: z.ZodObject<
+        {
+          id: z.ZodString;
+        },
+        z.core.$loose
+      >;
+      wsUrl: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      staged: z.ZodBoolean;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      staged: z.ZodBoolean;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            title: z.ZodString;
+            status: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_name: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+      dependency_edges: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            depends_on_bead_id: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcSlingResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead: z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            in_review: 'in_review';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >;
+      agent: z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        },
+        z.core.$strip
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      alarm: z.ZodObject<
+        {
+          nextFireAt: z.ZodNullable<z.ZodString>;
+          intervalMs: z.ZodNumber;
+          intervalLabel: z.ZodString;
+        },
+        z.core.$strip
+      >;
+      agents: z.ZodObject<
+        {
+          working: z.ZodNumber;
+          idle: z.ZodNumber;
+          stalled: z.ZodNumber;
+          dead: z.ZodNumber;
+          total: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      beads: z.ZodObject<
+        {
+          open: z.ZodNumber;
+          inProgress: z.ZodNumber;
+          inReview: z.ZodNumber;
+          failed: z.ZodNumber;
+          triageRequests: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      patrol: z.ZodObject<
+        {
+          guppWarnings: z.ZodNumber;
+          guppEscalations: z.ZodNumber;
+          stalledAgents: z.ZodNumber;
+          orphanedHooks: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      recentEvents: z.ZodArray<
+        z.ZodObject<
+          {
+            time: z.ZodString;
+            type: z.ZodString;
+            message: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      agents: z.ZodArray<
+        z.ZodObject<
+          {
+            id: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            role: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  mayor: 'mayor';
+                  polecat: 'polecat';
+                  refinery: 'refinery';
+                }>,
+                z.ZodString,
+              ]
+            >;
+            name: z.ZodString;
+            identity: z.ZodString;
+            status: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  dead: 'dead';
+                  idle: 'idle';
+                  stalled: 'stalled';
+                  working: 'working';
+                }>,
+                z.ZodString,
+              ]
+            >;
+            current_hook_bead_id: z.ZodNullable<z.ZodString>;
+            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+            last_activity_at: z.ZodNullable<z.ZodString>;
+            checkpoint: z.ZodOptional<z.ZodUnknown>;
+            created_at: z.ZodString;
+            agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+            agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          },
+          z.core.$strip
+        >
+      >;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            type: z.ZodEnum<{
+              agent: 'agent';
+              convoy: 'convoy';
+              escalation: 'escalation';
+              issue: 'issue';
+              merge_request: 'merge_request';
+              message: 'message';
+              molecule: 'molecule';
+            }>;
+            status: z.ZodEnum<{
+              closed: 'closed';
+              failed: 'failed';
+              in_progress: 'in_progress';
+              in_review: 'in_review';
+              open: 'open';
+            }>;
+            title: z.ZodString;
+            body: z.ZodNullable<z.ZodString>;
+            rig_id: z.ZodNullable<z.ZodString>;
+            parent_bead_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+            priority: z.ZodEnum<{
+              critical: 'critical';
+              high: 'high';
+              low: 'low';
+              medium: 'medium';
+            }>;
+            labels: z.ZodArray<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            created_by: z.ZodNullable<z.ZodString>;
+            created_at: z.ZodString;
+            updated_at: z.ZodString;
+            closed_at: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -135,6 +135,7 @@ const TownConfigRecord = z.object({
   alarm_interval_active: z.number().optional(),
   alarm_interval_idle: z.number().optional(),
   container: z.object({ sleep_after_minutes: z.number().optional() }).optional(),
+  staged_convoys_default: z.boolean().optional(),
 });
 
 const ConvoyDetailRecord = z.object({


### PR DESCRIPTION
## Summary

- Adds `staged` status to convoy metadata — staged convoys have beads defined but no agents hooked or dispatched
- Updates `gt_sling_batch` with a `staged: boolean` parameter (default `false`); when `true`, creates convoy + beads without triggering agent dispatch
- Adds new `gt_convoy_start` tool that transitions a staged convoy to `open`, hooks agents to all tracked beads, and triggers dispatch on the next alarm tick
- Dashboard displays staged convoys with draft visual state (muted styling, "STAGED" badge) and a prominent "Start Convoy" button
- Updates mayor system prompt with staged convoy instructions: when users ask to "plan" or "prepare" work, the Mayor creates staged convoys for review

Closes #1006

## Verification

- Code review of diff against fork branch — all patches applied cleanly to `origin/main`
- Mayor tools test file updated with new tool registrations

## Visual Changes

N/A (dashboard staged convoy display added but not visually verified)

## Reviewer Notes

- The staged → open transition in `gt_convoy_start` hooks agents and dispatches atomically; if a rig has no available agents, the bead will wait in the dispatch queue
- `convoy_metadata.table.ts` gains the `staged` column — ensure migration runs cleanly in production
- The mayor prompt change means the Mayor will default to staged convoys when users say "plan" or "prepare" — this is intentional per the issue spec