### PR TITLE
perf(notifications): pre-fetch shared data to eliminate duplicate DB queries

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -105,6 +105,8 @@ export async function generateUserNotifications(user: User): Promise<KiloNotific
   ]);
   const ctx: NotificationContext = {
     userOrganizations,
+    // Replaces the old userHasOrganizations() LIMIT-1 existence check; acceptable
+    // because getUserOrganizationsWithSeats is already needed by other generators.
     isInTeam: userOrganizations.length > 0,
     balance,
   };

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,10 +1,8 @@
 import { type User } from '@kilocode/db/schema';
-import { getBalanceForUser } from './user.balance';
+import { type BalanceForUser, getBalanceForUser } from './user.balance';
 import { FIRST_TOPUP_BONUS_AMOUNT, APP_URL } from '@/lib/constants';
-import {
-  getUserOrganizationsWithSeats,
-  userHasOrganizations,
-} from '@/lib/organizations/organizations';
+import { getUserOrganizationsWithSeats } from '@/lib/organizations/organizations';
+import type { UserOrganizationWithSeats } from '@/lib/organizations/organization-types';
 import { summarizeUserPayments } from '@/lib/creditTransactions';
 import { hasOrganizationEverPaid, hasUserEverPaid } from '@/lib/creditTransactions';
 import { cachedPosthogQuery } from '@/lib/posthog-query';
@@ -16,6 +14,13 @@ import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
 import { db } from '@/lib/drizzle';
 import { fromMicrodollars } from '@/lib/utils';
 import { KILO_AUTO_FREE_MODEL } from '@/lib/kilo-auto-model';
+
+/** Pre-fetched data shared across notification generators to avoid duplicate DB queries. */
+type NotificationContext = {
+  userOrganizations: UserOrganizationWithSeats[];
+  isInTeam: boolean;
+  balance: BalanceForUser;
+};
 
 export type KiloNotification = {
   id: string;
@@ -91,7 +96,23 @@ const normalUnconditionalNotifications: KiloNotification[] = [
 ];
 
 export async function generateUserNotifications(user: User): Promise<KiloNotification[]> {
-  const conditionalNotifications: ((user: User) => Promise<KiloNotification[]>)[] = [
+  // Pre-fetch shared data once to avoid duplicate DB queries across generators.
+  // This eliminates ~5 redundant queries per request (2× userHasOrganizations,
+  // 3× getUserOrganizationsWithSeats, 2× getBalanceForUser → 1+1 queries).
+  const [userOrganizations, balance] = await Promise.all([
+    getUserOrganizationsWithSeats(user.id),
+    getBalanceForUser(user),
+  ]);
+  const ctx: NotificationContext = {
+    userOrganizations,
+    isInTeam: userOrganizations.length > 0,
+    balance,
+  };
+
+  const conditionalNotifications: ((
+    user: User,
+    ctx: NotificationContext
+  ) => Promise<KiloNotification[]>)[] = [
     generateTeamsTrialNotification,
     generateLowCreditNotification,
     generateAutoTopUpNotification,
@@ -103,7 +124,7 @@ export async function generateUserNotifications(user: User): Promise<KiloNotific
   ];
 
   const resolvedConditionalNotifications = (
-    await Promise.all(conditionalNotifications.map(f => f(user)))
+    await Promise.all(conditionalNotifications.map(f => f(user, ctx)))
   ).flat();
 
   const now = new Date();
@@ -112,12 +133,14 @@ export async function generateUserNotifications(user: User): Promise<KiloNotific
   );
 }
 
-async function generateLowCreditNotification(user: User): Promise<KiloNotification[]> {
-  const isInTeam = await userHasOrganizations(user.id);
+async function generateLowCreditNotification(
+  user: User,
+  ctx: NotificationContext
+): Promise<KiloNotification[]> {
   // For now, let's not confuse users when they're on a team
-  if (isInTeam) return [];
+  if (ctx.isInTeam) return [];
 
-  const { balance } = await getBalanceForUser(user);
+  const { balance } = ctx.balance;
 
   if (balance >= 2) return [];
   const payments = await summarizeUserPayments(user.id);
@@ -141,12 +164,15 @@ async function generateLowCreditNotification(user: User): Promise<KiloNotificati
   ];
 }
 
-async function generateAutoTopUpNotification(user: User): Promise<KiloNotification[]> {
+async function generateAutoTopUpNotification(
+  user: User,
+  ctx: NotificationContext
+): Promise<KiloNotification[]> {
   if (!(await hasUserEverPaid(user.id))) {
     return [];
   }
 
-  for (const org of await getUserOrganizationsWithSeats(user.id)) {
+  for (const org of ctx.userOrganizations) {
     if (await hasOrganizationEverPaid(org.organizationId)) {
       return [];
     }
@@ -167,9 +193,11 @@ async function generateAutoTopUpNotification(user: User): Promise<KiloNotificati
   ];
 }
 
-async function generateAutoTopUpOrgsNotification(user: User): Promise<KiloNotification[]> {
-  const orgs = await getUserOrganizationsWithSeats(user.id);
-  const isOwnerOrAdmin = orgs.some(org => org.role === 'owner');
+async function generateAutoTopUpOrgsNotification(
+  _user: User,
+  ctx: NotificationContext
+): Promise<KiloNotification[]> {
+  const isOwnerOrAdmin = ctx.userOrganizations.some(org => org.role === 'owner');
   if (!isOwnerOrAdmin) return [];
 
   return [
@@ -187,10 +215,12 @@ async function generateAutoTopUpOrgsNotification(user: User): Promise<KiloNotifi
   ];
 }
 
-async function generateTeamsTrialNotification(user: User): Promise<KiloNotification[]> {
+async function generateTeamsTrialNotification(
+  _user: User,
+  ctx: NotificationContext
+): Promise<KiloNotification[]> {
   // Only show teams notification if user is NOT already in a team
-  const isInTeam = await userHasOrganizations(user.id);
-  if (isInTeam) return [];
+  if (ctx.isInTeam) return [];
 
   return [
     {
@@ -207,7 +237,10 @@ async function generateTeamsTrialNotification(user: User): Promise<KiloNotificat
   ];
 }
 
-async function generateByokProvidersNotification(user: User): Promise<KiloNotification[]> {
+async function generateByokProvidersNotification(
+  user: User,
+  _ctx: NotificationContext
+): Promise<KiloNotification[]> {
   try {
     const byokProviderUsers = await cachedPosthogQuery(
       z.array(
@@ -274,7 +307,10 @@ async function generateByokProvidersNotification(user: User): Promise<KiloNotifi
   }
 }
 
-async function generateFirstDayWelcomeNotification(user: User): Promise<KiloNotification[]> {
+async function generateFirstDayWelcomeNotification(
+  user: User,
+  ctx: NotificationContext
+): Promise<KiloNotification[]> {
   // Check if user was created within the last day
   if (new Date(user.created_at) < subDays(new Date(), 1)) {
     return [];
@@ -287,8 +323,7 @@ async function generateFirstDayWelcomeNotification(user: User): Promise<KiloNoti
   }
 
   // Check if user still has credit balance
-  const { balance } = await getBalanceForUser(user);
-  if (balance <= 1) {
+  if (ctx.balance.balance <= 1) {
     return [];
   }
 
@@ -307,7 +342,10 @@ async function generateFirstDayWelcomeNotification(user: User): Promise<KiloNoti
   ];
 }
 
-async function generateKiloPassNotification(user: User): Promise<KiloNotification[]> {
+async function generateKiloPassNotification(
+  user: User,
+  ctx: NotificationContext
+): Promise<KiloNotification[]> {
   // Exclude users who already have a Kilo Pass
   const kiloPassState = await getKiloPassStateForUser(db, user.id);
   if (kiloPassState) {
@@ -315,8 +353,7 @@ async function generateKiloPassNotification(user: User): Promise<KiloNotificatio
   }
 
   // Check if user belongs to an organization with balance > $5
-  const orgs = await getUserOrganizationsWithSeats(user.id);
-  const hasHighBalanceOrg = orgs.some(org => fromMicrodollars(org.balance) > 5);
+  const hasHighBalanceOrg = ctx.userOrganizations.some(org => fromMicrodollars(org.balance) > 5);
   if (hasHighBalanceOrg) {
     return [];
   }
@@ -335,7 +372,10 @@ async function generateKiloPassNotification(user: User): Promise<KiloNotificatio
   ];
 }
 
-async function generateKimiFreeEndingNotification(user: User): Promise<KiloNotification[]> {
+async function generateKimiFreeEndingNotification(
+  user: User,
+  _ctx: NotificationContext
+): Promise<KiloNotification[]> {
   try {
     const kimiFreeUsers = await cachedPosthogQuery(
       z.array(z.tuple([z.string()]).transform(([userId]) => userId))


### PR DESCRIPTION
## Summary

Pre-fetches `getUserOrganizationsWithSeats` and `getBalanceForUser` once in `generateUserNotifications` and passes a shared `NotificationContext` to all conditional notification generators. This eliminates ~5 redundant DB queries per request that were previously made independently inside each generator (2× `userHasOrganizations`, 3× `getUserOrganizationsWithSeats`, 2× `getBalanceForUser` → 1+1 queries via `Promise.all`).

The `userHasOrganizations` import is removed entirely — its lightweight `LIMIT 1` existence check is replaced by `userOrganizations.length > 0` on the already-fetched list, which is a net win since the full query is needed by other generators anyway.

## Verification

- [x] `pnpm format:check` — passed
- [x] `pnpm lint` (all workspace projects) — passed
- [x] `pnpm typecheck` (tsgo + all workspace projects) — passed
- [x] Code review confirmed semantic equivalence of `isInTeam` vs old `userHasOrganizations()` check

## Visual Changes

N/A

## Reviewer Notes

- The `isInTeam` field replaces the old `userHasOrganizations()` `LIMIT 1` existence check with a length check on the pre-fetched organizations list. This is documented with an inline comment explaining the tradeoff.
- Functions that no longer use `user` directly have it prefixed with `_` — this is the intentionally-unused positional parameter exception per the style guide.