### PR TITLE
fix(test): add missing handleSignupPromotion mock to account-verification test

### DIFF
--- a/src/tests/account-verification-redirect.test.ts
+++ b/src/tests/account-verification-redirect.test.ts
@@ -37,8 +37,10 @@ jest.mock('@/lib/user.server', () => ({
 }));
 
 const mockGetStytchStatus = jest.fn<Promise<boolean | null>, [User, string | null, Headers]>();
+const mockHandleSignupPromotion = jest.fn<Promise<void>, [User, boolean]>();
 jest.mock('@/lib/stytch', () => ({
   getStytchStatus: (...args: [User, string | null, Headers]) => mockGetStytchStatus(...args),
+  handleSignupPromotion: (...args: [User, boolean]) => mockHandleSignupPromotion(...args),
 }));
 
 // Mock React components that aren't relevant to redirect testing


### PR DESCRIPTION
## Summary

PR #1119 added `handleSignupPromotion` to `src/app/account-verification/page.tsx` (imported from `@/lib/stytch`), but the test file's mock for `@/lib/stytch` was not updated to include it. This caused all 13 tests in `account-verification-redirect.test.ts` to fail with `TypeError: handleSignupPromotion is not a function`.

Adds the missing `handleSignupPromotion` mock to the `@/lib/stytch` jest mock.

## Verification

- [x] `pnpm jest src/tests/account-verification-redirect.test.ts` — all 13 tests pass
- [x] `pnpm prettier --check src/tests/account-verification-redirect.test.ts` — passes

## Visual Changes

N/A

## Reviewer Notes

One-line fix. The mock just needs to exist (returns `undefined` by default) since the test is only exercising redirect logic, not signup promotion behavior.