### PR TITLE
feat(kiloclaw): add 'starting' status for nonblocking async provision

### DIFF
--- a/kiloclaw/AGENTS.md
+++ b/kiloclaw/AGENTS.md
@@ -100,14 +100,15 @@ src/
 
 ## Instance Statuses
 
-| Status        | Meaning                                                  |
-| ------------- | -------------------------------------------------------- |
-| `provisioned` | Config stored, volume created, no machine yet            |
-| `running`     | Machine is started and healthy                           |
-| `stopped`     | Machine is stopped, volume persists                      |
-| `destroying`  | Two-phase destroy in progress, pending resource deletion |
+| Status        | Meaning                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `provisioned` | Config stored, volume created, no machine yet                   |
+| `starting`    | startAsync() fired; start() running in background via waitUntil |
+| `running`     | Machine is started and healthy                                  |
+| `stopped`     | Machine is stopped, volume persists                             |
+| `destroying`  | Two-phase destroy in progress, pending resource deletion        |
 
-The alarm runs for ALL statuses (not just `running`). `destroying` short-circuits reconciliation -- only retries pending deletes, never recreates resources.
+The alarm runs for ALL statuses (not just `running`). `destroying` short-circuits reconciliation -- only retries pending deletes, never recreates resources. `starting` uses a 1-min alarm cadence; reconcileStarting() checks Fly machine state and transitions to `running` or `stopped`. If `startingAt` is set and more than 5 minutes have elapsed, it falls back to `stopped` automatically.
 
 ## Environment Variables
 

--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -45,6 +45,10 @@ export const DEFAULT_FLY_REGION = 'dfw,ewr,iad,lax,sjc,eu';
 // Alarm cadence by instance status
 /** Running machines: fast health checks */
 export const ALARM_INTERVAL_RUNNING_MS = 5 * 60 * 1000; // 5 min
+/** Starting: wait for start() to complete and reconcile quickly */
+export const ALARM_INTERVAL_STARTING_MS = 60 * 1000; // 1 min
+/** Maximum time to stay in 'starting' before falling back to 'stopped' */
+export const STARTING_TIMEOUT_MS = 5 * 60 * 1000; // 5 min
 /** Destroying: retry pending deletes quickly */
 export const ALARM_INTERVAL_DESTROYING_MS = 60 * 1000; // 1 min
 /** Provisioned/stopped: slow drift detection */

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -115,7 +115,10 @@ function createFakeStorage() {
   let alarmTime: number | null = null;
 
   return {
-    get(keys: string[]): Map<string, unknown> {
+    get(keys: string | string[]): unknown {
+      if (typeof keys === 'string') {
+        return store.get(keys);
+      }
       const result = new Map<string, unknown>();
       for (const k of keys) {
         if (store.has(k)) result.set(k, store.get(k));
@@ -3580,6 +3583,29 @@ describe("status guards: 'starting'", () => {
     await expect(instance.startAsync()).rejects.toThrow(
       'Cannot start: instance is being destroyed'
     );
+  });
+
+  it('background start() aborts if instance was destroyed while starting', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-1',
+      region: 'iad',
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.provision('user-1', {});
+    expect(storage._store.get('status')).toBe('starting');
+
+    // Simulate destroy happening while start() is in flight
+    storage._store.set('status', 'destroying');
+
+    // Let the background start() complete — it should see 'destroying' and bail
+    await Promise.all(waitUntilPromises);
+
+    expect(storage._store.get('status')).toBe('destroying');
   });
 });
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -97,10 +97,12 @@ import { resolveLatestVersion } from '../lib/image-version';
 import { verifyKiloToken } from '@kilocode/worker-utils';
 import {
   ALARM_INTERVAL_RUNNING_MS,
+  ALARM_INTERVAL_STARTING_MS,
   ALARM_INTERVAL_DESTROYING_MS,
   ALARM_INTERVAL_IDLE_MS,
   ALARM_JITTER_MS,
   SELF_HEAL_THRESHOLD,
+  STARTING_TIMEOUT_MS,
   STALE_PROVISION_THRESHOLD_MS,
 } from '../config';
 
@@ -225,6 +227,18 @@ async function seedRunning(
     status: 'running',
     flyMachineId: 'machine-1',
     lastStartedAt: Date.now(),
+    ...overrides,
+  });
+}
+
+async function seedStarting(
+  storage: ReturnType<typeof createFakeStorage>,
+  overrides: Record<string, unknown> = {}
+) {
+  await seedProvisioned(storage, {
+    status: 'starting',
+    startingAt: Date.now(),
+    lastStartedAt: null,
     ...overrides,
   });
 }
@@ -2862,8 +2876,8 @@ describe('approveDevicePairingRequest', () => {
 // ============================================================================
 
 describe('provision: auto-start after fresh provision', () => {
-  it('calls start() on fresh provision and ends in running state', async () => {
-    const { instance, storage } = createInstance();
+  it('calls startAsync() on fresh provision; status is starting then running after background start', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
 
     (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
       id: 'vol-1',
@@ -2876,6 +2890,13 @@ describe('provision: auto-start after fresh provision', () => {
     const result = await instance.provision('user-1', {});
 
     expect(result.sandboxId).toBeDefined();
+    // provision() returns before start() runs: waitUntil defers the promise,
+    // so status must be 'starting' here — not 'running'.
+    expect(storage._store.get('status')).toBe('starting');
+
+    // Await background tasks to let start() complete
+    await Promise.all(waitUntilPromises);
+
     expect(flyClient.createMachine).toHaveBeenCalled();
     expect(storage._store.get('status')).toBe('running');
     expect(storage._store.get('flyMachineId')).toBe('machine-1');
@@ -3496,5 +3517,228 @@ describe('reconcileApiKeyExpiry', () => {
     await instance.alarm();
 
     expect(storage._store.get('kilocodeApiKey')).toBe('old-jwt');
+  });
+});
+
+// ============================================================================
+// 'starting' status
+// ============================================================================
+
+describe("provision: async start sets status to 'starting'", () => {
+  it("sets status='starting' immediately and fires start() via waitUntil", async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-1',
+      region: 'iad',
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.provision('user-1', {});
+
+    // provision() returned; waitUntil defers the background start() promise,
+    // so status must be 'starting' at this point — not yet 'running'.
+    expect(storage._store.get('status')).toBe('starting');
+
+    // Await all background tasks to let start() complete.
+    await Promise.all(waitUntilPromises);
+
+    expect(storage._store.get('status')).toBe('running');
+    expect(storage._store.get('flyMachineId')).toBe('machine-1');
+  });
+
+  it('skips async start on re-provision of existing instance', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.createMachine as Mock).mockClear();
+
+    await instance.provision('user-1', { kilocodeApiKey: 'new-key' });
+
+    expect(flyClient.createMachine).not.toHaveBeenCalled();
+    expect(storage._store.get('status')).toBe('running');
+  });
+});
+
+describe("status guards: 'starting'", () => {
+  it('stop() is a no-op when starting', async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, { flyMachineId: 'machine-1' });
+
+    await instance.stop();
+
+    expect(storage._store.get('status')).toBe('starting');
+    expect(flyClient.stopMachineAndWait).not.toHaveBeenCalled();
+  });
+
+  it('startAsync() rejects when destroying', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'destroying' });
+
+    await expect(instance.startAsync()).rejects.toThrow(
+      'Cannot start: instance is being destroyed'
+    );
+  });
+});
+
+describe("alarm cadence: 'starting'", () => {
+  it('schedules fast alarm for starting instances', async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, { flyMachineId: 'machine-1' });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'starting',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    const alarm = storage._getAlarm();
+    expect(alarm).not.toBeNull();
+    const delta = alarm! - Date.now();
+    expect(delta).toBeGreaterThanOrEqual(ALARM_INTERVAL_STARTING_MS);
+    expect(delta).toBeLessThanOrEqual(ALARM_INTERVAL_STARTING_MS + ALARM_JITTER_MS + 100);
+  });
+});
+
+describe('reconcileStarting: Fly-driven status transitions', () => {
+  it("transitions to 'running' when Fly machine is started", async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, { flyMachineId: 'machine-1', lastStartedAt: null });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('running');
+    expect(storage._store.get('healthCheckFailCount')).toBe(0);
+    // lastStartedAt should be backfilled since it was null
+    expect(storage._store.get('lastStartedAt')).not.toBeNull();
+  });
+
+  it("transitions to 'stopped' when Fly machine is 404", async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, { flyMachineId: 'machine-1' });
+
+    (flyClient.getMachine as Mock).mockRejectedValue(
+      new FlyApiError('not found', 404, 'machine not found')
+    );
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('flyMachineId')).toBeNull();
+  });
+
+  it("stays 'starting' when flyMachineId is not yet set (start in progress)", async () => {
+    const { instance, storage } = createInstance();
+    // No flyMachineId — start() hasn't created the machine yet
+    await seedStarting(storage);
+
+    await instance.alarm();
+
+    // Status remains starting; getMachine was NOT called
+    expect(storage._store.get('status')).toBe('starting');
+    expect(flyClient.getMachine).not.toHaveBeenCalled();
+  });
+
+  it("falls back to 'stopped' when startingAt exceeds STARTING_TIMEOUT_MS (no machine)", async () => {
+    const { instance, storage } = createInstance();
+    // Seed with a startingAt older than the timeout — no machine ID (start() never completed)
+    await seedStarting(storage, {
+      startingAt: Date.now() - STARTING_TIMEOUT_MS - 1000,
+    });
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('startingAt')).toBeNull();
+    // getMachine should NOT have been called — no flyMachineId to check
+    expect(flyClient.getMachine).not.toHaveBeenCalled();
+  });
+
+  it('checks Fly before timing out when flyMachineId is set and machine is started', async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, {
+      flyMachineId: 'machine-1',
+      startingAt: Date.now() - STARTING_TIMEOUT_MS - 1000,
+    });
+
+    // Machine actually started on Fly — timeout should NOT force 'stopped'
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // syncStatusWithFly should have transitioned to 'running' despite the timeout
+    expect(storage._store.get('status')).toBe('running');
+    expect(storage._store.get('startingAt')).toBeNull();
+    expect(storage._store.get('lastStartedAt')).not.toBeNull();
+  });
+
+  it("falls back to 'stopped' on timeout when flyMachineId is set but machine not started", async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, {
+      flyMachineId: 'machine-1',
+      startingAt: Date.now() - STARTING_TIMEOUT_MS - 1000,
+    });
+
+    // Machine exists but still in 'created' state after 5 min
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'created',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // Checked Fly first, but machine wasn't started — timeout kicks in
+    expect(flyClient.getMachine).toHaveBeenCalledWith(expect.anything(), 'machine-1');
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('startingAt')).toBeNull();
+  });
+});
+
+describe("syncStatusWithFly: backfill lastStartedAt on 'starting' → 'running'", () => {
+  it("sets lastStartedAt when transitioning from 'starting' to 'running'", async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, { flyMachineId: 'machine-1', lastStartedAt: null });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    expect(storage._store.get('lastStartedAt')).toBeGreaterThan(0);
+  });
+
+  it('does not overwrite existing lastStartedAt when already running', async () => {
+    const existingStartedAt = Date.now() - 10_000;
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { lastStartedAt: existingStartedAt });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    // lastStartedAt should be unchanged (already running, no sync_status transition)
+    expect(storage._store.get('lastStartedAt')).toBe(existingStartedAt);
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -758,6 +758,15 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       await gateway.waitForHealthy(this.s, this.env, flyConfig.appName, this.s.flyMachineId);
     }
 
+    // Re-check status directly from storage: if the instance was destroyed while
+    // start() was running in the background (via startAsync/waitUntil), bail out
+    // so teardown wins. We bypass loadState() because it no-ops when already loaded.
+    const currentStatus = await this.ctx.storage.get('status');
+    if (currentStatus === 'destroying') {
+      console.warn('[DO] start: instance was destroyed while starting, aborting');
+      return;
+    }
+
     this.s.status = 'running';
     this.s.startingAt = null;
     this.s.lastStartedAt = Date.now();

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -296,7 +296,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     if (isNew) {
-      await this.start(userId);
+      await this.startAsync(userId);
     }
 
     return { sandboxId };
@@ -591,6 +591,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     if (this.s.status === 'destroying') {
       throw new Error('Cannot start: instance is being destroyed');
     }
+    // NOTE: status may be 'starting' here when called from startAsync() via
+    // waitUntil. That is intentional — 'starting' is the expected in-flight
+    // state and must not be treated as an error or early-return condition.
+    // Do not add a guard that rejects non-stopped/provisioned statuses without
+    // also explicitly allowing 'starting'.
 
     if (!this.s.userId || !this.s.sandboxId) {
       const restoreUserId = userId ?? this.s.userId;
@@ -754,16 +759,47 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     this.s.status = 'running';
+    this.s.startingAt = null;
     this.s.lastStartedAt = Date.now();
     this.s.healthCheckFailCount = 0;
     await this.persist({
       status: 'running',
+      startingAt: null,
       lastStartedAt: this.s.lastStartedAt,
       healthCheckFailCount: 0,
       flyMachineId: this.s.flyMachineId,
     });
 
     await this.scheduleAlarm();
+  }
+
+  /**
+   * Non-blocking start: immediately persists status='starting', schedules a fast
+   * alarm, then fires start() in the background via waitUntil.
+   * Used by provision() so the RPC call returns quickly instead of waiting for
+   * the full Fly startup sequence (which can take up to ~60 s).
+   */
+  async startAsync(userId?: string): Promise<void> {
+    await this.loadState();
+
+    if (this.s.status === 'destroying') {
+      throw new Error('Cannot start: instance is being destroyed');
+    }
+
+    // Mark as starting so the UI can show a polling state immediately.
+    // Record startingAt so reconcileStarting() can time out after STARTING_TIMEOUT_MS.
+    this.s.status = 'starting';
+    this.s.startingAt = Date.now();
+    await this.persist({ status: 'starting', startingAt: this.s.startingAt });
+    await this.scheduleAlarm();
+
+    // Run the actual start in the background; the reconcile alarm will
+    // pick up the result and transition to 'running' (or fall back on error).
+    this.ctx.waitUntil(
+      this.start(userId).catch(err => {
+        console.error('[DO] startAsync: background start failed:', err);
+      })
+    );
   }
 
   async stop(): Promise<void> {
@@ -775,6 +811,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     if (
       this.s.status === 'stopped' ||
       this.s.status === 'provisioned' ||
+      this.s.status === 'starting' ||
       this.s.status === 'destroying'
     ) {
       console.log('[DO] Instance not running (status:', this.s.status, '), no-op');

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/log.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/log.ts
@@ -1,6 +1,7 @@
 import type { InstanceStatus } from './types';
 import {
   ALARM_INTERVAL_RUNNING_MS,
+  ALARM_INTERVAL_STARTING_MS,
   ALARM_INTERVAL_DESTROYING_MS,
   ALARM_INTERVAL_IDLE_MS,
   ALARM_JITTER_MS,
@@ -32,6 +33,8 @@ export function alarmIntervalForStatus(status: InstanceStatus): number {
   switch (status) {
     case 'running':
       return ALARM_INTERVAL_RUNNING_MS;
+    case 'starting':
+      return ALARM_INTERVAL_STARTING_MS;
     case 'destroying':
       return ALARM_INTERVAL_DESTROYING_MS;
     case 'provisioned':

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -6,6 +6,7 @@ import * as fly from '../../fly/client';
 import {
   SELF_HEAL_THRESHOLD,
   STARTUP_TIMEOUT_SECONDS,
+  STARTING_TIMEOUT_MS,
   getProactiveRefreshThresholdMs,
 } from '../../config';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../../utils/env-encryption';
@@ -41,6 +42,11 @@ export async function reconcileWithFly(
 ): Promise<void> {
   if (state.status === 'destroying') {
     await retryPendingDestroy(flyConfig, ctx, state, reason, markDestroyedInPostgres);
+    return;
+  }
+
+  if (state.status === 'starting') {
+    await reconcileStarting(flyConfig, ctx, state, env, reason);
     return;
   }
 
@@ -211,6 +217,118 @@ async function reconcileApiKeyExpiry(
   });
 }
 
+// ---- Starting reconciliation ----
+
+/**
+ * Reconcile a 'starting' instance.
+ *
+ * startAsync() fires start() via waitUntil, so start() may still be in
+ * progress when the alarm fires. We check Fly to decide what to do:
+ *
+ * - Machine started  → transition to 'running' (backfilling lastStartedAt).
+ * - Machine in a terminal stopped state → fall back to 'stopped'
+ *   (start() failed; the next alarm / user action will retry).
+ * - No machine yet (no flyMachineId, or Fly 404) → start() hasn't finished
+ *   or didn't create a machine; leave in 'starting' for the next alarm.
+ */
+async function reconcileStarting(
+  flyConfig: FlyClientConfig,
+  ctx: DurableObjectState,
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  reason: string
+): Promise<void> {
+  const startingAt = state.startingAt;
+  const isTimedOut = startingAt !== null && Date.now() - startingAt > STARTING_TIMEOUT_MS;
+
+  if (!state.flyMachineId) {
+    if (isTimedOut) {
+      // No machine after STARTING_TIMEOUT_MS — start() never created one. Give up.
+      reconcileLog(reason, 'starting_timeout', {
+        user_id: state.userId,
+        starting_at: state.startingAt,
+        elapsed_ms: Date.now() - startingAt,
+        new_state: 'stopped',
+      });
+      state.status = 'stopped';
+      state.startingAt = null;
+      state.lastStoppedAt = Date.now();
+      state.healthCheckFailCount = 0;
+      await ctx.storage.put(
+        storageUpdate({
+          status: 'stopped',
+          startingAt: null,
+          lastStoppedAt: state.lastStoppedAt,
+          healthCheckFailCount: 0,
+        })
+      );
+      return;
+    }
+    // start() hasn't persisted a machine ID yet — still in progress, wait.
+    reconcileLog(reason, 'starting_no_machine_yet', { user_id: state.userId });
+    return;
+  }
+
+  // We have a flyMachineId — always check Fly state, even if timed out.
+  // The machine may have started successfully despite the timeout.
+  try {
+    const machine = await fly.getMachine(flyConfig, state.flyMachineId);
+    await syncStatusWithFly(ctx, state, machine.state, reason);
+    // Ensure volume reconciliation doesn't get skipped while starting.
+    await reconcileVolume(flyConfig, ctx, state, env, reason);
+
+    // If syncStatusWithFly transitioned us out of 'starting', we're done.
+    // If still 'starting' after the timeout, the machine exists but isn't
+    // started yet — fall back to 'stopped' so the user can retry.
+    if (isTimedOut && state.status === 'starting') {
+      reconcileLog(reason, 'starting_timeout_with_machine', {
+        machine_id: state.flyMachineId,
+        fly_state: machine.state,
+        elapsed_ms: Date.now() - startingAt,
+        new_state: 'stopped',
+      });
+      state.status = 'stopped';
+      state.startingAt = null;
+      state.lastStoppedAt = Date.now();
+      state.healthCheckFailCount = 0;
+      await ctx.storage.put(
+        storageUpdate({
+          status: 'stopped',
+          startingAt: null,
+          lastStoppedAt: state.lastStoppedAt,
+          healthCheckFailCount: 0,
+        })
+      );
+    }
+  } catch (err) {
+    if (fly.isFlyNotFound(err)) {
+      // Machine was never created or was cleaned up externally.
+      reconcileLog(reason, 'starting_machine_gone', {
+        machine_id: state.flyMachineId,
+        new_state: 'stopped',
+      });
+      state.flyMachineId = null;
+      state.status = 'stopped';
+      state.startingAt = null;
+      state.lastStoppedAt = Date.now();
+      state.healthCheckFailCount = 0;
+      await ctx.storage.put(
+        storageUpdate({
+          flyMachineId: null,
+          status: 'stopped',
+          startingAt: null,
+          lastStoppedAt: state.lastStoppedAt,
+          healthCheckFailCount: 0,
+        })
+      );
+    } else {
+      // Transient Fly API error — leave in 'starting', alarm will retry.
+      // If timed out, still give the next alarm a chance to reach Fly.
+      console.error('[DO] reconcileStarting: transient error checking machine:', err);
+    }
+  }
+}
+
 // ---- Volume reconciliation ----
 
 async function reconcileVolume(
@@ -370,8 +488,23 @@ export async function syncStatusWithFly(
   if (flyState === 'started' && state.status !== 'running') {
     reconcileLog(reason, 'sync_status', { old_state: state.status, new_state: 'running' });
     state.status = 'running';
+    state.startingAt = null;
     state.healthCheckFailCount = 0;
-    await ctx.storage.put(storageUpdate({ status: 'running', healthCheckFailCount: 0 }));
+    // Backfill lastStartedAt whenever a transition to 'running' is observed and
+    // it hasn't been set yet. This covers both the async-start path (starting →
+    // running) and DO-wipe + metadata recovery (stopped → running with null
+    // lastStartedAt). Intentionally broader than just the 'starting' case.
+    if (state.lastStartedAt === null) {
+      state.lastStartedAt = Date.now();
+    }
+    await ctx.storage.put(
+      storageUpdate({
+        status: 'running',
+        startingAt: null,
+        healthCheckFailCount: 0,
+        lastStartedAt: state.lastStartedAt,
+      })
+    );
     return;
   }
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -38,6 +38,7 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.channels = d.channels;
     s.googleCredentials = d.googleCredentials;
     s.provisionedAt = d.provisionedAt;
+    s.startingAt = d.startingAt;
     s.lastStartedAt = d.lastStartedAt;
     s.lastStoppedAt = d.lastStoppedAt;
     s.flyAppName = d.flyAppName;
@@ -91,6 +92,7 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.channels = null;
   s.googleCredentials = null;
   s.provisionedAt = null;
+  s.startingAt = null;
   s.lastStartedAt = null;
   s.lastStoppedAt = null;
   s.flyAppName = null;
@@ -137,6 +139,7 @@ export function createMutableState(): InstanceMutableState {
     channels: null,
     googleCredentials: null,
     provisionedAt: null,
+    startingAt: null,
     lastStartedAt: null,
     lastStoppedAt: null,
     flyAppName: null,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -50,6 +50,7 @@ export type InstanceMutableState = {
   channels: PersistedState['channels'];
   googleCredentials: GoogleCredentials | null;
   provisionedAt: number | null;
+  startingAt: number | null;
   lastStartedAt: number | null;
   lastStoppedAt: number | null;
   flyAppName: string | null;

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -116,7 +116,9 @@ export const DestroyRequestSchema = z.object({
 export const PersistedStateSchema = z.object({
   userId: z.string().default(''),
   sandboxId: z.string().default(''),
-  status: z.enum(['provisioned', 'running', 'stopped', 'destroying']).default('stopped'),
+  status: z
+    .enum(['provisioned', 'starting', 'running', 'stopped', 'destroying'])
+    .default('stopped'),
   envVars: z.record(z.string(), z.string()).nullable().default(null),
   encryptedSecrets: z.record(z.string(), EncryptedEnvelopeSchema).nullable().default(null),
   kilocodeApiKey: z.string().nullable().default(null),
@@ -133,6 +135,7 @@ export const PersistedStateSchema = z.object({
     .default(null),
   googleCredentials: GoogleCredentialsSchema.nullable().default(null),
   provisionedAt: z.number().nullable().default(null),
+  startingAt: z.number().nullable().default(null),
   lastStartedAt: z.number().nullable().default(null),
   lastStoppedAt: z.number().nullable().default(null),
   // Fly.io app/machine/volume identifiers

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -45,6 +45,7 @@ export function InstanceControls({
   const posthog = usePostHog();
   const isRunning = status.status === 'running';
   const isProvisioned = status.status === 'provisioned';
+  const isStarting = status.status === 'starting';
   const isStopped = status.status === 'stopped' || isProvisioned;
   const isDestroying = status.status === 'destroying';
   // Auto-start runs only on fresh provision (status=provisioned), not re-provision
@@ -78,14 +79,16 @@ export function InstanceControls({
           size="sm"
           variant="outline"
           className="border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-300"
-          disabled={!isStopped || mutations.start.isPending || isAutoStarting || isDestroying}
+          disabled={
+            !isStopped || mutations.start.isPending || isAutoStarting || isDestroying || isStarting
+          }
           onClick={() => {
             posthog?.capture('claw_start_instance_clicked', { instance_status: status.status });
             mutations.start.mutate();
           }}
         >
           <Play className="h-4 w-4" />
-          {mutations.start.isPending || isAutoStarting ? (
+          {mutations.start.isPending || isAutoStarting || isStarting ? (
             <>
               Starting
               <AnimatedDots />
@@ -98,7 +101,7 @@ export function InstanceControls({
           size="sm"
           variant="outline"
           className="border-violet-500/30 text-violet-400 hover:bg-violet-500/10 hover:text-violet-300"
-          disabled={!isRunning || mutations.restartOpenClaw.isPending || isDestroying}
+          disabled={!isRunning || mutations.restartOpenClaw.isPending || isDestroying || isStarting}
           onClick={() => {
             posthog?.capture('claw_restart_openclaw_prompted', {
               instance_status: status.status,
@@ -113,7 +116,7 @@ export function InstanceControls({
           size="sm"
           variant="outline"
           className="border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
-          disabled={!isRunning || mutations.restartMachine.isPending || isDestroying}
+          disabled={!isRunning || mutations.restartMachine.isPending || isDestroying || isStarting}
           onClick={() => {
             posthog?.capture('claw_redeploy_prompted', { instance_status: status.status });
             setRedeployMode('redeploy');
@@ -127,7 +130,7 @@ export function InstanceControls({
           size="sm"
           variant="outline"
           className="border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/10 hover:text-cyan-300"
-          disabled={!isRunning || mutations.runDoctor.isPending || isDestroying}
+          disabled={!isRunning || mutations.runDoctor.isPending || isDestroying || isStarting}
           onClick={() => {
             posthog?.capture('claw_doctor_clicked', { instance_status: status.status });
             setDoctorOpen(true);

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -248,6 +248,7 @@ export function SettingsTab({
   );
 
   const isSaving = mutations.patchConfig.isPending;
+  const isStarting = status.status === 'starting';
   const isDestroying = status.status === 'destroying';
   const supportsConfigRestore = calverAtLeast(
     cleanVersion(controllerVersion?.version),
@@ -614,7 +615,7 @@ export function SettingsTab({
               <Button
                 variant="outline"
                 size="sm"
-                disabled={!isRunning || mutations.stop.isPending || isDestroying}
+                disabled={!isRunning || mutations.stop.isPending || isDestroying || isStarting}
                 onClick={() => {
                   posthog?.capture('claw_stop_instance_clicked', {
                     instance_status: status.status,

--- a/src/app/(app)/claw/components/claw.types.ts
+++ b/src/app/(app)/claw/components/claw.types.ts
@@ -10,6 +10,10 @@ export const CLAW_STATUS_BADGE: Record<
     label: 'Machine Online',
     className: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-400',
   },
+  starting: {
+    label: 'Starting',
+    className: 'border-blue-500/30 bg-blue-500/15 text-blue-400 animate-pulse',
+  },
   stopped: {
     label: 'Machine Stopped',
     className: 'border-red-500/30 bg-red-500/15 text-red-400',

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -113,6 +113,8 @@ function StatusBadge({ status }: { status: string | null }) {
   switch (status) {
     case 'running':
       return <Badge className="bg-green-600">Running</Badge>;
+    case 'starting':
+      return <Badge className="bg-blue-500">Starting</Badge>;
     case 'stopped':
       return <Badge variant="secondary">Stopped</Badge>;
     case 'provisioned':

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -119,7 +119,7 @@ export type MachineSize = {
 export type PlatformStatusResponse = {
   userId: string | null;
   sandboxId: string | null;
-  status: 'provisioned' | 'running' | 'stopped' | 'destroying' | null;
+  status: 'provisioned' | 'starting' | 'running' | 'stopped' | 'destroying' | null;
   provisionedAt: number | null;
   lastStartedAt: number | null;
   lastStoppedAt: number | null;


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Adds starting status to the kiloclaw instance lifecycle so provision() returns immediately   (~1s) instead of blocking up to 60s waiting for the Fly machine to start
- startAsync() sets status='starting', records startingAt timestamp, then fires the full   start() in the background via waitUntil
- New reconcileStarting() handles the starting state: checks Fly machine state, transitions   to running when started, falls back to stopped on timeout (5 min) or 404
- Timeout check with flyMachineId set always queries Fly first — a machine that actually   started is never incorrectly forced to stopped
- start() re-reads status from storage before persisting running to prevent a background   start from resurrecting a destroyed instance
- syncStatusWithFly backfills lastStartedAt on any transition to running where it was null
- Frontend shows "Starting" badge with pulse animation, disables Start/Restart/Stop/Doctor   buttons during starting

## Verification

- 678 unit tests passing (includes 12 new tests for starting status)
- Tests cover: async provision flow, status guards, alarm cadence, reconcile transitions   (running/stopped/404/no-machine/timeout), timeout with and without flyMachineId,   lastStartedAt backfill, destroy-race prevention
- Prettier formatting clean
- ESLint clean
- Rebased on latest main, resolved merge conflicts with proactive API key refresh feature
- Reviewed and addressed 3 of 5 kilo-code-bot findings (1 fixed, 2 acknowledged as   designed/existing behavior, 2 tracked as follow-ups)


## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->
- New "Starting" status badge (blue, pulsing) in both user and admin views
- Start button shows "Starting..." with animated dots during starting state
- All action buttons (Start, Restart OpenClaw, Redeploy, Doctor, Stop) disabled during   starting


## Reviewer Notes

- startAsync() reuses the full existing start() method via waitUntil rather than duplicating   machine-creation logic — simpler and keeps the synchronous start() path unchanged for   explicit user-initiated starts
- The 5-min STARTING_TIMEOUT_MS is a safety net for cases where start() fails before creating    a machine. A follow-up ticket exists to fast-fail by setting stopped directly in the   .catch() handler
- stop() is a no-op during starting — the background start may complete afterward.   Cancellation would require significant complexity; tracked as a follow-up
- External start() calls during starting could theoretically race with the background start,   but the UI disables the button and DO single-threading limits practical risk; tracked as a   follow-up
