### PR TITLE
Update revalidation time for gateway error rate

### DIFF
--- a/src/lib/providers/gateway-error-rate.ts
+++ b/src/lib/providers/gateway-error-rate.ts
@@ -26,7 +26,7 @@ const getGatewayErrorRate_cached = unstable_cache(
       .parse(rows);
   },
   undefined,
-  { revalidate: 60 }
+  { revalidate: 600 }
 );
 
 export async function getGatewayErrorRate() {


### PR DESCRIPTION
Increased revalidation time from 60 seconds to 600 seconds.

Right now we get an avalanche of queries every minute, which is not great.