### PR TITLE
fix(cloud-agent-next): detect zombie ingest sockets with ping probe

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -1015,6 +1015,19 @@ export class CloudAgentSession extends DurableObject {
       return;
     }
 
+    // Diagnostic: log connection and heartbeat health each alarm cycle
+    const ingestSocketCount = this.ctx.getWebSockets(`ingest:${activeExecutionId}`).length;
+    const heartbeatAge = execution.lastHeartbeat ? now - execution.lastHeartbeat : null;
+    logger
+      .withFields({
+        sessionId: this.sessionId,
+        executionId: activeExecutionId,
+        status: execution.status,
+        ingestSocketCount,
+        heartbeatAge,
+      })
+      .debug('Alarm diagnostic for active execution');
+
     // Check if execution is stale (no heartbeat for STALE_THRESHOLD_MS)
     if (execution.status === 'running') {
       const staleThresholdMs = this.getStaleThresholdMs();

--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -89,6 +89,10 @@ const KILO_SERVER_IDLE_TIMEOUT_MS_DEFAULT = 15 * 60 * 1000;
  *  Covers the first few reconnection attempts (exponential backoff: 1s, 2s, 4s …). */
 const DISCONNECT_GRACE_MS = 10_000;
 
+/** Heartbeat age (60 s) at which we probe the ingest WebSocket.
+ *  Well below STALE_THRESHOLD_MS (600 s) so zombie sockets are caught early. */
+const HEARTBEAT_PROBE_AGE_MS = 60_000;
+
 /** DO storage key for persisting disconnect grace state across hibernation. */
 const DISCONNECT_GRACE_KEY = 'disconnect_grace';
 
@@ -1050,6 +1054,21 @@ export class CloudAgentSession extends DurableObject {
           error: 'Execution timeout - no heartbeat received',
           streamEventType: 'error',
         });
+      } else if (
+        execution.lastHeartbeat &&
+        now - execution.lastHeartbeat > HEARTBEAT_PROBE_AGE_MS
+      ) {
+        // Heartbeat is older than expected but not yet stale.
+        // Probe the ingest WebSocket to detect zombie connections early.
+        const heartbeatAge = now - execution.lastHeartbeat;
+        logger
+          .withFields({
+            sessionId: this.sessionId,
+            executionId: activeExecutionId,
+            heartbeatAge,
+          })
+          .debug('Heartbeat age exceeds probe threshold — probing ingest connection');
+        await this.probeIngestConnection(activeExecutionId);
       }
     }
 
@@ -1233,6 +1252,47 @@ export class CloudAgentSession extends DurableObject {
           error: error instanceof Error ? error.message : String(error),
         })
         .warn('Failed to reset sandbox sleep timer');
+    }
+  }
+
+  /**
+   * Probe the ingest WebSocket for a running execution to detect zombie
+   * connections.  Sends a `{ type: 'ping' }` command; if the socket is
+   * already dead, `ws.send()` throws and Cloudflare closes it, which fires
+   * `webSocketClose` → `startDisconnectGrace`.
+   *
+   * If no ingest sockets exist at all, starts the disconnect grace period
+   * immediately (the wrapper is already gone).
+   */
+  private async probeIngestConnection(executionId: ExecutionId): Promise<void> {
+    const sockets = this.ctx.getWebSockets(`ingest:${executionId}`);
+
+    if (sockets.length === 0) {
+      logger
+        .withFields({ sessionId: this.sessionId, executionId })
+        .warn('No ingest sockets found during probe — starting disconnect grace');
+      await this.startDisconnectGrace(executionId, 0, 'probe: no ingest sockets');
+      return;
+    }
+
+    logger
+      .withFields({ sessionId: this.sessionId, executionId, socketCount: sockets.length })
+      .debug('Probing ingest sockets with ping');
+
+    for (const ws of sockets) {
+      try {
+        ws.send(JSON.stringify({ type: 'ping' }));
+      } catch (error) {
+        // send() threw — socket is dead. Cloudflare will fire webSocketClose
+        // which triggers startDisconnectGrace via the normal close path.
+        logger
+          .withFields({
+            sessionId: this.sessionId,
+            executionId,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          .warn('Ping send failed — socket is dead');
+      }
     }
   }
 

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -328,6 +328,8 @@ export function createIngestHandler(
         // Update heartbeat (debounced to every HEARTBEAT_DEBOUNCE_MS)
         const now = Date.now();
         if (now - attachment.lastHeartbeatUpdate >= HEARTBEAT_DEBOUNCE_MS) {
+          const gap = now - attachment.lastHeartbeatUpdate;
+          console.debug(`Heartbeat update for ${executionId}: gap=${gap}ms since last update`);
           attachment.lastHeartbeatUpdate = now;
           ws.serializeAttachment(attachment);
           void doContext.updateHeartbeat(executionId, now);


### PR DESCRIPTION
## Summary

When a sandbox container crashes (e.g. OOM), the TCP connection between the wrapper and the DO can die silently — no FIN, no RST, nothing. The DO still thinks the WebSocket is alive, so it keeps waiting for heartbeats that will never come. The execution only fails after the full stale threshold (10 min), plus extra alarm cycles on top of that — roughly 12 minutes of wasted time.

This PR adds an early detection step. Every alarm cycle, if the heartbeat is older than 60 seconds but hasn't hit the stale threshold yet, we send a `ping` over the ingest WebSocket. Two things can happen:

- **The socket is actually dead**: `ws.send()` throws, Cloudflare closes the socket, and the normal disconnect grace path kicks in (10s). The execution fails within ~2.5 minutes instead of ~12.
- **The socket is fine**: the wrapper replies with `pong`, which refreshes the heartbeat. Nothing changes.

If there are no sockets at all (wrapper already fully gone), we skip straight to the grace period.

The ping/pong protocol was already fully implemented end-to-end but never used. No new types, no wrapper changes, no threshold changes.

Diagnostic logs are added so we can see socket count and heartbeat age in production.

## Verification

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 650 tests pass
- [x] `pnpm run test:integration` — 30 tests pass

## Visual Changes

N/A

## Reviewer Notes

The probe is deliberately conservative: it only runs when the heartbeat is already late (>60s), and it relies on existing paths (`startDisconnectGrace`, `webSocketClose`) rather than adding new failure logic. The worst case if `ws.send()` silently succeeds on a zombie socket is that nothing changes — the next alarm cycle tries again, and eventually the stale threshold catches it as before.