### PR TITLE
fix(gastown): propagate container-push errors in manual token refresh

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -454,13 +454,17 @@ export class TownDO extends DurableObject<Env> {
    * Force-refresh the container token, bypassing the 1-hour throttle.
    * Called from the user-facing tRPC mutation so operators can manually
    * push a fresh JWT to the running container.
+   *
+   * Unlike the alarm-driven refreshContainerToken, this propagates ALL
+   * errors (including container-down) so the UI can show a real failure
+   * instead of a false success.
    */
   async forceRefreshContainerToken(): Promise<void> {
     const townId = this.townId;
     if (!townId) throw new Error('townId not set');
     const townConfig = await this.getTownConfig();
     const userId = townConfig.owner_user_id ?? townId;
-    await dispatch.refreshContainerToken(this.env, townId, userId);
+    await dispatch.forceRefreshContainerToken(this.env, townId, userId);
     this.lastContainerTokenRefreshAt = Date.now();
   }
 

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -127,6 +127,56 @@ export async function ensureContainerToken(
  */
 export const refreshContainerToken = ensureContainerToken;
 
+/**
+ * Force-refresh variant for manual user-triggered refreshes.
+ *
+ * Unlike ensureContainerToken (which tolerates a downed container
+ * because the token is persisted in envVars for next boot), this
+ * function throws on ANY failure to push the token to the running
+ * container — including network errors. This ensures the UI reports
+ * a real failure instead of a false success when the container
+ * never actually received the fresh JWT.
+ */
+export async function forceRefreshContainerToken(
+  env: Env,
+  townId: string,
+  userId: string
+): Promise<string> {
+  const jwtSecret = await resolveJWTSecret(env);
+  if (!jwtSecret) {
+    throw new Error('No JWT secret available — cannot mint container token');
+  }
+
+  const token = signContainerJWT({ townId, userId }, jwtSecret);
+  const container = getTownContainerStub(env, townId);
+
+  // Store for next boot (best-effort — the critical step is the live push below)
+  try {
+    await container.setEnvVar('GASTOWN_CONTAINER_TOKEN', token);
+  } catch (err) {
+    console.warn(
+      `${TOWN_LOG} forceRefreshContainerToken: setEnvVar failed:`,
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  // Push to running container — propagate ALL errors so the caller
+  // (and ultimately the UI) knows the refresh didn't land.
+  const resp = await container.fetch('http://container/refresh-token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new Error(
+      `Container rejected token refresh (HTTP ${resp.status})${body ? `: ${body.slice(0, 200)}` : ''}`
+    );
+  }
+
+  return token;
+}
+
 /** Build the initial prompt for an agent from its bead. */
 export function buildPrompt(params: {
   beadTitle: string;


### PR DESCRIPTION
## Summary

- The manual "Refresh Token" button in town settings was reporting success even when the container never received the fresh JWT. This happened because `forceRefreshContainerToken` on the TownDO called `ensureContainerToken`, which silently swallows network errors to the container (by design for the alarm path — the token is persisted in envVars for next boot).
- Added a dedicated `forceRefreshContainerToken` function in `container-dispatch.ts` that propagates ALL errors from the container push, so the UI shows a real failure toast instead of false success when the container is unreachable or rejects the token.
- The alarm-driven `refreshContainerToken` / `ensureContainerToken` path is unchanged — it still tolerates a downed container.

Closes #1101

## Verification

- [x] `pnpm typecheck` — all 28 workspace projects pass

## Visual Changes

N/A — the UI button already existed. The change is behavioral: it now correctly shows an error toast when the token push fails, instead of a false success.

## Reviewer Notes

- The existing `ensureContainerToken` error-swallowing behavior (lines 110-116 of `container-dispatch.ts`) is intentional for the alarm path and left untouched. The new `forceRefreshContainerToken` is a parallel function that duplicates the minting + push logic but without the `isContainerDown` catch.
- The `setEnvVar` call (persisting for next boot) remains best-effort in both paths — if the container isn't running at all, the envVar store may not be reachable, but that's fine since there's no running process to receive the token anyway.