### PR TITLE
fix(google-setup): use manual OAuth flow for gog auth

### DIFF
--- a/kiloclaw/google-setup/Dockerfile
+++ b/kiloclaw/google-setup/Dockerfile
@@ -16,10 +16,10 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dea
   && apt-get update && apt-get install -y --no-install-recommends google-cloud-cli \
   && rm -rf /var/lib/apt/lists/*
 
-# Install gogcli v0.11.0 pre-built binary (arch-aware)
+# Install gogcli v0.12.0 pre-built binary (arch-aware)
 ARG TARGETARCH
 RUN GOARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
-  && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v0.11.0/gogcli_0.11.0_linux_${GOARCH}.tar.gz" \
+  && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${GOARCH}.tar.gz" \
     | tar xz -C /usr/local/bin gog \
   && chmod +x /usr/local/bin/gog
 

--- a/kiloclaw/google-setup/README.md
+++ b/kiloclaw/google-setup/README.md
@@ -14,7 +14,7 @@ Docker image that guides users through connecting their Google account to KiloCl
 ## Usage
 
 ```bash
-docker run -it --network host ghcr.io/kilo-org/google-setup --token="YOUR_SESSION_JWT"
+docker run -it ghcr.io/kilo-org/google-setup --token="YOUR_SESSION_JWT"
 ```
 
 For local development against a local worker:
@@ -24,6 +24,9 @@ docker run -it --network host ghcr.io/kilo-org/google-setup \
   --token="YOUR_SESSION_JWT" \
   --worker-url=http://localhost:8795
 ```
+
+> **Note:** `--network host` is only needed when using `--worker-url` pointing to localhost.
+> The OAuth flow uses a manual code-paste flow, so no port mapping is required.
 
 ## Publishing
 

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -12,7 +12,7 @@
  * 6. Tarballs the gog config, encrypts, and POSTs to the worker
  *
  * Usage:
- *   docker run -it --network host kilocode/google-setup --token=<jwt>
+ *   docker run -it ghcr.io/kilo-org/google-setup --token=<jwt>
  */
 
 import { spawn, execSync, execFileSync } from 'node:child_process';
@@ -38,7 +38,7 @@ const gmailPushWorkerUrl = gmailPushWorkerUrlArg
   : 'https://kiloclaw-gmail.kiloapps.io';
 
 if (!token) {
-  console.error('Usage: docker run -it --network host kilocode/google-setup --token=<session-jwt>');
+  console.error('Usage: docker run -it ghcr.io/kilo-org/google-setup --token=<session-jwt>');
   process.exit(1);
 }
 
@@ -388,17 +388,19 @@ try {
 // Use the gcloud account email for gog auth add
 const userEmail = gcloudAccount;
 console.log(`\nAuthorizing ${userEmail} with gog...`);
-console.log('A browser window will open for you to authorize Google Workspace access.\n');
+console.log('You will need to open a URL in your browser to authorize Google Workspace access.\n');
 console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-console.log('  When the browser opens:');
-console.log('  1. Google will warn "Google hasn\'t verified this app"');
+console.log('  gog will print an authorization URL.');
+console.log('  1. Open the URL in your browser');
+console.log('  2. Google will warn "Google hasn\'t verified this app"');
 console.log('     → Click "Continue"');
-console.log('  2. Select ALL permissions (check every box)');
-console.log('  3. Click "Continue"');
+console.log('  3. Select ALL permissions (check every box)');
+console.log('  4. Click "Continue"');
+console.log('  5. Copy the redirect URL from your browser and paste it here');
 console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
 
 try {
-  await runCommand('gog', ['auth', 'add', userEmail, '--services=all', '--force-consent'], {
+  await runCommand('gog', ['auth', 'add', userEmail, '--services=all', '--force-consent', '--manual'], {
     env: gogEnv,
   });
 } catch (err) {


### PR DESCRIPTION
## Summary
- Switch `gog auth add` to `--manual` mode so the OAuth flow works on Docker Desktop (macOS/Windows), where `--network host` doesn't actually share the host network
- Bump gogcli from v0.11.0 to v0.12.0
- Remove `--network host` from default usage instructions (only needed for `--worker-url=localhost`)

## Context
Users on macOS were getting "connection refused" errors at the gog auth step. The root cause: `gog auth add` starts a local HTTP server for the OAuth callback, but on Docker Desktop the container runs in a Linux VM — so `localhost` inside the container isn't reachable from the host browser.

The `--manual` flag makes gog print an auth URL instead. The user opens it in their browser, completes OAuth, then pastes the redirect URL back into the terminal.

## Test plan
- [x] Image built and pushed to `ghcr.io/kilo-org/google-setup:latest` (amd64 + arm64)
- [x] Run setup on macOS with Docker Desktop (no `--network host`)
- [x] Verify gcloud auth step still works
- [x] Verify gog auth step completes with manual URL paste flow
- [x] Verify credential upload succeeds