### PR TITLE
fix(billing): require org owner role for Stripe checkout URL creation

### DIFF
--- a/src/routers/organizations/organization-subscription-router.test.ts
+++ b/src/routers/organizations/organization-subscription-router.test.ts
@@ -57,6 +57,32 @@ describe('organizations subscription trpc router', () => {
     });
   });
 
+  describe('getSubscriptionStripeUrl procedure', () => {
+    it('should throw UNAUTHORIZED error for non-owner members', async () => {
+      const caller = await createCallerForUser(memberUser.id);
+
+      await expect(
+        caller.organizations.subscription.getSubscriptionStripeUrl({
+          organizationId: testOrganization.id,
+          seats: 1,
+          cancelUrl: 'https://example.com',
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('should throw UNAUTHORIZED error for non-member users', async () => {
+      const caller = await createCallerForUser(_nonMemberUser.id);
+
+      await expect(
+        caller.organizations.subscription.getSubscriptionStripeUrl({
+          organizationId: testOrganization.id,
+          seats: 1,
+          cancelUrl: 'https://example.com',
+        })
+      ).rejects.toThrow('You do not have access to this organization');
+    });
+  });
+
   describe('cancel procedure', () => {
     it('should throw UNAUTHORIZED error for non-owner users', async () => {
       const caller = await createCallerForUser(memberUser.id);

--- a/src/routers/organizations/organization-subscription-router.ts
+++ b/src/routers/organizations/organization-subscription-router.ts
@@ -15,7 +15,6 @@ import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import {
   OrganizationIdInputSchema,
   organizationOwnerProcedure,
-  ensureOrganizationAccess,
   organizationMemberProcedure,
 } from '@/routers/organizations/utils';
 import { TRPCError } from '@trpc/server';
@@ -117,7 +116,7 @@ export const organizationsSubscriptionRouter = createTRPCRouter({
       return { status: paymentStatus };
     }),
 
-  getSubscriptionStripeUrl: baseProcedure
+  getSubscriptionStripeUrl: organizationOwnerProcedure
     .input(SubscriptionRequestSchema)
     .mutation(async ({ input, ctx }) => {
       const { user } = ctx;
@@ -132,18 +131,11 @@ export const organizationsSubscriptionRouter = createTRPCRouter({
       const customerId = await getOrCreateStripeCustomerIdForOrganization(org.id);
       const subscriptions = await getSubscriptionsForStripeCustomerId(customerId);
 
-      // if any subscriptions are not ended, throw bad request error
       if (subscriptions.find(sub => sub.ended_at == null)) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Organization has active subscription(s)',
         });
-      }
-
-      // if any subscriptions exist we need to enforce security
-      // otherwise, we can't enforce ownership as the org is still not finished being set up
-      if (subscriptions.length) {
-        await ensureOrganizationAccess(ctx, organizationId, ['owner', 'billing_manager']);
       }
 
       const result = await getStripeSeatsCheckoutUrl({


### PR DESCRIPTION
## Summary

The `getSubscriptionStripeUrl` mutation used `baseProcedure` and only enforced ownership via `ensureOrganizationAccess` when existing subscriptions were found. This meant that for new organizations without any subscriptions yet, any authenticated user could trigger Stripe customer creation without ownership checks. This switches the procedure to `organizationOwnerProcedure`, which enforces the owner role unconditionally before any Stripe interaction occurs. The now-unused conditional `ensureOrganizationAccess` call and its import are removed.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm test -- 'src/routers/organizations/organization-subscription-router.test.ts'` — 9/9 tests passed (including 2 new authorization tests)

## Visual Changes

N/A

## Reviewer Notes

- The two new tests verify that non-owner members and non-members are both rejected by `getSubscriptionStripeUrl`, matching the pattern used by `cancel`, `stopCancellation`, and `updateSeatCount` tests in the same file.
- The stale comment "if any subscriptions exist we need to enforce security / otherwise, we can't enforce ownership as the org is still not finished being set up" is removed since ownership is now enforced unconditionally by the procedure middleware.