### PR TITLE
feat(admin): add session detail modal to code review error analysis

### DIFF
--- a/src/app/admin/api/code-reviews/hooks.ts
+++ b/src/app/admin/api/code-reviews/hooks.ts
@@ -60,6 +60,18 @@ export function useCodeReviewUserSegmentation(params: FilterParams) {
   });
 }
 
+export function useCodeReviewErrorSessions(params: FilterParams & { errorMessage: string | null }) {
+  const trpc = useTRPC();
+  const { errorMessage, ...filterParams } = params;
+  return useQuery({
+    ...trpc.admin.codeReviews.getErrorSessions.queryOptions({
+      ...filterParams,
+      errorMessage: errorMessage ?? '',
+    }),
+    enabled: Boolean(params.startDate && params.endDate && errorMessage),
+  });
+}
+
 export function useSearchUsers(query: string, enabled: boolean = true) {
   const trpc = useTRPC();
   return useQuery({

--- a/src/app/admin/code-reviews/page.tsx
+++ b/src/app/admin/code-reviews/page.tsx
@@ -466,7 +466,9 @@ export default function CodeReviewsPage() {
             )}
 
             {/* Error Analysis */}
-            {errorQuery.data && <CodeReviewErrorAnalysis data={errorQuery.data} />}
+            {errorQuery.data && (
+              <CodeReviewErrorAnalysis data={errorQuery.data} filterParams={filterParams} />
+            )}
           </>
         )}
 

--- a/src/app/admin/components/CodeReviewErrorAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewErrorAnalysis.tsx
@@ -1,6 +1,15 @@
 'use client';
 
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   Table,
   TableBody,
@@ -10,6 +19,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { formatDate } from '@/lib/admin-utils';
+import { useCodeReviewErrorSessions, type FilterParams } from '@/app/admin/api/code-reviews/hooks';
 
 type CategoryData = {
   category: string;
@@ -31,6 +41,11 @@ type ErrorAnalysisData = {
   details: DetailData[];
 };
 
+type Props = {
+  data: ErrorAnalysisData;
+  filterParams: FilterParams;
+};
+
 const CATEGORY_COLORS: Record<string, string> = {
   'Rate Limited': 'bg-amber-500',
   Timeout: 'bg-orange-500',
@@ -44,7 +59,86 @@ const CATEGORY_COLORS: Record<string, string> = {
   Other: 'bg-gray-500',
 };
 
-export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
+function ErrorSessionsModal({
+  error,
+  filterParams,
+  onClose,
+}: {
+  error: DetailData;
+  filterParams: FilterParams;
+  onClose: () => void;
+}) {
+  const { data: sessions, isLoading } = useCodeReviewErrorSessions({
+    ...filterParams,
+    errorMessage: error.errorType,
+  });
+
+  return (
+    <Dialog open onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Recent Sessions — {error.category}</DialogTitle>
+          <DialogDescription className="max-w-full truncate font-mono text-xs">
+            {error.errorType}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+          </div>
+        ) : !sessions?.length ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">No sessions found.</p>
+        ) : (
+          <div className="max-h-[60vh] overflow-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Session ID</TableHead>
+                  <TableHead>User / Org</TableHead>
+                  <TableHead>Repo</TableHead>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Timestamp</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sessions.map(session => (
+                  <TableRow key={session.sessionId ?? session.createdAt}>
+                    <TableCell className="font-mono text-xs">
+                      {session.sessionId ?? session.cliSessionId ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {session.orgId ? (
+                        <span title={`Org: ${session.orgId}`}>org:{session.orgId.slice(0, 8)}</span>
+                      ) : session.userId ? (
+                        <span title={`User: ${session.userId}`}>
+                          user:{session.userId.slice(0, 12)}
+                        </span>
+                      ) : (
+                        '—'
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-[200px] truncate text-xs">
+                      {session.repoFullName}#{session.prNumber}
+                    </TableCell>
+                    <TableCell className="text-xs">{session.agentVersion ?? '—'}</TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatDate(session.createdAt)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function CodeReviewErrorAnalysis({ data, filterParams }: Props) {
+  const [selectedError, setSelectedError] = useState<DetailData | null>(null);
+
   const totalCategoryErrors = data.categories.reduce((sum, cat) => sum + cat.count, 0);
   // Use category totals (uncapped) as the denominator so percentages are accurate
   // even when the detail list is truncated to top 50.
@@ -68,79 +162,93 @@ export function CodeReviewErrorAnalysis({ data }: { data: ErrorAnalysisData }) {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Error Analysis</CardTitle>
-        <CardDescription>
-          {data.categories.length} error categories, {totalCategoryErrors.toLocaleString()} total
-          failures
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Category horizontal bar chart */}
-        <div className="space-y-2">
-          {data.categories.map(cat => {
-            const pct = totalCategoryErrors > 0 ? (cat.count / totalCategoryErrors) * 100 : 0;
-            const barWidth = (cat.count / maxCategoryCount) * 100;
-            const colorClass = CATEGORY_COLORS[cat.category] ?? 'bg-gray-500';
-            return (
-              <div key={cat.category} className="flex items-center gap-3">
-                <span className="w-44 shrink-0 truncate text-right text-xs font-medium">
-                  {cat.category}
-                </span>
-                <div className="bg-muted relative h-5 flex-1 overflow-hidden rounded">
-                  <div
-                    className={`${colorClass} absolute inset-y-0 left-0 rounded transition-all`}
-                    style={{ width: `${barWidth}%` }}
-                  />
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Error Analysis</CardTitle>
+          <CardDescription>
+            {data.categories.length} error categories, {totalCategoryErrors.toLocaleString()} total
+            failures
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Category horizontal bar chart */}
+          <div className="space-y-2">
+            {data.categories.map(cat => {
+              const pct = totalCategoryErrors > 0 ? (cat.count / totalCategoryErrors) * 100 : 0;
+              const barWidth = (cat.count / maxCategoryCount) * 100;
+              const colorClass = CATEGORY_COLORS[cat.category] ?? 'bg-gray-500';
+              return (
+                <div key={cat.category} className="flex items-center gap-3">
+                  <span className="w-44 shrink-0 truncate text-right text-xs font-medium">
+                    {cat.category}
+                  </span>
+                  <div className="bg-muted relative h-5 flex-1 overflow-hidden rounded">
+                    <div
+                      className={`${colorClass} absolute inset-y-0 left-0 rounded transition-all`}
+                      style={{ width: `${barWidth}%` }}
+                    />
+                  </div>
+                  <span className="text-muted-foreground w-20 shrink-0 text-right text-xs">
+                    {cat.count.toLocaleString()} ({pct.toFixed(1)}%)
+                  </span>
                 </div>
-                <span className="text-muted-foreground w-20 shrink-0 text-right text-xs">
-                  {cat.count.toLocaleString()} ({pct.toFixed(1)}%)
-                </span>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
 
-        {/* Detail table */}
-        <div className="max-h-[400px] overflow-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Category</TableHead>
-                <TableHead className="w-[40%]">Error Message</TableHead>
-                <TableHead className="text-right">Count</TableHead>
-                <TableHead className="text-right">% of Errors</TableHead>
-                <TableHead>First Seen</TableHead>
-                <TableHead>Last Seen</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.details.map((error, idx) => (
-                <TableRow key={idx}>
-                  <TableCell className="text-xs">{error.category}</TableCell>
-                  <TableCell
-                    className="max-w-[400px] truncate font-mono text-xs"
-                    title={error.errorType}
-                  >
-                    {error.errorType}
-                  </TableCell>
-                  <TableCell className="text-right font-medium">{error.count}</TableCell>
-                  <TableCell className="text-muted-foreground text-right">
-                    {((error.count / totalErrors) * 100).toFixed(1)}%
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-xs">
-                    {formatDate(error.firstOccurrence)}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-xs">
-                    {formatDate(error.lastOccurrence)}
-                  </TableCell>
+          {/* Detail table */}
+          <div className="max-h-[400px] overflow-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Category</TableHead>
+                  <TableHead className="w-[40%]">Error Message</TableHead>
+                  <TableHead className="text-right">Count</TableHead>
+                  <TableHead className="text-right">% of Errors</TableHead>
+                  <TableHead>First Seen</TableHead>
+                  <TableHead>Last Seen</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      </CardContent>
-    </Card>
+              </TableHeader>
+              <TableBody>
+                {data.details.map((error, idx) => (
+                  <TableRow
+                    key={idx}
+                    className="hover:bg-muted/50 cursor-pointer"
+                    onClick={() => setSelectedError(error)}
+                  >
+                    <TableCell className="text-xs">{error.category}</TableCell>
+                    <TableCell
+                      className="max-w-[400px] truncate font-mono text-xs"
+                      title={error.errorType}
+                    >
+                      {error.errorType}
+                    </TableCell>
+                    <TableCell className="text-right font-medium">{error.count}</TableCell>
+                    <TableCell className="text-muted-foreground text-right">
+                      {((error.count / totalErrors) * 100).toFixed(1)}%
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatDate(error.firstOccurrence)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatDate(error.lastOccurrence)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {selectedError && (
+        <ErrorSessionsModal
+          error={selectedError}
+          filterParams={filterParams}
+          onClose={() => setSelectedError(null)}
+        />
+      )}
+    </>
   );
 }

--- a/src/app/admin/components/CodeReviewErrorAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewErrorAnalysis.tsx
@@ -68,7 +68,11 @@ function ErrorSessionsModal({
   filterParams: FilterParams;
   onClose: () => void;
 }) {
-  const { data: sessions, isLoading } = useCodeReviewErrorSessions({
+  const {
+    data: sessions,
+    isLoading,
+    error: fetchError,
+  } = useCodeReviewErrorSessions({
     ...filterParams,
     errorMessage: error.errorType,
   });
@@ -87,6 +91,10 @@ function ErrorSessionsModal({
           <div className="flex items-center justify-center py-8">
             <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
           </div>
+        ) : fetchError ? (
+          <p className="text-destructive py-4 text-center text-sm">
+            Failed to load sessions: {fetchError.message}
+          </p>
         ) : !sessions?.length ? (
           <p className="text-muted-foreground py-4 text-center text-sm">No sessions found.</p>
         ) : (
@@ -102,8 +110,8 @@ function ErrorSessionsModal({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {sessions.map(session => (
-                  <TableRow key={session.sessionId ?? session.createdAt}>
+                {sessions.map((session, idx) => (
+                  <TableRow key={session.sessionId ?? `${session.createdAt}-${idx}`}>
                     <TableCell className="font-mono text-xs">
                       {session.sessionId ?? session.cliSessionId ?? '—'}
                     </TableCell>

--- a/src/app/admin/components/CodeReviewErrorAnalysis.tsx
+++ b/src/app/admin/components/CodeReviewErrorAnalysis.tsx
@@ -19,6 +19,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { formatDate } from '@/lib/admin-utils';
+import { CopyButton } from '@/components/admin/CopyButton';
 import { useCodeReviewErrorSessions, type FilterParams } from '@/app/admin/api/code-reviews/hooks';
 
 type CategoryData = {
@@ -113,7 +114,15 @@ function ErrorSessionsModal({
                 {sessions.map((session, idx) => (
                   <TableRow key={session.sessionId ?? `${session.createdAt}-${idx}`}>
                     <TableCell className="font-mono text-xs">
-                      {session.sessionId ?? session.cliSessionId ?? '—'}
+                      {(() => {
+                        const copyableId = session.sessionId ?? session.cliSessionId;
+                        return (
+                          <span className="flex items-center gap-1">
+                            {copyableId ?? '—'}
+                            {copyableId && <CopyButton text={copyableId} label="session ID" />}
+                          </span>
+                        );
+                      })()}
                     </TableCell>
                     <TableCell className="text-xs">
                       {session.orgId ? (

--- a/src/routers/admin-code-reviews-router.ts
+++ b/src/routers/admin-code-reviews-router.ts
@@ -337,6 +337,65 @@ export const adminCodeReviewsRouter = createTRPCRouter({
     };
   }),
 
+  // Get the 20 most recent sessions for a specific error message pattern (drill-down from error table)
+  getErrorSessions: adminProcedure
+    .input(FilterSchema.extend({ errorMessage: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const {
+        startDate,
+        endDate,
+        userId,
+        organizationId,
+        ownershipType,
+        agentVersion,
+        errorMessage,
+      } = input;
+      const ownershipFilter = buildOwnershipFilter(userId, organizationId, ownershipType);
+      const agentVersionFilter = buildAgentVersionFilter(agentVersion);
+
+      const conditions = [
+        eq(cloud_agent_code_reviews.status, 'failed'),
+        excludeInsufficientCreditsError,
+        gte(cloud_agent_code_reviews.created_at, startDate),
+        lt(cloud_agent_code_reviews.created_at, endDate),
+        eq(
+          sql`COALESCE(SUBSTRING(${cloud_agent_code_reviews.error_message} FROM 1 FOR 200), 'Unknown Error')`,
+          errorMessage
+        ),
+        ownershipFilter,
+        agentVersionFilter,
+      ].filter(Boolean) as SQL[];
+
+      const rows = await db
+        .select({
+          session_id: cloud_agent_code_reviews.session_id,
+          cli_session_id: cloud_agent_code_reviews.cli_session_id,
+          user_id: cloud_agent_code_reviews.owned_by_user_id,
+          org_id: cloud_agent_code_reviews.owned_by_organization_id,
+          error_message: cloud_agent_code_reviews.error_message,
+          created_at: cloud_agent_code_reviews.created_at,
+          repo_full_name: cloud_agent_code_reviews.repo_full_name,
+          pr_number: cloud_agent_code_reviews.pr_number,
+          agent_version: cloud_agent_code_reviews.agent_version,
+        })
+        .from(cloud_agent_code_reviews)
+        .where(and(...conditions))
+        .orderBy(desc(cloud_agent_code_reviews.created_at))
+        .limit(20);
+
+      return rows.map(row => ({
+        sessionId: row.session_id,
+        cliSessionId: row.cli_session_id,
+        userId: row.user_id,
+        orgId: row.org_id,
+        errorMessage: row.error_message,
+        createdAt: row.created_at,
+        repoFullName: row.repo_full_name,
+        prNumber: row.pr_number,
+        agentVersion: row.agent_version,
+      }));
+    }),
+
   // Get user segmentation (note: this doesn't use filters since it shows top users/orgs for selection)
   getUserSegmentation: adminProcedure.input(FilterSchema).query(async ({ input }) => {
     const { startDate, endDate, userId, organizationId, ownershipType, agentVersion } = input;


### PR DESCRIPTION
## Summary

Followup to https://github.com/Kilo-Org/cloud/pull/985

- Clicking an error row in the admin code review dashboard now opens a modal showing the 20 most recent sessions that hit that error
- Each row shows session ID, user/org, repo + PR, agent version, and timestamp
- Adds a new `getErrorSessions` tRPC procedure and a lazy-loading hook that only fires when you click

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` — passed

## Visual Changes

N/A

## Reviewer Notes

- No database changes
- The error matching uses the same `SUBSTRING(error_message, 1, 200)` grouping as the existing `getErrorAnalysis` procedure
- Query is admin-only, limited to 20 rows, and uses existing status + created_at indexes for filtering