### PR TITLE
fix(kiloclaw): google setup improvements

### DIFF
--- a/cloudflare-gmail-push/src/routes/push.ts
+++ b/cloudflare-gmail-push/src/routes/push.ts
@@ -43,7 +43,7 @@ pushRoute.post('/user/:userId', async c => {
   }
 
   // Validate Google OIDC token: issuer, per-user audience, and SA email.
-  const perUserAudience = `${c.env.OIDC_AUDIENCE_BASE}/push/user/${userId}`;
+  const perUserAudience = `${c.env.OIDC_AUDIENCE_BASE}/push/user/${encodeURIComponent(userId)}`;
   const oidcResult = await validateOidcToken(
     c.req.header('authorization'),
     perUserAudience,

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -214,10 +214,7 @@ if (projectChoice === '2') {
     projectId = await ask('\nEnter your project ID: ');
   }
 } else {
-  // Generate a project ID based on date
-  const now = new Date();
-  const dateStr = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
-  const defaultId = `kiloclaw-${dateStr}`;
+  const defaultId = `kiloclaw-${crypto.randomBytes(4).toString('hex')}`;
   const inputId = await ask(`Project ID [${defaultId}]: `);
   projectId = inputId || defaultId;
 

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -250,6 +250,7 @@ if (projectChoice === '2') {
       }
     } else {
       console.error(`Failed to create project "${projectId}". It may already exist.`);
+      console.error('You may also need to accept the Google Cloud Terms of Service at https://console.cloud.google.com');
       console.error('Try a different name, or choose option 2 to use an existing project.');
       process.exit(1);
     }

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -229,7 +229,7 @@ if (projectChoice === '2') {
     console.log('Project created.\n');
   } catch (err) {
     const errOutput = err.stderr?.toString() ?? err.message;
-    if (errOutput.includes('Terms of Service')) {
+    if (/terms/i.test(errOutput)) {
       console.log('');
       console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
       console.log('  You need to accept the Google Cloud Terms of Service first.');

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -252,6 +252,7 @@ if (projectChoice === '2') {
       console.error(`Failed to create project "${projectId}". It may already exist.`);
       console.error('You may also need to accept the Google Cloud Terms of Service at https://console.cloud.google.com');
       console.error('Try a different name, or choose option 2 to use an existing project.');
+      console.error(`\nRaw error:\n${errOutput}`);
       process.exit(1);
     }
   }

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -590,12 +590,13 @@ if (pushUserId && pushSetupOk) {
 
   // Create or update push subscription
   if (pushSetupOk) {
-    const subscriptionName = `gog-gmail-push-${pushUserId.slice(0, 8)}`;
-    const pushEndpoint = `${gmailPushWorkerUrl}/push/user/${pushUserId}`;
+    const safeId = pushUserId.replaceAll(/[^a-zA-Z0-9_-]/g, '-');
+    const subscriptionName = `gog-gmail-push-${safeId.slice(0, 8)}`;
+    const pushEndpoint = `${gmailPushWorkerUrl}/push/user/${encodeURIComponent(pushUserId)}`;
     // The OIDC audience must always use the production domain so the worker's
     // OIDC_AUDIENCE_BASE validation matches, even when the push endpoint
     // targets a different environment (e.g. tunnel, dev).
-    const pushAudience = `https://kiloclaw-gmail.kiloapps.io/push/user/${pushUserId}`;
+    const pushAudience = `https://kiloclaw-gmail.kiloapps.io/push/user/${encodeURIComponent(pushUserId)}`;
     console.log(`Creating push subscription ${subscriptionName} → ${pushEndpoint}`);
     try {
       execSync(

--- a/kiloclaw/google-setup/setup.mjs
+++ b/kiloclaw/google-setup/setup.mjs
@@ -704,7 +704,7 @@ console.log('');
 console.log('  Next steps:');
 console.log('  1. Redeploy your kiloclaw instance to activate Google services');
 if (pushSetupOk) {
-  console.log('  2. Enable Gmail notifications in Settings → Google Account');
+  console.log('  2. Gmail push notifications have been enabled automatically.');
 } else {
   console.log('  2. Gmail push notifications could not be set up (see errors above).');
   console.log('     Google Workspace access will still work. Re-run setup to retry.');

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2059,6 +2059,31 @@ describe('updateGoogleCredentials', () => {
 
     expect(storage._store.get('gmailPushOidcEmail')).toBeNull();
   });
+
+  it('enables gmailNotificationsEnabled when storing Google credentials', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+
+    const putSpy = vi.spyOn(storage, 'put');
+
+    await instance.updateGoogleCredentials({
+      gogConfigTarball: {
+        encryptedData: 'enc-data',
+        encryptedDEK: 'enc-dek',
+        algorithm: 'rsa-aes-256-gcm' as const,
+        version: 1 as const,
+      },
+      email: 'user@example.com',
+      gmailPushOidcEmail: 'sa@project.iam.gserviceaccount.com',
+    });
+
+    expect(putSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gmailNotificationsEnabled: true,
+      })
+    );
+    expect(storage._store.get('gmailNotificationsEnabled')).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -471,9 +471,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     this.s.googleCredentials = credentials;
     this.s.gmailPushOidcEmail = credentials.gmailPushOidcEmail ?? null;
+    this.s.gmailNotificationsEnabled = true;
+
     await this.ctx.storage.put({
       googleCredentials: this.s.googleCredentials,
       gmailPushOidcEmail: this.s.gmailPushOidcEmail,
+      gmailNotificationsEnabled: true,
     });
 
     return { googleConnected: true };

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -516,6 +516,14 @@ EOFTOOLS
     else
         echo "TOOLS.md: Google Workspace section already present"
     fi
+elif [ -f "$TOOLS_MD" ]; then
+    # Google not connected — remove stale gog section if present
+    if grep -q '## Google Workspace' "$TOOLS_MD"; then
+        sed -i '/^## Google Workspace$/,$ d' "$TOOLS_MD"
+        # Trim trailing blank lines left behind
+        sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$TOOLS_MD"
+        echo "TOOLS.md: removed stale Google Workspace section"
+    fi
 fi
 
 # ============================================================

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -489,6 +489,36 @@ EOFPATCH
 export GOG_KEYRING_PASSWORD="kiloclaw"
 
 # ============================================================
+# TOOLS.MD — GOOGLE WORKSPACE SECTION
+# ============================================================
+# When gog credentials are present, append a Google Workspace section to
+# TOOLS.md so the agent knows gog is available. Idempotent: skips if the
+# marker is already present (e.g. after a restart on an existing volume).
+TOOLS_MD="/root/.openclaw/workspace/TOOLS.md"
+if [ -n "${KILOCLAW_GOG_CONFIG_TARBALL:-}" ] && [ -f "$TOOLS_MD" ]; then
+    if ! grep -q '## Google Workspace' "$TOOLS_MD"; then
+        cat >> "$TOOLS_MD" << 'EOFTOOLS'
+
+## Google Workspace
+
+The `gog` CLI is configured and ready for Google Workspace operations (Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Forms, Chat, Classroom).
+
+- List accounts: `gog auth list`
+- Gmail — search: `gog gmail search --account <email> --query "from:X"`
+- Gmail — read: `gog gmail get --account <email> <message-id>`
+- Gmail — send: `gog gmail send --account <email> --to <addr> --subject "..." --body "..."`
+- Calendar — list events: `gog calendar events list --account <email>`
+- Drive — list files: `gog drive files list --account <email>`
+- Docs — read: `gog docs get --account <email> <doc-id>`
+- Run `gog --help` and `gog <service> --help` for all available commands.
+EOFTOOLS
+        echo "TOOLS.md: added Google Workspace section"
+    else
+        echo "TOOLS.md: Google Workspace section already present"
+    fi
+fi
+
+# ============================================================
 # START CONTROLLER
 # ============================================================
 # Tell the gateway it's running under a supervisor. On SIGUSR1 restart,

--- a/kiloclaw/start-openclaw.sh
+++ b/kiloclaw/start-openclaw.sh
@@ -494,23 +494,27 @@ export GOG_KEYRING_PASSWORD="kiloclaw"
 # When gog credentials are present, append a Google Workspace section to
 # TOOLS.md so the agent knows gog is available. Idempotent: skips if the
 # marker is already present (e.g. after a restart on an existing volume).
+GOG_MARKER_BEGIN="<!-- BEGIN:google-workspace -->"
+GOG_MARKER_END="<!-- END:google-workspace -->"
 TOOLS_MD="/root/.openclaw/workspace/TOOLS.md"
 if [ -n "${KILOCLAW_GOG_CONFIG_TARBALL:-}" ] && [ -f "$TOOLS_MD" ]; then
-    if ! grep -q '## Google Workspace' "$TOOLS_MD"; then
-        cat >> "$TOOLS_MD" << 'EOFTOOLS'
+    if ! grep -q "$GOG_MARKER_BEGIN" "$TOOLS_MD"; then
+        cat >> "$TOOLS_MD" << EOFTOOLS
 
+${GOG_MARKER_BEGIN}
 ## Google Workspace
 
-The `gog` CLI is configured and ready for Google Workspace operations (Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Forms, Chat, Classroom).
+The \`gog\` CLI is configured and ready for Google Workspace operations (Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Forms, Chat, Classroom).
 
-- List accounts: `gog auth list`
-- Gmail — search: `gog gmail search --account <email> --query "from:X"`
-- Gmail — read: `gog gmail get --account <email> <message-id>`
-- Gmail — send: `gog gmail send --account <email> --to <addr> --subject "..." --body "..."`
-- Calendar — list events: `gog calendar events list --account <email>`
-- Drive — list files: `gog drive files list --account <email>`
-- Docs — read: `gog docs get --account <email> <doc-id>`
-- Run `gog --help` and `gog <service> --help` for all available commands.
+- List accounts: \`gog auth list\`
+- Gmail — search: \`gog gmail search --account <email> --query "from:X"\`
+- Gmail — read: \`gog gmail get --account <email> <message-id>\`
+- Gmail — send: \`gog gmail send --account <email> --to <addr> --subject "..." --body "..."\`
+- Calendar — list events: \`gog calendar events list --account <email>\`
+- Drive — list files: \`gog drive files list --account <email>\`
+- Docs — read: \`gog docs get --account <email> <doc-id>\`
+- Run \`gog --help\` and \`gog <service> --help\` for all available commands.
+${GOG_MARKER_END}
 EOFTOOLS
         echo "TOOLS.md: added Google Workspace section"
     else
@@ -518,8 +522,8 @@ EOFTOOLS
     fi
 elif [ -f "$TOOLS_MD" ]; then
     # Google not connected — remove stale gog section if present
-    if grep -q '## Google Workspace' "$TOOLS_MD"; then
-        sed -i '/^## Google Workspace$/,$ d' "$TOOLS_MD"
+    if grep -q "$GOG_MARKER_BEGIN" "$TOOLS_MD"; then
+        sed -i "/${GOG_MARKER_BEGIN}/,/${GOG_MARKER_END}/d" "$TOOLS_MD"
         # Trim trailing blank lines left behind
         sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$TOOLS_MD"
         echo "TOOLS.md: removed stale Google Workspace section"


### PR DESCRIPTION
## Summary

- **ToS error detection**: Use case-insensitive `/terms/i` regex instead of brittle `includes('Terms of Service')` for GCP project creation error handling
- **userId slash handling**: `encodeURIComponent()` for push endpoint/audience URLs and regex sanitization for Pub/Sub subscription names, preventing breakage when user IDs contain `/`
- **Auto-enable gmail notifications**: `updateGoogleCredentials` now sets `gmailNotificationsEnabled: true` upon connecting a Google account (disconnect already resets to `false`)
- **TOOLS.md gog section**: Idempotently appends a Google Workspace section to TOOLS.md in `start-openclaw.sh` when `KILOCLAW_GOG_CONFIG_TARBALL` is set, so the openclaw agent knows `gog` is available

## Test plan

- [x] All 804 kiloclaw tests pass
- [x] Verify OIDC audience percent-encoding is preserved by Google Pub/Sub before deploying userId slash fix to production (see commit message for details)
- [x] Deploy to dev and run google-setup end-to-end