### PR TITLE
feat(kiloclaw): apply openclaw doctor recommend optimizations and fixes

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -113,7 +113,7 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy startup script
-# Build cache bust: 2026-03-12-v62-github-machine-user
+# Build cache bust: 2026-03-16-v63-startup-optimization
 RUN echo "10"
 COPY start-openclaw.sh /usr/local/bin/start-openclaw.sh
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -20,8 +20,22 @@ WORKSPACE_DIR="/root/clawd"
 echo "Config directory: $CONFIG_DIR"
 
 mkdir -p "$CONFIG_DIR"
+chmod 700 "$CONFIG_DIR"
 mkdir -p "$WORKSPACE_DIR"
 cd "$WORKSPACE_DIR"
+
+# ============================================================
+# STARTUP OPTIMIZATION (openclaw doctor → Startup optimization)
+# ============================================================
+# Avoid extra process self-respawn overhead — the controller already supervises
+# the gateway, so the CLI/gateway don't need their own detached-restart path.
+export OPENCLAW_NO_RESPAWN=1
+
+# Enable Node's module compile cache on the persistent volume so warm bytecode
+# survives machine stop/start cycles. /root is the Fly Volume mount, so this
+# cache persists across restarts (unlike /var/tmp which is ephemeral in Fly VMs).
+export NODE_COMPILE_CACHE=/root/.openclaw/cache/node-compile-cache
+mkdir -p "$NODE_COMPILE_CACHE"
 
 # ============================================================
 # DECRYPT ENCRYPTED ENV VARS

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -31,10 +31,11 @@ cd "$WORKSPACE_DIR"
 # the gateway, so the CLI/gateway don't need their own detached-restart path.
 export OPENCLAW_NO_RESPAWN=1
 
-# Enable Node's module compile cache on the persistent volume so warm bytecode
-# survives machine stop/start cycles. /root is the Fly Volume mount, so this
-# cache persists across restarts (unlike /var/tmp which is ephemeral in Fly VMs).
-export NODE_COMPILE_CACHE=/root/.openclaw/cache/node-compile-cache
+# Enable Node's module compile cache. The cache is version-keyed (Node
+# auto-creates a subdirectory per NODE_VERSION+ARCH+V8 tag), so stale
+# entries from a different Node version are harmlessly ignored.
+# /var/tmp matches the upstream openclaw doctor recommendation.
+export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
 mkdir -p "$NODE_COMPILE_CACHE"
 
 # ============================================================

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-03-17',
+    description:
+      'Reduced OpenClaw startup overhead by disabling unnecessary CLI self-respawn, enabled Node compile cache for faster repeated CLI runs, and tightened state directory permissions.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
     date: '2026-03-16',
     description: 'Updated OpenClaw to 2026.3.13.',
     category: 'feature',


### PR DESCRIPTION
## Summary

Applies the three recommendations from `openclaw doctor` that fire on KiloClaw's Fly VMs (Linux, ≤8 GB RAM):

- **`OPENCLAW_NO_RESPAWN=1`** — Disables the CLI self-respawn path (`src/entry.ts` bootstrap fork for `--disable-warning=ExperimentalWarning`). The KiloClaw controller already supervises the gateway, so the extra fork-and-exec on startup is wasted overhead. Note: this is complementary to the existing `INVOCATION_ID=1` marker — `OPENCLAW_NO_RESPAWN` handles the CLI entry point respawn, while `INVOCATION_ID` tells the gateway runtime to exit cleanly on SIGUSR1 restart instead of forking (letting the controller respawn it). Both remain set.
- **`NODE_COMPILE_CACHE`** — Enables Node's module compile cache at `/var/tmp/openclaw-compile-cache`, matching the upstream `openclaw doctor` recommendation. The cache is version-keyed by Node (subdirectory per `NODE_VERSION+ARCH+V8 tag`), so stale entries from a different Node version are harmlessly ignored. `/var/tmp` avoids accumulating dead cache directories on the persistent volume across Node upgrades.
- **`chmod 700 ~/.openclaw`** — Tightens state directory permissions to owner-only, satisfying the "State directory permissions are too open" doctor check.

Both env vars are exported before any `openclaw` CLI invocation (`onboard`, `doctor --fix`) and before the controller/gateway launch.

## Verification

- [x] `pnpm format:check` — passed (pre-push hook)
- [x] `pnpm lint` — passed (pre-push hook; pre-existing gastown lint errors unrelated)
- [ ] Docker build + `scripts/controller-entrypoint-smoke-test.sh` (not run locally — recommend verifying in CI or staging)

## Visual Changes

N/A

## Reviewer Notes

- Dockerfile cache bust bumped from `v62` to `v63-startup-optimization` per the kiloclaw change checklist (AGENTS.md requires this when `start-openclaw.sh` changes).
- All three changes are idempotent — safe for existing volumes that already have `~/.openclaw` with different permissions or a missing cache directory.
- No config or worker-side changes needed; these are purely machine-boot-time environment tweaks.
- `OPENCLAW_NO_RESPAWN=1` and `INVOCATION_ID=1` serve different code paths and both remain necessary. `OPENCLAW_NO_RESPAWN` is checked first in `process-respawn.ts` (returns `disabled` before supervisor detection runs), but `INVOCATION_ID` is still needed because the gateway run-loop checks supervisor detection independently for its restart strategy.