### PR TITLE
fix(kiloclaw): inform user they need a subscription

### DIFF
--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -84,7 +84,9 @@ export function InstanceControls({
           }
           onClick={() => {
             posthog?.capture('claw_start_instance_clicked', { instance_status: status.status });
-            mutations.start.mutate();
+            mutations.start.mutate(undefined, {
+              onError: err => toast.error(err.message, { duration: 10000 }),
+            });
           }}
         >
           <Play className="h-4 w-4" />
@@ -162,7 +164,7 @@ export function InstanceControls({
               toast.success('OpenClaw restarting');
               setConfirmRestart(false);
             },
-            onError: err => toast.error(err.message),
+            onError: err => toast.error(err.message, { duration: 10000 }),
           });
         }}
       />
@@ -233,7 +235,7 @@ export function InstanceControls({
                     setConfirmRedeploy(false);
                     onRedeploySuccess?.();
                   },
-                  onError: err => toast.error(err.message),
+                  onError: err => toast.error(err.message, { duration: 10000 }),
                 });
               }}
               disabled={mutations.restartMachine.isPending}

--- a/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
+++ b/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
@@ -71,6 +71,15 @@ function getLockContent(reason: ClawLockReason) {
         action: 'update_payment' as const,
         icon: CreditCard,
       };
+    case 'no_access':
+      return {
+        title: 'Subscription Required',
+        description:
+          'A KiloClaw subscription is required to continue. Subscribe to keep your instance running.',
+        cta: 'Subscribe',
+        action: 'subscribe' as const,
+        icon: Lock,
+      };
     default:
       return null;
   }
@@ -85,6 +94,9 @@ function getInfoBoxMessage(reason: ClawLockReason): string {
   }
   if (reason === 'past_due_grace_exceeded') {
     return 'Your KiloClaw will resume automatically once payment is resolved.';
+  }
+  if (reason === 'no_access') {
+    return 'Subscribe to unlock full access to KiloClaw.';
   }
   return 'Your KiloClaw will resume automatically once you subscribe.';
 }
@@ -112,7 +124,7 @@ export function AccessLockedDialog({
   }
 
   function handleDismiss() {
-    router.push('/claw');
+    router.push('/');
   }
 
   return (

--- a/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
+import { Button } from '@/components/ui/button';
 import { BillingBanner } from './BillingBanner';
 import { AccessLockedDialog } from './AccessLockedDialog';
 import { PlanSelectionDialog } from './PlanSelectionDialog';
@@ -10,7 +11,13 @@ import { SubscriptionCard } from './SubscriptionCard';
 import { CancelDialog } from './CancelDialog';
 import { deriveBannerState, deriveLockReason, formatBillingDate } from './billing-types';
 
-function EarlybirdActiveCard({ expiresAt }: { expiresAt: string }) {
+function EarlybirdActiveCard({
+  expiresAt,
+  onSubscribeClick,
+}: {
+  expiresAt: string;
+  onSubscribeClick: () => void;
+}) {
   return (
     <div className="border-brand-primary/30 bg-brand-primary/5 flex items-center gap-3 rounded-xl border p-4">
       <span className="text-xl">🦀</span>
@@ -22,6 +29,9 @@ function EarlybirdActiveCard({ expiresAt }: { expiresAt: string }) {
           Your earlybird hosting expires {formatBillingDate(expiresAt)}.
         </span>
       </div>
+      <Button variant="outline" size="sm" onClick={onSubscribeClick} className="shrink-0">
+        Subscribe
+      </Button>
     </div>
   );
 }
@@ -74,7 +84,10 @@ export function BillingWrapper({ children }: BillingWrapperProps) {
     <>
       {/* Banner — or earlybird card in the banner position */}
       {bannerState === 'earlybird_active' && billing.earlybird ? (
-        <EarlybirdActiveCard expiresAt={billing.earlybird.expiresAt} />
+        <EarlybirdActiveCard
+          expiresAt={billing.earlybird.expiresAt}
+          onSubscribeClick={handleSubscribe}
+        />
       ) : (
         <BillingBanner
           billing={billing}

--- a/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Check } from 'lucide-react';
 import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -91,9 +92,15 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   const planName = selectedPlan === 'commit' ? 'Commit' : 'Standard';
 
   async function handlePurchase() {
-    const result = await checkout.mutateAsync({ plan: selectedPlan });
-    if (result.url) {
-      window.location.href = result.url;
+    try {
+      const result = await checkout.mutateAsync({ plan: selectedPlan });
+      if (result.url) {
+        window.location.href = result.url;
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to start checkout. Please try again.';
+      toast.error(message, { duration: 10000 });
     }
   }
 

--- a/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/src/app/(app)/claw/components/billing/billing-types.ts
@@ -121,7 +121,11 @@ export function deriveLockReason(billing: ClawBillingStatus): ClawLockReason {
     }
     // Fallback: access is revoked but no specific expired state was matched.
     // This covers cases like an account with an instance but no trial/subscription/earlybird row.
-    return 'no_access';
+    // Only lock if the user has an instance — new trial-eligible users with no instance
+    // should see CreateInstanceCard, not a lock dialog.
+    if (billing.instance) {
+      return 'no_access';
+    }
   }
   return null;
 }

--- a/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/src/app/(app)/claw/components/billing/billing-types.ts
@@ -68,6 +68,7 @@ export type ClawLockReason =
   | 'subscription_expired_instance_alive'
   | 'subscription_expired_instance_destroyed'
   | 'past_due_grace_exceeded'
+  | 'no_access'
   | null;
 
 export function deriveBannerState(billing: ClawBillingStatus): ClawBannerState {
@@ -118,6 +119,9 @@ export function deriveLockReason(billing: ClawBillingStatus): ClawLockReason {
     if (billing.earlybird && billing.earlybird.daysRemaining <= 0) {
       return 'earlybird_expired';
     }
+    // Fallback: access is revoked but no specific expired state was matched.
+    // This covers cases like an account with an instance but no trial/subscription/earlybird row.
+    return 'no_access';
   }
   return null;
 }


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Adds a no_access fallback lock reason so users without any billing    coverage (no trial, no subscription, no earlybird) but with an existing    instance are shown a "Subscription Required" dialog instead of   silently passing through
- Adds a "Subscribe" button to the earlybird active card so earlybird   users can proactively upgrade before expiration
- Surfaces checkout and instance control errors via toast notifications    with a 10s duration (previously errors were silent or dismissed too   quickly)
- Fixes lock dialog dismiss redirect: now sends users to / instead of   /claw which would re-trigger the lock dialog and trap them
- Guards trial-eligible new users from the no_access lock — only users   with an existing instance are locked out


## Verification
- 684 unit tests passing (6 new tests for failed state   handling)
- Tests cover: running→stopped via failed (single alarm, no    threshold), starting→stopped via failed (clears   startingAt), no-op when already stopped, live check   in-memory update, metadata recovery with failed candidate,   startExistingMachine restart of failed machine
- Prettier formatting clean
- ESLint clean
- No Zod schema changes needed — FlyMachineState is a   TypeScript type only, not validated via Zod at runtime


## Visual Changes
  No lock dialog for users without billing coverage → Now shows
  "Subscription Required" lock dialog with Subscribe CTA

  Earlybird card has no subscribe action → Now includes a "Subscribe"
  button

  Lock dialog dismiss navigates to /claw (re-triggers lock) → Now
  navigates to / (main page)
  



## Reviewer Notes

- The no_access lock is a catch-all for edge cases where hasAccess is   false but no specific expired state matches (e.g., an account with an   instance but missing trial/subscription/earlybird rows). It   intentionally skips users with no instance to avoid blocking   trial-eligible new users who are routed to CreateInstanceCard by   page.tsx
- Error toast duration increased to 10s across InstanceControls — error    messages need more reading time than the default ~4s
