### PR TITLE
fix(kiloclaw): back off pairing cache refresh retries

### DIFF
--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createPairingCache, OPENCLAW_BIN } from './pairing-cache';
+import {
+  createPairingCache,
+  OPENCLAW_BIN,
+  DEBOUNCE_DELAY_MS,
+  INITIAL_REFRESH_DELAY_MS,
+  PERIODIC_INTERVAL_MS,
+  FAILURE_RETRY_BASE_MS,
+  FAILURE_RETRY_MAX_MS,
+} from './pairing-cache';
 
 type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
 
@@ -406,7 +414,7 @@ describe('createPairingCache', () => {
   });
 
   describe('periodic refresh', () => {
-    it('refreshes every 60s after start', async () => {
+    it('starts after initial delay and then refreshes every 120s', async () => {
       const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
         stdout: JSON.stringify({ requests: [] }),
         stderr: '',
@@ -418,19 +426,21 @@ describe('createPairingCache', () => {
       const { cache } = createTestHarness({ execImpl, readConfigImpl });
       cache.start();
 
-      // Initial fetch fires immediately
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(INITIAL_REFRESH_DELAY_MS - 1);
+      expect(execImpl).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
       const callsAfterInitial = execImpl.mock.calls.length;
       expect(callsAfterInitial).toBeGreaterThan(0);
 
-      // Advance to 60s — periodic fires
-      await vi.advanceTimersByTimeAsync(60_000);
+      // Advance to periodic interval — periodic fires
+      await vi.advanceTimersByTimeAsync(PERIODIC_INTERVAL_MS);
       expect(execImpl.mock.calls.length).toBeGreaterThan(callsAfterInitial);
 
       const callsBefore = execImpl.mock.calls.length;
 
-      // Advance another 60s — periodic fires again
-      await vi.advanceTimersByTimeAsync(60_000);
+      // Advance another periodic interval — periodic fires again
+      await vi.advanceTimersByTimeAsync(PERIODIC_INTERVAL_MS);
       expect(execImpl.mock.calls.length).toBeGreaterThan(callsBefore);
 
       cache.cleanup();
@@ -438,7 +448,7 @@ describe('createPairingCache', () => {
   });
 
   describe('initial fetch', () => {
-    it('fires immediately on start', async () => {
+    it('waits 120s before first refresh', async () => {
       const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
         stdout: JSON.stringify({ requests: [] }),
         stderr: '',
@@ -450,8 +460,10 @@ describe('createPairingCache', () => {
       const { cache } = createTestHarness({ execImpl, readConfigImpl });
       cache.start();
 
-      // Flush the microtask queue so the fire-and-forget refreshAll resolves
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(INITIAL_REFRESH_DELAY_MS - 1);
+      expect(execImpl).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
       expect(execImpl).toHaveBeenCalled();
 
       cache.cleanup();
@@ -535,8 +547,8 @@ describe('createPairingCache', () => {
       const { cache } = createTestHarness({ execImpl, readConfigImpl });
       cache.start();
 
-      // Flush the immediate initial refresh
-      await vi.advanceTimersByTimeAsync(0);
+      // Let the delayed initial refresh run
+      await vi.advanceTimersByTimeAsync(INITIAL_REFRESH_DELAY_MS);
       const callsAfterInitial = execImpl.mock.calls.length;
 
       cache.onPairingLogLine('pairing event');
@@ -910,13 +922,72 @@ describe('createPairingCache', () => {
       cache.start();
       cache.start(); // second call should be no-op
 
-      // Flush microtask queue for the immediate initial refresh
-      await vi.advanceTimersByTimeAsync(0);
+      // Wait for delayed initial refresh
+      await vi.advanceTimersByTimeAsync(INITIAL_REFRESH_DELAY_MS);
 
       // With two channels (telegram), initial fetch calls exec twice
       // If start() wasn't idempotent, we'd see 4 calls
       const callsAfterInitial = execImpl.mock.calls.length;
       expect(callsAfterInitial).toBe(2); // telegram channel + device list
+
+      cache.cleanup();
+    });
+  });
+
+  describe('failure backoff', () => {
+    it('uses exponential backoff and caps retries at 5 minutes', async () => {
+      const execImpl = vi.fn<ExecImpl>().mockRejectedValue(new Error('cli down'));
+      const readConfigImpl = vi.fn(() => ({
+        channels: { telegram: { enabled: true, botToken: 'tok' } },
+      }));
+
+      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      cache.start();
+
+      await vi.advanceTimersByTimeAsync(INITIAL_REFRESH_DELAY_MS);
+      const callsAfterFirstFailure = execImpl.mock.calls.length;
+      expect(callsAfterFirstFailure).toBeGreaterThan(0);
+
+      // Still within first failure backoff window, so no retry yet.
+      expect(execImpl.mock.calls.length).toBe(callsAfterFirstFailure);
+
+      await vi.advanceTimersByTimeAsync(FAILURE_RETRY_BASE_MS - 1);
+      expect(execImpl.mock.calls.length).toBe(callsAfterFirstFailure);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const callsAfterSecondFailure = execImpl.mock.calls.length;
+      expect(callsAfterSecondFailure).toBeGreaterThan(callsAfterFirstFailure);
+
+      // Second failure should back off longer (2x base).
+      await vi.advanceTimersByTimeAsync(FAILURE_RETRY_BASE_MS * 2 - 1);
+      expect(execImpl.mock.calls.length).toBe(callsAfterSecondFailure);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const callsAfterThirdFailure = execImpl.mock.calls.length;
+      expect(callsAfterThirdFailure).toBeGreaterThan(callsAfterSecondFailure);
+
+      // Third failure backs off to 4x base.
+      await vi.advanceTimersByTimeAsync(FAILURE_RETRY_BASE_MS * 4 - 1);
+      expect(execImpl.mock.calls.length).toBe(callsAfterThirdFailure);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const callsAfterFourthFailure = execImpl.mock.calls.length;
+      expect(callsAfterFourthFailure).toBeGreaterThan(callsAfterThirdFailure);
+
+      // Fourth failure backs off to 8x base.
+      await vi.advanceTimersByTimeAsync(FAILURE_RETRY_BASE_MS * 8 - 1);
+      expect(execImpl.mock.calls.length).toBe(callsAfterFourthFailure);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const callsAfterFifthFailure = execImpl.mock.calls.length;
+      expect(callsAfterFifthFailure).toBeGreaterThan(callsAfterFourthFailure);
+
+      // Next delay should be capped at max (5 minutes), not continue doubling.
+      await vi.advanceTimersByTimeAsync(FAILURE_RETRY_MAX_MS - 1);
+      expect(execImpl.mock.calls.length).toBe(callsAfterFifthFailure);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(execImpl.mock.calls.length).toBeGreaterThan(callsAfterFifthFailure);
 
       cache.cleanup();
     });

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -50,8 +50,11 @@ type PairingCacheOptions = {
   nowImpl?: () => string;
 };
 
-export const PERIODIC_INTERVAL_MS = 60_000;
+export const PERIODIC_INTERVAL_MS = 120_000;
 export const DEBOUNCE_DELAY_MS = 2_000;
+export const INITIAL_REFRESH_DELAY_MS = 120_000;
+export const FAILURE_RETRY_BASE_MS = 30_000;
+export const FAILURE_RETRY_MAX_MS = 300_000;
 export const CLI_TIMEOUT_MS = 45_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
 
@@ -124,8 +127,12 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
 
   let started = false;
   let stopped = false;
-  let periodicTimer: ReturnType<typeof setInterval> | null = null;
+  let periodicTimer: ReturnType<typeof setTimeout> | null = null;
+  let initialTimer: ReturnType<typeof setTimeout> | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let nextAllowedRefreshAt = 0;
+  let hasCompletedInitialRefresh = false;
+  let consecutiveFailureCount = 0;
 
   // Generation counters prevent stale concurrent refreshes from overwriting
   // newer data.  Each refresh captures the counter at start; if another
@@ -133,8 +140,8 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
   let channelGeneration = 0;
   let deviceGeneration = 0;
 
-  const refreshChannelPairing = async (): Promise<void> => {
-    if (stopped) return;
+  const refreshChannelPairingInternal = async (): Promise<boolean> => {
+    if (stopped) return false;
     const gen = ++channelGeneration;
     let channels: string[];
     try {
@@ -142,14 +149,14 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       channels = detectChannels(config);
     } catch (err) {
       console.warn(`[pairing-cache] could not read config: ${errorMessage(err)}`);
-      return;
+      return false;
     }
 
     if (channels.length === 0) {
       if (gen === channelGeneration) {
         channelCache = { requests: [], lastUpdated: nowImpl() };
       }
-      return;
+      return true;
     }
 
     const results = await Promise.allSettled(
@@ -200,13 +207,15 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       if (gen === channelGeneration) {
         channelCache = { requests: allRequests, lastUpdated: nowImpl() };
       }
+      return true;
     } else {
       console.warn('[pairing-cache] channel refresh: all channels failed, cache not updated');
+      return false;
     }
   };
 
-  const refreshDevicePairing = async (): Promise<void> => {
-    if (stopped) return;
+  const refreshDevicePairingInternal = async (): Promise<boolean> => {
+    if (stopped) return false;
     const gen = ++deviceGeneration;
     try {
       const { stdout } = await execImpl(OPENCLAW_BIN, ['devices', 'list', '--json']);
@@ -231,13 +240,60 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       if (gen === deviceGeneration) {
         deviceCache = { requests, lastUpdated: nowImpl() };
       }
+      return true;
     } catch (err) {
       console.error(`[pairing-cache] device refresh failed: ${errorMessage(err)}`);
+      return false;
     }
   };
 
-  const refreshAll = async (): Promise<void> => {
-    await Promise.allSettled([refreshChannelPairing(), refreshDevicePairing()]);
+  const refreshAll = async (): Promise<boolean> => {
+    if (stopped) return false;
+    const [channelOk, deviceOk] = await Promise.all([
+      refreshChannelPairingInternal(),
+      refreshDevicePairingInternal(),
+    ]);
+    const ok = channelOk && deviceOk;
+    if (ok) {
+      consecutiveFailureCount = 0;
+      nextAllowedRefreshAt = 0;
+    } else {
+      consecutiveFailureCount += 1;
+      const failureDelayMs = Math.min(
+        FAILURE_RETRY_BASE_MS * 2 ** (consecutiveFailureCount - 1),
+        FAILURE_RETRY_MAX_MS
+      );
+      nextAllowedRefreshAt = Date.now() + failureDelayMs;
+    }
+    return ok;
+  };
+
+  const scheduleNextPeriodicRefresh = (delayMs: number): void => {
+    if (stopped) return;
+    if (periodicTimer !== null) {
+      clearTimeout(periodicTimer);
+    }
+    periodicTimer = setTimeout(() => {
+      void runPeriodicRefresh();
+    }, delayMs);
+  };
+
+  const runPeriodicRefresh = async (): Promise<void> => {
+    if (stopped) return;
+    const ok = await refreshAll();
+    hasCompletedInitialRefresh = true;
+    const now = Date.now();
+    const delayMs = ok ? PERIODIC_INTERVAL_MS : Math.max(0, nextAllowedRefreshAt - now);
+    scheduleNextPeriodicRefresh(delayMs);
+  };
+
+  const runDebouncedRefresh = async (): Promise<void> => {
+    if (stopped) return;
+    if (Date.now() < nextAllowedRefreshAt) return;
+    const ok = await refreshAll();
+    const now = Date.now();
+    const delayMs = ok ? PERIODIC_INTERVAL_MS : Math.max(0, nextAllowedRefreshAt - now);
+    scheduleNextPeriodicRefresh(delayMs);
   };
 
   const approveChannel = async (channel: string, code: string): Promise<ApproveResult> => {
@@ -252,7 +308,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       return approveFail(errorMessage(err), 500);
     }
 
-    await refreshChannelPairing();
+    await refreshChannelPairingInternal();
     return approveOk('Pairing approved');
   };
 
@@ -267,12 +323,13 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       return approveFail(errorMessage(err), 500);
     }
 
-    await refreshDevicePairing();
+    await refreshDevicePairingInternal();
     return approveOk('Device approved');
   };
 
   const onPairingLogLine = (line: string): void => {
     if (stopped) return;
+    if (started && !hasCompletedInitialRefresh) return;
     const lower = line.toLowerCase();
     const isPairingLine = PAIRING_KEYWORDS.some(kw => lower.includes(kw));
     if (!isPairingLine) return;
@@ -281,32 +338,37 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
 
     debounceTimer = setTimeout(() => {
       debounceTimer = null;
-      void refreshAll();
+      void runDebouncedRefresh();
     }, DEBOUNCE_DELAY_MS);
+  };
+
+  const refreshChannelPairing = async (): Promise<void> => {
+    await refreshChannelPairingInternal();
+  };
+
+  const refreshDevicePairing = async (): Promise<void> => {
+    await refreshDevicePairingInternal();
   };
 
   const start = (): void => {
     if (started) return;
     started = true;
 
-    // Fire-and-forget: do not await the initial refresh.  Awaiting here blocks
-    // server.listen(), which can delay the health endpoint past the DO's 60s
-    // startup probe when the CLI is slow or wedged (each path has a 45s timeout).
-    // An empty cache during the brief warmup window is acceptable — the DO-side
-    // fallback chain (controller → KV → fly exec) handles it, and the cache
-    // self-heals within seconds via the periodic timer and log-triggered debounce.
-    void refreshAll();
-
-    periodicTimer = setInterval(() => {
-      void refreshAll();
-    }, PERIODIC_INTERVAL_MS);
+    initialTimer = setTimeout(() => {
+      initialTimer = null;
+      void runPeriodicRefresh();
+    }, INITIAL_REFRESH_DELAY_MS);
   };
 
   const cleanup = (): void => {
     stopped = true;
     if (periodicTimer !== null) {
-      clearInterval(periodicTimer);
+      clearTimeout(periodicTimer);
       periodicTimer = null;
+    }
+    if (initialTimer !== null) {
+      clearTimeout(initialTimer);
+      initialTimer = null;
     }
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);


### PR DESCRIPTION
## Summary

This updates the KiloClaw controller pairing cache refresh strategy to reduce noisy startup and failure churn from OpenClaw CLI calls. The cache now waits 120 seconds before its first automatic refresh, runs steady-state refreshes every 120 seconds, and applies exponential retry backoff on failures (30s base, capped at 5 minutes).

Architecturally, the scheduler moved from a fixed `setInterval` loop to adaptive `setTimeout` scheduling so refresh cadence can dynamically switch between normal periodic polling and backoff-driven retry timing. Channel/device refresh execution remains parallel, and tests were expanded to cover delayed startup refresh plus exponential backoff/cap behavior.

## Verification

- ✅ `pnpm vitest run controller/src/pairing-cache.test.ts` (pass)
- ✅ `pnpm typecheck` (pass)
- ✅ Pre-push hook checks passed:
  - `pnpm format:check` (pass)
  - `pnpm lint` (pass)
  - `pnpm typecheck` (workspace recursive) (pass)
- [ ] Additional verification details from reviewer/author

## Visual Changes

N/A

## Reviewer Notes

- Main risk area is refresh scheduling behavior under repeated CLI failures (timing/backoff semantics).
- Retry delay progression is exponential and capped: `30s -> 60s -> 120s -> 240s -> 300s`.
- Debounced log-triggered refreshes are gated during startup warmup and by failure backoff windows.