### PR TITLE
feat(cloud-agent-next): add async session preparation with fast response

### DIFF
--- a/cloud-agent-next/Dockerfile.dev
+++ b/cloud-agent-next/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.7.13
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="next"
+ARG KILOCODE_CLI_VERSION="7.0.47"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/cloud-agent-next/src/execution/orchestrator.ts
+++ b/cloud-agent-next/src/execution/orchestrator.ts
@@ -60,7 +60,10 @@ export class ExecutionOrchestrator {
    *
    * @throws ExecutionError with appropriate code on failure (no internal retry)
    */
-  async execute(plan: ExecutionPlan): Promise<ExecutionResult> {
+  async execute(
+    plan: ExecutionPlan,
+    options?: { onProgress?: (step: string, message: string) => void }
+  ): Promise<ExecutionResult> {
     const { executionId, sessionId, userId, orgId, prompt, mode, workspace, wrapper } = plan;
 
     logger.setTags({
@@ -91,7 +94,7 @@ export class ExecutionOrchestrator {
     }
 
     // 2. Workspace preparation (may throw WORKSPACE_SETUP_FAILED)
-    const prepared = await this.prepareWorkspace(sandbox, plan);
+    const prepared = await this.prepareWorkspace(sandbox, plan, options?.onProgress);
 
     // 3. Update git remote token if needed (resume path with token overrides)
     if (!workspace.shouldPrepare) {
@@ -179,7 +182,8 @@ export class ExecutionOrchestrator {
    */
   private async prepareWorkspace(
     sandbox: SandboxInstance,
-    plan: ExecutionPlan
+    plan: ExecutionPlan,
+    onProgress?: (step: string, message: string) => void
   ): Promise<PreparedSession> {
     const { workspace, sessionId, userId, orgId } = plan;
 
@@ -203,6 +207,7 @@ export class ExecutionOrchestrator {
           env: this.deps.env,
           githubToken: resumeContext.githubToken,
           gitToken: resumeContext.gitToken,
+          onProgress,
         });
       }
 

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -1171,6 +1171,39 @@ export class CloudAgentSession extends DurableObject {
           logger
             .withFields({ error: JSON.stringify(parsed.error.format()) })
             .error('Invalid pending preparation data in storage');
+
+          // Clean up resources left behind by registerSession/createCliSession
+          // so the session doesn't sit in a zombie preparing state forever.
+          const metadata = await this.ctx.storage.get<CloudAgentSessionState>('metadata');
+          await this.ctx.storage.delete('metadata');
+
+          if (metadata?.kiloSessionId && metadata?.userId) {
+            const svc = new SessionService();
+            try {
+              await svc.deleteCliSessionViaSessionIngest(
+                metadata.kiloSessionId,
+                metadata.userId,
+                this.env as unknown as WorkerEnv,
+                { onlyIfEmpty: true }
+              );
+            } catch {
+              // Best-effort — already logged the root cause above
+            }
+          }
+
+          if (this.sessionId) {
+            const prepId: EventSourceId = `prep_${this.sessionId}`;
+            this.broadcastVolatileEvent({
+              executionId: prepId,
+              sessionId: this.sessionId,
+              streamEventType: 'preparing',
+              payload: JSON.stringify({
+                step: 'failed',
+                message: 'Internal error: invalid preparation data',
+              }),
+              timestamp: Date.now(),
+            });
+          }
         }
       }
 

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -989,10 +989,9 @@ export class CloudAgentSession extends DurableObject {
 
       await this.recordKiloServerActivity();
 
-      // 11. Emit ready
-      emitProgress('ready', 'Session ready');
-
-      // 12. Auto-initiate if requested
+      // 11. Auto-initiate if requested, then emit ready only on success.
+      // Emitting 'ready' before startExecutionV2 would let the client
+      // unlock chat input for a session that may fail to initiate.
       if (input.autoInitiate) {
         const initiateResult = await this.startExecutionV2({
           kind: 'initiatePrepared',
@@ -1006,8 +1005,12 @@ export class CloudAgentSession extends DurableObject {
             .withFields({ sessionId, error: initiateResult.error })
             .error('Auto-initiate failed after async preparation');
           emitProgress('failed', `Auto-initiate failed: ${initiateResult.error}`);
+          return;
         }
       }
+
+      // 12. Emit ready — session is prepared (and initiated, if autoInitiate)
+      emitProgress('ready', 'Session ready');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -1004,6 +1004,16 @@ export class CloudAgentSession extends DurableObject {
           logger
             .withFields({ sessionId, error: initiateResult.error })
             .error('Auto-initiate failed after async preparation');
+
+          // startExecutionV2 persists initiatedAt via tryInitiate() before
+          // attempting execution. Roll it back so the session doesn't appear
+          // initiated with no running execution (stuck state).
+          const staleMetadata = await this.ctx.storage.get<CloudAgentSessionState>('metadata');
+          if (staleMetadata?.initiatedAt) {
+            const { initiatedAt: _, ...rest } = staleMetadata;
+            await this.ctx.storage.put('metadata', { ...rest, version: Date.now() });
+          }
+
           emitProgress('failed', `Auto-initiate failed: ${initiateResult.error}`);
           return;
         }

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -7,7 +7,12 @@
 import { DurableObject } from 'cloudflare:workers';
 import { TRPCError } from '@trpc/server';
 import type { CloudAgentSessionState, OperationResult, MCPServerConfig } from './types.js';
-import { MetadataSchema, type Images } from './schemas.js';
+import {
+  MetadataSchema,
+  PreparationInputSchema,
+  type Images,
+  type PreparationInput,
+} from './schemas.js';
 import type { EncryptedSecrets } from '../router/schemas.js';
 import type { CallbackJob, CallbackTarget } from '../callbacks/index.js';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
@@ -26,7 +31,7 @@ import {
   type LeaseAcquireError,
 } from '../session/queries/index.js';
 import { createExecutionId } from '../types/ids.js';
-import type { ExecutionId, SessionId, UserId } from '../types/ids.js';
+import type { ExecutionId, EventSourceId, EventId, SessionId, UserId } from '../types/ids.js';
 import type {
   ExecutionMetadata,
   AddExecutionParams,
@@ -46,7 +51,7 @@ import {
   type IngestDOContext,
 } from '../websocket/ingest.js';
 import type { StoredEvent } from '../websocket/types.js';
-import type { WrapperCommand } from '../shared/protocol.js';
+import type { WrapperCommand, PreparingStep } from '../shared/protocol.js';
 import { STALE_THRESHOLD_MS, SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
 import { ExecutionOrchestrator, type OrchestratorDeps } from '../execution/orchestrator.js';
 import type {
@@ -65,6 +70,8 @@ import { GitHubTokenService } from '../services/github-token-service.js';
 import { validateStreamTicket } from '../auth.js';
 import { getSandbox } from '@cloudflare/sandbox';
 import { stopWrapper } from '../kilo/wrapper-manager.js';
+import { SessionService } from '../session-service.js';
+import { executePreparationSteps } from './async-preparation.js';
 
 // ---------------------------------------------------------------------------
 // Alarm Constants
@@ -97,6 +104,9 @@ const DISCONNECT_GRACE_MS = 10_000;
 
 /** DO storage key for persisting disconnect grace state across hibernation. */
 const DISCONNECT_GRACE_KEY = 'disconnect_grace';
+
+/** DO storage key for pending async preparation input. */
+const PENDING_PREPARATION_KEY = 'pending_preparation';
 
 /** Stored in DO storage under DISCONNECT_GRACE_KEY while a grace period is active. */
 type DisconnectGraceState = {
@@ -468,7 +478,7 @@ export class CloudAgentSession extends DurableObject {
   }
 
   private insertAndBroadcastEvent(params: {
-    executionId: ExecutionId;
+    executionId: EventSourceId;
     sessionId: string;
     streamEventType: string;
     payload: string;
@@ -483,6 +493,28 @@ export class CloudAgentSession extends DurableObject {
     });
     this.broadcastEvent({
       id: eventId,
+      execution_id: params.executionId,
+      session_id: params.sessionId,
+      stream_event_type: params.streamEventType,
+      payload: params.payload,
+      timestamp: params.timestamp,
+    });
+  }
+
+  /**
+   * Broadcast an event to connected /stream clients without persisting it.
+   * Used for transient progress events (e.g. `preparing`) that have no
+   * replay value — avoids stale indicators on WebSocket reconnect.
+   */
+  private broadcastVolatileEvent(params: {
+    executionId: EventSourceId;
+    sessionId: string;
+    streamEventType: string;
+    payload: string;
+    timestamp: number;
+  }): void {
+    this.broadcastEvent({
+      id: 0 as EventId,
       execution_id: params.executionId,
       session_id: params.sessionId,
       stream_event_type: params.streamEventType,
@@ -791,6 +823,209 @@ export class CloudAgentSession extends DurableObject {
   }
 
   /**
+   * Lightweight registration for async preparation flow.
+   * Stores minimal metadata WITHOUT setting preparedAt.
+   * Makes getMetadata() return non-null so the chat page can distinguish
+   * "async prep in progress" from "no DO at all".
+   */
+  async registerSession(input: {
+    sessionId: string;
+    userId: string;
+    orgId?: string;
+    botId?: string;
+    prompt: string;
+    mode: string;
+    model: string;
+    variant?: string;
+    kiloSessionId?: string;
+  }): Promise<OperationResult> {
+    await this.requireSessionId(input.sessionId as SessionId);
+    const existing = await this.ctx.storage.get<CloudAgentSessionState>('metadata');
+    if (existing) {
+      return { success: false, error: 'Session already registered' };
+    }
+
+    const now = Date.now();
+    const metadata: CloudAgentSessionState = {
+      sessionId: input.sessionId,
+      userId: input.userId,
+      orgId: input.orgId,
+      botId: input.botId,
+      prompt: input.prompt,
+      mode: input.mode,
+      model: input.model,
+      variant: input.variant,
+      kiloSessionId: input.kiloSessionId,
+      version: now,
+      timestamp: now,
+      // NOTE: preparedAt is NOT set — this is the key difference from prepare()
+    };
+
+    const parseResult = MetadataSchema.safeParse(metadata);
+    if (!parseResult.success) {
+      return {
+        success: false,
+        error: `Invalid metadata: ${JSON.stringify(parseResult.error.format())}`,
+      };
+    }
+
+    await this.ctx.storage.put('metadata', parseResult.data);
+    await this.updateLastActivity();
+    await this.ensureAlarmScheduled();
+
+    return { success: true };
+  }
+
+  /**
+   * Schedule async preparation via alarm.
+   * Stores the preparation input in DO storage and schedules an immediate
+   * alarm. The alarm handler will pick it up and run the expensive work.
+   * This approach is safe regardless of caller lifetime — the DO wakes
+   * itself up via the alarm even if the original worker request has ended.
+   */
+  async startPreparationAsync(input: PreparationInput): Promise<void> {
+    await this.ctx.storage.put(PENDING_PREPARATION_KEY, input);
+    // Schedule an immediate alarm to run the preparation.
+    // If an alarm is already pending (e.g. reaper), setAlarm replaces it —
+    // the reaper will self-reschedule when it next runs.
+    await this.ctx.storage.setAlarm(Date.now());
+  }
+
+  /**
+   * Internal: run all expensive preparation steps, emitting progress events.
+   * Workspace orchestration (clone, setup, wrapper start) is delegated to
+   * executePreparationSteps(); this method handles the DO-specific bookkeeping
+   * (metadata, progress events, auto-initiate, error cleanup).
+   */
+  private async runPreparationAsync(input: PreparationInput): Promise<void> {
+    const sessionId = input.sessionId as SessionId;
+    const prepExecutionId: EventSourceId = `prep_${input.sessionId}`;
+    const env = this.env as unknown as WorkerEnv;
+
+    const emitProgress = (step: PreparingStep, message: string) => {
+      this.broadcastVolatileEvent({
+        executionId: prepExecutionId,
+        sessionId: input.sessionId,
+        streamEventType: 'preparing',
+        payload: JSON.stringify({ step, message }),
+        timestamp: Date.now(),
+      });
+    };
+
+    let createdKiloSessionId: string | undefined = input.kiloSessionId;
+
+    const cleanupCliSession = async () => {
+      if (!createdKiloSessionId) return;
+      const svc = new SessionService();
+      try {
+        await svc.deleteCliSessionViaSessionIngest(createdKiloSessionId, input.userId, env, {
+          onlyIfEmpty: true,
+        });
+      } catch (cleanupError) {
+        logger
+          .withFields({
+            sessionId,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          })
+          .warn('Failed to clean up cli_sessions_v2 record (onlyIfEmpty)');
+      }
+    };
+
+    try {
+      // Steps 1–9: workspace orchestration (token, disk, clone, branch, setup, wrapper)
+      const result = await executePreparationSteps(input, env, emitProgress);
+      if (!result) {
+        // executePreparationSteps already emitted 'failed' — clean up DO metadata
+        await this.ctx.storage.delete('metadata');
+        await cleanupCliSession();
+        return;
+      }
+
+      createdKiloSessionId = result.kiloSessionId;
+
+      // 10. Store full metadata via prepare() — sets preparedAt
+      const prepareResult = await this.prepare({
+        sessionId: input.sessionId,
+        userId: input.userId,
+        orgId: input.orgId,
+        botId: input.botId,
+        kiloSessionId: result.kiloSessionId,
+        prompt: input.prompt,
+        mode: input.mode,
+        model: input.model,
+        variant: input.variant,
+        kilocodeToken: input.authToken,
+        githubRepo: input.githubRepo,
+        githubToken: input.githubToken,
+        githubInstallationId: result.resolvedInstallationId,
+        githubAppType: result.resolvedGithubAppType,
+        gitUrl: input.gitUrl,
+        gitToken: input.gitToken,
+        platform: input.platform,
+        envVars: input.envVars,
+        encryptedSecrets: input.encryptedSecrets,
+        setupCommands: input.setupCommands,
+        mcpServers: input.mcpServers,
+        upstreamBranch: input.upstreamBranch,
+        autoCommit: input.autoCommit,
+        condenseOnComplete: input.condenseOnComplete,
+        appendSystemPrompt: input.appendSystemPrompt,
+        callbackTarget: input.callbackTarget,
+        images: input.images,
+        createdOnPlatform: input.createdOnPlatform,
+        gateThreshold: input.gateThreshold,
+        workspacePath: result.workspacePath,
+        sessionHome: result.sessionHome,
+        branchName: result.branchName,
+        sandboxId: result.sandboxId,
+      });
+
+      if (!prepareResult.success) {
+        emitProgress('failed', prepareResult.error ?? 'Failed to prepare session');
+        await this.ctx.storage.delete('metadata');
+        await cleanupCliSession();
+        return;
+      }
+
+      await this.recordKiloServerActivity();
+
+      // 11. Emit ready
+      emitProgress('ready', 'Session ready');
+
+      // 12. Auto-initiate if requested
+      if (input.autoInitiate) {
+        const initiateResult = await this.startExecutionV2({
+          kind: 'initiatePrepared',
+          userId: input.userId as UserId,
+          botId: input.botId,
+          authToken: input.authToken,
+        });
+
+        if (!initiateResult.success) {
+          logger
+            .withFields({ sessionId, error: initiateResult.error })
+            .error('Auto-initiate failed after async preparation');
+          emitProgress('failed', `Auto-initiate failed: ${initiateResult.error}`);
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger
+        .withFields({
+          sessionId,
+          error: message,
+          stack: error instanceof Error ? error.stack : undefined,
+        })
+        .error('Async preparation failed');
+
+      await cleanupCliSession();
+
+      emitProgress('failed', message);
+      await this.ctx.storage.delete('metadata');
+    }
+  }
+
+  /**
    * Atomically update a prepared session - only succeeds if prepared but not initiated.
    * Single DO request ensures atomicity.
    * Validates updated metadata against MetadataSchema before storing.
@@ -910,6 +1145,22 @@ export class CloudAgentSession extends DurableObject {
       .info('Alarm fired');
 
     try {
+      // Run pending async preparation if scheduled.
+      // This must run before other alarm duties because it can take minutes
+      // (git clone, setup commands, etc.). The reaper self-reschedules at the end.
+      const pendingPrep = await this.ctx.storage.get(PENDING_PREPARATION_KEY);
+      if (pendingPrep) {
+        await this.ctx.storage.delete(PENDING_PREPARATION_KEY);
+        const parsed = PreparationInputSchema.safeParse(pendingPrep);
+        if (parsed.success) {
+          await this.runPreparationAsync(parsed.data);
+        } else {
+          logger
+            .withFields({ error: JSON.stringify(parsed.error.format()) })
+            .error('Invalid pending preparation data in storage');
+        }
+      }
+
       // Check disconnect grace period first — this alarm may have been
       // rescheduled specifically for the grace deadline.
       await this.checkDisconnectGrace();
@@ -991,7 +1242,7 @@ export class CloudAgentSession extends DurableObject {
     logger
       .withFields({ sessionId: this.sessionId, nextInterval, elapsedMs: Date.now() - now })
       .info('Rescheduling alarm');
-    await this.ctx.storage.setAlarm(now + nextInterval);
+    await this.ctx.storage.setAlarm(Date.now() + nextInterval);
   }
 
   /**
@@ -2229,7 +2480,18 @@ export class CloudAgentSession extends DurableObject {
     // Execute via orchestrator
     try {
       const orchestrator = this.getOrCreateOrchestrator();
-      const result = await orchestrator.execute(plan);
+
+      const emitProgress = (step: string, message: string) => {
+        this.broadcastVolatileEvent({
+          executionId,
+          sessionId,
+          streamEventType: 'preparing',
+          payload: JSON.stringify({ step, message }),
+          timestamp: Date.now(),
+        });
+      };
+
+      const result = await orchestrator.execute(plan, { onProgress: emitProgress });
 
       logger
         .withFields({ sessionId, executionId, kiloSessionId: result.kiloSessionId })

--- a/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/cloud-agent-next/src/persistence/async-preparation.ts
@@ -1,0 +1,229 @@
+import { logger } from '../logger.js';
+import { SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
+import { generateSandboxId, getSandboxNamespace } from '../sandbox-id.js';
+import { GitHubTokenService } from '../services/github-token-service.js';
+import { InstallationLookupService } from '../services/installation-lookup-service.js';
+import { getSandbox } from '@cloudflare/sandbox';
+import {
+  checkDiskAndCleanBeforeSetup,
+  setupWorkspace,
+  cloneGitHubRepo,
+  cloneGitRepo,
+  manageBranch,
+} from '../workspace.js';
+import {
+  SessionService,
+  determineBranchName,
+  runSetupCommands,
+  writeAuthFile,
+} from '../session-service.js';
+import { WrapperClient } from '../kilo/wrapper-client.js';
+import type { PreparingStep } from '../shared/protocol.js';
+import type { PreparationInput } from './schemas.js';
+import type { Env as WorkerEnv, SandboxId, SessionId as AgentSessionId } from '../types.js';
+
+type EmitProgress = (step: PreparingStep, message: string) => void;
+
+/** Result returned by executePreparationSteps on success. */
+export type PreparationStepsResult = {
+  sandboxId: SandboxId;
+  workspacePath: string;
+  sessionHome: string;
+  branchName: string;
+  kiloSessionId: string;
+  resolvedInstallationId: string | undefined;
+  resolvedGithubAppType: 'standard' | 'lite' | undefined;
+};
+
+/**
+ * Execute all expensive workspace preparation steps (token resolution, disk
+ * check, clone, branch, setup commands, auth file, session import, wrapper start).
+ *
+ * This is a pure orchestration function with no Durable Object dependencies.
+ * On early failure it emits a 'failed' progress event and returns undefined.
+ */
+export async function executePreparationSteps(
+  input: PreparationInput,
+  env: WorkerEnv,
+  emitProgress: EmitProgress
+): Promise<PreparationStepsResult | undefined> {
+  const sessionService = new SessionService();
+
+  // 1. Resolve GitHub installation + token
+  let resolvedGithubToken = input.githubToken;
+  let resolvedInstallationId: string | undefined;
+  let resolvedGithubAppType: 'standard' | 'lite' | undefined;
+
+  if (input.githubRepo && !input.githubToken) {
+    const lookupService = new InstallationLookupService(env);
+    if (lookupService.isConfigured()) {
+      const result = await lookupService.findInstallationId({
+        githubRepo: input.githubRepo,
+        userId: input.userId,
+        orgId: input.orgId,
+      });
+      if (result) {
+        resolvedInstallationId = result.installationId;
+        resolvedGithubAppType = result.githubAppType;
+        const tokenService = new GitHubTokenService(env);
+        resolvedGithubToken = await tokenService.getToken(
+          resolvedInstallationId,
+          resolvedGithubAppType ?? 'standard'
+        );
+      }
+    }
+    if (!resolvedGithubToken) {
+      emitProgress(
+        'failed',
+        'GitHub token or active app installation required for this repository'
+      );
+      return undefined;
+    }
+  }
+
+  // 2. Disk check
+  emitProgress('disk_check', 'Checking disk space…');
+  const sandboxId = await generateSandboxId(
+    env.PER_SESSION_SANDBOX_ORG_IDS,
+    input.orgId,
+    input.userId,
+    input.sessionId,
+    input.botId
+  );
+  const sandbox = getSandbox(getSandboxNamespace(env, sandboxId), sandboxId, {
+    sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS,
+  });
+  await checkDiskAndCleanBeforeSetup(sandbox, input.orgId, input.userId, input.sessionId);
+
+  // 3. Workspace setup
+  emitProgress('workspace_setup', 'Setting up workspace…');
+  const { workspacePath, sessionHome } = await setupWorkspace(
+    sandbox,
+    input.userId,
+    input.orgId,
+    input.sessionId
+  );
+
+  // 4. Clone repository
+  emitProgress('cloning', 'Cloning repository…');
+  const branchName = determineBranchName(input.sessionId, input.upstreamBranch);
+  const sessionId = input.sessionId as AgentSessionId;
+  const context = sessionService.buildContext({
+    sandboxId,
+    orgId: input.orgId,
+    userId: input.userId,
+    sessionId,
+    workspacePath,
+    sessionHome,
+    githubRepo: input.githubRepo,
+    githubToken: resolvedGithubToken,
+    gitUrl: input.gitUrl,
+    gitToken: input.gitToken,
+    platform: input.platform,
+    upstreamBranch: input.upstreamBranch,
+    botId: input.botId,
+  });
+
+  const session = await sessionService.getOrCreateSession(
+    sandbox,
+    context,
+    env,
+    input.authToken,
+    input.model,
+    input.orgId,
+    input.encryptedSecrets,
+    input.createdOnPlatform,
+    input.appendSystemPrompt,
+    input.mcpServers
+  );
+
+  const cloneOptions = input.shallow ? { shallow: true } : undefined;
+  if (input.gitUrl) {
+    await cloneGitRepo(
+      session,
+      workspacePath,
+      input.gitUrl,
+      input.gitToken,
+      undefined,
+      cloneOptions
+    );
+  } else if (input.githubRepo) {
+    await cloneGitHubRepo(
+      session,
+      workspacePath,
+      input.githubRepo,
+      resolvedGithubToken,
+      {
+        GITHUB_APP_SLUG: env.GITHUB_APP_SLUG,
+        GITHUB_APP_BOT_USER_ID: env.GITHUB_APP_BOT_USER_ID,
+      },
+      cloneOptions
+    );
+  }
+
+  // 5. Branch management
+  emitProgress('branch', 'Setting up branch…');
+  await manageBranch(session, workspacePath, branchName, !!input.upstreamBranch);
+
+  // 6. Setup commands
+  if (input.setupCommands && input.setupCommands.length > 0) {
+    emitProgress('setup_commands', 'Running setup commands…');
+    await runSetupCommands(session, context, input.setupCommands, true);
+  }
+
+  // 7. Write auth file
+  await writeAuthFile(sandbox, sessionHome, input.authToken);
+
+  // 8. Import pre-generated session into CLI's SQLite so the wrapper picks it up
+  if (input.kiloSessionId) {
+    emitProgress('kilo_session', 'Importing session…');
+    const now = Date.now();
+    const minimalSessionJson = JSON.stringify({
+      info: {
+        id: input.kiloSessionId,
+        slug: '',
+        projectID: '',
+        directory: '',
+        title: '',
+        version: '2',
+        time: { created: now, updated: now },
+      },
+      messages: [],
+    });
+    const importFilePath = `/tmp/kilo-empty-session-${input.kiloSessionId}.json`;
+    await sandbox.writeFile(importFilePath, minimalSessionJson);
+    const escapedFile = importFilePath.replaceAll("'", "'\\''");
+    const escapedId = input.kiloSessionId.replaceAll("'", "'\\''");
+    const escapedWorkspace = workspacePath.replaceAll("'", "'\\''");
+    const restoreResult = await session.exec(
+      `bun /usr/local/bin/kilo-restore-session.js --file '${escapedFile}' '${escapedId}' '${escapedWorkspace}'`
+    );
+    if (restoreResult.exitCode !== 0) {
+      const stdout = restoreResult.stdout?.trim() ?? '';
+      logger
+        .withFields({ exitCode: restoreResult.exitCode, stdout })
+        .error('Session import failed');
+      emitProgress('failed', `Session import failed (exit ${restoreResult.exitCode})`);
+      return undefined;
+    }
+  }
+
+  // 9. Start wrapper (with --session-id if pre-imported)
+  emitProgress('kilo_server', 'Starting Kilo…');
+  const { sessionId: wrapperSessionId } = await WrapperClient.ensureWrapper(sandbox, session, {
+    agentSessionId: input.sessionId,
+    userId: input.userId,
+    workspacePath,
+    sessionId: input.kiloSessionId,
+  });
+
+  return {
+    sandboxId,
+    workspacePath,
+    sessionHome,
+    branchName,
+    kiloSessionId: input.kiloSessionId ?? wrapperSessionId,
+    resolvedInstallationId,
+    resolvedGithubAppType,
+  };
+}

--- a/cloud-agent-next/src/persistence/schemas.ts
+++ b/cloud-agent-next/src/persistence/schemas.ts
@@ -183,3 +183,49 @@ export const MetadataSchema = z.object({
     .transform(s => s as SandboxId)
     .optional(),
 });
+
+/**
+ * Schema for async preparation input stored in DO storage.
+ * Single source of truth for the shape of data passed between
+ * startPreparationAsync (write) and runPreparationAsync (read via alarm).
+ */
+export const PreparationInputSchema = z.object({
+  // Session identity
+  sessionId: z.string(),
+  kiloSessionId: z.string().optional(),
+  userId: z.string(),
+  orgId: z.string().optional(),
+  botId: z.string().optional(),
+  // Auth
+  authToken: z.string(),
+  // Git source
+  githubRepo: z.string().optional(),
+  githubToken: z.string().optional(),
+  gitUrl: z.string().optional(),
+  gitToken: z.string().optional(),
+  platform: z.enum(['github', 'gitlab']).optional(),
+  // Execution params
+  prompt: z.string(),
+  mode: z.string(),
+  model: z.string(),
+  variant: z.string().optional(),
+  // Configuration
+  envVars: z.record(z.string(), z.string()).optional(),
+  encryptedSecrets: EncryptedSecretsSchema.optional(),
+  setupCommands: z.array(z.string()).optional(),
+  mcpServers: z.record(z.string(), MCPServerConfigSchema).optional(),
+  upstreamBranch: z.string().optional(),
+  autoCommit: z.boolean().optional(),
+  condenseOnComplete: z.boolean().optional(),
+  appendSystemPrompt: z.string().optional(),
+  callbackTarget: CallbackTargetSchema.optional(),
+  images: ImagesSchema.optional(),
+  createdOnPlatform: z.string().optional(),
+  shallow: z.boolean().optional(),
+  gateThreshold: z.enum(['off', 'all', 'warning', 'critical']).optional(),
+  kilocodeOrganizationId: z.string().optional(),
+  // Auto-initiate after preparation
+  autoInitiate: z.boolean(),
+});
+
+export type PreparationInput = z.infer<typeof PreparationInputSchema>;

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -27,6 +27,7 @@ import {
 } from '../../workspace.js';
 import { WrapperClient } from '../../kilo/wrapper-client.js';
 import { withDORetry } from '../../utils/do-retry.js';
+import { generateKiloSessionId } from '../../utils/kilo-session-id.js';
 import { SANDBOX_SLEEP_AFTER_SECONDS } from '../../core/lease.js';
 
 type SessionPrepareHandlers = {
@@ -196,6 +197,109 @@ const prepareSessionHandler = internalApiProtectedProcedure
             message: `Failed to generate GitHub token: ${tokenError instanceof Error ? tokenError.message : String(tokenError)}`,
           });
         }
+      }
+
+      // --- Fast path: autoInitiate returns immediately, runs preparation asynchronously ---
+      if (input.autoInitiate) {
+        logger.info('autoInitiate=true: fast-path return, async preparation');
+
+        // Generate kiloSessionId upfront so the ID is stable from the start (no URL rewriting)
+        const kiloSessionId = generateKiloSessionId();
+        logger.setTags({ kiloSessionId });
+
+        // Create cli_sessions_v2 record immediately (stream-ticket route needs it for ownership)
+        await sessionService.createCliSessionViaSessionIngest(
+          kiloSessionId,
+          cloudAgentSessionId,
+          ctx.userId,
+          ctx.env,
+          input.kilocodeOrganizationId,
+          input.createdOnPlatform ?? 'cloud-agent'
+        );
+
+        const rollbackCliSession = async () => {
+          await sessionService
+            .deleteCliSessionViaSessionIngest(kiloSessionId, ctx.userId, ctx.env, {
+              onlyIfEmpty: true,
+            })
+            .catch((rollbackError: unknown) => {
+              logger
+                .withFields({
+                  error:
+                    rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+                })
+                .error('Failed to rollback cli_sessions_v2 record (fast path)');
+            });
+        };
+
+        // Register minimal metadata in DO (makes getSession return non-null runtimeState)
+        const doId = ctx.env.CLOUD_AGENT_SESSION.idFromName(`${ctx.userId}:${cloudAgentSessionId}`);
+        const stub = ctx.env.CLOUD_AGENT_SESSION.get(doId);
+
+        const registerResult = await stub.registerSession({
+          sessionId: cloudAgentSessionId,
+          userId: ctx.userId,
+          orgId: input.kilocodeOrganizationId,
+          botId: ctx.botId,
+          prompt: input.prompt,
+          mode: input.mode,
+          model: input.model,
+          variant: input.variant,
+          kiloSessionId,
+        });
+
+        if (!registerResult.success) {
+          await rollbackCliSession();
+          logger
+            .withFields({ error: registerResult.error })
+            .error('Failed to register session in DO');
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: registerResult.error ?? 'Failed to register session',
+          });
+        }
+
+        // Schedule async preparation via DO alarm (returns immediately)
+        try {
+          await stub.startPreparationAsync({
+            sessionId: cloudAgentSessionId,
+            kiloSessionId,
+            userId: ctx.userId,
+            orgId: input.kilocodeOrganizationId,
+            botId: ctx.botId,
+            authToken: ctx.authToken,
+            githubRepo: input.githubRepo,
+            githubToken: input.githubToken,
+            gitUrl: input.gitUrl,
+            gitToken: input.gitToken,
+            platform: input.platform,
+            prompt: input.prompt,
+            mode: input.mode,
+            model: input.model,
+            variant: input.variant,
+            envVars: input.envVars,
+            encryptedSecrets: input.encryptedSecrets,
+            setupCommands: input.setupCommands,
+            mcpServers: input.mcpServers,
+            upstreamBranch: input.upstreamBranch,
+            autoCommit: input.autoCommit,
+            condenseOnComplete: input.condenseOnComplete,
+            appendSystemPrompt: input.appendSystemPrompt,
+            callbackTarget: input.callbackTarget,
+            images: input.images,
+            createdOnPlatform: input.createdOnPlatform,
+            shallow: input.shallow,
+            gateThreshold: input.gateThreshold,
+            kilocodeOrganizationId: input.kilocodeOrganizationId,
+            autoInitiate: true,
+          });
+        } catch (error) {
+          await rollbackCliSession();
+          throw error;
+        }
+
+        logger.info('Session registered, async preparation scheduled');
+        return { cloudAgentSessionId, kiloSessionId };
       }
 
       // 3. Get sandbox

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -221,6 +221,13 @@ export const PrepareSessionInput = z
       .describe(
         'PR gate threshold — when not "off", the agent should evaluate findings and report gateResult in its callback'
       ),
+    autoInitiate: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'When true, return immediately after creating IDs and run preparation asynchronously. Progress events are streamed via WebSocket.'
+      ),
   })
   .refine(validateGitSource, {
     message: 'Must provide either githubRepo or gitUrl, but not both',
@@ -234,7 +241,7 @@ export const PrepareSessionInput = z
 /** Output schema for prepareSession endpoint */
 export const PrepareSessionOutput = z.object({
   cloudAgentSessionId: z.string().describe('The generated cloud-agent session ID'),
-  kiloSessionId: z.string().describe('The generated Kilo CLI session ID'),
+  kiloSessionId: z.string().describe('The Kilo CLI session ID'),
 });
 
 /**

--- a/cloud-agent-next/src/session-ingest-binding.ts
+++ b/cloud-agent-next/src/session-ingest-binding.ts
@@ -19,6 +19,7 @@ export type CreateSessionForCloudAgentParams = {
 export type DeleteSessionForCloudAgentParams = {
   sessionId: string;
   kiloUserId: string;
+  onlyIfEmpty?: boolean;
 };
 
 export type SessionIngestBinding = Fetcher & {

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1232,6 +1232,7 @@ export class SessionService {
         kilocodeToken,
         freshGithubToken,
         freshGitToken,
+        onProgress: options.onProgress,
       });
     }
 
@@ -1252,6 +1253,7 @@ export class SessionService {
     kilocodeToken,
     freshGithubToken,
     freshGitToken,
+    onProgress,
   }: {
     session: ExecutionSession;
     sessionId: string;
@@ -1263,6 +1265,7 @@ export class SessionService {
     kilocodeToken: string;
     freshGithubToken?: string;
     freshGitToken?: string;
+    onProgress?: (step: string, message: string) => void;
   }): Promise<void> {
     if (!metadata) {
       throw new Error(
@@ -1284,6 +1287,7 @@ export class SessionService {
       // Clone first so .git exists when `kilo import` runs — the CLI derives
       // the project ID from the repo's root commit hash; without a repo the
       // FK on session.project_id fails.
+      onProgress?.('cloning', 'Cloning repository…');
       await restoreWorkspace(session, context.workspacePath, context.branchName, {
         githubRepo: metadata.githubRepo,
         githubToken: freshGithubToken ?? metadata.githubToken,
@@ -1294,11 +1298,13 @@ export class SessionService {
         platform: context.platform,
       });
       // Write auth file BEFORE kilo import so KiloSessions.bootstrap() can authenticate
+      onProgress?.('workspace_setup', 'Setting up workspace…');
       await writeAuthFile(sandbox, context.sessionHome, kilocodeToken);
       await writeGlobalRules(sandbox, context.sessionHome, sessionId);
 
       // Single restore script handles download, import, and diff application inside
       // the sandbox — the snapshot never enters worker memory.
+      onProgress?.('kilo_session', 'Restoring session…');
       logger.info('Starting cold-start session restore');
 
       const escapedId = metadata.kiloSessionId.replaceAll("'", "'\\''");
@@ -1369,9 +1375,13 @@ export class SessionService {
 
       // Re-run setup commands (fresh clone, need to reinstall)
       if (metadata.setupCommands && metadata.setupCommands.length > 0) {
+        onProgress?.('setup_commands', 'Running setup commands…');
         logger.info('Re-running setup commands after fresh clone');
         await runSetupCommands(session, context, metadata.setupCommands, false); // lenient
       }
+
+      // Wrapper will be (re)started by the orchestrator after we return
+      onProgress?.('kilo_server', 'Starting Kilo…');
     } catch (error) {
       // Remove the workspace and sessionHome so the next retry sees a true
       // cold start and re-runs the full restore from scratch.
@@ -1723,12 +1733,14 @@ export class SessionService {
   async deleteCliSessionViaSessionIngest(
     kiloSessionId: string,
     kiloUserId: string,
-    env: PersistenceEnv
+    env: PersistenceEnv,
+    opts?: { onlyIfEmpty?: boolean }
   ): Promise<void> {
     try {
       await env.SESSION_INGEST.deleteSessionForCloudAgent({
         sessionId: kiloSessionId,
         kiloUserId,
+        onlyIfEmpty: opts?.onlyIfEmpty,
       });
     } catch (error) {
       logger
@@ -1859,6 +1871,7 @@ export interface ResumeOptions {
   env: PersistenceEnv;
   githubToken?: string;
   gitToken?: string;
+  onProgress?: (step: string, message: string) => void;
 }
 
 /**

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -6,7 +6,7 @@
  *   autocommit_started, autocommit_completed
  *
  * From DO -> /stream clients:
- *   All of the above, plus wrapper_disconnected, wrapper_reconnected
+ *   All of the above, plus wrapper_disconnected, wrapper_reconnected, preparing
  */
 export type StreamEventType =
   // Wrapper -> DO (execution lifecycle)
@@ -24,7 +24,9 @@ export type StreamEventType =
   | 'autocommit_completed' // Auto-commit finished (success, skip, or failure)
   // DO -> /stream clients (connection status)
   | 'wrapper_disconnected' // Wrapper WebSocket closed unexpectedly
-  | 'wrapper_reconnected'; // Wrapper reconnected successfully
+  | 'wrapper_reconnected' // Wrapper reconnected successfully
+  // DO -> /stream clients (async preparation progress)
+  | 'preparing'; // Async preparation step progress (autoInitiate flow)
 
 /**
  * Event envelope sent by wrapper to DO via /ingest WebSocket.
@@ -76,6 +78,29 @@ export type AutocommitCompletedData = {
   skipped?: boolean;
   commitHash?: string;
   commitMessage?: string;
+};
+
+/**
+ * Preparation step identifiers for async preparation progress events.
+ */
+export type PreparingStep =
+  | 'disk_check'
+  | 'workspace_setup'
+  | 'cloning'
+  | 'branch'
+  | 'setup_commands'
+  | 'kilo_server'
+  | 'kilo_session'
+  | 'ready'
+  | 'failed';
+
+/**
+ * Data included in 'preparing' events (async preparation progress).
+ * Emitted by the DO during startPreparationAsync to report progress to /stream clients.
+ */
+export type PreparingEventData = {
+  step: PreparingStep;
+  message: string;
 };
 
 /**

--- a/cloud-agent-next/src/types/ids.ts
+++ b/cloud-agent-next/src/types/ids.ts
@@ -16,6 +16,15 @@ import { ulid } from 'ulid';
 export type ExecutionId = `exc_${string}`;
 
 /**
+ * Unique identifier for a preparation request.
+ * Format: prep_<string>
+ */
+export type PreparationId = `prep_${string}`;
+
+/** Union of IDs that can be used as an event source */
+export type EventSourceId = ExecutionId | PreparationId;
+
+/**
  * Session identifier - supports both:
  * - `sess_*` for new WebSocket sessions
  * - `agent_*` for backward compatibility with existing session format
@@ -47,6 +56,9 @@ export const createLeaseId = (): LeaseId => `lease_${crypto.randomUUID()}`;
 
 /** Check if a string is a valid ExecutionId (exc_<ulid> format) */
 export const isExecutionId = (s: string): s is ExecutionId => s.startsWith('exc_');
+
+/** Check if a string is a valid PreparationId */
+export const isPreparationId = (s: string): s is PreparationId => s.startsWith('prep_');
 
 /** Check if a string is a valid SessionId (supports both sess_ and agent_ prefixes) */
 export const isSessionId = (s: string): s is SessionId =>

--- a/cloud-agent-next/src/utils/kilo-session-id.ts
+++ b/cloud-agent-next/src/utils/kilo-session-id.ts
@@ -1,0 +1,28 @@
+const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+let counter = 0;
+
+function descendingTimestampHex(): string {
+  const tick = BigInt(Date.now()) * 0x1000n + BigInt(counter);
+  counter = (counter + 1) & 0xfff;
+
+  // 6-byte mask (48 bits) — invert so newer timestamps sort first
+  const descending = ~tick & 0xffff_ffff_ffffn;
+
+  return descending.toString(16).padStart(12, '0');
+}
+
+function randomBase62(length: number): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += BASE62[bytes[i] % 62];
+  }
+  return result;
+}
+
+export function generateKiloSessionId(): string {
+  return `ses_${descendingTimestampHex()}${randomBase62(14)}`;
+}

--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -298,7 +298,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-2",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.0.46",
+            "KILOCODE_CLI_VERSION": "7.0.47",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,

--- a/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 export type RestoreResult =
   | {
       ok: true;
-      downloaded: true;
+      downloaded: boolean;
       imported: true;
       diffs: { applied: number; skipped: number; total: number };
     }
@@ -83,47 +83,54 @@ export async function extractDiffs(snapshotPath: string): Promise<SnapshotDiff[]
 
 export async function restoreSession(
   kiloSessionId: string,
-  workspacePath: string
+  workspacePath: string,
+  filePath?: string
 ): Promise<RestoreResult> {
-  const ingestUrl = process.env.KILO_SESSION_INGEST_URL;
-  const token = process.env.KILOCODE_TOKEN;
-  const tmpPath = `/tmp/kilo-session-export-${kiloSessionId}.json`;
+  const tmpPath = filePath ?? `/tmp/kilo-session-export-${kiloSessionId}.json`;
+  const downloaded = !filePath;
 
   log(`starting kiloSessionId=${kiloSessionId} workspace=${workspacePath}`);
 
-  if (!ingestUrl || !token) {
-    const missing = [!ingestUrl && 'KILO_SESSION_INGEST_URL', !token && 'KILOCODE_TOKEN']
-      .filter(Boolean)
-      .join(', ');
-    return fail(`missing env vars: ${missing}`, null, 'download');
-  }
+  if (!filePath) {
+    const ingestUrl = process.env.KILO_SESSION_INGEST_URL;
+    const token = process.env.KILOCODE_TOKEN;
 
-  log(`ingestUrl=${ingestUrl}`);
-
-  // ---- Step 1: Download snapshot (stream directly to disk) ----
-  log('downloading snapshot');
-  try {
-    const url = `${ingestUrl}/api/session/${encodeURIComponent(kiloSessionId)}/export`;
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(300_000),
-    });
-
-    if (!res.ok) {
-      if (res.status === 404) {
-        log('snapshot not found (404)');
-        return fail('snapshot not found (404)', 404, 'download');
-      }
-      log(`download failed status=${res.status}`);
-      return fail(`download failed status=${res.status}`, 502, 'download');
+    if (!ingestUrl || !token) {
+      const missing = [!ingestUrl && 'KILO_SESSION_INGEST_URL', !token && 'KILOCODE_TOKEN']
+        .filter(Boolean)
+        .join(', ');
+      return fail(`missing env vars: ${missing}`, null, 'download');
     }
 
-    const bytesWritten = await Bun.write(tmpPath, res);
-    log(`snapshot downloaded bytes=${bytesWritten}`);
-  } catch (err) {
-    tryUnlink(tmpPath);
-    const message = err instanceof Error ? err.message : String(err);
-    return fail(message, null, 'download');
+    log(`ingestUrl=${ingestUrl}`);
+
+    // ---- Step 1: Download snapshot (stream directly to disk) ----
+    log('downloading snapshot');
+    try {
+      const url = `${ingestUrl}/api/session/${encodeURIComponent(kiloSessionId)}/export`;
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(300_000),
+      });
+
+      if (!res.ok) {
+        if (res.status === 404) {
+          log('snapshot not found (404)');
+          return fail('snapshot not found (404)', 404, 'download');
+        }
+        log(`download failed status=${res.status}`);
+        return fail(`download failed status=${res.status}`, 502, 'download');
+      }
+
+      const bytesWritten = await Bun.write(tmpPath, res);
+      log(`snapshot downloaded bytes=${bytesWritten}`);
+    } catch (err) {
+      tryUnlink(tmpPath);
+      const message = err instanceof Error ? err.message : String(err);
+      return fail(message, null, 'download');
+    }
+  } else {
+    log(`using provided file=${filePath}`);
   }
 
   try {
@@ -155,7 +162,7 @@ export async function restoreSession(
       log('no diffs to apply');
       return {
         ok: true,
-        downloaded: true,
+        downloaded,
         imported: true,
         diffs: { applied: 0, skipped: 0, total: 0 },
       };
@@ -200,7 +207,7 @@ export async function restoreSession(
     log(`diffs applied=${applied} skipped=${skipped} total=${total}`);
     log('completed successfully');
 
-    return { ok: true, downloaded: true, imported: true, diffs: { applied, skipped, total } };
+    return { ok: true, downloaded, imported: true, diffs: { applied, skipped, total } };
   } finally {
     tryUnlink(tmpPath);
   }
@@ -211,19 +218,31 @@ export async function restoreSession(
 // ---------------------------------------------------------------------------
 
 if (import.meta.main) {
-  const [kiloSessionId, workspacePath] = process.argv.slice(2);
+  const rawArgs = process.argv.slice(2);
+  let filePath: string | undefined;
+  const positional: string[] = [];
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    if (rawArgs[i] === '--file') {
+      filePath = rawArgs[++i];
+    } else {
+      positional.push(rawArgs[i]);
+    }
+  }
+
+  const [kiloSessionId, workspacePath] = positional;
   if (!kiloSessionId || !workspacePath) {
     console.log(
       JSON.stringify({
         ok: false,
-        error: 'Usage: kilo-restore-session <kiloSessionId> <workspacePath>',
+        error: 'Usage: kilo-restore-session [--file <path>] <kiloSessionId> <workspacePath>',
         code: null,
         step: 'download',
       })
     );
     process.exit(1);
   }
-  void restoreSession(kiloSessionId, workspacePath).then(result => {
+  void restoreSession(kiloSessionId, workspacePath, filePath).then(result => {
     console.log(JSON.stringify(result));
     process.exit(result.ok ? 0 : 1);
   });

--- a/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
+++ b/cloudflare-session-ingest/src/dos/SessionIngestDO.ts
@@ -480,6 +480,20 @@ export class SessionIngestDO extends DurableObject<Env> {
     }
   }
 
+  /** Returns true when no ingest data has been stored for this session. */
+  isEmpty(): boolean {
+    const row = this.db.select({ id: ingestItems.id }).from(ingestItems).limit(1).get();
+    return !row;
+  }
+
+  /** Atomically check emptiness and clear within a single DO request,
+   *  preventing TOCTOU races where data arrives between isEmpty() and clear(). */
+  async clearIfEmpty(): Promise<boolean> {
+    if (!this.isEmpty()) return false;
+    await this.clear();
+    return true;
+  }
+
   async clear(): Promise<void> {
     // Delete any R2-backed item blobs before wiping SQLite
     const r2Rows = this.db

--- a/cloudflare-session-ingest/src/session-ingest-rpc.ts
+++ b/cloudflare-session-ingest/src/session-ingest-rpc.ts
@@ -91,13 +91,33 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> {
   async deleteSessionForCloudAgent(params: {
     sessionId: string;
     kiloUserId: string;
+    onlyIfEmpty?: boolean;
   }): Promise<void> {
     const parsed = z
       .object({
         sessionId: sessionIdSchema,
         kiloUserId: z.string().min(1),
+        onlyIfEmpty: z.boolean().optional(),
       })
       .parse(params);
+
+    // When onlyIfEmpty is set, atomically check emptiness and clear within a
+    // single DO request to prevent a TOCTOU race where ingest data arrives
+    // between an isEmpty() check and a subsequent clear() call.
+    if (parsed.onlyIfEmpty) {
+      const cleared = await withDORetry(
+        () =>
+          getSessionIngestDO(this.env, {
+            kiloUserId: parsed.kiloUserId,
+            sessionId: parsed.sessionId,
+          }),
+        stub => stub.clearIfEmpty(),
+        'SessionIngestDO.clearIfEmpty'
+      );
+      if (!cleared) {
+        return;
+      }
+    }
 
     const db = getWorkerDb(this.env.HYPERDRIVE.connectionString);
 
@@ -124,20 +144,23 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> {
       );
     }
 
-    try {
-      await withDORetry(
-        () =>
-          getSessionIngestDO(this.env, {
-            kiloUserId: parsed.kiloUserId,
-            sessionId: parsed.sessionId,
-          }),
-        stub => stub.clear(),
-        'SessionIngestDO.clear'
-      );
-    } catch (error) {
-      cacheErrors.push(
-        `SessionIngestDO.clear: ${error instanceof Error ? error.message : String(error)}`
-      );
+    // When onlyIfEmpty was set, the DO was already cleared atomically above.
+    if (!parsed.onlyIfEmpty) {
+      try {
+        await withDORetry(
+          () =>
+            getSessionIngestDO(this.env, {
+              kiloUserId: parsed.kiloUserId,
+              sessionId: parsed.sessionId,
+            }),
+          stub => stub.clear(),
+          'SessionIngestDO.clear'
+        );
+      } catch (error) {
+        cacheErrors.push(
+          `SessionIngestDO.clear: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
     }
 
     if (cacheErrors.length > 0) {

--- a/src/app/api/cloud-agent-next/sessions/stream-ticket/route.ts
+++ b/src/app/api/cloud-agent-next/sessions/stream-ticket/route.ts
@@ -91,16 +91,18 @@ export async function POST(request: Request) {
         user.id,
         cloudAgentSessionId
       );
+
       if (!sessionOwnership) {
         return NextResponse.json(
           { error: 'Organization does not own this session' },
           { status: 403 }
         );
       }
+      const kiloSessionId: string | undefined = sessionOwnership.kiloSessionId;
 
       const result = signStreamTicket({
         userId: user.id,
-        kiloSessionId: sessionOwnership.kiloSessionId,
+        kiloSessionId,
         cloudAgentSessionId,
         organizationId,
       });
@@ -112,13 +114,15 @@ export async function POST(request: Request) {
         user.id,
         cloudAgentSessionId
       );
+
       if (!sessionOwnership) {
         return NextResponse.json({ error: 'Session not found or access denied' }, { status: 403 });
       }
+      const kiloSessionId: string | undefined = sessionOwnership.kiloSessionId;
 
       const result = signStreamTicket({
         userId: user.id,
-        kiloSessionId: sessionOwnership.kiloSessionId,
+        kiloSessionId,
         cloudAgentSessionId,
       });
       return NextResponse.json(result);

--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -265,6 +265,8 @@ export function CloudChatContainer({
 
   // Legacy sessions may have cloudAgentSessionId without prepared state in the DO
   const [needsLegacyPrepare, setNeedsLegacyPrepare] = useState(false);
+  // Async preparation in progress (autoInitiate flow: DO has metadata but no preparedAt)
+  const [isPreparingAsync, setIsPreparingAsync] = useState(false);
   const [preflightComplete, setPreflightComplete] = useState(false);
   const preflightedCloudAgentSessionRef = useRef<string | null>(null);
 
@@ -289,6 +291,24 @@ export function CloudChatContainer({
     setFailedMessageText(messageText);
   }, []);
 
+  // Handle async preparation progress — show progress in chat feed
+  const handlePreparationReady = useCallback(() => {
+    setIsPreparingAsync(false);
+    setIsSessionInitiated(true);
+  }, []);
+
+  const handlePreparationFailed = useCallback(
+    (message: string) => {
+      setIsPreparingAsync(false);
+      // Prevent the auto-initiate effect from firing after preparation failure
+      if (cloudAgentSessionId) {
+        setAutoInitiatedSessionId(cloudAgentSessionId);
+      }
+      setError(`Session preparation failed: ${message}`);
+    },
+    [setError, cloudAgentSessionId]
+  );
+
   // Stream hook (V2 WebSocket-based)
   const {
     sendMessage: sendMessageV2,
@@ -308,6 +328,8 @@ export function CloudChatContainer({
     onBranchChanged: useCallback((branch: string) => {
       setLoadedDbSession(prev => (prev ? { ...prev, git_branch: branch } : prev));
     }, []),
+    onPreparationReady: handlePreparationReady,
+    onPreparationFailed: handlePreparationFailed,
   });
 
   // Wrapper for sendMessage that doesn't use sessionIdOverride
@@ -460,12 +482,20 @@ export function CloudChatContainer({
           const isInitiated = runtimeState?.initiatedAt ? true : hasMessages;
           setIsSessionInitiated(isInitiated);
 
-          // Check if this is a legacy session (has cloud_agent_session_id but no preparedAt in DO)
+          // Check session state: distinguish legacy (no DO), async-preparing, and ready
           if (sessionData.cloud_agent_session_id) {
-            if (!runtimeState || !runtimeState.preparedAt) {
+            if (!runtimeState) {
+              // No DO at all — truly legacy session
               setNeedsLegacyPrepare(true);
-            } else {
+              setIsPreparingAsync(false);
+            } else if (!runtimeState.preparedAt) {
+              // DO exists but not yet prepared — async preparation in progress
               setNeedsLegacyPrepare(false);
+              setIsPreparingAsync(true);
+            } else {
+              // Fully prepared — ready to initiate
+              setNeedsLegacyPrepare(false);
+              setIsPreparingAsync(false);
             }
             // Mark preflight tracking ref so we don't re-run
             preflightedCloudAgentSessionRef.current = sessionData.cloud_agent_session_id;
@@ -537,6 +567,7 @@ export function CloudChatContainer({
     isLoadingFromDb,
     isStreaming,
     cloudAgentSessionId,
+    organizationId,
     refetchSession,
     refetchMessages,
     loadSessionToIndexedDb,
@@ -555,6 +586,7 @@ export function CloudChatContainer({
       !cloudAgentSessionId ||
       !preflightComplete ||
       needsLegacyPrepare ||
+      isPreparingAsync ||
       isSessionInitiated ||
       isStreaming ||
       isLoadingFromDb ||
@@ -577,6 +609,7 @@ export function CloudChatContainer({
     cloudAgentSessionId,
     preflightComplete,
     needsLegacyPrepare,
+    isPreparingAsync,
     isSessionInitiated,
     isStreaming,
     isLoadingFromDb,
@@ -589,10 +622,10 @@ export function CloudChatContainer({
   // Track which sessions we've already connected to (for existing sessions)
   const connectedExistingSessionRef = useRef<string | null>(null);
 
-  // Connect to WebSocket for already-initiated sessions (e.g., when loading a previously started session)
+  // Connect to WebSocket for already-initiated sessions or during async preparation
   useEffect(() => {
-    // Only connect if session was previously initiated (has blob URLs)
-    if (!isSessionInitiated) {
+    // Connect if session was previously initiated OR async preparation is in progress
+    if (!isSessionInitiated && !isPreparingAsync) {
       return;
     }
 
@@ -639,6 +672,7 @@ export function CloudChatContainer({
     cloudAgentSessionId,
     currentSessionId,
     isSessionInitiated,
+    isPreparingAsync,
     isStreaming,
     isLoadingFromDb,
     connectionState.status,
@@ -656,6 +690,7 @@ export function CloudChatContainer({
       // Disconnect old WebSocket to prevent events from old session updating UI
       cleanup();
       setAutoInitiatedSessionId(null);
+      setIsPreparingAsync(false);
       setPersistedConfig(null);
       setResumeConfigError(null);
       connectedExistingSessionRef.current = null;

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -384,6 +384,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
         setupCommands: manualSetupCommands.length > 0 ? manualSetupCommands : undefined,
         profileName: selectedProfile?.name,
         autoCommit: true,
+        autoInitiate: true,
       };
 
       let result: { kiloSessionId: string; cloudAgentSessionId: string };

--- a/src/components/cloud-agent-next/SessionStatusIndicator.tsx
+++ b/src/components/cloud-agent-next/SessionStatusIndicator.tsx
@@ -29,6 +29,13 @@ function IndicatorContent({ indicator }: { indicator: SessionStatusIndicatorType
           <span>{indicator.message}</span>
         </span>
       );
+    case 'progress':
+      return (
+        <span className="text-muted-foreground flex items-center gap-2">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span>{indicator.message}</span>
+        </span>
+      );
     case 'info':
       return (
         <span className="text-muted-foreground flex items-center gap-2">

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -98,7 +98,7 @@ export const autocommitStatusMapAtom = atom<Map<string, AutocommitStatus>>(new M
  * Non-recoverable errors still go through `errorAtom` → `ErrorBanner`.
  */
 export type SessionStatusIndicator = {
-  type: 'error' | 'warning' | 'info';
+  type: 'error' | 'warning' | 'info' | 'progress';
   message: string;
   timestamp: number;
 };

--- a/src/components/cloud-agent-next/useCloudAgentStream.ts
+++ b/src/components/cloud-agent-next/useCloudAgentStream.ts
@@ -72,6 +72,12 @@ export type UseCloudAgentStreamOptions = {
   onSendFailed?: (messageText: string) => void;
   /** Callback when the agent's current branch changes (from complete event) */
   onBranchChanged?: (branch: string) => void;
+  /** Callback when async preparation emits a progress event */
+  onPreparingProgress?: (step: string, message: string) => void;
+  /** Callback when async preparation completes (step === 'ready') */
+  onPreparationReady?: () => void;
+  /** Callback when async preparation fails (step === 'failed') */
+  onPreparationFailed?: (message: string) => void;
 };
 
 export type UseCloudAgentStreamReturn = {
@@ -111,6 +117,9 @@ export function useCloudAgentStream({
   onQuestionAsked,
   onSendFailed,
   onBranchChanged,
+  onPreparingProgress,
+  onPreparationReady,
+  onPreparationFailed,
 }: UseCloudAgentStreamOptions): UseCloudAgentStreamReturn {
   const trpcClient = useRawTRPCClient();
 
@@ -179,6 +188,9 @@ export function useCloudAgentStream({
   const onQuestionAskedRef = useRef(onQuestionAsked);
   const onSendFailedRef = useRef(onSendFailed);
   const onBranchChangedRef = useRef(onBranchChanged);
+  const onPreparingProgressRef = useRef(onPreparingProgress);
+  const onPreparationReadyRef = useRef(onPreparationReady);
+  const onPreparationFailedRef = useRef(onPreparationFailed);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -205,6 +217,18 @@ export function useCloudAgentStream({
   }, [onSendFailed]);
 
   useEffect(() => {
+    onPreparingProgressRef.current = onPreparingProgress;
+  }, [onPreparingProgress]);
+
+  useEffect(() => {
+    onPreparationReadyRef.current = onPreparationReady;
+  }, [onPreparationReady]);
+
+  useEffect(() => {
+    onPreparationFailedRef.current = onPreparationFailed;
+  }, [onPreparationFailed]);
+
+  useEffect(() => {
     cloudAgentSessionIdRef.current = cloudAgentSessionIdProp ?? null;
   }, [cloudAgentSessionIdProp]);
 
@@ -218,7 +242,11 @@ export function useCloudAgentStream({
    */
   const setIndicator = useCallback(
     (
-      indicator: { type: 'error' | 'warning' | 'info'; message: string; timestamp: number } | null
+      indicator: {
+        type: 'error' | 'warning' | 'info' | 'progress';
+        message: string;
+        timestamp: number;
+      } | null
     ) => {
       if (infoClearTimerRef.current) {
         clearTimeout(infoClearTimerRef.current);
@@ -449,6 +477,47 @@ export function useCloudAgentStream({
 
   const handleEvent = useCallback(
     (event: CloudAgentEvent) => {
+      // Handle preparation progress events (async preparation flow)
+      if (event.streamEventType === 'preparing') {
+        const raw = event.data;
+        const step =
+          typeof raw === 'object' && raw !== null && 'step' in raw && typeof raw.step === 'string'
+            ? raw.step
+            : 'unknown';
+        const message =
+          typeof raw === 'object' &&
+          raw !== null &&
+          'message' in raw &&
+          typeof raw.message === 'string'
+            ? raw.message
+            : '';
+
+        onPreparingProgressRef.current?.(step, message);
+
+        if (step === 'ready') {
+          onPreparationReadyRef.current?.();
+          setIndicator({
+            type: 'progress',
+            message: 'Starting session…',
+            timestamp: Date.now(),
+          });
+        } else if (step === 'failed') {
+          onPreparationFailedRef.current?.(message);
+          setIndicator({
+            type: 'error',
+            message: message || 'Preparation failed',
+            timestamp: Date.now(),
+          });
+        } else {
+          setIndicator({
+            type: 'progress',
+            message,
+            timestamp: Date.now(),
+          });
+        }
+        return;
+      }
+
       // Set inline indicator for session-level events (no ErrorBanner).
       // The event processor handles streaming state and message completion.
       if (event.streamEventType === 'wrapper_disconnected') {

--- a/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -98,10 +98,13 @@ export type PrepareSessionInput = {
   createdOnPlatform?: string;
   /** PR gate threshold — when not 'off', the agent reports gateResult in its callback */
   gateThreshold?: 'off' | 'all' | 'warning' | 'critical';
+  /** When true, return immediately and run preparation asynchronously */
+  autoInitiate?: boolean;
 };
 
 /** Output from prepareSession procedure */
 export type PrepareSessionOutput = {
+  /** The Kilo CLI session ID */
   kiloSessionId: string;
   cloudAgentSessionId: string;
 };

--- a/src/lib/cloud-agent-next/websocket-manager.ts
+++ b/src/lib/cloud-agent-next/websocket-manager.ts
@@ -195,7 +195,12 @@ export function createWebSocketManager(config: WebSocketManagerConfig): {
       }
 
       const event = parsed.event;
-      lastEventId = event.eventId;
+      // Only advance the cursor for persisted events (positive IDs).
+      // Volatile events (e.g. preparing progress) use id 0; allowing them
+      // to regress the cursor causes a full replay on the next reconnect.
+      if (event.eventId > lastEventId) {
+        lastEventId = event.eventId;
+      }
 
       // Reset ticket refresh flag on successful message
       ticketRefreshAttempted = false;

--- a/src/lib/cloud-agent/stream-ticket.ts
+++ b/src/lib/cloud-agent/stream-ticket.ts
@@ -4,7 +4,7 @@ import { NEXTAUTH_SECRET } from '@/lib/config.server';
 
 export type StreamTicketPayload = {
   userId: string;
-  kiloSessionId: string;
+  kiloSessionId?: string;
   cloudAgentSessionId: string;
   organizationId?: string;
 };

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -87,6 +87,7 @@ export const basePrepareSessionNextSchema = z
     mcpServers: z.record(z.string(), mcpServerConfigNextSchema).optional(),
     upstreamBranch: z.string().optional(),
     autoCommit: z.boolean().optional(),
+    autoInitiate: z.boolean().optional(),
   })
   .refine(
     data => (data.githubRepo || data.gitlabProject) && !(data.githubRepo && data.gitlabProject),


### PR DESCRIPTION
## Summary

Add an async session preparation path to cloud-agent-next, reducing perceived wait time from 30–120s to ~500ms when starting a session from the landing page.

- **Fast return path**: `autoInitiate: true` flag on `prepareSession` returns immediately after creating IDs and registering minimal DO metadata. Expensive work (git clone, setup commands, kilo server start) runs asynchronously via a DO alarm.
- **Single stable ID**: Generate a `ses_*` session ID upfront in the fast path and import it into the CLI's SQLite before the wrapper starts. Eliminates dual-ID complexity and URL rewriting.
- **Streaming progress**: New `preparing` event type streams real-time preparation steps (disk check → clone → branch → setup → ready/failed) over the existing WebSocket infrastructure.
- **Chat page integration**: WebSocket connects during async preparation to display progress events. Auto-initiates execution once preparation completes. New `progress` status indicator (muted spinner, no auto-clear).
- **Cold-start resume progress**: Threaded `onProgress` callback through the resume path so follow-up messages also report progress during sandbox re-creation.

`autoInitiate: false` (default) preserves existing synchronous behavior exactly — zero changes to existing callers.

**Architecture**: Preparation runs inside the DO via `setAlarm(Date.now())`, safe regardless of caller lifetime (no reliance on `ctx.waitUntil` which is a no-op in DOs). `cli_sessions_v2` is created before return so the stream-ticket route can verify ownership immediately. `restore-session.ts` gains a `--file` flag to accept pre-written session files for import (Docker rebuild needed).

## Verification

- [x] Manual check

## Visual Changes

| Before | After |
| ------ | ----- |
| Landing page blocks 10–30s during `prepareSession` before redirect | Redirects in ~500ms; chat page shows streaming progress (disk check → clone → setup → ready) |
| No progress during cold-start resume on follow-up messages | Progress spinner for each cold-start step (clone, workspace setup, session restore, kilo start) |
