### PR TITLE
feat(gastown): add manual user ID allowlist for feature flag bypass

### DIFF
--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -32,6 +32,7 @@ import SidebarUserFooter from './SidebarUserFooter';
 import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
 import { isEnabledForUser } from '@/lib/code-indexing/util';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
+import { useGastownEnabled } from '@/hooks/useGastownEnabled';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 
 export default function PersonalAppSidebar(props: React.ComponentProps<typeof Sidebar>) {
@@ -39,7 +40,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
 
   // Feature flags
   const isAutoTriageFeatureEnabled = useFeatureFlagEnabled('auto-triage-feature');
-  const isGastownEnabled = useFeatureFlagEnabled('gastown-access');
+  const isGastownEnabled = useGastownEnabled();
   const isDevelopment = process.env.NODE_ENV === 'development';
 
   // Dashboard group

--- a/src/hooks/useGastownEnabled.ts
+++ b/src/hooks/useGastownEnabled.ts
@@ -1,0 +1,12 @@
+import { useFeatureFlagEnabled } from 'posthog-js/react';
+import { useUser } from './useUser';
+import { GASTOWN_MANUAL_USER_IDS } from '@/lib/gastown/manual-access';
+
+const GASTOWN_ACCESS_FLAG = 'gastown-access';
+
+export function useGastownEnabled() {
+  const { data: user } = useUser();
+  const flagEnabled = useFeatureFlagEnabled(GASTOWN_ACCESS_FLAG);
+  const isManuallyEnabled = user ? GASTOWN_MANUAL_USER_IDS.has(user.id) : false;
+  return isManuallyEnabled || flagEnabled;
+}

--- a/src/lib/gastown/feature-flags.ts
+++ b/src/lib/gastown/feature-flags.ts
@@ -1,4 +1,5 @@
 import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
+import { GASTOWN_MANUAL_USER_IDS } from './manual-access';
 
 const GASTOWN_ACCESS_FLAG = 'gastown-access';
 
@@ -13,9 +14,14 @@ const GASTOWN_ACCESS_FLAG = 'gastown-access';
  *
  * See #901 for details.
  */
-export async function isGastownEnabled(userId: string): Promise<boolean> {
+export async function isGastownEnabled(userId?: string): Promise<boolean> {
   if (process.env.NODE_ENV !== 'production') {
     return true;
   }
-  return isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, userId);
+
+  if (!userId) {
+    return false;
+  }
+
+  return GASTOWN_MANUAL_USER_IDS.has(userId) || isFeatureFlagEnabled(GASTOWN_ACCESS_FLAG, userId);
 }

--- a/src/lib/gastown/manual-access.ts
+++ b/src/lib/gastown/manual-access.ts
@@ -1,0 +1,3 @@
+// User IDs that are manually granted Gastown access, bypassing PostHog.
+// Sid - PostHog is not recognizing Sid as in the cohort.
+export const GASTOWN_MANUAL_USER_IDS = new Set(['8e09400a-72c5-46a4-97fd-51f1e93cdaef']);


### PR DESCRIPTION
## Summary

- Adds a manual user ID allowlist (`MANUAL_USER_IDS`) to `isGastownEnabled` in `src/lib/gastown/feature-flags.ts`
- Works around PostHog not recognizing Sid's user ID as part of the `gastown-access` cohort
- The allowlist is checked before the PostHog feature flag, so listed users get immediate access

## Verification

- [x] Reviewed the diff for correctness
- [x] Confirmed the logic short-circuits correctly (`MANUAL_USER_IDS.has(userId) || isFeatureFlagEnabled(...)`)

## Visual Changes

N/A

## Reviewer Notes

- The hardcoded UUID belongs to Sid. Once PostHog cohort recognition is fixed, this entry can be removed.
- If more users need manual enablement, add their UUIDs to the `MANUAL_USER_IDS` set.