### PR TITLE
fix(cloud-agent): prevent repeated session-not-found toast and query loop

### DIFF
--- a/src/components/cloud-agent-next/CloudChatContainer.tsx
+++ b/src/components/cloud-agent-next/CloudChatContainer.tsx
@@ -484,7 +484,6 @@ export function CloudChatContainer({
           });
 
           setResumeStrategy(result.resumeStrategy);
-          loadedDbSessionIdRef.current = sessionIdFromParams;
           setLoadedDbSession(session);
 
           // Apply runtime state from DO (mode, model, repository)
@@ -526,6 +525,7 @@ export function CloudChatContainer({
           setNeedsLegacyPrepare(true);
         }
       } finally {
+        loadedDbSessionIdRef.current = sessionIdFromParams;
         setIsLoadingFromDb(false);
         setPreflightComplete(true);
       }

--- a/src/components/cloud-agent/CloudChatContainer.tsx
+++ b/src/components/cloud-agent/CloudChatContainer.tsx
@@ -402,7 +402,6 @@ export function CloudChatContainer({
           });
 
           setResumeStrategy(result.resumeStrategy);
-          loadedDbSessionIdRef.current = sessionIdFromParams;
           setLoadedDbSession(session);
 
           if (result.needsOrgContextPrompt) {
@@ -418,6 +417,7 @@ export function CloudChatContainer({
         console.error('Failed to load session from database:', err);
         toast.error('Failed to load session');
       } finally {
+        loadedDbSessionIdRef.current = sessionIdFromParams;
         setIsLoadingFromDb(false);
       }
     };


### PR DESCRIPTION
## Summary

When navigating to a non-existent session URL, the cloud agent UI would repeatedly query the server and show "Session not found" / "Failed to load session" toasts. This happened because `loadedDbSessionIdRef` was only set on the success path of the `loadFromDb` effect — when the session wasn't found, the ref stayed unset, so any dependency change in the effect (12 dependencies in the next version) would re-trigger it, firing another query and another toast.

The fix moves `loadedDbSessionIdRef.current = sessionIdFromParams` into the `finally` block so it's set regardless of success or failure, ensuring the effect runs exactly once per session ID.

Applied to both `cloud-agent-next` and `cloud-agent` (legacy) implementations.

## Verification

- [x] `pnpm typecheck` — passed (all workspace projects)
- [x] `prettier --check` — passed
- [x] `eslint` — passed (all workspace projects)
- [x] Manually tested locally — navigating to a non-existent session URL now shows a single toast and stops querying

## Visual Changes

N/A

## Reviewer Notes

The fix is intentionally minimal — a one-line move in each file. The `finally` block guarantees the ref is always set, which is the correct guard behavior: we've already attempted loading this session ID, so there's no reason to retry it on re-renders.