### PR TITLE
fix(sentry): only capture warning/error/fatal in sentryLogger

### DIFF
--- a/src/lib/utils.server.test.ts
+++ b/src/lib/utils.server.test.ts
@@ -1,0 +1,86 @@
+import { captureMessage } from '@sentry/nextjs';
+import { sentryLogger } from './utils.server';
+
+jest.mock('@sentry/nextjs', () => ({
+  captureMessage: jest.fn(),
+}));
+
+jest.mock('@/lib/config.server', () => ({
+  IS_IN_AUTOMATED_TEST: false,
+}));
+
+const mockCaptureMessage = jest.mocked(captureMessage);
+
+describe('sentryLogger', () => {
+  const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    debugSpy.mockRestore();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('logs debug messages without creating a Sentry event', () => {
+    sentryLogger('test-source', 'debug')('debug message', { foo: 'bar' });
+
+    expect(debugSpy).toHaveBeenCalledWith('debug message', { foo: 'bar' });
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs info messages without creating a Sentry event', () => {
+    sentryLogger('test-source', 'info')('informational message', { foo: 'bar' });
+
+    expect(infoSpy).toHaveBeenCalledWith('informational message', { foo: 'bar' });
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs default messages without creating a Sentry event', () => {
+    sentryLogger('test-source')('default message', { foo: 'bar' });
+
+    expect(logSpy).toHaveBeenCalledWith('default message', { foo: 'bar' });
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it('captures warning messages in Sentry', () => {
+    sentryLogger('test-source', 'warning')('warning message', { foo: 'bar' });
+
+    expect(warnSpy).toHaveBeenCalledWith('warning message', { foo: 'bar' });
+    expect(mockCaptureMessage).toHaveBeenCalledWith('warning message', {
+      level: 'warning',
+      tags: { source: 'test-source' },
+      extra: { args: [{ foo: 'bar' }] },
+    });
+  });
+
+  it('captures error messages in Sentry', () => {
+    sentryLogger('test-source', 'error')('error message', { foo: 'bar' });
+
+    expect(errorSpy).toHaveBeenCalledWith('error message', { foo: 'bar' });
+    expect(mockCaptureMessage).toHaveBeenCalledWith('error message', {
+      level: 'error',
+      tags: { source: 'test-source' },
+      extra: { args: [{ foo: 'bar' }] },
+    });
+  });
+
+  it('routes fatal messages to console.error and captures them in Sentry', () => {
+    sentryLogger('test-source', 'fatal')('fatal message');
+
+    expect(errorSpy).toHaveBeenCalledWith('fatal message');
+    expect(mockCaptureMessage).toHaveBeenCalledWith('fatal message', {
+      level: 'fatal',
+      tags: { source: 'test-source' },
+      extra: undefined,
+    });
+  });
+});

--- a/src/lib/utils.server.ts
+++ b/src/lib/utils.server.ts
@@ -16,12 +16,14 @@ export function sentryLogger(source: string, severity: SeverityLevel = 'log') {
   const logger = consoleExceptInTest(
     severity === 'fatal' ? 'error' : severity === 'warning' ? 'warn' : severity
   );
-  return function warnInSentry(message: string, ...args: unknown[]) {
+  return function logAndMaybeCaptureInSentry(message: string, ...args: unknown[]) {
     logger(message, ...args);
-    captureMessage(message, {
-      level: severity,
-      tags: { source },
-      extra: args.length ? { args } : undefined,
-    });
+    if (severity === 'warning' || severity === 'error' || severity === 'fatal') {
+      captureMessage(message, {
+        level: severity,
+        tags: { source },
+        extra: args.length ? { args } : undefined,
+      });
+    }
   };
 }


### PR DESCRIPTION
## Summary

`sentryLogger` previously called `captureMessage` for every severity level (debug, info, log, warning, error, fatal), creating unnecessary noise in Sentry. This change gates `captureMessage` behind a severity check so only `warning`, `error`, and `fatal` messages are forwarded to Sentry. All severity levels still log to the console as before.

Also adds unit tests covering each severity level to verify the new behavior.

## Verification

- [ ] Tests written covering all severity levels (debug, info, log, warning, error, fatal)
- [ ] `node_modules` not present in worktree — typecheck and test runner could not be executed locally. Tests are syntactically correct and follow project jest conventions.

## Visual Changes

N/A

## Reviewer Notes

- The inner function was renamed from `warnInSentry` to `logAndMaybeCaptureInSentry` to reflect the new conditional behavior. This is not a breaking change since the function name is only visible in stack traces.
- Risk is low — the change is a strict narrowing of when `captureMessage` is called.