### PR TITLE
Add dev-start script for KiloClaw local development

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -1,27 +1,39 @@
-# Copy this to .dev.vars and fill in your values
-# .dev.vars is gitignored and used by wrangler dev
+# KiloClaw worker secrets (used by wrangler dev).
+# The dev-start script creates .dev.vars from this file on first run.
+#
+# Most values below are working defaults. The script auto-manages:
+#   NEXTAUTH_SECRET, INTERNAL_API_SECRET  (synced from Vercel)
+#   FLY_API_TOKEN                         (auto-created/refreshed)
+#   KILOCODE_API_BASE_URL                 (set from tunnel URL)
+#
+# Values you may need to set manually:
+#   AGENT_ENV_VARS_PRIVATE_KEY            (get from 1Password)
+#   FLY_IMAGE_TAG / FLY_IMAGE_DIGEST / OPENCLAW_VERSION
+#                                         (set by scripts/push-dev.sh,
+#                                          or ask a team member for values)
 
-# Auth
+# Auth (synced automatically from Vercel by the dev-start script)
 NEXTAUTH_SECRET=dev-secret-change-me
 INTERNAL_API_SECRET=dev-internal-secret
+
+# Auth (static defaults — these work as-is for local dev)
 GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
 # Override WORKER_ENV to "development" for local development.
 # Production default is set in wrangler.jsonc. This selects the development
 # Fly app naming prefix ("dev-") for per-user app creation.
 WORKER_ENV=development
 
-# Optional: Override KiloCode provider base URL (local dev only)
+# Tunnel URL (set automatically by the dev-start script)
 # OpenClaw's native kilocode provider hardcodes https://api.kilo.ai/api/gateway/.
-# In dev, set this to a Cloudflare tunnel or ngrok URL pointing to your local Next.js app
-# so that Fly machines route model requests through the tunnel instead of production.
-# e.g.: `cloudflared tunnel --url http://localhost:3000`
+# In dev, the script sets this to the Cloudflare tunnel URL pointing to your
+# local Next.js app so Fly machines route model requests through the tunnel.
 # KILOCODE_API_BASE_URL=https://<tunnel>.trycloudflare.com/api/gateway/
 
 # Fly.io Machines API
-# Get an org-scoped token (run: `fly tokens create -o kilo-dev my-dev-token`)
+# Token is auto-created/refreshed by the dev-start script.
 FLY_API_TOKEN=fo1_...
-# Your Fly org slug (run: `fly orgs list`). Use `kilo-dev` for Kilo team
-# members, or `personal` if you're running under your own Fly account.
+# Fly org slug. The dev-start script reads this value for token creation.
+# Use "kilo-dev" for Kilo team members, or "personal" for your own Fly account.
 FLY_ORG_SLUG=kilo-dev
 # Shared Docker image registry app (images are pushed here, referenced by all per-user apps)
 FLY_REGISTRY_APP=kiloclaw-dev
@@ -31,8 +43,7 @@ FLY_REGISTRY_APP=kiloclaw-dev
 # The platform API can override per-user at provision time.
 FLY_REGION=us,eu
 # Docker image tag on registry.fly.io/{FLY_REGISTRY_APP}:{tag}.
-# In dev, use "latest" or run scripts/push-dev.sh which sets a timestamped tag.
-# In production, pin to a version (e.g., v40, sha-abc1234).
+# Set automatically by scripts/push-dev.sh, or use "latest" to start.
 FLY_IMAGE_TAG=latest
 # OpenClaw version (must match the openclaw@x.x.x version in the Dockerfile).
 # Used by the worker to self-register the version → image tag mapping in KV,
@@ -51,6 +62,7 @@ FLY_APP_NAME=kiloclaw-dev
 OPENCLAW_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8795,http://claw.kilosessions.ai
 
 # Encryption (for user secrets)
+# Get the dev version from 1Password (engineering vault). Quote the value.
 # AGENT_ENV_VARS_PRIVATE_KEY=...
 
 # Hyperdrive is configured in wrangler.jsonc, not here.

--- a/kiloclaw/.gitignore
+++ b/kiloclaw/.gitignore
@@ -162,6 +162,7 @@ dist
 
 .dev.vars*
 !.dev.vars.example
+scripts/.dev-start.conf
 .env*
 !.env.example
 .wrangler/

--- a/kiloclaw/DEVELOPMENT_LOCAL.md
+++ b/kiloclaw/DEVELOPMENT_LOCAL.md
@@ -162,7 +162,7 @@ are auto-managed and which require manual setup.
 | `FLY_ORG_SLUG`     | Fly org slug (read by script for token creation)                                        | Example      | No           |
 | `FLY_REGISTRY_APP` | Shared Fly app that holds Docker images (e.g., `kiloclaw-dev`)                          | Example      | No           |
 | `FLY_APP_NAME`     | Legacy fallback app name for existing instances (may be removed in future)              | Example      | No           |
-| `FLY_REGION`       | Region priority list, e.g. `us,eu`. Tries US first, falls back to EU, then gives up.   | Example      | No           |
+| `FLY_REGION`       | Region priority list, e.g. `us,eu`. Tries US first, falls back to EU, then gives up.    | Example      | No           |
 | `FLY_IMAGE_TAG`    | Docker image tag. Set automatically by `scripts/push-dev.sh`, or use `latest` to start. | push-dev.sh  | Yes          |
 | `FLY_IMAGE_DIGEST` | Docker image digest. Set automatically by `scripts/push-dev.sh`.                        | push-dev.sh  | Yes          |
 | `OPENCLAW_VERSION` | OpenClaw version in the image. Set automatically by `scripts/push-dev.sh`.              | push-dev.sh  | Yes          |
@@ -180,9 +180,9 @@ values or use `latest` (if a `latest` tag exists in the registry).
 
 **Encryption:**
 
-| Variable                     | Description                                                                                                        | Source     | Auto-managed |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------- | ------------ |
-| `AGENT_ENV_VARS_PRIVATE_KEY` | RSA private key (PEM). Get the **dev** version from 1Password (engineering vault). Quote the value in `.dev.vars`. | 1Password  | No           |
+| Variable                     | Description                                                                                                        | Source    | Auto-managed |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- | ------------ |
+| `AGENT_ENV_VARS_PRIVATE_KEY` | RSA private key (PEM). Get the **dev** version from 1Password (engineering vault). Quote the value in `.dev.vars`. | 1Password | No           |
 
 **Other:**
 

--- a/kiloclaw/DEVELOPMENT_LOCAL.md
+++ b/kiloclaw/DEVELOPMENT_LOCAL.md
@@ -147,25 +147,25 @@ are auto-managed and which require manual setup.
 
 **Auth:**
 
-| Variable               | Description                                                                 | Auto-managed               |
-| ---------------------- | --------------------------------------------------------------------------- | -------------------------- |
-| `NEXTAUTH_SECRET`      | JWT signing key. Must match the Next.js app's `NEXTAUTH_SECRET`             | Yes (synced from Vercel)   |
-| `INTERNAL_API_SECRET`  | Platform API key. Must match Next.js `KILOCLAW_INTERNAL_API_SECRET`         | Yes (synced from Vercel)   |
-| `GATEWAY_TOKEN_SECRET` | HMAC key for per-sandbox gateway tokens. Can be any arbitrary value in dev. | No (example default works) |
-| `WORKER_ENV`           | Set to `development`                                                        | No (example default works) |
+| Variable               | Description                                                                 | Source  | Auto-managed |
+| ---------------------- | --------------------------------------------------------------------------- | ------- | ------------ |
+| `NEXTAUTH_SECRET`      | JWT signing key. Must match the Next.js app's `NEXTAUTH_SECRET`             | Vercel  | Yes          |
+| `INTERNAL_API_SECRET`  | Platform API key. Must match Next.js `KILOCLAW_INTERNAL_API_SECRET`         | Vercel  | Yes          |
+| `GATEWAY_TOKEN_SECRET` | HMAC key for per-sandbox gateway tokens. Can be any arbitrary value in dev. | Example | No           |
+| `WORKER_ENV`           | Set to `development`                                                        | Example | No           |
 
 **Fly.io:**
 
-| Variable           | Description                                                                             | Auto-managed                 |
-| ------------------ | --------------------------------------------------------------------------------------- | ---------------------------- |
-| `FLY_API_TOKEN`    | Fly org token                                                                           | Yes (auto-created/refreshed) |
-| `FLY_ORG_SLUG`     | Fly org slug (read by script for token creation)                                        | No (example default works)   |
-| `FLY_REGISTRY_APP` | Shared Fly app that holds Docker images (e.g., `kiloclaw-dev`)                          | No (example default works)   |
-| `FLY_APP_NAME`     | Legacy fallback app name for existing instances (may be removed in future)              | No (example default works)   |
-| `FLY_REGION`       | Region priority list, e.g. `us,eu`. Tries US first, falls back to EU, then gives up.    | No (example default works)   |
-| `FLY_IMAGE_TAG`    | Docker image tag. Set automatically by `scripts/push-dev.sh`, or use `latest` to start. | By push-dev.sh               |
-| `FLY_IMAGE_DIGEST` | Docker image digest. Set automatically by `scripts/push-dev.sh`.                        | By push-dev.sh               |
-| `OPENCLAW_VERSION` | OpenClaw version in the image. Set automatically by `scripts/push-dev.sh`.              | By push-dev.sh               |
+| Variable           | Description                                                                             | Source       | Auto-managed |
+| ------------------ | --------------------------------------------------------------------------------------- | ------------ | ------------ |
+| `FLY_API_TOKEN`    | Fly org token                                                                           | dev-start.sh | Yes          |
+| `FLY_ORG_SLUG`     | Fly org slug (read by script for token creation)                                        | Example      | No           |
+| `FLY_REGISTRY_APP` | Shared Fly app that holds Docker images (e.g., `kiloclaw-dev`)                          | Example      | No           |
+| `FLY_APP_NAME`     | Legacy fallback app name for existing instances (may be removed in future)              | Example      | No           |
+| `FLY_REGION`       | Region priority list, e.g. `us,eu`. Tries US first, falls back to EU, then gives up.   | Example      | No           |
+| `FLY_IMAGE_TAG`    | Docker image tag. Set automatically by `scripts/push-dev.sh`, or use `latest` to start. | push-dev.sh  | Yes          |
+| `FLY_IMAGE_DIGEST` | Docker image digest. Set automatically by `scripts/push-dev.sh`.                        | push-dev.sh  | Yes          |
+| `OPENCLAW_VERSION` | OpenClaw version in the image. Set automatically by `scripts/push-dev.sh`.              | push-dev.sh  | Yes          |
 
 `FLY_IMAGE_TAG`, `FLY_IMAGE_DIGEST`, and `OPENCLAW_VERSION` together control
 what version gets deployed by default for your dev instances. The build script
@@ -174,21 +174,21 @@ values or use `latest` (if a `latest` tag exists in the registry).
 
 **Tunnel / API:**
 
-| Variable                | Description                       | Auto-managed                  |
-| ----------------------- | --------------------------------- | ----------------------------- |
-| `KILOCODE_API_BASE_URL` | Your tunnel URL + `/api/gateway/` | Yes (set by dev-start script) |
+| Variable                | Description                       | Source       | Auto-managed |
+| ----------------------- | --------------------------------- | ------------ | ------------ |
+| `KILOCODE_API_BASE_URL` | Your tunnel URL + `/api/gateway/` | dev-start.sh | Yes          |
 
 **Encryption:**
 
-| Variable                     | Description                                                                                                        | Auto-managed |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------ |
-| `AGENT_ENV_VARS_PRIVATE_KEY` | RSA private key (PEM). Get the **dev** version from 1Password (engineering vault). Quote the value in `.dev.vars`. | No           |
+| Variable                     | Description                                                                                                        | Source     | Auto-managed |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------- | ------------ |
+| `AGENT_ENV_VARS_PRIVATE_KEY` | RSA private key (PEM). Get the **dev** version from 1Password (engineering vault). Quote the value in `.dev.vars`. | 1Password  | No           |
 
 **Other:**
 
-| Variable                   | Description                                       | Auto-managed               |
-| -------------------------- | ------------------------------------------------- | -------------------------- |
-| `OPENCLAW_ALLOWED_ORIGINS` | Comma-separated origins for WebSocket connections | No (example default works) |
+| Variable                   | Description                                       | Source  | Auto-managed |
+| -------------------------- | ------------------------------------------------- | ------- | ------------ |
+| `OPENCLAW_ALLOWED_ORIGINS` | Comma-separated origins for WebSocket connections | Example | No           |
 
 ### `.env.local` (Next.js, monorepo root)
 

--- a/kiloclaw/DEVELOPMENT_LOCAL.md
+++ b/kiloclaw/DEVELOPMENT_LOCAL.md
@@ -55,77 +55,74 @@ app as a kind of image registry for all other apps -- in dev, that app is
 1. Accept the Fly.io org invite(s) from your email (there should be two --
    check spam if you only see one).
 2. Verify with `fly orgs list` -- the dev org should appear.
-3. Create an org-scoped token for dev use (personal tokens also have production
-   access):
+3. Log in to the Fly CLI: `fly auth login`
 
-```bash
-fly tokens create -o kilo-dev my-dev-token
-```
-
-Save this token -- you'll need it for `FLY_API_TOKEN` in `.dev.vars`.
+The dev-start script creates and refreshes Fly API tokens automatically -- you
+don't need to manage tokens manually.
 
 ## Quick Start
 
+One-time prerequisites:
+
+1. Link the Vercel project (from monorepo root): `vercel link`
+2. Accept Fly.io org invites and `fly auth login` (see above)
+
+Then, from the `kiloclaw/` directory:
+
 ```bash
-# 1. Install dependencies (run from monorepo root)
-pnpm install
-
-# 2. Copy the example env file (from kiloclaw/)
-cp kiloclaw/.dev.vars.example kiloclaw/.dev.vars
-
-# 3. Edit .dev.vars -- see "Environment Variables" below
-
-# 4. Ensure Next.js has KiloClaw env vars (from monorepo root).
-#    `vercel env pull` includes KILOCLAW_API_URL and
-#    KILOCLAW_INTERNAL_API_SECRET. If you haven't run it yet, see
-#    the root DEVELOPMENT.md for Next.js setup.
-
-# 5. Start the local database (from monorepo root)
-docker compose -f dev/docker-compose.yml up -d
-
-# 6. Run database migrations (from monorepo root)
-pnpm drizzle migrate
-
-# 7. Start the tunnel (separate terminal)
-cloudflared tunnel --url http://localhost:3000
-# Copy the tunnel URL into KILOCODE_API_BASE_URL in .dev.vars
-
-# 8. Start Next.js (separate terminal, from monorepo root)
-pnpm dev
-
-# 9. Start the KiloClaw worker (separate terminal, from kiloclaw/)
-pnpm run dev
+./scripts/dev-start.sh
 ```
 
-Each of the three long-running processes (tunnel, Next.js, worker) needs its
-own terminal tab. The Next.js app must run on port 3000 -- other services
-depend on it.
+The script handles everything: creates `.dev.vars` if missing, pulls Vercel
+env, syncs secrets, validates/refreshes the Fly token, installs dependencies,
+starts the database, runs migrations, starts a Cloudflare tunnel (and captures
+the URL into `.dev.vars`), and launches all three processes.
+
+Open <http://localhost:3000> to use the dashboard.
+
+### Display modes
+
+Control how the three processes are displayed with `--display <mode>`:
+
+| Mode    | Description                                                           |
+| ------- | --------------------------------------------------------------------- |
+| `tabs`  | Separate terminal tabs (default; auto-detects iTerm2 vs Terminal.app) |
+| `split` | Single tab with split panes (requires iTerm2)                         |
+| `tmux`  | tmux session `kiloclaw` (attach with `tmux attach -t kiloclaw`)       |
+
+### Other flags
+
+| Flag                       | Description                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `--has-controller-changes` | Build and push a new Docker image before starting    |
+| `--tunnel-name <name>`     | Use a named Cloudflare tunnel instead of a quick one |
+
+### Script configuration
+
+Save defaults in a config file so you don't need to pass flags every time.
+The script checks two locations (project-local overrides user-global):
+
+| Location                            | Scope                       |
+| ----------------------------------- | --------------------------- |
+| `kiloclaw/scripts/.dev-start.conf`  | Per-worktree (gitignored)   |
+| `~/.config/kiloclaw/dev-start.conf` | Shared across all worktrees |
+
+See `scripts/.dev-start.conf.example` for available options. CLI flags
+override config file values.
 
 ## Tunnel setup
 
-Use Cloudflare Tunnel (recommended) or ngrok to expose your local Next.js:
-
-```bash
-# Cloudflare Tunnel (free, no account needed for quick tunnels)
-cloudflared tunnel --url http://localhost:3000
-
-# Or ngrok
-ngrok http 3000
-```
-
-Copy the tunnel URL and set it in `.dev.vars`:
-
-```
-KILOCODE_API_BASE_URL=https://<your-tunnel>.trycloudflare.com/api/gateway/
-```
+The dev-start script automatically starts a Cloudflare quick tunnel, captures
+its URL, and writes `KILOCODE_API_BASE_URL` into `.dev.vars`. You generally
+don't need to manage this manually.
 
 ### Free vs named tunnels
 
-- **Free quick tunnel**: hostname changes on every restart of `cloudflared`.
-  Update `.dev.vars` and restart the worker when the URL changes.
+- **Free quick tunnel** (default): hostname changes on every restart. The
+  script handles this automatically.
 - **Named tunnel**: preconfigure in the Cloudflare dashboard for a persistent
-  hostname (e.g., `yourname.devclaw.dev`). Avoids updating the URL on each
-  restart.
+  hostname (e.g., `yourname.devclaw.dev`). Use `--tunnel-name <name>` or set
+  `TUNNEL_NAME` and `TUNNEL_HOSTNAME` in your config file.
 
 ### If the tunnel isn't working
 
@@ -136,71 +133,68 @@ The error manifests in OpenClaw as one of:
 
 If you see either, check:
 
-- `cloudflared` (or ngrok) is running
+- `cloudflared` is running (check its terminal tab/window)
 - `KILOCODE_API_BASE_URL` in `.dev.vars` matches the current tunnel URL
 - The KiloClaw worker was restarted after changing `.dev.vars`
 
 ## Environment Variables
 
-There are two env files to configure:
+### `kiloclaw/.dev.vars` (worker secrets)
 
-### 1. `kiloclaw/.dev.vars` (worker secrets)
+The dev-start script creates `.dev.vars` from `.dev.vars.example` on first run
+and automatically manages several values. The table below shows which variables
+are auto-managed and which require manual setup.
 
-Copy `.dev.vars.example` and fill in:
+**Auth:**
 
-**Auth** -- must match the Next.js app's values:
+| Variable               | Description                                                                 | Auto-managed               |
+| ---------------------- | --------------------------------------------------------------------------- | -------------------------- |
+| `NEXTAUTH_SECRET`      | JWT signing key. Must match the Next.js app's `NEXTAUTH_SECRET`             | Yes (synced from Vercel)   |
+| `INTERNAL_API_SECRET`  | Platform API key. Must match Next.js `KILOCLAW_INTERNAL_API_SECRET`         | Yes (synced from Vercel)   |
+| `GATEWAY_TOKEN_SECRET` | HMAC key for per-sandbox gateway tokens. Can be any arbitrary value in dev. | No (example default works) |
+| `WORKER_ENV`           | Set to `development`                                                        | No (example default works) |
 
-| Variable               | Description                                                                 |
-| ---------------------- | --------------------------------------------------------------------------- |
-| `NEXTAUTH_SECRET`      | JWT signing key. Must match the Next.js app's `NEXTAUTH_SECRET`             |
-| `INTERNAL_API_SECRET`  | Platform API key. Must match Next.js `KILOCLAW_INTERNAL_API_SECRET`         |
-| `GATEWAY_TOKEN_SECRET` | HMAC key for per-sandbox gateway tokens. Can be any arbitrary value in dev. |
-| `WORKER_ENV`           | Set to `development`                                                        |
+**Fly.io:**
 
-`NEXTAUTH_SECRET` and `INTERNAL_API_SECRET` must match the Next.js app's
-values. Pull them from Vercel (`vercel env pull` from the monorepo root) or
-get them from a team member.
-
-**Fly.io** -- requires access to the Kilo (dev) org:
-
-| Variable           | Description                                                                             |
-| ------------------ | --------------------------------------------------------------------------------------- |
-| `FLY_API_TOKEN`    | Fly org token. Generate with `fly tokens create -o kilo-dev my-dev-token`               |
-| `FLY_ORG_SLUG`     | Fly org slug (run `fly orgs list` to find it)                                           |
-| `FLY_REGISTRY_APP` | Shared Fly app that holds Docker images (e.g., `kiloclaw-dev`)                          |
-| `FLY_APP_NAME`     | Legacy fallback app name for existing instances (may be removed in future)              |
-| `FLY_REGION`       | Region priority list, e.g. `us,eu`. Tries US first, falls back to EU, then gives up.    |
-| `FLY_IMAGE_TAG`    | Docker image tag. Set automatically by `scripts/push-dev.sh`, or use `latest` to start. |
-| `FLY_IMAGE_DIGEST` | Docker image digest. Set automatically by `scripts/push-dev.sh`.                        |
-| `OPENCLAW_VERSION` | OpenClaw version in the image. Set automatically by `scripts/push-dev.sh`.              |
+| Variable           | Description                                                                             | Auto-managed                 |
+| ------------------ | --------------------------------------------------------------------------------------- | ---------------------------- |
+| `FLY_API_TOKEN`    | Fly org token                                                                           | Yes (auto-created/refreshed) |
+| `FLY_ORG_SLUG`     | Fly org slug (read by script for token creation)                                        | No (example default works)   |
+| `FLY_REGISTRY_APP` | Shared Fly app that holds Docker images (e.g., `kiloclaw-dev`)                          | No (example default works)   |
+| `FLY_APP_NAME`     | Legacy fallback app name for existing instances (may be removed in future)              | No (example default works)   |
+| `FLY_REGION`       | Region priority list, e.g. `us,eu`. Tries US first, falls back to EU, then gives up.    | No (example default works)   |
+| `FLY_IMAGE_TAG`    | Docker image tag. Set automatically by `scripts/push-dev.sh`, or use `latest` to start. | By push-dev.sh               |
+| `FLY_IMAGE_DIGEST` | Docker image digest. Set automatically by `scripts/push-dev.sh`.                        | By push-dev.sh               |
+| `OPENCLAW_VERSION` | OpenClaw version in the image. Set automatically by `scripts/push-dev.sh`.              | By push-dev.sh               |
 
 `FLY_IMAGE_TAG`, `FLY_IMAGE_DIGEST`, and `OPENCLAW_VERSION` together control
 what version gets deployed by default for your dev instances. The build script
 auto-updates all three. For initial setup, ask a team member for known-working
 values or use `latest` (if a `latest` tag exists in the registry).
 
-**Tunnel / API** -- so Fly machines can reach your local Next.js:
+**Tunnel / API:**
 
-| Variable                | Description                                                |
-| ----------------------- | ---------------------------------------------------------- |
-| `KILOCODE_API_BASE_URL` | Your tunnel URL + `/api/gateway/` (see tunnel setup above) |
+| Variable                | Description                       | Auto-managed                  |
+| ----------------------- | --------------------------------- | ----------------------------- |
+| `KILOCODE_API_BASE_URL` | Your tunnel URL + `/api/gateway/` | Yes (set by dev-start script) |
 
-**Encryption** -- for decrypting user-provided secrets:
+**Encryption:**
 
-| Variable                     | Description                                                                                                        |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `AGENT_ENV_VARS_PRIVATE_KEY` | RSA private key (PEM). Get the **dev** version from 1Password (engineering vault). Quote the value in `.dev.vars`. |
+| Variable                     | Description                                                                                                        | Auto-managed |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------ |
+| `AGENT_ENV_VARS_PRIVATE_KEY` | RSA private key (PEM). Get the **dev** version from 1Password (engineering vault). Quote the value in `.dev.vars`. | No           |
 
 **Other:**
 
-| Variable                   | Description                                       |
-| -------------------------- | ------------------------------------------------- |
-| `OPENCLAW_ALLOWED_ORIGINS` | Comma-separated origins for WebSocket connections |
+| Variable                   | Description                                       | Auto-managed               |
+| -------------------------- | ------------------------------------------------- | -------------------------- |
+| `OPENCLAW_ALLOWED_ORIGINS` | Comma-separated origins for WebSocket connections | No (example default works) |
 
-### 2. `.env.local` (Next.js, monorepo root)
+### `.env.local` (Next.js, monorepo root)
 
 The Next.js app also needs these two variables to talk to the KiloClaw worker.
-Both are included in `vercel env pull` (see root `DEVELOPMENT.md`):
+Both are included in `vercel env pull` (run automatically by the dev-start
+script):
 
 | Variable                       | Description                                     |
 | ------------------------------ | ----------------------------------------------- |
@@ -469,9 +463,10 @@ All scripts support overrides via env vars (`IMAGE`, `PORT`, `TOKEN`).
 
 **Fly machine can't reach your Next.js / "models require auth":**
 Check that the tunnel is running and `KILOCODE_API_BASE_URL` in `.dev.vars`
-matches the current tunnel URL. Restart the worker after changing it. Symptoms
-are either silent failure (three dots, then nothing) or "models require
-authentication."
+matches the current tunnel URL. The dev-start script sets this automatically,
+but if the tunnel restarts you'll need to re-run the script or update the URL
+manually and restart the worker. Symptoms are either silent failure (three
+dots, then nothing) or "models require authentication."
 
 **"tag latest unknown manifest":**
 The image tag in `FLY_IMAGE_TAG` doesn't exist in the Fly registry. Get

--- a/kiloclaw/scripts/.dev-start.conf.example
+++ b/kiloclaw/scripts/.dev-start.conf.example
@@ -9,6 +9,9 @@
 # TUNNEL_NAME=          # tunnel
 # TUNNEL_HOSTNAME=      # tunnel.yourdomain.com
 
+# RSA private key for agent env var encryption (get from 1Password, engineering vault)
+# AGENT_ENV_VARS_PRIVATE_KEY=
+
 # How to display the 3 dev processes:
 #   tabs   — separate terminal tabs (default; auto-detects iTerm2 vs Terminal.app)
 #   split  — single tab with split panes (requires iTerm2)

--- a/kiloclaw/scripts/.dev-start.conf.example
+++ b/kiloclaw/scripts/.dev-start.conf.example
@@ -6,11 +6,11 @@
 #   kiloclaw/scripts/.dev-start.conf    (per-worktree override, gitignored)
 
 # Named Cloudflare tunnel (leave empty for temporary quick tunnel)
-# TUNNEL_NAME=
-# TUNNEL_HOSTNAME=tunnel.yourdomain.com
+# TUNNEL_NAME=          # tunnel
+# TUNNEL_HOSTNAME=      # tunnel.yourdomain.com
 
 # How to display the 3 dev processes:
 #   tabs   — separate terminal tabs (default; auto-detects iTerm2 vs Terminal.app)
 #   split  — single tab with split panes (requires iTerm2)
 #   tmux   — tmux session "kiloclaw"
-# DISPLAY_MODE=tabs
+DISPLAY_MODE=tabs

--- a/kiloclaw/scripts/.dev-start.conf.example
+++ b/kiloclaw/scripts/.dev-start.conf.example
@@ -1,0 +1,16 @@
+# Dev-start script configuration.
+# CLI flags override these values.
+#
+# Place this file in either location:
+#   ~/.config/kiloclaw/dev-start.conf   (shared across all worktrees)
+#   kiloclaw/scripts/.dev-start.conf    (per-worktree override, gitignored)
+
+# Named Cloudflare tunnel (leave empty for temporary quick tunnel)
+# TUNNEL_NAME=
+# TUNNEL_HOSTNAME=tunnel.yourdomain.com
+
+# How to display the 3 dev processes:
+#   tabs   — separate terminal tabs (default; auto-detects iTerm2 vs Terminal.app)
+#   split  — single tab with split panes (requires iTerm2)
+#   tmux   — tmux session "kiloclaw"
+# DISPLAY_MODE=tabs

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -88,6 +88,18 @@ if [ ! -f "$KILOCLAW_DIR/.dev.vars" ]; then
   cp "$KILOCLAW_DIR/.dev.vars.example" "$KILOCLAW_DIR/.dev.vars"
 fi
 
+# Sync AGENT_ENV_VARS_PRIVATE_KEY from config into .dev.vars
+if [ -n "${AGENT_ENV_VARS_PRIVATE_KEY:-}" ]; then
+  echo "==> Syncing AGENT_ENV_VARS_PRIVATE_KEY from config into .dev.vars..."
+  if grep -q '^AGENT_ENV_VARS_PRIVATE_KEY=' "$KILOCLAW_DIR/.dev.vars"; then
+    sed "s|^AGENT_ENV_VARS_PRIVATE_KEY=.*|AGENT_ENV_VARS_PRIVATE_KEY=$AGENT_ENV_VARS_PRIVATE_KEY|" \
+      "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+    mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+  else
+    echo "AGENT_ENV_VARS_PRIVATE_KEY=$AGENT_ENV_VARS_PRIVATE_KEY" >> "$KILOCLAW_DIR/.dev.vars"
+  fi
+fi
+
 # Check AGENT_ENV_VARS_PRIVATE_KEY is configured
 AGENT_KEY="$(grep '^AGENT_ENV_VARS_PRIVATE_KEY=' "$KILOCLAW_DIR/.dev.vars" | head -1 | sed 's/^[^=]*=//' | sed 's/^"//;s/"$//')"
 if [ -z "$AGENT_KEY" ] || [ "$AGENT_KEY" = "..." ]; then

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -88,6 +88,15 @@ if [ ! -f "$KILOCLAW_DIR/.dev.vars" ]; then
   cp "$KILOCLAW_DIR/.dev.vars.example" "$KILOCLAW_DIR/.dev.vars"
 fi
 
+# Check AGENT_ENV_VARS_PRIVATE_KEY is configured
+AGENT_KEY="$(grep '^AGENT_ENV_VARS_PRIVATE_KEY=' "$KILOCLAW_DIR/.dev.vars" | head -1 | sed 's/^[^=]*=//' | sed 's/^"//;s/"$//')"
+if [ -z "$AGENT_KEY" ] || [ "$AGENT_KEY" = "..." ]; then
+  echo "ERROR: AGENT_ENV_VARS_PRIVATE_KEY is not configured in .dev.vars."
+  echo "Get the dev version from 1Password (engineering vault) and set it in"
+  echo "  $KILOCLAW_DIR/.dev.vars"
+  exit 1
+fi
+
 # ---------- Pull dev environment from Vercel ----------
 
 if [ ! -d "$MONOREPO_ROOT/.vercel" ] || [ ! -f "$MONOREPO_ROOT/.vercel/project.json" ]; then

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -1,0 +1,478 @@
+#!/bin/bash
+# Start the local KiloClaw development environment.
+#
+# Opens three terminal windows: Next.js, KiloClaw worker, and cloudflared tunnel.
+# Handles both named and temporary (quick) Cloudflare tunnels.
+#
+# Usage:
+#   ./scripts/dev-start.sh [options]
+#
+# Options:
+#   --has-controller-changes   Build and push a new Docker image before starting.
+#                              After the push, you must restart/redeploy your
+#                              instance from the dashboard.
+#   --tunnel-name <name>       Use a named Cloudflare tunnel instead of a
+#                              temporary quick tunnel. Named tunnels have a
+#                              stable hostname that doesn't change between restarts.
+#   --display <mode>           How to display the 3 dev processes:
+#                                tabs   — separate terminal tabs (default)
+#                                split  — single tab with split panes (requires iTerm2)
+#                                tmux   — tmux session "kiloclaw"
+#
+# Config (highest priority wins):
+#   1. CLI flags
+#   2. Project-local:  kiloclaw/scripts/.dev-start.conf (gitignored, per-worktree overrides)
+#   3. User-global:    ~/.config/kiloclaw/dev-start.conf (shared across worktrees)
+#   4. Built-in defaults
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+KILOCLAW_DIR="$(dirname "$SCRIPT_DIR")"
+MONOREPO_ROOT="$(cd "$KILOCLAW_DIR/.." && pwd)"
+
+# ---------- Defaults (overridden by .dev-start.conf, then by CLI flags) ----------
+
+HAS_CONTROLLER_CHANGES=false
+TUNNEL_NAME=""
+TUNNEL_HOSTNAME=""
+DISPLAY_MODE="tabs"
+
+# Source user config: project-local overrides user-global
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/kiloclaw/dev-start.conf" ]; then
+  # shellcheck source=/dev/null
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/kiloclaw/dev-start.conf"
+fi
+if [ -f "$SCRIPT_DIR/.dev-start.conf" ]; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/.dev-start.conf"
+fi
+
+# CLI flags override config
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --has-controller-changes)
+      HAS_CONTROLLER_CHANGES=true
+      shift
+      ;;
+    --tunnel-name)
+      TUNNEL_NAME="$2"
+      shift 2
+      ;;
+    --display)
+      DISPLAY_MODE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--has-controller-changes] [--tunnel-name <name>] [--display <mode>]"
+      echo "Display modes: tabs (default), split, tmux"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate DISPLAY_MODE
+case "$DISPLAY_MODE" in
+  tabs|split|tmux) ;;
+  *)
+    echo "ERROR: Unknown display mode '$DISPLAY_MODE'."
+    echo "Valid modes: tabs, split, tmux"
+    exit 1
+    ;;
+esac
+
+# ---------- Pre-flight checks ----------
+
+if [ ! -f "$KILOCLAW_DIR/.dev.vars" ]; then
+  echo "==> Creating .dev.vars from .dev.vars.example..."
+  cp "$KILOCLAW_DIR/.dev.vars.example" "$KILOCLAW_DIR/.dev.vars"
+fi
+
+# ---------- Pull dev environment from Vercel ----------
+
+if [ ! -d "$MONOREPO_ROOT/.vercel" ] || [ ! -f "$MONOREPO_ROOT/.vercel/project.json" ]; then
+  echo "ERROR: Vercel project not linked."
+  echo "Run 'vercel link' in $MONOREPO_ROOT first."
+  exit 1
+fi
+
+echo "==> Pulling development environment from Vercel..."
+(cd "$MONOREPO_ROOT" && vercel env pull --environment=development)
+
+# ---------- Sync shared secrets from .env.local into .dev.vars ----------
+
+ENV_LOCAL="$MONOREPO_ROOT/.env.local"
+if [ -f "$ENV_LOCAL" ]; then
+  echo "==> Syncing secrets from .env.local into .dev.vars..."
+
+  # Extract a value from .env.local, stripping surrounding quotes
+  env_local_val() {
+    grep "^$1=" "$ENV_LOCAL" | head -1 | sed 's/^[^=]*=//' | sed 's/^"//;s/"$//'
+  }
+
+  # NEXTAUTH_SECRET → NEXTAUTH_SECRET
+  NEXTAUTH_SECRET_VAL="$(env_local_val NEXTAUTH_SECRET)"
+  if [ -n "$NEXTAUTH_SECRET_VAL" ]; then
+    sed "s|^NEXTAUTH_SECRET=.*|NEXTAUTH_SECRET=$NEXTAUTH_SECRET_VAL|" \
+      "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+    mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+  fi
+
+  # KILOCLAW_INTERNAL_API_SECRET → INTERNAL_API_SECRET
+  INTERNAL_SECRET_VAL="$(env_local_val KILOCLAW_INTERNAL_API_SECRET)"
+  if [ -n "$INTERNAL_SECRET_VAL" ]; then
+    sed "s|^INTERNAL_API_SECRET=.*|INTERNAL_API_SECRET=$INTERNAL_SECRET_VAL|" \
+      "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+    mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+  fi
+fi
+
+# ---------- Validate / refresh Fly API token ----------
+
+# Read FLY_ORG_SLUG from .dev.vars (defaults to kilo-dev in .dev.vars.example)
+FLY_ORG="$(grep '^FLY_ORG_SLUG=' "$KILOCLAW_DIR/.dev.vars" | head -1 | sed 's/^[^=]*=//' | sed 's/^"//;s/"$//')"
+if [ -z "$FLY_ORG" ]; then
+  FLY_ORG="kilo-dev"
+fi
+
+refresh_fly_token() {
+  echo "==> Generating new Fly API token for org '$FLY_ORG'..."
+  if ! command -v fly &>/dev/null; then
+    echo "ERROR: 'fly' CLI not found. Install it: https://fly.io/docs/flyctl/install/"
+    exit 1
+  fi
+  NEW_TOKEN="$(fly tokens create org "$FLY_ORG" 2>&1)"
+  if [ $? -ne 0 ] || [ -z "$NEW_TOKEN" ]; then
+    echo "ERROR: Failed to create Fly token. Are you logged in? Try 'fly auth login'."
+    echo "$NEW_TOKEN"
+    exit 1
+  fi
+  sed "s|^FLY_API_TOKEN=.*|FLY_API_TOKEN=$NEW_TOKEN|" \
+    "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+  mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+  FLY_TOKEN="$NEW_TOKEN"
+  echo "    Token saved to .dev.vars."
+}
+
+FLY_TOKEN="$(grep '^FLY_API_TOKEN=' "$KILOCLAW_DIR/.dev.vars" | head -1 | sed 's/^[^=]*=//' | sed 's/^"//;s/"$//')"
+
+if [ -z "$FLY_TOKEN" ] || [ "$FLY_TOKEN" = "fo1_..." ]; then
+  refresh_fly_token
+fi
+
+echo "==> Validating Fly API token..."
+FLY_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $FLY_TOKEN" \
+  "https://api.machines.dev/v1/apps?org_slug=$FLY_ORG&limit=1")
+
+if [ "$FLY_STATUS" != "200" ]; then
+  echo "    Token is invalid or expired (HTTP $FLY_STATUS). Refreshing..."
+  refresh_fly_token
+
+  FLY_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $FLY_TOKEN" \
+    "https://api.machines.dev/v1/apps?org_slug=$FLY_ORG&limit=1")
+
+  if [ "$FLY_STATUS" != "200" ]; then
+    echo "ERROR: New token still failing (HTTP $FLY_STATUS). Check 'fly auth login' and org access."
+    exit 1
+  fi
+fi
+
+echo "    Fly API token is valid."
+
+# ---------- Install dependencies ----------
+
+echo "==> Installing dependencies..."
+(cd "$MONOREPO_ROOT" && pnpm install)
+
+# ---------- Start database and run migrations ----------
+
+echo "==> Starting local database..."
+(cd "$MONOREPO_ROOT" && docker compose -f dev/docker-compose.yml up -d)
+
+echo "==> Running database migrations..."
+(cd "$MONOREPO_ROOT" && pnpm drizzle migrate)
+
+# ---------- Controller image push (optional) ----------
+
+if [ "$HAS_CONTROLLER_CHANGES" = true ]; then
+  echo "==> Building and pushing controller image..."
+  echo ""
+  "$KILOCLAW_DIR/scripts/push-dev.sh"
+  echo ""
+  echo "============================================================"
+  echo "  IMAGE PUSHED — ACTION REQUIRED"
+  echo "============================================================"
+  echo ""
+  echo "  Your KiloClaw instance is still running the old image."
+  echo "  To pick up the new controller:"
+  echo ""
+  echo "  1. Open the dashboard at http://localhost:3000"
+  echo "  2. Go to your instance's Settings tab"
+  echo "  3. Click 'Destroy', then re-provision a new instance"
+  echo ""
+  echo "  (A simple restart is enough if only controller routes"
+  echo "   changed. Destroy + re-provision is needed if the volume"
+  echo "   or Fly app config changed.)"
+  echo ""
+  echo "============================================================"
+  echo ""
+fi
+
+# ---------- Helpers: open commands in terminal ----------
+
+open_terminal_tab() {
+  local title="$1"
+  local cmd="$2"
+
+  if osascript -e 'tell application "System Events" to (name of processes) contains "iTerm2"' 2>/dev/null | grep -q true; then
+    osascript <<EOF
+tell application "iTerm"
+  activate
+  tell current window
+    create tab with default profile
+    tell current session
+      set name to "$title"
+      write text "echo '--- $title ---'; $cmd"
+    end tell
+  end tell
+end tell
+EOF
+  else
+    osascript <<EOF
+tell application "Terminal"
+  activate
+  do script "printf '\\e]0;$title\\a'; $cmd"
+end tell
+EOF
+  fi
+}
+
+# Open 3 commands in a single iTerm2 tab with vertical/horizontal splits:
+#   ┌──────────────┬──────────────┐
+#   │   tunnel     │   Next.js    │
+#   │              ├──────────────┤
+#   │              │   worker     │
+#   └──────────────┴──────────────┘
+open_split_screen() {
+  local title1="$1" cmd1="$2"
+  local title2="$3" cmd2="$4"
+  local title3="$5" cmd3="$6"
+
+  osascript <<EOF
+tell application "iTerm"
+  activate
+  tell current window
+    create tab with default profile
+
+    -- Left pane: tunnel (named "KiloClaw Dev" so the tab title is readable)
+    tell current session
+      set name to "KiloClaw Dev"
+      write text "echo '--- $title1 ---'; $cmd1"
+
+      -- Split right
+      set rightSession to (split vertically with default profile)
+    end tell
+
+    -- Top-right pane: Next.js
+    tell rightSession
+      set name to "$title2"
+      write text "echo '--- $title2 ---'; $cmd2"
+
+      -- Split bottom
+      set bottomRightSession to (split horizontally with default profile)
+    end tell
+
+    -- Bottom-right pane: worker
+    tell bottomRightSession
+      set name to "$title3"
+      write text "echo '--- $title3 ---'; $cmd3"
+    end tell
+  end tell
+end tell
+EOF
+}
+
+# Open 3 commands in a tmux session called "kiloclaw" with 3 windows:
+open_tmux_session() {
+  local title1="$1" cmd1="$2"
+  local title2="$3" cmd2="$4"
+  local title3="$5" cmd3="$6"
+
+  local session="kiloclaw"
+
+  # Kill existing session if present
+  tmux kill-session -t "$session" 2>/dev/null || true
+
+  tmux new-session -d -s "$session" -n "$title1"
+  tmux send-keys -t "$session:$title1" "$cmd1" C-m
+
+  tmux new-window -t "$session" -n "$title2"
+  tmux send-keys -t "$session:$title2" "$cmd2" C-m
+
+  tmux new-window -t "$session" -n "$title3"
+  tmux send-keys -t "$session:$title3" "$cmd3" C-m
+
+  # Select the first window
+  tmux select-window -t "$session:$title1"
+}
+
+# ---------- Helper: update KILOCODE_API_BASE_URL in .dev.vars ----------
+
+set_api_base_url() {
+  local url="$1"
+  echo "    Setting KILOCODE_API_BASE_URL=$url"
+  if grep -q '^KILOCODE_API_BASE_URL=' "$KILOCLAW_DIR/.dev.vars"; then
+    sed "s|^KILOCODE_API_BASE_URL=.*|KILOCODE_API_BASE_URL=$url|" \
+      "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+    mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+  elif grep -q '^# KILOCODE_API_BASE_URL=' "$KILOCLAW_DIR/.dev.vars"; then
+    sed "s|^# KILOCODE_API_BASE_URL=.*|KILOCODE_API_BASE_URL=$url|" \
+      "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+    mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+  else
+    echo "KILOCODE_API_BASE_URL=$url" >> "$KILOCLAW_DIR/.dev.vars"
+  fi
+}
+
+# ---------- Prepare tunnel command and update .dev.vars ----------
+
+if [ -n "$TUNNEL_NAME" ]; then
+  echo "==> Using named tunnel: $TUNNEL_NAME"
+  TUNNEL_CMD="cloudflared tunnel run $TUNNEL_NAME"
+
+  if [ -n "$TUNNEL_HOSTNAME" ]; then
+    set_api_base_url "https://${TUNNEL_HOSTNAME}/api/gateway/"
+  fi
+else
+  # Temporary quick tunnel — start it early to capture the URL.
+  echo "==> Starting temporary cloudflared tunnel..."
+  echo "    (Capturing tunnel URL to update .dev.vars)"
+
+  TUNNEL_CMD="cloudflared tunnel --url http://localhost:3000"
+  TUNNEL_LOG="$(mktemp)"
+  QUICK_TUNNEL_STARTED=false
+
+  if [ "$DISPLAY_MODE" = "tmux" ]; then
+    # For tmux, start the tunnel in the background to capture the URL
+    $TUNNEL_CMD > "$TUNNEL_LOG" 2>&1 &
+    TUNNEL_PID=$!
+    QUICK_TUNNEL_STARTED=true
+  else
+    open_terminal_tab "cloudflared tunnel" "$TUNNEL_CMD 2>&1 | tee $TUNNEL_LOG"
+  fi
+
+  echo "    Waiting for tunnel URL..."
+  TUNNEL_URL=""
+  for i in $(seq 1 30); do
+    TUNNEL_URL=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -1 || true)
+    if [ -n "$TUNNEL_URL" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  if [ -z "$TUNNEL_URL" ]; then
+    echo ""
+    echo "WARNING: Could not capture tunnel URL after 30 seconds."
+    echo "Check the cloudflared terminal tab and manually update"
+    echo "KILOCODE_API_BASE_URL in .dev.vars, then restart the worker."
+    echo ""
+  else
+    echo "    Tunnel URL: $TUNNEL_URL"
+    set_api_base_url "${TUNNEL_URL}/api/gateway/"
+  fi
+
+  # For tmux, kill the background tunnel — it will be restarted inside tmux
+  if [ "$QUICK_TUNNEL_STARTED" = true ]; then
+    kill "$TUNNEL_PID" 2>/dev/null || true
+    wait "$TUNNEL_PID" 2>/dev/null || true
+  fi
+
+  rm -f "$TUNNEL_LOG"
+fi
+
+# ---------- Launch processes ----------
+
+NEXTJS_CMD="cd '$MONOREPO_ROOT' && pnpm dev"
+WORKER_CMD="sleep 2 && cd '$KILOCLAW_DIR' && pnpm run dev"
+
+case "$DISPLAY_MODE" in
+  tmux)
+    echo "==> Starting tmux session 'kiloclaw'..."
+
+    if ! command -v tmux &>/dev/null; then
+      echo "ERROR: 'tmux' not found. Install it: brew install tmux"
+      exit 1
+    fi
+
+    open_tmux_session \
+      "tunnel" "$TUNNEL_CMD" \
+      "nextjs" "$NEXTJS_CMD" \
+      "worker" "$WORKER_CMD"
+
+    echo ""
+    echo "Dev environment running in tmux session 'kiloclaw'."
+    echo "  Attach with: tmux attach -t kiloclaw"
+    ;;
+
+  split)
+    echo "==> Opening split-screen tab in iTerm2..."
+
+    if [ -n "$TUNNEL_NAME" ]; then
+      # Named tunnel: all 3 in one split tab
+      open_split_screen \
+        "cloudflared tunnel" "$TUNNEL_CMD" \
+        "Next.js" "$NEXTJS_CMD" \
+        "KiloClaw worker" "$WORKER_CMD"
+    else
+      # Quick tunnel already running in its own tab; put Next.js + worker in splits
+      osascript <<EOF
+tell application "iTerm"
+  activate
+  tell current window
+    create tab with default profile
+
+    tell current session
+      set name to "Next.js"
+      write text "echo '--- Next.js ---'; $NEXTJS_CMD"
+      set workerSession to (split horizontally with default profile)
+    end tell
+
+    tell workerSession
+      set name to "KiloClaw worker"
+      write text "echo '--- KiloClaw worker ---'; $WORKER_CMD"
+    end tell
+  end tell
+end tell
+EOF
+    fi
+
+    echo ""
+    echo "Dev environment starting in split-screen iTerm2 tab."
+    ;;
+
+  tabs)
+    # Separate tabs
+    if [ -n "$TUNNEL_NAME" ]; then
+      open_terminal_tab "cloudflared tunnel" "$TUNNEL_CMD"
+    fi
+    # Quick tunnel tab was already opened above
+
+    echo "==> Starting Next.js (pnpm dev)..."
+    open_terminal_tab "Next.js" "$NEXTJS_CMD"
+
+    echo "==> Starting KiloClaw worker (pnpm run dev)..."
+    open_terminal_tab "KiloClaw worker" "$WORKER_CMD"
+
+    echo ""
+    echo "Dev environment starting in 3 terminal tabs:"
+    echo "  1. cloudflared tunnel"
+    echo "  2. Next.js (port 3000)"
+    echo "  3. KiloClaw worker (port 8795)"
+    ;;
+esac
+
+echo ""
+echo "Open http://localhost:3000 to use the dashboard."


### PR DESCRIPTION
## Summary

- One-command dev environment setup: `./scripts/dev-start.sh`
- Auto-manages `.dev.vars` (creates from example, syncs secrets from Vercel, refreshes Fly tokens, sets tunnel URL)
- `--display tabs|split|tmux` flag for terminal layout preference
- Persistent config via `.dev-start.conf` (per-worktree or user-global)
- Updated DEVELOPMENT_LOCAL.md to document the script

## Test plan

- [x] Run `./scripts/dev-start.sh` with no `.dev.vars` (should auto-create)
- [x] Test `--display tabs`, `--display split`, `--display tmux`
- [x] Test `--tunnel-name` with a named tunnel
- [x] Test config file override via `scripts/.dev-start.conf`