### PR TITLE
feat(gastown): add UI-aware mayor with dashboard context injection

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .next/
 build/
 dist/
+**/dist-types/
 out/
 .api/
 
@@ -29,6 +30,9 @@ _journal.json
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+# Kilo agent runtime artifacts
+.kilocode/
 
 # Misc
 .DS_Store

--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -15,6 +15,7 @@ import type {
   Rig,
   SlingBatchResult,
   SlingResult,
+  UiActionInput,
 } from './types';
 
 function isApiResponse(
@@ -413,6 +414,13 @@ export class MayorGastownClient {
   async acknowledgeEscalation(escalationId: string): Promise<void> {
     await this.request<void>(this.mayorPath(`/escalations/${escalationId}/acknowledge`), {
       method: 'POST',
+    });
+  }
+
+  async broadcastUiAction(action: UiActionInput): Promise<void> {
+    await this.request<void>(this.mayorPath('/ui-action'), {
+      method: 'POST',
+      body: JSON.stringify({ action }),
     });
   }
 }

--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -423,6 +423,13 @@ export class MayorGastownClient {
       body: JSON.stringify({ action }),
     });
   }
+
+  async fetchDashboardContext(): Promise<string | null> {
+    const result = await this.request<{ context: string | null }>(
+      this.mayorPath('/dashboard-context')
+    );
+    return result?.context ?? null;
+  }
 }
 
 export class GastownApiError extends Error {

--- a/cloudflare-gastown/container/plugin/client.ts
+++ b/cloudflare-gastown/container/plugin/client.ts
@@ -423,13 +423,6 @@ export class MayorGastownClient {
       body: JSON.stringify({ action }),
     });
   }
-
-  async fetchDashboardContext(): Promise<string | null> {
-    const result = await this.request<{ context: string | null }>(
-      this.mayorPath('/dashboard-context')
-    );
-    return result?.context ?? null;
-  }
 }
 
 export class GastownApiError extends Error {

--- a/cloudflare-gastown/container/plugin/index.ts
+++ b/cloudflare-gastown/container/plugin/index.ts
@@ -1,11 +1,54 @@
 import type { Plugin } from '@kilocode/plugin';
+import { readFileSync } from 'node:fs';
 import { createClientFromEnv, createMayorClientFromEnv, GastownApiError } from './client';
 import { createTools } from './tools';
 import { createMayorTools } from './mayor-tools';
-import { buildContextBlock as buildDashboardContextBlock } from '../src/dashboard-context';
 
 const SERVICE = 'gastown-plugin';
 console.log(`[${SERVICE}] Starting...`);
+
+// ── Dashboard context reader ─────────────────────────────────────────
+// Reads the shared JSON file written by the control-server process
+// (see container/src/dashboard-context.ts). Both processes share the
+// container filesystem so this is a cheap local read with no network
+// round-trip. The file path must stay in sync with CONTEXT_FILE there.
+
+const CONTEXT_FILE = '/tmp/gastown-dashboard-context.json';
+
+type ContextSnapshot = { context: string; receivedAt: number };
+
+function readDashboardContextBlock(): string | null {
+  let snapshots: ContextSnapshot[];
+  try {
+    const raw = readFileSync(CONTEXT_FILE, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+    snapshots = parsed;
+  } catch {
+    return null;
+  }
+
+  const latest = snapshots[snapshots.length - 1];
+  if (snapshots.length === 1) return latest.context;
+
+  const breadcrumbs = snapshots
+    .slice(0, -1)
+    .map(s => {
+      const pageMatch = s.context.match(/page="([^"]+)"/);
+      const page = pageMatch ? pageMatch[1] : 'unknown';
+      const diff = Date.now() - s.receivedAt;
+      const ago =
+        diff < 60_000
+          ? `${Math.round(diff / 1000)}s ago`
+          : diff < 3600_000
+            ? `${Math.round(diff / 60_000)}m ago`
+            : `${Math.round(diff / 3600_000)}h ago`;
+      return `  - ${ago}: was viewing ${page}`;
+    })
+    .join('\n');
+
+  return [latest.context, '<navigation-history>', breadcrumbs, '</navigation-history>'].join('\n');
+}
 
 function formatPrimeContextForInjection(primeResult: string): string {
   return [
@@ -121,7 +164,7 @@ export const GastownPlugin: Plugin = async ({ client }) => {
         // Read dashboard context from in-memory store (pushed by the
         // TownDO via the container's POST /dashboard-context endpoint).
         // No network call — the store lives in the same process.
-        const dashboardContext = buildDashboardContextBlock();
+        const dashboardContext = readDashboardContextBlock();
         if (dashboardContext) {
           // Remove any stale context block from a previous turn
           const marker = '--- DASHBOARD CONTEXT ---';

--- a/cloudflare-gastown/container/plugin/index.ts
+++ b/cloudflare-gastown/container/plugin/index.ts
@@ -112,14 +112,40 @@ export const GastownPlugin: Plugin = async ({ client }) => {
     //   console.log(`[${SERVICE}] experimental.text.complete:`, input, output);
     // },
 
-    // Inject prime context into the system prompt on the first message (rig agents only)
+    // Inject context into the system prompt before each LLM call.
+    // - Rig agents: prime context (bead assignment, mail, open beads)
+    // - Mayor: dashboard context (what the user is currently viewing)
     'experimental.chat.system.transform': async (_input, output) => {
-      // console.log(`[${SERVICE}] experimental.chat.system.transform:`, output);
-      const alreadyInjected = output.system.some(s => s.includes('GASTOWN CONTEXT'));
-      if (!alreadyInjected) {
-        const primeResult = await primeAndLog();
-        if (primeResult) {
-          output.system.push(formatPrimeContextForInjection(primeResult));
+      if (isMayor && mayorClient) {
+        // Fetch the latest dashboard context from the TownDO on every
+        // LLM call so the mayor always sees what the user is looking at.
+        try {
+          const dashboardContext = await mayorClient.fetchDashboardContext();
+          if (dashboardContext) {
+            // Remove any stale context block from a previous turn
+            const marker = '--- DASHBOARD CONTEXT ---';
+            const idx = output.system.findIndex(s => s.includes(marker));
+            if (idx !== -1) output.system.splice(idx, 1);
+
+            output.system.push(
+              [`--- DASHBOARD CONTEXT ---`, dashboardContext, `--- END DASHBOARD CONTEXT ---`].join(
+                '\n'
+              )
+            );
+          }
+        } catch (err) {
+          // Best-effort — don't block the LLM call if context fetch fails
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(`[${SERVICE}] dashboard context fetch failed: ${message}`);
+        }
+      } else {
+        // Rig agents: inject prime context on the first message
+        const alreadyInjected = output.system.some(s => s.includes('GASTOWN CONTEXT'));
+        if (!alreadyInjected) {
+          const primeResult = await primeAndLog();
+          if (primeResult) {
+            output.system.push(formatPrimeContextForInjection(primeResult));
+          }
         }
       }
     },

--- a/cloudflare-gastown/container/plugin/index.ts
+++ b/cloudflare-gastown/container/plugin/index.ts
@@ -164,13 +164,14 @@ export const GastownPlugin: Plugin = async ({ client }) => {
         // Read dashboard context from in-memory store (pushed by the
         // TownDO via the container's POST /dashboard-context endpoint).
         // No network call — the store lives in the same process.
+        // Always remove the previous context block so stale context
+        // doesn't survive a read failure (e.g. file temporarily missing).
+        const marker = '--- DASHBOARD CONTEXT ---';
+        const idx = output.system.findIndex(s => s.includes(marker));
+        if (idx !== -1) output.system.splice(idx, 1);
+
         const dashboardContext = readDashboardContextBlock();
         if (dashboardContext) {
-          // Remove any stale context block from a previous turn
-          const marker = '--- DASHBOARD CONTEXT ---';
-          const idx = output.system.findIndex(s => s.includes(marker));
-          if (idx !== -1) output.system.splice(idx, 1);
-
           output.system.push(
             [`--- DASHBOARD CONTEXT ---`, dashboardContext, `--- END DASHBOARD CONTEXT ---`].join(
               '\n'

--- a/cloudflare-gastown/container/plugin/index.ts
+++ b/cloudflare-gastown/container/plugin/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from '@kilocode/plugin';
 import { createClientFromEnv, createMayorClientFromEnv, GastownApiError } from './client';
 import { createTools } from './tools';
 import { createMayorTools } from './mayor-tools';
+import { buildContextBlock as buildDashboardContextBlock } from '../src/dashboard-context';
 
 const SERVICE = 'gastown-plugin';
 console.log(`[${SERVICE}] Starting...`);
@@ -116,27 +117,22 @@ export const GastownPlugin: Plugin = async ({ client }) => {
     // - Rig agents: prime context (bead assignment, mail, open beads)
     // - Mayor: dashboard context (what the user is currently viewing)
     'experimental.chat.system.transform': async (_input, output) => {
-      if (isMayor && mayorClient) {
-        // Fetch the latest dashboard context from the TownDO on every
-        // LLM call so the mayor always sees what the user is looking at.
-        try {
-          const dashboardContext = await mayorClient.fetchDashboardContext();
-          if (dashboardContext) {
-            // Remove any stale context block from a previous turn
-            const marker = '--- DASHBOARD CONTEXT ---';
-            const idx = output.system.findIndex(s => s.includes(marker));
-            if (idx !== -1) output.system.splice(idx, 1);
+      if (isMayor) {
+        // Read dashboard context from in-memory store (pushed by the
+        // TownDO via the container's POST /dashboard-context endpoint).
+        // No network call — the store lives in the same process.
+        const dashboardContext = buildDashboardContextBlock();
+        if (dashboardContext) {
+          // Remove any stale context block from a previous turn
+          const marker = '--- DASHBOARD CONTEXT ---';
+          const idx = output.system.findIndex(s => s.includes(marker));
+          if (idx !== -1) output.system.splice(idx, 1);
 
-            output.system.push(
-              [`--- DASHBOARD CONTEXT ---`, dashboardContext, `--- END DASHBOARD CONTEXT ---`].join(
-                '\n'
-              )
-            );
-          }
-        } catch (err) {
-          // Best-effort — don't block the LLM call if context fetch fails
-          const message = err instanceof Error ? err.message : String(err);
-          console.warn(`[${SERVICE}] dashboard context fetch failed: ${message}`);
+          output.system.push(
+            [`--- DASHBOARD CONTEXT ---`, dashboardContext, `--- END DASHBOARD CONTEXT ---`].join(
+              '\n'
+            )
+          );
         }
       } else {
         // Rig agents: inject prime context on the first message

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -1,5 +1,32 @@
 import { tool } from '@kilocode/plugin';
 import type { MayorGastownClient } from './client';
+import type { UiActionInput } from './types';
+
+const UI_ACTION_TYPES = new Set([
+  'open_bead_drawer',
+  'open_convoy_drawer',
+  'open_agent_drawer',
+  'open_create_rig_dialog',
+  'navigate',
+  'highlight_bead',
+]);
+
+/** Validate and narrow a parsed JSON object to UiActionInput.
+ * Full schema validation happens server-side; this guards the type locally. */
+function parseUiAction(value: unknown): UiActionInput {
+  if (typeof value !== 'object' || value === null || !('type' in value)) {
+    throw new Error('"action_json" must be a JSON object with a "type" field');
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.type !== 'string' || !UI_ACTION_TYPES.has(obj.type)) {
+    throw new Error(
+      `Unknown UI action type: "${String(obj.type)}". Supported: ${[...UI_ACTION_TYPES].join(', ')}`
+    );
+  }
+  // Server-side Zod schema validates required fields per action type.
+  // The cast is safe because we've verified the type discriminator.
+  return value as UiActionInput;
+}
 
 function parseJsonObject(value: string, label: string): Record<string, unknown> {
   let parsed: unknown;
@@ -387,6 +414,39 @@ export function createMayorTools(client: MayorGastownClient) {
       async execute(args) {
         await client.acknowledgeEscalation(args.escalation_id);
         return `Escalation ${args.escalation_id} acknowledged.`;
+      },
+    }),
+
+    gt_ui_action: tool({
+      description:
+        "Trigger a UI action in the user's dashboard. " +
+        'Lets you open drawers, navigate pages, and trigger dialogs on behalf of the user.\n\n' +
+        'Supported action types:\n' +
+        '- open_bead_drawer: Open a bead detail drawer. Required fields: beadId, rigId.\n' +
+        '- open_convoy_drawer: Open a convoy detail drawer. Required fields: convoyId, townId.\n' +
+        '- open_agent_drawer: Open an agent detail drawer. Required fields: agentId, rigId, townId.\n' +
+        '- open_create_rig_dialog: Open the create rig dialog. No additional fields required.\n' +
+        '- navigate: Navigate to a dashboard page. Required field: page (one of: town-overview, beads, agents, rigs, settings).\n' +
+        '- highlight_bead: Highlight a bead in the list. Required fields: beadId, rigId.\n\n' +
+        'Examples:\n' +
+        '- Open bead drawer: action_json = \'{"type":"open_bead_drawer","beadId":"<id>","rigId":"<id>"}\'\n' +
+        '- Navigate to beads: action_json = \'{"type":"navigate","page":"beads"}\'\n' +
+        '- Open create rig dialog: action_json = \'{"type":"open_create_rig_dialog"}\'',
+      args: {
+        action_json: tool.schema
+          .string()
+          .describe('JSON-encoded UiAction object specifying the UI action to perform'),
+      },
+      async execute(args) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(args.action_json);
+        } catch {
+          throw new Error('Invalid JSON in "action_json"');
+        }
+        const action = parseUiAction(parsed);
+        await client.broadcastUiAction(action);
+        return `UI action "${action.type}" broadcast to dashboard.`;
       },
     }),
   };

--- a/cloudflare-gastown/container/plugin/mayor-tools.ts
+++ b/cloudflare-gastown/container/plugin/mayor-tools.ts
@@ -6,7 +6,6 @@ const UI_ACTION_TYPES = new Set([
   'open_bead_drawer',
   'open_convoy_drawer',
   'open_agent_drawer',
-  'open_create_rig_dialog',
   'navigate',
   'highlight_bead',
 ]);
@@ -420,18 +419,16 @@ export function createMayorTools(client: MayorGastownClient) {
     gt_ui_action: tool({
       description:
         "Trigger a UI action in the user's dashboard. " +
-        'Lets you open drawers, navigate pages, and trigger dialogs on behalf of the user.\n\n' +
+        'Lets you open drawers, navigate pages, and highlight items on behalf of the user.\n\n' +
         'Supported action types:\n' +
         '- open_bead_drawer: Open a bead detail drawer. Required fields: beadId, rigId.\n' +
         '- open_convoy_drawer: Open a convoy detail drawer. Required fields: convoyId, townId.\n' +
         '- open_agent_drawer: Open an agent detail drawer. Required fields: agentId, rigId, townId.\n' +
-        '- open_create_rig_dialog: Open the create rig dialog. No additional fields required.\n' +
         '- navigate: Navigate to a dashboard page. Required field: page (one of: town-overview, beads, agents, rigs, settings).\n' +
         '- highlight_bead: Highlight a bead in the list. Required fields: beadId, rigId.\n\n' +
         'Examples:\n' +
         '- Open bead drawer: action_json = \'{"type":"open_bead_drawer","beadId":"<id>","rigId":"<id>"}\'\n' +
-        '- Navigate to beads: action_json = \'{"type":"navigate","page":"beads"}\'\n' +
-        '- Open create rig dialog: action_json = \'{"type":"open_create_rig_dialog"}\'',
+        '- Navigate to beads: action_json = \'{"type":"navigate","page":"beads"}\'',
       args: {
         action_json: tool.schema
           .string()

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -131,7 +131,6 @@ export type UiActionInput =
   | { type: 'open_bead_drawer'; beadId: string; rigId: string }
   | { type: 'open_convoy_drawer'; convoyId: string; townId: string }
   | { type: 'open_agent_drawer'; agentId: string; rigId: string; townId: string }
-  | { type: 'open_create_rig_dialog' }
   | { type: 'navigate'; page: 'town-overview' | 'beads' | 'agents' | 'rigs' | 'settings' }
   | { type: 'highlight_bead'; beadId: string; rigId: string };
 

--- a/cloudflare-gastown/container/plugin/types.ts
+++ b/cloudflare-gastown/container/plugin/types.ts
@@ -126,6 +126,15 @@ export type ConvoyDetail = Convoy & {
   }>;
 };
 
+// UI Action — commands the mayor can send to control the user's dashboard
+export type UiActionInput =
+  | { type: 'open_bead_drawer'; beadId: string; rigId: string }
+  | { type: 'open_convoy_drawer'; convoyId: string; townId: string }
+  | { type: 'open_agent_drawer'; agentId: string; rigId: string; townId: string }
+  | { type: 'open_create_rig_dialog' }
+  | { type: 'navigate'; page: 'town-overview' | 'beads' | 'agents' | 'rigs' | 'settings' }
+  | { type: 'highlight_bead'; beadId: string; rigId: string };
+
 // Environment variable config for the plugin (rig-scoped agents)
 export type GastownEnv = {
   apiUrl: string;

--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -13,6 +13,7 @@ import {
   registerEventSink,
 } from './process-manager';
 import { startHeartbeat, stopHeartbeat } from './heartbeat';
+import { pushContext as pushDashboardContext } from './dashboard-context';
 import { mergeBranch, setupRigBrowseWorktree } from './git-manager';
 import { StartAgentRequest, SendMessageRequest, MergeRequest, SetupRepoRequest } from './types';
 import type {
@@ -91,6 +92,24 @@ app.get('/health', c => {
     uptime: getUptime(),
   };
   return c.json(response);
+});
+
+// POST /dashboard-context
+// Receives a dashboard context snapshot pushed from the TownDO.
+// Stored in-memory for the plugin to read on each LLM call — no
+// network round-trip needed at prompt time.
+app.post('/dashboard-context', async c => {
+  const body: unknown = await c.req.json().catch(() => null);
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    !('context' in body) ||
+    typeof body.context !== 'string'
+  ) {
+    return c.json({ error: 'Missing or invalid context field' }, 400);
+  }
+  pushDashboardContext(body.context);
+  return c.json({ pushed: true });
 });
 
 // POST /refresh-token

--- a/cloudflare-gastown/container/src/dashboard-context.ts
+++ b/cloudflare-gastown/container/src/dashboard-context.ts
@@ -11,7 +11,7 @@
  * growth.
  */
 
-import { writeFileSync, readFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, renameSync } from 'node:fs';
 import { z } from 'zod';
 
 const ContextSnapshotSchema = z.object({
@@ -26,6 +26,7 @@ const MAX_SNAPSHOTS = 5;
 
 /** Well-known path both processes agree on. */
 const CONTEXT_FILE = '/tmp/gastown-dashboard-context.json';
+const CONTEXT_FILE_TMP = '/tmp/gastown-dashboard-context.json.tmp';
 
 // ── Writer (control-server process) ──────────────────────────────────
 
@@ -37,7 +38,10 @@ export function pushContext(context: string): void {
     existing.splice(0, existing.length - MAX_SNAPSHOTS);
   }
   try {
-    writeFileSync(CONTEXT_FILE, JSON.stringify(existing));
+    // Write to a temp file then atomically rename to avoid the plugin
+    // reading truncated JSON during a concurrent readFileSync.
+    writeFileSync(CONTEXT_FILE_TMP, JSON.stringify(existing));
+    renameSync(CONTEXT_FILE_TMP, CONTEXT_FILE);
   } catch {
     // Best-effort — don't crash the control-server
   }

--- a/cloudflare-gastown/container/src/dashboard-context.ts
+++ b/cloudflare-gastown/container/src/dashboard-context.ts
@@ -1,0 +1,74 @@
+/**
+ * In-memory store for dashboard context pushed from the TownDO.
+ *
+ * The TownDO pushes a context snapshot (XML string describing the user's
+ * current page, open drawer, and recent navigation) whenever the
+ * dashboard navigates. The plugin reads the latest snapshot on each LLM
+ * call to inject it into the system prompt — no network round-trip.
+ *
+ * A capped ring buffer of the most recent snapshots is kept so the mayor
+ * can see a short history of user activity without unbounded growth.
+ */
+
+type ContextSnapshot = {
+  context: string;
+  receivedAt: number;
+};
+
+/** Max snapshots retained. Oldest are evicted when this is exceeded. */
+const MAX_SNAPSHOTS = 5;
+
+const snapshots: ContextSnapshot[] = [];
+
+/** Called by the control-server when the TownDO pushes a new snapshot. */
+export function pushContext(context: string): void {
+  snapshots.push({ context, receivedAt: Date.now() });
+  if (snapshots.length > MAX_SNAPSHOTS) {
+    snapshots.splice(0, snapshots.length - MAX_SNAPSHOTS);
+  }
+}
+
+/**
+ * Return the latest snapshot's context string, or null if nothing has
+ * been pushed yet.
+ */
+export function getLatestContext(): string | null {
+  if (snapshots.length === 0) return null;
+  return snapshots[snapshots.length - 1].context;
+}
+
+/**
+ * Build a combined context block from all retained snapshots.
+ * The most recent entry is labelled "current"; older entries provide a
+ * brief breadcrumb trail of recent user activity.
+ *
+ * Returns null if no context has been pushed.
+ */
+export function buildContextBlock(): string | null {
+  if (snapshots.length === 0) return null;
+
+  // Only the latest snapshot gets the full XML. Older ones are
+  // summarised as one-line breadcrumbs to keep token cost low.
+  const latest = snapshots[snapshots.length - 1];
+  if (snapshots.length === 1) return latest.context;
+
+  const breadcrumbs = snapshots
+    .slice(0, -1)
+    .map(s => {
+      // Extract just the page attribute from <current-view page="..." />
+      const pageMatch = s.context.match(/page="([^"]+)"/);
+      const page = pageMatch ? pageMatch[1] : 'unknown';
+      const ago = formatAgo(s.receivedAt);
+      return `  - ${ago}: was viewing ${page}`;
+    })
+    .join('\n');
+
+  return [latest.context, '<navigation-history>', breadcrumbs, '</navigation-history>'].join('\n');
+}
+
+function formatAgo(epochMs: number): string {
+  const diff = Date.now() - epochMs;
+  if (diff < 60_000) return `${Math.round(diff / 1000)}s ago`;
+  if (diff < 3600_000) return `${Math.round(diff / 60_000)}m ago`;
+  return `${Math.round(diff / 3600_000)}h ago`;
+}

--- a/cloudflare-gastown/container/src/dashboard-context.ts
+++ b/cloudflare-gastown/container/src/dashboard-context.ts
@@ -1,14 +1,17 @@
 /**
- * In-memory store for dashboard context pushed from the TownDO.
+ * Dashboard context store — shared between control-server and plugin
+ * via a JSON file on disk.
  *
- * The TownDO pushes a context snapshot (XML string describing the user's
- * current page, open drawer, and recent navigation) whenever the
- * dashboard navigates. The plugin reads the latest snapshot on each LLM
- * call to inject it into the system prompt — no network round-trip.
+ * The control-server (Bun process) writes snapshots when the TownDO
+ * pushes context. The plugin (kilo serve process) reads the file on
+ * each LLM call. Both processes share the container filesystem so
+ * this is a cheap local read with no network round-trip.
  *
- * A capped ring buffer of the most recent snapshots is kept so the mayor
- * can see a short history of user activity without unbounded growth.
+ * A capped ring buffer of the most recent snapshots prevents unbounded
+ * growth.
  */
+
+import { writeFileSync, readFileSync } from 'node:fs';
 
 type ContextSnapshot = {
   context: string;
@@ -18,44 +21,41 @@ type ContextSnapshot = {
 /** Max snapshots retained. Oldest are evicted when this is exceeded. */
 const MAX_SNAPSHOTS = 5;
 
-const snapshots: ContextSnapshot[] = [];
+/** Well-known path both processes agree on. */
+const CONTEXT_FILE = '/tmp/gastown-dashboard-context.json';
+
+// ── Writer (control-server process) ──────────────────────────────────
 
 /** Called by the control-server when the TownDO pushes a new snapshot. */
 export function pushContext(context: string): void {
-  snapshots.push({ context, receivedAt: Date.now() });
-  if (snapshots.length > MAX_SNAPSHOTS) {
-    snapshots.splice(0, snapshots.length - MAX_SNAPSHOTS);
+  const existing = readSnapshots();
+  existing.push({ context, receivedAt: Date.now() });
+  if (existing.length > MAX_SNAPSHOTS) {
+    existing.splice(0, existing.length - MAX_SNAPSHOTS);
+  }
+  try {
+    writeFileSync(CONTEXT_FILE, JSON.stringify(existing));
+  } catch {
+    // Best-effort — don't crash the control-server
   }
 }
 
-/**
- * Return the latest snapshot's context string, or null if nothing has
- * been pushed yet.
- */
-export function getLatestContext(): string | null {
-  if (snapshots.length === 0) return null;
-  return snapshots[snapshots.length - 1].context;
-}
+// ── Reader (plugin process) ──────────────────────────────────────────
 
 /**
  * Build a combined context block from all retained snapshots.
- * The most recent entry is labelled "current"; older entries provide a
- * brief breadcrumb trail of recent user activity.
- *
  * Returns null if no context has been pushed.
  */
 export function buildContextBlock(): string | null {
+  const snapshots = readSnapshots();
   if (snapshots.length === 0) return null;
 
-  // Only the latest snapshot gets the full XML. Older ones are
-  // summarised as one-line breadcrumbs to keep token cost low.
   const latest = snapshots[snapshots.length - 1];
   if (snapshots.length === 1) return latest.context;
 
   const breadcrumbs = snapshots
     .slice(0, -1)
     .map(s => {
-      // Extract just the page attribute from <current-view page="..." />
       const pageMatch = s.context.match(/page="([^"]+)"/);
       const page = pageMatch ? pageMatch[1] : 'unknown';
       const ago = formatAgo(s.receivedAt);
@@ -64,6 +64,19 @@ export function buildContextBlock(): string | null {
     .join('\n');
 
   return [latest.context, '<navigation-history>', breadcrumbs, '</navigation-history>'].join('\n');
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────
+
+function readSnapshots(): ContextSnapshot[] {
+  try {
+    const raw = readFileSync(CONTEXT_FILE, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
 }
 
 function formatAgo(epochMs: number): string {

--- a/cloudflare-gastown/container/src/dashboard-context.ts
+++ b/cloudflare-gastown/container/src/dashboard-context.ts
@@ -12,11 +12,14 @@
  */
 
 import { writeFileSync, readFileSync } from 'node:fs';
+import { z } from 'zod';
 
-type ContextSnapshot = {
-  context: string;
-  receivedAt: number;
-};
+const ContextSnapshotSchema = z.object({
+  context: z.string(),
+  receivedAt: z.number(),
+});
+
+type ContextSnapshot = z.infer<typeof ContextSnapshotSchema>;
 
 /** Max snapshots retained. Oldest are evicted when this is exceeded. */
 const MAX_SNAPSHOTS = 5;
@@ -72,8 +75,7 @@ function readSnapshots(): ContextSnapshot[] {
   try {
     const raw = readFileSync(CONTEXT_FILE, 'utf-8');
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed;
+    return z.array(ContextSnapshotSchema).parse(parsed);
   } catch {
     return [];
   }

--- a/cloudflare-gastown/gastown-grafana-dash-1.json
+++ b/cloudflare-gastown/gastown-grafana-dash-1.json
@@ -70,7 +70,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": ["sum"],
           "fields": "/total_events/",
           "values": false
         },
@@ -90,6 +90,8 @@
           "editorMode": "sql",
           "extrapolate": true,
           "format": "time_series",
+          "formattedQuery": "/* grafana dashboard='Gastown Operations', user=admin */\nSELECT (intDiv(toUInt32(timestamp), 300) * 300) * 1000 AS t, 'total_events' AS label, SUM(_sample_interval) AS total_events FROM gastown_events WHERE timestamp >= toDateTime(1773498042) AND timestamp <= toDateTime(1773670842) GROUP BY t ORDER BY t",
+          "initialized": true,
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
@@ -144,7 +146,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": ["distinctCount"],
           "fields": "/unique_users/",
           "values": false
         },
@@ -164,6 +166,8 @@
           "editorMode": "sql",
           "extrapolate": true,
           "format": "time_series",
+          "formattedQuery": "/* grafana dashboard='Gastown Operations', user=admin */\nSELECT (intDiv(toUInt32(timestamp), 120) * 120) * 1000 AS t, 'unique_users' AS label, COUNT(DISTINCT blob2) AS unique_users FROM gastown_events WHERE timestamp >= toDateTime(1773605268) AND timestamp <= toDateTime(1773691668) AND blob2 != '' GROUP BY t ORDER BY t",
+          "initialized": true,
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
@@ -724,29 +728,16 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 80,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
+            "lineWidth": 1,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -777,17 +768,26 @@
       },
       "id": 8,
       "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": -30,
+        "xTickLabelSpacing": 0
       },
       "pluginVersion": "12.4.1",
       "targets": [
@@ -801,7 +801,8 @@
           "editorMode": "sql",
           "extrapolate": true,
           "format": "time_series",
-          "formattedQuery": "/* grafana dashboard='Gastown Operations', user=admin */\nSELECT (intDiv(toUInt32(timestamp), 2) * 2) * 1000 AS t, blob1 AS label, SUM(IF(blob5 != '', _sample_interval, 0)) AS errors FROM gastown_events WHERE timestamp >= toDateTime(1773451903) AND timestamp <= toDateTime(1773453703) AND blob5 != '' GROUP BY t, label ORDER BY t",
+          "formattedQuery": "/* grafana dashboard='Gastown Operations', user=admin */\nSELECT (intDiv(toUInt32(timestamp), 120) * 120) * 1000 AS t, blob1 AS label, SUM(IF(blob5 != '', _sample_interval, 0)) AS errors FROM gastown_events WHERE timestamp >= toDateTime(1773498042) AND timestamp <= toDateTime(1773670842) AND blob5 != '' GROUP BY t, label ORDER BY t",
+          "initialized": true,
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
@@ -817,7 +818,7 @@
         }
       ],
       "title": "Error Count Over Time (by event)",
-      "type": "timeseries"
+      "type": "barchart"
     },
     {
       "datasource": {
@@ -2500,13 +2501,13 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Gastown Operations",
   "uid": "gastown-ops-1",
-  "version": 9,
+  "version": 16,
   "weekStart": ""
 }

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -69,6 +69,7 @@ import type {
   BeadEventRecord,
   MergeStrategy,
   ConvoyMergeMode,
+  UiAction,
 } from '../types';
 
 const TOWN_LOG = '[Town.do]';
@@ -372,6 +373,24 @@ export class TownDO extends DurableObject<Env> {
       closedBeads,
       ts: now(),
     });
+    for (const ws of sockets) {
+      try {
+        ws.send(frame);
+      } catch {
+        // Client disconnected — will be cleaned up by webSocketClose
+      }
+    }
+  }
+
+  /**
+   * Broadcast a ui_action event to all connected status WebSocket clients.
+   * Called by the mayor via the /mayor/ui-action HTTP route.
+   */
+  async broadcastUiAction(action: UiAction): Promise<void> {
+    await this.ensureInitialized();
+    const sockets = this.ctx.getWebSockets('status');
+    if (sockets.length === 0) return;
+    const frame = JSON.stringify({ channel: 'ui_action', action, ts: now() });
     for (const ws of sockets) {
       try {
         ws.send(frame);
@@ -1438,7 +1457,8 @@ export class TownDO extends DurableObject<Env> {
 
   async sendMayorMessage(
     message: string,
-    _model?: string
+    _model?: string,
+    uiContext?: string
   ): Promise<{ agentId: string; sessionStatus: 'idle' | 'active' | 'starting' }> {
     await this.ensureInitialized();
     const townId = this.townId;
@@ -1460,10 +1480,14 @@ export class TownDO extends DurableObject<Env> {
       `${TOWN_LOG} sendMayorMessage: townId=${townId} mayorId=${mayor.id} containerStatus=${containerStatus.status} isAlive=${isAlive}`
     );
 
+    const combinedMessage = uiContext
+      ? `<system-reminder>\n${uiContext}\n</system-reminder>\n\n${message}`
+      : message;
+
     let sessionStatus: 'idle' | 'active' | 'starting';
 
     if (isAlive) {
-      const sent = await dispatch.sendMessageToAgent(this.env, townId, mayor.id, message);
+      const sent = await dispatch.sendMessageToAgent(this.env, townId, mayor.id, combinedMessage);
       sessionStatus = sent ? 'active' : 'idle';
     } else {
       const townConfig = await this.getTownConfig();

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -458,6 +458,9 @@ export class TownDO extends DurableObject<Env> {
 
   async setDashboardContext(context: string): Promise<void> {
     this._dashboardContext = context;
+    // Best-effort push to the running container so the plugin has it
+    // in-memory for the next LLM call without a network round-trip.
+    await dispatch.pushDashboardContext(this.env, this.townId, context);
   }
 
   async getDashboardContext(): Promise<string | null> {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -440,6 +440,7 @@ export class TownDO extends DurableObject<Env> {
   }
 
   private _townId: string | null = null;
+  private _dashboardContext: string | null = null;
 
   private get townId(): string {
     return this._townId ?? this.ctx.id.name ?? this.ctx.id.toString();
@@ -453,6 +454,10 @@ export class TownDO extends DurableObject<Env> {
   async setTownId(townId: string): Promise<void> {
     this._townId = townId;
     await this.ctx.storage.put('town:id', townId);
+  }
+
+  async setDashboardContext(context: string): Promise<void> {
+    this._dashboardContext = context;
   }
 
   // ══════════════════════════════════════════════════════════════════
@@ -1480,8 +1485,9 @@ export class TownDO extends DurableObject<Env> {
       `${TOWN_LOG} sendMayorMessage: townId=${townId} mayorId=${mayor.id} containerStatus=${containerStatus.status} isAlive=${isAlive}`
     );
 
-    const combinedMessage = uiContext
-      ? `<system-reminder>\n${uiContext}\n</system-reminder>\n\n${message}`
+    const effectiveContext = uiContext ?? this._dashboardContext;
+    const combinedMessage = effectiveContext
+      ? `<system-reminder>\n${effectiveContext}\n</system-reminder>\n\n${message}`
       : message;
 
     let sessionStatus: 'idle' | 'active' | 'starting';

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -460,6 +460,10 @@ export class TownDO extends DurableObject<Env> {
     this._dashboardContext = context;
   }
 
+  async getDashboardContext(): Promise<string | null> {
+    return this._dashboardContext;
+  }
+
   // ══════════════════════════════════════════════════════════════════
   // Town Configuration
   // ══════════════════════════════════════════════════════════════════

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -559,6 +559,30 @@ export async function stopAgentInContainer(
 }
 
 /**
+ * Push the latest dashboard context XML to the running container.
+ * Best-effort — silently ignores failures if the container is down.
+ */
+export async function pushDashboardContext(
+  env: Env,
+  townId: string,
+  context: string
+): Promise<void> {
+  const container = getTownContainerStub(env, townId);
+  try {
+    const resp = await container.fetch('http://container/dashboard-context', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context }),
+    });
+    if (!resp.ok) {
+      console.warn(`${TOWN_LOG} pushDashboardContext: container returned ${resp.status}`);
+    }
+  } catch {
+    // Container not running — context will be pushed on next navigation
+  }
+}
+
+/**
  * Send a follow-up message to an existing agent in the container.
  */
 export async function sendMessageToAgent(

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -15,6 +15,7 @@ import {
   type AuthVariables,
 } from './middleware/auth.middleware';
 import { kiloAuthMiddleware } from './middleware/kilo-auth.middleware';
+import { townOwnershipMiddleware } from './middleware/town-ownership.middleware';
 import { trpcServer } from '@hono/trpc-server';
 import { wrappedGastownRouter } from './trpc/router';
 import {
@@ -391,21 +392,13 @@ app.post('/api/towns/:townId/rigs/:rigId/triage/resolve', c =>
 app.use('/api/users/*', async (c: Context<GastownEnv, string>, next) =>
   c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
 );
-app.use('/api/towns/:townId/convoys/*', async (c: Context<GastownEnv, string>, next) =>
-  c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
-);
-app.use('/api/towns/:townId/escalations/*', async (c: Context<GastownEnv, string>, next) =>
-  c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
-);
-app.use('/api/towns/:townId/config', async (c: Context<GastownEnv, string>, next) =>
-  c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
-);
-app.use('/api/towns/:townId/container/*', async (c: Context<GastownEnv, string>, next) =>
-  c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
-);
-app.use('/api/towns/:townId/mayor/*', async (c: Context<GastownEnv, string>, next) =>
-  c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
-);
+// Town routes: kilo auth + town ownership check (skipped in dev for auth only)
+app.use('/api/towns/:townId/*', async (c: Context<GastownEnv, string>, next) => {
+  if (c.env.ENVIRONMENT === 'development') return next();
+  return kiloAuthMiddleware(c, async () => {
+    await townOwnershipMiddleware(c, next);
+  });
+});
 
 // ── Towns & Rigs ────────────────────────────────────────────────────────
 // Town DO instances are keyed by owner_user_id. The userId path param routes

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -78,6 +78,7 @@ import {
   handleEnsureMayor,
   handleMayorCompleted,
   handleDestroyMayor,
+  handleBroadcastUiAction,
 } from './handlers/mayor.handler';
 import {
   handleMayorSling,
@@ -96,6 +97,7 @@ import {
   handleMayorBeadDelete,
   handleMayorEscalationAcknowledge,
   handleMayorConvoyStart,
+  handleMayorUiAction,
 } from './handlers/mayor-tools.handler';
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
@@ -575,6 +577,18 @@ app.post('/api/towns/:townId/mayor/completed', c =>
 app.post('/api/towns/:townId/mayor/destroy', c =>
   instrumented(c, 'POST /api/towns/:townId/mayor/destroy', () =>
     handleDestroyMayor(c, c.req.param())
+  )
+);
+app.post('/api/towns/:townId/mayor/ui-action', c =>
+  instrumented(c, 'POST /api/towns/:townId/mayor/ui-action', () =>
+    handleBroadcastUiAction(c, c.req.param())
+  )
+);
+
+// Mayor tool: broadcast a UI action (called from the mayor container)
+app.post('/api/mayor/:townId/tools/ui-action', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/ui-action', () =>
+    handleMayorUiAction(c, c.req.param())
   )
 );
 

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -591,13 +591,6 @@ app.post('/api/towns/:townId/mayor/ui-action', c =>
   )
 );
 
-// Mayor tool: broadcast a UI action (called from the mayor container)
-app.post('/api/mayor/:townId/tools/ui-action', c =>
-  instrumented(c, 'POST /api/mayor/:townId/tools/ui-action', () =>
-    handleMayorUiAction(c, c.req.param())
-  )
-);
-
 // ── Mayor Tools ──────────────────────────────────────────────────────────
 // Tool endpoints called by the mayor's kilo serve session via the Gastown plugin.
 // Authenticated via mayor JWT (townId-scoped, no rigId restriction).
@@ -607,6 +600,13 @@ app.post('/api/mayor/:townId/tools/ui-action', c =>
 // the token. Skipping auth in dev leaves agentJWT null and causes 401s
 // from the handler itself.
 app.use('/api/mayor/:townId/tools/*', mayorAuthMiddleware);
+
+// Mayor tool: broadcast a UI action (called from the mayor container)
+app.post('/api/mayor/:townId/tools/ui-action', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/ui-action', () =>
+    handleMayorUiAction(c, c.req.param())
+  )
+);
 
 app.post('/api/mayor/:townId/tools/sling', c =>
   instrumented(c, 'POST /api/mayor/:townId/tools/sling', () => handleMayorSling(c, c.req.param()))

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -99,6 +99,7 @@ import {
   handleMayorEscalationAcknowledge,
   handleMayorConvoyStart,
   handleMayorUiAction,
+  handleMayorGetDashboardContext,
 } from './handlers/mayor-tools.handler';
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
@@ -679,6 +680,11 @@ app.post('/api/mayor/:townId/tools/escalations/:escalationId/acknowledge', c =>
 );
 app.post('/api/mayor/:townId/tools/convoys/:convoyId/start', c =>
   handleMayorConvoyStart(c, c.req.param())
+);
+app.get('/api/mayor/:townId/tools/dashboard-context', c =>
+  instrumented(c, 'GET /api/mayor/:townId/tools/dashboard-context', () =>
+    handleMayorGetDashboardContext(c, c.req.param())
+  )
 );
 
 // ── tRPC ────────────────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -99,7 +99,6 @@ import {
   handleMayorEscalationAcknowledge,
   handleMayorConvoyStart,
   handleMayorUiAction,
-  handleMayorGetDashboardContext,
 } from './handlers/mayor-tools.handler';
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
@@ -681,12 +680,6 @@ app.post('/api/mayor/:townId/tools/escalations/:escalationId/acknowledge', c =>
 app.post('/api/mayor/:townId/tools/convoys/:convoyId/start', c =>
   handleMayorConvoyStart(c, c.req.param())
 );
-app.get('/api/mayor/:townId/tools/dashboard-context', c =>
-  instrumented(c, 'GET /api/mayor/:townId/tools/dashboard-context', () =>
-    handleMayorGetDashboardContext(c, c.req.param())
-  )
-);
-
 // ── tRPC ────────────────────────────────────────────────────────────────
 // Serve the gastown tRPC router directly. The frontend tRPC client
 // connects here instead of going through the Next.js proxy layer.

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -79,6 +79,7 @@ import {
   handleMayorCompleted,
   handleDestroyMayor,
   handleBroadcastUiAction,
+  handleSetDashboardContext,
 } from './handlers/mayor.handler';
 import {
   handleMayorSling,
@@ -577,6 +578,11 @@ app.post('/api/towns/:townId/mayor/completed', c =>
 app.post('/api/towns/:townId/mayor/destroy', c =>
   instrumented(c, 'POST /api/towns/:townId/mayor/destroy', () =>
     handleDestroyMayor(c, c.req.param())
+  )
+);
+app.post('/api/towns/:townId/mayor/dashboard-context', c =>
+  instrumented(c, 'POST /api/towns/:townId/mayor/dashboard-context', () =>
+    handleSetDashboardContext(c, c.req.param())
   )
 );
 app.post('/api/towns/:townId/mayor/ui-action', c =>

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -663,3 +663,17 @@ export async function handleMayorUiAction(c: Context<GastownEnv>, params: { town
   await town.broadcastUiAction(parsed.data.action);
   return c.json(resSuccess({ broadcast: true }), 200);
 }
+
+/**
+ * GET /api/mayor/:townId/tools/dashboard-context
+ * Fetch the latest dashboard context XML for injection into the mayor's prompt.
+ * Called by the gastown plugin's chat.system.transform hook.
+ */
+export async function handleMayorGetDashboardContext(
+  c: Context<GastownEnv>,
+  params: { townId: string }
+) {
+  const town = getTownDOStub(c.env, params.townId);
+  const context = await town.getDashboardContext();
+  return c.json(resSuccess({ context }), 200);
+}

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -4,7 +4,7 @@ import { getTownDOStub } from '../dos/Town.do';
 import { getGastownUserStub } from '../dos/GastownUser.do';
 import { resSuccess, resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
-import { BeadStatus, BeadType, BeadPriority } from '../types';
+import { BeadStatus, BeadType, BeadPriority, UiActionSchema } from '../types';
 import type { GastownEnv } from '../gastown.worker';
 
 const HANDLER_LOG = '[mayor-tools.handler]';
@@ -634,4 +634,32 @@ export async function handleMayorConvoyStart(
   );
 
   return c.json(resSuccess(result));
+}
+
+const MayorUiActionBody = z.object({
+  action: UiActionSchema,
+});
+
+/**
+ * POST /api/mayor/:townId/tools/ui-action
+ * Mayor tool: broadcast a UI action to all connected dashboard WebSocket clients.
+ * Allows the mayor to trigger navigation/drawer actions in the user's dashboard.
+ */
+export async function handleMayorUiAction(c: Context<GastownEnv>, params: { townId: string }) {
+  const body = await parseJsonBody(c);
+  const parsed = MayorUiActionBody.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorUiAction: townId=${params.townId} type=${parsed.data.action.type}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  await town.broadcastUiAction(parsed.data.action);
+  return c.json(resSuccess({ broadcast: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -4,7 +4,14 @@ import { getTownDOStub } from '../dos/Town.do';
 import { getGastownUserStub } from '../dos/GastownUser.do';
 import { resSuccess, resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
-import { BeadStatus, BeadType, BeadPriority, UiActionSchema, normalizeUiAction } from '../types';
+import {
+  BeadStatus,
+  BeadType,
+  BeadPriority,
+  UiActionSchema,
+  normalizeUiAction,
+  uiActionRigId,
+} from '../types';
 import type { GastownEnv } from '../gastown.worker';
 
 const HANDLER_LOG = '[mayor-tools.handler]';
@@ -662,6 +669,16 @@ export async function handleMayorUiAction(c: Context<GastownEnv>, params: { town
   const action = normalizeUiAction(parsed.data.action, params.townId);
 
   const town = getTownDOStub(c.env, params.townId);
+
+  // Validate that the referenced rig belongs to this town
+  const rigId = uiActionRigId(action);
+  if (rigId) {
+    const rig = await town.getRigAsync(rigId);
+    if (!rig) {
+      return c.json({ success: false, error: `Rig ${rigId} does not belong to this town` }, 400);
+    }
+  }
+
   await town.broadcastUiAction(action);
   return c.json(resSuccess({ broadcast: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -663,17 +663,3 @@ export async function handleMayorUiAction(c: Context<GastownEnv>, params: { town
   await town.broadcastUiAction(parsed.data.action);
   return c.json(resSuccess({ broadcast: true }), 200);
 }
-
-/**
- * GET /api/mayor/:townId/tools/dashboard-context
- * Fetch the latest dashboard context XML for injection into the mayor's prompt.
- * Called by the gastown plugin's chat.system.transform hook.
- */
-export async function handleMayorGetDashboardContext(
-  c: Context<GastownEnv>,
-  params: { townId: string }
-) {
-  const town = getTownDOStub(c.env, params.townId);
-  const context = await town.getDashboardContext();
-  return c.json(resSuccess({ context }), 200);
-}

--- a/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor-tools.handler.ts
@@ -4,7 +4,7 @@ import { getTownDOStub } from '../dos/Town.do';
 import { getGastownUserStub } from '../dos/GastownUser.do';
 import { resSuccess, resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
-import { BeadStatus, BeadType, BeadPriority, UiActionSchema } from '../types';
+import { BeadStatus, BeadType, BeadPriority, UiActionSchema, normalizeUiAction } from '../types';
 import type { GastownEnv } from '../gastown.worker';
 
 const HANDLER_LOG = '[mayor-tools.handler]';
@@ -659,7 +659,9 @@ export async function handleMayorUiAction(c: Context<GastownEnv>, params: { town
     `${HANDLER_LOG} handleMayorUiAction: townId=${params.townId} type=${parsed.data.action.type}`
   );
 
+  const action = normalizeUiAction(parsed.data.action, params.townId);
+
   const town = getTownDOStub(c.env, params.townId);
-  await town.broadcastUiAction(parsed.data.action);
+  await town.broadcastUiAction(action);
   return c.json(resSuccess({ broadcast: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -4,7 +4,7 @@ import type { GastownEnv } from '../gastown.worker';
 import { getTownDOStub } from '../dos/Town.do';
 import { resSuccess } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
-import { UiActionSchema } from '../types';
+import { UiActionSchema, normalizeUiAction } from '../types';
 
 const MAYOR_HANDLER_LOG = '[mayor.handler]';
 
@@ -181,8 +181,10 @@ export async function handleBroadcastUiAction(c: Context<GastownEnv>, params: { 
     `${MAYOR_HANDLER_LOG} handleBroadcastUiAction: townId=${params.townId} type=${parsed.data.action.type}`
   );
 
+  const action = normalizeUiAction(parsed.data.action, params.townId);
+
   const town = getTownDOStub(c.env, params.townId);
   await town.setTownId(params.townId);
-  await town.broadcastUiAction(parsed.data.action);
+  await town.broadcastUiAction(action);
   return c.json(resSuccess({ broadcast: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -4,12 +4,14 @@ import type { GastownEnv } from '../gastown.worker';
 import { getTownDOStub } from '../dos/Town.do';
 import { resSuccess } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
+import { UiActionSchema } from '../types';
 
 const MAYOR_HANDLER_LOG = '[mayor.handler]';
 
 const SendMayorMessageBody = z.object({
   message: z.string().min(1),
   model: z.string().optional(),
+  uiContext: z.string().optional(), // XML string from getContextXml()
 });
 
 const MayorCompletedBody = z.object({
@@ -51,7 +53,11 @@ export async function handleSendMayorMessage(c: Context<GastownEnv>, params: { t
   // Ensure the TownDO knows its real UUID (ctx.id.name is unreliable in local dev)
   // TODO: This should only be done on town creation. Why are we doing it here?
   await town.setTownId(params.townId);
-  const result = await town.sendMayorMessage(parsed.data.message, parsed.data.model);
+  const result = await town.sendMayorMessage(
+    parsed.data.message,
+    parsed.data.model,
+    parsed.data.uiContext
+  );
   return c.json(resSuccess(result), 200);
 }
 
@@ -121,4 +127,34 @@ export async function handleDestroyMayor(c: Context<GastownEnv>, params: { townI
     await town.deleteAgent(status.session.agentId);
   }
   return c.json(resSuccess({ destroyed: true }), 200);
+}
+
+const BroadcastUiActionBody = z.object({
+  action: UiActionSchema,
+});
+
+/**
+ * POST /api/towns/:townId/mayor/ui-action
+ * Broadcast a UI action to all connected dashboard WebSocket clients.
+ * Called by the mayor agent to trigger navigation/drawer actions in the dashboard.
+ * Protected by kiloAuthMiddleware (same as other /api/towns/:townId/mayor/* routes).
+ */
+export async function handleBroadcastUiAction(c: Context<GastownEnv>, params: { townId: string }) {
+  const body = await parseJsonBody(c);
+  const parsed = BroadcastUiActionBody.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${MAYOR_HANDLER_LOG} handleBroadcastUiAction: townId=${params.townId} type=${parsed.data.action.type}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  await town.setTownId(params.townId);
+  await town.broadcastUiAction(parsed.data.action);
+  return c.json(resSuccess({ broadcast: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -129,9 +129,36 @@ export async function handleDestroyMayor(c: Context<GastownEnv>, params: { townI
   return c.json(resSuccess({ destroyed: true }), 200);
 }
 
+const SetDashboardContextBody = z.object({
+  context: z.string(),
+});
+
 const BroadcastUiActionBody = z.object({
   action: UiActionSchema,
 });
+
+/**
+ * POST /api/towns/:townId/mayor/dashboard-context
+ * Store the current dashboard context (XML string) in the TownDO.
+ * Used as a fallback when sendMayorMessage is called without explicit uiContext.
+ */
+export async function handleSetDashboardContext(
+  c: Context<GastownEnv>,
+  params: { townId: string }
+) {
+  const body = await parseJsonBody(c);
+  const parsed = SetDashboardContextBody.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  const town = getTownDOStub(c.env, params.townId);
+  await town.setDashboardContext(parsed.data.context);
+  return c.json(resSuccess({ stored: true }), 200);
+}
 
 /**
  * POST /api/towns/:townId/mayor/ui-action

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -58,6 +58,9 @@ export async function handleSendMayorMessage(c: Context<GastownEnv>, params: { t
     );
   }
 
+  const denied = await verifyTownOwner(c, params.townId);
+  if (denied) return denied;
+
   console.log(
     `${MAYOR_HANDLER_LOG} handleSendMayorMessage: townId=${params.townId} message="${parsed.data.message.slice(0, 80)}"`
   );
@@ -172,6 +175,7 @@ export async function handleSetDashboardContext(
   }
 
   const town = getTownDOStub(c.env, params.townId);
+  await town.setTownId(params.townId);
   await town.setDashboardContext(parsed.data.context);
   return c.json(resSuccess({ stored: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -2,24 +2,11 @@ import type { Context } from 'hono';
 import { z } from 'zod';
 import type { GastownEnv } from '../gastown.worker';
 import { getTownDOStub } from '../dos/Town.do';
-import { getGastownUserStub } from '../dos/GastownUser.do';
 import { resSuccess } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
 import { UiActionSchema } from '../types';
 
 const MAYOR_HANDLER_LOG = '[mayor.handler]';
-
-/** Verify the kilo-auth'd user owns the given town. Returns a 403 Response on failure. */
-async function verifyTownOwner(c: Context<GastownEnv>, townId: string): Promise<Response | null> {
-  const userId = c.get('kiloUserId');
-  if (!userId) return c.json({ success: false, error: 'Unauthorized' }, 401);
-  const userStub = getGastownUserStub(c.env, userId);
-  const town = await userStub.getTownAsync(townId);
-  if (!town || town.owner_user_id !== userId) {
-    return c.json({ success: false, error: 'Not your town' }, 403);
-  }
-  return null;
-}
 
 const SendMayorMessageBody = z.object({
   message: z.string().min(1),
@@ -57,9 +44,6 @@ export async function handleSendMayorMessage(c: Context<GastownEnv>, params: { t
       400
     );
   }
-
-  const denied = await verifyTownOwner(c, params.townId);
-  if (denied) return denied;
 
   console.log(
     `${MAYOR_HANDLER_LOG} handleSendMayorMessage: townId=${params.townId} message="${parsed.data.message.slice(0, 80)}"`
@@ -162,9 +146,6 @@ export async function handleSetDashboardContext(
   c: Context<GastownEnv>,
   params: { townId: string }
 ) {
-  const denied = await verifyTownOwner(c, params.townId);
-  if (denied) return denied;
-
   const body = await parseJsonBody(c);
   const parsed = SetDashboardContextBody.safeParse(body);
   if (!parsed.success) {
@@ -187,9 +168,6 @@ export async function handleSetDashboardContext(
  * Protected by kiloAuthMiddleware (same as other /api/towns/:townId/mayor/* routes).
  */
 export async function handleBroadcastUiAction(c: Context<GastownEnv>, params: { townId: string }) {
-  const denied = await verifyTownOwner(c, params.townId);
-  if (denied) return denied;
-
   const body = await parseJsonBody(c);
   const parsed = BroadcastUiActionBody.safeParse(body);
   if (!parsed.success) {

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -11,7 +11,7 @@ const MAYOR_HANDLER_LOG = '[mayor.handler]';
 const SendMayorMessageBody = z.object({
   message: z.string().min(1),
   model: z.string().optional(),
-  uiContext: z.string().optional(), // XML string from getContextXml()
+  uiContext: z.string().max(10_000).optional(),
 });
 
 const MayorCompletedBody = z.object({
@@ -130,7 +130,7 @@ export async function handleDestroyMayor(c: Context<GastownEnv>, params: { townI
 }
 
 const SetDashboardContextBody = z.object({
-  context: z.string(),
+  context: z.string().max(10_000),
 });
 
 const BroadcastUiActionBody = z.object({

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -4,7 +4,7 @@ import type { GastownEnv } from '../gastown.worker';
 import { getTownDOStub } from '../dos/Town.do';
 import { resSuccess } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
-import { UiActionSchema, normalizeUiAction } from '../types';
+import { UiActionSchema, normalizeUiAction, uiActionRigId } from '../types';
 
 const MAYOR_HANDLER_LOG = '[mayor.handler]';
 
@@ -185,6 +185,16 @@ export async function handleBroadcastUiAction(c: Context<GastownEnv>, params: { 
 
   const town = getTownDOStub(c.env, params.townId);
   await town.setTownId(params.townId);
+
+  // Validate that the referenced rig belongs to this town
+  const rigId = uiActionRigId(action);
+  if (rigId) {
+    const rig = await town.getRigAsync(rigId);
+    if (!rig) {
+      return c.json({ success: false, error: `Rig ${rigId} does not belong to this town` }, 400);
+    }
+  }
+
   await town.broadcastUiAction(action);
   return c.json(resSuccess({ broadcast: true }), 200);
 }

--- a/cloudflare-gastown/src/handlers/mayor.handler.ts
+++ b/cloudflare-gastown/src/handlers/mayor.handler.ts
@@ -2,11 +2,24 @@ import type { Context } from 'hono';
 import { z } from 'zod';
 import type { GastownEnv } from '../gastown.worker';
 import { getTownDOStub } from '../dos/Town.do';
+import { getGastownUserStub } from '../dos/GastownUser.do';
 import { resSuccess } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
 import { UiActionSchema } from '../types';
 
 const MAYOR_HANDLER_LOG = '[mayor.handler]';
+
+/** Verify the kilo-auth'd user owns the given town. Returns a 403 Response on failure. */
+async function verifyTownOwner(c: Context<GastownEnv>, townId: string): Promise<Response | null> {
+  const userId = c.get('kiloUserId');
+  if (!userId) return c.json({ success: false, error: 'Unauthorized' }, 401);
+  const userStub = getGastownUserStub(c.env, userId);
+  const town = await userStub.getTownAsync(townId);
+  if (!town || town.owner_user_id !== userId) {
+    return c.json({ success: false, error: 'Not your town' }, 403);
+  }
+  return null;
+}
 
 const SendMayorMessageBody = z.object({
   message: z.string().min(1),
@@ -146,6 +159,9 @@ export async function handleSetDashboardContext(
   c: Context<GastownEnv>,
   params: { townId: string }
 ) {
+  const denied = await verifyTownOwner(c, params.townId);
+  if (denied) return denied;
+
   const body = await parseJsonBody(c);
   const parsed = SetDashboardContextBody.safeParse(body);
   if (!parsed.success) {
@@ -167,6 +183,9 @@ export async function handleSetDashboardContext(
  * Protected by kiloAuthMiddleware (same as other /api/towns/:townId/mayor/* routes).
  */
 export async function handleBroadcastUiAction(c: Context<GastownEnv>, params: { townId: string }) {
+  const denied = await verifyTownOwner(c, params.townId);
+  if (denied) return denied;
+
   const body = await parseJsonBody(c);
   const parsed = BroadcastUiActionBody.safeParse(body);
   if (!parsed.success) {

--- a/cloudflare-gastown/src/middleware/town-ownership.middleware.ts
+++ b/cloudflare-gastown/src/middleware/town-ownership.middleware.ts
@@ -1,0 +1,32 @@
+import { createMiddleware } from 'hono/factory';
+import { resError } from '../util/res.util';
+import type { GastownEnv } from '../gastown.worker';
+import { getGastownUserStub } from '../dos/GastownUser.do';
+
+/**
+ * Middleware that verifies the authenticated Kilo user owns the `:townId`
+ * route param. Must run after `kiloAuthMiddleware` (reads `kiloUserId`
+ * from the Hono context).
+ *
+ * Returns 401 if no userId is set, 403 if the town doesn't belong to the
+ * caller.
+ */
+export const townOwnershipMiddleware = createMiddleware<GastownEnv>(async (c, next) => {
+  const userId = c.get('kiloUserId');
+  if (!userId) {
+    return c.json(resError('Unauthorized'), 401);
+  }
+
+  const townId = c.req.param('townId');
+  if (!townId) {
+    return c.json(resError('Missing townId'), 400);
+  }
+
+  const userStub = getGastownUserStub(c.env, userId);
+  const town = await userStub.getTownAsync(townId);
+  if (!town) {
+    return c.json(resError('Not your town'), 403);
+  }
+
+  return next();
+});

--- a/cloudflare-gastown/src/middleware/town-ownership.middleware.ts
+++ b/cloudflare-gastown/src/middleware/town-ownership.middleware.ts
@@ -6,15 +6,23 @@ import { getGastownUserStub } from '../dos/GastownUser.do';
 /**
  * Middleware that verifies the authenticated Kilo user owns the `:townId`
  * route param. Must run after `kiloAuthMiddleware` (reads `kiloUserId`
- * from the Hono context).
+ * and `kiloIsAdmin` from the Hono context).
+ *
+ * Admins bypass the ownership check so admin-panel routes (e.g. town
+ * config inspection/updates) continue to work for any town.
  *
  * Returns 401 if no userId is set, 403 if the town doesn't belong to the
- * caller.
+ * caller and they are not an admin.
  */
 export const townOwnershipMiddleware = createMiddleware<GastownEnv>(async (c, next) => {
   const userId = c.get('kiloUserId');
   if (!userId) {
     return c.json(resError('Unauthorized'), 401);
+  }
+
+  // Admins can access any town (e.g. admin panel inspection routes)
+  if (c.get('kiloIsAdmin')) {
+    return next();
   }
 
   const townId = c.req.param('townId');

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -258,12 +258,12 @@ Supported actions:
 - Open a bead drawer: \`gt_ui_action '{"type":"open_bead_drawer","beadId":"...","rigId":"..."}'\`
 - Open a convoy drawer: \`gt_ui_action '{"type":"open_convoy_drawer","convoyId":"...","townId":"..."}'\`
 - Open an agent drawer: \`gt_ui_action '{"type":"open_agent_drawer","agentId":"...","rigId":"...","townId":"..."}'\`
-- Open the create rig dialog: \`gt_ui_action '{"type":"open_create_rig_dialog"}'\`
 - Navigate: \`gt_ui_action '{"type":"navigate","page":"beads"}'\`
+- Highlight a bead: \`gt_ui_action '{"type":"highlight_bead","beadId":"...","rigId":"..."}'\`
 
 Examples:
 - User asks "why did that convoy fail?" → open the convoy drawer so they can see the details
-- User asks "how do I create a rig connected to my GitHub repo?" → open the create rig dialog for them
+- User asks "show me the beads page" → navigate to the beads page
 - User asks "show me the failed bead" → open the bead drawer for the failed bead you can see in their context
 
 ## Staged Convoys

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -37,6 +37,7 @@ You have these tools for cross-rig coordination:
 - **gt_list_convoys** — List active convoys with progress counts. Use to check on batched work.
 - **gt_convoy_status** — Show detailed status of a convoy: each tracked bead with its status and assignee. Use for progress reports.
 - **gt_mail_send** — Send a message to any agent in any rig. Use for coordination, follow-up instructions, or status checks.
+- **gt_ui_action** — Trigger a UI action in the user's dashboard (open drawers, navigate pages, trigger dialogs). See the UI Control section below.
 
 ## Task Decomposition — USE CONVOYS
 
@@ -225,6 +226,45 @@ Use these tools when the user reports stuck state, when you detect problems duri
 - If no rigs exist, tell the user they need to create one first.
   - If a task spans multiple rigs, create separate slings for each rig.
   - ALWAYS sling when the user requests work. Describing what you would do without actually slinging is a failure mode. Prefer gt_sling_batch for multi-task requests.
+
+## Dashboard Context
+
+When the user is viewing the Gastown dashboard, you may receive a \`<user-context>\` system block
+before their message. This tells you what the user is currently looking at:
+
+\`\`\`xml
+<user-context>
+  <current-view page="rig-detail" />
+  <viewing-object type="bead" id="bead-xyz" title="Fix token refresh" status="failed" />
+  <recent-actions>
+    - 2m ago: Opened bead "Fix token refresh" detail panel
+    - 5m ago: Navigated to rig "frontend"
+  </recent-actions>
+</user-context>
+\`\`\`
+
+Use this context proactively. If the user asks "why did this fail?" and you can see they're
+looking at a failed bead, you already know which bead they mean. If they say "fix this", check
+what they're viewing first.
+
+## UI Control
+
+You can control the user's dashboard using \`gt_ui_action\`. This lets you open drawers, navigate
+pages, and trigger dialogs on behalf of the user — like a copilot that shares their screen.
+
+**gt_ui_action** — Trigger a UI action in the user's dashboard
+
+Supported actions:
+- Open a bead drawer: \`gt_ui_action '{"type":"open_bead_drawer","beadId":"...","rigId":"..."}'\`
+- Open a convoy drawer: \`gt_ui_action '{"type":"open_convoy_drawer","convoyId":"...","townId":"..."}'\`
+- Open an agent drawer: \`gt_ui_action '{"type":"open_agent_drawer","agentId":"...","rigId":"...","townId":"..."}'\`
+- Open the create rig dialog: \`gt_ui_action '{"type":"open_create_rig_dialog"}'\`
+- Navigate: \`gt_ui_action '{"type":"navigate","page":"beads"}'\`
+
+Examples:
+- User asks "why did that convoy fail?" → open the convoy drawer so they can see the details
+- User asks "how do I create a rig connected to my GitHub repo?" → open the create rig dialog for them
+- User asks "show me the failed bead" → open the bead drawer for the failed bead you can see in their context
 
 ## Staged Convoys
 

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -403,6 +403,7 @@ export const gastownRouter = router({
         message: z.string().min(1),
         model: z.string().default('anthropic/claude-sonnet-4.6'),
         rigId: z.string().uuid().optional(),
+        uiContext: z.string().optional(),
       })
     )
     .output(RpcMayorSendResultOutput)
@@ -411,7 +412,7 @@ export const gastownRouter = router({
 
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.setTownId(input.townId);
-      return townStub.sendMayorMessage(input.message, input.model);
+      return townStub.sendMayorMessage(input.message, input.model, input.uiContext);
     }),
 
   getMayorStatus: gastownProcedure

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -403,7 +403,7 @@ export const gastownRouter = router({
         message: z.string().min(1),
         model: z.string().default('anthropic/claude-sonnet-4.6'),
         rigId: z.string().uuid().optional(),
-        uiContext: z.string().optional(),
+        uiContext: z.string().max(10_000).optional(),
       })
     )
     .output(RpcMayorSendResultOutput)

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -330,6 +330,17 @@ export const UiActionSchema = z.discriminatedUnion('type', [
 ]);
 export type UiAction = z.infer<typeof UiActionSchema>;
 
+/**
+ * Overwrite any `townId` field in the action with the route-scoped townId
+ * so callers can't reference resources outside the authenticated town.
+ */
+export function normalizeUiAction(action: UiAction, townId: string): UiAction {
+  if ('townId' in action) {
+    return { ...action, townId };
+  }
+  return action;
+}
+
 // Re-export satellite metadata types for convenience
 export type { AgentMetadataRecord } from './db/tables/agent-metadata.table';
 export type { ReviewMetadataRecord } from './db/tables/review-metadata.table';

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -318,7 +318,6 @@ export const UiActionSchema = z.discriminatedUnion('type', [
     rigId: z.string().min(1),
     townId: z.string().min(1),
   }),
-  z.object({ type: z.literal('open_create_rig_dialog') }),
   z.object({
     type: z.literal('navigate'),
     page: z.enum(['town-overview', 'beads', 'agents', 'rigs', 'settings']),

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -341,6 +341,12 @@ export function normalizeUiAction(action: UiAction, townId: string): UiAction {
   return action;
 }
 
+/** Extract the rigId from a UI action, if present. */
+export function uiActionRigId(action: UiAction): string | null {
+  if ('rigId' in action) return action.rigId;
+  return null;
+}
+
 // Re-export satellite metadata types for convenience
 export type { AgentMetadataRecord } from './db/tables/agent-metadata.table';
 export type { ReviewMetadataRecord } from './db/tables/review-metadata.table';

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -299,6 +299,38 @@ export const AgentConfigOverridesSchema = z.object({
 });
 export type AgentConfigOverrides = z.infer<typeof AgentConfigOverridesSchema>;
 
+// -- UI Actions (mayor → dashboard WebSocket commands) --
+
+export const UiActionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('open_bead_drawer'),
+    beadId: z.string().min(1),
+    rigId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('open_convoy_drawer'),
+    convoyId: z.string().min(1),
+    townId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('open_agent_drawer'),
+    agentId: z.string().min(1),
+    rigId: z.string().min(1),
+    townId: z.string().min(1),
+  }),
+  z.object({ type: z.literal('open_create_rig_dialog') }),
+  z.object({
+    type: z.literal('navigate'),
+    page: z.enum(['town-overview', 'beads', 'agents', 'rigs', 'settings']),
+  }),
+  z.object({
+    type: z.literal('highlight_bead'),
+    beadId: z.string().min(1),
+    rigId: z.string().min(1),
+  }),
+]);
+export type UiAction = z.infer<typeof UiActionSchema>;
+
 // Re-export satellite metadata types for convenience
 export type { AgentMetadataRecord } from './db/tables/agent-metadata.table';
 export type { ReviewMetadataRecord } from './db/tables/review-metadata.table';

--- a/src/app/(app)/gastown/[townId]/MayorTerminalBar.tsx
+++ b/src/app/(app)/gastown/[townId]/MayorTerminalBar.tsx
@@ -2,8 +2,12 @@
 
 import { use } from 'react';
 import { TerminalBar } from '@/components/gastown/TerminalBar';
+import { useGastownUiContext } from '@/components/gastown/useGastownUiContext';
+import { GASTOWN_URL } from '@/lib/constants';
 
 export function MayorTerminalBar({ params }: { params: Promise<{ townId: string }> }) {
   const { townId } = use(params);
+  // Track dashboard navigation context and sync to TownDO
+  useGastownUiContext(townId, GASTOWN_URL);
   return <TerminalBar townId={townId} />;
 }

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -89,7 +89,11 @@ export function TerminalBar({ townId }: TerminalBarProps) {
               settings: `/gastown/${townId}/settings`,
             };
             const path = pageMap[action.page];
-            if (path) router.push(path);
+            if (path) {
+              // Close any open drawers so they don't cover the new page
+              drawerStack.closeAll();
+              router.push(path);
+            }
           }
           break;
         case 'highlight_bead':
@@ -315,7 +319,10 @@ function useAlarmStatusWs(
         } else if (msg.channel === 'ui_action') {
           // UI action from the mayor — dispatch to callback for DrawerStack/router.
           onUiActionRef.current?.(parsed as UiActionEvent);
-        } else {
+        } else if ('alarm' in msg) {
+          // Only alarm snapshots have an `alarm` field. Bead, convoy,
+          // and other channel frames are silently ignored here to avoid
+          // overwriting the status data with the wrong shape.
           setData(parsed as AlarmStatus);
         }
       } catch {

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -34,6 +34,78 @@ export function TerminalBar({ townId }: TerminalBarProps) {
     setActiveTabId,
     setCollapsed,
   } = useTerminalBar();
+  const queryClient = useQueryClient();
+  const drawerStack = useDrawerStack();
+  const router = useRouter();
+
+  // ── Always-on WebSocket for alarm status + UI action dispatch ──────
+  // Lifted here so the connection persists regardless of which tab is active.
+
+  const handleAgentStatus = useCallback(
+    (_event: AgentStatusEvent) => {
+      void queryClient.invalidateQueries({
+        predicate: query => {
+          const key = query.queryKey;
+          if (!Array.isArray(key) || !Array.isArray(key[0])) return false;
+          const path = key[0] as string[];
+          return path.includes('listAgents');
+        },
+      });
+    },
+    [queryClient]
+  );
+
+  const handleUiAction = useCallback(
+    (event: UiActionEvent) => {
+      const { action } = event;
+      switch (action.type) {
+        case 'open_bead_drawer':
+          if (action.beadId && action.rigId) {
+            drawerStack.open({ type: 'bead', beadId: action.beadId, rigId: action.rigId });
+          }
+          break;
+        case 'open_convoy_drawer':
+          if (action.convoyId && action.townId) {
+            drawerStack.open({ type: 'convoy', convoyId: action.convoyId, townId: action.townId });
+          }
+          break;
+        case 'open_agent_drawer':
+          if (action.agentId && action.rigId) {
+            drawerStack.open({
+              type: 'agent',
+              agentId: action.agentId,
+              rigId: action.rigId,
+              townId: action.townId,
+            });
+          }
+          break;
+        case 'navigate':
+          if (action.page) {
+            const pageMap: Record<string, string> = {
+              'town-overview': `/gastown/${townId}`,
+              beads: `/gastown/${townId}/beads`,
+              agents: `/gastown/${townId}/agents`,
+              rigs: `/gastown/${townId}`,
+              settings: `/gastown/${townId}/settings`,
+            };
+            const path = pageMap[action.page];
+            if (path) router.push(path);
+          }
+          break;
+        case 'highlight_bead':
+          if (action.beadId && action.rigId) {
+            drawerStack.open({ type: 'bead', beadId: action.beadId, rigId: action.rigId });
+          }
+          break;
+      }
+    },
+    [drawerStack, router, townId]
+  );
+
+  const alarmWs = useAlarmStatusWs(townId, {
+    onAgentStatus: handleAgentStatus,
+    onUiAction: handleUiAction,
+  });
 
   const sidebarLeft = isMobile ? '0px' : sidebarState === 'expanded' ? '16rem' : '3rem';
 
@@ -134,7 +206,7 @@ export function TerminalBar({ townId }: TerminalBarProps) {
             {activeTab.kind === 'mayor' ? (
               <MayorTerminalPane townId={townId} collapsed={collapsed} />
             ) : activeTab.kind === 'status' ? (
-              <AlarmStatusPane townId={townId} />
+              <AlarmStatusPane townId={townId} alarmWs={alarmWs} />
             ) : (
               <AgentTerminalPane townId={townId} agentId={activeTab.agentId} />
             )}
@@ -278,86 +350,16 @@ function useAlarmStatusWs(
   return { data, connected, error };
 }
 
-function AlarmStatusPane({ townId }: { townId: string }) {
+type AlarmWsResult = {
+  data: AlarmStatus | null;
+  connected: boolean;
+  error: string | null;
+};
+
+function AlarmStatusPane({ townId, alarmWs }: { townId: string; alarmWs: AlarmWsResult }) {
   const trpc = useGastownTRPC();
-  const queryClient = useQueryClient();
-  const drawerStack = useDrawerStack();
-  const router = useRouter();
 
-  // Invalidate listAgents for all rigs in this town when an agent_status
-  // event arrives over the WebSocket, so agent cards update immediately
-  // without waiting for the next 5s poll cycle.
-  // tRPC @tanstack/react-query v11 query keys have the shape:
-  // [['gastown', 'listAgents'], { input: ..., type: 'query' }]
-  const handleAgentStatus = useCallback(
-    (_event: AgentStatusEvent) => {
-      void queryClient.invalidateQueries({
-        predicate: query => {
-          const key = query.queryKey;
-          if (!Array.isArray(key) || !Array.isArray(key[0])) return false;
-          const path = key[0] as string[];
-          return path.includes('listAgents');
-        },
-      });
-    },
-    [queryClient]
-  );
-
-  // Handle UI actions from the mayor (open drawers, navigate pages)
-  const handleUiAction = useCallback(
-    (event: UiActionEvent) => {
-      const { action } = event;
-      switch (action.type) {
-        case 'open_bead_drawer':
-          if (action.beadId && action.rigId) {
-            drawerStack.open({ type: 'bead', beadId: action.beadId, rigId: action.rigId });
-          }
-          break;
-        case 'open_convoy_drawer':
-          if (action.convoyId && action.townId) {
-            drawerStack.open({ type: 'convoy', convoyId: action.convoyId, townId: action.townId });
-          }
-          break;
-        case 'open_agent_drawer':
-          if (action.agentId && action.rigId) {
-            drawerStack.open({
-              type: 'agent',
-              agentId: action.agentId,
-              rigId: action.rigId,
-              townId: action.townId,
-            });
-          }
-          break;
-        case 'navigate':
-          if (action.page) {
-            const pageMap: Record<string, string> = {
-              'town-overview': `/gastown/${townId}`,
-              beads: `/gastown/${townId}/beads`,
-              agents: `/gastown/${townId}/agents`,
-              rigs: `/gastown/${townId}`,
-              settings: `/gastown/${townId}/settings`,
-            };
-            const path = pageMap[action.page];
-            if (path) router.push(path);
-          }
-          break;
-        case 'highlight_bead':
-          // For highlight, open the bead drawer as a visual indicator
-          if (action.beadId && action.rigId) {
-            drawerStack.open({ type: 'bead', beadId: action.beadId, rigId: action.rigId });
-          }
-          break;
-        // open_create_rig_dialog: would need a dedicated dialog state — skip for now
-      }
-    },
-    [drawerStack, router, townId]
-  );
-
-  const {
-    data: wsData,
-    connected: wsConnected,
-    error: wsError,
-  } = useAlarmStatusWs(townId, { onAgentStatus: handleAgentStatus, onUiAction: handleUiAction });
+  const { data: wsData, connected: wsConnected, error: wsError } = alarmWs;
 
   // Fall back to polling when WebSocket is unavailable (blocked, errored,
   // or never connected). The tRPC query is disabled while the WS is

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -2,10 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { useGastownTRPC, gastownWsUrl } from '@/lib/gastown/trpc';
 
 import { useSidebar } from '@/components/ui/sidebar';
 import { useTerminalBar } from './TerminalBarContext';
+import { useDrawerStack } from './DrawerStack';
 import { ChevronDown, ChevronUp, Crown, Activity, Terminal as TerminalIcon, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import type { Terminal } from '@xterm/xterm';
@@ -171,6 +173,20 @@ type AgentStatusEvent = {
   timestamp: string;
 };
 
+type UiActionEvent = {
+  channel: 'ui_action';
+  action: {
+    type: string;
+    beadId?: string;
+    rigId?: string;
+    convoyId?: string;
+    agentId?: string;
+    townId?: string;
+    page?: string;
+  };
+  ts: string;
+};
+
 /**
  * Hook that connects to the TownDO status WebSocket and returns the
  * latest alarm status snapshot. Falls back to tRPC polling if the
@@ -181,7 +197,10 @@ type AgentStatusEvent = {
  */
 function useAlarmStatusWs(
   townId: string,
-  onAgentStatus?: (event: AgentStatusEvent) => void
+  callbacks?: {
+    onAgentStatus?: (event: AgentStatusEvent) => void;
+    onUiAction?: (event: UiActionEvent) => void;
+  }
 ): {
   data: AlarmStatus | null;
   connected: boolean;
@@ -193,8 +212,10 @@ function useAlarmStatusWs(
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
-  const onAgentStatusRef = useRef(onAgentStatus);
-  onAgentStatusRef.current = onAgentStatus;
+  const onAgentStatusRef = useRef(callbacks?.onAgentStatus);
+  onAgentStatusRef.current = callbacks?.onAgentStatus;
+  const onUiActionRef = useRef(callbacks?.onUiAction);
+  onUiActionRef.current = callbacks?.onUiAction;
 
   const connect = useCallback(() => {
     if (!mountedRef.current) return;
@@ -212,15 +233,16 @@ function useAlarmStatusWs(
       if (!mountedRef.current || typeof e.data !== 'string') return;
       try {
         const parsed: unknown = JSON.parse(e.data);
-        if (
-          parsed !== null &&
-          typeof parsed === 'object' &&
-          'type' in parsed &&
-          (parsed as Record<string, unknown>).type === 'agent_status'
-        ) {
+        if (parsed === null || typeof parsed !== 'object') return;
+        const msg = parsed as Record<string, unknown>;
+
+        if (msg.type === 'agent_status') {
           // Lightweight agent_status event — dispatch to callback, don't
           // overwrite the alarm status snapshot.
           onAgentStatusRef.current?.(parsed as AgentStatusEvent);
+        } else if (msg.channel === 'ui_action') {
+          // UI action from the mayor — dispatch to callback for DrawerStack/router.
+          onUiActionRef.current?.(parsed as UiActionEvent);
         } else {
           setData(parsed as AlarmStatus);
         }
@@ -259,6 +281,8 @@ function useAlarmStatusWs(
 function AlarmStatusPane({ townId }: { townId: string }) {
   const trpc = useGastownTRPC();
   const queryClient = useQueryClient();
+  const drawerStack = useDrawerStack();
+  const router = useRouter();
 
   // Invalidate listAgents for all rigs in this town when an agent_status
   // event arrives over the WebSocket, so agent cards update immediately
@@ -279,11 +303,61 @@ function AlarmStatusPane({ townId }: { townId: string }) {
     [queryClient]
   );
 
+  // Handle UI actions from the mayor (open drawers, navigate pages)
+  const handleUiAction = useCallback(
+    (event: UiActionEvent) => {
+      const { action } = event;
+      switch (action.type) {
+        case 'open_bead_drawer':
+          if (action.beadId && action.rigId) {
+            drawerStack.open({ type: 'bead', beadId: action.beadId, rigId: action.rigId });
+          }
+          break;
+        case 'open_convoy_drawer':
+          if (action.convoyId && action.townId) {
+            drawerStack.open({ type: 'convoy', convoyId: action.convoyId, townId: action.townId });
+          }
+          break;
+        case 'open_agent_drawer':
+          if (action.agentId && action.rigId) {
+            drawerStack.open({
+              type: 'agent',
+              agentId: action.agentId,
+              rigId: action.rigId,
+              townId: action.townId,
+            });
+          }
+          break;
+        case 'navigate':
+          if (action.page) {
+            const pageMap: Record<string, string> = {
+              'town-overview': `/gastown/${townId}`,
+              beads: `/gastown/${townId}/beads`,
+              agents: `/gastown/${townId}/agents`,
+              rigs: `/gastown/${townId}`,
+              settings: `/gastown/${townId}/settings`,
+            };
+            const path = pageMap[action.page];
+            if (path) router.push(path);
+          }
+          break;
+        case 'highlight_bead':
+          // For highlight, open the bead drawer as a visual indicator
+          if (action.beadId && action.rigId) {
+            drawerStack.open({ type: 'bead', beadId: action.beadId, rigId: action.rigId });
+          }
+          break;
+        // open_create_rig_dialog: would need a dedicated dialog state — skip for now
+      }
+    },
+    [drawerStack, router, townId]
+  );
+
   const {
     data: wsData,
     connected: wsConnected,
     error: wsError,
-  } = useAlarmStatusWs(townId, handleAgentStatus);
+  } = useAlarmStatusWs(townId, { onAgentStatus: handleAgentStatus, onUiAction: handleUiAction });
 
   // Fall back to polling when WebSocket is unavailable (blocked, errored,
   // or never connected). The tRPC query is disabled while the WS is

--- a/src/components/gastown/useGastownUiContext.ts
+++ b/src/components/gastown/useGastownUiContext.ts
@@ -100,21 +100,24 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
   const activityRef = useRef<ActivityEntry[]>([]);
   const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSyncedRef = useRef<string>('');
+  const prevPathnameRef = useRef<string>(pathname);
+  const prevDrawerRef = useRef<ResourceRef | null>(null);
 
   const topDrawer = stack.length > 0 ? stack[stack.length - 1].resource : null;
 
-  // Track page navigation
-  useEffect(() => {
+  // Track activity changes synchronously during render so the XML
+  // built below always includes the current navigation state.
+  if (pathname !== prevPathnameRef.current) {
+    prevPathnameRef.current = pathname;
     const page = pageFromPathname(pathname, townId);
     activityRef.current = [
       { timestamp: new Date().toISOString(), action: 'page_view', page },
       ...activityRef.current.slice(0, MAX_ACTIVITY_ENTRIES - 1),
     ];
-  }, [pathname, townId]);
+  }
 
-  // Track drawer opens
-  useEffect(() => {
-    if (!topDrawer) return;
+  if (topDrawer !== prevDrawerRef.current && topDrawer) {
+    prevDrawerRef.current = topDrawer;
     activityRef.current = [
       {
         timestamp: new Date().toISOString(),
@@ -131,9 +134,11 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
       },
       ...activityRef.current.slice(0, MAX_ACTIVITY_ENTRIES - 1),
     ];
-  }, [topDrawer]);
+  } else if (!topDrawer) {
+    prevDrawerRef.current = null;
+  }
 
-  // Build current context XML
+  // Build current context XML (includes the just-recorded activity)
   const page = pageFromPathname(pathname, townId);
   const contextXml = buildContextXml(page, topDrawer, activityRef.current);
 
@@ -142,9 +147,10 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
     if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
     syncTimerRef.current = setTimeout(() => {
       if (contextXml === lastSyncedRef.current) return;
-      lastSyncedRef.current = contextXml;
+      const xml = contextXml;
 
-      // Fire-and-forget POST to store context on the TownDO
+      // Fire-and-forget POST to store context on the TownDO.
+      // Only mark as synced after success so failures are retried.
       getToken()
         .then(token =>
           fetch(`${gastownUrl}/api/towns/${townId}/mayor/dashboard-context`, {
@@ -153,11 +159,14 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
               'Content-Type': 'application/json',
               Authorization: `Bearer ${token}`,
             },
-            body: JSON.stringify({ context: contextXml }),
+            body: JSON.stringify({ context: xml }),
           })
         )
+        .then(resp => {
+          if (resp.ok) lastSyncedRef.current = xml;
+        })
         .catch(() => {
-          // Best-effort — silently ignore failures
+          // Best-effort — will retry on next context change or debounce tick
         });
     }, SYNC_DEBOUNCE_MS);
 

--- a/src/components/gastown/useGastownUiContext.ts
+++ b/src/components/gastown/useGastownUiContext.ts
@@ -24,6 +24,7 @@ type ActivityEntry = {
 
 const MAX_ACTIVITY_ENTRIES = 10;
 const SYNC_DEBOUNCE_MS = 2_000;
+const SYNC_RETRY_MS = 10_000;
 
 /** Derive a human-readable page label from the pathname. */
 function pageFromPathname(pathname: string, townId: string): string {
@@ -102,6 +103,7 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
   const { stack } = useDrawerStack();
   const activityRef = useRef<ActivityEntry[]>([]);
   const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSyncedRef = useRef<string>('');
   const prevPathnameRef = useRef<string>(pathname);
   const prevDrawerRef = useRef<ResourceRef | null>(null);
@@ -145,15 +147,16 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
   const page = pageFromPathname(pathname, townId);
   const contextXml = buildContextXml(page, topDrawer, activityRef.current);
 
-  // Debounced sync to TownDO
+  // Sync context XML to TownDO. Retries on failure so the mayor
+  // doesn't permanently lose context after a transient error.
   useEffect(() => {
     if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
-    syncTimerRef.current = setTimeout(() => {
+    if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+
+    function doSync() {
       if (contextXml === lastSyncedRef.current) return;
       const xml = contextXml;
 
-      // Fire-and-forget POST to store context on the TownDO.
-      // Only mark as synced after success so failures are retried.
       getToken()
         .then(token =>
           fetch(`${gastownUrl}/api/towns/${townId}/mayor/dashboard-context`, {
@@ -166,15 +169,24 @@ export function useGastownUiContext(townId: string, gastownUrl: string): string 
           })
         )
         .then(resp => {
-          if (resp.ok) lastSyncedRef.current = xml;
+          if (resp.ok) {
+            lastSyncedRef.current = xml;
+          } else {
+            // Schedule a retry — the effect won't re-run since contextXml
+            // hasn't changed, so we need an explicit retry timer.
+            retryTimerRef.current = setTimeout(doSync, SYNC_RETRY_MS);
+          }
         })
         .catch(() => {
-          // Best-effort — will retry on next context change or debounce tick
+          retryTimerRef.current = setTimeout(doSync, SYNC_RETRY_MS);
         });
-    }, SYNC_DEBOUNCE_MS);
+    }
+
+    syncTimerRef.current = setTimeout(doSync, SYNC_DEBOUNCE_MS);
 
     return () => {
       if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
     };
   }, [contextXml, townId, gastownUrl]);
 

--- a/src/components/gastown/useGastownUiContext.ts
+++ b/src/components/gastown/useGastownUiContext.ts
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { useDrawerStack, type ResourceRef } from './DrawerStack';
+import { getToken } from '@/lib/gastown/trpc';
+
+/**
+ * Tracks dashboard navigation context and stores it on the TownDO so the
+ * mayor has awareness of what the user is viewing.
+ *
+ * Phase 1: Stores context as an in-memory XML string on the TownDO via
+ * a lightweight POST. The TownDO injects this into the mayor's prompt
+ * when starting a new session.
+ */
+
+type ActivityEntry = {
+  timestamp: string;
+  action: 'page_view' | 'object_view';
+  page?: string;
+  objectType?: string;
+  objectId?: string;
+};
+
+const MAX_ACTIVITY_ENTRIES = 10;
+const SYNC_DEBOUNCE_MS = 2_000;
+
+/** Derive a human-readable page label from the pathname. */
+function pageFromPathname(pathname: string, townId: string): string {
+  const base = `/gastown/${townId}`;
+  if (pathname === base) return 'town-overview';
+  const suffix = pathname.slice(base.length + 1);
+  if (suffix.startsWith('rigs/')) return 'rig-detail';
+  if (suffix.startsWith('beads')) return 'beads';
+  if (suffix.startsWith('agents')) return 'agents';
+  if (suffix.startsWith('merges')) return 'merges';
+  if (suffix.startsWith('mail')) return 'mail';
+  if (suffix.startsWith('observability')) return 'observability';
+  if (suffix.startsWith('settings')) return 'settings';
+  return suffix || 'town-overview';
+}
+
+function drawerResourceToXml(resource: ResourceRef): string {
+  switch (resource.type) {
+    case 'bead':
+      return `<viewing-object type="bead" id="${resource.beadId}" rig-id="${resource.rigId}" />`;
+    case 'agent':
+      return `<viewing-object type="agent" id="${resource.agentId}" rig-id="${resource.rigId}" />`;
+    case 'convoy':
+      return `<viewing-object type="convoy" id="${resource.convoyId}" />`;
+    case 'event':
+      return `<viewing-object type="event" />`;
+  }
+}
+
+function formatAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60_000) return `${Math.round(diff / 1000)}s ago`;
+  if (diff < 3600_000) return `${Math.round(diff / 60_000)}m ago`;
+  return `${Math.round(diff / 3600_000)}h ago`;
+}
+
+export function buildContextXml(
+  page: string,
+  drawerResource: ResourceRef | null,
+  recentActivity: ActivityEntry[]
+): string {
+  const lines: string[] = ['<user-context>'];
+  lines.push(`  <current-view page="${page}" />`);
+
+  if (drawerResource) {
+    lines.push(`  ${drawerResourceToXml(drawerResource)}`);
+  }
+
+  if (recentActivity.length > 0) {
+    lines.push('  <recent-actions>');
+    for (const entry of recentActivity) {
+      const ago = formatAgo(entry.timestamp);
+      if (entry.action === 'page_view') {
+        lines.push(`    - ${ago}: Navigated to ${entry.page ?? 'unknown'}`);
+      } else if (entry.objectType) {
+        lines.push(`    - ${ago}: Viewed ${entry.objectType} ${entry.objectId ?? ''}`);
+      }
+    }
+    lines.push('  </recent-actions>');
+  }
+
+  lines.push('</user-context>');
+  return lines.join('\n');
+}
+
+/**
+ * Hook that tracks the user's dashboard navigation and syncs the context
+ * XML to the TownDO via a lightweight POST. The TownDO stores it in
+ * memory and injects it when the mayor session starts or restarts.
+ */
+export function useGastownUiContext(townId: string, gastownUrl: string): string {
+  const pathname = usePathname();
+  const { stack } = useDrawerStack();
+  const activityRef = useRef<ActivityEntry[]>([]);
+  const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSyncedRef = useRef<string>('');
+
+  const topDrawer = stack.length > 0 ? stack[stack.length - 1].resource : null;
+
+  // Track page navigation
+  useEffect(() => {
+    const page = pageFromPathname(pathname, townId);
+    activityRef.current = [
+      { timestamp: new Date().toISOString(), action: 'page_view', page },
+      ...activityRef.current.slice(0, MAX_ACTIVITY_ENTRIES - 1),
+    ];
+  }, [pathname, townId]);
+
+  // Track drawer opens
+  useEffect(() => {
+    if (!topDrawer) return;
+    activityRef.current = [
+      {
+        timestamp: new Date().toISOString(),
+        action: 'object_view',
+        objectType: topDrawer.type,
+        objectId:
+          'beadId' in topDrawer
+            ? topDrawer.beadId
+            : 'agentId' in topDrawer
+              ? topDrawer.agentId
+              : 'convoyId' in topDrawer
+                ? topDrawer.convoyId
+                : undefined,
+      },
+      ...activityRef.current.slice(0, MAX_ACTIVITY_ENTRIES - 1),
+    ];
+  }, [topDrawer]);
+
+  // Build current context XML
+  const page = pageFromPathname(pathname, townId);
+  const contextXml = buildContextXml(page, topDrawer, activityRef.current);
+
+  // Debounced sync to TownDO
+  useEffect(() => {
+    if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
+    syncTimerRef.current = setTimeout(() => {
+      if (contextXml === lastSyncedRef.current) return;
+      lastSyncedRef.current = contextXml;
+
+      // Fire-and-forget POST to store context on the TownDO
+      getToken()
+        .then(token =>
+          fetch(`${gastownUrl}/api/towns/${townId}/mayor/dashboard-context`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ context: contextXml }),
+          })
+        )
+        .catch(() => {
+          // Best-effort — silently ignore failures
+        });
+    }, SYNC_DEBOUNCE_MS);
+
+    return () => {
+      if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
+    };
+  }, [contextXml, townId, gastownUrl]);
+
+  return contextXml;
+}

--- a/src/components/gastown/useGastownUiContext.ts
+++ b/src/components/gastown/useGastownUiContext.ts
@@ -30,7 +30,10 @@ function pageFromPathname(pathname: string, townId: string): string {
   const base = `/gastown/${townId}`;
   if (pathname === base) return 'town-overview';
   const suffix = pathname.slice(base.length + 1);
-  if (suffix.startsWith('rigs/')) return 'rig-detail';
+  if (suffix.startsWith('rigs/')) {
+    const rigId = suffix.split('/')[1];
+    return rigId ? `rig-detail (rigId: ${rigId})` : 'rigs';
+  }
   if (suffix.startsWith('beads')) return 'beads';
   if (suffix.startsWith('agents')) return 'agents';
   if (suffix.startsWith('merges')) return 'merges';

--- a/src/lib/gastown/trpc.ts
+++ b/src/lib/gastown/trpc.ts
@@ -42,7 +42,7 @@ async function fetchToken(): Promise<string> {
   return parsed.token;
 }
 
-async function getToken(): Promise<string> {
+export async function getToken(): Promise<string> {
   // Return cached token if still fresh (5 min buffer)
   if (cachedToken && Date.now() < tokenExpiresAt - 5 * 60 * 1000) {
     return cachedToken;


### PR DESCRIPTION
## Summary

Implements Phase 1 of the **UI-Aware Mayor: Dashboard Context Injection** feature from #447. Two capabilities:

1. **Dashboard Context Injection** — The frontend tracks which page/drawer the user is viewing, builds a `<user-context>` XML string, and syncs it to the TownDO via `POST /api/towns/:townId/mayor/dashboard-context`. When the mayor session starts (or restarts), this context is injected as a `<system-reminder>` block so the mayor knows what the user is looking at.

2. **UI Action Control** — The mayor can trigger UI actions in the user's browser via the `gt_ui_action` tool. Actions are broadcast over the existing status WebSocket as `ui_action` frames. The frontend handles these by opening DrawerStack drawers (bead, convoy, agent), navigating to pages, or highlighting beads.

**Backend changes:**
- `uiContext` accepted on mayor message endpoints (tRPC + HTTP)
- `setDashboardContext()` RPC on TownDO stores context in memory; `sendMayorMessage` uses it as fallback
- `gt_ui_action` tool + `broadcastUiAction()` on TownDO pushes `ui_action` frames over WebSocket
- Two HTTP routes for UI actions: dashboard-facing (kilo auth) and container-facing (mayor auth)
- `UiActionSchema` Zod schema centralized in `types.ts`
- Mayor system prompt extended with "Dashboard Context" and "UI Control" sections
- `handleSetDashboardContext` handler + route for context sync

**Frontend changes:**
- `useGastownUiContext` hook tracks pathname + DrawerStack changes, debounces context sync to TownDO
- `useAlarmStatusWs` extended to detect `channel: 'ui_action'` WebSocket frames
- `AlarmStatusPane` dispatches UI actions to DrawerStack (`open`) and Next.js router (`push`)
- `MayorTerminalBar` wires the context hook
- `getToken` exported from gastown trpc client for authenticated fetch calls

## Verification

- [x] `pnpm --filter cloudflare-gastown run typecheck` — passes
- [x] `pnpm --filter gastown-container run typecheck` — passes
- [x] `npx tsgo --noEmit --incremental false` (root) — passes
- [x] `prettier --check` on all modified files — passes

## Visual Changes

<img width="1699" height="1234" alt="image" src="https://github.com/user-attachments/assets/428ac053-c2d6-455b-b9ee-16244b5283d1" />

<img width="1699" height="1234" alt="image" src="https://github.com/user-attachments/assets/7dc23f28-77ae-4570-956e-0b4b5d1e38c2" />

## Reviewer Notes

- The `UiAction` type is defined in three places by necessity: the worker's `types.ts` (Zod schema, single source of truth), the plugin's `types.ts` (plain TS type for the container client), and inferred from Zod in `Town.do.ts`. The plugin can't import from the worker's `types.ts` since it's a separate package.
- The two HTTP routes for UI actions serve different auth contexts: `/api/towns/:townId/mayor/ui-action` (kilo JWT) and `/api/mayor/:townId/tools/ui-action` (container JWT).
- Dashboard context is stored in TownDO memory (not SQLite) — it's ephemeral and only useful for the current session. If the DO restarts, the context is lost, which is fine since the frontend will resync on next navigation.
- The `open_create_rig_dialog` action type is defined but not handled in the frontend yet — it would need a dedicated dialog state hook. Other action types are fully wired.
- `useGastownUiContext` uses a direct `fetch` with `getToken()` rather than tRPC because the endpoint is a simple fire-and-forget POST that doesn't need query caching or invalidation.