### PR TITLE
fix(kiloclaw): include fly app name in reconcile logs

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -45,6 +45,7 @@ export async function ensureVolume(
   await ctx.storage.put(storageUpdate({ flyVolumeId: volume.id, flyRegion: volume.region }));
 
   reconcileLog(reason, 'create_volume', {
+    fly_app_name: flyConfig.appName,
     volume_id: volume.id,
     region: volume.region,
   });
@@ -74,7 +75,10 @@ export async function replaceStrandedVolume(
     let machineGone = false;
     try {
       await fly.destroyMachine(flyConfig, state.flyMachineId);
-      reconcileLog(reason, 'destroy_stranded_machine', { machine_id: state.flyMachineId });
+      reconcileLog(reason, 'destroy_stranded_machine', {
+        fly_app_name: flyConfig.appName,
+        machine_id: state.flyMachineId,
+      });
       machineGone = true;
     } catch (err) {
       if (fly.isFlyNotFound(err)) {
@@ -102,6 +106,7 @@ export async function replaceStrandedVolume(
     state.flyVolumeId = forkedVolume.id;
     state.flyRegion = forkedVolume.region;
     reconcileLog(reason, 'fork_stranded_volume', {
+      fly_app_name: flyConfig.appName,
       old_volume_id: oldVolumeId,
       old_region: oldRegion,
       new_volume_id: forkedVolume.id,
@@ -124,6 +129,7 @@ export async function replaceStrandedVolume(
     state.flyVolumeId = freshVolume.id;
     state.flyRegion = freshVolume.region;
     reconcileLog(reason, 'create_replacement_volume', {
+      fly_app_name: flyConfig.appName,
       old_volume_id: oldVolumeId,
       old_region: oldRegion,
       new_volume_id: freshVolume.id,
@@ -138,7 +144,10 @@ export async function replaceStrandedVolume(
   // Delete old volume (best-effort cleanup)
   try {
     await fly.deleteVolume(flyConfig, oldVolumeId);
-    reconcileLog(reason, 'delete_stranded_volume', { volume_id: oldVolumeId });
+    reconcileLog(reason, 'delete_stranded_volume', {
+      fly_app_name: flyConfig.appName,
+      volume_id: oldVolumeId,
+    });
   } catch (err) {
     if (!fly.isFlyNotFound(err)) {
       console.warn('[DO] Failed to delete stranded volume (will leak):', oldVolumeId, err);


### PR DESCRIPTION
## Summary

Adds `fly_app_name` to reconciliation logs emitted by `KiloClawInstance` so recovery events can be tied directly to the per-user Fly app.

- Adds `fly_app_name: flyConfig.appName` to structured `reconcileLog(...)` payloads for:
  - `create_volume`
  - `destroy_stranded_machine`
  - `fork_stranded_volume`
  - `create_replacement_volume`
  - `delete_stranded_volume`
- This makes `start_409_recovery` / stranded-volume events actionable in log search without correlating separate records.
- `flyConfig.appName` is guaranteed in this path via `getFlyConfig` (`state.flyAppName ?? env.FLY_APP_NAME`, otherwise throws), so the field is reliably populated.

## Verification

- [x] `pnpm format:check` — passed
- [x] `pnpm lint` — passed
- [x] `pnpm test` — passed (`36` files, `684` tests)

## Visual Changes

N/A

## Reviewer Notes

- No behavior change to machine lifecycle/recovery logic; this is observability-only.
- Existing warning text (`Failed to delete stranded volume (will leak)`) is unchanged; only structured fields were expanded.
- There is an unrelated untracked file in parent workspace (`../push-refreshed-token-deviations.md`) not included in this PR.