### PR TITLE
fix(terminal): inject Kitty CSI u sequences for Shift/Alt/Ctrl+Enter in xterm.js

### DIFF
--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -10,6 +10,7 @@ import { ChevronDown, ChevronUp, Crown, Activity, Terminal as TerminalIcon, X } 
 import { motion, AnimatePresence } from 'motion/react';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
+import { attachKittyEnterHandler } from './useXtermPty';
 
 const COLLAPSED_HEIGHT = 38;
 const EXPANDED_HEIGHT = 300;
@@ -622,22 +623,7 @@ function MayorTerminalPane({ townId, collapsed }: { townId: string; collapsed: b
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
-      term.attachCustomKeyEventHandler(ev => {
-        if (ev.type !== 'keydown') return true;
-        if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
-          term.input('\x1b[13;2u');
-          return false;
-        }
-        if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
-          term.input('\x1b[13;3u');
-          return false;
-        }
-        if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
-          term.input('\x1b[13;5u');
-          return false;
-        }
-        return true;
-      });
+      attachKittyEnterHandler(term);
       fitAddon.fit();
 
       xtermRef.current = term;
@@ -823,22 +809,7 @@ function AgentTerminalPane({ townId, agentId }: { townId: string; agentId: strin
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
-      term.attachCustomKeyEventHandler(ev => {
-        if (ev.type !== 'keydown') return true;
-        if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
-          term.input('\x1b[13;2u');
-          return false;
-        }
-        if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
-          term.input('\x1b[13;3u');
-          return false;
-        }
-        if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
-          term.input('\x1b[13;5u');
-          return false;
-        }
-        return true;
-      });
+      attachKittyEnterHandler(term);
       fitAddon.fit();
 
       xtermRef.current = term;

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -622,6 +622,22 @@ function MayorTerminalPane({ townId, collapsed }: { townId: string; collapsed: b
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
+      term.attachCustomKeyEventHandler(ev => {
+        if (ev.type !== 'keydown') return true;
+        if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+          term.input('\x1b[13;2u');
+          return false;
+        }
+        if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
+          term.input('\x1b[13;3u');
+          return false;
+        }
+        if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
+          term.input('\x1b[13;5u');
+          return false;
+        }
+        return true;
+      });
       fitAddon.fit();
 
       xtermRef.current = term;
@@ -807,6 +823,22 @@ function AgentTerminalPane({ townId, agentId }: { townId: string; agentId: strin
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
+      term.attachCustomKeyEventHandler(ev => {
+        if (ev.type !== 'keydown') return true;
+        if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+          term.input('\x1b[13;2u');
+          return false;
+        }
+        if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
+          term.input('\x1b[13;3u');
+          return false;
+        }
+        if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
+          term.input('\x1b[13;5u');
+          return false;
+        }
+        return true;
+      });
       fitAddon.fit();
 
       xtermRef.current = term;

--- a/src/components/gastown/useXtermPty.ts
+++ b/src/components/gastown/useXtermPty.ts
@@ -6,6 +6,31 @@ import { useGastownTRPC, gastownWsUrl } from '@/lib/gastown/trpc';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 
+/**
+ * xterm.js 6.0.0 doesn't support the Kitty keyboard protocol — all Enter
+ * variants are encoded as bare \r.  This handler intercepts modified Enter
+ * keys and injects the correct CSI u escape sequences so downstream
+ * consumers (e.g. the Kilo TUI) see the expected keycodes.
+ */
+export function attachKittyEnterHandler(term: Terminal) {
+  term.attachCustomKeyEventHandler(ev => {
+    if (ev.type !== 'keydown') return true;
+    if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+      term.input('\x1b[13;2u');
+      return false;
+    }
+    if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
+      term.input('\x1b[13;3u');
+      return false;
+    }
+    if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
+      term.input('\x1b[13;5u');
+      return false;
+    }
+    return true;
+  });
+}
+
 type XtermPtyOptions = {
   townId: string;
   agentId: string | null;
@@ -107,22 +132,7 @@ export function useXtermPty({
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
-      term.attachCustomKeyEventHandler(ev => {
-        if (ev.type !== 'keydown') return true;
-        if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
-          term.input('\x1b[13;2u');
-          return false;
-        }
-        if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
-          term.input('\x1b[13;3u');
-          return false;
-        }
-        if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
-          term.input('\x1b[13;5u');
-          return false;
-        }
-        return true;
-      });
+      attachKittyEnterHandler(term);
       fitAddon.fit();
 
       xtermRef.current = term;

--- a/src/components/gastown/useXtermPty.ts
+++ b/src/components/gastown/useXtermPty.ts
@@ -107,6 +107,22 @@ export function useXtermPty({
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
+      term.attachCustomKeyEventHandler(ev => {
+        if (ev.type !== 'keydown') return true;
+        if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+          term.input('\x1b[13;2u');
+          return false;
+        }
+        if (ev.key === 'Enter' && ev.altKey && !ev.ctrlKey && !ev.shiftKey && !ev.metaKey) {
+          term.input('\x1b[13;3u');
+          return false;
+        }
+        if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
+          term.input('\x1b[13;5u');
+          return false;
+        }
+        return true;
+      });
       fitAddon.fit();
 
       xtermRef.current = term;


### PR DESCRIPTION
## Summary

xterm.js 6.0.0 does not support the Kitty keyboard protocol and encodes all Enter variants as bare `\r`. This adds `attachCustomKeyEventHandler` to all three xterm `Terminal` instances (`useXtermPty.ts`, `MayorTerminalPane`, and `AgentTerminalPane` in `TerminalBar.tsx`) to intercept modified Enter keys and inject the correct Kitty CSI u escape sequences:

- Shift+Enter → `\x1b[13;2u`
- Alt+Enter → `\x1b[13;3u`
- Ctrl+Enter → `\x1b[13;5u`

Plain Enter is unaffected (falls through to xterm's default `\r` handling). Returning `false` from the handler prevents xterm's default processing after the sequence is manually written via `term.input()`. The `keydown` guard avoids double-firing on `keyup`.

Originally authored in https://github.com/jrf0110/kilocode-cloud/pull/16.

## Verification

- [x] Prettier formatting passes on both changed files
- [x] Escape sequences verified against Kitty keyboard protocol spec
- [x] All three terminal instances receive identical handlers

## Visual Changes

N/A

## Reviewer Notes

The handler is identical across all three terminal instances. A future improvement could extract it into a shared utility, but keeping it inline matches the existing pattern in the codebase where each terminal instance sets up its own addons independently.