### PR TITLE
fix(kiloclaw): handle Fly 'failed' machine state

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -722,6 +722,71 @@ describe('reconciliation: machine status sync', () => {
   });
 });
 
+describe('reconciliation: Fly failed state', () => {
+  it("immediately transitions running → stopped on Fly 'failed' (no threshold)", async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'failed', config: {} });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    // Single alarm should be enough — no SELF_HEAL_THRESHOLD wait
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('healthCheckFailCount')).toBe(0);
+    expect(storage._store.get('lastStoppedAt')).not.toBeNull();
+  });
+
+  it("immediately transitions starting → stopped on Fly 'failed' and clears startingAt", async () => {
+    const { instance, storage } = createInstance();
+    await seedStarting(storage, { flyMachineId: 'machine-1' });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'failed', config: {} });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('startingAt')).toBeNull();
+    expect(storage._store.get('lastStoppedAt')).not.toBeNull();
+  });
+
+  it("is a no-op when already stopped and Fly reports 'failed'", async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'stopped', flyMachineId: 'machine-1' });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'failed', config: {} });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+  });
+
+  it("live check marks stopped in-memory on Fly 'failed'", async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'failed',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+
+    // First call returns cached 'running'; live check fires in background
+    const result1 = await instance.getStatus();
+    await Promise.all(waitUntilPromises);
+
+    // Second call sees in-memory update from live check
+    const result2 = await instance.getStatus();
+
+    expect(result1.status).toBe('running'); // fire-and-forget: cached
+    expect(result2.status).toBe('stopped'); // updated in-memory by live check
+    // Storage is NOT updated — alarm loop owns persistence
+    expect(storage._store.get('status')).toBe('running');
+  });
+});
+
 describe('reconciliation: missing machine (404)', () => {
   it('clears stale machineId and marks stopped', async () => {
     const { instance, storage } = createInstance();
@@ -1172,6 +1237,25 @@ describe('startExistingMachine: transient vs 404 errors', () => {
   });
 });
 
+describe('startExistingMachine: failed Fly machine', () => {
+  it('restarts a failed machine via updateMachine instead of timing out', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'stopped', flyMachineId: 'machine-1' });
+
+    // Machine is in 'failed' state on Fly
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'failed', config: {} });
+    (flyClient.updateMachine as Mock).mockResolvedValue({});
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.start('user-1');
+
+    // updateMachine should have been called (not just waitForState)
+    expect(flyClient.updateMachine).toHaveBeenCalled();
+    expect(storage._store.get('status')).toBe('running');
+  });
+});
+
 describe('createNewMachine: persist ID before waitForState', () => {
   it('persists machine ID to storage before calling waitForState', async () => {
     const { instance, storage } = createInstance();
@@ -1554,6 +1638,26 @@ describe('metadata recovery via alarm', () => {
 
     // listMachines should NOT have been called due to cooldown
     expect(flyClient.listMachines).not.toHaveBeenCalled();
+  });
+
+  it("recovers failed machine as 'stopped'", async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { flyMachineId: null });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+    (flyClient.listMachines as Mock).mockResolvedValue([
+      fakeMachine({
+        id: 'failed-machine',
+        state: 'failed',
+        region: 'ord',
+        config: { image: 'test:latest', mounts: [{ volume: 'vol-1', path: '/root' }] },
+      }),
+    ]);
+
+    await instance.alarm();
+
+    expect(storage._store.get('flyMachineId')).toBe('failed-machine');
+    expect(storage._store.get('status')).toBe('stopped');
   });
 
   it('does not attempt recovery during destroying', async () => {

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -172,7 +172,8 @@ export async function startExistingMachine(
       machineConfig = { ...machineConfig, guest: guestFromSize(state.machineSize) };
     }
 
-    if (machine.state === 'stopped' || machine.state === 'created') {
+    // failed machines are restartable via updateMachine (Fly re-launches on the next available host)
+    if (machine.state === 'stopped' || machine.state === 'created' || machine.state === 'failed') {
       await fly.updateMachine(flyConfig, state.flyMachineId, machineConfig, { minSecretsVersion });
       await fly.waitForState(flyConfig, state.flyMachineId, 'started', STARTUP_TIMEOUT_SECONDS);
       console.log('[DO] Machine updated and started:', state.flyMachineId);

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -275,6 +275,10 @@ async function reconcileStarting(
     const machine = await fly.getMachine(flyConfig, state.flyMachineId);
     await syncStatusWithFly(ctx, state, machine.state, reason);
     // Ensure volume reconciliation doesn't get skipped while starting.
+    // Note: reconcileApiKeyExpiry and reconcileMachineMount are intentionally
+    // skipped — the machine isn't running yet so there's no endpoint to push
+    // a refreshed key to, and mount drift will be caught on the first regular
+    // alarm once status transitions to 'running'.
     await reconcileVolume(flyConfig, ctx, state, env, reason);
 
     // If syncStatusWithFly transitioned us out of 'starting', we're done.
@@ -442,7 +446,11 @@ export async function attemptMetadataRecovery(
     if (candidate.state === 'started') {
       state.status = 'running';
       updates.status = 'running';
-    } else if (candidate.state === 'stopped' || candidate.state === 'created') {
+    } else if (
+      candidate.state === 'stopped' ||
+      candidate.state === 'created' ||
+      candidate.state === 'failed'
+    ) {
       state.status = 'stopped';
       updates.status = 'stopped';
     }
@@ -513,6 +521,25 @@ export async function syncStatusWithFly(
       state.healthCheckFailCount = 0;
       await ctx.storage.put(storageUpdate({ healthCheckFailCount: 0 }));
     }
+    return;
+  }
+
+  // failed is definitively terminal — transition immediately without waiting for
+  // SELF_HEAL_THRESHOLD consecutive checks like we do for stopped/created.
+  if (flyState === 'failed' && state.status !== 'stopped') {
+    reconcileLog(reason, 'sync_status_failed', { old_state: state.status, fly_state: flyState });
+    state.status = 'stopped';
+    state.startingAt = null;
+    state.lastStoppedAt = Date.now();
+    state.healthCheckFailCount = 0;
+    await ctx.storage.put(
+      storageUpdate({
+        status: 'stopped',
+        startingAt: null,
+        lastStoppedAt: state.lastStoppedAt,
+        healthCheckFailCount: 0,
+      })
+    );
     return;
   }
 

--- a/kiloclaw/src/durable-objects/machine-recovery.ts
+++ b/kiloclaw/src/durable-objects/machine-recovery.ts
@@ -31,7 +31,8 @@ const STATE_PRIORITY: ReadonlyMap<FlyMachineState, number> = new Map([
   ['created', 3],
   ['stopping', 4],
   ['replacing', 5],
-  ['failed', 6],
+  ['suspended', 6],
+  ['failed', 7],
 ]);
 
 /**

--- a/kiloclaw/src/durable-objects/machine-recovery.ts
+++ b/kiloclaw/src/durable-objects/machine-recovery.ts
@@ -17,6 +17,7 @@ export const TERMINAL_STOPPED_STATES: ReadonlySet<FlyMachineState> = new Set([
   'created',
   'destroyed',
   'suspended',
+  'failed',
 ]);
 
 /**
@@ -30,6 +31,7 @@ const STATE_PRIORITY: ReadonlyMap<FlyMachineState, number> = new Map([
   ['created', 3],
   ['stopping', 4],
   ['replacing', 5],
+  ['failed', 6],
 ]);
 
 /**

--- a/kiloclaw/src/fly/types.ts
+++ b/kiloclaw/src/fly/types.ts
@@ -14,7 +14,8 @@ export type FlyMachineState =
   | 'suspended'
   | 'replacing'
   | 'destroying'
-  | 'destroyed';
+  | 'destroyed'
+  | 'failed';
 
 /**
  * States accepted by the /wait endpoint (spec.json:1549).


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Handle Fly failed machine state, which was previously unrecognized and   left instances stuck in running with a dead machine indefinitely
- Add failed to FlyMachineState type, TERMINAL_STOPPED_STATES, and   STATE_PRIORITY
- Immediate transition to stopped in syncStatusWithFly when Fly reports   failed (no SELF_HEAL_THRESHOLD wait — failed is definitively terminal)
- Clear startingAt on failed transition for instances in starting state
- Handle failed in metadata recovery candidate mapping (maps to stopped)
- Handle failed in startExistingMachine so start() restarts via   updateMachine instead of timing out on waitForState
- Add suspended to STATE_PRIORITY so recovery prefers a hibernated machine   over a crashed one


## Verification

- 684 unit tests passing (6 new tests for failed state handling)
- Tests cover: running→stopped via failed (single alarm, no threshold),   starting→stopped via failed (clears startingAt), no-op when already stopped,    live check in-memory update, metadata recovery with failed candidate,   startExistingMachine restart of failed machine
- Prettier formatting clean
- ESLint clean
- No Zod schema changes needed — FlyMachineState is a TypeScript type only,   not validated via Zod at runtime


## Visual Changes
N/A

## Reviewer Notes

- failed is treated as immediately terminal in syncStatusWithFly rather than    going through the SELF_HEAL_THRESHOLD debounce used for stopped/created.   Unlike those states which can be transient during restarts, failed is   definitively terminal — a machine won't self-heal from it
- syncStatusFromLiveCheck was previously actively harmful for failed — it   fell into the else branch and reset healthCheckFailCount to 0, treating it   as a transitional state. Adding failed to TERMINAL_STOPPED_STATES fixes this
- The startExistingMachine fix ensures that when a user clicks "Start" on a   stopped instance whose underlying Fly machine is in failed state, it calls   updateMachine (which relaunches on the next available host) instead of   calling waitForState which would always time out
- STATE_PRIORITY now includes both suspended (6) and failed (7) — in the   rare duplicate-machine recovery scenario, a hibernated machine is preferred   over a crashed one
