### PR TITLE
Improvement/kiloclaw pair with controller read file

### DIFF
--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -32,8 +32,7 @@ function createTestHarness(overrides?: {
     overrides?.readChannelPairingImpl ??
     vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
   const readDevicePairingImpl =
-    overrides?.readDevicePairingImpl ??
-    vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
+    overrides?.readDevicePairingImpl ?? vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
   const nowImpl = vi.fn(() => '2026-03-12T00:00:00.000Z');
   const nowMsImpl = vi.fn(() => NOW_MS);
 
@@ -72,9 +71,13 @@ describe('createPairingCache', () => {
     it('merges requests from multiple channels', async () => {
       const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram') {
-          return Promise.resolve({ requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
+          return Promise.resolve({
+            requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
+          });
         }
-        return Promise.resolve({ requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }] });
+        return Promise.resolve({
+          requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }],
+        });
       });
 
       const { cache } = createTestHarness({ readChannelPairingImpl });
@@ -115,7 +118,9 @@ describe('createPairingCache', () => {
         if (channel === 'telegram') {
           return Promise.reject(new Error('read failed'));
         }
-        return Promise.resolve({ requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }] });
+        return Promise.resolve({
+          requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }],
+        });
       });
 
       const { cache } = createTestHarness({ readChannelPairingImpl });
@@ -139,9 +144,13 @@ describe('createPairingCache', () => {
           return Promise.reject(new Error('read failed'));
         }
         if (channel === 'telegram') {
-          return Promise.resolve({ requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
+          return Promise.resolve({
+            requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
+          });
         }
-        return Promise.resolve({ requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }] });
+        return Promise.resolve({
+          requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }],
+        });
       });
 
       const { cache } = createTestHarness({ readChannelPairingImpl });
@@ -172,7 +181,9 @@ describe('createPairingCache', () => {
         if (channel === 'telegram' && callCount > 1) {
           return Promise.reject(new Error('read down'));
         }
-        return Promise.resolve({ requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
+        return Promise.resolve({
+          requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
+        });
       });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
@@ -197,7 +208,9 @@ describe('createPairingCache', () => {
 
     it('logs no WARNING when failing channel had no prior data', async () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockRejectedValue(new Error('read down'));
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockRejectedValue(new Error('read down'));
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
@@ -301,7 +314,9 @@ describe('createPairingCache', () => {
       const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram') {
           return Promise.resolve({
-            requests: [{ code: 'BOUNDARY', id: 'b1', createdAt: new Date(exactBoundaryTs).toISOString() }],
+            requests: [
+              { code: 'BOUNDARY', id: 'b1', createdAt: new Date(exactBoundaryTs).toISOString() },
+            ],
           });
         }
         return Promise.resolve({ requests: [] });
@@ -319,7 +334,9 @@ describe('createPairingCache', () => {
       const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram') {
           return Promise.resolve({
-            requests: [{ code: 'EXPIRED', id: 'e1', createdAt: new Date(justExpiredTs).toISOString() }],
+            requests: [
+              { code: 'EXPIRED', id: 'e1', createdAt: new Date(justExpiredTs).toISOString() },
+            ],
           });
         }
         return Promise.resolve({ requests: [] });
@@ -502,7 +519,9 @@ describe('createPairingCache', () => {
         callCount++;
         if (callCount <= 2) {
           // First refresh succeeds (two channels)
-          return Promise.resolve({ requests: [{ code: 'A', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
+          return Promise.resolve({
+            requests: [{ code: 'A', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
+          });
         }
         return Promise.reject(new Error('read down'));
       });
@@ -532,7 +551,9 @@ describe('createPairingCache', () => {
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          return Promise.resolve({ r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' } });
+          return Promise.resolve({
+            r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' },
+          });
         }
         return Promise.reject(new Error('fail'));
       });
@@ -573,7 +594,9 @@ describe('createPairingCache', () => {
       const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          return Promise.resolve({ requests: [{ code: 'STALE', id: 's1', createdAt: new Date(RECENT_TS).toISOString() }] });
+          return Promise.resolve({
+            requests: [{ code: 'STALE', id: 's1', createdAt: new Date(RECENT_TS).toISOString() }],
+          });
         }
         return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
       });
@@ -592,7 +615,11 @@ describe('createPairingCache', () => {
       expect(cache.getChannelPairing().requests[0].code).toBe('STALE');
 
       const warnCalls = consoleWarnSpy.mock.calls.map(args => String(args[0]));
-      expect(warnCalls.some(msg => msg.includes('WARNING: keeping stale data for') && msg.includes('telegram'))).toBe(true);
+      expect(
+        warnCalls.some(
+          msg => msg.includes('WARNING: keeping stale data for') && msg.includes('telegram')
+        )
+      ).toBe(true);
 
       consoleWarnSpy.mockRestore();
     });
@@ -600,13 +627,19 @@ describe('createPairingCache', () => {
 
   describe('periodic refresh', () => {
     it('refreshes every 60s after start', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
+      const { cache } = createTestHarness({
+        readChannelPairingImpl,
+        readDevicePairingImpl,
+        readConfigImpl,
+      });
       cache.start();
 
       // Initial fetch fires immediately
@@ -632,7 +665,9 @@ describe('createPairingCache', () => {
 
   describe('initial fetch', () => {
     it('fires immediately on start', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
@@ -650,7 +685,9 @@ describe('createPairingCache', () => {
 
   describe('debounced refresh', () => {
     it('fires 2s after first trigger', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
@@ -666,13 +703,19 @@ describe('createPairingCache', () => {
     });
 
     it('collapses burst into single refresh (non-sliding window)', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
+      const { cache } = createTestHarness({
+        readChannelPairingImpl,
+        readDevicePairingImpl,
+        readConfigImpl,
+      });
 
       cache.onPairingLogLine('pairing event 1');
       await vi.advanceTimersByTimeAsync(500);
@@ -711,13 +754,19 @@ describe('createPairingCache', () => {
 
   describe('cleanup', () => {
     it('clears all timers so no further refreshes fire', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
+      const { cache } = createTestHarness({
+        readChannelPairingImpl,
+        readDevicePairingImpl,
+        readConfigImpl,
+      });
       cache.start();
 
       // Flush the immediate initial refresh
@@ -740,7 +789,9 @@ describe('createPairingCache', () => {
       let shouldFail = false;
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockImplementation(() => {
         if (shouldFail) return Promise.reject(new Error('fail'));
-        return Promise.resolve({ r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' } });
+        return Promise.resolve({
+          r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' },
+        });
       });
       const readConfigImpl = vi.fn(() => ({ channels: {} }));
 
@@ -838,7 +889,9 @@ describe('createPairingCache', () => {
 
   describe('post-cleanup behavior', () => {
     it('refreshChannelPairing is a no-op after cleanup', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
@@ -889,7 +942,9 @@ describe('createPairingCache', () => {
     });
 
     it('onPairingLogLine is ignored after cleanup', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
@@ -1012,7 +1067,9 @@ describe('createPairingCache', () => {
       expect(cache.getChannelPairing().requests).toHaveLength(0);
 
       // Now let the slow refresh finish with stale pre-approve data
-      resolveSlowChannel({ requests: [{ code: 'STALE', id: '99', createdAt: new Date(RECENT_TS).toISOString() }] });
+      resolveSlowChannel({
+        requests: [{ code: 'STALE', id: '99', createdAt: new Date(RECENT_TS).toISOString() }],
+      });
       await slowPromise;
 
       // Cache must still reflect the newer (empty) result, NOT the stale data
@@ -1049,13 +1106,19 @@ describe('createPairingCache', () => {
 
   describe('start idempotency', () => {
     it('calling start twice does not create duplicate timers', async () => {
-      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockResolvedValue({ requests: [] });
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
+      const { cache } = createTestHarness({
+        readChannelPairingImpl,
+        readDevicePairingImpl,
+        readConfigImpl,
+      });
       cache.start();
       cache.start(); // second call should be no-op
 

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -1173,7 +1173,11 @@ describe('createPairingCache', () => {
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
+      const { cache } = createTestHarness({
+        readChannelPairingImpl,
+        readDevicePairingImpl,
+        readConfigImpl,
+      });
       cache.start();
 
       // First refresh fires immediately and succeeds, populating stale data into cache.

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -352,7 +352,7 @@ describe('createPairingCache', () => {
       expect(cache.getChannelPairing().requests).toHaveLength(0);
     });
 
-    it('strips unknown fields from channel pairing requests', async () => {
+    it('passes through unknown fields from channel pairing requests (.passthrough())', async () => {
       const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram') {
           return Promise.resolve({
@@ -362,8 +362,7 @@ describe('createPairingCache', () => {
                 id: 'r1',
                 meta: { foo: 1 },
                 createdAt: new Date(RECENT_TS).toISOString(),
-                secretToken: 'SHOULD_BE_STRIPPED',
-                internalFlag: true,
+                extraField: 'forward-compat',
               },
             ],
           });
@@ -376,15 +375,8 @@ describe('createPairingCache', () => {
 
       const result = cache.getChannelPairing();
       expect(result.requests).toHaveLength(1);
-      expect(result.requests[0]).toEqual({
-        code: 'ABC',
-        id: 'r1',
-        channel: 'telegram',
-        meta: { foo: 1 },
-        createdAt: new Date(RECENT_TS).toISOString(),
-      });
-      expect('secretToken' in result.requests[0]).toBe(false);
-      expect('internalFlag' in result.requests[0]).toBe(false);
+      // .passthrough() keeps unknown fields for forward compatibility
+      expect((result.requests[0] as Record<string, unknown>)['extraField']).toBe('forward-compat');
     });
   });
 

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -595,7 +595,9 @@ describe('createPairingCache', () => {
     it('non-ENOENT cold-start channel failure → returns false (triggers backoff)', async () => {
       const readChannelPairingImpl = vi
         .fn<ReadChannelPairingImpl>()
-        .mockRejectedValue(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }));
+        .mockRejectedValue(
+          Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+        );
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -401,7 +401,7 @@ describe('createPairingCache', () => {
       expect(result.requests[0].requestId).toBe('r-fresh');
     });
 
-    it('preserves entries with missing ts (NaN > TTL is always false)', async () => {
+    it('preserves entries with missing ts (isUnexpiredDeviceRequest returns true when ts is undefined)', async () => {
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
         // ts is intentionally absent — matches openclaw pruneExpiredPending behaviour
         missingTs: { requestId: 'r-missing', deviceId: 'd-missing', publicKey: 'k' },

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -351,6 +351,41 @@ describe('createPairingCache', () => {
 
       expect(cache.getChannelPairing().requests).toHaveLength(0);
     });
+
+    it('strips unknown fields from channel pairing requests', async () => {
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [
+              {
+                code: 'ABC',
+                id: 'r1',
+                meta: { foo: 1 },
+                createdAt: new Date(RECENT_TS).toISOString(),
+                secretToken: 'SHOULD_BE_STRIPPED',
+                internalFlag: true,
+              },
+            ],
+          });
+        }
+        return Promise.resolve({ requests: [] });
+      });
+
+      const { cache } = createTestHarness({ readChannelPairingImpl });
+      await cache.refreshChannelPairing();
+
+      const result = cache.getChannelPairing();
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0]).toEqual({
+        code: 'ABC',
+        id: 'r1',
+        channel: 'telegram',
+        meta: { foo: 1 },
+        createdAt: new Date(RECENT_TS).toISOString(),
+      });
+      expect('secretToken' in result.requests[0]).toBe(false);
+      expect('internalFlag' in result.requests[0]).toBe(false);
+    });
   });
 
   describe('device pairing list', () => {

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createPairingCache, OPENCLAW_BIN } from './pairing-cache';
+import {
+  createPairingCache,
+  OPENCLAW_BIN,
+  type ReadChannelPairingImpl,
+  type ReadDevicePairingImpl,
+} from './pairing-cache';
 
 type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
 
-function createTestHarness(overrides?: { execImpl?: ExecImpl; readConfigImpl?: () => unknown }) {
+// Epoch-ms equivalent of the nowImpl ISO string, for TTL comparisons
+const NOW_MS = new Date('2026-03-12T00:00:00.000Z').getTime();
+// A timestamp 1 minute in the past — well within both TTLs
+const RECENT_TS = NOW_MS - 60_000;
+
+function createTestHarness(overrides?: {
+  execImpl?: ExecImpl;
+  readConfigImpl?: () => unknown;
+  readChannelPairingImpl?: ReadChannelPairingImpl;
+  readDevicePairingImpl?: ReadDevicePairingImpl;
+}) {
   const execImpl = overrides?.execImpl ?? vi.fn<ExecImpl>();
   const readConfigImpl =
     overrides?.readConfigImpl ??
@@ -13,15 +28,33 @@ function createTestHarness(overrides?: { execImpl?: ExecImpl; readConfigImpl?: (
         discord: { enabled: true, token: 'tok' },
       },
     }));
+  const readChannelPairingImpl =
+    overrides?.readChannelPairingImpl ??
+    vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+  const readDevicePairingImpl =
+    overrides?.readDevicePairingImpl ??
+    vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
   const nowImpl = vi.fn(() => '2026-03-12T00:00:00.000Z');
+  const nowMsImpl = vi.fn(() => NOW_MS);
 
   const cache = createPairingCache({
     execImpl,
     readConfigImpl,
+    readChannelPairingImpl,
+    readDevicePairingImpl,
     nowImpl,
+    nowMsImpl,
   });
 
-  return { cache, execImpl, readConfigImpl, nowImpl };
+  return {
+    cache,
+    execImpl,
+    readConfigImpl,
+    readChannelPairingImpl,
+    readDevicePairingImpl,
+    nowImpl,
+    nowMsImpl,
+  };
 }
 
 beforeEach(() => {
@@ -37,27 +70,30 @@ afterEach(() => {
 describe('createPairingCache', () => {
   describe('channel pairing list', () => {
     it('merges requests from multiple channels', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockImplementation((_cmd, args) => {
-        const channel = args[2];
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram') {
-          return Promise.resolve({
-            stdout: JSON.stringify({ requests: [{ code: 'ABC', id: '1' }] }),
-            stderr: '',
-          });
+          return Promise.resolve({ requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
         }
-        return Promise.resolve({
-          stdout: JSON.stringify({ requests: [{ code: 'DEF', id: '2' }] }),
-          stderr: '',
-        });
+        return Promise.resolve({ requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }] });
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl });
       await cache.refreshChannelPairing();
 
       const result = cache.getChannelPairing();
       expect(result.requests).toHaveLength(2);
-      expect(result.requests[0]).toEqual({ code: 'ABC', id: '1', channel: 'telegram' });
-      expect(result.requests[1]).toEqual({ code: 'DEF', id: '2', channel: 'discord' });
+      expect(result.requests[0]).toEqual({
+        code: 'ABC',
+        id: '1',
+        channel: 'telegram',
+        createdAt: new Date(RECENT_TS).toISOString(),
+      });
+      expect(result.requests[1]).toEqual({
+        code: 'DEF',
+        id: '2',
+        channel: 'discord',
+        createdAt: new Date(RECENT_TS).toISOString(),
+      });
       expect(result.lastUpdated).toBe('2026-03-12T00:00:00.000Z');
     });
 
@@ -65,56 +101,50 @@ describe('createPairingCache', () => {
       const readConfigImpl = vi.fn(() => {
         throw new Error('no config');
       });
-      const execImpl = vi.fn<ExecImpl>();
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>();
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       await cache.refreshChannelPairing();
 
       expect(cache.getChannelPairing()).toEqual({ requests: [], lastUpdated: '' });
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readChannelPairingImpl).not.toHaveBeenCalled();
     });
 
     it('handles per-channel failures with Promise.allSettled', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockImplementation((_cmd, args) => {
-        const channel = args[2];
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram') {
-          return Promise.reject(new Error('cli failed'));
+          return Promise.reject(new Error('read failed'));
         }
-        return Promise.resolve({
-          stdout: JSON.stringify({ requests: [{ code: 'DEF', id: '2' }] }),
-          stderr: '',
-        });
+        return Promise.resolve({ requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }] });
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl });
       await cache.refreshChannelPairing();
 
       const result = cache.getChannelPairing();
       // telegram had no prior data, so only discord's results appear
       expect(result.requests).toHaveLength(1);
-      expect(result.requests[0]).toEqual({ code: 'DEF', id: '2', channel: 'discord' });
+      expect(result.requests[0]).toEqual({
+        code: 'DEF',
+        id: '2',
+        channel: 'discord',
+        createdAt: new Date(RECENT_TS).toISOString(),
+      });
     });
 
     it('preserves stale data for a failed channel when it had prior cached requests', async () => {
       let telegramShouldFail = false;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation((_cmd, args) => {
-        const channel = args[2];
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         if (channel === 'telegram' && telegramShouldFail) {
-          return Promise.reject(new Error('cli failed'));
+          return Promise.reject(new Error('read failed'));
         }
         if (channel === 'telegram') {
-          return Promise.resolve({
-            stdout: JSON.stringify({ requests: [{ code: 'ABC', id: '1' }] }),
-            stderr: '',
-          });
+          return Promise.resolve({ requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
         }
-        return Promise.resolve({
-          stdout: JSON.stringify({ requests: [{ code: 'DEF', id: '2' }] }),
-          stderr: '',
-        });
+        return Promise.resolve({ requests: [{ code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() }] });
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl });
 
       // First refresh: both channels succeed
       await cache.refreshChannelPairing();
@@ -128,31 +158,27 @@ describe('createPairingCache', () => {
       expect(result.requests).toHaveLength(2);
       expect(result.requests).toEqual(
         expect.arrayContaining([
-          { code: 'ABC', id: '1', channel: 'telegram' },
-          { code: 'DEF', id: '2', channel: 'discord' },
+          expect.objectContaining({ code: 'ABC', id: '1', channel: 'telegram' }),
+          expect.objectContaining({ code: 'DEF', id: '2', channel: 'discord' }),
         ])
       );
     });
 
     it('logs WARNING prefix when a previously-successful channel fails', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       let callCount = 0;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation((_cmd, args) => {
-        const channel = args[2];
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
         callCount++;
         if (channel === 'telegram' && callCount > 1) {
-          return Promise.reject(new Error('cli down'));
+          return Promise.reject(new Error('read down'));
         }
-        return Promise.resolve({
-          stdout: JSON.stringify({ requests: [{ code: 'ABC', id: '1' }] }),
-          stderr: '',
-        });
+        return Promise.resolve({ requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
       });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
 
       // First refresh: telegram succeeds and populates the cache
       await cache.refreshChannelPairing();
@@ -161,70 +187,166 @@ describe('createPairingCache', () => {
       // Second refresh: telegram fails — should log WARNING since it had prior data
       await cache.refreshChannelPairing();
 
-      const calls = consoleErrorSpy.mock.calls.map(args => String(args[0]));
+      const calls = consoleWarnSpy.mock.calls.map(args => String(args[0]));
       const warnCall = calls.find(msg => msg.includes('WARNING: keeping stale data for'));
       expect(warnCall).toBeDefined();
       expect(warnCall).toContain('telegram');
 
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
-    it('logs plain error prefix (no WARNING) when failing channel had no prior data', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-      const execImpl = vi.fn<ExecImpl>().mockRejectedValue(new Error('cli down'));
+    it('logs no WARNING when failing channel had no prior data', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockRejectedValue(new Error('read down'));
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
 
       // First refresh: telegram fails immediately (no prior data)
       await cache.refreshChannelPairing();
 
-      const calls = consoleErrorSpy.mock.calls.map(args => String(args[0]));
+      const calls = consoleWarnSpy.mock.calls.map(args => String(args[0]));
       const warnCall = calls.find(msg => msg.includes('WARNING'));
       expect(warnCall).toBeUndefined();
 
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
-    it('returns cached data on subsequent calls without re-exec', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [{ code: 'A', id: '1' }] }),
-        stderr: '',
+    it('returns cached data on subsequent calls without re-read', async () => {
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({
+        requests: [{ code: 'A', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl });
       await cache.refreshChannelPairing();
 
       const first = cache.getChannelPairing();
       const second = cache.getChannelPairing();
       expect(first).toBe(second);
-      // Only the initial refresh calls exec, getChannelPairing is synchronous
-      expect(execImpl).toHaveBeenCalledTimes(2); // once per channel
+      // Only the initial refresh reads files; getChannelPairing is synchronous
+      expect(readChannelPairingImpl).toHaveBeenCalledTimes(2); // once per channel
+    });
+  });
+
+  describe('channel TTL filtering', () => {
+    it('filters out entries with expired createdAt (> 60 min ago)', async () => {
+      const expiredTs = NOW_MS - 61 * 60 * 1000; // 61 minutes ago
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [
+              { code: 'EXPIRED', id: 'e1', createdAt: new Date(expiredTs).toISOString() },
+              { code: 'FRESH', id: 'f1', createdAt: new Date(RECENT_TS).toISOString() },
+            ],
+          });
+        }
+        return Promise.resolve({ requests: [] });
+      });
+
+      const { cache } = createTestHarness({ readChannelPairingImpl });
+      await cache.refreshChannelPairing();
+
+      const result = cache.getChannelPairing();
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].code).toBe('FRESH');
+    });
+
+    it('filters out entries with invalid createdAt (empty string)', async () => {
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [
+              { code: 'EMPTY', id: 'e1', createdAt: '' },
+              { code: 'FRESH', id: 'f1', createdAt: new Date(RECENT_TS).toISOString() },
+            ],
+          });
+        }
+        return Promise.resolve({ requests: [] });
+      });
+
+      const { cache } = createTestHarness({ readChannelPairingImpl });
+      await cache.refreshChannelPairing();
+
+      const result = cache.getChannelPairing();
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].code).toBe('FRESH');
+    });
+
+    it('filters out entries with garbage createdAt (non-parseable string)', async () => {
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [
+              { code: 'GARBAGE', id: 'g1', createdAt: 'not-a-date' },
+              { code: 'FRESH', id: 'f1', createdAt: new Date(RECENT_TS).toISOString() },
+            ],
+          });
+        }
+        return Promise.resolve({ requests: [] });
+      });
+
+      const { cache } = createTestHarness({ readChannelPairingImpl });
+      await cache.refreshChannelPairing();
+
+      const result = cache.getChannelPairing();
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].code).toBe('FRESH');
+    });
+
+    it('keeps entry at exactly TTL boundary (not yet expired)', async () => {
+      // Exactly at the boundary: nowMs - createdAt === TTL → NOT > TTL → keep
+      const exactBoundaryTs = NOW_MS - 60 * 60 * 1000;
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [{ code: 'BOUNDARY', id: 'b1', createdAt: new Date(exactBoundaryTs).toISOString() }],
+          });
+        }
+        return Promise.resolve({ requests: [] });
+      });
+
+      const { cache } = createTestHarness({ readChannelPairingImpl });
+      await cache.refreshChannelPairing();
+
+      expect(cache.getChannelPairing().requests).toHaveLength(1);
+      expect(cache.getChannelPairing().requests[0].code).toBe('BOUNDARY');
+    });
+
+    it('filters entry just past TTL boundary (just expired)', async () => {
+      const justExpiredTs = NOW_MS - 60 * 60 * 1000 - 1;
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [{ code: 'EXPIRED', id: 'e1', createdAt: new Date(justExpiredTs).toISOString() }],
+          });
+        }
+        return Promise.resolve({ requests: [] });
+      });
+
+      const { cache } = createTestHarness({ readChannelPairingImpl });
+      await cache.refreshChannelPairing();
+
+      expect(cache.getChannelPairing().requests).toHaveLength(0);
     });
   });
 
   describe('device pairing list', () => {
     it('returns device requests with stripped publicKey', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({
-          pending: [
-            {
-              requestId: 'r1',
-              deviceId: 'd1',
-              role: 'operator',
-              platform: 'ios',
-              clientId: 'c1',
-              ts: 1234,
-              publicKey: 'SHOULD_BE_STRIPPED',
-            },
-          ],
-        }),
-        stderr: '',
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        r1: {
+          requestId: 'r1',
+          deviceId: 'd1',
+          role: 'operator',
+          platform: 'ios',
+          clientId: 'c1',
+          ts: RECENT_TS,
+          publicKey: 'SHOULD_BE_STRIPPED',
+        },
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readDevicePairingImpl });
       await cache.refreshDevicePairing();
 
       const result = cache.getDevicePairing();
@@ -235,10 +357,41 @@ describe('createPairingCache', () => {
         role: 'operator',
         platform: 'ios',
         clientId: 'c1',
-        ts: 1234,
+        ts: RECENT_TS,
       });
       expect(result.lastUpdated).toBe('2026-03-12T00:00:00.000Z');
       expect('publicKey' in result.requests[0]).toBe(false);
+    });
+  });
+
+  describe('device TTL filtering', () => {
+    it('filters out entries with expired ts (> 5 min ago)', async () => {
+      const expiredTs = NOW_MS - 6 * 60 * 1000; // 6 minutes ago
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        expired: { requestId: 'r-expired', deviceId: 'd-expired', ts: expiredTs, publicKey: 'k' },
+        fresh: { requestId: 'r-fresh', deviceId: 'd-fresh', ts: RECENT_TS, publicKey: 'k' },
+      });
+
+      const { cache } = createTestHarness({ readDevicePairingImpl });
+      await cache.refreshDevicePairing();
+
+      const result = cache.getDevicePairing();
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].requestId).toBe('r-fresh');
+    });
+
+    it('preserves entries with missing ts (NaN > TTL is always false)', async () => {
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        // ts is intentionally absent — matches openclaw pruneExpiredPending behaviour
+        missingTs: { requestId: 'r-missing', deviceId: 'd-missing', publicKey: 'k' },
+      });
+
+      const { cache } = createTestHarness({ readDevicePairingImpl });
+      await cache.refreshDevicePairing();
+
+      const result = cache.getDevicePairing();
+      expect(result.requests).toHaveLength(1);
+      expect(result.requests[0].requestId).toBe('r-missing');
     });
   });
 
@@ -343,21 +496,18 @@ describe('createPairingCache', () => {
   });
 
   describe('error handling', () => {
-    it('returns last-known-good data on CLI failure after prior success', async () => {
+    it('returns last-known-good data on read failure after prior success', async () => {
       let callCount = 0;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation(() => {
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(() => {
         callCount++;
         if (callCount <= 2) {
           // First refresh succeeds (two channels)
-          return Promise.resolve({
-            stdout: JSON.stringify({ requests: [{ code: 'A', id: '1' }] }),
-            stderr: '',
-          });
+          return Promise.resolve({ requests: [{ code: 'A', id: '1', createdAt: new Date(RECENT_TS).toISOString() }] });
         }
-        return Promise.reject(new Error('cli down'));
+        return Promise.reject(new Error('read down'));
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl });
 
       await cache.refreshChannelPairing();
       const good = cache.getChannelPairing();
@@ -365,7 +515,7 @@ describe('createPairingCache', () => {
 
       await cache.refreshChannelPairing();
       // Should still have the last-known-good data (both channels failed, so no update)
-      // Actually allSettled: all channels failed so anySuccess=false, cache not updated
+      // allSettled: all channels failed so anySuccess=false, cache not updated
       const after = cache.getChannelPairing();
       expect(after.requests).toHaveLength(2);
       expect(after.lastUpdated).toBe(good.lastUpdated);
@@ -377,24 +527,18 @@ describe('createPairingCache', () => {
       expect(cache.getDevicePairing()).toEqual({ requests: [], lastUpdated: '' });
     });
 
-    it('keeps device cache on CLI failure', async () => {
+    it('keeps device cache on read failure', async () => {
       let callCount = 0;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation((_cmd, args) => {
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockImplementation(() => {
         callCount++;
-        if (args[0] === 'devices' && args[1] === 'list') {
-          if (callCount === 1) {
-            return Promise.resolve({
-              stdout: JSON.stringify({ pending: [{ requestId: 'r1', deviceId: 'd1' }] }),
-              stderr: '',
-            });
-          }
-          return Promise.reject(new Error('fail'));
+        if (callCount === 1) {
+          return Promise.resolve({ r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' } });
         }
-        return Promise.resolve({ stdout: '{}', stderr: '' });
+        return Promise.reject(new Error('fail'));
       });
 
       const readConfigImpl = vi.fn(() => ({ channels: {} }));
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readDevicePairingImpl, readConfigImpl });
 
       await cache.refreshDevicePairing();
       expect(cache.getDevicePairing().requests).toHaveLength(1);
@@ -403,35 +547,84 @@ describe('createPairingCache', () => {
       // Should keep last-known-good
       expect(cache.getDevicePairing().requests).toHaveLength(1);
     });
-  });
 
-  describe('periodic refresh', () => {
-    it('refreshes every 60s after start', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
+    it('ENOENT on first channel read → empty cache, no warning logged', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockRejectedValue(enoentError);
+      const readConfigImpl = vi.fn(() => ({
+        channels: { telegram: { enabled: true, botToken: 'tok' } },
+      }));
+
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
+      await cache.refreshChannelPairing();
+
+      // No warn at all — ENOENT with no prior data should be fully silent
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      // Cache should remain empty
+      expect(cache.getChannelPairing().requests).toHaveLength(0);
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('ENOENT on subsequent channel read → stale cache preserved, warning logged', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      let callCount = 0;
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({ requests: [{ code: 'STALE', id: 's1', createdAt: new Date(RECENT_TS).toISOString() }] });
+        }
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
       });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
+
+      await cache.refreshChannelPairing();
+      expect(cache.getChannelPairing().requests).toHaveLength(1);
+
+      await cache.refreshChannelPairing();
+      // Stale data preserved
+      expect(cache.getChannelPairing().requests).toHaveLength(1);
+      expect(cache.getChannelPairing().requests[0].code).toBe('STALE');
+
+      const warnCalls = consoleWarnSpy.mock.calls.map(args => String(args[0]));
+      expect(warnCalls.some(msg => msg.includes('WARNING: keeping stale data for') && msg.includes('telegram'))).toBe(true);
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('periodic refresh', () => {
+    it('refreshes every 60s after start', async () => {
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
+      const readConfigImpl = vi.fn(() => ({
+        channels: { telegram: { enabled: true, botToken: 'tok' } },
+      }));
+
+      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
       cache.start();
 
       // Initial fetch fires immediately
       await vi.advanceTimersByTimeAsync(0);
-      const callsAfterInitial = execImpl.mock.calls.length;
+      const readCalls = () =>
+        readChannelPairingImpl.mock.calls.length + readDevicePairingImpl.mock.calls.length;
+      const callsAfterInitial = readCalls();
       expect(callsAfterInitial).toBeGreaterThan(0);
 
       // Advance to 60s — periodic fires
       await vi.advanceTimersByTimeAsync(60_000);
-      expect(execImpl.mock.calls.length).toBeGreaterThan(callsAfterInitial);
+      expect(readCalls()).toBeGreaterThan(callsAfterInitial);
 
-      const callsBefore = execImpl.mock.calls.length;
+      const callsBefore = readCalls();
 
       // Advance another 60s — periodic fires again
       await vi.advanceTimersByTimeAsync(60_000);
-      expect(execImpl.mock.calls.length).toBeGreaterThan(callsBefore);
+      expect(readCalls()).toBeGreaterThan(callsBefore);
 
       cache.cleanup();
     });
@@ -439,20 +632,17 @@ describe('createPairingCache', () => {
 
   describe('initial fetch', () => {
     it('fires immediately on start', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       cache.start();
 
       // Flush the microtask queue so the fire-and-forget refreshAll resolves
       await vi.advanceTimersByTimeAsync(0);
-      expect(execImpl).toHaveBeenCalled();
+      expect(readChannelPairingImpl).toHaveBeenCalled();
 
       cache.cleanup();
     });
@@ -460,34 +650,29 @@ describe('createPairingCache', () => {
 
   describe('debounced refresh', () => {
     it('fires 2s after first trigger', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
 
       cache.onPairingLogLine('new pairing request received');
 
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readChannelPairingImpl).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(2_000);
-      expect(execImpl).toHaveBeenCalled();
+      expect(readChannelPairingImpl).toHaveBeenCalled();
     });
 
     it('collapses burst into single refresh (non-sliding window)', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
 
       cache.onPairingLogLine('pairing event 1');
       await vi.advanceTimersByTimeAsync(500);
@@ -496,71 +681,70 @@ describe('createPairingCache', () => {
       cache.onPairingLogLine('pairing event 3');
 
       // 1s has elapsed since first trigger, should not have fired yet
-      expect(execImpl).not.toHaveBeenCalled();
+      const readCalls = () =>
+        readChannelPairingImpl.mock.calls.length + readDevicePairingImpl.mock.calls.length;
+      expect(readCalls()).toBe(0);
 
       // Advance to 2s from first trigger (1s more)
       await vi.advanceTimersByTimeAsync(1_000);
-      expect(execImpl).toHaveBeenCalled();
+      expect(readCalls()).toBeGreaterThan(0);
 
       // Should only have fired once (channel + device refreshes)
-      const callsAtFirstFire = execImpl.mock.calls.length;
+      const callsAtFirstFire = readCalls();
 
       // After the debounce fires, a new trigger should work
       cache.onPairingLogLine('another pairing event');
       await vi.advanceTimersByTimeAsync(2_000);
-      expect(execImpl.mock.calls.length).toBeGreaterThan(callsAtFirstFire);
+      expect(readCalls()).toBeGreaterThan(callsAtFirstFire);
     });
 
     it('ignores lines without pairing keywords', async () => {
-      const execImpl = vi.fn<ExecImpl>();
-      const { cache } = createTestHarness({ execImpl });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>();
+      const { cache } = createTestHarness({ readChannelPairingImpl });
 
       cache.onPairingLogLine('some unrelated log output');
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readChannelPairingImpl).not.toHaveBeenCalled();
     });
   });
 
   describe('cleanup', () => {
     it('clears all timers so no further refreshes fire', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
       cache.start();
 
       // Flush the immediate initial refresh
       await vi.advanceTimersByTimeAsync(0);
-      const callsAfterInitial = execImpl.mock.calls.length;
+      const readCalls = () =>
+        readChannelPairingImpl.mock.calls.length + readDevicePairingImpl.mock.calls.length;
+      const callsAfterInitial = readCalls();
 
       cache.onPairingLogLine('pairing event');
       cache.cleanup();
 
       await vi.advanceTimersByTimeAsync(120_000);
       // No additional calls beyond the initial refresh
-      expect(execImpl.mock.calls.length).toBe(callsAfterInitial);
+      expect(readCalls()).toBe(callsAfterInitial);
     });
   });
 
   describe('lastUpdated', () => {
     it('is set on successful fetch and not updated on failure', async () => {
       let shouldFail = false;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation(() => {
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockImplementation(() => {
         if (shouldFail) return Promise.reject(new Error('fail'));
-        return Promise.resolve({
-          stdout: JSON.stringify({ pending: [{ requestId: 'r1', deviceId: 'd1' }] }),
-          stderr: '',
-        });
+        return Promise.resolve({ r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' } });
       });
       const readConfigImpl = vi.fn(() => ({ channels: {} }));
 
-      const { cache, nowImpl } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache, nowImpl } = createTestHarness({ readDevicePairingImpl, readConfigImpl });
 
       nowImpl.mockReturnValue('2026-03-12T01:00:00.000Z');
       await cache.refreshDevicePairing();
@@ -576,20 +760,22 @@ describe('createPairingCache', () => {
 
   describe('empty-field filtering', () => {
     it('filters out channel requests with empty code', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({
-          requests: [
-            { code: '', id: '1' },
-            { code: 'ABC', id: '2' },
-          ],
-        }),
-        stderr: '',
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [
+              { code: '', id: '1', createdAt: new Date(RECENT_TS).toISOString() },
+              { code: 'ABC', id: '2', createdAt: new Date(RECENT_TS).toISOString() },
+            ],
+          });
+        }
+        return Promise.resolve({ requests: [] });
       });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       await cache.refreshChannelPairing();
 
       const result = cache.getChannelPairing();
@@ -598,20 +784,22 @@ describe('createPairingCache', () => {
     });
 
     it('filters out channel requests with empty id', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({
-          requests: [
-            { code: 'ABC', id: '' },
-            { code: 'DEF', id: '2' },
-          ],
-        }),
-        stderr: '',
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
+        if (channel === 'telegram') {
+          return Promise.resolve({
+            requests: [
+              { code: 'ABC', id: '', createdAt: new Date(RECENT_TS).toISOString() },
+              { code: 'DEF', id: '2', createdAt: new Date(RECENT_TS).toISOString() },
+            ],
+          });
+        }
+        return Promise.resolve({ requests: [] });
       });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       await cache.refreshChannelPairing();
 
       const result = cache.getChannelPairing();
@@ -620,17 +808,12 @@ describe('createPairingCache', () => {
     });
 
     it('filters out device requests with empty requestId', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({
-          pending: [
-            { requestId: '', deviceId: 'd1' },
-            { requestId: 'r2', deviceId: 'd2' },
-          ],
-        }),
-        stderr: '',
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        '': { requestId: '', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' },
+        r2: { requestId: 'r2', deviceId: 'd2', ts: RECENT_TS, publicKey: 'k' },
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readDevicePairingImpl });
       await cache.refreshDevicePairing();
 
       const result = cache.getDevicePairing();
@@ -639,17 +822,12 @@ describe('createPairingCache', () => {
     });
 
     it('filters out device requests with empty deviceId', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({
-          pending: [
-            { requestId: 'r1', deviceId: '' },
-            { requestId: 'r2', deviceId: 'd2' },
-          ],
-        }),
-        stderr: '',
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        r1: { requestId: 'r1', deviceId: '', ts: RECENT_TS, publicKey: 'k' },
+        r2: { requestId: 'r2', deviceId: 'd2', ts: RECENT_TS, publicKey: 'k' },
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readDevicePairingImpl });
       await cache.refreshDevicePairing();
 
       const result = cache.getDevicePairing();
@@ -660,32 +838,26 @@ describe('createPairingCache', () => {
 
   describe('post-cleanup behavior', () => {
     it('refreshChannelPairing is a no-op after cleanup', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       cache.cleanup();
 
       await cache.refreshChannelPairing();
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readChannelPairingImpl).not.toHaveBeenCalled();
     });
 
     it('refreshDevicePairing is a no-op after cleanup', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ pending: [] }),
-        stderr: '',
-      });
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readDevicePairingImpl });
       cache.cleanup();
 
       await cache.refreshDevicePairing();
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readDevicePairingImpl).not.toHaveBeenCalled();
     });
 
     it('approveChannel returns 500 after cleanup', async () => {
@@ -717,29 +889,25 @@ describe('createPairingCache', () => {
     });
 
     it('onPairingLogLine is ignored after cleanup', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       cache.cleanup();
 
       cache.onPairingLogLine('new pairing request received');
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readChannelPairingImpl).not.toHaveBeenCalled();
     });
   });
 
   describe('detectChannels', () => {
     it('detects Slack with botToken', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [{ code: 'A', id: '1' }] }),
-        stderr: '',
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({
+        requests: [{ code: 'A', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
       });
       const readConfigImpl = vi.fn(() => ({
         channels: {
@@ -747,16 +915,15 @@ describe('createPairingCache', () => {
         },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       await cache.refreshChannelPairing();
 
-      expect(execImpl).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['slack']));
+      expect(readChannelPairingImpl).toHaveBeenCalledWith('slack');
     });
 
     it('detects Slack with appToken only', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [{ code: 'A', id: '1' }] }),
-        stderr: '',
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({
+        requests: [{ code: 'A', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
       });
       const readConfigImpl = vi.fn(() => ({
         channels: {
@@ -764,30 +931,29 @@ describe('createPairingCache', () => {
         },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       await cache.refreshChannelPairing();
 
-      expect(execImpl).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['slack']));
+      expect(readChannelPairingImpl).toHaveBeenCalledWith('slack');
     });
 
     it('skips Slack when disabled even with tokens', async () => {
-      const execImpl = vi.fn<ExecImpl>();
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>();
       const readConfigImpl = vi.fn(() => ({
         channels: {
           slack: { enabled: false, botToken: 'xoxb-tok' },
         },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
       await cache.refreshChannelPairing();
 
-      expect(execImpl).not.toHaveBeenCalled();
+      expect(readChannelPairingImpl).not.toHaveBeenCalled();
     });
 
     it('clears stale channel cache when all channels are removed', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [{ code: 'ABC', id: '1' }] }),
-        stderr: '',
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({
+        requests: [{ code: 'ABC', id: '1', createdAt: new Date(RECENT_TS).toISOString() }],
       });
       const configWithChannel: unknown = {
         channels: { telegram: { enabled: true, botToken: 'tok' } },
@@ -795,7 +961,7 @@ describe('createPairingCache', () => {
       const configNoChannels: unknown = { channels: {} };
 
       const readConfigImpl = vi.fn(() => configWithChannel);
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
 
       // First refresh populates the cache
       await cache.refreshChannelPairing();
@@ -815,32 +981,26 @@ describe('createPairingCache', () => {
     it('stale refresh does not overwrite newer data (channel)', async () => {
       // Simulate: slow refresh starts, then a fast post-approve refresh
       // completes first with updated data.  The slow one must not clobber it.
-      let resolveSlowChannel!: (v: { stdout: string; stderr: string }) => void;
+      let resolveSlowChannel!: (v: unknown) => void;
       let callCount = 0;
 
-      const execImpl = vi.fn<ExecImpl>().mockImplementation((_cmd, args) => {
-        if (args[0] === 'pairing' && args[1] === 'list') {
-          callCount++;
-          if (callCount === 1) {
-            // First (slow) refresh — parks until we resolve manually
-            return new Promise(resolve => {
-              resolveSlowChannel = resolve;
-            });
-          }
-          // Second (fast) refresh — returns immediately with post-approve data
-          return Promise.resolve({
-            stdout: JSON.stringify({ requests: [] }),
-            stderr: '',
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First (slow) refresh — parks until we resolve manually
+          return new Promise(resolve => {
+            resolveSlowChannel = resolve;
           });
         }
-        return Promise.resolve({ stdout: '{}', stderr: '' });
+        // Second (fast) refresh — returns immediately with post-approve data
+        return Promise.resolve({ requests: [] });
       });
 
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
 
       // Start slow refresh (does not await)
       const slowPromise = cache.refreshChannelPairing();
@@ -852,10 +1012,7 @@ describe('createPairingCache', () => {
       expect(cache.getChannelPairing().requests).toHaveLength(0);
 
       // Now let the slow refresh finish with stale pre-approve data
-      resolveSlowChannel({
-        stdout: JSON.stringify({ requests: [{ code: 'STALE', id: '99' }] }),
-        stderr: '',
-      });
+      resolveSlowChannel({ requests: [{ code: 'STALE', id: '99', createdAt: new Date(RECENT_TS).toISOString() }] });
       await slowPromise;
 
       // Cache must still reflect the newer (empty) result, NOT the stale data
@@ -863,33 +1020,27 @@ describe('createPairingCache', () => {
     });
 
     it('stale refresh does not overwrite newer data (device)', async () => {
-      let resolveSlowDevice!: (v: { stdout: string; stderr: string }) => void;
+      let resolveSlowDevice!: (v: unknown) => void;
       let callCount = 0;
 
-      const execImpl = vi.fn<ExecImpl>().mockImplementation(() => {
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
           return new Promise(resolve => {
             resolveSlowDevice = resolve;
           });
         }
-        return Promise.resolve({
-          stdout: JSON.stringify({ pending: [] }),
-          stderr: '',
-        });
+        return Promise.resolve({});
       });
 
-      const { cache } = createTestHarness({ execImpl });
+      const { cache } = createTestHarness({ readDevicePairingImpl });
 
       const slowPromise = cache.refreshDevicePairing();
       await cache.refreshDevicePairing();
 
       expect(cache.getDevicePairing().requests).toHaveLength(0);
 
-      resolveSlowDevice({
-        stdout: JSON.stringify({ pending: [{ requestId: 'r1', deviceId: 'd1' }] }),
-        stderr: '',
-      });
+      resolveSlowDevice({ r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS, publicKey: 'k' } });
       await slowPromise;
 
       expect(cache.getDevicePairing().requests).toHaveLength(0);
@@ -898,25 +1049,23 @@ describe('createPairingCache', () => {
 
   describe('start idempotency', () => {
     it('calling start twice does not create duplicate timers', async () => {
-      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({
-        stdout: JSON.stringify({ requests: [] }),
-        stderr: '',
-      });
+      const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
       const readConfigImpl = vi.fn(() => ({
         channels: { telegram: { enabled: true, botToken: 'tok' } },
       }));
 
-      const { cache } = createTestHarness({ execImpl, readConfigImpl });
+      const { cache } = createTestHarness({ readChannelPairingImpl, readDevicePairingImpl, readConfigImpl });
       cache.start();
       cache.start(); // second call should be no-op
 
       // Flush microtask queue for the immediate initial refresh
       await vi.advanceTimersByTimeAsync(0);
 
-      // With two channels (telegram), initial fetch calls exec twice
+      // With one channel (telegram): 1 readChannelPairingImpl call + 1 readDevicePairingImpl call
       // If start() wasn't idempotent, we'd see 4 calls
-      const callsAfterInitial = execImpl.mock.calls.length;
-      expect(callsAfterInitial).toBe(2); // telegram channel + device list
+      expect(readChannelPairingImpl.mock.calls.length).toBe(1);
+      expect(readDevicePairingImpl.mock.calls.length).toBe(1);
 
       cache.cleanup();
     });

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -456,13 +456,11 @@ describe('createPairingCache', () => {
     });
 
     it('returns success when approve succeeds but post-approve refresh throws', async () => {
-      let callCount = 0;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) return Promise.resolve({ stdout: '{}', stderr: '' });
-        return Promise.reject(new Error('refresh boom'));
-      });
-      const { cache } = createTestHarness({ execImpl });
+      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockRejectedValue(new Error('refresh boom'));
+      const { cache } = createTestHarness({ execImpl, readChannelPairingImpl });
 
       const result = await cache.approveChannel('telegram', 'ABC');
       expect(result).toEqual({ success: true, message: 'Pairing approved', statusHint: 200 });
@@ -493,13 +491,11 @@ describe('createPairingCache', () => {
     });
 
     it('returns success when approve succeeds but post-approve refresh throws', async () => {
-      let callCount = 0;
-      const execImpl = vi.fn<ExecImpl>().mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) return Promise.resolve({ stdout: '{}', stderr: '' });
-        return Promise.reject(new Error('refresh boom'));
-      });
-      const { cache } = createTestHarness({ execImpl });
+      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const readDevicePairingImpl = vi
+        .fn<ReadDevicePairingImpl>()
+        .mockRejectedValue(new Error('refresh boom'));
+      const { cache } = createTestHarness({ execImpl, readDevicePairingImpl });
 
       const result = await cache.approveDevice('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
       expect(result).toEqual({ success: true, message: 'Device approved', statusHint: 200 });
@@ -571,6 +567,29 @@ describe('createPairingCache', () => {
       await cache.refreshDevicePairing();
       // Should keep last-known-good
       expect(cache.getDevicePairing().requests).toHaveLength(1);
+    });
+
+    it('ENOENT on device read → clears device cache to empty (file removed after last approval)', async () => {
+      let callCount = 0;
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            r1: { requestId: 'r1', deviceId: 'd1', ts: RECENT_TS },
+          });
+        }
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      });
+
+      const readConfigImpl = vi.fn(() => ({ channels: {} }));
+      const { cache } = createTestHarness({ readDevicePairingImpl, readConfigImpl });
+
+      await cache.refreshDevicePairing();
+      expect(cache.getDevicePairing().requests).toHaveLength(1);
+
+      await cache.refreshDevicePairing();
+      // ENOENT means file was removed → no pending requests, cache should be cleared
+      expect(cache.getDevicePairing().requests).toHaveLength(0);
     });
 
     it('ENOENT on first channel read → empty cache, no warning logged', async () => {

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -592,6 +592,38 @@ describe('createPairingCache', () => {
       expect(cache.getDevicePairing().requests).toHaveLength(0);
     });
 
+    it('non-ENOENT cold-start channel failure → returns false (triggers backoff)', async () => {
+      const readChannelPairingImpl = vi
+        .fn<ReadChannelPairingImpl>()
+        .mockRejectedValue(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }));
+      const readConfigImpl = vi.fn(() => ({
+        channels: { telegram: { enabled: true, botToken: 'tok' } },
+      }));
+
+      const { cache } = createTestHarness({ readChannelPairingImpl, readConfigImpl });
+      // refreshChannelPairingInternal returns false for non-ENOENT cold-start failures
+      // so that backoff fires rather than silently treating the error as success
+      await cache.refreshChannelPairing();
+
+      // Cache stays empty — nothing to preserve
+      expect(cache.getChannelPairing().requests).toHaveLength(0);
+
+      // Verify backoff was armed: after a false return, consecutiveFailureCount > 0
+      // which means nextAllowedRefreshAt is in the future. Start the cache and check
+      // that a debounce triggered immediately after is skipped.
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      cache.start();
+      await vi.advanceTimersByTimeAsync(0); // flush initial refresh (also fails → backoff set)
+      cache.onPairingLogLine('pairing event');
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_DELAY_MS);
+      const skipped = consoleLogSpy.mock.calls.some(args =>
+        String(args[0]).includes('debounced refresh skipped')
+      );
+      expect(skipped).toBe(true);
+      consoleLogSpy.mockRestore();
+      cache.cleanup();
+    });
+
     it('ENOENT on first channel read → empty cache, no warning logged', async () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });

--- a/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/kiloclaw/controller/src/pairing-cache.test.ts
@@ -3,7 +3,6 @@ import {
   createPairingCache,
   OPENCLAW_BIN,
   DEBOUNCE_DELAY_MS,
-  // INITIAL_REFRESH_DELAY_MS, // commented out alongside the constant — re-enable with file-read delay
   PERIODIC_INTERVAL_MS,
   FAILURE_RETRY_BASE_MS,
   FAILURE_RETRY_MAX_MS,
@@ -631,7 +630,7 @@ describe('createPairingCache', () => {
   });
 
   describe('periodic refresh', () => {
-    it('refreshes every 60s after start', async () => {
+    it('fires immediately on start then refreshes every 120s', async () => {
       const readChannelPairingImpl = vi
         .fn<ReadChannelPairingImpl>()
         .mockResolvedValue({ requests: [] });

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -229,7 +229,9 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
             if (!Number.isFinite(createdAtMs)) return false; // garbage timestamp → expired
             return nowMs - createdAtMs <= CHANNEL_PAIRING_TTL_MS;
           });
-        console.log(`[pairing-cache] channel ${channel}: read ok, ${filtered.length} request(s) after filtering`);
+        console.log(
+          `[pairing-cache] channel ${channel}: read ok, ${filtered.length} request(s) after filtering`
+        );
         return filtered;
       })
     );
@@ -359,7 +361,9 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     if (stopped) return;
     const remaining = nextAllowedRefreshAt - Date.now();
     if (remaining > 0) {
-      console.log(`[pairing-cache] debounced refresh skipped (backoff, ${Math.ceil(remaining / 1000)}s remaining)`);
+      console.log(
+        `[pairing-cache] debounced refresh skipped (backoff, ${Math.ceil(remaining / 1000)}s remaining)`
+      );
       return;
     }
     console.log('[pairing-cache] debounced refresh');

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -65,8 +65,10 @@ export const FAILURE_RETRY_MAX_MS = 300_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
 
 // TTL constants — exact matches to openclaw source
-export const CHANNEL_PAIRING_TTL_MS = 60 * 60 * 1000; // pairing-store.ts:15 PAIRING_PENDING_TTL_MS
-export const DEVICE_PAIRING_TTL_MS = 5 * 60 * 1000; // device-pairing.ts:98 PENDING_TTL_MS
+// https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/pairing/pairing-store.ts#L15 PAIRING_PENDING_TTL_MS
+export const CHANNEL_PAIRING_TTL_MS = 60 * 60 * 1000;
+// https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/infra/device-pairing.ts#L98 PENDING_TTL_MS
+export const DEVICE_PAIRING_TTL_MS = 5 * 60 * 1000;
 
 const CHANNEL_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 const CODE_RE = /^[A-Za-z0-9]{1,32}$/;
@@ -222,7 +224,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
           .filter(req => req.code !== '' && req.id !== '')
           .filter(req => {
             // Mirrors pairing-store.ts isExpired() — PAIRING_PENDING_TTL_MS = 60 * 60 * 1000
-            // ~/Developer/OpenSource/openclaw/src/pairing/pairing-store.ts:171
+            // https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/pairing/pairing-store.ts#L171
             if (!req.createdAt) return false; // falsy (undefined, empty string) → expired
             const createdAtMs = Date.parse(req.createdAt);
             if (!Number.isFinite(createdAtMs)) return false; // garbage timestamp → expired
@@ -281,7 +283,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
         .filter(isRecord)
         .filter(entry => {
           // Mirrors pairing-files.ts pruneExpiredPending() — PENDING_TTL_MS = 5 * 60 * 1000
-          // ~/Developer/OpenSource/openclaw/src/infra/device-pairing.ts:98
+          // https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/infra/device-pairing.ts#L98
           // No typeof guard: if ts is missing, nowMs - undefined = NaN, NaN > TTL is false → preserved
           return !(nowMs - (entry.ts as number) > DEVICE_PAIRING_TTL_MS);
         })

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -99,7 +99,9 @@ export function resolveOpenClawStateDir(): string {
 }
 
 export function resolveCredentialsDir(): string {
-  return process.env.OPENCLAW_OAUTH_DIR?.trim() || path.join(resolveOpenClawStateDir(), 'credentials');
+  return (
+    process.env.OPENCLAW_OAUTH_DIR?.trim() || path.join(resolveOpenClawStateDir(), 'credentials')
+  );
 }
 
 export function resolveDevicePendingPath(): string {

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -130,19 +130,22 @@ function defaultReadConfigImpl(): unknown {
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 }
 
-// No .passthrough() — Zod's default strip behavior drops unknown fields so that
-// new keys openclaw adds to <channel>-pairing.json don't leak into the controller
-// API response.  Mirrors the devicePendingEntrySchema pattern below.
-const channelPairingRequestSchema = z.object({
-  code: z.string(),
-  id: z.string(),
-  meta: z.unknown().optional(),
-  createdAt: z.string().optional(),
-});
+// Zod schemas for IO boundary parsing — .passthrough() keeps forward compatibility
+// when openclaw adds fields without breaking the controller.
+const channelPairingRequestSchema = z
+  .object({
+    code: z.string(),
+    id: z.string(),
+    meta: z.unknown().optional(),
+    createdAt: z.string().optional(),
+  })
+  .passthrough();
 
-const channelPairingFileSchema = z.object({
-  requests: z.array(z.unknown()).catch([]),
-});
+const channelPairingFileSchema = z
+  .object({
+    requests: z.array(z.unknown()).catch([]),
+  })
+  .passthrough();
 
 // No .passthrough() — Zod's default strip behavior drops unknown fields (including
 // publicKey, which is sensitive and must not be forwarded to clients). This is

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
+import { z } from 'zod';
 
 const execFileAsync = promisify(execFile);
 
@@ -129,13 +130,63 @@ function defaultReadConfigImpl(): unknown {
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+// Zod schemas for IO boundary parsing — .passthrough() keeps forward compatibility
+// when openclaw adds fields without breaking the controller.
+const channelPairingRequestSchema = z
+  .object({
+    code: z.string(),
+    id: z.string(),
+    meta: z.unknown().optional(),
+    createdAt: z.string().optional(),
+  })
+  .passthrough();
+
+const channelPairingFileSchema = z
+  .object({
+    requests: z.array(z.unknown()).catch([]),
+  })
+  .passthrough();
+
+// No .passthrough() — Zod's default strip behavior drops unknown fields (including
+// publicKey, which is sensitive and must not be forwarded to clients). This is
+// intentional and structurally enforced: only the fields listed below survive parsing.
+// See test: 'returns device requests with stripped publicKey'.
+const devicePendingEntrySchema = z.object({
+  requestId: z.string(),
+  deviceId: z.string(),
+  role: z.string().optional(),
+  platform: z.string().optional(),
+  clientId: z.string().optional(),
+  ts: z.number().optional(),
+});
+
+const devicePendingFileSchema = z.record(z.string(), z.unknown());
+
+// Collects entries from an iterable that pass the given schema, skipping malformed ones.
+// Keeps tolerant per-entry parsing — one bad entry never kills the whole list.
+function collectValidEntries<T extends z.ZodTypeAny>(
+  items: Iterable<unknown>,
+  schema: T
+): Array<z.infer<T>> {
+  const results: Array<z.infer<T>> = [];
+  for (const item of items) {
+    const parsed = schema.safeParse(item);
+    if (parsed.success) {
+      results.push(parsed.data);
+    }
+  }
+  return results;
 }
 
-function getArray(obj: Record<string, unknown>, key: string): unknown[] {
-  const val = obj[key];
-  return Array.isArray(val) ? val : [];
+// Mirrors pruneExpiredPending() in openclaw/src/infra/pairing-files.ts:
+// entries with missing ts are preserved (no expiry); entries with a ts are compared to TTL.
+function isUnexpiredDeviceRequest(req: DevicePairingRequest, nowMs: number): boolean {
+  if (req.ts === undefined) return true;
+  return nowMs - req.ts <= DEVICE_PAIRING_TTL_MS;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function detectChannels(config: unknown): string[] {
@@ -209,19 +260,10 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     const results = await Promise.allSettled(
       channels.map(async channel => {
         const parsed: unknown = await readChannelPairingImpl(channel);
-        const data = isRecord(parsed) ? parsed : {};
-        const requests = getArray(data, 'requests');
-        const filtered = requests
-          .map((req): ChannelPairingRequest => {
-            const r = isRecord(req) ? req : {};
-            return {
-              code: String(r.code ?? ''),
-              id: String(r.id ?? ''),
-              channel,
-              ...('meta' in r ? { meta: r.meta } : {}),
-              ...('createdAt' in r ? { createdAt: String(r.createdAt) } : {}),
-            };
-          })
+        const parsedFile = channelPairingFileSchema.safeParse(parsed);
+        const entries = parsedFile.success ? parsedFile.data.requests : [];
+        const filtered = collectValidEntries(entries, channelPairingRequestSchema)
+          .map((req): ChannelPairingRequest => ({ ...req, channel }))
           .filter(req => req.code !== '' && req.id !== '')
           .filter(req => {
             // Mirrors pairing-store.ts isExpired() — PAIRING_PENDING_TTL_MS = 60 * 60 * 1000
@@ -287,26 +329,22 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     const gen = ++deviceGeneration;
     try {
       const parsed: unknown = await readDevicePairingImpl();
-      const pendingById = isRecord(parsed) ? parsed : {};
+      const parsedFile = devicePendingFileSchema.safeParse(parsed);
+      // Graceful fallback: if the file is valid JSON but not an object (e.g. [] or null),
+      // treat as empty rather than triggering backoff — matches the channel path pattern.
+      // This returns true (success), so the periodic timer stays at its normal 120s cadence
+      // and self-heals on the next refresh once openclaw rewrites the file correctly.
+      const entries = parsedFile.success ? Object.values(parsedFile.data) : [];
       const nowMs = nowMsImpl();
 
-      const requests: DevicePairingRequest[] = Object.values(pendingById)
-        .filter(isRecord)
-        .filter(entry => {
-          // Mirrors pairing-files.ts pruneExpiredPending() — PENDING_TTL_MS = 5 * 60 * 1000
-          // https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/infra/device-pairing.ts#L98
-          // No typeof guard: if ts is missing, nowMs - undefined = NaN, NaN > TTL is false → preserved
-          return !(nowMs - (entry.ts as number) > DEVICE_PAIRING_TTL_MS);
-        })
-        .map(entry => ({
-          requestId: String(entry.requestId ?? ''),
-          deviceId: String(entry.deviceId ?? ''),
-          ...(entry.role !== undefined ? { role: String(entry.role) } : {}),
-          ...(entry.platform !== undefined ? { platform: String(entry.platform) } : {}),
-          ...(entry.clientId !== undefined ? { clientId: String(entry.clientId) } : {}),
-          ...(typeof entry.ts === 'number' ? { ts: entry.ts } : {}),
-        }))
+      const requests: DevicePairingRequest[] = collectValidEntries(
+        entries,
+        devicePendingEntrySchema
+      )
         .filter(req => req.requestId !== '' && req.deviceId !== '')
+        // Mirrors pairing-files.ts pruneExpiredPending() — PENDING_TTL_MS = 5 * 60 * 1000
+        // https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/infra/device-pairing.ts#L98
+        .filter(req => isUnexpiredDeviceRequest(req, nowMs))
         // Mirrors listDevicePairing() sort — descending ts (newest first)
         // https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/infra/device-pairing.ts#L261
         .sort((a, b) => (b.ts ?? 0) - (a.ts ?? 0));

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -130,22 +130,19 @@ function defaultReadConfigImpl(): unknown {
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 }
 
-// Zod schemas for IO boundary parsing — .passthrough() keeps forward compatibility
-// when openclaw adds fields without breaking the controller.
-const channelPairingRequestSchema = z
-  .object({
-    code: z.string(),
-    id: z.string(),
-    meta: z.unknown().optional(),
-    createdAt: z.string().optional(),
-  })
-  .passthrough();
+// No .passthrough() — Zod's default strip behavior drops unknown fields so that
+// new keys openclaw adds to <channel>-pairing.json don't leak into the controller
+// API response.  Mirrors the devicePendingEntrySchema pattern below.
+const channelPairingRequestSchema = z.object({
+  code: z.string(),
+  id: z.string(),
+  meta: z.unknown().optional(),
+  createdAt: z.string().optional(),
+});
 
-const channelPairingFileSchema = z
-  .object({
-    requests: z.array(z.unknown()).catch([]),
-  })
-  .passthrough();
+const channelPairingFileSchema = z.object({
+  requests: z.array(z.unknown()).catch([]),
+});
 
 // No .passthrough() — Zod's default strip behavior drops unknown fields (including
 // publicKey, which is sensitive and must not be forwarded to clients). This is

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -59,7 +59,7 @@ type PairingCacheOptions = {
 
 export const PERIODIC_INTERVAL_MS = 120_000;
 export const DEBOUNCE_DELAY_MS = 2_000;
-// export const INITIAL_REFRESH_DELAY_MS = 120_000; // obsolete once file-reads are fully enabled — was protecting against startup CLI churn
+
 export const FAILURE_RETRY_BASE_MS = 30_000;
 export const FAILURE_RETRY_MAX_MS = 300_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
@@ -208,7 +208,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
         const parsed: unknown = await readChannelPairingImpl(channel);
         const data = isRecord(parsed) ? parsed : {};
         const requests = getArray(data, 'requests');
-        return requests
+        const filtered = requests
           .map((req): ChannelPairingRequest => {
             const r = isRecord(req) ? req : {};
             return {
@@ -228,6 +228,8 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
             if (!Number.isFinite(createdAtMs)) return false; // garbage timestamp → expired
             return nowMs - createdAtMs <= CHANNEL_PAIRING_TTL_MS;
           });
+        console.log(`[pairing-cache] channel ${channel}: read ok, ${filtered.length} request(s) after filtering`);
+        return filtered;
       })
     );
 
@@ -247,8 +249,9 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
           anyHadPriorData = true;
           console.warn(`[pairing-cache] WARNING: keeping stale data for ${channels[i]}: ${msg}`);
           allRequests.push(...priorRequests);
+        } else {
+          console.log(`[pairing-cache] channel ${channels[i]}: read failed: ${msg}`);
         }
-        // No log when no prior data — ENOENT is expected when no pairing is in progress
       }
     }
 
@@ -295,6 +298,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       if (gen === deviceGeneration) {
         deviceCache = { requests, lastUpdated: nowImpl() };
       }
+      console.log(`[pairing-cache] devices: read ok, ${requests.length} pending`);
       return true;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') return true;
@@ -336,6 +340,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
 
   const runPeriodicRefresh = async (): Promise<void> => {
     if (stopped) return;
+    console.log('[pairing-cache] periodic refresh');
     const ok = await refreshAll();
     hasCompletedInitialRefresh = true;
     const now = Date.now();
@@ -345,7 +350,12 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
 
   const runDebouncedRefresh = async (): Promise<void> => {
     if (stopped) return;
-    if (Date.now() < nextAllowedRefreshAt) return;
+    const remaining = nextAllowedRefreshAt - Date.now();
+    if (remaining > 0) {
+      console.log(`[pairing-cache] debounced refresh skipped (backoff, ${Math.ceil(remaining / 1000)}s remaining)`);
+      return;
+    }
+    console.log('[pairing-cache] debounced refresh');
     const ok = await refreshAll();
     const now = Date.now();
     const delayMs = ok ? PERIODIC_INTERVAL_MS : Math.max(0, nextAllowedRefreshAt - now);
@@ -392,6 +402,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
 
     if (debounceTimer !== null) return;
 
+    console.log(`[pairing-cache] debounce armed: "${line.slice(0, 80)}"`);
     debounceTimer = setTimeout(() => {
       debounceTimer = null;
       void runDebouncedRefresh();
@@ -414,9 +425,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     // server.listen() and delays the health endpoint past the DO's 60s startup probe.
     // An empty cache during the brief warmup window is acceptable — the DO-side
     // fallback chain (controller → KV → fly exec) handles it, and the cache
-    // self-heals within ms via the periodic timer and log-triggered debounce.
-    // Note: previously delayed by INITIAL_REFRESH_DELAY_MS to protect against CLI startup churn;
-    // no longer needed now that refreshes are file reads instead of subprocess calls.
+    // self-heals quickly via the periodic timer and log-triggered debounce.
     void runPeriodicRefresh();
   };
 

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -173,7 +173,6 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
   let started = false;
   let stopped = false;
   let periodicTimer: ReturnType<typeof setTimeout> | null = null;
-  let initialTimer: ReturnType<typeof setTimeout> | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let nextAllowedRefreshAt = 0;
   let hasCompletedInitialRefresh = false;
@@ -303,7 +302,13 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       console.log(`[pairing-cache] devices: read ok, ${requests.length} pending`);
       return true;
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return true;
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // File absent means no pending requests (e.g. last request was approved/expired).
+        if (gen === deviceGeneration) {
+          deviceCache = { requests: [], lastUpdated: nowImpl() };
+        }
+        return true;
+      }
       console.error(`[pairing-cache] device refresh failed: ${errorMessage(err)}`);
       return false;
     }
@@ -436,10 +441,6 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     if (periodicTimer !== null) {
       clearTimeout(periodicTimer);
       periodicTimer = null;
-    }
-    if (initialTimer !== null) {
-      clearTimeout(initialTimer);
-      initialTimer = null;
     }
     if (debounceTimer !== null) {
       clearTimeout(debounceTimer);

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -306,7 +306,10 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
           ...(entry.clientId !== undefined ? { clientId: String(entry.clientId) } : {}),
           ...(typeof entry.ts === 'number' ? { ts: entry.ts } : {}),
         }))
-        .filter(req => req.requestId !== '' && req.deviceId !== '');
+        .filter(req => req.requestId !== '' && req.deviceId !== '')
+        // Mirrors listDevicePairing() sort — descending ts (newest first)
+        // https://github.com/openclaw/openclaw/blob/d073ec42cd7fabd1004f6959628743817a4cb0e8/src/infra/device-pairing.ts#L261
+        .sort((a, b) => (b.ts ?? 0) - (a.ts ?? 0));
 
       if (gen === deviceGeneration) {
         deviceCache = { requests, lastUpdated: nowImpl() };

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import fs from 'node:fs';
+import path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
@@ -44,16 +45,25 @@ export type PairingCache = {
 
 type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
 
+export type ReadChannelPairingImpl = (channel: string) => Promise<unknown>;
+export type ReadDevicePairingImpl = () => Promise<unknown>;
+
 type PairingCacheOptions = {
   execImpl?: ExecImpl;
   readConfigImpl?: () => unknown;
   nowImpl?: () => string;
+  readChannelPairingImpl?: ReadChannelPairingImpl;
+  readDevicePairingImpl?: ReadDevicePairingImpl;
+  nowMsImpl?: () => number;
 };
 
 export const PERIODIC_INTERVAL_MS = 60_000;
 export const DEBOUNCE_DELAY_MS = 2_000;
-export const CLI_TIMEOUT_MS = 45_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
+
+// TTL constants — exact matches to openclaw source
+export const CHANNEL_PAIRING_TTL_MS = 60 * 60 * 1000; // pairing-store.ts:15 PAIRING_PENDING_TTL_MS
+export const DEVICE_PAIRING_TTL_MS = 5 * 60 * 1000; // device-pairing.ts:98 PENDING_TTL_MS
 
 const CHANNEL_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 const CODE_RE = /^[A-Za-z0-9]{1,32}$/;
@@ -75,13 +85,33 @@ function approveFail(message: string, statusHint: 400 | 500): ApproveResult {
 
 export const OPENCLAW_BIN = '/usr/local/bin/openclaw';
 
+// Mirrors resolveStateDir() / resolveOAuthDir() in openclaw/src/config/paths.ts
+// Includes legacy CLAWDBOT_STATE_DIR fallback (openclaw paths.ts:65)
+// Note: openclaw's full resolveStateDir() also does filesystem-existence checks for
+// legacy .clawdbot dirs — those are omitted here because the container Dockerfile
+// always creates /root/.openclaw, making the existence check unreachable in practice.
+export function resolveOpenClawStateDir(): string {
+  return (
+    process.env.OPENCLAW_STATE_DIR?.trim() ||
+    process.env.CLAWDBOT_STATE_DIR?.trim() ||
+    '/root/.openclaw'
+  );
+}
+
+export function resolveCredentialsDir(): string {
+  return process.env.OPENCLAW_OAUTH_DIR?.trim() || path.join(resolveOpenClawStateDir(), 'credentials');
+}
+
+export function resolveDevicePendingPath(): string {
+  return path.join(resolveOpenClawStateDir(), 'devices', 'pending.json');
+}
+
 function defaultExecImpl(
   command: string,
   args: string[]
 ): Promise<{ stdout: string; stderr: string }> {
   return execFileAsync(command, args, {
     encoding: 'utf8',
-    timeout: CLI_TIMEOUT_MS,
     env: { ...process.env, HOME: '/root' },
   });
 }
@@ -117,6 +147,17 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     execImpl = defaultExecImpl,
     readConfigImpl = defaultReadConfigImpl,
     nowImpl = () => new Date().toISOString(),
+    readChannelPairingImpl = async (channel: string) => {
+      // Path resolved at call time for testability
+      const filePath = path.join(resolveCredentialsDir(), `${channel}-pairing.json`);
+      return JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as unknown;
+    },
+    readDevicePairingImpl = async () => {
+      // Path resolved at call time for testability
+      const filePath = resolveDevicePendingPath();
+      return JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as unknown;
+    },
+    nowMsImpl = () => Date.now(),
   } = options ?? {};
 
   let channelCache: CacheEntry<ChannelPairingRequest> = { requests: [], lastUpdated: '' };
@@ -152,10 +193,10 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       return;
     }
 
+    const nowMs = nowMsImpl();
     const results = await Promise.allSettled(
       channels.map(async channel => {
-        const { stdout } = await execImpl(OPENCLAW_BIN, ['pairing', 'list', channel, '--json']);
-        const parsed: unknown = JSON.parse(stdout.trim());
+        const parsed: unknown = await readChannelPairingImpl(channel);
         const data = isRecord(parsed) ? parsed : {};
         const requests = getArray(data, 'requests');
         return requests
@@ -169,12 +210,21 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
               ...('createdAt' in r ? { createdAt: String(r.createdAt) } : {}),
             };
           })
-          .filter(req => req.code !== '' && req.id !== '');
+          .filter(req => req.code !== '' && req.id !== '')
+          .filter(req => {
+            // Mirrors pairing-store.ts isExpired() — PAIRING_PENDING_TTL_MS = 60 * 60 * 1000
+            // ~/Developer/OpenSource/openclaw/src/pairing/pairing-store.ts:171
+            if (!req.createdAt) return false; // falsy (undefined, empty string) → expired
+            const createdAtMs = Date.parse(req.createdAt);
+            if (!Number.isFinite(createdAtMs)) return false; // garbage timestamp → expired
+            return nowMs - createdAtMs <= CHANNEL_PAIRING_TTL_MS;
+          });
       })
     );
 
     const allRequests: ChannelPairingRequest[] = [];
     let anySuccess = false;
+    let anyHadPriorData = false;
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === 'fulfilled') {
@@ -182,17 +232,14 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
         anySuccess = true;
       } else {
         const err = result.reason;
-        const msg =
-          err && typeof err === 'object' && 'stderr' in err
-            ? String(err.stderr).trim()
-            : String(err);
+        const msg = errorMessage(err);
         const priorRequests = channelCache.requests.filter(r => r.channel === channels[i]);
         if (priorRequests.length > 0) {
-          console.error(`[pairing-cache] WARNING: keeping stale data for ${channels[i]}: ${msg}`);
+          anyHadPriorData = true;
+          console.warn(`[pairing-cache] WARNING: keeping stale data for ${channels[i]}: ${msg}`);
           allRequests.push(...priorRequests);
-        } else {
-          console.error(`[pairing-cache] ${channels[i]}: ${msg}`);
         }
+        // No log when no prior data — ENOENT is expected when no pairing is in progress
       }
     }
 
@@ -200,39 +247,44 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       if (gen === channelGeneration) {
         channelCache = { requests: allRequests, lastUpdated: nowImpl() };
       }
-    } else {
+    } else if (anyHadPriorData) {
+      // All channels failed but some had prior data — already warned per-channel above
       console.warn('[pairing-cache] channel refresh: all channels failed, cache not updated');
     }
+    // else: all failures had no prior data (e.g. cold-start ENOENT) — stay silent
   };
 
   const refreshDevicePairing = async (): Promise<void> => {
     if (stopped) return;
     const gen = ++deviceGeneration;
     try {
-      const { stdout } = await execImpl(OPENCLAW_BIN, ['devices', 'list', '--json']);
-      const parsed: unknown = JSON.parse(stdout.trim());
-      const data = isRecord(parsed) ? parsed : {};
-      const pending = getArray(data, 'pending');
+      const parsed: unknown = await readDevicePairingImpl();
+      const pendingById = isRecord(parsed) ? parsed : {};
+      const nowMs = nowMsImpl();
 
-      const requests: DevicePairingRequest[] = pending
-        .map((req: unknown) => {
-          const r = isRecord(req) ? req : {};
-          return {
-            requestId: String(r.requestId ?? ''),
-            deviceId: String(r.deviceId ?? ''),
-            ...(r.role !== undefined ? { role: String(r.role) } : {}),
-            ...(r.platform !== undefined ? { platform: String(r.platform) } : {}),
-            ...(r.clientId !== undefined ? { clientId: String(r.clientId) } : {}),
-            ...(typeof r.ts === 'number' ? { ts: r.ts } : {}),
-          };
+      const requests: DevicePairingRequest[] = Object.values(pendingById)
+        .filter(isRecord)
+        .filter(entry => {
+          // Mirrors pairing-files.ts pruneExpiredPending() — PENDING_TTL_MS = 5 * 60 * 1000
+          // ~/Developer/OpenSource/openclaw/src/infra/device-pairing.ts:98
+          // No typeof guard: if ts is missing, nowMs - undefined = NaN, NaN > TTL is false → preserved
+          return !(nowMs - (entry.ts as number) > DEVICE_PAIRING_TTL_MS);
         })
+        .map(entry => ({
+          requestId: String(entry.requestId ?? ''),
+          deviceId: String(entry.deviceId ?? ''),
+          ...(entry.role !== undefined ? { role: String(entry.role) } : {}),
+          ...(entry.platform !== undefined ? { platform: String(entry.platform) } : {}),
+          ...(entry.clientId !== undefined ? { clientId: String(entry.clientId) } : {}),
+          ...(typeof entry.ts === 'number' ? { ts: entry.ts } : {}),
+        }))
         .filter(req => req.requestId !== '' && req.deviceId !== '');
 
       if (gen === deviceGeneration) {
         deviceCache = { requests, lastUpdated: nowImpl() };
       }
     } catch (err) {
-      console.error(`[pairing-cache] device refresh failed: ${errorMessage(err)}`);
+      console.warn(`[pairing-cache] device refresh failed: ${errorMessage(err)}`);
     }
   };
 
@@ -290,8 +342,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     started = true;
 
     // Fire-and-forget: do not await the initial refresh.  Awaiting here blocks
-    // server.listen(), which can delay the health endpoint past the DO's 60s
-    // startup probe when the CLI is slow or wedged (each path has a 45s timeout).
+    // server.listen() and delays the health endpoint past the DO's 60s startup probe.
     // An empty cache during the brief warmup window is acceptable — the DO-side
     // fallback chain (controller → KV → fly exec) handles it, and the cache
     // self-heals within seconds via the periodic timer and log-triggered debounce.

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -62,6 +62,7 @@ export const DEBOUNCE_DELAY_MS = 2_000;
 
 export const FAILURE_RETRY_BASE_MS = 30_000;
 export const FAILURE_RETRY_MAX_MS = 300_000;
+export const APPROVE_TIMEOUT_MS = 45_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
 
 // TTL constants — exact matches to openclaw source
@@ -119,6 +120,7 @@ function defaultExecImpl(
 ): Promise<{ stdout: string; stderr: string }> {
   return execFileAsync(command, args, {
     encoding: 'utf8',
+    timeout: APPROVE_TIMEOUT_MS,
     env: { ...process.env, HOME: '/root' },
   });
 }
@@ -239,6 +241,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     const allRequests: ChannelPairingRequest[] = [];
     let anySuccess = false;
     let anyHadPriorData = false;
+    let anyUnexpectedColdFailure = false;
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === 'fulfilled') {
@@ -252,7 +255,11 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
           anyHadPriorData = true;
           console.warn(`[pairing-cache] WARNING: keeping stale data for ${channels[i]}: ${msg}`);
           allRequests.push(...priorRequests);
+        } else if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          // Cold-start: file not written yet — silently ignore
         } else {
+          // Unexpected failure (permissions, corrupt JSON, etc.) with no prior data
+          anyUnexpectedColdFailure = true;
           console.log(`[pairing-cache] channel ${channels[i]}: read failed: ${msg}`);
         }
       }
@@ -267,8 +274,11 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       // All channels failed but some had prior data — already warned per-channel above
       console.warn('[pairing-cache] channel refresh: all channels failed, cache not updated');
       return false;
+    } else if (anyUnexpectedColdFailure) {
+      // Non-ENOENT failures with no prior data — trigger backoff
+      return false;
     }
-    // else: all failures had no prior data (e.g. cold-start ENOENT) — stay silent
+    // else: all failures were cold-start ENOENT — stay silent
     return true;
   };
 


### PR DESCRIPTION
## Summary

Replaces the `PairingCache`'s use of `openclaw pairing list <channel> --json` and `openclaw devices list --json` subprocess calls with direct `fs.readFile` reads of the JSON files openclaw writes to disk:

- Channel requests: `~/.openclaw/credentials/<channel>-pairing.json`
- Device pending: `~/.openclaw/devices/pending.json`

This eliminates the subprocess overhead (45s timeout, process fork, Node.js startup) on the hot read path. Approvals still go through the CLI since they need openclaw's lock/notify logic.

**Architectural changes:**
- `ReadChannelPairingImpl` / `ReadDevicePairingImpl` injectable function types replace the old exec-based fetch path; path resolution happens at call time for testability
- `nowMsImpl` injectable added (distinct from `nowImpl`) for TTL comparisons without Date parsing
- Path resolvers exported (`resolveOpenClawStateDir`, `resolveCredentialsDir`, `resolveDevicePendingPath`), built from `OPENCLAW_STATE_DIR` / `OPENCLAW_OAUTH_DIR` env vars, mirroring openclaw's own `paths.ts` resolution including the legacy `CLAWDBOT_STATE_DIR` fallback
- TTL filtering now happens in the controller at read time, exactly mirroring openclaw's own expiry logic:
  - Channel: 60 min TTL matching `pairing-store.ts isExpired()`
  - Device: 5 min TTL matching `pairing-files.ts pruneExpiredPending()`, including the NaN-preserves-missing-ts behaviour
- Cold-start ENOENT (no prior data) is fully silent; ENOENT on a channel that previously had data logs `WARNING: keeping stale data` and preserves the cache
- `start()` now fires immediately via `runPeriodicRefresh()` instead of the previous 120s `INITIAL_REFRESH_DELAY_MS` delay (which was only needed to avoid CLI subprocess churn)
- Observability logs added: periodic/debounced refresh triggers, per-channel read results, device read result, debounce armed, and backoff-skip with remaining time

**Test changes (+219 net lines):**
- Harness switched to `readChannelPairingImpl` / `readDevicePairingImpl` fns throughout
- 8 new test cases: TTL boundary (exact / just-past), expired/invalid `createdAt`, missing `ts` preservation, ENOENT first-read and stale-preservation paths
- ENOENT first-read test strengthened to assert `console.warn` not called at all
- Failure backoff test rewritten to use `readChannelPairingImpl` (succeed once to populate cache, then fail) rather than `execImpl`
- Periodic refresh test description updated from "60s" to "120s / fires immediately"

## Verification

- `pnpm typecheck` — pass
- `pnpm test` — pass (all test suites including `pairing-cache.test.ts`)
- `pnpm lint` — pass
- Manual testing pairing telegram

## Visual Changes

N/A

## Reviewer Notes

The path resolution logic in `resolveOpenClawStateDir` / `resolveCredentialsDir` / `resolveDevicePendingPath` deliberately omits the filesystem-existence checks that openclaw's full `resolveStateDir()` performs for legacy `.clawdbot` dirs — those paths are unreachable in the container since the Dockerfile always creates `/root/.openclaw`.

The `INITIAL_REFRESH_DELAY_MS` constant (and its `initialTimer`) has been removed entirely; it was only there to avoid hammering the CLI on startup, which is no longer a concern with direct file reads.