### PR TITLE
fix(cloud-agent): handle non-object summary in snapshot jq filter

### DIFF
--- a/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.ts
@@ -49,8 +49,9 @@ function tryUnlink(filePath: string): void {
 // deduplication by file path. Runs as a subprocess so the full parsed snapshot
 // is never loaded into the main process's heap — jq's C-native parser uses
 // ~half the memory of a V8 heap.
+// `objects` filters out non-object .summary values (e.g. compaction messages set summary=true)
 const JQ_EXTRACT_DIFFS_FILTER =
-  'reduce (.messages[]?.info.summary.diffs[]? // empty) as $d ({}; .[$d.file] = $d) | [.[]]';
+  'reduce (.messages[]?.info.summary | objects | .diffs[]? // empty) as $d ({}; .[$d.file] = $d) | [.[]]';
 
 /**
  * Extract last-write-wins diffs from a snapshot file via a jq subprocess so the


### PR DESCRIPTION
## Summary

- Cold-start session restore fails permanently when the session snapshot contains compaction messages, which set `info.summary` to boolean `true` instead of an object with a `diffs` array.
- The jq filter `(.messages[]?.info.summary.diffs[]?)` errors with `Cannot index boolean with string "diffs"` because jq's `?` operator only suppresses null/missing-key errors, not type errors from indexing a boolean.
- Fix: pipe `.summary` through jq's `objects` builtin, which silently drops non-object values (booleans, nulls, strings) before `.diffs` is accessed.
- This unblocks ~58 permanently stuck sessions that have been producing ~550+ errors over the last 48 hours. Every retry re-downloads the same snapshot and hits the same parse failure, so affected users are stuck in a loop until this is deployed.

## Verification

- [x] `pnpm run test` in `cloud-agent-next/` — 657 tests passed
- [x] Manually validated the fix against a real corrupt snapshot (`ses_308ead238ffeuRGn6dDkglc041`, 13.7 MB) — old filter errors, new filter extracts 75 diffs successfully

## Visual Changes

N/A

## Reviewer Notes

- One-line change to the jq filter string in `cloud-agent-next/wrapper/src/restore-session.ts:53`
- The root cause is that the `minimax/minimax-m2.5:free` compaction agent produces messages where `info.summary = true` (a boolean flag) rather than `info.summary = { diffs: [...] }`. This is valid data — the jq filter just wasn't defensive against it.
- The `?` suffix in jq (e.g. `.summary?.diffs`) is commonly misunderstood — it only suppresses errors for null/undefined access, not type mismatches. `| objects |` is the idiomatic jq way to filter by type.