### PR TITLE
fix(cloud-agent-next): use lastIndexOf for DO name sessionId extraction

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -170,9 +170,12 @@ export class CloudAgentSession extends DurableObject {
     super(ctx, env);
 
     // Extract sessionId from DO name pattern: "userId:sessionId"
-    // The DO name is set by the worker when creating the stub
+    // The DO name is set by the worker when creating the stub.
+    // Split on the *last* colon because userId may contain colons
+    // (e.g. "oauth/google:12345:agent_abc" → sessionId = "agent_abc").
     const doName = ctx.id.name;
-    const sessionIdPart = doName?.split(':')[1];
+    const lastColon = doName?.lastIndexOf(':') ?? -1;
+    const sessionIdPart = doName && lastColon > 0 ? doName.slice(lastColon + 1) : undefined;
     this.sessionId = sessionIdPart ? (sessionIdPart as SessionId) : undefined;
 
     const db = drizzle(ctx.storage, { logger: false });

--- a/cloud-agent-next/test/integration/session/session-id-parsing.test.ts
+++ b/cloud-agent-next/test/integration/session/session-id-parsing.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration test for DO name → sessionId parsing.
+ *
+ * Ensures that userIds containing colons (e.g. "oauth/google:12345") don't
+ * break the session-id extraction in the CloudAgentSession constructor.
+ */
+
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+
+describe('CloudAgentSession sessionId parsing from DO name', () => {
+  it('extracts sessionId correctly when userId contains a colon (OAuth provider)', async () => {
+    const userId = 'oauth/google:103883072551006019454';
+    const sessionId = 'agent_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async instance => {
+      return instance.prepare({
+        sessionId,
+        userId,
+        kiloSessionId: 'kilo_test_session',
+        prompt: 'test prompt',
+        mode: 'code',
+        model: 'test-model',
+      });
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('extracts sessionId correctly when userId has no colon', async () => {
+    const userId = 'user_simple';
+    const sessionId = 'agent_11111111-2222-3333-4444-555555555555';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const result = await runInDurableObject(stub, async instance => {
+      return instance.prepare({
+        sessionId,
+        userId,
+        kiloSessionId: 'kilo_test_session',
+        prompt: 'test prompt',
+        mode: 'code',
+        model: 'test-model',
+      });
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('stores the correct sessionId in metadata (not the userId fragment)', async () => {
+    const userId = 'oauth/github:99999';
+    const sessionId = 'agent_metadata-check';
+    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
+    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+
+    const metadata = await runInDurableObject(stub, async instance => {
+      await instance.prepare({
+        sessionId,
+        userId,
+        kiloSessionId: 'kilo_test_session',
+        prompt: 'test prompt',
+        mode: 'code',
+        model: 'test-model',
+      });
+      return instance.getMetadata();
+    });
+
+    // The stored sessionId must be the agent session ID, not the OAuth numeric ID
+    expect(metadata?.sessionId).toBe(sessionId);
+    expect(metadata?.sessionId).not.toBe('99999');
+  });
+});


### PR DESCRIPTION
## Summary

The `CloudAgentSession` constructor parsed the Durable Object name using `split(':')[1]` to extract the session ID. The DO name format is `userId:sessionId` (e.g. `oauth/google:12345:agent_abc`). When the userId itself contains a colon (as with all OAuth provider IDs like `oauth/google:XXXXX`), splitting on the first colon incorrectly extracted the OAuth numeric ID (`12345`) instead of the actual session ID (`agent_abc`). This caused a `SessionId mismatch` error that blocked **all** session creation for OAuth-authenticated users.

The fix switches from `split(':')[1]` to `lastIndexOf(':')` + `slice()`, so the session ID is always extracted from after the final colon regardless of how many colons appear in the userId.

## Verification

- [x] `pnpm run typecheck` — passed (tsgo + wrapper)
- [x] `pnpm run test` — 650 unit tests passed
- [x] `pnpm run test:integration` — 30 integration tests passed (including 3 new tests for this fix)

## Visual Changes

N/A

## Reviewer Notes

- The bug only affects users whose `userId` contains a colon — all `oauth/*` provider IDs have this format. Users with plain UUID-style IDs were unaffected.
- The new integration test in `test/integration/session/session-id-parsing.test.ts` covers: OAuth userId with colon, plain userId without colon, and metadata correctness verification.
- `CloudAgentSession.ts:174-177` is the only location where the DO name is parsed into a sessionId.