### PR TITLE
fix(gastown): auto token refresh, rework dispatch, and escalation close

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2339,7 +2339,12 @@ export class TownDO extends DurableObject<Env> {
     );
     // Acknowledging an escalation also closes it — the mayor has seen
     // the issue and doesn't need it sitting open in the queue.
-    beadOps.updateBeadStatus(this.sql, escalationId, 'closed', null);
+    // Guard with getBead so stale/duplicate acknowledge calls remain
+    // idempotent instead of throwing on a missing bead.
+    const escalationBead = beadOps.getBead(this.sql, escalationId);
+    if (escalationBead && escalationBead.status !== 'closed') {
+      beadOps.updateBeadStatus(this.sql, escalationId, 'closed', null);
+    }
     this.emitEvent({
       event: 'escalation.acknowledged',
       townId: this.townId,

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2498,12 +2498,13 @@ export class TownDO extends DurableObject<Env> {
       } catch (err) {
         console.warn(`${TOWN_LOG} alarm: container health check failed`, err);
       }
-    }
 
-    // Refresh the container-scoped JWT before any work that might
-    // trigger API calls. Throttled to once per hour (tokens have 8h
-    // expiry, so hourly refresh provides ample safety margin).
-    if (this.hasActiveWork()) {
+      // Refresh the container-scoped JWT before any work that might
+      // trigger API calls. Throttled to once per hour (tokens have 8h
+      // expiry, so hourly refresh provides ample safety margin).
+      // Gated on hasRigs (not hasActiveWork) because the container may
+      // still be running with an idle mayor accepting user messages,
+      // even when there are no active beads or agents.
       try {
         await this.refreshContainerToken();
       } catch (err) {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1086,7 +1086,7 @@ export class TownDO extends DurableObject<Env> {
       if (mayor) resolvedAgentId = mayor.id;
     }
     if (resolvedAgentId) {
-      reviewQueue.agentCompleted(this.sql, resolvedAgentId, input);
+      const result = reviewQueue.agentCompleted(this.sql, resolvedAgentId, input);
       const agent = agents.getAgent(this.sql, resolvedAgentId);
       this.emitEvent({
         event: 'agent.exited',
@@ -1094,6 +1094,35 @@ export class TownDO extends DurableObject<Env> {
         agentId: resolvedAgentId,
         role: agent?.role,
       });
+
+      // If the refinery exited without merging (rework), dispatch a
+      // polecat to re-work the source bead. This mirrors the rework
+      // dispatch in completeReviewWithResult.
+      if (result.reworkSourceBeadId) {
+        const sourceBead = beadOps.getBead(this.sql, result.reworkSourceBeadId);
+        if (sourceBead?.rig_id) {
+          try {
+            const reworkAgent = agents.getOrCreateAgent(
+              this.sql,
+              'polecat',
+              sourceBead.rig_id,
+              this.townId
+            );
+            agents.hookBead(this.sql, reworkAgent.id, result.reworkSourceBeadId);
+            this.dispatchAgent(reworkAgent, sourceBead).catch(err =>
+              console.error(
+                `${TOWN_LOG} agentCompleted: rework dispatch failed for bead=${result.reworkSourceBeadId}`,
+                err
+              )
+            );
+          } catch (err) {
+            console.warn(
+              `${TOWN_LOG} agentCompleted: could not dispatch rework for bead=${result.reworkSourceBeadId}:`,
+              err
+            );
+          }
+        }
+      }
     }
   }
 
@@ -2308,6 +2337,9 @@ export class TownDO extends DurableObject<Env> {
       `,
       [now(), escalationId]
     );
+    // Acknowledging an escalation also closes it — the mayor has seen
+    // the issue and doesn't need it sitting open in the queue.
+    beadOps.updateBeadStatus(this.sql, escalationId, 'closed', null);
     this.emitEvent({
       event: 'escalation.acknowledged',
       townId: this.townId,

--- a/cloudflare-gastown/src/dos/town/beads.ts
+++ b/cloudflare-gastown/src/dos/town/beads.ts
@@ -250,7 +250,7 @@ export function updateBeadStatus(
   sql: SqlStorage,
   beadId: string,
   status: string,
-  agentId: string
+  agentId: string | null
 ): Bead {
   const bead = getBead(sql, beadId);
   if (!bead) throw new Error(`Bead ${beadId} not found`);

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -570,21 +570,60 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
 }
 
 /**
+ * Result from agentCompleted indicating whether a rework was triggered.
+ * When non-null, the TownDO caller should dispatch a polecat for the
+ * source bead.
+ */
+export type AgentCompletedResult = {
+  reworkSourceBeadId: string | null;
+};
+
+/**
  * Called by the container when an agent process completes (or fails).
  * Closes/fails the bead and unhooks the agent.
+ *
+ * For refineries that exit with 'completed' without having merged,
+ * this triggers the rework flow: the MR bead is failed and the source
+ * bead is returned to in_progress so a polecat can be re-dispatched.
  */
 export function agentCompleted(
   sql: SqlStorage,
   agentId: string,
   input: { status: 'completed' | 'failed'; reason?: string }
-): void {
+): AgentCompletedResult {
+  const result: AgentCompletedResult = { reworkSourceBeadId: null };
   const agent = getAgent(sql, agentId);
-  if (!agent) return;
+  if (!agent) return result;
 
   if (agent.current_hook_bead_id) {
-    const beadStatus = input.status === 'completed' ? 'closed' : 'failed';
-    updateBeadStatus(sql, agent.current_hook_bead_id, beadStatus, agentId);
-    unhookBead(sql, agentId);
+    // When a refinery exits with 'completed' but the MR bead is still
+    // in_progress (not closed/merged), it means the refinery requested
+    // rework. Route through completeReviewWithResult so the source bead
+    // is returned to in_progress for re-dispatch.
+    if (agent.role === 'refinery' && input.status === 'completed') {
+      const mrBead = getBead(sql, agent.current_hook_bead_id);
+      if (mrBead && mrBead.status !== 'closed') {
+        const sourceBeadId =
+          typeof mrBead.metadata?.source_bead_id === 'string'
+            ? mrBead.metadata.source_bead_id
+            : null;
+        completeReviewWithResult(sql, {
+          entry_id: agent.current_hook_bead_id,
+          status: 'failed',
+          message: input.reason ?? 'Refinery exited without merge — rework needed',
+        });
+        result.reworkSourceBeadId = sourceBeadId;
+        unhookBead(sql, agentId);
+        // Mark agent idle (below)
+      } else {
+        // MR was already closed (merged) — normal completion
+        unhookBead(sql, agentId);
+      }
+    } else {
+      const beadStatus = input.status === 'completed' ? 'closed' : 'failed';
+      updateBeadStatus(sql, agent.current_hook_bead_id, beadStatus, agentId);
+      unhookBead(sql, agentId);
+    }
   }
 
   // Mark agent idle
@@ -598,6 +637,8 @@ export function agentCompleted(
     `,
     [agentId]
   );
+
+  return result;
 }
 
 // ── Molecules ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three fixes for gastown control-plane issues:

1. **Alarm-driven token refresh never fires for idle mayor towns**: The `refreshContainerToken()` call in the alarm was gated behind `hasActiveWork()`, which returns `false` when the mayor is idle. But the container can still be running with an idle mayor. After 8h the JWT expires and agents get 401s. Moved the refresh under the `hasRigs` guard instead — if a town has rigs, the container could be running.

2. **Refinery rework requests never land on an agent**: The refinery system prompt tells the agent to exit without calling `gt_done` when requesting rework, claiming "the system detects that no merge was performed." But no such detection existed — `agentCompleted` just closed the MR bead as "completed" and left the source bead stuck in `in_review` forever. Now `agentCompleted` detects when a refinery exits with `completed` but the MR bead was never merged: it calls `completeReviewWithResult` with `status='failed'`, which returns the source bead to `in_progress`, then dispatches a new polecat for the rework.

3. **Escalation acknowledge doesn't close the bead**: The mayor would acknowledge an escalation via `gt_escalation_acknowledge` but the bead stayed open, cluttering the queue and triggering re-escalation. Now `acknowledgeEscalation` also closes the bead. Widened `updateBeadStatus` `agentId` parameter to accept `null` for system-initiated status changes.

Part of #204

## Verification

- [x] `pnpm typecheck` — all 28 workspace projects pass

## Visual Changes

N/A

## Reviewer Notes

- The `agentCompleted` function in `review-queue.ts` now returns an `AgentCompletedResult` with `reworkSourceBeadId` so the TownDO caller can dispatch a polecat. This is the same rework dispatch pattern used in `Town.do.ts::completeReviewWithResult` (lines 1045-1069).
- The refinery rework detection checks `mrBead.status !== 'closed'` — if the refinery already merged (status is `closed`), it falls through to normal completion. This prevents false rework triggers when the refinery exits after a successful merge without calling `gt_done`.
- `updateBeadStatus` `agentId` parameter widened from `string` to `string | null`. The only downstream consumer (`logBeadEvent`) already accepted `string | null`, so this is a safe change.