### PR TITLE
fix(gitlab): sync integration_type on OAuth reconnect and drop self_rotate scope

### DIFF
--- a/src/app/api/integrations/gitlab/callback/route.ts
+++ b/src/app/api/integrations/gitlab/callback/route.ts
@@ -145,6 +145,7 @@ export async function GET(request: NextRequest) {
       await db
         .update(platform_integrations)
         .set({
+          integration_type: 'oauth',
           platform_account_id: gitlabUser.id.toString(),
           platform_account_login: gitlabUser.username,
           scopes: tokens.scope.split(' '),

--- a/src/lib/integrations/gitlab-service.ts
+++ b/src/lib/integrations/gitlab-service.ts
@@ -553,7 +553,7 @@ export async function getOrCreateProjectAccessToken(
       projectId,
       KILO_BOT_TOKEN_NAME,
       expiresAt,
-      ['api', 'self_rotate'], // api for full access, self_rotate for token rotation
+      ['api'], // api for full access; self_rotate not needed since rotation uses the user's token
       30, // Developer access level
       instanceUrl
     );

--- a/src/lib/integrations/platforms/gitlab/adapter.ts
+++ b/src/lib/integrations/platforms/gitlab/adapter.ts
@@ -1595,7 +1595,7 @@ export class GitLabProjectAccessTokenPermissionError extends Error {
  * @param projectId - GitLab project ID or path (URL-encoded)
  * @param tokenName - Name for the token (e.g., "Kilo Code Review Bot")
  * @param expiresAt - Expiration date in YYYY-MM-DD format (max 1 year from now)
- * @param scopes - Token scopes (default: ['api', 'self_rotate'])
+ * @param scopes - Token scopes (default: ['api'])
  * @param accessLevel - Access level for the token (default: DEVELOPER = 30)
  * @param instanceUrl - GitLab instance URL (defaults to gitlab.com)
  * @throws {GitLabProjectAccessTokenPermissionError} When user doesn't have Maintainer+ role
@@ -1607,7 +1607,7 @@ export async function createProjectAccessToken(
   projectId: string | number,
   tokenName: string,
   expiresAt: string,
-  scopes: string[] = ['api', 'self_rotate'],
+  scopes: string[] = ['api'],
   accessLevel: number = GITLAB_ACCESS_LEVELS.DEVELOPER,
   instanceUrl: string = DEFAULT_GITLAB_URL
 ): Promise<GitLabProjectAccessToken> {


### PR DESCRIPTION
## Summary

- When a GitLab PAT integration was reconnected via OAuth, the callback update path overwrote `metadata.auth_type` to `"oauth"` but left the `integration_type` column as `"pat"`, causing a data inconsistency. Now the OAuth callback also sets `integration_type: 'oauth'` on update.
- Removed the `self_rotate` scope from project access token creation. Token rotation already uses the user's OAuth/PAT token (not the project token itself), so `self_rotate` is unnecessary. It also causes `"scopes does not have a valid value"` errors on self-hosted GitLab instances running versions older than 16.6 (when that scope was introduced).

## Verification

- [x] `pnpm typecheck` — all packages pass
- [x] `prettier --check` — all files pass
- [x] `eslint` — all packages pass
- [x] Pre-push hooks (format, lint, typecheck) — all pass

## Visual Changes

N/A

## Reviewer Notes

- The `integration_type` column is not currently read for GitLab runtime logic (all code reads `metadata.auth_type`), so the mismatch didn't cause functional breakage — but it's semantically wrong and could confuse DB queries or admin tools.
- The `self_rotate` scope removal is safe because `rotateProjectAccessToken()` in `adapter.ts` authenticates with the user's token (`Authorization: Bearer ${accessToken}`), not the project access token. The scope was only needed if the project token were rotating itself.