### PR TITLE
feat(kiloclaw): add KILOCLAW_BILLING_ENFORCEMENT env var toggle

### DIFF
--- a/src/lib/config.server.ts
+++ b/src/lib/config.server.ts
@@ -196,6 +196,11 @@ if (rawBillingStart && Number.isNaN(new Date(rawBillingStart).getTime())) {
 }
 export const STRIPE_KILOCLAW_BILLING_START = rawBillingStart;
 
+// KiloClaw Billing Enforcement — opt-in gate for subscription/trial/earlybird checks.
+// When false (default), all billing gates are no-ops so users are never blocked.
+export const KILOCLAW_BILLING_ENFORCEMENT =
+  getEnvVariable('KILOCLAW_BILLING_ENFORCEMENT') === 'true';
+
 // Webhook Agent Ingest Worker
 export const WEBHOOK_AGENT_URL =
   getEnvVariable('WEBHOOK_AGENT_URL') || 'https://hooks.kilosessions.ai';

--- a/src/lib/kiloclaw/access-gate.ts
+++ b/src/lib/kiloclaw/access-gate.ts
@@ -6,6 +6,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/lib/drizzle';
 import { kiloclaw_subscriptions, kiloclaw_earlybird_purchases } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import { KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
 import { baseProcedure } from '@/lib/trpc/init';
 
 /**
@@ -13,6 +14,8 @@ import { baseProcedure } from '@/lib/trpc/init';
  * Throws TRPCError FORBIDDEN if the user has no valid access.
  */
 export async function requireKiloClawAccess(userId: string): Promise<void> {
+  if (!KILOCLAW_BILLING_ENFORCEMENT) return;
+
   // 1. Active subscription
   const [sub] = await db
     .select({

--- a/src/lib/kiloclaw/billing-lifecycle-cron.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.ts
@@ -17,7 +17,7 @@ import type { TemplateName } from '@/lib/email';
 import { send as sendEmail } from '@/lib/email';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
-import { NEXTAUTH_URL } from '@/lib/config.server';
+import { NEXTAUTH_URL, KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
 import { sentryLogger } from '@/lib/utils.server';
 
 const logInfo = sentryLogger('kiloclaw-billing-cron', 'info');
@@ -100,6 +100,11 @@ export async function runKiloClawBillingLifecycleCron(
     emails_skipped: 0,
     errors: 0,
   };
+
+  if (!KILOCLAW_BILLING_ENFORCEMENT) {
+    logInfo('KiloClaw billing enforcement is disabled, skipping lifecycle cron');
+    return summary;
+  }
 
   const now = new Date().toISOString();
   const client = new KiloClawInternalClient();

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -18,6 +18,7 @@ import {
   STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID,
   STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID,
   STRIPE_KILOCLAW_BILLING_START,
+  KILOCLAW_BILLING_ENFORCEMENT,
 } from '@/lib/config.server';
 import { db } from '@/lib/drizzle';
 import {
@@ -318,6 +319,8 @@ async function ensureProvisionAccess(userId: string): Promise<void> {
       return;
     }
   }
+
+  if (!KILOCLAW_BILLING_ENFORCEMENT) return;
 
   throw new TRPCError({
     code: 'FORBIDDEN',
@@ -1015,8 +1018,8 @@ export const kiloclawRouter = createTRPCRouter({
 
     const now = new Date();
 
-    // Compute hasAccess
-    let hasAccess = false;
+    // Compute hasAccess — when enforcement is off, always grant access
+    let hasAccess = !KILOCLAW_BILLING_ENFORCEMENT;
     let accessReason: 'trial' | 'subscription' | 'earlybird' | null = null;
 
     if (sub?.status === 'active' || (sub?.status === 'past_due' && !sub.suspended_at)) {


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Adds KILOCLAW_BILLING_ENFORCEMENT env var (default: off) to disable all billing gates without removing billing   code
- When unset or not "true", all billing enforcement becomes a no-op: no access blocking, no provision blocking, no   lifecycle cron sweeps, no frontend lock dialogs
- Trial auto-creation, earlybird recognition, subscription checkout/management, Stripe webhooks, and billing status   queries remain fully functional
- To re-enable enforcement later, set KILOCLAW_BILLING_ENFORCEMENT=true in Vercel/env


## Verification

- pnpm run typecheck — pass
- pnpm run lint — pass
- pnpm run format:check — pass


## Visual Changes

N/A

## Reviewer Notes

- The env var does not need to be added to any environment yet — absence = enforcement off, which is the desired   default
- ensureProvisionAccess() still creates trial rows for new users even when enforcement is off — this is intentional   so billing data stays accurate
- getBillingStatus returns real billing data (trial, subscription, earlybird info) with just hasAccess forced to   true — downstream UI logic is unaffected since deriveLockReason only branches on !hasAccess
- Devs can test enforcement locally by adding KILOCLAW_BILLING_ENFORCEMENT=true to .env
