### PR TITLE
feat(kiloclaw): add credit-funded billing for KiloClaw subscriptions

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -18,13 +18,15 @@ capitals, as shown here.
 KiloClaw Billing manages the subscription lifecycle for KiloClaw hosted
 instances. Users access the service through one of two subscription
 plans: a discounted six-month commit plan or a month-to-month standard
-plan. The commit plan auto-renews for successive six-month periods at
-the same price; users may switch between plans at any time. New users
-who provision an instance without subscribing first automatically
+plan. Each plan can be funded either through the external payment
+provider (Stripe) or by deducting from the user's KiloPass credit
+balance. The commit plan auto-renews for successive six-month periods
+at the same price; users may switch between plans at any time. New
+users who provision an instance without subscribing first automatically
 receive a 7-day free trial. A legacy earlybird purchase also grants
 access until a fixed expiry date. A periodic background job enforces
-expiry, suspension, and eventual instance destruction when access
-lapses, with email notifications at each stage.
+expiry, credit renewal, suspension, and eventual instance destruction
+when access lapses, with email notifications at each stage.
 
 ## Rules
 
@@ -37,10 +39,37 @@ lapses, with email notifications at each stage.
 3. A commit plan MUST cover a six-calendar-month billing period.
 4. A standard plan MUST bill on a monthly recurring cycle.
 5. The system MUST enforce at most one subscription record per user.
-6. Plan pricing MUST be configured in the payment provider; the system
-   MUST NOT independently validate or enforce specific price amounts.
-7. The system MUST fail with an error at checkout time if a required
-   plan price identifier is not configured.
+6. The user-visible price for each plan MUST be identical regardless
+   of payment source.
+7. Stripe-funded billing MUST use configured payment-provider price
+   identifiers. Credit-funded billing MUST use internal microdollar
+   amounts that correspond to the same plan prices.
+8. The system MUST fail with an error if required billing
+   configuration for the selected plan is missing. For Stripe-funded
+   billing this includes the payment-provider price identifier.
+9. Each plan MUST support two payment sources: payment-provider
+   (Stripe) and credits. Plan pricing, access rules, failure handling,
+   and suspension/destruction timelines MUST be identical regardless
+   of payment source. The payment mechanism and the internal
+   implementation of plan switching and cancellation differ by payment
+   source (see Plan Switching and Cancellation and Reactivation).
+
+### Payment Sources
+
+1. The system MUST record a payment source for each subscription. The
+   value MUST be either `stripe` or `credits`.
+2. A subscription with payment source `stripe` MUST have a non-null
+   payment provider subscription ID. A subscription with payment source
+   `credits` MUST have a null payment provider subscription ID.
+3. A subscription with payment source `credits` MUST record a credit
+   renewal timestamp indicating when the next credit deduction is due.
+4. At most one subscription record per user is allowed regardless of
+   payment source (see Plans rule 5).
+5. The system MUST NOT allow a user to hold simultaneous subscriptions
+   with different payment sources. Switching between payment sources
+   is deferred to a future phase; users who wish to change payment
+   source MUST cancel their current subscription and re-enroll after
+   the billing period ends.
 
 ### Trial Eligibility and Creation
 
@@ -74,7 +103,7 @@ lapses, with email notifications at each stage.
    configuration changes) MUST be gated behind the access check, except
    for provisioning which uses the trial-bootstrap flow.
 
-### Subscription Checkout
+### Subscription Checkout (Stripe)
 
 1. The system MUST reject a checkout request if the user already has a
    subscription in active, past-due, or unpaid status.
@@ -104,6 +133,48 @@ lapses, with email notifications at each stage.
    independent user action to complete, and rule 3 prevents duplicate
    subscriptions.
 
+### Credit Enrollment
+
+1. The system MUST reject a credit enrollment request if the user
+   already has a subscription in active, past-due, or unpaid status.
+   This is the same guard as Subscription Checkout rule 1.
+2. The system MUST allow credit enrollment when the existing
+   subscription status is trialing or canceled.
+3. The system MUST verify that the user's credit balance is sufficient
+   to cover the first billing period before proceeding: 25,000,000
+   microdollars for the standard plan (one month) or 54,000,000
+   microdollars for the commit plan (six months paid upfront).
+4. The system MUST check whether the user was previously suspended
+   (has a non-null suspension timestamp) before mutating the
+   subscription row.
+5. The system MUST deduct the first period's cost as a negative credit
+   transaction. The deduction MUST use a period-encoded idempotency
+   key (see Credit Renewal rule 2) with conflict-safe insertion. The
+   key MUST distinguish the plan and billing period, for example
+   `kiloclaw-subscription:YYYY-MM` for standard or
+   `kiloclaw-subscription-commit:YYYY-MM` for commit. If the insertion
+   detects a duplicate, the system MUST abort the enrollment as a
+   duplicate attempt.
+6. The system MUST atomically decrement the user's acquired credit
+   balance by the deducted amount in the same database transaction as
+   the credit transaction insertion.
+7. The system MUST create or upsert the subscription record with
+   payment source set to `credits`, status set to active, the billing
+   period set from the current time, the credit renewal timestamp set
+   to the period end, and the payment provider subscription ID set to
+   null.
+8. The subscription upsert MUST clear any prior suspension state:
+   past-due-since, suspension timestamp, and destruction deadline MUST
+   all be set to null.
+9. If the user was previously suspended (per rule 4), the system MUST
+   call the auto-resume procedure after the upsert to restart the
+   instance, clear suspension-cycle email log entries, and clear
+   suspension columns. This MUST happen after the subscription row is
+   in active state.
+10. For the commit plan, the system MUST record a commit-period end
+    date six calendar months from enrollment, consistent with Commit
+    Plan Lifecycle rule 2.
+
 ### Commit Plan Lifecycle
 
 1. A commit subscription MUST remain on the commit price in the payment
@@ -128,10 +199,12 @@ lapses, with email notifications at each stage.
    for active subscriptions.
 2. The system MUST reject a switch if the user is already on the
    requested plan.
-3. A switch from standard to commit MUST create a schedule with two
-   phases: current plan until period end, then commit (open-ended).
-4. A switch from commit to standard MUST create a schedule with two
-   phases: current plan until period end, then standard.
+3. For Stripe-funded subscriptions, a switch from standard to commit
+   MUST create a payment-provider schedule with two phases: current
+   plan until period end, then commit (open-ended).
+4. For Stripe-funded subscriptions, a switch from commit to standard
+   MUST create a payment-provider schedule with two phases: current
+   plan until period end, then standard.
 5. For a standard-to-commit switch, the recorded scheduled-plan MUST
    be commit.
 6. When a plan-switch schedule reaches a terminal status (completed or
@@ -145,21 +218,46 @@ lapses, with email notifications at each stage.
    the commit-period end date to six calendar months from the
    transition date.
 8. The system MUST allow cancellation of user-initiated plan switches.
+9. For credit-funded subscriptions, a plan switch MUST NOT create a
+   payment-provider schedule. The system MUST record the scheduled
+   plan locally and apply it at the next period boundary during
+   the credit renewal sweep.
+10. For credit-funded subscriptions, canceling a plan switch MUST clear
+    the locally recorded scheduled plan. No payment-provider API call
+    is needed.
+11. Cross-payment-source switching (credits to Stripe or vice versa) is
+    NOT RECOMMENDED in v1. Users who wish to change payment source
+    MUST cancel their current subscription and re-enroll after the
+    billing period ends.
 
 ### Cancellation and Reactivation
 
 1. The system MUST reject a cancellation request if no active
-   subscription with a payment provider ID exists.
+   subscription exists. For Stripe-funded subscriptions, the payment
+   provider subscription ID MUST be present. For credit-funded
+   subscriptions, the payment source MUST be `credits` and status
+   MUST be active.
 2. The system MUST reject a cancellation request if cancellation is
    already pending.
-3. When canceling a subscription that has a pending schedule, the system
-   MUST release the schedule before setting the cancel-at-period-end
-   flag.
+3. When canceling a Stripe-funded subscription that has a pending
+   schedule, the system MUST release the schedule before setting the
+   cancel-at-period-end flag.
 4. Cancellation MUST NOT terminate access immediately; access MUST
    continue until the current billing period ends.
-5. The system MUST allow reactivation of a subscription that is pending
+5. For Stripe-funded subscriptions, the system MUST set the
+   cancel-at-period-end flag on both the payment provider and in the
+   local database.
+6. For credit-funded subscriptions, the system MUST set the
+   cancel-at-period-end flag in the local database only. No payment
+   provider API call is needed. The credit renewal sweep handles the
+   period-end transition (see Credit Renewal rule 5).
+7. The system MUST allow reactivation of a subscription that is pending
    cancellation.
-6. On reactivation, the system MUST clear the cancel-at-period-end flag.
+8. On reactivation of a Stripe-funded subscription, the system MUST
+   clear the cancel-at-period-end flag on both the payment provider
+   and in the local database.
+9. On reactivation of a credit-funded subscription, the system MUST
+   clear the cancel-at-period-end flag in the local database only.
 
 ### Billing Lifecycle Background Job
 
@@ -169,6 +267,117 @@ lapses, with email notifications at each stage.
 2. Each sweep in the background job MUST process users independently;
    a failure for one user MUST NOT prevent processing of other users.
 3. All errors during sweep processing MUST be captured for monitoring.
+4. The credit renewal sweep MUST run before all other sweeps so that
+   credit-funded subscriptions are renewed (or marked past-due, or
+   canceled) before the existing sweeps evaluate expiry and suspension.
+
+### Credit Renewal
+
+1. The credit renewal sweep MUST select all subscriptions where
+   payment source is `credits`, status is active or past-due, and
+   the credit renewal timestamp is at or before the current time.
+2. Each credit deduction MUST use a period-encoded category key
+   with a uniqueness constraint. The key MUST be derived from the
+   subscription's credit renewal timestamp (the period boundary being
+   charged for), not from the current wall-clock time. The format
+   MUST distinguish the renewal cadence and plan, for example
+   `kiloclaw-subscription:2026-04` for a standard renewal or
+   `kiloclaw-subscription-commit:2026-04` for a commit renewal.
+   The insertion MUST use conflict-safe semantics so that a duplicate
+   key is silently ignored rather than causing an error.
+   The sweep MUST advance the subscription by exactly one billing
+   period per successful deduction. If the subscription has fallen
+   behind by multiple periods (e.g., the sweep was delayed), the
+   sweep MUST NOT attempt to catch up multiple periods in a single
+   run. Instead, each successive sweep run advances by one period
+   until the credit renewal timestamp is in the future. This ensures
+   each period produces a distinct idempotency key.
+3. The credit deduction insert and subscription period advancement
+   MUST be performed in a single database transaction. If the
+   transaction is interrupted, the database MUST roll back both
+   operations so that a retry can re-attempt the deduction without
+   the idempotency key blocking it.
+4. If the deduction insert returns zero affected rows (duplicate key
+   from a prior committed transaction), the subscription update
+   within the same transaction is a no-op (same values). The system
+   MUST skip further processing for that row.
+5. If the subscription has cancel-at-period-end set, the sweep MUST
+   skip the deduction, set the subscription status to canceled, and
+   clear the cancel-at-period-end flag. The billing period MUST NOT
+   be advanced; current-period-end retains its existing value.
+   Subscription Period Expiry Enforcement rule 1 handles suspension
+   once current-period-end has passed.
+6. When balance is sufficient and the deduction succeeds (one affected
+   row), the system MUST atomically decrement the user's acquired
+   credit balance and advance the subscription's billing period
+   (current-period-start, current-period-end, credit-renewal-
+   timestamp) within the same transaction.
+7. When a commit-plan renewal succeeds and the commit-period end date
+   has been reached, the system MUST extend the commit-period end date
+   by six calendar months from the previous boundary.
+8. When the deduction succeeds and the subscription was previously
+   past-due, the system MUST clear the past-due-since timestamp and
+   set the status to active.
+9. When the deduction succeeds, the subscription was past-due, and
+   the suspension timestamp is null (grace-period recovery), the
+   system MUST delete the credit-renewal-failed email log entry for
+   the user so that future failures can re-trigger the notification.
+10. When the deduction succeeds, the subscription was past-due, and
+    the suspension timestamp is non-null (suspended recovery), the
+    system MUST call the auto-resume procedure to restart the instance,
+    clear the suspension-cycle email log entries (including the
+    credit-renewal-failed entry), and clear the suspension columns.
+11. When balance is insufficient, the system MUST first check whether
+    the user has auto top-up enabled. If auto top-up is available,
+    the system MUST trigger it and skip the row without changing any
+    state (fire-and-skip). The next sweep run MUST re-evaluate the
+    row after the top-up webhook has credited the balance.
+12. When balance is insufficient, auto top-up is not available or has
+    already been attempted and failed, the system MUST set the
+    subscription status to past-due and record a past-due-since
+    timestamp (preserving any existing value). Past-Due Payment
+    Enforcement rule 1 handles suspension after 14 days.
+13. When balance is insufficient and the system enters the past-due
+    path (rule 12), the system MUST send a credit-renewal-failed
+    notification, subject to the standard email idempotency rules.
+    The notification MUST NOT be sent when the system takes the
+    fire-and-skip path (rule 11).
+14. The credit renewal sweep MUST handle three distinct recovery paths
+    in a single pass: active renewal (status active, renewal due),
+    grace-period recovery (status past-due, not suspended), and
+    suspended recovery (status past-due, suspended). Separate sweeps
+    are not needed.
+15. When a credit-funded subscription has a scheduled plan change and
+    the current period has ended, the renewal sweep MUST apply the
+    plan change before computing the next period's cost, deriving the
+    idempotency key, and deducting the new period's charge. Applying
+    the plan change MUST:
+    - Update the subscription's plan to the scheduled plan value.
+    - Clear the scheduled-plan and scheduled-by fields.
+    - If switching to commit: set the commit-period end date to six
+      calendar months from the transition date, consistent with Plan
+      Switching rule 7.
+    - If switching to standard: clear the commit-period end date.
+      After the plan change is applied, subsequent sweeps MUST NOT
+      reapply it (the cleared scheduled-plan field prevents this).
+
+### Auto Top-Up Integration with Credit Renewal
+
+1. The auto top-up flow is asynchronous: triggering auto top-up
+   creates and pays a payment-provider invoice, but credits are only
+   applied when the invoice-paid webhook fires. The credit renewal
+   sweep MUST NOT wait for the top-up to complete.
+2. When the sweep triggers auto top-up for a row, the sweep MUST skip
+   that row entirely without setting past-due status, sending failure
+   notifications, or advancing the billing period.
+3. On the next sweep run, if the auto top-up succeeded and balance is
+   now sufficient, the sweep MUST proceed with the normal deduction.
+   If balance is still insufficient, the sweep MUST enter the
+   insufficient-balance path (Credit Renewal rule 11).
+4. The system MUST enter the insufficient-balance path (not fire-and-
+   skip) when auto top-up is not enabled, has been disabled due to a
+   prior card decline, or was triggered on a prior run and balance
+   remains insufficient.
 
 ### Trial Expiry Warnings
 
@@ -226,11 +435,15 @@ lapses, with email notifications at each stage.
 
 1. When a subscription has been in past-due status for more than 14 days
    and has not been suspended, the system MUST stop the user's instance.
+   This applies equally to Stripe-funded and credit-funded subscriptions.
 2. The system MUST set a suspension timestamp and a destruction deadline
    7 days in the future.
 3. The system MUST send a payment-suspended notification.
 4. The 14-day threshold MUST be measured from the time the subscription
    first entered past-due status, not from the last database update.
+   For credit-funded subscriptions, past-due status is set by the
+   credit renewal sweep; for Stripe-funded subscriptions, it is set
+   by the payment provider webhook.
 
 ### Email Notifications
 
@@ -240,18 +453,29 @@ lapses, with email notifications at each stage.
    to be retried on the next background job run.
 3. The system MUST prevent concurrent duplicate sends of the same
    notification to the same user.
+4. The system MUST support a credit-renewal-failed notification type
+   for credit-funded subscriptions. This notification MUST be sent
+   when the credit renewal sweep enters the insufficient-balance path
+   and MUST be subject to the same idempotency rules as other
+   notification types.
 
 ### Auto-Resume on Payment Recovery
 
 1. When a subscription transitions to active while the user is
    suspended, the system MUST attempt to start the user's instance.
+   For Stripe-funded subscriptions, this transition is detected by
+   the payment provider webhook. For credit-funded subscriptions,
+   this transition is detected by the credit renewal sweep when a
+   past-due subscription with a non-null suspension timestamp is
+   successfully renewed.
 2. If the instance start attempt fails, the system MUST log the failure
    but MUST still proceed with clearing the suspension state. The system
    does not retry the instance start.
 3. The system MUST clear the suspension timestamp and destruction
    deadline.
-4. The system MUST clear email log entries for suspension and destruction
-   notifications so they can fire again in a future suspension cycle.
+4. The system MUST clear email log entries for suspension, destruction,
+   and credit-renewal-failed notifications so they can fire again in a
+   future suspension cycle.
 5. The system MUST NOT clear email log entries for trial or earlybird
    warning notifications, as those are one-time events.
 
@@ -263,6 +487,10 @@ lapses, with email notifications at each stage.
 2. When the payment provider reports "incomplete" or "paused" status,
    the system MUST map these to terminal statuses (unpaid or canceled
    respectively).
+3. Credit-funded subscriptions have no payment provider status. Their
+   status MUST be managed entirely by the credit renewal sweep and
+   the billing lifecycle sweeps. Payment provider status mapping rules
+   MUST NOT apply to credit-funded subscriptions.
 
 ### Billing Status Reporting
 
@@ -275,20 +503,33 @@ lapses, with email notifications at each stage.
 3. The billing status MUST include trial data (start, end, days
    remaining, expired flag) when a trial exists or existed.
 4. The billing status MUST include subscription data (plan, status,
-   cancel-at-period-end, period end, commit end, scheduled plan) when a
-   paid subscription exists.
-5. The billing status MUST include earlybird data (expiry date, days
+   cancel-at-period-end, period end, commit end, scheduled plan,
+   payment source) when a paid subscription exists. Subscription data
+   MUST be included when either a payment provider subscription ID is
+   present or the payment source is `credits`; it MUST NOT be
+   suppressed solely because a payment provider subscription ID is
+   absent.
+5. When the payment source is `credits`, the billing status MUST also
+   include the credit renewal timestamp and the renewal cost for the
+   next billing period so the frontend can display the next renewal
+   date and amount due.
+6. The billing status MUST include earlybird data (expiry date, days
    remaining) when the user has an earlybird purchase.
-6. The billing status MUST include instance data (whether an
+7. The billing status MUST include instance data (whether an
    undestroyed instance exists, suspension timestamp, destruction
    deadline, and destroyed flag) when any instance record exists.
 
 ### Billing Portal
 
-1. The system MUST allow users to access the payment provider's billing
-   portal to manage their payment methods.
+1. The system MUST allow users with Stripe-funded subscriptions to
+   access the payment provider's billing portal to manage their payment
+   methods.
 2. The billing portal session MUST redirect the user back to the
    dashboard upon completion.
+3. The billing portal MUST NOT be offered for credit-funded
+   subscriptions. The frontend MUST NOT call the billing portal
+   endpoint when the user's payment source is `credits`; it MUST
+   direct the user to the credit top-up flow instead.
 
 ### User Data Deletion
 
@@ -296,6 +537,10 @@ lapses, with email notifications at each stage.
    records for that user.
 2. When a user is soft-deleted, the system MUST delete all email
    notification log entries for that user.
+3. Credit transaction records created by subscription deductions are
+   managed by the credit system's own data deletion rules, not by
+   KiloClaw billing. This spec does not impose additional deletion
+   requirements on credit transaction records.
 
 ### Changelog
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -140,10 +140,17 @@ when access lapses, with email notifications at each stage.
    This is the same guard as Subscription Checkout rule 1.
 2. The system MUST allow credit enrollment when the existing
    subscription status is trialing or canceled.
-3. The system MUST verify that the user's credit balance is sufficient
-   to cover the first billing period before proceeding: 25,000,000
-   microdollars for the standard plan (one month) or 54,000,000
-   microdollars for the commit plan (six months paid upfront).
+3. The system MUST verify that the user's effective credit balance is
+   sufficient to cover the first billing period before proceeding:
+   25,000,000 microdollars for the standard plan (one month) or
+   54,000,000 microdollars for the commit plan (six months paid
+   upfront). The effective balance MUST be computed as the current
+   credit balance plus the projected bonus credits the user would earn
+   from the deduction. The projected bonus MUST be obtained by querying
+   the Kilo Pass entitlement system for the bonus that would result
+   from the deduction amount, without committing any credit award.
+   When the user has no Kilo Pass, the effective balance equals the
+   current credit balance.
 4. The system MUST check whether the user was previously suspended
    (has a non-null suspension timestamp) before mutating the
    subscription row.
@@ -158,22 +165,45 @@ when access lapses, with email notifications at each stage.
 6. The system MUST atomically decrement the user's acquired credit
    balance by the deducted amount in the same database transaction as
    the credit transaction insertion.
-7. The system MUST create or upsert the subscription record with
+7. After the credit deduction transaction commits (rules 5–6), the
+   system MUST trigger a bonus credit evaluation. This step determines
+   whether the user's cumulative spend now qualifies for additional
+   bonus credits under their Kilo Pass entitlement and, if so, awards
+   them. The user's acquired credit balance MAY be temporarily negative
+   between the deduction in rule 6 and the bonus award; other
+   balance-observing systems (monitoring, display, renewal sweeps)
+   MUST tolerate transient negative balances from this flow. When
+   the user has no Kilo Pass, this step is a no-op. If the bonus
+   evaluation fails or times out, the system MUST log the failure but
+   MUST still proceed to rule 8 (subscription upsert). The missed
+   bonus SHOULD be recovered by a subsequent reconciliation process;
+   this spec does not define that process.
+8. The system MUST create or upsert the subscription record with
    payment source set to `credits`, status set to active, the billing
    period set from the current time, the credit renewal timestamp set
    to the period end, and the payment provider subscription ID set to
    null.
-8. The subscription upsert MUST clear any prior suspension state:
+9. The subscription upsert MUST clear any prior suspension state:
    past-due-since, suspension timestamp, and destruction deadline MUST
    all be set to null.
-9. If the user was previously suspended (per rule 4), the system MUST
-   call the auto-resume procedure after the upsert to restart the
-   instance, clear suspension-cycle email log entries, and clear
-   suspension columns. This MUST happen after the subscription row is
-   in active state.
-10. For the commit plan, the system MUST record a commit-period end
+10. If the user was previously suspended (per rule 4), the system MUST
+    call the auto-resume procedure after the upsert to restart the
+    instance, clear suspension-cycle email log entries, and clear
+    suspension columns. This MUST happen after the subscription row is
+    in active state.
+11. For the commit plan, the system MUST record a commit-period end
     date six calendar months from enrollment, consistent with Commit
     Plan Lifecycle rule 2.
+
+> **Implementation note:** If the process crashes after the deduction
+> transaction commits (rule 6) but before the subscription upsert
+> (rule 8), the user is left with deducted credits and no active
+> subscription. The idempotency key (rule 5) blocks re-deduction on
+> retry, so the normal enrollment path cannot recover this state. This
+> gap is pre-existing (it applies with or without the bonus evaluation
+> step), but the bonus step widens the crash-vulnerability window.
+> Operational monitoring SHOULD detect deductions without corresponding
+> active subscriptions and alert for manual reconciliation.
 
 ### Commit Plan Lifecycle
 
@@ -307,11 +337,18 @@ when access lapses, with email notifications at each stage.
    be advanced; current-period-end retains its existing value.
    Subscription Period Expiry Enforcement rule 1 handles suspension
    once current-period-end has passed.
-6. When balance is sufficient and the deduction succeeds (one affected
-   row), the system MUST atomically decrement the user's acquired
-   credit balance and advance the subscription's billing period
-   (current-period-start, current-period-end, credit-renewal-
-   timestamp) within the same transaction.
+6. When the effective balance (as defined in Credit Enrollment rule 3)
+   is sufficient and the deduction succeeds (one affected row), the
+   system MUST atomically decrement the user's acquired credit balance
+   and advance the subscription's billing period (current-period-start,
+   current-period-end, credit-renewal-timestamp) within the same
+   transaction. After the transaction commits, the system MUST trigger
+   a bonus credit evaluation as described in Credit Enrollment rule 7.
+   The user's acquired credit balance MAY be temporarily negative
+   between the deduction and the bonus award. If the bonus evaluation
+   fails or times out, the system MUST log the failure and continue
+   processing the row; the missed bonus SHOULD be recovered by a
+   subsequent reconciliation process.
 7. When a commit-plan renewal succeeds and the commit-period end date
    has been reached, the system MUST extend the commit-period end date
    by six calendar months from the previous boundary.
@@ -327,17 +364,19 @@ when access lapses, with email notifications at each stage.
     system MUST call the auto-resume procedure to restart the instance,
     clear the suspension-cycle email log entries (including the
     credit-renewal-failed entry), and clear the suspension columns.
-11. When balance is insufficient, the system MUST first check whether
+11. When the effective balance (as defined in Credit Enrollment
+    rule 3) is insufficient, the system MUST first check whether
     the user has auto top-up enabled. If auto top-up is available,
     the system MUST trigger it and skip the row without changing any
     state (fire-and-skip). The next sweep run MUST re-evaluate the
     row after the top-up webhook has credited the balance.
-12. When balance is insufficient, auto top-up is not available or has
-    already been attempted and failed, the system MUST set the
+12. When the effective balance is still insufficient (per rule 11),
+    auto top-up is not available or has already been attempted and
+    failed, the system MUST set the
     subscription status to past-due and record a past-due-since
     timestamp (preserving any existing value). Past-Due Payment
     Enforcement rule 1 handles suspension after 14 days.
-13. When balance is insufficient and the system enters the past-due
+13. When the effective balance is insufficient and the system enters the past-due
     path (rule 12), the system MUST send a credit-renewal-failed
     notification, subject to the standard email idempotency rules.
     The notification MUST NOT be sent when the system takes the
@@ -370,14 +409,15 @@ when access lapses, with email notifications at each stage.
 2. When the sweep triggers auto top-up for a row, the sweep MUST skip
    that row entirely without setting past-due status, sending failure
    notifications, or advancing the billing period.
-3. On the next sweep run, if the auto top-up succeeded and balance is
-   now sufficient, the sweep MUST proceed with the normal deduction.
-   If balance is still insufficient, the sweep MUST enter the
-   insufficient-balance path (Credit Renewal rule 11).
+3. On the next sweep run, if the auto top-up succeeded and the
+   effective balance (as defined in Credit Enrollment rule 3) is now
+   sufficient, the sweep MUST proceed with the normal deduction. If
+   the effective balance is still insufficient, the sweep MUST enter
+   the insufficient-balance path (Credit Renewal rule 11).
 4. The system MUST enter the insufficient-balance path (not fire-and-
    skip) when auto top-up is not enabled, has been disabled due to a
-   prior card decline, or was triggered on a prior run and balance
-   remains insufficient.
+   prior card decline, or was triggered on a prior run and the
+   effective balance remains insufficient.
 
 ### Trial Expiry Warnings
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -154,62 +154,57 @@ when access lapses, with email notifications at each stage.
 4. The system MUST check whether the user was previously suspended
    (has a non-null suspension timestamp) before mutating the
    subscription row.
-5. The system MUST deduct the first period's cost as a negative credit
-   transaction. The deduction MUST use a period-encoded idempotency
-   key (see Credit Renewal rule 2) with conflict-safe insertion. The
-   key MUST distinguish the plan and billing period, for example
-   `kiloclaw-subscription:YYYY-MM` for standard or
-   `kiloclaw-subscription-commit:YYYY-MM` for commit. If the insertion
-   detects a duplicate, the system MUST abort the enrollment as a
-   duplicate attempt.
-6. The system MUST atomically decrement the user's acquired credit
-   balance by the deducted amount in the same database transaction as
-   the credit transaction insertion.
-7. After the credit deduction transaction commits (rules 5–6), the
-   system MUST trigger a bonus credit evaluation. This step determines
-   whether the user's cumulative spend now qualifies for additional
-   bonus credits under their Kilo Pass entitlement and, if so, awards
-   them. The user's acquired credit balance MAY be temporarily negative
-   between the deduction in rule 6 and the bonus award; other
+5. The credit deduction and subscription upsert MUST be performed in
+   a single database transaction so that a crash cannot
+   leave the user with deducted credits and no active subscription.
+   Within this transaction the system MUST:
+   a. Insert a negative credit transaction for the first period's cost.
+      The insertion MUST use a period-encoded idempotency key (see
+      Credit Renewal rule 2) with conflict-safe semantics. The key
+      MUST distinguish the plan and billing period, for example
+      `kiloclaw-subscription:YYYY-MM` for standard or
+      `kiloclaw-subscription-commit:YYYY-MM` for commit. If the
+      insertion detects a duplicate, the system MUST abort the
+      enrollment as a duplicate attempt.
+   b. Atomically decrement the user's acquired credit balance by the
+      deducted amount.
+   c. Create or upsert the subscription record with payment source set
+      to `credits`, status set to active, the billing period set from
+      the current time, the credit renewal timestamp set to the period
+      end, and the payment provider subscription ID set to null.
+   d. The subscription upsert MUST clear the past-due-since timestamp
+      and set the status to active, but MUST NOT clear the suspension
+      timestamp or destruction deadline at this step. If the user was
+      previously suspended, those columns are needed as a signal for
+      the auto-resume procedure in rule 7.
+   If the transaction is interrupted, the database MUST roll back all
+   operations so that a retry can re-attempt without the idempotency
+   key blocking it.
+6. After the enrollment transaction commits (rule 5), the system MUST
+   trigger a bonus credit evaluation. This step determines whether the
+   user's cumulative spend now qualifies for additional bonus credits
+   under their Kilo Pass entitlement and, if so, awards them. The
+   user's acquired credit balance MAY be temporarily negative between
+   the deduction in rule 5b and the bonus award; other
    balance-observing systems (monitoring, display, renewal sweeps)
-   MUST tolerate transient negative balances from this flow. When
-   the user has no Kilo Pass, this step is a no-op. If the bonus
+   MUST tolerate transient negative balances from this flow. When the
+   user has no Kilo Pass, this step is a no-op. If the bonus
    evaluation fails or times out, the system MUST log the failure but
-   MUST still proceed to rule 8 (subscription upsert). The missed
-   bonus SHOULD be recovered by a subsequent reconciliation process;
-   this spec does not define that process.
-8. The system MUST create or upsert the subscription record with
-   payment source set to `credits`, status set to active, the billing
-   period set from the current time, the credit renewal timestamp set
-   to the period end, and the payment provider subscription ID set to
-   null.
-9. The subscription upsert MUST clear the past-due-since timestamp
-   and set the status to active, but MUST NOT clear the suspension
-   timestamp or destruction deadline at this step. If the user was
-   previously suspended, those columns are needed as a signal for the
-   auto-resume procedure in rule 10.
-10. If the user was previously suspended (per rule 4), the system MUST
-    call the auto-resume procedure after the upsert to restart the
-    instance, clear suspension-cycle email log entries, and clear
-    the suspension timestamp and destruction deadline. This MUST
-    happen after the subscription row is in active state. If the
-    process crashes before auto-resume completes, the non-null
-    suspension timestamp on an active subscription signals that
-    resume is still required; the next background job run MUST
-    detect this state and retry the auto-resume.
-11. For the commit plan, the system MUST record a commit-period end
-    date six calendar months from enrollment, consistent with Commit
-    Plan Lifecycle rule 2.
-
-> **Implementation note:** If the process crashes after the deduction
-> transaction commits (rule 6) but before the subscription upsert
-> (rule 8), the user is left with deducted credits and no active
-> subscription. The idempotency key (rule 5) blocks re-deduction on
-> retry, so the normal enrollment path cannot recover this state. This
-> gap is pre-existing (it applies with or without the bonus evaluation
-> step), but the bonus step widens the crash-vulnerability window.
-> Operational monitoring SHOULD detect deductions without corresponding
-> active subscriptions and alert for manual reconciliation.
+   MUST NOT roll back the enrollment. The missed bonus SHOULD be
+   recovered by a subsequent reconciliation process; this spec does
+   not define that process.
+7. If the user was previously suspended (per rule 4), the system MUST
+   call the auto-resume procedure after the transaction commits to
+   restart the instance, clear suspension-cycle email log entries, and
+   clear the suspension timestamp and destruction deadline. This MUST
+   happen after the subscription row is in active state. If the
+   process crashes before auto-resume completes, the non-null
+   suspension timestamp on an active subscription signals that
+   resume is still required; the next background job run MUST
+   detect this state and retry the auto-resume.
+8. For the commit plan, the system MUST record a commit-period end
+   date six calendar months from enrollment, consistent with Commit
+   Plan Lifecycle rule 2.
 
 ### Commit Plan Lifecycle
 
@@ -353,7 +348,7 @@ when access lapses, with email notifications at each stage.
    and advance the subscription's billing period (current-period-start,
    current-period-end, credit-renewal-timestamp) within the same
    transaction. After the transaction commits, the system MUST trigger
-   a bonus credit evaluation as described in Credit Enrollment rule 7.
+   a bonus credit evaluation as described in Credit Enrollment rule 6.
    The user's acquired credit balance MAY be temporarily negative
    between the deduction and the bonus award. If the bonus evaluation
    fails or times out, the system MUST log the failure and continue
@@ -379,14 +374,23 @@ when access lapses, with email notifications at each stage.
     the user has auto top-up enabled and whether a top-up has
     already been triggered for the current renewal period. If auto
     top-up is available and has NOT yet been triggered for this
-    period, the system MUST trigger it, record a durable marker
-    (the credit renewal timestamp of the period being charged) on
-    the subscription row to indicate that a top-up has been
-    requested, and skip the row without changing any other state
-    (fire-and-skip). The next sweep run MUST re-evaluate the row
-    after the top-up webhook has credited the balance. The marker
-    MUST be cleared when the billing period advances (successful
-    deduction) or when the subscription is canceled.
+    period, the system MUST persist the durable marker (the credit
+    renewal timestamp of the period being charged) on the
+    subscription row BEFORE triggering the auto top-up call. This
+    ensures that if the process crashes after the payment-provider
+    invoice is created but before the marker write would otherwise
+    have committed, the marker already exists and prevents a
+    duplicate top-up on the next sweep. The auto top-up call MUST
+    include a deterministic idempotency key derived from the user ID
+    and the credit renewal timestamp of the period being charged, so
+    that the payment provider de-duplicates repeated requests for the
+    same renewal period. After the marker is persisted and the
+    top-up triggered, the system MUST skip the row without changing
+    any other state (fire-and-skip). The next sweep run MUST
+    re-evaluate the row after the top-up webhook has credited the
+    balance. The marker MUST be cleared when the billing period
+    advances (successful deduction) or when the subscription is
+    canceled.
 12. When the effective balance is still insufficient (per rule 11)
     and auto top-up is not available, has been disabled due to a
     prior card decline, or was already triggered for the current

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -409,10 +409,13 @@ when access lapses, with email notifications at each stage.
     suspended recovery (status past-due, suspended). Separate sweeps
     are not needed.
 15. When a credit-funded subscription has a scheduled plan change and
-    the current period has ended, the renewal sweep MUST apply the
-    plan change before computing the next period's cost, deriving the
-    idempotency key, and deducting the new period's charge. Applying
-    the plan change MUST:
+    the current period has ended, the renewal sweep MUST determine
+    the effective plan and cost before the deduction, but MUST apply
+    the plan mutation inside the same database transaction as the
+    credit deduction and period advancement (rule 3). This ensures
+    that a crash between the plan switch and the charge cannot leave
+    the subscription on the new plan without a corresponding
+    deduction. Applying the plan change MUST:
     - Update the subscription's plan to the scheduled plan value.
     - Clear the scheduled-plan and scheduled-by fields.
     - If switching to commit: set the commit-period end date to six
@@ -533,10 +536,13 @@ when access lapses, with email notifications at each stage.
    past-due subscription with a non-null suspension timestamp is
    successfully renewed.
 2. If the instance start attempt fails, the system MUST log the failure
-   but MUST still proceed with clearing the suspension state. The system
-   does not retry the instance start.
+   and MUST NOT clear the suspension timestamp or destruction deadline.
+   Leaving these fields intact allows the background job (Billing
+   Lifecycle Background Job rule 5) to detect the incomplete
+   auto-resume and retry on the next sweep.
 3. The system MUST clear the suspension timestamp and destruction
-   deadline.
+   deadline only after a successful instance start (or when no instance
+   exists to restart).
 4. The system MUST clear email log entries for suspension, destruction,
    and credit-renewal-failed notifications so they can fire again in a
    future suspension cycle.

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -1,9 +1,21 @@
 # KiloClaw Billing
 
+## Role of This Document
+
+This spec defines the business rules and invariants for KiloClaw
+billing. It is the source of truth for _what_ the system must
+guarantee — valid states, ownership boundaries, correctness
+properties, and user-facing behavior. It deliberately does not
+prescribe _how_ to implement those guarantees: handler names, column
+layouts, conflict-resolution strategies, null-safety patterns, and
+other implementation choices belong in plan documents and code, not
+here.
+
 ## Status
 
 Draft -- generated from branch `jdp/kiloclaw-billing` on 2026-03-13.
 Updated 2026-03-19 -- pricing and trial duration changes.
+Updated 2026-03-20 -- Stripe-to-credits hybrid billing model.
 
 ## Conventions
 
@@ -13,6 +25,30 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 BCP 14 [RFC 2119] [RFC 8174] when, and only when, they appear in all
 capitals, as shown here.
 
+## Definitions
+
+- **Legacy Stripe subscription**: A subscription with payment source
+  `stripe` and a non-null payment provider subscription ID. The
+  payment provider owns all state.
+- **Hybrid subscription**: A subscription with payment source
+  `credits` and a non-null payment provider subscription ID. The
+  payment provider collects payment; the local billing engine tracks
+  the period via credits.
+- **Pure credit subscription**: A subscription with payment source
+  `credits` and a null payment provider subscription ID. The local
+  credit renewal sweep owns all state.
+- **Stripe-funded subscription**: Any subscription with a non-null
+  payment provider subscription ID (legacy Stripe or hybrid). Used
+  throughout this spec to mean "has Stripe billing infrastructure"
+  regardless of payment source.
+- **Invoice settlement**: The process triggered by a paid KiloClaw
+  invoice from the payment provider that converts the payment into
+  balanced credit ledger entries and advances the subscription
+  period. Defined in Stripe-Funded Credit Settlement.
+- **Dunning state**: A non-active payment failure status reported by
+  the payment provider (past-due, unpaid, or defensive terminal
+  fallback).
+
 ## Overview
 
 KiloClaw Billing manages the subscription lifecycle for KiloClaw hosted
@@ -20,13 +56,18 @@ instances. Users access the service through one of two subscription
 plans: a discounted six-month commit plan or a month-to-month standard
 plan. Each plan can be funded either through the external payment
 provider (Stripe) or by deducting from the user's KiloPass credit
-balance. The commit plan auto-renews for successive six-month periods
-at the same price; users may switch between plans at any time. New
-users who provision an instance without subscribing first automatically
-receive a 7-day free trial. A legacy earlybird purchase also grants
-access until a fixed expiry date. A periodic background job enforces
-expiry, credit renewal, suspension, and eventual instance destruction
-when access lapses, with email notifications at each stage.
+balance. Stripe-funded subscriptions are lazily converted to a hybrid
+state on their first settled invoice: the system records the payment
+source as `credits` while preserving the payment provider subscription
+ID, allowing Stripe to continue collecting payment while the local
+billing engine tracks the period via credits. The commit plan
+auto-renews for successive six-month periods at the same price; users
+may switch between plans at any time. New users who provision an
+instance without subscribing first automatically receive a 7-day free
+trial. A legacy earlybird purchase also grants access until a fixed
+expiry date. A periodic background job enforces expiry, credit
+renewal, suspension, and eventual instance destruction when access
+lapses, with email notifications at each stage.
 
 ## Rules
 
@@ -58,18 +99,73 @@ when access lapses, with email notifications at each stage.
 
 1. The system MUST record a payment source for each subscription. The
    value MUST be either `stripe` or `credits`.
-2. A subscription with payment source `stripe` MUST have a non-null
+2. The system MUST enforce exactly three valid combinations of payment
+   source and payment provider subscription ID:
+
+   | State         | payment_source | provider subscription ID |
+   | ------------- | -------------- | ------------------------ |
+   | Legacy Stripe | `stripe`       | non-null                 |
+   | Hybrid        | `credits`      | non-null                 |
+   | Pure credit   | `credits`      | null                     |
+
+   A subscription with payment source `stripe` MUST have a non-null
    payment provider subscription ID. A subscription with payment source
-   `credits` MUST have a null payment provider subscription ID.
+   `credits` MAY have a non-null payment provider subscription ID
+   (hybrid) or a null one (pure credit). No other combination is
+   valid.
+
 3. A subscription with payment source `credits` MUST record a credit
    renewal timestamp indicating when the next credit deduction is due.
 4. At most one subscription record per user is allowed regardless of
    payment source (see Plans rule 5).
-5. The system MUST NOT allow a user to hold simultaneous subscriptions
-   with different payment sources. Switching between payment sources
-   is deferred to a future phase; users who wish to change payment
-   source MUST cancel their current subscription and re-enroll after
-   the billing period ends.
+5. User-initiated switching between payment sources is not supported.
+   Users MUST NOT be able to manually change a subscription's payment
+   source; they MUST cancel and re-enroll to change funding method.
+   System-initiated conversion from legacy Stripe to hybrid (`stripe`
+   to `credits` with the provider subscription ID preserved) occurs
+   automatically when a KiloClaw invoice is settled (see
+   Stripe-Funded Credit Settlement). This is a one-way lazy
+   migration, not a user action.
+
+### Hybrid Subscription Ownership
+
+When a subscription is in the hybrid state, multiple events may
+attempt to mutate the same subscription. The following ownership
+rules resolve conflicts.
+
+1. Invoice settlement MUST be the sole authority for hybrid-row
+   successful payment: advancing the billing period, mutating the
+   plan, updating the credit renewal timestamp, updating the
+   commitment end date, and recovering the subscription to active
+   status. No other event or background process MAY perform these
+   operations on a hybrid row.
+2. Subscription status-change events from the payment provider for
+   hybrid rows MUST be limited to propagating cancel intent and
+   dunning states. They MUST NOT overwrite the payment source,
+   plan, billing period, credit renewal timestamp, or commitment end
+   date. They MUST NOT recover hybrid rows to active status, clear
+   suspension state, or trigger auto-resume.
+3. Subscription creation events from the payment provider MUST NOT
+   revert an already-hybrid row's converted state. The hybrid row's
+   payment source, plan, billing period, credit renewal timestamp,
+   and commitment end date MUST be preserved. Payment provider
+   metadata (subscription ID, cancel intent) MUST still be updated.
+4. Schedule lifecycle events (completion, release) for hybrid rows
+   MUST clear schedule tracking state but MUST NOT mutate the plan
+   or commitment end date. Plan mutation is owned by invoice
+   settlement (rule 1). Schedule events and settled invoices may
+   arrive in either order; the system MUST tolerate both orderings.
+5. The credit renewal sweep MUST NOT select hybrid rows (see Credit
+   Renewal rule 1). Hybrid-row renewal is owned entirely by invoice
+   settlement.
+6. The interrupted auto-resume retry in the billing lifecycle
+   background job MUST include hybrid rows. A hybrid row can need
+   retry if auto-resume was interrupted after invoice settlement
+   recovered it to active (see Billing Lifecycle Background Job
+   rule 5).
+7. For non-hybrid rows (legacy Stripe or pure credit), all existing
+   event-handling and sweep behaviors MUST remain unchanged. The
+   ownership rules in this section apply ONLY to hybrid rows.
 
 ### Trial Eligibility and Creation
 
@@ -132,6 +228,12 @@ when access lapses, with email notifications at each stage.
    sessions from concurrent requests are tolerable because each requires
    independent user action to complete, and rule 3 prevents duplicate
    subscriptions.
+10. After a Stripe checkout completes, the subscription MUST NOT be
+    reported as fully activated until invoice settlement has completed
+    (see Stripe-Funded Credit Settlement). Subscription creation from
+    the payment provider is an intermediate state; the system MUST
+    treat a subscription as fully activated only after settlement has
+    converted it to the hybrid state.
 
 ### Credit Enrollment
 
@@ -206,6 +308,60 @@ when access lapses, with email notifications at each stage.
    date six calendar months from enrollment, consistent with Commit
    Plan Lifecycle rule 2.
 
+### Stripe-Funded Credit Settlement
+
+When the payment provider reports a paid invoice for a KiloClaw
+subscription, the system converts the payment into credit-accounted
+settlement. This is the mechanism by which legacy Stripe rows become
+hybrid rows (see Payment Sources rule 2) and by which existing hybrid
+rows renew.
+
+1. The system MUST identify KiloClaw invoices by matching a line
+   item's price against the configured KiloClaw price identifiers.
+   Invoices with no matching line item MUST NOT be processed by
+   this flow. If required invoice data (charge identifier,
+   subscription identifier, matching line item, or period
+   boundaries) is absent, the system MUST log a warning and skip
+   the invoice.
+2. The settled plan and billing period boundaries MUST be derived
+   from the invoice, not from local subscription state or
+   wall-clock time. The invoice is authoritative because local
+   schedule tracking may have been cleared before the invoice
+   arrives (see Hybrid Subscription Ownership rule 4).
+3. Settlement MUST be balance-neutral: the system MUST record a
+   positive credit entry and a matching negative credit deduction
+   in a single atomic operation. The user's visible credit balance
+   MUST NOT change as a result.
+4. The deduction amount MUST equal the settled invoice amount. The
+   system MUST NOT substitute locally defined plan cost constants.
+   Payment-provider-side adjustments (first-month discounts,
+   prorations) flow through as-is.
+5. Settlement MUST be idempotent. Processing the same invoice twice
+   MUST NOT produce duplicate credits or duplicate deductions.
+6. On successful settlement the system MUST:
+   a. Set payment source to `credits`, preserving the payment
+   provider subscription ID (converting a legacy Stripe row to
+   hybrid, or no-op for an already-hybrid row).
+   b. Set subscription status to active.
+   c. Advance the billing period and credit renewal timestamp to
+   the invoice-derived boundaries.
+   d. For commit plans, update the commitment end date to the
+   invoice's period end. For standard plans, clear it.
+   e. Clear past-due state and any auto-top-up marker for the
+   prior period.
+7. If a scheduled plan change matches the settled invoice's plan,
+   the system MUST clear the schedule tracking state atomically
+   with settlement. If the invoice plan differs from the current
+   plan and there is no matching scheduled change, the system MUST
+   treat the settled invoice as authoritative and log a warning.
+8. If the subscription was past-due or suspended before settlement,
+   the system MUST trigger the auto-resume procedure after the
+   settlement transaction commits (see Auto-Resume on Payment
+   Recovery).
+9. After the settlement transaction commits, the system MUST
+   trigger a bonus credit evaluation as described in Credit
+   Enrollment rule 6.
+
 ### Commit Plan Lifecycle
 
 1. A commit subscription MUST remain on the commit price in the payment
@@ -216,10 +372,14 @@ when access lapses, with email notifications at each stage.
    When a delayed-billing period is configured, the six months MUST
    start from the delayed-billing end date, not from subscription
    creation.
-3. When a subscription update is received and the commit-period end
-   date is in the past, the system MUST extend it by six calendar
-   months from the previous boundary, keeping the subscription on the
-   commit plan.
+3. For legacy Stripe rows, when a subscription update is received and
+   the commit-period end date is in the past, the system MUST extend
+   it by six calendar months from the previous boundary, keeping the
+   subscription on the commit plan. For hybrid rows, commit-period
+   extension is handled by invoice settlement (see Stripe-Funded
+   Credit Settlement rule 6d); subscription status-change events
+   MUST NOT extend the commit-period end date (see Hybrid
+   Subscription Ownership rule 2).
 4. When a user-initiated plan-switch schedule completes or is
    released/canceled, the system MUST apply or clear the schedule
    tracking fields as appropriate (see Plan Switching).
@@ -239,35 +399,42 @@ when access lapses, with email notifications at each stage.
 5. For a standard-to-commit switch, the recorded scheduled-plan MUST
    be commit.
 6. When a plan-switch schedule reaches a terminal status (completed or
-   released) and the local schedule tracking fields still reference
-   the schedule, the system MUST apply the scheduled plan and update
-   the commit-period end date accordingly. Intentional releases
+   released) and the local schedule tracking state still references
+   the schedule: for legacy Stripe rows the system MUST apply the
+   scheduled plan and update the commit-period end date accordingly;
+   for hybrid rows the system MUST clear the schedule tracking state
+   but MUST NOT mutate the plan or commitment end date (see Hybrid
+   Subscription Ownership rule 4). Plan mutation for hybrid rows
+   occurs when the corresponding invoice is settled (see
+   Stripe-Funded Credit Settlement rule 7). Intentional releases
    (cancellation or cancel-plan-switch) clear the local schedule
-   reference before the webhook fires, so the schedule event handler
-   MUST NOT match those rows.
+   reference before the event fires, so the schedule event MUST NOT
+   match those rows.
 7. When a standard-to-commit switch takes effect, the system MUST set
    the commit-period end date to six calendar months from the
    transition date.
 8. The system MUST allow cancellation of user-initiated plan switches.
-9. For credit-funded subscriptions, a plan switch MUST NOT create a
+9. For pure credit subscriptions, a plan switch MUST NOT create a
    payment-provider schedule. The system MUST record the scheduled
-   plan locally and apply it at the next period boundary during
-   the credit renewal sweep.
-10. For credit-funded subscriptions, canceling a plan switch MUST clear
+   plan locally and apply it at the next period boundary during the
+   credit renewal sweep.
+10. For pure credit subscriptions, canceling a plan switch MUST clear
     the locally recorded scheduled plan. No payment-provider API call
     is needed.
-11. Cross-payment-source switching (credits to Stripe or vice versa) is
-    NOT RECOMMENDED in v1. Users who wish to change payment source
-    MUST cancel their current subscription and re-enroll after the
-    billing period ends.
+11. User-initiated cross-payment-source switching (credits to Stripe or
+    vice versa) is NOT RECOMMENDED. Users who wish to change payment
+    source MUST cancel their current subscription and re-enroll after
+    the billing period ends. System-initiated conversion from legacy
+    Stripe to hybrid via invoice settlement (see Payment Sources
+    rule 5 and Stripe-Funded Credit Settlement) is not governed by
+    this rule.
 
 ### Cancellation and Reactivation
 
 1. The system MUST reject a cancellation request if no active
-   subscription exists. For Stripe-funded subscriptions, the payment
-   provider subscription ID MUST be present. For credit-funded
-   subscriptions, the payment source MUST be `credits` and status
-   MUST be active.
+   subscription exists. For Stripe-funded subscriptions, the provider
+   subscription ID MUST be present. For pure credit subscriptions,
+   the payment source MUST be `credits` and status MUST be active.
 2. The system MUST reject a cancellation request if cancellation is
    already pending.
 3. When canceling a Stripe-funded subscription that has a pending
@@ -278,7 +445,7 @@ when access lapses, with email notifications at each stage.
 5. For Stripe-funded subscriptions, the system MUST set the
    cancel-at-period-end flag on both the payment provider and in the
    local database.
-6. For credit-funded subscriptions, the system MUST set the
+6. For pure credit subscriptions, the system MUST set the
    cancel-at-period-end flag in the local database only. No payment
    provider API call is needed. The credit renewal sweep handles the
    period-end transition (see Credit Renewal rule 5).
@@ -287,7 +454,7 @@ when access lapses, with email notifications at each stage.
 8. On reactivation of a Stripe-funded subscription, the system MUST
    clear the cancel-at-period-end flag on both the payment provider
    and in the local database.
-9. On reactivation of a credit-funded subscription, the system MUST
+9. On reactivation of a pure credit subscription, the system MUST
    clear the cancel-at-period-end flag in the local database only.
 
 ### Billing Lifecycle Background Job
@@ -299,18 +466,27 @@ when access lapses, with email notifications at each stage.
    a failure for one user MUST NOT prevent processing of other users.
 3. All errors during sweep processing MUST be captured for monitoring.
 4. The credit renewal sweep MUST run before all other sweeps so that
-   credit-funded subscriptions are renewed (or marked past-due, or
+   pure credit subscriptions are renewed (or marked past-due, or
    canceled) before the existing sweeps evaluate expiry and suspension.
-5. The background job MUST detect credit-funded subscriptions in
-   active status that still have a non-null suspension timestamp
-   (indicating a prior auto-resume was interrupted) and retry the
-   auto-resume procedure for those subscriptions.
+   Hybrid rows are excluded from the credit renewal sweep (see Credit
+   Renewal rule 1); their renewal is handled by invoice settlement.
+5. The background job MUST detect subscriptions with payment source
+   `credits` (both hybrid and pure credit) in active status that
+   still have a non-null suspension timestamp (indicating a prior
+   auto-resume was interrupted) and retry the auto-resume procedure
+   for those subscriptions. This MUST include hybrid rows; a hybrid
+   row can need retry if auto-resume was interrupted after invoice
+   settlement recovered it to active.
 
 ### Credit Renewal
 
-1. The credit renewal sweep MUST select all subscriptions where
-   payment source is `credits`, status is active or past-due, and
-   the credit renewal timestamp is at or before the current time.
+1. The credit renewal sweep MUST select only pure credit subscriptions
+   where status is active or past-due and the credit renewal timestamp
+   is at or before the current time. Hybrid subscriptions MUST NOT be
+   selected; their renewal is owned by invoice settlement (see
+   Stripe-Funded Credit Settlement). The payment provider's dunning
+   process handles payment failure for hybrid subscriptions;
+   status-change events propagate past-due state to the local row.
 2. Each credit deduction MUST use a period-encoded category key
    with a uniqueness constraint. The key MUST be derived from the
    subscription's credit renewal timestamp (the period boundary being
@@ -408,7 +584,7 @@ when access lapses, with email notifications at each stage.
     grace-period recovery (status past-due, not suspended), and
     suspended recovery (status past-due, suspended). Separate sweeps
     are not needed.
-15. When a credit-funded subscription has a scheduled plan change and
+15. When a pure credit subscription has a scheduled plan change and
     the current period has ended, the renewal sweep MUST determine
     the effective plan and cost before the deduction, but MUST apply
     the plan mutation inside the same database transaction as the
@@ -424,6 +600,8 @@ when access lapses, with email notifications at each stage.
     - If switching to standard: clear the commit-period end date.
       After the plan change is applied, subsequent sweeps MUST NOT
       reapply it (the cleared scheduled-plan field prevents this).
+      This rule does not apply to hybrid rows; hybrid plan switching
+      is handled by Stripe-Funded Credit Settlement rule 10.
 
 ### Auto Top-Up Integration with Credit Renewal
 
@@ -508,9 +686,11 @@ when access lapses, with email notifications at each stage.
 3. The system MUST send a payment-suspended notification.
 4. The 14-day threshold MUST be measured from the time the subscription
    first entered past-due status, not from the last database update.
-   For credit-funded subscriptions, past-due status is set by the
-   credit renewal sweep; for Stripe-funded subscriptions, it is set
-   by the payment provider webhook.
+   For pure credit subscriptions, past-due status is set by the credit
+   renewal sweep. For legacy Stripe subscriptions, it is set by the
+   payment provider status-change event. For hybrid subscriptions, it
+   is set by the payment provider's dunning state propagation (see
+   Hybrid Subscription Ownership rule 2).
 
 ### Email Notifications
 
@@ -530,11 +710,15 @@ when access lapses, with email notifications at each stage.
 
 1. When a subscription transitions to active while the user is
    suspended, the system MUST attempt to start the user's instance.
-   For Stripe-funded subscriptions, this transition is detected by
-   the payment provider webhook. For credit-funded subscriptions,
-   this transition is detected by the credit renewal sweep when a
-   past-due subscription with a non-null suspension timestamp is
-   successfully renewed.
+   For legacy Stripe subscriptions, this transition is detected by a
+   payment provider status-change event. For pure credit
+   subscriptions, this transition is detected by the credit renewal
+   sweep when a past-due subscription with a non-null suspension
+   timestamp is successfully renewed. For hybrid subscriptions, this
+   transition is detected by the invoice settlement path (see
+   Stripe-Funded Credit Settlement rule 8); payment provider
+   status-change events MUST NOT trigger auto-resume for hybrid rows
+   (see Hybrid Subscription Ownership rule 2).
 2. If the instance start attempt fails, the system MUST log the failure
    and MUST NOT clear the suspension timestamp or destruction deadline.
    Leaving these fields intact allows the background job (Billing
@@ -557,10 +741,17 @@ when access lapses, with email notifications at each stage.
 2. When the payment provider reports "incomplete" or "paused" status,
    the system MUST map these to terminal statuses (unpaid or canceled
    respectively).
-3. Credit-funded subscriptions have no payment provider status. Their
+3. Pure credit subscriptions have no payment provider status. Their
    status MUST be managed entirely by the credit renewal sweep and
-   the billing lifecycle sweeps. Payment provider status mapping rules
-   MUST NOT apply to credit-funded subscriptions.
+   the billing lifecycle sweeps. Payment provider status mapping
+   rules MUST NOT apply to pure credit subscriptions.
+4. Hybrid subscriptions receive limited payment provider status
+   mapping. Only dunning states MUST be propagated from payment
+   provider status changes. Recovery to active status, plan changes,
+   period advancement, and clearing of suspension state MUST NOT
+   be applied from status-change events for hybrid subscriptions;
+   these are owned by invoice settlement (see Hybrid Subscription
+   Ownership rules 1-2).
 
 ### Billing Status Reporting
 
@@ -582,10 +773,18 @@ when access lapses, with email notifications at each stage.
 5. When the payment source is `credits`, the billing status MUST also
    include the credit renewal timestamp and the renewal cost for the
    next billing period so the frontend can display the next renewal
-   date and amount due.
-6. The billing status MUST include earlybird data (expiry date, days
+   date and amount due. For hybrid subscriptions, the renewal cost is
+   Stripe-determined; the system MUST report a plan-based
+   approximation or indicate that renewal is billed via Stripe.
+6. The billing status MUST include a Stripe-funding indicator that is
+   true for Stripe-funded subscriptions and false for pure credit
+   subscriptions. The frontend MUST use this indicator — not payment
+   source alone — to determine whether to show Stripe portal access,
+   payment method management, or credit-specific UI such as the
+   top-up flow.
+7. The billing status MUST include earlybird data (expiry date, days
    remaining) when the user has an earlybird purchase.
-7. The billing status MUST include instance data (whether an
+8. The billing status MUST include instance data (whether an
    undestroyed instance exists, suspension timestamp, destruction
    deadline, and destroyed flag) when any instance record exists.
 
@@ -596,10 +795,12 @@ when access lapses, with email notifications at each stage.
    methods.
 2. The billing portal session MUST redirect the user back to the
    dashboard upon completion.
-3. The billing portal MUST NOT be offered for credit-funded
-   subscriptions. The frontend MUST NOT call the billing portal
-   endpoint when the user's payment source is `credits`; it MUST
-   direct the user to the credit top-up flow instead.
+3. The billing portal MUST NOT be offered for pure credit
+   subscriptions. The frontend MUST use the Stripe-funding indicator
+   (see Billing Status Reporting rule 6), not payment source alone,
+   to determine portal eligibility. Hybrid subscriptions MUST have
+   portal access for Stripe payment method management. Pure credit
+   users MUST be directed to the credit top-up flow instead.
 
 ### User Data Deletion
 
@@ -613,6 +814,25 @@ when access lapses, with email notifications at each stage.
    requirements on credit transaction records.
 
 ### Changelog
+
+#### 2026-03-20 -- Stripe-to-credits hybrid billing model
+
+- Introduced the hybrid subscription state: `payment_source='credits'`
+  with a non-null payment provider subscription ID. Legacy Stripe rows
+  lazily convert to hybrid on their next settled invoice.
+- Added Stripe-Funded Credit Settlement section defining the invoice
+  settlement path.
+- Added Hybrid Subscription Ownership section defining which events
+  own which mutations for hybrid rows.
+- Changed discriminants throughout the spec from payment source to
+  payment provider subscription ID presence for: plan switching,
+  cancellation, reactivation, billing portal, and renewal sweep scope.
+- Credit renewal sweep now excludes hybrid rows; hybrid renewal is
+  owned by invoice settlement.
+- Payment provider status mapping now includes a limited hybrid path:
+  non-active dunning states only.
+- Billing status now includes a Stripe-funding indicator.
+- Checkout success activation now requires invoice settlement.
 
 #### 2026-03-19 -- Pricing and trial changes
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -183,14 +183,20 @@ when access lapses, with email notifications at each stage.
    period set from the current time, the credit renewal timestamp set
    to the period end, and the payment provider subscription ID set to
    null.
-9. The subscription upsert MUST clear any prior suspension state:
-   past-due-since, suspension timestamp, and destruction deadline MUST
-   all be set to null.
+9. The subscription upsert MUST clear the past-due-since timestamp
+   and set the status to active, but MUST NOT clear the suspension
+   timestamp or destruction deadline at this step. If the user was
+   previously suspended, those columns are needed as a signal for the
+   auto-resume procedure in rule 10.
 10. If the user was previously suspended (per rule 4), the system MUST
     call the auto-resume procedure after the upsert to restart the
     instance, clear suspension-cycle email log entries, and clear
-    suspension columns. This MUST happen after the subscription row is
-    in active state.
+    the suspension timestamp and destruction deadline. This MUST
+    happen after the subscription row is in active state. If the
+    process crashes before auto-resume completes, the non-null
+    suspension timestamp on an active subscription signals that
+    resume is still required; the next background job run MUST
+    detect this state and retry the auto-resume.
 11. For the commit plan, the system MUST record a commit-period end
     date six calendar months from enrollment, consistent with Commit
     Plan Lifecycle rule 2.
@@ -300,6 +306,10 @@ when access lapses, with email notifications at each stage.
 4. The credit renewal sweep MUST run before all other sweeps so that
    credit-funded subscriptions are renewed (or marked past-due, or
    canceled) before the existing sweeps evaluate expiry and suspension.
+5. The background job MUST detect credit-funded subscriptions in
+   active status that still have a non-null suspension timestamp
+   (indicating a prior auto-resume was interrupted) and retry the
+   auto-resume procedure for those subscriptions.
 
 ### Credit Renewal
 
@@ -366,16 +376,24 @@ when access lapses, with email notifications at each stage.
     credit-renewal-failed entry), and clear the suspension columns.
 11. When the effective balance (as defined in Credit Enrollment
     rule 3) is insufficient, the system MUST first check whether
-    the user has auto top-up enabled. If auto top-up is available,
-    the system MUST trigger it and skip the row without changing any
-    state (fire-and-skip). The next sweep run MUST re-evaluate the
-    row after the top-up webhook has credited the balance.
-12. When the effective balance is still insufficient (per rule 11),
-    auto top-up is not available or has already been attempted and
-    failed, the system MUST set the
-    subscription status to past-due and record a past-due-since
-    timestamp (preserving any existing value). Past-Due Payment
-    Enforcement rule 1 handles suspension after 14 days.
+    the user has auto top-up enabled and whether a top-up has
+    already been triggered for the current renewal period. If auto
+    top-up is available and has NOT yet been triggered for this
+    period, the system MUST trigger it, record a durable marker
+    (the credit renewal timestamp of the period being charged) on
+    the subscription row to indicate that a top-up has been
+    requested, and skip the row without changing any other state
+    (fire-and-skip). The next sweep run MUST re-evaluate the row
+    after the top-up webhook has credited the balance. The marker
+    MUST be cleared when the billing period advances (successful
+    deduction) or when the subscription is canceled.
+12. When the effective balance is still insufficient (per rule 11)
+    and auto top-up is not available, has been disabled due to a
+    prior card decline, or was already triggered for the current
+    period (marker present), the system MUST set the subscription
+    status to past-due and record a past-due-since timestamp
+    (preserving any existing value). Past-Due Payment Enforcement
+    rule 1 handles suspension after 14 days.
 13. When the effective balance is insufficient and the system enters the past-due
     path (rule 12), the system MUST send a credit-renewal-failed
     notification, subject to the standard email idempotency rules.
@@ -416,8 +434,10 @@ when access lapses, with email notifications at each stage.
    the insufficient-balance path (Credit Renewal rule 11).
 4. The system MUST enter the insufficient-balance path (not fire-and-
    skip) when auto top-up is not enabled, has been disabled due to a
-   prior card decline, or was triggered on a prior run and the
-   effective balance remains insufficient.
+   prior card decline, or was already triggered for the current
+   renewal period (as indicated by the durable marker described in
+   Credit Renewal rule 11) and the effective balance remains
+   insufficient.
 
 ### Trial Expiry Warnings
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -142,8 +142,8 @@ when access lapses, with email notifications at each stage.
    subscription status is trialing or canceled.
 3. The system MUST verify that the user's effective credit balance is
    sufficient to cover the first billing period before proceeding:
-   25,000,000 microdollars for the standard plan (one month) or
-   54,000,000 microdollars for the commit plan (six months paid
+   9,000,000 microdollars for the standard plan (one month) or
+   48,000,000 microdollars for the commit plan (six months paid
    upfront). The effective balance MUST be computed as the current
    credit balance plus the projected bonus credits the user would earn
    from the deduction. The projected bonus MUST be obtained by querying

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -159,24 +159,24 @@ when access lapses, with email notifications at each stage.
    leave the user with deducted credits and no active subscription.
    Within this transaction the system MUST:
    a. Insert a negative credit transaction for the first period's cost.
-      The insertion MUST use a period-encoded idempotency key (see
-      Credit Renewal rule 2) with conflict-safe semantics. The key
-      MUST distinguish the plan and billing period, for example
-      `kiloclaw-subscription:YYYY-MM` for standard or
-      `kiloclaw-subscription-commit:YYYY-MM` for commit. If the
-      insertion detects a duplicate, the system MUST abort the
-      enrollment as a duplicate attempt.
+   The insertion MUST use a period-encoded idempotency key (see
+   Credit Renewal rule 2) with conflict-safe semantics. The key
+   MUST distinguish the plan and billing period, for example
+   `kiloclaw-subscription:YYYY-MM` for standard or
+   `kiloclaw-subscription-commit:YYYY-MM` for commit. If the
+   insertion detects a duplicate, the system MUST abort the
+   enrollment as a duplicate attempt.
    b. Atomically decrement the user's acquired credit balance by the
-      deducted amount.
+   deducted amount.
    c. Create or upsert the subscription record with payment source set
-      to `credits`, status set to active, the billing period set from
-      the current time, the credit renewal timestamp set to the period
-      end, and the payment provider subscription ID set to null.
+   to `credits`, status set to active, the billing period set from
+   the current time, the credit renewal timestamp set to the period
+   end, and the payment provider subscription ID set to null.
    d. The subscription upsert MUST clear the past-due-since timestamp
-      and set the status to active, but MUST NOT clear the suspension
-      timestamp or destruction deadline at this step. If the user was
-      previously suspended, those columns are needed as a signal for
-      the auto-resume procedure in rule 7.
+   and set the status to active, but MUST NOT clear the suspension
+   timestamp or destruction deadline at this step. If the user was
+   previously suspended, those columns are needed as a signal for
+   the auto-resume procedure in rule 7.
    If the transaction is interrupted, the database MUST roll back all
    operations so that a retry can re-attempt without the idempotency
    key blocking it.

--- a/packages/db/src/migrations/0055_kiloclaw-credit-billing.sql
+++ b/packages/db/src/migrations/0055_kiloclaw-credit-billing.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "kiloclaw_subscriptions" ADD COLUMN "payment_source" text;--> statement-breakpoint
+ALTER TABLE "kiloclaw_subscriptions" ADD COLUMN "credit_renewal_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "kiloclaw_subscriptions" ADD COLUMN "auto_top_up_triggered_for_period" timestamp with time zone;--> statement-breakpoint
+UPDATE "kiloclaw_subscriptions" SET "payment_source" = 'stripe' WHERE "stripe_subscription_id" IS NOT NULL AND "payment_source" IS NULL;--> statement-breakpoint
+ALTER TABLE "kiloclaw_subscriptions" ADD CONSTRAINT "kiloclaw_subscriptions_payment_source_check" CHECK ("kiloclaw_subscriptions"."payment_source" IN ('stripe', 'credits'));

--- a/packages/db/src/migrations/0055_lush_bedlam.sql
+++ b/packages/db/src/migrations/0055_lush_bedlam.sql
@@ -1,5 +1,4 @@
 ALTER TABLE "kiloclaw_subscriptions" ADD COLUMN "payment_source" text;--> statement-breakpoint
 ALTER TABLE "kiloclaw_subscriptions" ADD COLUMN "credit_renewal_at" timestamp with time zone;--> statement-breakpoint
 ALTER TABLE "kiloclaw_subscriptions" ADD COLUMN "auto_top_up_triggered_for_period" timestamp with time zone;--> statement-breakpoint
-UPDATE "kiloclaw_subscriptions" SET "payment_source" = 'stripe' WHERE "stripe_subscription_id" IS NOT NULL AND "payment_source" IS NULL;--> statement-breakpoint
 ALTER TABLE "kiloclaw_subscriptions" ADD CONSTRAINT "kiloclaw_subscriptions_payment_source_check" CHECK ("kiloclaw_subscriptions"."payment_source" IN ('stripe', 'credits'));

--- a/packages/db/src/migrations/meta/0055_snapshot.json
+++ b/packages/db/src/migrations/meta/0055_snapshot.json
@@ -1,0 +1,14346 @@
+{
+  "id": "0aac3b28-6d4a-4e06-8498-598994aca366",
+  "prevId": "e224c983-7ffd-44ad-a3c4-0ea790a845ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_configs_org_id": {
+          "name": "IDX_agent_configs_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_owned_by_user_id": {
+          "name": "IDX_agent_configs_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_agent_type": {
+          "name": "IDX_agent_configs_agent_type",
+          "columns": [
+            {
+              "expression": "agent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_platform": {
+          "name": "IDX_agent_configs_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_configs_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_configs_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_configs_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_configs_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_configs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_configs_org_agent_platform": {
+          "name": "UQ_agent_configs_org_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by_organization_id",
+            "agent_type",
+            "platform"
+          ]
+        },
+        "UQ_agent_configs_user_agent_platform": {
+          "name": "UQ_agent_configs_user_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by_user_id",
+            "agent_type",
+            "platform"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_configs_owner_check": {
+          "name": "agent_configs_owner_check",
+          "value": "(\n        (\"agent_configs\".\"owned_by_user_id\" IS NOT NULL AND \"agent_configs\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_configs\".\"owned_by_user_id\" IS NULL AND \"agent_configs\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "agent_configs_agent_type_check": {
+          "name": "agent_configs_agent_type_check",
+          "value": "\"agent_configs\".\"agent_type\" IN ('code_review', 'auto_triage', 'auto_fix', 'security_scan')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_commands": {
+      "name": "agent_environment_profile_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_env_profile_commands_profile_id": {
+          "name": "IDX_agent_env_profile_commands_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_commands_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_commands_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_commands",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_env_profile_commands_profile_sequence": {
+          "name": "UQ_agent_env_profile_commands_profile_sequence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_vars": {
+      "name": "agent_environment_profile_vars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_env_profile_vars_profile_id": {
+          "name": "IDX_agent_env_profile_vars_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_vars_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_vars_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_vars",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_env_profile_vars_profile_key": {
+          "name": "UQ_agent_env_profile_vars_profile_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profiles": {
+      "name": "agent_environment_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_agent_env_profiles_org_name": {
+          "name": "UQ_agent_env_profiles_org_name",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_user_name": {
+          "name": "UQ_agent_env_profiles_user_name",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_org_default": {
+          "name": "UQ_agent_env_profiles_org_default",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"is_default\" = true AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_user_default": {
+          "name": "UQ_agent_env_profiles_user_default",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"is_default\" = true AND \"agent_environment_profiles\".\"owned_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_env_profiles_org_id": {
+          "name": "IDX_agent_env_profiles_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_env_profiles_user_id": {
+          "name": "IDX_agent_env_profiles_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profiles_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_environment_profiles_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_environment_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_environment_profiles_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_environment_profiles_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_environment_profiles",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_env_profiles_owner_check": {
+          "name": "agent_env_profiles_owner_check",
+          "value": "(\n        (\"agent_environment_profiles\".\"owned_by_user_id\" IS NOT NULL AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_environment_profiles\".\"owned_by_user_id\" IS NULL AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_kind": {
+      "name": "api_kind",
+      "schema": "",
+      "columns": {
+        "api_kind_id": {
+          "name": "api_kind_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_kind": {
+          "name": "api_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_api_kind": {
+          "name": "UQ_api_kind",
+          "columns": [
+            {
+              "expression": "api_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_log": {
+      "name": "api_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_request_log_created_at": {
+          "name": "idx_api_request_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_feedback": {
+      "name": "app_builder_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_status": {
+          "name": "preview_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streaming": {
+          "name": "is_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_messages": {
+          "name": "recent_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_feedback_created_at": {
+          "name": "IDX_app_builder_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_feedback_kilo_user_id": {
+          "name": "IDX_app_builder_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_feedback_project_id": {
+          "name": "IDX_app_builder_feedback_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "app_builder_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "app_builder_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "app_builder_feedback_project_id_app_builder_projects_id_fk": {
+          "name": "app_builder_feedback_project_id_app_builder_projects_id_fk",
+          "tableFrom": "app_builder_feedback",
+          "tableTo": "app_builder_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_project_sessions": {
+      "name": "app_builder_project_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_project_sessions_project_id": {
+          "name": "IDX_app_builder_project_sessions_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_project_sessions_project_id_app_builder_projects_id_fk": {
+          "name": "app_builder_project_sessions_project_id_app_builder_projects_id_fk",
+          "tableFrom": "app_builder_project_sessions",
+          "tableTo": "app_builder_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_app_builder_project_sessions_cloud_agent_session_id": {
+          "name": "UQ_app_builder_project_sessions_cloud_agent_session_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cloud_agent_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_projects": {
+      "name": "app_builder_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo_full_name": {
+          "name": "git_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_platform_integration_id": {
+          "name": "git_platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_projects_created_by_user_id": {
+          "name": "IDX_app_builder_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_owned_by_user_id": {
+          "name": "IDX_app_builder_projects_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_owned_by_organization_id": {
+          "name": "IDX_app_builder_projects_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_created_at": {
+          "name": "IDX_app_builder_projects_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_last_message_at": {
+          "name": "IDX_app_builder_projects_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_projects_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "app_builder_projects_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_owned_by_organization_id_organizations_id_fk": {
+          "name": "app_builder_projects_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_deployment_id_deployments_id_fk": {
+          "name": "app_builder_projects_deployment_id_deployments_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_git_platform_integration_id_platform_integrations_id_fk": {
+          "name": "app_builder_projects_git_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "git_platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_builder_projects_owner_check": {
+          "name": "app_builder_projects_owner_check",
+          "value": "(\n        (\"app_builder_projects\".\"owned_by_user_id\" IS NOT NULL AND \"app_builder_projects\".\"owned_by_organization_id\" IS NULL) OR\n        (\"app_builder_projects\".\"owned_by_user_id\" IS NULL AND \"app_builder_projects\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_reported_messages": {
+      "name": "app_reported_messages",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_reported_messages_cli_session_id_cli_sessions_session_id_fk": {
+          "name": "app_reported_messages_cli_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "app_reported_messages",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "cli_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_fix_tickets": {
+      "name": "auto_fix_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triage_ticket_id": {
+          "name": "triage_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_body": {
+          "name": "issue_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_labels": {
+          "name": "issue_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'label'"
+        },
+        "review_comment_id": {
+          "name": "review_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment_body": {
+          "name": "review_comment_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_hunk": {
+          "name": "diff_hunk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_head_ref": {
+          "name": "pr_head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_files": {
+          "name": "related_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch": {
+          "name": "pr_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_fix_tickets_repo_issue": {
+          "name": "UQ_auto_fix_tickets_repo_issue",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_fix_tickets\".\"trigger_source\" = 'label'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_auto_fix_tickets_repo_review_comment": {
+          "name": "UQ_auto_fix_tickets_repo_review_comment",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_fix_tickets\".\"review_comment_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_owned_by_org": {
+          "name": "IDX_auto_fix_tickets_owned_by_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_owned_by_user": {
+          "name": "IDX_auto_fix_tickets_owned_by_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_status": {
+          "name": "IDX_auto_fix_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_created_at": {
+          "name": "IDX_auto_fix_tickets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_triage_ticket_id": {
+          "name": "IDX_auto_fix_tickets_triage_ticket_id",
+          "columns": [
+            {
+              "expression": "triage_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_session_id": {
+          "name": "IDX_auto_fix_tickets_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_fix_tickets_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_fix_tickets_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_fix_tickets_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_platform_integration_id_platform_integrations_id_fk": {
+          "name": "auto_fix_tickets_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_triage_ticket_id_auto_triage_tickets_id_fk": {
+          "name": "auto_fix_tickets_triage_ticket_id_auto_triage_tickets_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "auto_triage_tickets",
+          "columnsFrom": [
+            "triage_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_cli_session_id_cli_sessions_session_id_fk": {
+          "name": "auto_fix_tickets_cli_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "cli_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_fix_tickets_owner_check": {
+          "name": "auto_fix_tickets_owner_check",
+          "value": "(\n        (\"auto_fix_tickets\".\"owned_by_user_id\" IS NOT NULL AND \"auto_fix_tickets\".\"owned_by_organization_id\" IS NULL) OR\n        (\"auto_fix_tickets\".\"owned_by_user_id\" IS NULL AND \"auto_fix_tickets\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "auto_fix_tickets_status_check": {
+          "name": "auto_fix_tickets_status_check",
+          "value": "\"auto_fix_tickets\".\"status\" IN ('pending', 'running', 'completed', 'failed', 'cancelled')"
+        },
+        "auto_fix_tickets_classification_check": {
+          "name": "auto_fix_tickets_classification_check",
+          "value": "\"auto_fix_tickets\".\"classification\" IN ('bug', 'feature', 'question', 'unclear')"
+        },
+        "auto_fix_tickets_confidence_check": {
+          "name": "auto_fix_tickets_confidence_check",
+          "value": "\"auto_fix_tickets\".\"confidence\" >= 0 AND \"auto_fix_tickets\".\"confidence\" <= 1"
+        },
+        "auto_fix_tickets_trigger_source_check": {
+          "name": "auto_fix_tickets_trigger_source_check",
+          "value": "\"auto_fix_tickets\".\"trigger_source\" IN ('label', 'review_comment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auto_model": {
+      "name": "auto_model",
+      "schema": "",
+      "columns": {
+        "auto_model_id": {
+          "name": "auto_model_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auto_model": {
+          "name": "auto_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_auto_model": {
+          "name": "UQ_auto_model",
+          "columns": [
+            {
+              "expression": "auto_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_top_up_configs": {
+      "name": "auto_top_up_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5000
+        },
+        "last_auto_top_up_at": {
+          "name": "last_auto_top_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_started_at": {
+          "name": "attempt_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_top_up_configs_owned_by_user_id": {
+          "name": "UQ_auto_top_up_configs_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_top_up_configs\".\"owned_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_auto_top_up_configs_owned_by_organization_id": {
+          "name": "UQ_auto_top_up_configs_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_top_up_configs\".\"owned_by_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_top_up_configs_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_top_up_configs_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_top_up_configs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "auto_top_up_configs_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_top_up_configs_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_top_up_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_top_up_configs_exactly_one_owner": {
+          "name": "auto_top_up_configs_exactly_one_owner",
+          "value": "(\"auto_top_up_configs\".\"owned_by_user_id\" IS NOT NULL AND \"auto_top_up_configs\".\"owned_by_organization_id\" IS NULL) OR (\"auto_top_up_configs\".\"owned_by_user_id\" IS NULL AND \"auto_top_up_configs\".\"owned_by_organization_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auto_triage_tickets": {
+      "name": "auto_triage_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_body": {
+          "name": "issue_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_labels": {
+          "name": "issue_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_files": {
+          "name": "related_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_duplicate": {
+          "name": "is_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duplicate_of_ticket_id": {
+          "name": "duplicate_of_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qdrant_point_id": {
+          "name": "qdrant_point_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_auto_fix": {
+          "name": "should_auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_metadata": {
+          "name": "action_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_triage_tickets_repo_issue": {
+          "name": "UQ_auto_triage_tickets_repo_issue",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owned_by_org": {
+          "name": "IDX_auto_triage_tickets_owned_by_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owned_by_user": {
+          "name": "IDX_auto_triage_tickets_owned_by_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_status": {
+          "name": "IDX_auto_triage_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_created_at": {
+          "name": "IDX_auto_triage_tickets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_qdrant_point_id": {
+          "name": "IDX_auto_triage_tickets_qdrant_point_id",
+          "columns": [
+            {
+              "expression": "qdrant_point_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owner_status_created": {
+          "name": "IDX_auto_triage_tickets_owner_status_created",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_user_status_created": {
+          "name": "IDX_auto_triage_tickets_user_status_created",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_repo_classification": {
+          "name": "IDX_auto_triage_tickets_repo_classification",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_triage_tickets_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_triage_tickets_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_triage_tickets_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_platform_integration_id_platform_integrations_id_fk": {
+          "name": "auto_triage_tickets_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_duplicate_of_ticket_id_auto_triage_tickets_id_fk": {
+          "name": "auto_triage_tickets_duplicate_of_ticket_id_auto_triage_tickets_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "auto_triage_tickets",
+          "columnsFrom": [
+            "duplicate_of_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_triage_tickets_owner_check": {
+          "name": "auto_triage_tickets_owner_check",
+          "value": "(\n        (\"auto_triage_tickets\".\"owned_by_user_id\" IS NOT NULL AND \"auto_triage_tickets\".\"owned_by_organization_id\" IS NULL) OR\n        (\"auto_triage_tickets\".\"owned_by_user_id\" IS NULL AND \"auto_triage_tickets\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "auto_triage_tickets_issue_type_check": {
+          "name": "auto_triage_tickets_issue_type_check",
+          "value": "\"auto_triage_tickets\".\"issue_type\" IN ('issue', 'pull_request')"
+        },
+        "auto_triage_tickets_classification_check": {
+          "name": "auto_triage_tickets_classification_check",
+          "value": "\"auto_triage_tickets\".\"classification\" IN ('bug', 'feature', 'question', 'duplicate', 'unclear')"
+        },
+        "auto_triage_tickets_confidence_check": {
+          "name": "auto_triage_tickets_confidence_check",
+          "value": "\"auto_triage_tickets\".\"confidence\" >= 0 AND \"auto_triage_tickets\".\"confidence\" <= 1"
+        },
+        "auto_triage_tickets_similarity_score_check": {
+          "name": "auto_triage_tickets_similarity_score_check",
+          "value": "\"auto_triage_tickets\".\"similarity_score\" >= 0 AND \"auto_triage_tickets\".\"similarity_score\" <= 1"
+        },
+        "auto_triage_tickets_status_check": {
+          "name": "auto_triage_tickets_status_check",
+          "value": "\"auto_triage_tickets\".\"status\" IN ('pending', 'analyzing', 'actioned', 'failed', 'skipped')"
+        },
+        "auto_triage_tickets_action_taken_check": {
+          "name": "auto_triage_tickets_action_taken_check",
+          "value": "\"auto_triage_tickets\".\"action_taken\" IN ('pr_created', 'comment_posted', 'closed_duplicate', 'needs_clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bot_requests": {
+      "name": "bot_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_thread_id": {
+          "name": "platform_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_message": {
+          "name": "user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_bot_requests_created_at": {
+          "name": "IDX_bot_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_created_by": {
+          "name": "IDX_bot_requests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_organization_id": {
+          "name": "IDX_bot_requests_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_platform_integration_id": {
+          "name": "IDX_bot_requests_platform_integration_id",
+          "columns": [
+            {
+              "expression": "platform_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_status": {
+          "name": "IDX_bot_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_requests_created_by_kilocode_users_id_fk": {
+          "name": "bot_requests_created_by_kilocode_users_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_requests_organization_id_organizations_id_fk": {
+          "name": "bot_requests_organization_id_organizations_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_requests_platform_integration_id_platform_integrations_id_fk": {
+          "name": "bot_requests_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_api_keys": {
+      "name": "byok_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_byok_api_keys_organization_id": {
+          "name": "IDX_byok_api_keys_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_byok_api_keys_kilo_user_id": {
+          "name": "IDX_byok_api_keys_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_byok_api_keys_provider_id": {
+          "name": "IDX_byok_api_keys_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_api_keys_organization_id_organizations_id_fk": {
+          "name": "byok_api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "byok_api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "byok_api_keys_kilo_user_id_kilocode_users_id_fk": {
+          "name": "byok_api_keys_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "byok_api_keys",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_byok_api_keys_org_provider": {
+          "name": "UQ_byok_api_keys_org_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ]
+        },
+        "UQ_byok_api_keys_user_provider": {
+          "name": "UQ_byok_api_keys_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_user_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "byok_api_keys_owner_check": {
+          "name": "byok_api_keys_owner_check",
+          "value": "(\n        (\"byok_api_keys\".\"kilo_user_id\" IS NOT NULL AND \"byok_api_keys\".\"organization_id\" IS NULL) OR\n        (\"byok_api_keys\".\"kilo_user_id\" IS NULL AND \"byok_api_keys\".\"organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_on_platform": {
+          "name": "created_on_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "api_conversation_history_blob_url": {
+          "name": "api_conversation_history_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_metadata_blob_url": {
+          "name": "task_metadata_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_messages_blob_url": {
+          "name": "ui_messages_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_state_blob_url": {
+          "name": "git_state_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_mode": {
+          "name": "last_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_model": {
+          "name": "last_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cli_sessions_kilo_user_id": {
+          "name": "IDX_cli_sessions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_created_at": {
+          "name": "IDX_cli_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_updated_at": {
+          "name": "IDX_cli_sessions_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_organization_id": {
+          "name": "IDX_cli_sessions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_user_updated": {
+          "name": "IDX_cli_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_sessions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cli_sessions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_forked_from_cli_sessions_session_id_fk": {
+          "name": "cli_sessions_forked_from_cli_sessions_session_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_parent_session_id_cli_sessions_session_id_fk": {
+          "name": "cli_sessions_parent_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_organization_id_organizations_id_fk": {
+          "name": "cli_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_cloud_agent_session_id_unique": {
+          "name": "cli_sessions_cloud_agent_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cloud_agent_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions_v2": {
+      "name": "cli_sessions_v2",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_on_platform": {
+          "name": "created_on_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cli_sessions_v2_parent_session_id_kilo_user_id": {
+          "name": "IDX_cli_sessions_v2_parent_session_id_kilo_user_id",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cli_sessions_v2_public_id": {
+          "name": "UQ_cli_sessions_v2_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cli_sessions_v2\".\"public_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cli_sessions_v2_cloud_agent_session_id": {
+          "name": "UQ_cli_sessions_v2_cloud_agent_session_id",
+          "columns": [
+            {
+              "expression": "cloud_agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cli_sessions_v2\".\"cloud_agent_session_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_organization_id": {
+          "name": "IDX_cli_sessions_v2_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_kilo_user_id": {
+          "name": "IDX_cli_sessions_v2_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_created_at": {
+          "name": "IDX_cli_sessions_v2_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_user_updated": {
+          "name": "IDX_cli_sessions_v2_user_updated",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_sessions_v2_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cli_sessions_v2_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_v2_organization_id_organizations_id_fk": {
+          "name": "cli_sessions_v2_organization_id_organizations_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_v2_parent_session_id_kilo_user_id_fk": {
+          "name": "cli_sessions_v2_parent_session_id_kilo_user_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "cli_sessions_v2",
+          "columnsFrom": [
+            "parent_session_id",
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "session_id",
+            "kilo_user_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cli_sessions_v2_session_id_kilo_user_id_pk": {
+          "name": "cli_sessions_v2_session_id_kilo_user_id_pk",
+          "columns": [
+            "session_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_code_reviews": {
+      "name": "cloud_agent_code_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_author_github_id": {
+          "name": "pr_author_github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "platform_project_id": {
+          "name": "platform_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'v1'"
+        },
+        "check_run_id": {
+          "name": "check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens_in": {
+          "name": "total_tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens_out": {
+          "name": "total_tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_musd": {
+          "name": "total_cost_musd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_cloud_agent_code_reviews_repo_pr_sha": {
+          "name": "UQ_cloud_agent_code_reviews_repo_pr_sha",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_owned_by_org_id": {
+          "name": "idx_cloud_agent_code_reviews_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_owned_by_user_id": {
+          "name": "idx_cloud_agent_code_reviews_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_session_id": {
+          "name": "idx_cloud_agent_code_reviews_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_cli_session_id": {
+          "name": "idx_cloud_agent_code_reviews_cli_session_id",
+          "columns": [
+            {
+              "expression": "cli_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_status": {
+          "name": "idx_cloud_agent_code_reviews_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_repo": {
+          "name": "idx_cloud_agent_code_reviews_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_pr_number": {
+          "name": "idx_cloud_agent_code_reviews_pr_number",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_created_at": {
+          "name": "idx_cloud_agent_code_reviews_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_pr_author_github_id": {
+          "name": "idx_cloud_agent_code_reviews_pr_author_github_id",
+          "columns": [
+            {
+              "expression": "pr_author_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_code_reviews_owned_by_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_code_reviews_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_code_reviews_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_code_reviews_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_code_reviews_platform_integration_id_platform_integrations_id_fk": {
+          "name": "cloud_agent_code_reviews_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cloud_agent_code_reviews_owner_check": {
+          "name": "cloud_agent_code_reviews_owner_check",
+          "value": "(\n        (\"cloud_agent_code_reviews\".\"owned_by_user_id\" IS NOT NULL AND \"cloud_agent_code_reviews\".\"owned_by_organization_id\" IS NULL) OR\n        (\"cloud_agent_code_reviews\".\"owned_by_user_id\" IS NULL AND \"cloud_agent_code_reviews\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_feedback": {
+      "name": "cloud_agent_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streaming": {
+          "name": "is_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_messages": {
+          "name": "recent_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cloud_agent_feedback_created_at": {
+          "name": "IDX_cloud_agent_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_feedback_kilo_user_id": {
+          "name": "IDX_cloud_agent_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_feedback_cloud_agent_session_id": {
+          "name": "IDX_cloud_agent_feedback_cloud_agent_session_id",
+          "columns": [
+            {
+              "expression": "cloud_agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "cloud_agent_feedback_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_feedback_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_feedback",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_webhook_triggers": {
+      "name": "cloud_agent_webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_cloud_agent_webhook_triggers_user_trigger": {
+          "name": "UQ_cloud_agent_webhook_triggers_user_trigger",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cloud_agent_webhook_triggers\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cloud_agent_webhook_triggers_org_trigger": {
+          "name": "UQ_cloud_agent_webhook_triggers_org_trigger",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cloud_agent_webhook_triggers\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_user": {
+          "name": "IDX_cloud_agent_webhook_triggers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_org": {
+          "name": "IDX_cloud_agent_webhook_triggers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_active": {
+          "name": "IDX_cloud_agent_webhook_triggers_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_profile": {
+          "name": "IDX_cloud_agent_webhook_triggers_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_webhook_triggers_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_webhook_triggers_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_webhook_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_profile_id_agent_environment_profiles_id_fk": {
+          "name": "cloud_agent_webhook_triggers_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "CHK_cloud_agent_webhook_triggers_owner": {
+          "name": "CHK_cloud_agent_webhook_triggers_owner",
+          "value": "(\n        (\"cloud_agent_webhook_triggers\".\"user_id\" IS NOT NULL AND \"cloud_agent_webhook_triggers\".\"organization_id\" IS NULL) OR\n        (\"cloud_agent_webhook_triggers\".\"user_id\" IS NULL AND \"cloud_agent_webhook_triggers\".\"organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.code_indexing_manifest": {
+      "name": "code_indexing_manifest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines": {
+          "name": "total_lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_ai_lines": {
+          "name": "total_ai_lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_code_indexing_manifest_organization_id": {
+          "name": "IDX_code_indexing_manifest_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_kilo_user_id": {
+          "name": "IDX_code_indexing_manifest_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_project_id": {
+          "name": "IDX_code_indexing_manifest_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_file_hash": {
+          "name": "IDX_code_indexing_manifest_file_hash",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_git_branch": {
+          "name": "IDX_code_indexing_manifest_git_branch",
+          "columns": [
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_created_at": {
+          "name": "IDX_code_indexing_manifest_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_indexing_manifest_kilo_user_id_kilocode_users_id_fk": {
+          "name": "code_indexing_manifest_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "code_indexing_manifest",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_code_indexing_manifest_org_user_project_hash_branch": {
+          "name": "UQ_code_indexing_manifest_org_user_project_hash_branch",
+          "nullsNotDistinct": true,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "project_id",
+            "file_path",
+            "git_branch"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_indexing_search": {
+      "name": "code_indexing_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_code_indexing_search_organization_id": {
+          "name": "IDX_code_indexing_search_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_kilo_user_id": {
+          "name": "IDX_code_indexing_search_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_project_id": {
+          "name": "IDX_code_indexing_search_project_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_created_at": {
+          "name": "IDX_code_indexing_search_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_indexing_search_kilo_user_id_kilocode_users_id_fk": {
+          "name": "code_indexing_search_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "code_indexing_search",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_microdollars": {
+          "name": "amount_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_baseline_microdollars_used": {
+          "name": "expiration_baseline_microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_baseline_microdollars_used": {
+          "name": "original_baseline_microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_transaction_id": {
+          "name": "original_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coinbase_credit_block_id": {
+          "name": "coinbase_credit_block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_category": {
+          "name": "credit_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_category_uniqueness": {
+          "name": "check_category_uniqueness",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "IDX_credit_transactions_created_at": {
+          "name": "IDX_credit_transactions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_is_free": {
+          "name": "IDX_credit_transactions_is_free",
+          "columns": [
+            {
+              "expression": "is_free",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_kilo_user_id": {
+          "name": "IDX_credit_transactions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_credit_category": {
+          "name": "IDX_credit_transactions_credit_category",
+          "columns": [
+            {
+              "expression": "credit_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_stripe_payment_id": {
+          "name": "IDX_credit_transactions_stripe_payment_id",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_original_transaction_id": {
+          "name": "IDX_credit_transactions_original_transaction_id",
+          "columns": [
+            {
+              "expression": "original_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_coinbase_credit_block_id": {
+          "name": "IDX_credit_transactions_coinbase_credit_block_id",
+          "columns": [
+            {
+              "expression": "coinbase_credit_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_organization_id": {
+          "name": "IDX_credit_transactions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_unique_category": {
+          "name": "IDX_credit_transactions_unique_category",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credit_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_transactions\".\"check_category_uniqueness\" = TRUE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_llm": {
+      "name": "custom_llm",
+      "schema": "",
+      "columns": {
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_completion_tokens": {
+          "name": "max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_ids": {
+          "name": "organization_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "included_tools": {
+          "name": "included_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_tools": {
+          "name": "excluded_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_image_input": {
+          "name": "supports_image_input",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "force_reasoning": {
+          "name": "force_reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opencode_settings": {
+          "name": "opencode_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interleaved_format": {
+          "name": "interleaved_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_builds": {
+      "name": "deployment_builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_builds_deployment_id": {
+          "name": "idx_deployment_builds_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_builds_status": {
+          "name": "idx_deployment_builds_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_builds_deployment_id_deployments_id_fk": {
+          "name": "deployment_builds_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_builds",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_env_vars": {
+      "name": "deployment_env_vars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_env_vars_deployment_id": {
+          "name": "idx_deployment_env_vars_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_env_vars_deployment_id_deployments_id_fk": {
+          "name": "deployment_env_vars_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_env_vars",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_deployment_env_vars_deployment_key": {
+          "name": "UQ_deployment_env_vars_deployment_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deployment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_events": {
+      "name": "deployment_events",
+      "schema": "",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'log'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_deployment_events_build_id": {
+          "name": "idx_deployment_events_build_id",
+          "columns": [
+            {
+              "expression": "build_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_events_timestamp": {
+          "name": "idx_deployment_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_events_type": {
+          "name": "idx_deployment_events_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_events_build_id_deployment_builds_id_fk": {
+          "name": "deployment_events_build_id_deployment_builds_id_fk",
+          "tableFrom": "deployment_events",
+          "tableTo": "deployment_builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deployment_events_build_id_event_id_pk": {
+          "name": "deployment_events_build_id_event_id_pk",
+          "columns": [
+            "build_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_threat_detections": {
+      "name": "deployment_threat_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threat_type": {
+          "name": "threat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_threat_detections_deployment_id": {
+          "name": "idx_deployment_threat_detections_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_threat_detections_created_at": {
+          "name": "idx_deployment_threat_detections_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_threat_detections_deployment_id_deployments_id_fk": {
+          "name": "deployment_threat_detections_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_threat_detections",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_threat_detections_build_id_deployment_builds_id_fk": {
+          "name": "deployment_threat_detections_build_id_deployment_builds_id_fk",
+          "tableFrom": "deployment_threat_detections",
+          "tableTo": "deployment_builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_slug": {
+          "name": "deployment_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_worker_name": {
+          "name": "internal_worker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source": {
+          "name": "repository_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_url": {
+          "name": "deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "git_auth_token": {
+          "name": "git_auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_build_id": {
+          "name": "last_build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threat_status": {
+          "name": "threat_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deployments_owned_by_user_id": {
+          "name": "idx_deployments_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_owned_by_organization_id": {
+          "name": "idx_deployments_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_platform_integration_id": {
+          "name": "idx_deployments_platform_integration_id",
+          "columns": [
+            {
+              "expression": "platform_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_repository_source_branch": {
+          "name": "idx_deployments_repository_source_branch",
+          "columns": [
+            {
+              "expression": "repository_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_threat_status_pending": {
+          "name": "idx_deployments_threat_status_pending",
+          "columns": [
+            {
+              "expression": "threat_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deployments\".\"threat_status\" = 'pending_scan'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "deployments_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployments_owned_by_organization_id_organizations_id_fk": {
+          "name": "deployments_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_deployments_deployment_slug": {
+          "name": "UQ_deployments_deployment_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deployment_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "deployments_owner_check": {
+          "name": "deployments_owner_check",
+          "value": "(\n        (\"deployments\".\"owned_by_user_id\" IS NOT NULL AND \"deployments\".\"owned_by_organization_id\" IS NULL) OR\n        (\"deployments\".\"owned_by_user_id\" IS NULL AND \"deployments\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "deployments_source_type_check": {
+          "name": "deployments_source_type_check",
+          "value": "\"deployments\".\"source_type\" IN ('github', 'git', 'app-builder')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_auth_requests": {
+      "name": "device_auth_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_device_auth_requests_code": {
+          "name": "UQ_device_auth_requests_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_status": {
+          "name": "IDX_device_auth_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_expires_at": {
+          "name": "IDX_device_auth_requests_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_kilo_user_id": {
+          "name": "IDX_device_auth_requests_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_auth_requests_kilo_user_id_kilocode_users_id_fk": {
+          "name": "device_auth_requests_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "device_auth_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_gateway_listener": {
+      "name": "discord_gateway_listener",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "listener_id": {
+          "name": "listener_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editor_name": {
+      "name": "editor_name",
+      "schema": "",
+      "columns": {
+        "editor_name_id": {
+          "name": "editor_name_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "editor_name": {
+          "name": "editor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_editor_name": {
+          "name": "UQ_editor_name",
+          "columns": [
+            {
+              "expression": "editor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichment_data": {
+      "name": "enrichment_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_enrichment_data": {
+          "name": "github_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_enrichment_data": {
+          "name": "linkedin_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clay_enrichment_data": {
+          "name": "clay_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_enrichment_data_user_id": {
+          "name": "IDX_enrichment_data_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_data_user_id_kilocode_users_id_fk": {
+          "name": "enrichment_data_user_id_kilocode_users_id_fk",
+          "tableFrom": "enrichment_data",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_enrichment_data_user_id": {
+          "name": "UQ_enrichment_data_user_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature": {
+      "name": "feature",
+      "schema": "",
+      "columns": {
+        "feature_id": {
+          "name": "feature_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_feature": {
+          "name": "UQ_feature",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finish_reason": {
+      "name": "finish_reason",
+      "schema": "",
+      "columns": {
+        "finish_reason_id": {
+          "name": "finish_reason_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_finish_reason": {
+          "name": "UQ_finish_reason",
+          "columns": [
+            {
+              "expression": "finish_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_model_usage": {
+      "name": "free_model_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_model_usage_ip_created_at": {
+          "name": "idx_free_model_usage_ip_created_at",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_model_usage_created_at": {
+          "name": "idx_free_model_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_ip": {
+      "name": "http_ip",
+      "schema": "",
+      "columns": {
+        "http_ip_id": {
+          "name": "http_ip_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "http_ip": {
+          "name": "http_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_http_ip": {
+          "name": "UQ_http_ip",
+          "columns": [
+            {
+              "expression": "http_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_user_agent": {
+      "name": "http_user_agent",
+      "schema": "",
+      "columns": {
+        "http_user_agent_id": {
+          "name": "http_user_agent_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_http_user_agent": {
+          "name": "UQ_http_user_agent",
+          "columns": [
+            {
+              "expression": "http_user_agent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ja4_digest": {
+      "name": "ja4_digest",
+      "schema": "",
+      "columns": {
+        "ja4_digest_id": {
+          "name": "ja4_digest_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ja4_digest": {
+          "name": "ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_ja4_digest": {
+          "name": "UQ_ja4_digest",
+          "columns": [
+            {
+              "expression": "ja4_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_audit_log": {
+      "name": "kilo_pass_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_credit_transaction_id": {
+          "name": "related_credit_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_monthly_issuance_id": {
+          "name": "related_monthly_issuance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_audit_log_created_at": {
+          "name": "IDX_kilo_pass_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_kilo_user_id": {
+          "name": "IDX_kilo_pass_audit_log_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_kilo_pass_subscription_id": {
+          "name": "IDX_kilo_pass_audit_log_kilo_pass_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_action": {
+          "name": "IDX_kilo_pass_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_result": {
+          "name": "IDX_kilo_pass_audit_log_result",
+          "columns": [
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_idempotency_key": {
+          "name": "IDX_kilo_pass_audit_log_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_event_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_event_id",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_invoice_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_subscription_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_related_credit_transaction_id": {
+          "name": "IDX_kilo_pass_audit_log_related_credit_transaction_id",
+          "columns": [
+            {
+              "expression": "related_credit_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_related_monthly_issuance_id": {
+          "name": "IDX_kilo_pass_audit_log_related_monthly_issuance_id",
+          "columns": [
+            {
+              "expression": "related_monthly_issuance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_audit_log_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_audit_log_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_audit_log_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_related_credit_transaction_id_credit_transactions_id_fk": {
+          "name": "kilo_pass_audit_log_related_credit_transaction_id_credit_transactions_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "credit_transactions",
+          "columnsFrom": [
+            "related_credit_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_related_monthly_issuance_id_kilo_pass_issuances_id_fk": {
+          "name": "kilo_pass_audit_log_related_monthly_issuance_id_kilo_pass_issuances_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilo_pass_issuances",
+          "columnsFrom": [
+            "related_monthly_issuance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_audit_log_action_check": {
+          "name": "kilo_pass_audit_log_action_check",
+          "value": "\"kilo_pass_audit_log\".\"action\" IN ('stripe_webhook_received', 'kilo_pass_invoice_paid_handled', 'base_credits_issued', 'bonus_credits_issued', 'bonus_credits_skipped_idempotent', 'first_month_50pct_promo_issued', 'yearly_monthly_base_cron_started', 'yearly_monthly_base_cron_completed', 'issue_yearly_remaining_credits', 'yearly_monthly_bonus_cron_started', 'yearly_monthly_bonus_cron_completed')"
+        },
+        "kilo_pass_audit_log_result_check": {
+          "name": "kilo_pass_audit_log_result_check",
+          "value": "\"kilo_pass_audit_log\".\"result\" IN ('success', 'skipped_idempotent', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_issuance_items": {
+      "name": "kilo_pass_issuance_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_issuance_id": {
+          "name": "kilo_pass_issuance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_transaction_id": {
+          "name": "credit_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_percent_applied": {
+          "name": "bonus_percent_applied",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_issuance_items_issuance_id": {
+          "name": "IDX_kilo_pass_issuance_items_issuance_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_issuance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuance_items_credit_transaction_id": {
+          "name": "IDX_kilo_pass_issuance_items_credit_transaction_id",
+          "columns": [
+            {
+              "expression": "credit_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_issuance_items_kilo_pass_issuance_id_kilo_pass_issuances_id_fk": {
+          "name": "kilo_pass_issuance_items_kilo_pass_issuance_id_kilo_pass_issuances_id_fk",
+          "tableFrom": "kilo_pass_issuance_items",
+          "tableTo": "kilo_pass_issuances",
+          "columnsFrom": [
+            "kilo_pass_issuance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_issuance_items_credit_transaction_id_credit_transactions_id_fk": {
+          "name": "kilo_pass_issuance_items_credit_transaction_id_credit_transactions_id_fk",
+          "tableFrom": "kilo_pass_issuance_items",
+          "tableTo": "credit_transactions",
+          "columnsFrom": [
+            "credit_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kilo_pass_issuance_items_credit_transaction_id_unique": {
+          "name": "kilo_pass_issuance_items_credit_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credit_transaction_id"
+          ]
+        },
+        "UQ_kilo_pass_issuance_items_issuance_kind": {
+          "name": "UQ_kilo_pass_issuance_items_issuance_kind",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_pass_issuance_id",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_issuance_items_bonus_percent_applied_range_check": {
+          "name": "kilo_pass_issuance_items_bonus_percent_applied_range_check",
+          "value": "\"kilo_pass_issuance_items\".\"bonus_percent_applied\" IS NULL OR (\"kilo_pass_issuance_items\".\"bonus_percent_applied\" >= 0 AND \"kilo_pass_issuance_items\".\"bonus_percent_applied\" <= 1)"
+        },
+        "kilo_pass_issuance_items_amount_usd_non_negative_check": {
+          "name": "kilo_pass_issuance_items_amount_usd_non_negative_check",
+          "value": "\"kilo_pass_issuance_items\".\"amount_usd\" >= 0"
+        },
+        "kilo_pass_issuance_items_kind_check": {
+          "name": "kilo_pass_issuance_items_kind_check",
+          "value": "\"kilo_pass_issuance_items\".\"kind\" IN ('base', 'bonus', 'promo_first_month_50pct')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_issuances": {
+      "name": "kilo_pass_issuances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_month": {
+          "name": "issue_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kilo_pass_issuances_stripe_invoice_id": {
+          "name": "UQ_kilo_pass_issuances_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_issuances\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuances_subscription_id": {
+          "name": "IDX_kilo_pass_issuances_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuances_issue_month": {
+          "name": "IDX_kilo_pass_issuances_issue_month",
+          "columns": [
+            {
+              "expression": "issue_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_issuances_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_issuances_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_issuances",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_kilo_pass_issuances_subscription_issue_month": {
+          "name": "UQ_kilo_pass_issuances_subscription_issue_month",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_pass_subscription_id",
+            "issue_month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_issuances_issue_month_day_one_check": {
+          "name": "kilo_pass_issuances_issue_month_day_one_check",
+          "value": "EXTRACT(DAY FROM \"kilo_pass_issuances\".\"issue_month\") = 1"
+        },
+        "kilo_pass_issuances_source_check": {
+          "name": "kilo_pass_issuances_source_check",
+          "value": "\"kilo_pass_issuances\".\"source\" IN ('stripe_invoice', 'cron')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_scheduled_changes": {
+      "name": "kilo_pass_scheduled_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_tier": {
+          "name": "from_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_cadence": {
+          "name": "from_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_tier": {
+          "name": "to_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_cadence": {
+          "name": "to_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_scheduled_changes_kilo_user_id": {
+          "name": "IDX_kilo_pass_scheduled_changes_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_status": {
+          "name": "IDX_kilo_pass_scheduled_changes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_stripe_subscription_id": {
+          "name": "IDX_kilo_pass_scheduled_changes_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kilo_pass_scheduled_changes_active_stripe_subscription_id": {
+          "name": "UQ_kilo_pass_scheduled_changes_active_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_scheduled_changes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_effective_at": {
+          "name": "IDX_kilo_pass_scheduled_changes_effective_at",
+          "columns": [
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_deleted_at": {
+          "name": "IDX_kilo_pass_scheduled_changes_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_scheduled_changes_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_scheduled_changes_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_scheduled_changes",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_scheduled_changes_stripe_subscription_id_kilo_pass_subscriptions_stripe_subscription_id_fk": {
+          "name": "kilo_pass_scheduled_changes_stripe_subscription_id_kilo_pass_subscriptions_stripe_subscription_id_fk",
+          "tableFrom": "kilo_pass_scheduled_changes",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "stripe_subscription_id"
+          ],
+          "columnsTo": [
+            "stripe_subscription_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_scheduled_changes_from_tier_check": {
+          "name": "kilo_pass_scheduled_changes_from_tier_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"from_tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_scheduled_changes_from_cadence_check": {
+          "name": "kilo_pass_scheduled_changes_from_cadence_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"from_cadence\" IN ('monthly', 'yearly')"
+        },
+        "kilo_pass_scheduled_changes_to_tier_check": {
+          "name": "kilo_pass_scheduled_changes_to_tier_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"to_tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_scheduled_changes_to_cadence_check": {
+          "name": "kilo_pass_scheduled_changes_to_cadence_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"to_cadence\" IN ('monthly', 'yearly')"
+        },
+        "kilo_pass_scheduled_changes_status_check": {
+          "name": "kilo_pass_scheduled_changes_status_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"status\" IN ('not_started', 'active', 'completed', 'released', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_subscriptions": {
+      "name": "kilo_pass_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_streak_months": {
+          "name": "current_streak_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_yearly_issue_at": {
+          "name": "next_yearly_issue_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_subscriptions_kilo_user_id": {
+          "name": "IDX_kilo_pass_subscriptions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_subscriptions_status": {
+          "name": "IDX_kilo_pass_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_subscriptions_cadence": {
+          "name": "IDX_kilo_pass_subscriptions_cadence",
+          "columns": [
+            {
+              "expression": "cadence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_subscriptions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_subscriptions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kilo_pass_subscriptions_stripe_subscription_id_unique": {
+          "name": "kilo_pass_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_subscriptions_current_streak_months_non_negative_check": {
+          "name": "kilo_pass_subscriptions_current_streak_months_non_negative_check",
+          "value": "\"kilo_pass_subscriptions\".\"current_streak_months\" >= 0"
+        },
+        "kilo_pass_subscriptions_tier_check": {
+          "name": "kilo_pass_subscriptions_tier_check",
+          "value": "\"kilo_pass_subscriptions\".\"tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_subscriptions_cadence_check": {
+          "name": "kilo_pass_subscriptions_cadence_check",
+          "value": "\"kilo_pass_subscriptions\".\"cadence\" IN ('monthly', 'yearly')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_access_codes": {
+      "name": "kiloclaw_access_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_access_codes_code": {
+          "name": "UQ_kiloclaw_access_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_access_codes_user_status": {
+          "name": "IDX_kiloclaw_access_codes_user_status",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kiloclaw_access_codes_one_active_per_user": {
+          "name": "UQ_kiloclaw_access_codes_one_active_per_user",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_access_codes_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_access_codes_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_access_codes",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_earlybird_purchases": {
+      "name": "kiloclaw_earlybird_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_payment_id": {
+          "name": "manual_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_earlybird_purchases_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_earlybird_purchases_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_earlybird_purchases",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_earlybird_purchases_user_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "kiloclaw_earlybird_purchases_stripe_charge_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_stripe_charge_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_charge_id"
+          ]
+        },
+        "kiloclaw_earlybird_purchases_manual_payment_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_manual_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "manual_payment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_email_log": {
+      "name": "kiloclaw_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_email_log_user_type": {
+          "name": "UQ_kiloclaw_email_log_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_email_log_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_email_log_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_email_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_image_catalog": {
+      "name": "kiloclaw_image_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openclaw_version": {
+          "name": "openclaw_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_digest": {
+          "name": "image_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_image_catalog_status": {
+          "name": "IDX_kiloclaw_image_catalog_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_image_catalog_variant": {
+          "name": "IDX_kiloclaw_image_catalog_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_image_catalog_image_tag_unique": {
+          "name": "kiloclaw_image_catalog_image_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "image_tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_instances": {
+      "name": "kiloclaw_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_instances_active": {
+          "name": "UQ_kiloclaw_instances_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kiloclaw_instances\".\"destroyed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_instances_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_instances_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_instances",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_subscriptions": {
+      "name": "kiloclaw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_plan": {
+          "name": "scheduled_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_by": {
+          "name": "scheduled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_ends_at": {
+          "name": "commit_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_since": {
+          "name": "past_due_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destruction_deadline": {
+          "name": "destruction_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_subscriptions_status": {
+          "name": "IDX_kiloclaw_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_subscriptions_stripe_schedule_id": {
+          "name": "IDX_kiloclaw_subscriptions_stripe_schedule_id",
+          "columns": [
+            {
+              "expression": "stripe_schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_subscriptions_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_subscriptions_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_subscriptions_user_id_unique": {
+          "name": "kiloclaw_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "kiloclaw_subscriptions_stripe_subscription_id_unique": {
+          "name": "kiloclaw_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kiloclaw_subscriptions_plan_check": {
+          "name": "kiloclaw_subscriptions_plan_check",
+          "value": "\"kiloclaw_subscriptions\".\"plan\" IN ('trial', 'commit', 'standard')"
+        },
+        "kiloclaw_subscriptions_scheduled_plan_check": {
+          "name": "kiloclaw_subscriptions_scheduled_plan_check",
+          "value": "\"kiloclaw_subscriptions\".\"scheduled_plan\" IN ('commit', 'standard')"
+        },
+        "kiloclaw_subscriptions_scheduled_by_check": {
+          "name": "kiloclaw_subscriptions_scheduled_by_check",
+          "value": "\"kiloclaw_subscriptions\".\"scheduled_by\" IN ('auto', 'user')"
+        },
+        "kiloclaw_subscriptions_status_check": {
+          "name": "kiloclaw_subscriptions_status_check",
+          "value": "\"kiloclaw_subscriptions\".\"status\" IN ('trialing', 'active', 'past_due', 'canceled', 'unpaid')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_version_pins": {
+      "name": "kiloclaw_version_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_version_pins_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_version_pins_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk": {
+          "name": "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kiloclaw_image_catalog",
+          "columnsFrom": [
+            "image_tag"
+          ],
+          "columnsTo": [
+            "image_tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk": {
+          "name": "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "pinned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_version_pins_user_id_unique": {
+          "name": "kiloclaw_version_pins_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilocode_users": {
+      "name": "kilocode_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_email": {
+          "name": "google_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_user_name": {
+          "name": "google_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_user_image_url": {
+          "name": "google_user_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hosted_domain": {
+          "name": "hosted_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microdollars_used": {
+          "name": "microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "kilo_pass_threshold": {
+          "name": "kilo_pass_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_microdollars_acquired": {
+          "name": "total_microdollars_acquired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "next_credit_expiration_at": {
+          "name": "next_credit_expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_validation_stytch": {
+          "name": "has_validation_stytch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_validation_novel_card_with_hold": {
+          "name": "has_validation_novel_card_with_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_pepper": {
+          "name": "api_token_pepper",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cohorts": {
+          "name": "cohorts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completed_welcome_form": {
+          "name": "completed_welcome_form",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_upstream_safety_identifier": {
+          "name": "openrouter_upstream_safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_source": {
+          "name": "customer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UQ_kilocode_users_openrouter_upstream_safety_identifier": {
+          "name": "UQ_kilocode_users_openrouter_upstream_safety_identifier",
+          "columns": [
+            {
+              "expression": "openrouter_upstream_safety_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilocode_users\".\"openrouter_upstream_safety_identifier\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_b1afacbcf43f2c7c4cb9f7e7faa": {
+          "name": "UQ_b1afacbcf43f2c7c4cb9f7e7faa",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_user_email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "blocked_reason_not_empty": {
+          "name": "blocked_reason_not_empty",
+          "value": "length(blocked_reason) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_magic_link_tokens_email": {
+          "name": "idx_magic_link_tokens_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_magic_link_tokens_expires_at": {
+          "name": "idx_magic_link_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_expires_at_future": {
+          "name": "check_expires_at_future",
+          "value": "\"magic_link_tokens\".\"expires_at\" > \"magic_link_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.microdollar_usage": {
+      "name": "microdollar_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_hit_tokens": {
+          "name": "cache_hit_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_discount": {
+          "name": "cache_discount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "abuse_classification": {
+          "name": "abuse_classification",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inference_provider": {
+          "name": "inference_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_abuse_classification": {
+          "name": "idx_abuse_classification",
+          "columns": [
+            {
+              "expression": "abuse_classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kilo_user_id_created_at2": {
+          "name": "idx_kilo_user_id_created_at2",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_microdollar_usage_organization_id": {
+          "name": "idx_microdollar_usage_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"microdollar_usage\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.microdollar_usage_metadata": {
+      "name": "microdollar_usage_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_user_agent_id": {
+          "name": "http_user_agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_ip_id": {
+          "name": "http_ip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_city_id": {
+          "name": "vercel_ip_city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_country_id": {
+          "name": "vercel_ip_country_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_latitude": {
+          "name": "vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_longitude": {
+          "name": "vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ja4_digest_id": {
+          "name": "ja4_digest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt_prefix": {
+          "name": "user_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_prefix_id": {
+          "name": "system_prompt_prefix_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_length": {
+          "name": "system_prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_middle_out_transform": {
+          "name": "has_middle_out_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason_id": {
+          "name": "finish_reason_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_latency": {
+          "name": "moderation_latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_time": {
+          "name": "generation_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_byok": {
+          "name": "is_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_byok": {
+          "name": "is_user_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_name_id": {
+          "name": "editor_name_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_kind_id": {
+          "name": "api_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_model_id": {
+          "name": "auto_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_cost": {
+          "name": "market_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_microdollar_usage_metadata_created_at": {
+          "name": "idx_microdollar_usage_metadata_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "microdollar_usage_metadata_http_user_agent_id_http_user_agent_http_user_agent_id_fk": {
+          "name": "microdollar_usage_metadata_http_user_agent_id_http_user_agent_http_user_agent_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "http_user_agent",
+          "columnsFrom": [
+            "http_user_agent_id"
+          ],
+          "columnsTo": [
+            "http_user_agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_http_ip_id_http_ip_http_ip_id_fk": {
+          "name": "microdollar_usage_metadata_http_ip_id_http_ip_http_ip_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "http_ip",
+          "columnsFrom": [
+            "http_ip_id"
+          ],
+          "columnsTo": [
+            "http_ip_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_vercel_ip_city_id_vercel_ip_city_vercel_ip_city_id_fk": {
+          "name": "microdollar_usage_metadata_vercel_ip_city_id_vercel_ip_city_vercel_ip_city_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "vercel_ip_city",
+          "columnsFrom": [
+            "vercel_ip_city_id"
+          ],
+          "columnsTo": [
+            "vercel_ip_city_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_vercel_ip_country_id_vercel_ip_country_vercel_ip_country_id_fk": {
+          "name": "microdollar_usage_metadata_vercel_ip_country_id_vercel_ip_country_vercel_ip_country_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "vercel_ip_country",
+          "columnsFrom": [
+            "vercel_ip_country_id"
+          ],
+          "columnsTo": [
+            "vercel_ip_country_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_ja4_digest_id_ja4_digest_ja4_digest_id_fk": {
+          "name": "microdollar_usage_metadata_ja4_digest_id_ja4_digest_ja4_digest_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "ja4_digest",
+          "columnsFrom": [
+            "ja4_digest_id"
+          ],
+          "columnsTo": [
+            "ja4_digest_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_system_prompt_prefix_id_system_prompt_prefix_system_prompt_prefix_id_fk": {
+          "name": "microdollar_usage_metadata_system_prompt_prefix_id_system_prompt_prefix_system_prompt_prefix_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "system_prompt_prefix",
+          "columnsFrom": [
+            "system_prompt_prefix_id"
+          ],
+          "columnsTo": [
+            "system_prompt_prefix_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mode": {
+      "name": "mode",
+      "schema": "",
+      "columns": {
+        "mode_id": {
+          "name": "mode_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_mode": {
+          "name": "UQ_mode",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stats": {
+      "name": "model_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_stealth": {
+          "name": "is_stealth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "openrouter_id": {
+          "name": "openrouter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aa_slug": {
+          "name": "aa_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_creator": {
+          "name": "model_creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_slug": {
+          "name": "creator_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_input": {
+          "name": "price_input",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_output": {
+          "name": "price_output",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coding_index": {
+          "name": "coding_index",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_tokens_per_sec": {
+          "name": "speed_tokens_per_sec",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_data": {
+          "name": "openrouter_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarks": {
+          "name": "benchmarks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chart_data": {
+          "name": "chart_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_model_stats_openrouter_id": {
+          "name": "IDX_model_stats_openrouter_id",
+          "columns": [
+            {
+              "expression": "openrouter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_slug": {
+          "name": "IDX_model_stats_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_is_active": {
+          "name": "IDX_model_stats_is_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_creator_slug": {
+          "name": "IDX_model_stats_creator_slug",
+          "columns": [
+            {
+              "expression": "creator_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_price_input": {
+          "name": "IDX_model_stats_price_input",
+          "columns": [
+            {
+              "expression": "price_input",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_coding_index": {
+          "name": "IDX_model_stats_coding_index",
+          "columns": [
+            {
+              "expression": "coding_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_context_length": {
+          "name": "IDX_model_stats_context_length",
+          "columns": [
+            {
+              "expression": "context_length",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_stats_openrouter_id_unique": {
+          "name": "model_stats_openrouter_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openrouter_id"
+          ]
+        },
+        "model_stats_slug_unique": {
+          "name": "model_stats_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models_by_provider": {
+      "name": "models_by_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openrouter": {
+          "name": "openrouter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel": {
+          "name": "vercel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_audit_logs": {
+      "name": "organization_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_audit_logs_organization_id": {
+          "name": "IDX_organization_audit_logs_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_action": {
+          "name": "IDX_organization_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_actor_id": {
+          "name": "IDX_organization_audit_logs_actor_id",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_created_at": {
+          "name": "IDX_organization_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invitations": {
+      "name": "organization_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_organization_invitations_token": {
+          "name": "UQ_organization_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_org_id": {
+          "name": "IDX_organization_invitations_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_email": {
+          "name": "IDX_organization_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_expires_at": {
+          "name": "IDX_organization_invitations_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_memberships_org_id": {
+          "name": "IDX_organization_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_memberships_user_id": {
+          "name": "IDX_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_memberships_org_user": {
+          "name": "UQ_organization_memberships_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_seats_purchases": {
+      "name": "organization_seats_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_stripe_id": {
+          "name": "subscription_stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "IDX_organization_seats_org_id": {
+          "name": "IDX_organization_seats_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_expires_at": {
+          "name": "IDX_organization_seats_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_created_at": {
+          "name": "IDX_organization_seats_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_updated_at": {
+          "name": "IDX_organization_seats_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_starts_at": {
+          "name": "IDX_organization_seats_starts_at",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_seats_idempotency_key": {
+          "name": "UQ_organization_seats_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_limits": {
+      "name": "organization_user_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microdollar_limit": {
+          "name": "microdollar_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_user_limits_org_id": {
+          "name": "IDX_organization_user_limits_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_user_limits_user_id": {
+          "name": "IDX_organization_user_limits_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_user_limits_org_user": {
+          "name": "UQ_organization_user_limits_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "limit_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_usage": {
+      "name": "organization_user_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microdollar_usage": {
+          "name": "microdollar_usage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_user_daily_usage_org_id": {
+          "name": "IDX_organization_user_daily_usage_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_user_daily_usage_user_id": {
+          "name": "IDX_organization_user_daily_usage_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_user_daily_usage_org_user_date": {
+          "name": "UQ_organization_user_daily_usage_org_user_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "limit_type",
+            "usage_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "microdollars_used": {
+          "name": "microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "microdollars_balance": {
+          "name": "microdollars_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_microdollars_acquired": {
+          "name": "total_microdollars_acquired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "next_credit_expiration_at": {
+          "name": "next_credit_expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "require_seats": {
+          "name": "require_seats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_kilo_user_id": {
+          "name": "created_by_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_domain": {
+          "name": "sso_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'teams'"
+        },
+        "free_trial_end_at": {
+          "name": "free_trial_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_domain": {
+          "name": "company_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_organizations_sso_domain": {
+          "name": "IDX_organizations_sso_domain",
+          "columns": [
+            {
+              "expression": "sso_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_name_not_empty_check": {
+          "name": "organizations_name_not_empty_check",
+          "value": "length(trim(\"organizations\".\"name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_modes": {
+      "name": "organization_modes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "IDX_organization_modes_organization_id": {
+          "name": "IDX_organization_modes_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_modes_org_id_slug": {
+          "name": "UQ_organization_modes_org_id_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "stripe_fingerprint": {
+          "name": "stripe_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "three_d_secure_supported": {
+          "name": "three_d_secure_supported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding": {
+          "name": "funding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regulated_status": {
+          "name": "regulated_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1_check_status": {
+          "name": "address_line1_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code_check_status": {
+          "name": "postal_code_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_for_free_credits": {
+          "name": "eligible_for_free_credits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_data": {
+          "name": "stripe_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_d7d7fb15569674aaadcfbc0428": {
+          "name": "IDX_d7d7fb15569674aaadcfbc0428",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_e1feb919d0ab8a36381d5d5138": {
+          "name": "IDX_e1feb919d0ab8a36381d5d5138",
+          "columns": [
+            {
+              "expression": "stripe_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_payment_methods_organization_id": {
+          "name": "IDX_payment_methods_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_29df1b0403df5792c96bbbfdbe6": {
+          "name": "UQ_29df1b0403df5792c96bbbfdbe6",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_integrations": {
+      "name": "platform_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_installation_id": {
+          "name": "platform_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_account_id": {
+          "name": "platform_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_account_login": {
+          "name": "platform_account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_access": {
+          "name": "repository_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repositories": {
+          "name": "repositories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repositories_synced_at": {
+          "name": "repositories_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_requester_user_id": {
+          "name": "kilo_requester_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_requester_account_id": {
+          "name": "platform_requester_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_status": {
+          "name": "integration_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_by": {
+          "name": "suspended_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_type": {
+          "name": "github_app_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_platform_integrations_owned_by_org_platform_inst": {
+          "name": "UQ_platform_integrations_owned_by_org_platform_inst",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"platform_integrations\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_platform_integrations_owned_by_user_platform_inst": {
+          "name": "UQ_platform_integrations_owned_by_user_platform_inst",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"platform_integrations\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_org_id": {
+          "name": "IDX_platform_integrations_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_user_id": {
+          "name": "IDX_platform_integrations_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform_inst_id": {
+          "name": "IDX_platform_integrations_platform_inst_id",
+          "columns": [
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform": {
+          "name": "IDX_platform_integrations_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_org_platform": {
+          "name": "IDX_platform_integrations_owned_by_org_platform",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_user_platform": {
+          "name": "IDX_platform_integrations_owned_by_user_platform",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_integration_status": {
+          "name": "IDX_platform_integrations_integration_status",
+          "columns": [
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_kilo_requester": {
+          "name": "IDX_platform_integrations_kilo_requester",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilo_requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform_requester": {
+          "name": "IDX_platform_integrations_platform_requester",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_requester_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_integrations_owned_by_organization_id_organizations_id_fk": {
+          "name": "platform_integrations_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "platform_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "platform_integrations_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "platform_integrations_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "platform_integrations",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_integrations_owner_check": {
+          "name": "platform_integrations_owner_check",
+          "value": "(\n        (\"platform_integrations\".\"owned_by_user_id\" IS NOT NULL AND \"platform_integrations\".\"owned_by_organization_id\" IS NULL) OR\n        (\"platform_integrations\".\"owned_by_user_id\" IS NULL AND \"platform_integrations\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.referral_code_usages": {
+      "name": "referral_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "referring_kilo_user_id": {
+          "name": "referring_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeeming_kilo_user_id": {
+          "name": "redeeming_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_referral_code_usages_redeeming_kilo_user_id": {
+          "name": "IDX_referral_code_usages_redeeming_kilo_user_id",
+          "columns": [
+            {
+              "expression": "redeeming_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_referral_code_usages_redeeming_user_id_code": {
+          "name": "UQ_referral_code_usages_redeeming_user_id_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "redeeming_kilo_user_id",
+            "referring_kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_referral_codes_kilo_user_id": {
+          "name": "UQ_referral_codes_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_referral_codes_code": {
+          "name": "IDX_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_analysis_owner_state": {
+      "name": "security_analysis_owner_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_analysis_enabled_at": {
+          "name": "auto_analysis_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_reason": {
+          "name": "block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_actor_resolution_failures": {
+          "name": "consecutive_actor_resolution_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_actor_resolution_failure_at": {
+          "name": "last_actor_resolution_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_security_analysis_owner_state_org_owner": {
+          "name": "UQ_security_analysis_owner_state_org_owner",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"security_analysis_owner_state\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_security_analysis_owner_state_user_owner": {
+          "name": "UQ_security_analysis_owner_state_user_owner",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"security_analysis_owner_state\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_analysis_owner_state_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_analysis_owner_state_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_analysis_owner_state",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_owner_state_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_analysis_owner_state_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_analysis_owner_state",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_analysis_owner_state_owner_check": {
+          "name": "security_analysis_owner_state_owner_check",
+          "value": "(\n        (\"security_analysis_owner_state\".\"owned_by_user_id\" IS NOT NULL AND \"security_analysis_owner_state\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_analysis_owner_state\".\"owned_by_user_id\" IS NULL AND \"security_analysis_owner_state\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "security_analysis_owner_state_block_reason_check": {
+          "name": "security_analysis_owner_state_block_reason_check",
+          "value": "\"security_analysis_owner_state\".\"block_reason\" IS NULL OR \"security_analysis_owner_state\".\"block_reason\" IN ('INSUFFICIENT_CREDITS', 'ACTOR_RESOLUTION_FAILED', 'OPERATOR_PAUSE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_analysis_queue": {
+      "name": "security_analysis_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_status": {
+          "name": "queue_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity_rank": {
+          "name": "severity_rank",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_job_id": {
+          "name": "claimed_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reopen_requeue_count": {
+          "name": "reopen_requeue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_redacted": {
+          "name": "last_error_redacted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_security_analysis_queue_finding_id": {
+          "name": "UQ_security_analysis_queue_finding_id",
+          "columns": [
+            {
+              "expression": "finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_claim_path_org": {
+          "name": "idx_security_analysis_queue_claim_path_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_claim_path_user": {
+          "name": "idx_security_analysis_queue_claim_path_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_in_flight_org": {
+          "name": "idx_security_analysis_queue_in_flight_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_in_flight_user": {
+          "name": "idx_security_analysis_queue_in_flight_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_lag_dashboards": {
+          "name": "idx_security_analysis_queue_lag_dashboards",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_pending_reconciliation": {
+          "name": "idx_security_analysis_queue_pending_reconciliation",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_running_reconciliation": {
+          "name": "idx_security_analysis_queue_running_reconciliation",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_failure_trend": {
+          "name": "idx_security_analysis_queue_failure_trend",
+          "columns": [
+            {
+              "expression": "failure_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"failure_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_analysis_queue_finding_id_security_findings_id_fk": {
+          "name": "security_analysis_queue_finding_id_security_findings_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "security_findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_queue_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_analysis_queue_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_queue_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_analysis_queue_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_analysis_queue_owner_check": {
+          "name": "security_analysis_queue_owner_check",
+          "value": "(\n        (\"security_analysis_queue\".\"owned_by_user_id\" IS NOT NULL AND \"security_analysis_queue\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_analysis_queue\".\"owned_by_user_id\" IS NULL AND \"security_analysis_queue\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "security_analysis_queue_status_check": {
+          "name": "security_analysis_queue_status_check",
+          "value": "\"security_analysis_queue\".\"queue_status\" IN ('queued', 'pending', 'running', 'failed', 'completed')"
+        },
+        "security_analysis_queue_claim_token_required_check": {
+          "name": "security_analysis_queue_claim_token_required_check",
+          "value": "\"security_analysis_queue\".\"queue_status\" NOT IN ('pending', 'running') OR \"security_analysis_queue\".\"claim_token\" IS NOT NULL"
+        },
+        "security_analysis_queue_attempt_count_non_negative_check": {
+          "name": "security_analysis_queue_attempt_count_non_negative_check",
+          "value": "\"security_analysis_queue\".\"attempt_count\" >= 0"
+        },
+        "security_analysis_queue_reopen_requeue_count_non_negative_check": {
+          "name": "security_analysis_queue_reopen_requeue_count_non_negative_check",
+          "value": "\"security_analysis_queue\".\"reopen_requeue_count\" >= 0"
+        },
+        "security_analysis_queue_severity_rank_check": {
+          "name": "security_analysis_queue_severity_rank_check",
+          "value": "\"security_analysis_queue\".\"severity_rank\" IN (0, 1, 2, 3)"
+        },
+        "security_analysis_queue_failure_code_check": {
+          "name": "security_analysis_queue_failure_code_check",
+          "value": "\"security_analysis_queue\".\"failure_code\" IS NULL OR \"security_analysis_queue\".\"failure_code\" IN (\n        'NETWORK_TIMEOUT',\n        'UPSTREAM_5XX',\n        'TEMP_TOKEN_FAILURE',\n        'START_CALL_AMBIGUOUS',\n        'REQUEUE_TEMPORARY_PRECONDITION',\n        'ACTOR_RESOLUTION_FAILED',\n        'GITHUB_TOKEN_UNAVAILABLE',\n        'INVALID_CONFIG',\n        'MISSING_OWNERSHIP',\n        'PERMISSION_DENIED_PERMANENT',\n        'UNSUPPORTED_SEVERITY',\n        'INSUFFICIENT_CREDITS',\n        'STATE_GUARD_REJECTED',\n        'SKIPPED_ALREADY_IN_PROGRESS',\n        'SKIPPED_NO_LONGER_ELIGIBLE',\n        'REOPEN_LOOP_GUARD',\n        'RUN_LOST'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_security_audit_log_org_created": {
+          "name": "IDX_security_audit_log_org_created",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_user_created": {
+          "name": "IDX_security_audit_log_user_created",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_resource": {
+          "name": "IDX_security_audit_log_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_actor": {
+          "name": "IDX_security_audit_log_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_action": {
+          "name": "IDX_security_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_audit_log_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_audit_log_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_audit_log_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_audit_log_owner_check": {
+          "name": "security_audit_log_owner_check",
+          "value": "(\"security_audit_log\".\"owned_by_user_id\" IS NOT NULL AND \"security_audit_log\".\"owned_by_organization_id\" IS NULL) OR (\"security_audit_log\".\"owned_by_user_id\" IS NULL AND \"security_audit_log\".\"owned_by_organization_id\" IS NOT NULL)"
+        },
+        "security_audit_log_action_check": {
+          "name": "security_audit_log_action_check",
+          "value": "\"security_audit_log\".\"action\" IN ('security.finding.created', 'security.finding.status_change', 'security.finding.dismissed', 'security.finding.auto_dismissed', 'security.finding.analysis_started', 'security.finding.analysis_completed', 'security.finding.deleted', 'security.config.enabled', 'security.config.disabled', 'security.config.updated', 'security.sync.triggered', 'security.sync.completed', 'security.audit_log.exported')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_findings": {
+      "name": "security_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ghsa_id": {
+          "name": "ghsa_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cve_id": {
+          "name": "cve_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_ecosystem": {
+          "name": "package_ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vulnerable_version_range": {
+          "name": "vulnerable_version_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patched_version": {
+          "name": "patched_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_path": {
+          "name": "manifest_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "ignored_reason": {
+          "name": "ignored_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_by": {
+          "name": "ignored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fixed_at": {
+          "name": "fixed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sla_due_at": {
+          "name": "sla_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependabot_html_url": {
+          "name": "dependabot_html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cwe_ids": {
+          "name": "cwe_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cvss_score": {
+          "name": "cvss_score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_scope": {
+          "name": "dependency_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_status": {
+          "name": "analysis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_started_at": {
+          "name": "analysis_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_completed_at": {
+          "name": "analysis_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_error": {
+          "name": "analysis_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_findings_org_id": {
+          "name": "idx_security_findings_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_user_id": {
+          "name": "idx_security_findings_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_repo": {
+          "name": "idx_security_findings_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_severity": {
+          "name": "idx_security_findings_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_status": {
+          "name": "idx_security_findings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_package": {
+          "name": "idx_security_findings_package",
+          "columns": [
+            {
+              "expression": "package_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_sla_due_at": {
+          "name": "idx_security_findings_sla_due_at",
+          "columns": [
+            {
+              "expression": "sla_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_session_id": {
+          "name": "idx_security_findings_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_cli_session_id": {
+          "name": "idx_security_findings_cli_session_id",
+          "columns": [
+            {
+              "expression": "cli_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_analysis_status": {
+          "name": "idx_security_findings_analysis_status",
+          "columns": [
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_org_analysis_in_flight": {
+          "name": "idx_security_findings_org_analysis_in_flight",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_findings\".\"analysis_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_user_analysis_in_flight": {
+          "name": "idx_security_findings_user_analysis_in_flight",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_findings\".\"analysis_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_findings_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_findings_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_findings_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_findings_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_findings_platform_integration_id_platform_integrations_id_fk": {
+          "name": "security_findings_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_security_findings_source": {
+          "name": "uq_security_findings_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repo_full_name",
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "security_findings_owner_check": {
+          "name": "security_findings_owner_check",
+          "value": "(\n        (\"security_findings\".\"owned_by_user_id\" IS NOT NULL AND \"security_findings\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_findings\".\"owned_by_user_id\" IS NULL AND \"security_findings\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_cli_sessions": {
+      "name": "shared_cli_sessions",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_state": {
+          "name": "shared_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "api_conversation_history_blob_url": {
+          "name": "api_conversation_history_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_metadata_blob_url": {
+          "name": "task_metadata_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_messages_blob_url": {
+          "name": "ui_messages_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_state_blob_url": {
+          "name": "git_state_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_shared_cli_sessions_session_id": {
+          "name": "IDX_shared_cli_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_shared_cli_sessions_created_at": {
+          "name": "IDX_shared_cli_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_cli_sessions_session_id_cli_sessions_session_id_fk": {
+          "name": "shared_cli_sessions_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "shared_cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shared_cli_sessions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "shared_cli_sessions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "shared_cli_sessions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shared_cli_sessions_shared_state_check": {
+          "name": "shared_cli_sessions_shared_state_check",
+          "value": "\"shared_cli_sessions\".\"shared_state\" IN ('public', 'organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_bot_requests": {
+      "name": "slack_bot_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_message": {
+          "name": "user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_message_truncated": {
+          "name": "user_message_truncated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_made": {
+          "name": "tool_calls_made",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_bot_requests_created_at": {
+          "name": "idx_slack_bot_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_slack_team_id": {
+          "name": "idx_slack_bot_requests_slack_team_id",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_owned_by_org_id": {
+          "name": "idx_slack_bot_requests_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_owned_by_user_id": {
+          "name": "idx_slack_bot_requests_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_status": {
+          "name": "idx_slack_bot_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_event_type": {
+          "name": "idx_slack_bot_requests_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_team_created": {
+          "name": "idx_slack_bot_requests_team_created",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_bot_requests_owned_by_organization_id_organizations_id_fk": {
+          "name": "slack_bot_requests_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_bot_requests_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "slack_bot_requests_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_bot_requests_platform_integration_id_platform_integrations_id_fk": {
+          "name": "slack_bot_requests_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_bot_requests_owner_check": {
+          "name": "slack_bot_requests_owner_check",
+          "value": "(\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NOT NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NULL) OR\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NOT NULL) OR\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_embeddings": {
+      "name": "source_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "is_base_branch": {
+          "name": "is_base_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_source_embeddings_organization_id": {
+          "name": "IDX_source_embeddings_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_kilo_user_id": {
+          "name": "IDX_source_embeddings_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_project_id": {
+          "name": "IDX_source_embeddings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_created_at": {
+          "name": "IDX_source_embeddings_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_updated_at": {
+          "name": "IDX_source_embeddings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_file_path_lower": {
+          "name": "IDX_source_embeddings_file_path_lower",
+          "columns": [
+            {
+              "expression": "LOWER(\"file_path\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_git_branch": {
+          "name": "IDX_source_embeddings_git_branch",
+          "columns": [
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_org_project_branch": {
+          "name": "IDX_source_embeddings_org_project_branch",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_embeddings_organization_id_organizations_id_fk": {
+          "name": "source_embeddings_organization_id_organizations_id_fk",
+          "tableFrom": "source_embeddings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_embeddings_kilo_user_id_kilocode_users_id_fk": {
+          "name": "source_embeddings_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "source_embeddings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_source_embeddings_org_project_branch_file_lines": {
+          "name": "UQ_source_embeddings_org_project_branch_file_lines",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "project_id",
+            "git_branch",
+            "file_path",
+            "start_line",
+            "end_line"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stytch_fingerprints": {
+      "name": "stytch_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_fingerprint": {
+          "name": "visitor_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_fingerprint": {
+          "name": "browser_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_id": {
+          "name": "browser_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardware_fingerprint": {
+          "name": "hardware_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_fingerprint": {
+          "name": "network_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_action": {
+          "name": "verdict_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_device_type": {
+          "name": "detected_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_authentic_device": {
+          "name": "is_authentic_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"\"}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_data": {
+          "name": "fingerprint_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_free_tier_allowed": {
+          "name": "kilo_free_tier_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fingerprint_data": {
+          "name": "idx_fingerprint_data",
+          "columns": [
+            {
+              "expression": "fingerprint_data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hardware_fingerprint": {
+          "name": "idx_hardware_fingerprint",
+          "columns": [
+            {
+              "expression": "hardware_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kilo_user_id": {
+          "name": "idx_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reasons": {
+          "name": "idx_reasons",
+          "columns": [
+            {
+              "expression": "reasons",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verdict_action": {
+          "name": "idx_verdict_action",
+          "columns": [
+            {
+              "expression": "verdict_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_visitor_fingerprint": {
+          "name": "idx_visitor_fingerprint",
+          "columns": [
+            {
+              "expression": "visitor_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_prompt_prefix": {
+      "name": "system_prompt_prefix",
+      "schema": "",
+      "columns": {
+        "system_prompt_prefix_id": {
+          "name": "system_prompt_prefix_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_prompt_prefix": {
+          "name": "system_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_system_prompt_prefix": {
+          "name": "UQ_system_prompt_prefix",
+          "columns": [
+            {
+              "expression": "system_prompt_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_admin_notes": {
+      "name": "user_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_content": {
+          "name": "note_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_kilo_user_id": {
+          "name": "admin_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_34517df0b385234babc38fe81b": {
+          "name": "IDX_34517df0b385234babc38fe81b",
+          "columns": [
+            {
+              "expression": "admin_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_ccbde98c4c14046daa5682ec4f": {
+          "name": "IDX_ccbde98c4c14046daa5682ec4f",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_d0270eb24ef6442d65a0b7853c": {
+          "name": "IDX_d0270eb24ef6442d65a0b7853c",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_auth_provider": {
+      "name": "user_auth_provider",
+      "schema": "",
+      "columns": {
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hosted_domain": {
+          "name": "hosted_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_auth_provider_kilo_user_id": {
+          "name": "IDX_user_auth_provider_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_auth_provider_hosted_domain": {
+          "name": "IDX_user_auth_provider_hosted_domain",
+          "columns": [
+            {
+              "expression": "hosted_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_auth_provider_provider_provider_account_id_pk": {
+          "name": "user_auth_provider_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feedback": {
+      "name": "user_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_for": {
+          "name": "feedback_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "feedback_batch": {
+          "name": "feedback_batch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_feedback_created_at": {
+          "name": "IDX_user_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_kilo_user_id": {
+          "name": "IDX_user_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_feedback_for": {
+          "name": "IDX_user_feedback_feedback_for",
+          "columns": [
+            {
+              "expression": "feedback_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_feedback_batch": {
+          "name": "IDX_user_feedback_feedback_batch",
+          "columns": [
+            {
+              "expression": "feedback_batch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_source": {
+          "name": "IDX_user_feedback_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "user_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_period_cache": {
+      "name": "user_period_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_type": {
+          "name": "cache_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "shared_url_token": {
+          "name": "shared_url_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_at": {
+          "name": "shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_user_period_cache_kilo_user_id": {
+          "name": "IDX_user_period_cache_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_user_period_cache": {
+          "name": "UQ_user_period_cache",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cache_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_period_cache_lookup": {
+          "name": "IDX_user_period_cache_lookup",
+          "columns": [
+            {
+              "expression": "cache_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_user_period_cache_share_token": {
+          "name": "UQ_user_period_cache_share_token",
+          "columns": [
+            {
+              "expression": "shared_url_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_period_cache\".\"shared_url_token\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_period_cache_kilo_user_id_kilocode_users_id_fk": {
+          "name": "user_period_cache_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_period_cache",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_period_cache_period_type_check": {
+          "name": "user_period_cache_period_type_check",
+          "value": "\"user_period_cache\".\"period_type\" IN ('year', 'quarter', 'month', 'week', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vercel_ip_city": {
+      "name": "vercel_ip_city",
+      "schema": "",
+      "columns": {
+        "vercel_ip_city_id": {
+          "name": "vercel_ip_city_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vercel_ip_city": {
+          "name": "vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_vercel_ip_city": {
+          "name": "UQ_vercel_ip_city",
+          "columns": [
+            {
+              "expression": "vercel_ip_city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_ip_country": {
+      "name": "vercel_ip_country",
+      "schema": "",
+      "columns": {
+        "vercel_ip_country_id": {
+          "name": "vercel_ip_country_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vercel_ip_country": {
+          "name": "vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_vercel_ip_country": {
+          "name": "UQ_vercel_ip_country",
+          "columns": [
+            {
+              "expression": "vercel_ip_country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlers_triggered": {
+          "name": "handlers_triggered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_signature": {
+          "name": "event_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_webhook_events_owned_by_org_id": {
+          "name": "IDX_webhook_events_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_owned_by_user_id": {
+          "name": "IDX_webhook_events_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_platform": {
+          "name": "IDX_webhook_events_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_event_type": {
+          "name": "IDX_webhook_events_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_created_at": {
+          "name": "IDX_webhook_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_events_owned_by_organization_id_organizations_id_fk": {
+          "name": "webhook_events_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_events_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "webhook_events_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_webhook_events_signature": {
+          "name": "UQ_webhook_events_signature",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_signature"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_owner_check": {
+          "name": "webhook_events_owner_check",
+          "value": "(\n        (\"webhook_events\".\"owned_by_user_id\" IS NOT NULL AND \"webhook_events\".\"owned_by_organization_id\" IS NULL) OR\n        (\"webhook_events\".\"owned_by_user_id\" IS NULL AND \"webhook_events\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.microdollar_usage_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_hit_tokens": {
+          "name": "cache_hit_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt_prefix": {
+          "name": "user_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_prefix": {
+          "name": "system_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_length": {
+          "name": "system_prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_discount": {
+          "name": "cache_discount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_middle_out_transform": {
+          "name": "has_middle_out_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abuse_classification": {
+          "name": "abuse_classification",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inference_provider": {
+          "name": "inference_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_latency": {
+          "name": "moderation_latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_time": {
+          "name": "generation_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_byok": {
+          "name": "is_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_byok": {
+          "name": "is_user_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_name": {
+          "name": "editor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_kind": {
+          "name": "api_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_model": {
+          "name": "auto_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_cost": {
+          "name": "market_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n  SELECT\n    mu.id,\n    mu.kilo_user_id,\n    meta.message_id,\n    mu.cost,\n    mu.input_tokens,\n    mu.output_tokens,\n    mu.cache_write_tokens,\n    mu.cache_hit_tokens,\n    mu.created_at,\n    ip.http_ip AS http_x_forwarded_for,\n    city.vercel_ip_city AS http_x_vercel_ip_city,\n    country.vercel_ip_country AS http_x_vercel_ip_country,\n    meta.vercel_ip_latitude AS http_x_vercel_ip_latitude,\n    meta.vercel_ip_longitude AS http_x_vercel_ip_longitude,\n    ja4.ja4_digest AS http_x_vercel_ja4_digest,\n    mu.provider,\n    mu.model,\n    mu.requested_model,\n    meta.user_prompt_prefix,\n    spp.system_prompt_prefix,\n    meta.system_prompt_length,\n    ua.http_user_agent,\n    mu.cache_discount,\n    meta.max_tokens,\n    meta.has_middle_out_transform,\n    mu.has_error,\n    mu.abuse_classification,\n    mu.organization_id,\n    mu.inference_provider,\n    mu.project_id,\n    meta.status_code,\n    meta.upstream_id,\n    frfr.finish_reason,\n    meta.latency,\n    meta.moderation_latency,\n    meta.generation_time,\n    meta.is_byok,\n    meta.is_user_byok,\n    meta.streamed,\n    meta.cancelled,\n    edit.editor_name,\n    ak.api_kind,\n    meta.has_tools,\n    meta.machine_id,\n    feat.feature,\n    meta.session_id,\n    md.mode,\n    am.auto_model,\n    meta.market_cost\n  FROM \"microdollar_usage\" mu\n  LEFT JOIN \"microdollar_usage_metadata\" meta ON mu.id = meta.id\n  LEFT JOIN \"http_ip\" ip ON meta.http_ip_id = ip.http_ip_id\n  LEFT JOIN \"vercel_ip_city\" city ON meta.vercel_ip_city_id = city.vercel_ip_city_id\n  LEFT JOIN \"vercel_ip_country\" country ON meta.vercel_ip_country_id = country.vercel_ip_country_id\n  LEFT JOIN \"ja4_digest\" ja4 ON meta.ja4_digest_id = ja4.ja4_digest_id\n  LEFT JOIN \"system_prompt_prefix\" spp ON meta.system_prompt_prefix_id = spp.system_prompt_prefix_id\n  LEFT JOIN \"http_user_agent\" ua ON meta.http_user_agent_id = ua.http_user_agent_id\n  LEFT JOIN \"finish_reason\" frfr ON meta.finish_reason_id = frfr.finish_reason_id\n  LEFT JOIN \"editor_name\" edit ON meta.editor_name_id = edit.editor_name_id\n  LEFT JOIN \"api_kind\" ak ON meta.api_kind_id = ak.api_kind_id\n  LEFT JOIN \"feature\" feat ON meta.feature_id = feat.feature_id\n  LEFT JOIN \"mode\" md ON meta.mode_id = md.mode_id\n  LEFT JOIN \"auto_model\" am ON meta.auto_model_id = am.auto_model_id\n",
+      "name": "microdollar_usage_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/0055_snapshot.json
+++ b/packages/db/src/migrations/meta/0055_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "0aac3b28-6d4a-4e06-8498-598994aca366",
-  "prevId": "e224c983-7ffd-44ad-a3c4-0ea790a845ba",
+  "id": "9600f403-2728-4aab-a953-205b55e2a683",
+  "prevId": "c4aaa257-8eab-4be2-871f-3cca574e68e2",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -4745,18 +4745,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "included_tools": {
-          "name": "included_tools",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "excluded_tools": {
-          "name": "excluded_tools",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
         "supports_image_input": {
           "name": "supports_image_input",
           "type": "boolean",
@@ -4777,6 +4765,12 @@
         },
         "extra_body": {
           "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_headers": {
+          "name": "extra_headers",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": false
@@ -7211,6 +7205,121 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.kiloclaw_admin_audit_logs": {
+      "name": "kiloclaw_admin_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_admin_audit_logs_target_user_id": {
+          "name": "IDX_kiloclaw_admin_audit_logs_target_user_id",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_admin_audit_logs_action": {
+          "name": "IDX_kiloclaw_admin_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_admin_audit_logs_created_at": {
+          "name": "IDX_kiloclaw_admin_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.kiloclaw_earlybird_purchases": {
       "name": "kiloclaw_earlybird_purchases",
       "schema": "",
@@ -7693,6 +7802,24 @@
           "primaryKey": false,
           "notNull": false
         },
+        "payment_source": {
+          "name": "payment_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_renewal_at": {
+          "name": "credit_renewal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_triggered_for_period": {
+          "name": "auto_top_up_triggered_for_period",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -7789,6 +7916,10 @@
         "kiloclaw_subscriptions_status_check": {
           "name": "kiloclaw_subscriptions_status_check",
           "value": "\"kiloclaw_subscriptions\".\"status\" IN ('trialing', 'active', 'past_due', 'canceled', 'unpaid')"
+        },
+        "kiloclaw_subscriptions_payment_source_check": {
+          "name": "kiloclaw_subscriptions_payment_source_check",
+          "value": "\"kiloclaw_subscriptions\".\"payment_source\" IN ('stripe', 'credits')"
         }
       },
       "isRLSEnabled": false

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1773915107293,
       "tag": "0054_strong_the_spike",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1773895178295,
+      "tag": "0055_kiloclaw-credit-billing",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -390,8 +390,8 @@
     {
       "idx": 55,
       "version": "7",
-      "when": 1773895178295,
-      "tag": "0055_kiloclaw-credit-billing",
+      "when": 1773986342535,
+      "tag": "0055_lush_bedlam",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -164,6 +164,14 @@ export const KiloClawAdminAuditAction = z.enum([
 
 export type KiloClawAdminAuditAction = z.infer<typeof KiloClawAdminAuditAction>;
 
+export const KiloClawPaymentSource = {
+  Stripe: 'stripe',
+  Credits: 'credits',
+} as const;
+
+export type KiloClawPaymentSource =
+  (typeof KiloClawPaymentSource)[keyof typeof KiloClawPaymentSource];
+
 // =============================================================================
 // B. Type-Only Definitions (used in $type<T>())
 // =============================================================================

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -101,6 +101,7 @@ describe('database schema', () => {
       KiloClawScheduledPlan: ['commit', 'standard'],
       KiloClawScheduledBy: ['auto', 'user'],
       KiloClawSubscriptionStatus: ['trialing', 'active', 'past_due', 'canceled', 'unpaid'],
+      KiloClawPaymentSource: ['stripe', 'credits'],
     };
 
     const actualEnumValues: Record<string, string[]> = {};

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -41,6 +41,7 @@ import {
   KiloClawScheduledPlan,
   KiloClawScheduledBy,
   KiloClawSubscriptionStatus,
+  KiloClawPaymentSource,
 } from './schema-types';
 import type { KiloClawAdminAuditAction } from './schema-types';
 import type {
@@ -3489,6 +3490,9 @@ export const kiloclaw_subscriptions = pgTable(
     past_due_since: timestamp({ withTimezone: true, mode: 'string' }),
     suspended_at: timestamp({ withTimezone: true, mode: 'string' }),
     destruction_deadline: timestamp({ withTimezone: true, mode: 'string' }),
+    payment_source: text().$type<KiloClawPaymentSource>(),
+    credit_renewal_at: timestamp({ withTimezone: true, mode: 'string' }),
+    auto_top_up_triggered_for_period: timestamp({ withTimezone: true, mode: 'string' }),
     created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
     updated_at: timestamp({ withTimezone: true, mode: 'string' })
       .defaultNow()
@@ -3506,6 +3510,11 @@ export const kiloclaw_subscriptions = pgTable(
     ),
     enumCheck('kiloclaw_subscriptions_scheduled_by_check', table.scheduled_by, KiloClawScheduledBy),
     enumCheck('kiloclaw_subscriptions_status_check', table.status, KiloClawSubscriptionStatus),
+    enumCheck(
+      'kiloclaw_subscriptions_payment_source_check',
+      table.payment_source,
+      KiloClawPaymentSource
+    ),
   ]
 );
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -113,6 +113,7 @@ export const SCHEMA_CHECK_ENUMS = {
   KiloClawScheduledPlan,
   KiloClawScheduledBy,
   KiloClawSubscriptionStatus,
+  KiloClawPaymentSource,
 } as const;
 
 export const credit_transactions = pgTable(

--- a/plans/kiloclaw-billing-credits.md
+++ b/plans/kiloclaw-billing-credits.md
@@ -1,0 +1,839 @@
+# KiloClaw Stripe-to-Credits Billing Migration
+
+## Background
+
+This plan converts KiloClaw Stripe subscriptions into credit-accounted
+subscriptions, where Stripe still collects payment but the local billing
+engine tracks the period via credits. The result is a "hybrid" row:
+`payment_source='credits'` with a non-null `stripe_subscription_id`.
+
+Based on PLAN-OPUS-CODEX.md (source of truth for ownership model and
+implementation order) and PLAN-OPUS-OPUS.md (supplementary reference for
+concrete code examples and risk walkthroughs).
+
+## Design Summary
+
+On each KiloClaw `invoice.paid`:
+
+1. Classify the invoice as KiloClaw by price ID
+2. Add credits via `processTopUp()` using the invoice's charge ID
+3. Insert a matching negative `credit_transactions` row (same transaction)
+4. Advance the billing period using invoice-derived boundaries
+5. Set `payment_source = 'credits'`, preserving `stripe_subscription_id`
+
+The user's visible credit balance never changes — the positive and negative
+entries cancel out atomically within a single DB transaction.
+
+Key design properties:
+
+- **Lazy migration**: existing Stripe rows convert on their next paid
+  invoice. No backfill, no flag day.
+- **Invoice amount in, same amount out**: the settled Stripe amount becomes
+  the credit deduction. First-month discounts ($5) flow through naturally.
+- **Balance neutrality**: `processTopUp` and the deduction share a single
+  DB transaction via `dbOrTx` (`credits.ts:59`).
+- **Idempotency**: positive entry keyed by Stripe charge ID via
+  `processTopUp()`; negative entry keyed by `buildCreditCategory()` with
+  `onConflictDoNothing()`.
+- **Explicit ownership split**: successful settlement owned by
+  `invoice.paid`; dunning/failure by `subscription.updated`; pure-credit
+  renewals by the local sweep.
+
+## Three Valid Subscription States
+
+After migration, these are the only valid `(payment_source,
+stripe_subscription_id)` combinations:
+
+| State         | payment_source | stripe_subscription_id | Owner                                                               |
+| ------------- | -------------- | ---------------------- | ------------------------------------------------------------------- |
+| Legacy Stripe | `stripe`       | non-null               | Stripe webhooks own everything                                      |
+| Hybrid        | `credits`      | non-null               | `invoice.paid` owns settlement; `subscription.updated` owns dunning |
+| Pure credit   | `credits`      | null                   | Local credit sweep owns renewal                                     |
+
+## Ownership Model
+
+- **`invoice.paid`**
+  - Authoritative for hybrid-row successful settlement
+  - Authoritative for hybrid-row period advancement
+  - Authoritative for hybrid-row plan transition at renewal
+  - Authoritative for hybrid-row recovery to `active`
+  - Authoritative for hybrid-row `commit_ends_at` when a settled commit
+    period is applied
+- **`subscription.updated`**
+  - Authoritative for legacy Stripe rows (current behavior, unchanged)
+  - For hybrid rows: cancel intent and non-active Stripe dunning state
+    propagation ONLY
+  - Must NOT recover hybrid rows to `active`, clear suspension fields,
+    or overwrite plan/period/commitment fields
+- **`subscription_schedule.*`**
+  - Still authoritative for schedule lifecycle cleanup
+  - Must NOT be relied on for hybrid plan mutation during natural releases
+- **`runCreditRenewalSweep()`**
+  - Authoritative only for pure credit-funded rows
+- **`billing-lifecycle-cron`**
+  - Retries interrupted auto-resumes for ALL credit-accounted rows,
+    including hybrid
+
+Critical behavioral boundary:
+
+- Hybrid success path -> `invoice.paid`
+- Hybrid failure path -> `subscription.updated`
+- Pure-credit renewal path -> renewal sweep
+
+## Prerequisite: Billing Spec Update
+
+The spec at `.specs/kiloclaw-billing.md` must be updated first. Current
+rules that prohibit the hybrid state:
+
+- Rule 2 (line 62): "A subscription with payment source `credits` MUST
+  have a null payment provider subscription ID."
+- Rule 5 (line 68): switching payment source requires cancel + re-enroll.
+
+The spec update must define:
+
+1. Three valid `(payment_source, stripe_subscription_id)` states (table
+   above)
+2. Hybrid-row ownership: `invoice.paid` owns settlement, plan mutation,
+   period fields, `credit_renewal_at`, and recovery to `active`;
+   `subscription.updated` owns cancel intent and non-active dunning state
+   propagation only
+3. Renewal-sweep scope: hybrid rows are excluded
+4. Auto-resume retry scope: the interrupted auto-resume retry
+   (`billing-lifecycle-cron.ts:155-179`) still includes hybrid rows
+5. Hybrid plan switching: when a settled invoice reflects a new plan, the
+   local plan mutation and schedule-field cleanup happen atomically in
+   the invoice-settlement path
+
+## Risks and Mitigations
+
+### 1. `subscription.created` races with `invoice.paid`
+
+Stripe fires both for a new checkout. Either can arrive first.
+`handleKiloClawSubscriptionCreated` (`stripe-handlers.ts:89-217`)
+unconditionally sets `payment_source: 'stripe'`, `plan`, `commit_ends_at`,
+`current_period_start`, and `current_period_end` — all of which would
+revert a row already converted by `invoice.paid`.
+
+**Mitigation (Step 2)**: Guard the upsert's `onConflictDoUpdate.set` with
+SQL `CASE` expressions. If the existing row has `payment_source = 'credits'`,
+preserve `payment_source`, `plan`, `commit_ends_at`, `current_period_start`,
+`current_period_end`, and `credit_renewal_at`. Still update
+`stripe_subscription_id`, `cancel_at_period_end`, and other Stripe metadata.
+
+### 2. `subscription.updated` reverts converted rows
+
+`handleKiloClawSubscriptionUpdated` (`stripe-handlers.ts:222-318`)
+unconditionally writes `payment_source: 'stripe'`, `plan`, period fields,
+`commit_ends_at`, and — when the incoming status is `active` — clears
+`suspended_at` and `destruction_deadline` (line 299).
+
+The suspension-clearing behavior is a real bug surface for hybrid rows.
+Current code at line 299:
+
+```ts
+...(status === 'active' ? { suspended_at: null, destruction_deadline: null } : {})
+```
+
+If `subscription.updated(active)` fires for a hybrid row before
+`invoice.paid` arrives, it would falsely clear suspension without the
+settlement having occurred. The success page
+(`KiloClawCheckoutSuccessClient.tsx:19`) also treats `status === 'active'`
+as sufficient, compounding the issue.
+
+**Mitigation (Step 3)**: Pre-read the row. For hybrid rows, allow ONLY:
+
+- `cancel_at_period_end`
+- Non-active Stripe dunning states (`past_due`, `unpaid`, defensive
+  terminal fallback)
+- `past_due_since` (via existing `COALESCE(...)` pattern)
+
+For hybrid rows, do NOT sync:
+
+- `payment_source`
+- `plan`
+- `current_period_start`, `current_period_end`
+- `credit_renewal_at`
+- `commit_ends_at`
+- Recovery to `active`
+- Clearing of `past_due_since`
+- Clearing of `suspended_at`
+- Clearing of `destruction_deadline`
+- `autoResumeIfSuspended()` side effects
+
+### 3. Sweep acts on hybrid rows before `invoice.paid` arrives
+
+The credit renewal sweep (`credit-billing.ts:329-360`) selects all
+`payment_source='credits'` rows with `credit_renewal_at <= now()`. After
+conversion, hybrid rows match this query.
+
+Concrete failure scenario:
+
+1. Hybrid row's `credit_renewal_at` passes
+2. Stripe is processing the subscription invoice; webhook hasn't fired
+3. Sweep runs, selects the row, checks balance: user has $2 in credits
+4. $2 < $9 (standard) or $2 < $48 (commit) -> insufficient balance
+5. If auto-top-up enabled: `triggerAutoTopUpForKiloClaw` fires
+   (`credit-billing.ts:533`), creating a spurious Stripe charge — user
+   gets double-billed
+6. If auto-top-up disabled: sweep marks the row `past_due` and sends a
+   `credit-renewal-failed` email for a subscription Stripe is about to
+   pay successfully
+
+The `buildCreditCategory` idempotency key prevents double _deduction_,
+but the insufficient-balance path (auto-top-up trigger, `past_due` marking,
+notification emails) executes _before_ the deduction attempt. The
+idempotency key protects the wrong layer.
+
+**Mitigation (Step 5)**: Add `isNull(stripe_subscription_id)` to the
+sweep's WHERE clause. For hybrid rows, Stripe's dunning handles payment
+failure; `subscription.updated` (with Step 3's guard) propagates
+`past_due` to the local row.
+
+### 4. Router blocks billing portal for converted rows
+
+`createBillingPortalSession` (`kiloclaw-router.ts:1547-1552`) blocks when
+`payment_source === 'credits'`. After conversion, hybrid rows need portal
+access for Stripe payment method management.
+
+**Mitigation (Step 4)**: Branch on `stripe_subscription_id` presence, not
+`payment_source`. This is a safe no-op before hybrid rows exist — no
+pure-credit rows have a `stripe_subscription_id`.
+
+### 5. `subscription.updated(active)` falsely implies successful settlement
+
+Current code clears suspension on `active` (`stripe-handlers.ts:299`) and
+the success page treats `active` alone as success. For hybrid rows, an
+`active` status from Stripe does not mean the invoice has been locally
+settled — `invoice.paid` owns that.
+
+**Mitigation**: Step 3's hybrid guard blocks recovery writes from
+`subscription.updated`. Step 9's success page change waits for both
+`status === 'active'` AND `paymentSource === 'credits'`.
+
+### 6. Natural schedule releases clear tracking before invoice settlement
+
+`handleKiloClawScheduleEvent` (`stripe-handlers.ts:406-412`) has a comment
+that says `subscription.updated` picks up the new price via
+`detectPlanFromSubscription`. The same assumption appears in `switchPlan`
+(`kiloclaw-router.ts:1468-1473`). Under the hybrid design, this is wrong:
+`invoice.paid` owns the plan mutation.
+
+If the schedule release event arrives before `invoice.paid`, it clears
+`scheduled_plan`, `scheduled_by`, and `stripe_schedule_id`. The settlement
+helper then has no local record of the pending switch.
+
+**Mitigation (Step 8)**: Update `handleKiloClawScheduleEvent` so hybrid
+rows don't rely on schedule events for plan mutation. The `invoice.paid`
+handler (Step 7) must derive the plan from the invoice line item's price
+ID, not from `scheduled_plan`.
+
+### 7. Invoice field extraction must be null-safe
+
+Relevant Stripe fields may be missing, string IDs instead of expanded
+objects, or arrays with no matching KiloClaw line item.
+
+**Mitigation**: Use explicit guards for `invoice.subscription`,
+`invoice.charge`, line-item selection, `line.period.start`, and
+`line.period.end`. No `!` assertions. No bare `[0]` indexing. Bail with
+a warning log if any required field is missing.
+
+Charge ID extraction pattern (from `stripe.ts:636`):
+
+```ts
+const chargeId = 'charge' in invoice && typeof invoice.charge === 'string' ? invoice.charge : null;
+```
+
+### 8. Balance inflation window
+
+If `processTopUp` and the deduction are not in the same transaction, the
+user's balance is temporarily inflated.
+
+**Mitigation**: Pass `dbOrTx` into `processTopUp()` (`credits.ts:59`) and
+perform the negative credit transaction, balance decrement, and
+subscription-row mutation in the same DB transaction.
+
+## Implementation Steps
+
+### Step 1: Fix stale code artifacts
+
+These misled adversarial reviews into flagging non-existent blockers. They
+will mislead implementing engineers the same way.
+
+**`src/lib/kiloclaw/stripe-handlers.ts` (line 271)**
+
+Change:
+
+```
+// This fires naturally on monthly renewal webhooks
+```
+
+To:
+
+```
+// This fires naturally on renewal webhooks
+```
+
+The commit price is $48 every 6 months, not monthly.
+
+**`src/lib/kiloclaw/credit-billing.ts` (line 48)**
+
+Change:
+
+```
+/** Standard bills monthly (1 month), commit bills every 6 months ($54/6mo). */
+```
+
+To:
+
+```
+/** Standard bills monthly (1 month), commit bills every 6 months ($48/6mo). */
+```
+
+The $54 price was changed to $48 on 2026-03-19.
+
+**`src/routers/kiloclaw-billing-router.test.ts` (line 176)**
+
+The `makeStripeSubscription` fixture uses `now + 86400 * 30` (30-day
+period) for all plans including commit, where the actual Stripe commit
+period is 6 months. Either use `86400 * 180` for commit plan fixtures or
+add a comment explaining the test is period-length-agnostic.
+
+### Step 2: Guard `handleKiloClawSubscriptionCreated`
+
+**File**: `src/lib/kiloclaw/stripe-handlers.ts` (lines 166-202)
+
+Change the upsert's `onConflictDoUpdate.set` to preserve converted-row
+state. For an existing hybrid row, preserve:
+
+- `payment_source`
+- `plan`
+- `current_period_start`
+- `current_period_end`
+- `credit_renewal_at`
+- `commit_ends_at`
+
+Use SQL `CASE` expressions:
+
+```ts
+payment_source: sql`CASE
+  WHEN ${kiloclaw_subscriptions.payment_source} = 'credits' THEN 'credits'
+  ELSE 'stripe'
+END`,
+plan: sql`CASE
+  WHEN ${kiloclaw_subscriptions.payment_source} = 'credits'
+    THEN ${kiloclaw_subscriptions.plan}
+  ELSE ${plan}
+END`,
+current_period_start: sql`CASE
+  WHEN ${kiloclaw_subscriptions.payment_source} = 'credits'
+    THEN ${kiloclaw_subscriptions.current_period_start}
+  ELSE ${periods.current_period_start}
+END`,
+current_period_end: sql`CASE
+  WHEN ${kiloclaw_subscriptions.payment_source} = 'credits'
+    THEN ${kiloclaw_subscriptions.current_period_end}
+  ELSE ${periods.current_period_end}
+END`,
+commit_ends_at: sql`CASE
+  WHEN ${kiloclaw_subscriptions.payment_source} = 'credits'
+    THEN ${kiloclaw_subscriptions.commit_ends_at}
+  ELSE ${commitEndsAt}
+END`,
+```
+
+Still update regardless of conversion state:
+
+- `stripe_subscription_id`
+- `cancel_at_period_end`
+- `status` (only for non-hybrid; for hybrid rows, `status` is already
+  managed by `invoice.paid` and `subscription.updated`'s dunning path)
+
+This guard is a safe no-op before hybrid rows exist. The `CASE` always
+takes the ELSE branch for existing `payment_source='stripe'` rows.
+
+### Step 3: Guard `handleKiloClawSubscriptionUpdated` for hybrid rows
+
+**File**: `src/lib/kiloclaw/stripe-handlers.ts` (lines 222-318)
+
+Before the main update (line 259), pre-read the row:
+
+```ts
+const [existingRow] = await db
+  .select({
+    payment_source: kiloclaw_subscriptions.payment_source,
+    stripe_subscription_id: kiloclaw_subscriptions.stripe_subscription_id,
+  })
+  .from(kiloclaw_subscriptions)
+  .where(
+    and(
+      eq(kiloclaw_subscriptions.user_id, kiloUserId),
+      eq(kiloclaw_subscriptions.stripe_subscription_id, subscription.id)
+    )
+  )
+  .limit(1);
+
+const isHybrid =
+  existingRow?.payment_source === 'credits' && existingRow?.stripe_subscription_id !== null;
+```
+
+**If `isHybrid`**, only sync:
+
+- `cancel_at_period_end`
+- Non-active Stripe dunning status: `past_due`, `unpaid`, defensive
+  terminal fallback
+- `past_due_since` (via existing `COALESCE(...)` pattern)
+
+**If `isHybrid`**, do NOT sync:
+
+- `payment_source`
+- `plan`
+- `current_period_start`, `current_period_end`
+- `credit_renewal_at`
+- `commit_ends_at`
+- Recovery to `active`
+- Clearing of `past_due_since`
+- Clearing of `suspended_at`
+- Clearing of `destruction_deadline`
+- `autoResumeIfSuspended()` side effects
+
+**If NOT hybrid** (`payment_source='stripe'`): keep current behavior
+unchanged.
+
+**Why status sync is needed for hybrid rows**: Step 5 excludes hybrid
+rows from the credit sweep's insufficient-balance path. Stripe's
+`subscription.updated` webhook is the only mechanism that can set
+`past_due` for hybrid rows when payment fails.
+
+**Why plan sync is skipped for hybrid rows**: `invoice.paid` is the
+authoritative moment when the plan and period advance together. If
+`subscription.updated` synced `plan` before the corresponding invoice
+is paid (e.g. a scheduled plan switch executes), the local row would
+show the new plan with the old period — an inconsistent state.
+
+Also update the stale comment at line 271 (if not already done in Step 1).
+
+### Step 4: Move router billing mutations to `stripe_subscription_id` branching
+
+**File**: `src/routers/kiloclaw-router.ts`
+
+Change branching from `payment_source === 'credits'` to
+`stripe_subscription_id` presence in:
+
+#### `cancelSubscription` (line 1284-1363)
+
+- Current: `if (sub.payment_source === 'credits')` -> local-only
+- New: `if (!sub.stripe_subscription_id)` -> local-only; else -> local + Stripe
+
+Converted rows cancel both locally and on Stripe, keeping the funding
+subscription in sync.
+
+#### `reactivateSubscription` (line 1365-1403)
+
+- Same change: `!sub.stripe_subscription_id` instead of
+  `payment_source === 'credits'`
+
+#### `switchPlan` (line 1405-1496)
+
+- Same change: `!sub.stripe_subscription_id`
+- Converted rows still use Stripe subscription schedules for plan switches
+
+#### `cancelPlanSwitch` (line 1498-1538)
+
+- Same change: `!sub.stripe_subscription_id` (and check
+  `!sub.stripe_schedule_id`)
+
+#### `createBillingPortalSession` (line 1540-1565)
+
+- Current: blocks when `payment_source === 'credits'` (line 1547-1552)
+- New: block when `!sub.stripe_subscription_id`
+
+**Why this deploys before the conversion path**: Without this fix, a
+freshly converted hybrid row would lose portal access. The branching
+change is a safe no-op — no pure-credit rows have a
+`stripe_subscription_id`, so behavior is identical for all existing rows.
+
+### Step 5: Exclude hybrid rows from `runCreditRenewalSweep`
+
+**File**: `src/lib/kiloclaw/credit-billing.ts` (lines 329-360)
+
+Add `isNull(stripe_subscription_id)` to the sweep's WHERE clause:
+
+```ts
+.where(
+  and(
+    eq(kiloclaw_subscriptions.payment_source, 'credits'),
+    isNull(kiloclaw_subscriptions.stripe_subscription_id),
+    or(
+      eq(kiloclaw_subscriptions.status, 'active'),
+      eq(kiloclaw_subscriptions.status, 'past_due')
+    ),
+    lte(kiloclaw_subscriptions.credit_renewal_at, now)
+  )
+)
+```
+
+**Important non-change**: Do NOT add the same filter to the interrupted
+auto-resume retry in `billing-lifecycle-cron.ts:155-179`. That retry
+should continue to select hybrid rows. A hybrid row can need retry if
+`autoResumeIfSuspended()` started but failed mid-flight —
+`autoResumeIfSuspended` (`credit-billing.ts:215`) explicitly leaves
+`suspended_at` set so the cron can retry.
+
+**Why this deploys before the conversion path**: Without the sweep
+exclusion, the sweep can act on newly converted rows before
+`invoice.paid` arrives. The `isNull(stripe_subscription_id)` filter is a
+safe no-op — no pure-credit rows have a `stripe_subscription_id`.
+
+### Step 6: Add `applyStripeFundedKiloClawPeriod`
+
+**File**: `src/lib/kiloclaw/credit-billing.ts`
+
+New exported function alongside `enrollWithCredits`:
+
+```ts
+applyStripeFundedKiloClawPeriod({
+  userId: string,
+  plan: 'commit' | 'standard',
+  invoiceAmountCents: number,
+  stripeSubscriptionId: string,
+  periodStart: string, // from invoice line item
+  periodEnd: string, // from invoice line item
+  chargeId: string, // for processTopUp stripe_payment_id
+  user: User, // for processTopUp
+});
+```
+
+Inside one DB transaction:
+
+1. Load the existing subscription row:
+   - `status`, `suspended_at`, `plan`, `commit_ends_at`, `scheduled_plan`,
+     `scheduled_by`, `stripe_schedule_id`
+
+2. Call `processTopUp(user, invoiceAmountCents, { type: 'stripe',
+stripe_payment_id: chargeId }, { skipPostTopUpFreeStuff: true,
+dbOrTx: tx })`
+
+3. If `processTopUp()` returns false (duplicate charge ID), return early
+   (idempotent)
+
+4. Build the deduction key: `buildCreditCategory(plan,
+new Date(periodStart))` — using the invoice's period start, not
+   wall-clock time
+
+5. Insert negative `credit_transactions` row with
+   `check_category_uniqueness: true`, `onConflictDoNothing()`
+
+6. Decrement `kilocode_users.total_microdollars_acquired` by
+   `invoiceAmountCents * 10_000` (microdollars)
+
+7. Upsert `kiloclaw_subscriptions`:
+   - `plan` = invoice-derived plan
+   - `status` = `'active'`
+   - `payment_source` = `'credits'`
+   - Preserve `stripe_subscription_id` (do NOT null it)
+   - `current_period_start` = `periodStart`
+   - `current_period_end` = `periodEnd`
+   - `credit_renewal_at` = `periodEnd`
+   - `commit_ends_at` = `periodEnd` for commit, `null` for standard
+   - Clear `past_due_since`
+   - Clear `auto_top_up_triggered_for_period`
+   - On conflict update (keyed on `user_id`)
+
+8. Hybrid plan-switch handling:
+   - If the local row has `scheduled_plan === plan`, clear
+     `scheduled_plan`, `scheduled_by`, and `stripe_schedule_id`
+     atomically with the plan update
+   - If the invoice plan differs from the local row and there is no
+     matching `scheduled_plan`, trust the settled invoice as authoritative
+     and log a warning
+
+Post-transaction:
+
+- If the pre-transaction row was `past_due` or `suspended_at` was set,
+  call `autoResumeIfSuspended()`
+- Call `evaluateKiloPassBonusAfterDeduction()`
+
+**Important rules for this helper**:
+
+- Use invoice-derived period boundaries only
+- Do NOT call `periodLengthMonths()` for the hybrid path
+- Do NOT call `planCostMicrodollars()` for the hybrid path
+- Apply hybrid plan transitions here, not in `subscription.updated`
+
+The deduction amount is `invoiceAmountCents * 10_000` (microdollars),
+matching `processTopUp`'s conversion. $5 discounted first month in from
+Stripe = $5 deducted from credits.
+
+**Open verification item**: Confirm in tests that the commit invoice line
+item's `period.end` is always the real six-month commitment boundary. If
+that holds, `commit_ends_at = periodEnd` is correct and simpler than
+computing from previous boundaries. If Stripe uses a different period
+representation for commit, adjust `commit_ends_at` computation
+accordingly.
+
+### Step 7: KiloClaw `invoice.paid` webhook handler
+
+**File**: `src/lib/stripe.ts` (in `processStripePaymentEventHook`,
+`invoice.paid` case)
+
+Insert new handling after the Kilo Pass check (line 623-628) and before
+the auto-top-up check (line 630):
+
+```ts
+const isKiloClawByPriceId = invoiceLooksLikeKiloClawByPriceId(invoice);
+if (isKiloClawByPriceId) {
+  await handleKiloClawInvoicePaid({ eventId: event.id, invoice });
+  break;
+}
+```
+
+New handler function (in `stripe-handlers.ts` or a new file):
+
+1. Extract `chargeId` safely (pattern from `stripe.ts:636`)
+2. Extract subscription ID from `invoice.subscription` (handle string
+   or expanded object)
+3. Fetch subscription via `stripe.subscriptions.retrieve(subId)`
+4. Extract `kiloUserId` from metadata via `getKiloClawMetadata`
+   (`stripe-handlers.ts:23`)
+5. Determine the settled plan from the matching KiloClaw invoice line
+   item's price ID via `getClawPlanForStripePriceId`
+   (`stripe-price-ids.server.ts:31`) — do NOT assume
+   `invoice.lines.data[0]` is the relevant line; find the line item
+   whose price ID maps to a KiloClaw plan
+6. Extract `periodStart` and `periodEnd` from that same matching line
+   item — verify `line.period` exists before accessing `.start`/`.end`
+7. Load user row for `processTopUp`
+8. Call `applyStripeFundedKiloClawPeriod(...)` from Step 6
+9. Log success
+
+**Null safety**: Every field extracted from the Stripe invoice must have
+explicit null/undefined guards. No `!` assertions. No bare `[0]`
+indexing without checking array length. Bail with a warning log if any
+required field is missing.
+
+This handler must not rely on `scheduled_plan` still existing locally
+because a schedule release event may have already cleared it.
+
+### Step 8: Align schedule-event behavior with hybrid ownership
+
+**File**: `src/lib/kiloclaw/stripe-handlers.ts` (lines 371-439)
+
+Update `handleKiloClawScheduleEvent()` to match the new ownership model.
+
+Required changes:
+
+- Remove or rewrite the comment at lines 406-412 that says
+  `subscription.updated` picks up the new price on natural release
+- Do not rely on schedule events to mutate hybrid `plan`
+- If needed, add a hybrid-row guard so terminal schedule events clear
+  tracking fields (`stripe_schedule_id`, `scheduled_plan`, `scheduled_by`)
+  without mutating `plan` or `commit_ends_at` for hybrid rows
+
+Legacy Stripe rows can keep their current schedule behavior until they
+convert.
+
+Also update `switchPlan` at `kiloclaw-router.ts:1468-1473` to remove the
+comment that says the plan change is picked up by `subscription.updated`
+via `detectPlanFromSubscription`.
+
+### Step 9: Update billing status, types, and success flow
+
+**File**: `src/routers/kiloclaw-router.ts` (lines 1110-1132)
+
+Add `hasStripeFunding` to the subscription object:
+
+```ts
+hasStripeFunding: !!sub.stripe_subscription_id,
+```
+
+Note: this is `!!sub.stripe_subscription_id`, NOT
+`payment_source === 'credits' && !!sub.stripe_subscription_id`. The
+latter would mis-classify legacy Stripe rows — they have Stripe funding
+too. The simpler form covers all Stripe-funded rows correctly:
+`hasStripeFunding` is true for both legacy and hybrid rows, false only for
+pure credit rows.
+
+**File**: `src/app/(app)/claw/components/billing/billing-types.ts`
+
+Add to the subscription type:
+
+```ts
+hasStripeFunding: boolean;
+```
+
+For `renewalCostMicrodollars`: for `hasStripeFunding` rows, display a
+plan-based approximation ($9 standard, $48 commit), or set to `null` and
+show "Billed via Stripe" in the UI.
+
+**File**: `src/app/payments/kiloclaw/success/KiloClawCheckoutSuccessClient.tsx`
+(line 19)
+
+Change the activation check to wait for conversion:
+
+```ts
+const isActive =
+  billingStatus?.subscription?.status === 'active' &&
+  billingStatus?.subscription?.paymentSource === 'credits';
+```
+
+This ensures the success page waits until `invoice.paid` has processed
+(which flips `payment_source` to `'credits'`), rather than showing success
+as soon as `subscription.created` sets status `active` with
+`payment_source='stripe'`.
+
+### Step 10: Frontend UI updates
+
+**File**: `src/app/(app)/claw/components/billing/SubscriptionCard.tsx`
+
+- `ActiveSubscriptionCard`: show "Manage" button (billing portal) only
+  when `hasStripeFunding` is true. Pure credit rows have no Stripe
+  subscription to manage.
+- `PastDueSubscriptionCard`: branch copy on `hasStripeFunding`:
+  - Stripe-funded: "Update your payment method"
+  - Pure credit: "Add credits" / "Top up balance"
+
+**File**: `src/app/(app)/claw/components/billing/AccessLockedDialog.tsx`
+
+- "Redirected to Stripe" messaging: show only for Stripe-funded rows.
+  Pure credit rows should reference credits.
+- `past_due_grace_exceeded` copy: branch on `hasStripeFunding`:
+  - Stripe-funded: "Update your payment method"
+  - Pure credit: "Insufficient KiloClaw credits"
+
+### Step 11: Tests
+
+**Files**:
+
+- `src/lib/kiloclaw/credit-billing.test.ts` (existing)
+- `src/routers/kiloclaw-billing-router.test.ts` (existing)
+- New handler-specific test file for `invoice.paid` if needed
+
+#### 1. `applyStripeFundedKiloClawPeriod`
+
+- Standard discounted first invoice ($5)
+- Standard full-price renewal ($9)
+- Commit 6-month renewal ($48)
+- Legacy Stripe row conversion (`payment_source` flips to `'credits'`)
+- Idempotency: duplicate `invoice.paid` -> no double credit, no double
+  deduction
+- Past-due recovery: row is `past_due` -> invoice arrives -> active
+- Suspended recovery: row has `suspended_at` -> invoice arrives ->
+  auto-resumes
+- Cancel-at-period-end + invoice arrives -> still advances period
+- Period boundaries come from invoice, not from `periodLengthMonths`
+- Settled hybrid plan switch applies plan and clears local schedule fields
+- Invoice plan diverges from local row with no matching `scheduled_plan`
+  -> trusts invoice, logs warning
+
+#### 2. Webhook guards
+
+- `subscription.created` after `invoice.paid` does NOT revert
+  `payment_source` to `'stripe'`
+- `subscription.created` after `invoice.paid` does NOT overwrite `plan`,
+  `commit_ends_at`, `current_period_start`, `current_period_end`, or
+  `credit_renewal_at`
+- `subscription.created` still updates `stripe_subscription_id` and cancel
+  intent for converted rows
+- Hybrid `subscription.updated` propagates `past_due`
+- Hybrid `subscription.updated` propagates `unpaid`
+- Hybrid `subscription.updated(active)` does NOT clear suspension or
+  advance period fields
+- Hybrid `subscription.updated` does NOT overwrite `payment_source`,
+  `plan`, `current_period_start`, `current_period_end`, or `commit_ends_at`
+- Non-hybrid `subscription.updated`: full current behavior preserved
+
+#### 3. Sweep exclusion
+
+- Hybrid row due for renewal is NOT selected by the sweep
+- Hybrid row due for renewal does NOT trigger KiloClaw auto-top-up
+- Hybrid row due for renewal does NOT get marked `past_due`
+- Pure credit sweep behavior remains unchanged
+
+#### 4. Interrupted auto-resume retry
+
+- Hybrid `active` row with non-null `suspended_at` is still selected
+  by the retry query
+- Retry still calls `autoResumeIfSuspended()` for hybrid rows
+
+#### 5. Router mutations
+
+- Hybrid cancel calls Stripe + local DB
+- Hybrid reactivate calls Stripe + local DB
+- Hybrid switch plan creates a Stripe schedule
+- Hybrid cancel plan switch releases the Stripe schedule
+- Hybrid billing portal is allowed
+- Pure credit billing portal remains blocked
+
+#### 6. Schedule/invoice ordering
+
+- Natural schedule release before `invoice.paid` does not prevent settled
+  invoice plan application
+- Natural schedule release after `invoice.paid` is harmless
+
+#### 7. Regressions
+
+- Pure `enrollWithCredits()` still works
+- Pure credit renewal sweep still works
+- Kilo Pass `invoice.paid` handling is unchanged
+- Generic top-up flow is unchanged
+
+## Implementation Order
+
+1. Update the billing spec (`.specs/kiloclaw-billing.md`)
+2. **Step 1**: Fix stale code artifacts
+3. **Step 2**: Guard `handleKiloClawSubscriptionCreated`
+4. **Step 3**: Guard `handleKiloClawSubscriptionUpdated` for hybrid rows
+5. **Step 4**: Router discriminant cleanup
+6. **Step 5**: Sweep exclusion for hybrid rows
+7. **Step 6**: `applyStripeFundedKiloClawPeriod` helper
+8. **Step 7**: KiloClaw `invoice.paid` handler
+9. **Step 8**: Schedule-event ownership cleanup
+10. **Step 9**: Billing status / success page / types
+11. **Step 10**: Frontend copy / visibility changes
+12. **Step 11**: Full test suite
+13. Run full test suite, typecheck, lint
+
+**Critical ordering constraints**:
+
+- Steps 3 and 4 must land before Steps 6 and 7
+- Step 5 must land before or atomically with Steps 6 and 7
+- Step 8 must land with or before Step 7
+
+**Ordering rationale**: Steps 2-5 are safe no-ops that prepare the
+codebase for converted rows. No hybrid rows exist yet, so:
+
+- The `subscription.created` SQL CASE (Step 2) always takes the ELSE
+  branch
+- The `subscription.updated` pre-read (Step 3) never finds a hybrid row
+- The router's `stripe_subscription_id` check (Step 4) behaves
+  identically to the current `payment_source` check for all existing rows
+- The sweep's `isNull(stripe_subscription_id)` filter (Step 5) excludes
+  nothing
+
+Steps 6-7 create converted rows. All guards are already in place.
+Steps 8-10 can be deployed in any order after Steps 6-7.
+
+## Permanent Complexity
+
+These are accepted trade-offs, not items to be resolved:
+
+- **Hybrid webhook guards are permanent.** The SQL `CASE` in Step 2 and
+  the pre-read in Step 3 must remain for as long as hybrid rows exist.
+  Future edits to `handleKiloClawSubscriptionCreated` or
+  `handleKiloClawSubscriptionUpdated` must preserve the hybrid ownership
+  split.
+
+- **Two renewal engines exist by design.** Pure credit rows renew in the
+  local sweep; hybrid rows renew in `invoice.paid`. Both use the same
+  `buildCreditCategory` key with `onConflictDoNothing`, so the deduction
+  itself is safe. But future changes to renewal logic must be applied to
+  both paths.
+
+- **Schedule ordering is eventually consistent.** Schedule events and
+  settled invoices may arrive in either order. The code must tolerate
+  either.
+
+- **Synthetic ledger entries are intentional.** Each Stripe-funded
+  renewal creates one positive credit event and one matching negative
+  deduction in `credit_transactions`. Any transaction history UI should
+  label them accordingly.

--- a/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/src/app/(app)/claw/components/billing/billing-types.ts
@@ -30,6 +30,9 @@ export type ClawBillingStatus = {
     commitEndsAt: string | null;
     scheduledPlan: 'commit' | 'standard' | null;
     scheduledBy: 'auto' | 'user' | null;
+    paymentSource: 'stripe' | 'credits' | null;
+    creditRenewalAt: string | null;
+    renewalCostMicrodollars: number | null;
   } | null;
 
   earlybird: {

--- a/src/lib/autoTopUp.ts
+++ b/src/lib/autoTopUp.ts
@@ -181,7 +181,8 @@ async function maybePerformAutoTopUpForEntity(entity: AutoTopUpEntity): Promise<
  */
 async function performAutoTopUpForEntity(
   entity: AutoTopUpEntity,
-  traceId: string
+  traceId: string,
+  idempotencyKey?: string
 ): Promise<AutoTopUpResult> {
   const ownerColumn =
     entity.type === 'user'
@@ -263,12 +264,15 @@ async function performAutoTopUpForEntity(
         ? { type: 'auto-topup', kiloUserId: entity.user.id, traceId }
         : { type: 'org-auto-topup', organizationId: entity.organization.id, traceId };
 
-    const invoice = await client.invoices.create({
-      customer: stripe_customer_id,
-      auto_advance: false,
-      metadata: invoiceMetadata,
-      description: 'Kilo automatic top up',
-    });
+    const invoice = await client.invoices.create(
+      {
+        customer: stripe_customer_id,
+        auto_advance: false,
+        metadata: invoiceMetadata,
+        description: 'Kilo automatic top up',
+      },
+      idempotencyKey ? { idempotencyKey } : undefined
+    );
 
     // Attach the line item directly to this invoice.
     // (Creating a pending invoice item and then creating an invoice can produce a $0 invoice,
@@ -384,6 +388,45 @@ const failureReasonMessages = {
 } as const;
 
 type KnownFailureReason = keyof typeof failureReasonMessages;
+
+/**
+ * Trigger auto-top-up for a KiloClaw credit renewal.
+ *
+ * Called by the credit renewal sweep when a user's balance is insufficient for
+ * renewal but they have auto-top-up enabled. Unlike {@link maybePerformAutoTopUp},
+ * this skips the balance-threshold check (the caller already determined the
+ * balance is insufficient) and passes a deterministic idempotency key to the
+ * payment provider so that duplicate triggers for the same renewal period are
+ * de-duplicated at the Stripe level.
+ */
+export async function triggerAutoTopUpForKiloClaw(
+  userId: string,
+  renewalTimestamp: string
+): Promise<void> {
+  const [user] = await db
+    .select()
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, userId))
+    .limit(1);
+  if (!user) return;
+
+  const idempotencyKey = `kiloclaw-renew:${userId}:${renewalTimestamp}`;
+  const traceId = idempotencyKey;
+
+  const result = await performAutoTopUpForEntity({ type: 'user', user }, traceId, idempotencyKey);
+
+  if (result.success) {
+    logExceptInTest(`KiloClaw auto-top-up successful for user ${userId}`, {
+      traceId,
+      stripe_id: result.stripe_id,
+    });
+  } else if (result.error !== 'concurrent_attempt_in_progress') {
+    sentryLogger('auto-topup', 'warning')(`KiloClaw auto-top-up failed for user ${userId}`, {
+      ...result,
+      traceId,
+    });
+  }
+}
 
 /**
  * Disable auto-top-up for an entity (user or organization).

--- a/src/lib/autoTopUp.ts
+++ b/src/lib/autoTopUp.ts
@@ -264,15 +264,15 @@ async function performAutoTopUpForEntity(
         ? { type: 'auto-topup', kiloUserId: entity.user.id, traceId }
         : { type: 'org-auto-topup', organizationId: entity.organization.id, traceId };
 
-    const invoice = await client.invoices.create(
-      {
-        customer: stripe_customer_id,
-        auto_advance: false,
-        metadata: invoiceMetadata,
-        description: 'Kilo automatic top up',
-      },
-      idempotencyKey ? { idempotencyKey } : undefined
-    );
+    const invoiceParams = {
+      customer: stripe_customer_id,
+      auto_advance: false,
+      metadata: invoiceMetadata,
+      description: 'Kilo automatic top up',
+    } as const;
+    const invoice = idempotencyKey
+      ? await client.invoices.create(invoiceParams, { idempotencyKey })
+      : await client.invoices.create(invoiceParams);
 
     // Attach the line item directly to this invoice.
     // (Creating a pending invoice item and then creating an invoice can produce a $0 invoice,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -28,6 +28,7 @@ export const templates = {
   clawInstanceDestroyed: '28',
   clawEarlybirdEndingSoon: '29',
   clawEarlybirdExpiresTomorrow: '30',
+  clawCreditRenewalFailed: '31',
 } as const;
 
 export type TemplateName = keyof typeof templates;
@@ -55,6 +56,7 @@ export const subjects: Record<TemplateName, string> = {
   clawInstanceDestroyed: 'Your KiloClaw Instance Has Been Deleted',
   clawEarlybirdEndingSoon: 'Your KiloClaw Earlybird Access Ends Soon',
   clawEarlybirdExpiresTomorrow: 'Your KiloClaw Earlybird Access Expires Tomorrow',
+  clawCreditRenewalFailed: 'Action Required: KiloClaw Credit Renewal Failed',
 };
 
 function escapeHtml(str: string): string {

--- a/src/lib/kiloclaw/billing-lifecycle-cron.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.ts
@@ -17,6 +17,7 @@ import type { TemplateName } from '@/lib/email';
 import { send as sendEmail } from '@/lib/email';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import { runCreditRenewalSweep, autoResumeIfSuspended } from '@/lib/kiloclaw/credit-billing';
 import { NEXTAUTH_URL, KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
 import { sentryLogger } from '@/lib/utils.server';
 
@@ -35,6 +36,13 @@ function formatDateForEmail(d: Date): string {
 }
 
 type CronSummary = {
+  credit_renewals: number;
+  credit_cancellations: number;
+  credit_past_due: number;
+  credit_auto_top_up_triggered: number;
+  credit_recoveries: number;
+  credit_plan_switches: number;
+  credit_auto_resumes: number;
   trial_warnings: number;
   earlybird_warnings: number;
   sweep1_trial_expiry: number;
@@ -97,6 +105,13 @@ export async function runKiloClawBillingLifecycleCron(
   database: PostgresJsDatabase<typeof schema>
 ): Promise<CronSummary> {
   const summary: CronSummary = {
+    credit_renewals: 0,
+    credit_cancellations: 0,
+    credit_past_due: 0,
+    credit_auto_top_up_triggered: 0,
+    credit_recoveries: 0,
+    credit_plan_switches: 0,
+    credit_auto_resumes: 0,
     trial_warnings: 0,
     earlybird_warnings: 0,
     sweep1_trial_expiry: 0,
@@ -117,6 +132,51 @@ export async function runKiloClawBillingLifecycleCron(
   const now = new Date().toISOString();
   const client = new KiloClawInternalClient();
   const clawUrl = `${NEXTAUTH_URL}/claw`;
+
+  // ── Credit Renewal Sweep (before all other sweeps) ─────────────────
+  try {
+    const creditSummary = await runCreditRenewalSweep(database);
+    summary.credit_renewals = creditSummary.renewals;
+    summary.credit_cancellations = creditSummary.cancellations;
+    summary.credit_past_due = creditSummary.past_due;
+    summary.credit_auto_top_up_triggered = creditSummary.auto_top_up_triggered;
+    summary.credit_recoveries = creditSummary.recoveries;
+    summary.credit_plan_switches = creditSummary.plan_switches;
+    summary.credit_auto_resumes = creditSummary.auto_resumes;
+    summary.errors += creditSummary.errors;
+  } catch (error) {
+    summary.errors++;
+    captureException(error);
+    logError('Credit renewal sweep failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // ── Interrupted auto-resume detection ──────────────────────────────
+  const interruptedAutoResumes = await database
+    .select({ user_id: kiloclaw_subscriptions.user_id })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.payment_source, 'credits'),
+        eq(kiloclaw_subscriptions.status, 'active'),
+        isNotNull(kiloclaw_subscriptions.suspended_at)
+      )
+    );
+
+  for (const row of interruptedAutoResumes) {
+    try {
+      await autoResumeIfSuspended(row.user_id);
+      summary.credit_auto_resumes++;
+    } catch (error) {
+      summary.errors++;
+      captureException(error);
+      logError('Interrupted auto-resume retry failed', {
+        user_id: row.user_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 
   // ── Sweep 0a: Trial ending-soon warning ─────────────────────────────
   const trialWarningCutoff = new Date(Date.now() + TRIAL_WARNING_DAYS * MS_PER_DAY).toISOString();

--- a/src/lib/kiloclaw/constants.ts
+++ b/src/lib/kiloclaw/constants.ts
@@ -3,3 +3,9 @@ export const KILOCLAW_EARLYBIRD_EXPIRY_DATE = '2026-09-26';
 
 /** Trial duration for new KiloClaw users. */
 export const KILOCLAW_TRIAL_DURATION_DAYS = 7;
+
+/** Standard plan monthly cost in microdollars ($9). */
+export const KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS = 9_000_000;
+
+/** Commit plan six-month cost in microdollars ($48). */
+export const KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS = 48_000_000;

--- a/src/lib/kiloclaw/credit-billing.test.ts
+++ b/src/lib/kiloclaw/credit-billing.test.ts
@@ -1,0 +1,1197 @@
+// Set env vars before any module loads
+process.env.STRIPE_KILOCLAW_COMMIT_PRICE_ID ||= 'price_commit';
+process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID ||= 'price_standard';
+process.env.KILOCLAW_BILLING_ENFORCEMENT = 'true';
+
+import {
+  describe,
+  expect,
+  it,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import {
+  kiloclaw_subscriptions,
+  kiloclaw_email_log,
+  kiloclaw_instances,
+  credit_transactions,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import type { CreditTransaction } from '@kilocode/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { addMonths } from 'date-fns';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import type { User } from '@kilocode/db/schema';
+import {
+  KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS,
+  KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS,
+} from '@/lib/kiloclaw/constants';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = jest.Mock<(...args: any[]) => any>;
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockStart = jest
+  .fn<(userId: string) => Promise<{ ok: true }>>()
+  .mockResolvedValue({ ok: true });
+const mockStop = jest
+  .fn<(userId: string) => Promise<{ ok: true }>>()
+  .mockResolvedValue({ ok: true });
+
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
+  KiloClawInternalClient: jest.fn().mockImplementation(() => ({
+    start: mockStart,
+    stop: mockStop,
+  })),
+  KiloClawApiError: class KiloClawApiError extends Error {
+    statusCode: number;
+    responseBody: string;
+    constructor(statusCode: number, responseBody = '') {
+      super(`KiloClawApiError: ${statusCode}`);
+      this.statusCode = statusCode;
+      this.responseBody = responseBody;
+    }
+  },
+}));
+
+jest.mock('@/lib/email', () => ({
+  send: jest.fn<AnyMock>().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/kiloclaw/kilo-pass-integration', () => ({
+  getProjectedKiloPassBonus: jest.fn<AnyMock>().mockResolvedValue(0),
+  evaluateKiloPassBonusAfterDeduction: jest.fn<AnyMock>().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/autoTopUp', () => ({
+  triggerAutoTopUpForKiloClaw: jest.fn<AnyMock>().mockResolvedValue(undefined),
+}));
+
+// ── Dynamic imports (after mocks) ─────────────────────────────────────────
+
+let enrollWithCredits: (userId: string, plan: 'commit' | 'standard') => Promise<void>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let runCreditRenewalSweep: (database: any) => Promise<any>;
+
+beforeAll(async () => {
+  const mod = await import('./credit-billing');
+  enrollWithCredits = mod.enrollWithCredits;
+  runCreditRenewalSweep = mod.runCreditRenewalSweep;
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+let user: User;
+
+const NOW = new Date('2026-04-15T12:00:00Z').getTime();
+const originalDateNow = Date.now;
+
+async function setUserBalance(userId: string, balance: number) {
+  await db
+    .update(kilocode_users)
+    .set({ total_microdollars_acquired: balance, microdollars_used: 0 })
+    .where(eq(kilocode_users.id, userId));
+}
+
+async function getSubscription(userId: string) {
+  const [row] = await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.user_id, userId))
+    .limit(1);
+  return row;
+}
+
+async function getCreditTransactions(userId: string) {
+  return db.select().from(credit_transactions).where(eq(credit_transactions.kilo_user_id, userId));
+}
+
+async function insertSubscription(
+  userId: string,
+  overrides: Partial<typeof kiloclaw_subscriptions.$inferInsert> = {}
+) {
+  const [row] = await db
+    .insert(kiloclaw_subscriptions)
+    .values({
+      user_id: userId,
+      plan: 'standard',
+      status: 'active',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  user = await insertTestUser({
+    total_microdollars_acquired: 100_000_000,
+    microdollars_used: 0,
+  });
+
+  // Reset all mocks
+  mockStart.mockClear();
+  mockStop.mockClear();
+
+  const { send } = jest.requireMock<{ send: AnyMock }>('@/lib/email');
+  send.mockClear();
+
+  const kiloPassMocks = jest.requireMock<{
+    getProjectedKiloPassBonus: AnyMock;
+    evaluateKiloPassBonusAfterDeduction: AnyMock;
+  }>('@/lib/kiloclaw/kilo-pass-integration');
+  kiloPassMocks.getProjectedKiloPassBonus.mockReset().mockResolvedValue(0);
+  kiloPassMocks.evaluateKiloPassBonusAfterDeduction.mockReset().mockResolvedValue(undefined);
+
+  const { triggerAutoTopUpForKiloClaw } = jest.requireMock<{
+    triggerAutoTopUpForKiloClaw: AnyMock;
+  }>('@/lib/autoTopUp');
+  triggerAutoTopUpForKiloClaw.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  Date.now = originalDateNow;
+});
+
+afterAll(async () => {
+  try {
+    await cleanupDbForTest();
+  } catch {
+    // DB may already be torn down
+  }
+});
+
+// ── Credit Enrollment ──────────────────────────────────────────────────────
+
+describe('enrollWithCredits', () => {
+  it('rejects if active subscription exists', async () => {
+    await insertSubscription(user.id, {
+      status: 'active',
+      payment_source: 'credits',
+    });
+
+    await expect(enrollWithCredits(user.id, 'standard')).rejects.toThrow();
+  });
+
+  it('rejects if past_due subscription exists', async () => {
+    await insertSubscription(user.id, {
+      status: 'past_due',
+      payment_source: 'credits',
+    });
+
+    await expect(enrollWithCredits(user.id, 'standard')).rejects.toThrow();
+  });
+
+  it('rejects if unpaid subscription exists', async () => {
+    await insertSubscription(user.id, {
+      status: 'unpaid',
+      payment_source: 'credits',
+    });
+
+    await expect(enrollWithCredits(user.id, 'standard')).rejects.toThrow();
+  });
+
+  it('allows enrollment when existing subscription is trialing', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      await insertSubscription(user.id, {
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: new Date(NOW - 86_400_000 * 10).toISOString(),
+        trial_ends_at: new Date(NOW + 86_400_000 * 20).toISOString(),
+      });
+      await setUserBalance(user.id, 30_000_000);
+
+      await enrollWithCredits(user.id, 'standard');
+
+      const sub = await getSubscription(user.id);
+      expect(sub.status).toBe('active');
+      expect(sub.payment_source).toBe('credits');
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('allows enrollment when existing subscription is canceled', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      await insertSubscription(user.id, {
+        status: 'canceled',
+        payment_source: 'credits',
+      });
+      await setUserBalance(user.id, 30_000_000);
+
+      await enrollWithCredits(user.id, 'standard');
+
+      const sub = await getSubscription(user.id);
+      expect(sub.status).toBe('active');
+      expect(sub.payment_source).toBe('credits');
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  describe('effective balance checks', () => {
+    it('rejects standard plan when balance is just under $25', async () => {
+      await setUserBalance(user.id, KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS - 1);
+
+      await expect(enrollWithCredits(user.id, 'standard')).rejects.toThrow(
+        /[Ii]nsufficient credit balance/
+      );
+    });
+
+    it('succeeds for standard plan with exactly $25', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS);
+
+        await enrollWithCredits(user.id, 'standard');
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('active');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('rejects commit plan when balance is just under $54', async () => {
+      await setUserBalance(user.id, KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS - 1);
+
+      await expect(enrollWithCredits(user.id, 'commit')).rejects.toThrow(
+        /[Ii]nsufficient credit balance/
+      );
+    });
+
+    it('succeeds for commit plan with exactly $54', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS);
+
+        await enrollWithCredits(user.id, 'commit');
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('active');
+        expect(sub.plan).toBe('commit');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('includes projected Kilo Pass bonus in effective balance', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        // Balance is $20, but projected bonus brings it to $25
+        await setUserBalance(user.id, 20_000_000);
+        const { getProjectedKiloPassBonus } = jest.requireMock<{
+          getProjectedKiloPassBonus: AnyMock;
+        }>('@/lib/kiloclaw/kilo-pass-integration');
+        getProjectedKiloPassBonus.mockResolvedValue(5_000_000);
+
+        await enrollWithCredits(user.id, 'standard');
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('active');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('credit deduction', () => {
+    it('inserts a negative credit transaction', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await enrollWithCredits(user.id, 'standard');
+
+        const txns = await getCreditTransactions(user.id);
+        const deduction = txns.find((t: CreditTransaction) => t.amount_microdollars < 0);
+        expect(deduction).toBeDefined();
+        expect(deduction!.amount_microdollars).toBe(-KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS);
+        expect(deduction!.check_category_uniqueness).toBe(true);
+        // Category encodes the billing period as YYYY-MM
+        expect(deduction!.credit_category).toMatch(/^kiloclaw-subscription:\d{4}-\d{2}$/);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('decrements total_microdollars_acquired', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const initialBalance = 100_000_000;
+        await setUserBalance(user.id, initialBalance);
+
+        await enrollWithCredits(user.id, 'standard');
+
+        const [updatedUser] = await db
+          .select({ total_microdollars_acquired: kilocode_users.total_microdollars_acquired })
+          .from(kilocode_users)
+          .where(eq(kilocode_users.id, user.id));
+        expect(updatedUser.total_microdollars_acquired).toBe(
+          initialBalance - KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS
+        );
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('uses commit prefix for idempotency key on commit plan', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await enrollWithCredits(user.id, 'commit');
+
+        const txns = await getCreditTransactions(user.id);
+        const deduction = txns.find((t: CreditTransaction) => t.amount_microdollars < 0);
+        expect(deduction).toBeDefined();
+        expect(deduction!.credit_category).toMatch(/^kiloclaw-subscription-commit:\d{4}-\d{2}$/);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('subscription upsert', () => {
+    it('sets correct fields for standard plan', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await enrollWithCredits(user.id, 'standard');
+
+        const sub = await getSubscription(user.id);
+        expect(sub.payment_source).toBe('credits');
+        expect(sub.status).toBe('active');
+        expect(sub.stripe_subscription_id).toBeNull();
+        expect(sub.plan).toBe('standard');
+        expect(sub.past_due_since).toBeNull();
+
+        // Period: now → +1 month
+        const periodStart = new Date(sub.current_period_start!);
+        const periodEnd = new Date(sub.current_period_end!);
+        expect(periodStart.getTime()).toBe(NOW);
+        const expectedEnd = addMonths(new Date(NOW), 1);
+        expect(periodEnd.getTime()).toBe(expectedEnd.getTime());
+
+        // credit_renewal_at = current_period_end
+        expect(sub.credit_renewal_at).toBe(sub.current_period_end);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('sets commit_ends_at for commit plan (6 months)', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await enrollWithCredits(user.id, 'commit');
+
+        const sub = await getSubscription(user.id);
+        expect(sub.plan).toBe('commit');
+        expect(sub.commit_ends_at).not.toBeNull();
+        const commitEnd = new Date(sub.commit_ends_at!);
+        const expectedCommitEnd = addMonths(new Date(NOW), 6);
+        expect(commitEnd.getTime()).toBe(expectedCommitEnd.getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('clears commit_ends_at for standard plan', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        // Pre-existing commit subscription
+        await insertSubscription(user.id, {
+          plan: 'commit',
+          status: 'canceled',
+          commit_ends_at: new Date(NOW - 86_400_000).toISOString(),
+        });
+
+        await enrollWithCredits(user.id, 'standard');
+
+        const sub = await getSubscription(user.id);
+        expect(sub.plan).toBe('standard');
+        expect(sub.commit_ends_at).toBeNull();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('sets current_period_end 6 months out for commit plan', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await enrollWithCredits(user.id, 'commit');
+
+        const sub = await getSubscription(user.id);
+        const periodEnd = new Date(sub.current_period_end!);
+        // Commit bills every 6 months at $54.
+        const expectedEnd = addMonths(new Date(NOW), 6);
+        expect(periodEnd.getTime()).toBe(expectedEnd.getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  it('rejects duplicate enrollment via idempotency key', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      await enrollWithCredits(user.id, 'standard');
+
+      // Second enrollment at the same time should fail
+      await expect(enrollWithCredits(user.id, 'standard')).rejects.toThrow();
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('does not clear suspended_at during enrollment', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      const suspendedTime = new Date(NOW - 86_400_000 * 3).toISOString();
+      await insertSubscription(user.id, {
+        status: 'canceled',
+        suspended_at: suspendedTime,
+      });
+      await db.insert(kiloclaw_instances).values({
+        user_id: user.id,
+        sandbox_id: 'test-sandbox',
+      });
+
+      await enrollWithCredits(user.id, 'standard');
+
+      await getSubscription(user.id);
+      // suspended_at is cleared by auto-resume, not enrollment itself
+      // However, if the enrollment triggers auto-resume, it may be cleared.
+      // The spec says enrollment calls auto-resume, so it should be cleared.
+      // Let's verify start() was called.
+      expect(mockStart).toHaveBeenCalled();
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('triggers bonus evaluation after enrollment', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      const { evaluateKiloPassBonusAfterDeduction } = jest.requireMock<{
+        evaluateKiloPassBonusAfterDeduction: AnyMock;
+      }>('@/lib/kiloclaw/kilo-pass-integration');
+
+      await enrollWithCredits(user.id, 'standard');
+
+      expect(evaluateKiloPassBonusAfterDeduction).toHaveBeenCalled();
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('calls auto-resume if previously suspended', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      const suspendedTime = new Date(NOW - 86_400_000 * 3).toISOString();
+      await insertSubscription(user.id, {
+        status: 'canceled',
+        suspended_at: suspendedTime,
+      });
+      await db.insert(kiloclaw_instances).values({
+        user_id: user.id,
+        sandbox_id: 'test-sandbox',
+      });
+
+      await enrollWithCredits(user.id, 'standard');
+
+      expect(mockStart).toHaveBeenCalledWith(user.id);
+      const sub = await getSubscription(user.id);
+      expect(sub.suspended_at).toBeNull();
+    } finally {
+      Date.now = realNow;
+    }
+  });
+});
+
+// ── Credit Renewal Sweep ───────────────────────────────────────────────────
+
+describe('runCreditRenewalSweep', () => {
+  describe('row selection', () => {
+    it('processes rows with payment_source=credits, active status, credit_renewal_at <= now', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const txns = await getCreditTransactions(user.id);
+        expect(txns.some((t: CreditTransaction) => t.amount_microdollars < 0)).toBe(true);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('processes rows with past_due status', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'past_due',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          past_due_since: new Date(NOW - 86_400_000 * 2).toISOString(),
+        });
+
+        await runCreditRenewalSweep(db);
+
+        // With enough balance, should recover
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('active');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('does NOT process stripe payment_source rows', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'stripe',
+          plan: 'standard',
+          stripe_subscription_id: `sub_stripe_${Math.random()}`,
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const txns = await getCreditTransactions(user.id);
+        expect(txns.filter((t: CreditTransaction) => t.amount_microdollars < 0)).toHaveLength(0);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('cancel-at-period-end', () => {
+    it('sets status to canceled and skips deduction', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          cancel_at_period_end: true,
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('canceled');
+        expect(sub.cancel_at_period_end).toBe(false);
+
+        const txns = await getCreditTransactions(user.id);
+        expect(txns.filter((t: CreditTransaction) => t.amount_microdollars < 0)).toHaveLength(0);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('successful renewal', () => {
+    it('advances billing period by one month for standard plan', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const oldPeriodEnd = new Date(NOW - 86_400_000).toISOString();
+        const oldPeriodStart = new Date(NOW - 86_400_000 * 31).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: oldPeriodStart,
+          current_period_end: oldPeriodEnd,
+          credit_renewal_at: oldPeriodEnd,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(new Date(sub.current_period_start!).getTime()).toBe(
+          new Date(oldPeriodEnd).getTime()
+        );
+        const expectedNewEnd = addMonths(new Date(oldPeriodEnd), 1);
+        expect(new Date(sub.current_period_end!).getTime()).toBe(expectedNewEnd.getTime());
+        expect(new Date(sub.credit_renewal_at!).getTime()).toBe(expectedNewEnd.getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('advances billing period by six months for commit plan', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const oldPeriodEnd = new Date(NOW - 86_400_000).toISOString();
+        const commitEnd = addMonths(new Date(NOW), 5).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'commit',
+          current_period_start: addMonths(new Date(oldPeriodEnd), -6).toISOString(),
+          current_period_end: oldPeriodEnd,
+          credit_renewal_at: oldPeriodEnd,
+          commit_ends_at: commitEnd,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(new Date(sub.current_period_start!).getTime()).toBe(
+          new Date(oldPeriodEnd).getTime()
+        );
+        const expectedNewEnd = addMonths(new Date(oldPeriodEnd), 6);
+        expect(new Date(sub.current_period_end!).getTime()).toBe(expectedNewEnd.getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('uses period-encoded idempotency key based on credit_renewal_at', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        // credit_renewal_at is 2026-03-14, so the idempotency key should encode 2026-03
+        const renewalAt = new Date('2026-03-14T12:00:00Z').toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date('2026-02-14T12:00:00Z').toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const txns = await getCreditTransactions(user.id);
+        const deduction = txns.find((t: CreditTransaction) => t.amount_microdollars < 0);
+        expect(deduction).toBeDefined();
+        // Key should be derived from the renewal period, not wall-clock time
+        expect(deduction!.credit_category).toContain('2026-03');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('advances only one period per sweep even if multiple periods behind', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        // credit_renewal_at is 3 months ago
+        const renewalAt = addMonths(new Date(NOW), -3).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: addMonths(new Date(NOW), -4).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        // Should advance by exactly 1 month from the old period end
+        const expectedNewEnd = addMonths(new Date(renewalAt), 1);
+        expect(new Date(sub.current_period_end!).getTime()).toBe(expectedNewEnd.getTime());
+
+        // Run sweep again — should advance one more month
+        await runCreditRenewalSweep(db);
+
+        const sub2 = await getSubscription(user.id);
+        const expectedSecondEnd = addMonths(expectedNewEnd, 1);
+        expect(new Date(sub2.current_period_end!).getTime()).toBe(expectedSecondEnd.getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('clears auto_top_up_triggered_for_period when billing period advances', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          auto_top_up_triggered_for_period: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.auto_top_up_triggered_for_period).toBeNull();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('duplicate deduction protection', () => {
+    it('skips further processing when idempotency key already exists', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        // Run sweep once (success)
+        await runCreditRenewalSweep(db);
+
+        // Reset credit_renewal_at to trigger another sweep attempt for same period
+        await db
+          .update(kiloclaw_subscriptions)
+          .set({ credit_renewal_at: renewalAt })
+          .where(eq(kiloclaw_subscriptions.user_id, user.id));
+
+        // Run sweep again — should not error, should not create another deduction
+        await runCreditRenewalSweep(db);
+
+        const txns = await getCreditTransactions(user.id);
+        const deductions = txns.filter((t: CreditTransaction) => t.amount_microdollars < 0);
+        // Only one deduction should exist due to idempotency
+        expect(deductions).toHaveLength(1);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('insufficient balance', () => {
+    it('sets status to past_due and records past_due_since', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, 0);
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('past_due');
+        expect(sub.past_due_since).not.toBeNull();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('sends credit-renewal-failed notification', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, 0);
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const { send } = jest.requireMock<{ send: AnyMock }>('@/lib/email');
+        expect(send).toHaveBeenCalled();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('preserves existing past_due_since when already past_due', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, 0);
+        const fiveDaysAgo = new Date(NOW - 86_400_000 * 5).toISOString();
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'past_due',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          past_due_since: fiveDaysAgo,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('past_due');
+        // past_due_since should NOT be reset to now; it should remain at the original value
+        expect(new Date(sub.past_due_since!).getTime()).toBe(new Date(fiveDaysAgo).getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('auto top-up', () => {
+    it('triggers auto top-up and skips past-due when balance insufficient', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, 0);
+        await db
+          .update(kilocode_users)
+          .set({ auto_top_up_enabled: true })
+          .where(eq(kilocode_users.id, user.id));
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        const { triggerAutoTopUpForKiloClaw } = jest.requireMock<{
+          triggerAutoTopUpForKiloClaw: AnyMock;
+        }>('@/lib/autoTopUp');
+
+        await runCreditRenewalSweep(db);
+
+        expect(triggerAutoTopUpForKiloClaw).toHaveBeenCalled();
+        const sub = await getSubscription(user.id);
+        // Status should remain active (fire-and-skip), not go past_due
+        expect(sub.status).toBe('active');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('sets durable marker before triggering auto top-up', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, 0);
+        await db
+          .update(kilocode_users)
+          .set({ auto_top_up_enabled: true })
+          .where(eq(kilocode_users.id, user.id));
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.auto_top_up_triggered_for_period).not.toBeNull();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('skips fire-and-skip when marker already present', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        await setUserBalance(user.id, 0);
+        await db
+          .update(kilocode_users)
+          .set({ auto_top_up_enabled: true })
+          .where(eq(kilocode_users.id, user.id));
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          // Marker already set — auto top-up was already triggered for this period
+          auto_top_up_triggered_for_period: renewalAt,
+        });
+
+        const { triggerAutoTopUpForKiloClaw } = jest.requireMock<{
+          triggerAutoTopUpForKiloClaw: AnyMock;
+        }>('@/lib/autoTopUp');
+
+        await runCreditRenewalSweep(db);
+
+        // Should NOT trigger auto top-up again
+        expect(triggerAutoTopUpForKiloClaw).not.toHaveBeenCalled();
+        // Should enter past-due path instead
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('past_due');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('past-due recovery', () => {
+    it('clears past_due_since and sets status active on grace-period recovery', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'past_due',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          past_due_since: new Date(NOW - 86_400_000 * 2).toISOString(),
+        });
+        // User has enough balance to cover renewal
+        await setUserBalance(user.id, 100_000_000);
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.status).toBe('active');
+        expect(sub.past_due_since).toBeNull();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('deletes credit-renewal-failed email log on recovery', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'past_due',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          past_due_since: new Date(NOW - 86_400_000 * 2).toISOString(),
+        });
+
+        // Insert the email log entry that should be deleted on recovery
+        await db.insert(kiloclaw_email_log).values({
+          user_id: user.id,
+          email_type: 'claw_credit_renewal_failed',
+        });
+
+        await setUserBalance(user.id, 100_000_000);
+
+        await runCreditRenewalSweep(db);
+
+        const emailLogs = await db
+          .select()
+          .from(kiloclaw_email_log)
+          .where(
+            and(
+              eq(kiloclaw_email_log.user_id, user.id),
+              eq(kiloclaw_email_log.email_type, 'claw_credit_renewal_failed')
+            )
+          );
+        expect(emailLogs).toHaveLength(0);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('calls auto-resume for suspended recovery', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        const suspendedAt = new Date(NOW - 86_400_000 * 5).toISOString();
+        await insertSubscription(user.id, {
+          status: 'past_due',
+          payment_source: 'credits',
+          plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          past_due_since: new Date(NOW - 86_400_000 * 5).toISOString(),
+          suspended_at: suspendedAt,
+        });
+        await db.insert(kiloclaw_instances).values({
+          user_id: user.id,
+          sandbox_id: 'test-sandbox',
+        });
+        await setUserBalance(user.id, 100_000_000);
+
+        await runCreditRenewalSweep(db);
+
+        expect(mockStart).toHaveBeenCalledWith(user.id);
+        const sub = await getSubscription(user.id);
+        expect(sub.suspended_at).toBeNull();
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('commit renewal after commit_ends_at', () => {
+    it('extends commit_ends_at by 6 months when past', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        const pastCommitEnd = new Date(NOW - 86_400_000 * 2).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'commit',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          commit_ends_at: pastCommitEnd,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        const newCommitEnd = new Date(sub.commit_ends_at!);
+        const expectedCommitEnd = addMonths(new Date(pastCommitEnd), 6);
+        expect(newCommitEnd.getTime()).toBe(expectedCommitEnd.getTime());
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
+  describe('plan switching during renewal', () => {
+    it('switches from standard to commit when scheduled', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'standard',
+          scheduled_plan: 'commit',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+        });
+        // Ensure enough balance for commit price
+        await setUserBalance(user.id, 100_000_000);
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.plan).toBe('commit');
+        expect(sub.scheduled_plan).toBeNull();
+        expect(sub.commit_ends_at).not.toBeNull();
+
+        // Deduction should be at commit price
+        const txns = await getCreditTransactions(user.id);
+        const deduction = txns.find((t: CreditTransaction) => t.amount_microdollars < 0);
+        expect(deduction).toBeDefined();
+        expect(deduction!.amount_microdollars).toBe(-KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('switches from commit to standard when scheduled', async () => {
+      const realNow = Date.now;
+      Date.now = () => NOW;
+      try {
+        const renewalAt = new Date(NOW - 86_400_000).toISOString();
+        const commitEnd = new Date(NOW - 86_400_000 * 2).toISOString();
+        await insertSubscription(user.id, {
+          status: 'active',
+          payment_source: 'credits',
+          plan: 'commit',
+          scheduled_plan: 'standard',
+          current_period_start: new Date(NOW - 86_400_000 * 31).toISOString(),
+          current_period_end: renewalAt,
+          credit_renewal_at: renewalAt,
+          commit_ends_at: commitEnd,
+        });
+
+        await runCreditRenewalSweep(db);
+
+        const sub = await getSubscription(user.id);
+        expect(sub.plan).toBe('standard');
+        expect(sub.scheduled_plan).toBeNull();
+        expect(sub.commit_ends_at).toBeNull();
+
+        // Deduction should be at standard price
+        const txns = await getCreditTransactions(user.id);
+        const deduction = txns.find((t: CreditTransaction) => t.amount_microdollars < 0);
+        expect(deduction).toBeDefined();
+        expect(deduction!.amount_microdollars).toBe(-KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+});

--- a/src/lib/kiloclaw/credit-billing.test.ts
+++ b/src/lib/kiloclaw/credit-billing.test.ts
@@ -525,6 +525,35 @@ describe('enrollWithCredits', () => {
       Date.now = realNow;
     }
   });
+
+  it('preserves suspended_at when auto-resume start fails', async () => {
+    const realNow = Date.now;
+    Date.now = () => NOW;
+    try {
+      mockStart.mockRejectedValueOnce(new Error('instance unreachable'));
+
+      const suspendedTime = new Date(NOW - 86_400_000 * 3).toISOString();
+      await insertSubscription(user.id, {
+        status: 'canceled',
+        suspended_at: suspendedTime,
+        destruction_deadline: new Date(NOW + 86_400_000 * 4).toISOString(),
+      });
+      await db.insert(kiloclaw_instances).values({
+        user_id: user.id,
+        sandbox_id: 'test-sandbox',
+      });
+
+      await enrollWithCredits(user.id, 'standard');
+
+      expect(mockStart).toHaveBeenCalledWith(user.id);
+      const sub = await getSubscription(user.id);
+      // Suspension state preserved so background job can retry
+      expect(sub.suspended_at).not.toBeNull();
+      expect(sub.destruction_deadline).not.toBeNull();
+    } finally {
+      Date.now = realNow;
+    }
+  });
 });
 
 // ── Credit Renewal Sweep ───────────────────────────────────────────────────

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -1,0 +1,576 @@
+import 'server-only';
+
+import { and, eq, lte, isNull, inArray, sql, or } from 'drizzle-orm';
+import { addMonths, format } from 'date-fns';
+import { TRPCError } from '@trpc/server';
+import { captureException } from '@sentry/nextjs';
+
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type * as schema from '@kilocode/db/schema';
+import {
+  kiloclaw_subscriptions,
+  kiloclaw_instances,
+  kiloclaw_email_log,
+  kilocode_users,
+  credit_transactions,
+} from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import type { DrizzleTransaction } from '@/lib/drizzle';
+import {
+  KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS,
+  KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS,
+} from '@/lib/kiloclaw/constants';
+import {
+  getProjectedKiloPassBonus,
+  evaluateKiloPassBonusAfterDeduction,
+} from '@/lib/kiloclaw/kilo-pass-integration';
+import { triggerAutoTopUpForKiloClaw } from '@/lib/autoTopUp';
+import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { send as sendEmail } from '@/lib/email';
+import type { TemplateName } from '@/lib/email';
+import { NEXTAUTH_URL, KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
+import { sentryLogger } from '@/lib/utils.server';
+
+const logInfo = sentryLogger('kiloclaw-credit-billing', 'info');
+const logError = sentryLogger('kiloclaw-credit-billing', 'error');
+
+export type CreditRenewalSweepSummary = {
+  renewals: number;
+  cancellations: number;
+  past_due: number;
+  auto_top_up_triggered: number;
+  recoveries: number;
+  plan_switches: number;
+  auto_resumes: number;
+  errors: number;
+};
+
+/** Standard bills monthly (1 month), commit bills every 6 months ($54/6mo). */
+function periodLengthMonths(plan: 'commit' | 'standard'): number {
+  return plan === 'commit' ? 6 : 1;
+}
+
+/** Returns the cost in microdollars for one billing period of the given plan. */
+function planCostMicrodollars(plan: 'commit' | 'standard'): number {
+  return plan === 'commit'
+    ? KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS
+    : KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS;
+}
+
+/** Builds the idempotency credit_category key for a given plan and renewal date. */
+function buildCreditCategory(plan: 'commit' | 'standard', renewalDate: Date): string {
+  const periodKey = format(renewalDate, 'yyyy-MM');
+  const prefix = plan === 'commit' ? 'kiloclaw-subscription-commit' : 'kiloclaw-subscription';
+  return `${prefix}:${periodKey}`;
+}
+
+// ---------------------------------------------------------------------------
+// enrollWithCredits
+// ---------------------------------------------------------------------------
+
+export async function enrollWithCredits(
+  userId: string,
+  plan: 'commit' | 'standard'
+): Promise<void> {
+  // 1. Guard: check existing subscription
+  const [existingSub] = await db
+    .select({
+      status: kiloclaw_subscriptions.status,
+      suspended_at: kiloclaw_subscriptions.suspended_at,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.user_id, userId))
+    .limit(1);
+
+  if (existingSub && existingSub.status !== 'trialing' && existingSub.status !== 'canceled') {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: 'Cannot enroll: existing subscription is active, past-due, or unpaid',
+    });
+  }
+
+  // 2. Compute cost
+  const cost = planCostMicrodollars(plan);
+
+  // 3. Effective balance check
+  const [userRow] = await db
+    .select({
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+      microdollars_used: kilocode_users.microdollars_used,
+    })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, userId))
+    .limit(1);
+
+  if (!userRow) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+  }
+
+  const currentBalance =
+    (userRow.total_microdollars_acquired ?? 0) - (userRow.microdollars_used ?? 0);
+  const projectedBonus = await getProjectedKiloPassBonus(userId, cost);
+  const effectiveBalance = currentBalance + projectedBonus;
+
+  if (effectiveBalance < cost) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Insufficient credit balance',
+    });
+  }
+
+  // 4. Check if previously suspended (before mutation)
+  const wasSuspended = !!existingSub?.suspended_at;
+
+  // 5. Compute billing period
+  const now = new Date(Date.now());
+  const periodStart = now.toISOString();
+  const periodEnd = addMonths(now, periodLengthMonths(plan)).toISOString();
+  const commitEndsAt = plan === 'commit' ? addMonths(now, 6).toISOString() : null;
+
+  // 6. Build idempotency key
+  const creditCategory = buildCreditCategory(plan, now);
+
+  // 7. Transaction: deduction + subscription upsert
+  await db.transaction(async (tx: DrizzleTransaction) => {
+    // a. Insert negative credit transaction (idempotent via unique category)
+    const insertResult = await tx
+      .insert(credit_transactions)
+      .values({
+        kilo_user_id: userId,
+        amount_microdollars: -cost,
+        is_free: false,
+        description: `KiloClaw ${plan} subscription`,
+        credit_category: creditCategory,
+        check_category_uniqueness: true,
+      })
+      .onConflictDoNothing();
+
+    if (insertResult.rowCount === 0) {
+      throw new TRPCError({ code: 'CONFLICT', message: 'Duplicate enrollment attempt' });
+    }
+
+    // b. Decrement total_microdollars_acquired
+    await tx
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${cost}`,
+      })
+      .where(eq(kilocode_users.id, userId));
+
+    // c. Upsert subscription
+    // Clears past_due_since but does NOT clear suspended_at or destruction_deadline
+    // (those are cleared by auto-resume below).
+    await tx
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: userId,
+        plan,
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: null,
+        current_period_start: periodStart,
+        current_period_end: periodEnd,
+        credit_renewal_at: periodEnd,
+        commit_ends_at: commitEndsAt,
+        cancel_at_period_end: false,
+        past_due_since: null,
+      })
+      .onConflictDoUpdate({
+        target: kiloclaw_subscriptions.user_id,
+        set: {
+          plan,
+          status: 'active',
+          payment_source: 'credits',
+          stripe_subscription_id: null,
+          stripe_schedule_id: null,
+          scheduled_plan: null,
+          scheduled_by: null,
+          current_period_start: periodStart,
+          current_period_end: periodEnd,
+          credit_renewal_at: periodEnd,
+          commit_ends_at: commitEndsAt,
+          cancel_at_period_end: false,
+          past_due_since: null,
+        },
+      });
+  });
+
+  // 8. Post-commit: Kilo Pass bonus evaluation
+  try {
+    await evaluateKiloPassBonusAfterDeduction(userId, cost);
+  } catch (error) {
+    logError('Kilo Pass bonus evaluation failed after enrollment', { userId, error });
+  }
+
+  // 9. Auto-resume if previously suspended
+  if (wasSuspended) {
+    await autoResumeIfSuspended(userId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// autoResumeIfSuspended
+// ---------------------------------------------------------------------------
+
+export async function autoResumeIfSuspended(kiloUserId: string): Promise<void> {
+  const [activeInstance] = await db
+    .select({ id: kiloclaw_instances.id })
+    .from(kiloclaw_instances)
+    .where(and(eq(kiloclaw_instances.user_id, kiloUserId), isNull(kiloclaw_instances.destroyed_at)))
+    .limit(1);
+
+  if (activeInstance) {
+    try {
+      const client = new KiloClawInternalClient();
+      await client.start(kiloUserId);
+    } catch (startError) {
+      logError('Failed to auto-resume instance', {
+        user_id: kiloUserId,
+        error: startError instanceof Error ? startError.message : String(startError),
+      });
+    }
+  }
+
+  // Clear suspension/destruction cycle emails + credit renewal failed.
+  // Trial and earlybird warnings are one-time events and must NOT be cleared.
+  const resettableEmailTypes = [
+    'claw_suspended_trial',
+    'claw_suspended_subscription',
+    'claw_suspended_payment',
+    'claw_destruction_warning',
+    'claw_instance_destroyed',
+    'claw_credit_renewal_failed',
+  ];
+  await db
+    .delete(kiloclaw_email_log)
+    .where(
+      and(
+        eq(kiloclaw_email_log.user_id, kiloUserId),
+        inArray(kiloclaw_email_log.email_type, resettableEmailTypes)
+      )
+    );
+
+  await db
+    .update(kiloclaw_subscriptions)
+    .set({ suspended_at: null, destruction_deadline: null })
+    .where(eq(kiloclaw_subscriptions.user_id, kiloUserId));
+}
+
+// ---------------------------------------------------------------------------
+// trySendEmail (private)
+// ---------------------------------------------------------------------------
+
+async function trySendEmail(
+  database: NodePgDatabase<typeof schema>,
+  userId: string,
+  userEmail: string,
+  emailType: string,
+  templateName: TemplateName,
+  templateVars: Record<string, string>
+): Promise<boolean> {
+  const result = await database
+    .insert(kiloclaw_email_log)
+    .values({ user_id: userId, email_type: emailType })
+    .onConflictDoNothing();
+  if (result.rowCount === 0) return false;
+  try {
+    await sendEmail({ to: userEmail, templateName, templateVars });
+  } catch (error) {
+    try {
+      await database
+        .delete(kiloclaw_email_log)
+        .where(
+          and(eq(kiloclaw_email_log.user_id, userId), eq(kiloclaw_email_log.email_type, emailType))
+        );
+    } catch (deleteError) {
+      console.error(
+        '[credit-billing] Failed to clean up email log row after send failure:',
+        deleteError,
+        { userId, emailType }
+      );
+    }
+    throw error;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// runCreditRenewalSweep
+// ---------------------------------------------------------------------------
+
+export async function runCreditRenewalSweep(
+  database: NodePgDatabase<typeof schema>
+): Promise<CreditRenewalSweepSummary> {
+  const summary: CreditRenewalSweepSummary = {
+    renewals: 0,
+    cancellations: 0,
+    past_due: 0,
+    auto_top_up_triggered: 0,
+    recoveries: 0,
+    plan_switches: 0,
+    auto_resumes: 0,
+    errors: 0,
+  };
+
+  if (!KILOCLAW_BILLING_ENFORCEMENT) return summary;
+
+  const now = new Date(Date.now()).toISOString();
+  const clawUrl = `${NEXTAUTH_URL}/claw`;
+
+  // Select qualifying rows: credit-funded, active or past_due, renewal due
+  const rows = await database
+    .select({
+      user_id: kiloclaw_subscriptions.user_id,
+      email: kilocode_users.google_user_email,
+      status: kiloclaw_subscriptions.status,
+      plan: kiloclaw_subscriptions.plan,
+      cancel_at_period_end: kiloclaw_subscriptions.cancel_at_period_end,
+      current_period_start: kiloclaw_subscriptions.current_period_start,
+      current_period_end: kiloclaw_subscriptions.current_period_end,
+      credit_renewal_at: kiloclaw_subscriptions.credit_renewal_at,
+      commit_ends_at: kiloclaw_subscriptions.commit_ends_at,
+      past_due_since: kiloclaw_subscriptions.past_due_since,
+      suspended_at: kiloclaw_subscriptions.suspended_at,
+      scheduled_plan: kiloclaw_subscriptions.scheduled_plan,
+      auto_top_up_triggered_for_period: kiloclaw_subscriptions.auto_top_up_triggered_for_period,
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+      microdollars_used: kilocode_users.microdollars_used,
+      auto_top_up_enabled: kilocode_users.auto_top_up_enabled,
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.payment_source, 'credits'),
+        or(
+          eq(kiloclaw_subscriptions.status, 'active'),
+          eq(kiloclaw_subscriptions.status, 'past_due')
+        ),
+        lte(kiloclaw_subscriptions.credit_renewal_at, now)
+      )
+    );
+
+  for (const row of rows) {
+    try {
+      // Cancel-at-period-end → set canceled, skip deduction
+      if (row.cancel_at_period_end) {
+        await database
+          .update(kiloclaw_subscriptions)
+          .set({
+            status: 'canceled',
+            cancel_at_period_end: false,
+            auto_top_up_triggered_for_period: null,
+          })
+          .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        summary.cancellations++;
+        continue;
+      }
+
+      // Apply scheduled plan change if current period has ended
+      let effectivePlan: 'commit' | 'standard' = row.plan === 'commit' ? 'commit' : 'standard';
+      if (row.scheduled_plan && row.current_period_end) {
+        const periodEndTime = new Date(row.current_period_end).getTime();
+        if (periodEndTime <= Date.now()) {
+          effectivePlan = row.scheduled_plan;
+          const planUpdateFields: Partial<typeof kiloclaw_subscriptions.$inferInsert> = {
+            plan: effectivePlan,
+            scheduled_plan: null,
+            scheduled_by: null,
+          };
+          if (effectivePlan === 'commit') {
+            planUpdateFields.commit_ends_at = addMonths(new Date(Date.now()), 6).toISOString();
+          } else {
+            planUpdateFields.commit_ends_at = null;
+          }
+          await database
+            .update(kiloclaw_subscriptions)
+            .set(planUpdateFields)
+            .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+          summary.plan_switches++;
+        }
+      }
+
+      // Compute cost based on (possibly switched) plan
+      const cost = planCostMicrodollars(effectivePlan);
+
+      // These fields are guaranteed non-null by the sweep query filter
+      if (!row.credit_renewal_at || !row.current_period_end) continue;
+
+      // Compute effective balance
+      const currentBalance = (row.total_microdollars_acquired ?? 0) - (row.microdollars_used ?? 0);
+      const projectedBonus = await getProjectedKiloPassBonus(row.user_id, cost);
+      const effectiveBalance = currentBalance + projectedBonus;
+
+      if (effectiveBalance >= cost) {
+        // ── SUFFICIENT BALANCE: deduct and advance ──
+
+        // Idempotency key from credit_renewal_at
+        const renewalDate = new Date(row.credit_renewal_at);
+        const creditCategory = buildCreditCategory(effectivePlan, renewalDate);
+
+        // Compute new period (advance by one billing period)
+        const months = periodLengthMonths(effectivePlan);
+        const newPeriodStart = row.current_period_end;
+        const newPeriodEnd = addMonths(new Date(newPeriodStart), months).toISOString();
+        const newCreditRenewalAt = newPeriodEnd;
+
+        const wasPastDue = row.status === 'past_due';
+        const wasSuspended = !!row.suspended_at;
+
+        // Transaction — deduction + period advance
+        let deductionSucceeded = false;
+        await database.transaction(async (tx: DrizzleTransaction) => {
+          const insertResult = await tx
+            .insert(credit_transactions)
+            .values({
+              kilo_user_id: row.user_id,
+              amount_microdollars: -cost,
+              is_free: false,
+              description: `KiloClaw ${effectivePlan} subscription renewal`,
+              credit_category: creditCategory,
+              check_category_uniqueness: true,
+            })
+            .onConflictDoNothing();
+
+          // Duplicate key → skip (idempotent)
+          if (insertResult.rowCount === 0) return;
+
+          deductionSucceeded = true;
+
+          // Decrement balance
+          await tx
+            .update(kilocode_users)
+            .set({
+              total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${cost}`,
+            })
+            .where(eq(kilocode_users.id, row.user_id));
+
+          // Build subscription update
+          const updateSet: Partial<typeof kiloclaw_subscriptions.$inferInsert> = {
+            current_period_start: newPeriodStart,
+            current_period_end: newPeriodEnd,
+            credit_renewal_at: newCreditRenewalAt,
+            auto_top_up_triggered_for_period: null,
+          };
+
+          // Clear past_due on recovery
+          if (wasPastDue) {
+            updateSet.status = 'active';
+            updateSet.past_due_since = null;
+          }
+
+          // Extend commit_ends_at if past
+          if (effectivePlan === 'commit' && row.commit_ends_at) {
+            const commitEnd = new Date(row.commit_ends_at);
+            if (commitEnd.getTime() <= Date.now()) {
+              updateSet.commit_ends_at = addMonths(commitEnd, 6).toISOString();
+            }
+          }
+
+          await tx
+            .update(kiloclaw_subscriptions)
+            .set(updateSet)
+            .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        });
+
+        if (!deductionSucceeded) continue; // Duplicate, no-op
+
+        summary.renewals++;
+
+        // Post-commit: Kilo Pass bonus evaluation
+        try {
+          await evaluateKiloPassBonusAfterDeduction(row.user_id, cost);
+        } catch (error) {
+          logError('Kilo Pass bonus evaluation failed after renewal', {
+            user_id: row.user_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+
+        // Grace-period recovery (past_due, not suspended) — delete email log
+        if (wasPastDue && !wasSuspended) {
+          await database
+            .delete(kiloclaw_email_log)
+            .where(
+              and(
+                eq(kiloclaw_email_log.user_id, row.user_id),
+                eq(kiloclaw_email_log.email_type, 'claw_credit_renewal_failed')
+              )
+            );
+          summary.recoveries++;
+        }
+
+        // Suspended recovery — auto-resume
+        if (wasPastDue && wasSuspended) {
+          await autoResumeIfSuspended(row.user_id);
+          summary.auto_resumes++;
+          summary.recoveries++;
+        }
+      } else {
+        // ── INSUFFICIENT BALANCE ──
+
+        // Check auto top-up eligibility
+        const hasAutoTopUp = !!row.auto_top_up_enabled;
+        const alreadyTriggered = !!row.auto_top_up_triggered_for_period;
+
+        if (hasAutoTopUp && !alreadyTriggered) {
+          // Fire-and-skip: persist marker BEFORE triggering
+          await database
+            .update(kiloclaw_subscriptions)
+            .set({ auto_top_up_triggered_for_period: row.credit_renewal_at })
+            .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+
+          try {
+            await triggerAutoTopUpForKiloClaw(row.user_id, row.credit_renewal_at);
+          } catch (error) {
+            logError('Auto top-up trigger failed', {
+              user_id: row.user_id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+
+          summary.auto_top_up_triggered++;
+          continue; // Skip — next sweep re-evaluates
+        }
+
+        // Set past_due (preserve existing past_due_since)
+        await database
+          .update(kiloclaw_subscriptions)
+          .set({
+            status: 'past_due',
+            past_due_since: sql`COALESCE(${kiloclaw_subscriptions.past_due_since}, ${new Date(Date.now()).toISOString()})`,
+          })
+          .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        summary.past_due++;
+
+        // Send credit-renewal-failed notification (idempotent)
+        try {
+          await trySendEmail(
+            database,
+            row.user_id,
+            row.email,
+            'claw_credit_renewal_failed',
+            'clawCreditRenewalFailed',
+            { claw_url: clawUrl }
+          );
+        } catch (error) {
+          captureException(error);
+          logError('Failed to send credit renewal failed email', {
+            user_id: row.user_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } catch (error) {
+      summary.errors++;
+      captureException(error);
+      logError('Credit renewal sweep failed for user', {
+        user_id: row.user_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  logInfo('Credit renewal sweep completed', { summary });
+  return summary;
+}

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -219,17 +219,26 @@ export async function autoResumeIfSuspended(kiloUserId: string): Promise<void> {
     .where(and(eq(kiloclaw_instances.user_id, kiloUserId), isNull(kiloclaw_instances.destroyed_at)))
     .limit(1);
 
+  let startSucceeded = true;
   if (activeInstance) {
     try {
       const client = new KiloClawInternalClient();
       await client.start(kiloUserId);
     } catch (startError) {
+      startSucceeded = false;
       logError('Failed to auto-resume instance', {
         user_id: kiloUserId,
         error: startError instanceof Error ? startError.message : String(startError),
       });
     }
   }
+
+  // Only clear suspension state and email log if the instance restart
+  // succeeded (or there was no instance to restart). When the start call
+  // fails, leaving suspended_at intact lets the background job
+  // (billing-lifecycle-cron rule 5) detect the incomplete auto-resume and
+  // retry on the next sweep.
+  if (!startSucceeded) return;
 
   // Clear suspension/destruction cycle emails + credit renewal failed.
   // Trial and earlybird warnings are one-time events and must NOT be cleared.
@@ -366,27 +375,14 @@ export async function runCreditRenewalSweep(
         continue;
       }
 
-      // Apply scheduled plan change if current period has ended
+      // Determine effective plan (apply scheduled switch if period ended)
       let effectivePlan: 'commit' | 'standard' = row.plan === 'commit' ? 'commit' : 'standard';
+      let hasPlanSwitch = false;
       if (row.scheduled_plan && row.current_period_end) {
         const periodEndTime = new Date(row.current_period_end).getTime();
         if (periodEndTime <= Date.now()) {
           effectivePlan = row.scheduled_plan;
-          const planUpdateFields: Partial<typeof kiloclaw_subscriptions.$inferInsert> = {
-            plan: effectivePlan,
-            scheduled_plan: null,
-            scheduled_by: null,
-          };
-          if (effectivePlan === 'commit') {
-            planUpdateFields.commit_ends_at = addMonths(new Date(Date.now()), 6).toISOString();
-          } else {
-            planUpdateFields.commit_ends_at = null;
-          }
-          await database
-            .update(kiloclaw_subscriptions)
-            .set(planUpdateFields)
-            .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
-          summary.plan_switches++;
+          hasPlanSwitch = true;
         }
       }
 
@@ -417,7 +413,7 @@ export async function runCreditRenewalSweep(
         const wasPastDue = row.status === 'past_due';
         const wasSuspended = !!row.suspended_at;
 
-        // Transaction — deduction + period advance
+        // Transaction — plan switch + deduction + period advance (atomic)
         let deductionSucceeded = false;
         await database.transaction(async (tx: DrizzleTransaction) => {
           const insertResult = await tx
@@ -453,6 +449,18 @@ export async function runCreditRenewalSweep(
             auto_top_up_triggered_for_period: null,
           };
 
+          // Apply plan switch atomically with the deduction
+          if (hasPlanSwitch) {
+            updateSet.plan = effectivePlan;
+            updateSet.scheduled_plan = null;
+            updateSet.scheduled_by = null;
+            if (effectivePlan === 'commit') {
+              updateSet.commit_ends_at = addMonths(new Date(Date.now()), 6).toISOString();
+            } else {
+              updateSet.commit_ends_at = null;
+            }
+          }
+
           // Clear past_due on recovery
           if (wasPastDue) {
             updateSet.status = 'active';
@@ -476,6 +484,7 @@ export async function runCreditRenewalSweep(
         if (!deductionSucceeded) continue; // Duplicate, no-op
 
         summary.renewals++;
+        if (hasPlanSwitch) summary.plan_switches++;
 
         // Post-commit: Kilo Pass bonus evaluation
         try {

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -455,7 +455,7 @@ export async function runCreditRenewalSweep(
             updateSet.scheduled_plan = null;
             updateSet.scheduled_by = null;
             if (effectivePlan === 'commit') {
-              updateSet.commit_ends_at = addMonths(new Date(Date.now()), 6).toISOString();
+              updateSet.commit_ends_at = addMonths(new Date(newPeriodStart), 6).toISOString();
             } else {
               updateSet.commit_ends_at = null;
             }

--- a/src/lib/kiloclaw/kilo-pass-integration.ts
+++ b/src/lib/kiloclaw/kilo-pass-integration.ts
@@ -1,0 +1,95 @@
+import 'server-only';
+
+import { credit_transactions, kilocode_users } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { eq, sql } from 'drizzle-orm';
+import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
+import { computeMonthlyCadenceBonusPercent } from '@/lib/kilo-pass/bonus';
+import { KILO_PASS_YEARLY_MONTHLY_BONUS_PERCENT } from '@/lib/kilo-pass/constants';
+import { KiloPassCadence } from '@/lib/kilo-pass/enums';
+import { sentryLogger } from '@/lib/utils.server';
+
+const logError = sentryLogger('kiloclaw-kilo-pass', 'error');
+
+function computeBonusPercent(
+  state: NonNullable<Awaited<ReturnType<typeof getKiloPassStateForUser>>>
+): number {
+  if (state.cadence === KiloPassCadence.Yearly) {
+    return KILO_PASS_YEARLY_MONTHLY_BONUS_PERCENT;
+  }
+
+  // isFirstTimeSubscriberEver=false is a conservative estimate that may
+  // undercount the bonus for users in the first-time 50% promo window.
+  // This is intentional: the projection is used for balance sufficiency
+  // checks, so under-projecting can cause a "try again later" rather than
+  // enrolling into a negative balance. A future iteration could query the
+  // subscription history for exact first-time status.
+  return computeMonthlyCadenceBonusPercent({
+    tier: state.tier,
+    streakMonths: Math.max(1, state.currentStreakMonths),
+    isFirstTimeSubscriberEver: false,
+    subscriptionStartedAtIso: state.startedAt,
+  });
+}
+
+/**
+ * Returns the projected bonus in microdollars that a user would receive from
+ * their Kilo Pass entitlement for a deduction of the given amount.
+ * Returns 0 when the user has no active Kilo Pass.
+ */
+export async function getProjectedKiloPassBonus(
+  userId: string,
+  deductionMicrodollars: number
+): Promise<number> {
+  try {
+    const state = await getKiloPassStateForUser(db, userId);
+    if (!state || state.status !== 'active') return 0;
+
+    const bonusPercent = computeBonusPercent(state);
+    return Math.round(deductionMicrodollars * bonusPercent);
+  } catch (error) {
+    logError('getProjectedKiloPassBonus failed', { userId, deductionMicrodollars, error });
+    return 0;
+  }
+}
+
+/**
+ * After a credit deduction commits, evaluates whether the user's Kilo Pass
+ * entitlement qualifies them for bonus credits and awards them if so.
+ * No-op when the user has no active Kilo Pass. Failures are logged but never thrown.
+ */
+export async function evaluateKiloPassBonusAfterDeduction(
+  userId: string,
+  deductionMicrodollars: number
+): Promise<void> {
+  try {
+    const state = await getKiloPassStateForUser(db, userId);
+    if (!state || state.status !== 'active') return;
+
+    const bonusPercent = computeBonusPercent(state);
+    const bonusMicrodollars = Math.round(deductionMicrodollars * bonusPercent);
+    if (bonusMicrodollars <= 0) return;
+
+    await db.insert(credit_transactions).values({
+      kilo_user_id: userId,
+      is_free: true,
+      amount_microdollars: bonusMicrodollars,
+      description: `KiloClaw Kilo Pass bonus (${state.cadence}, ${state.tier})`,
+      credit_category: 'kiloclaw-kilo-pass-bonus',
+      check_category_uniqueness: false,
+    });
+
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} + ${bonusMicrodollars}`,
+      })
+      .where(eq(kilocode_users.id, userId));
+  } catch (error) {
+    logError('evaluateKiloPassBonusAfterDeduction failed', {
+      userId,
+      deductionMicrodollars,
+      error,
+    });
+  }
+}

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -1,23 +1,18 @@
 import 'server-only';
 
 import type Stripe from 'stripe';
-import { eq, and, isNull, inArray, sql } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import { addMonths } from 'date-fns';
 
 import { db } from '@/lib/drizzle';
-import {
-  kiloclaw_subscriptions,
-  kiloclaw_instances,
-  kiloclaw_email_log,
-} from '@kilocode/db/schema';
+import { kiloclaw_subscriptions } from '@kilocode/db/schema';
 import type { KiloClawSubscriptionStatus } from '@kilocode/db/schema-types';
 import { getClawPlanForStripePriceId } from '@/lib/kiloclaw/stripe-price-ids.server';
 import { sentryLogger } from '@/lib/utils.server';
-import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { autoResumeIfSuspended } from '@/lib/kiloclaw/credit-billing';
 
 const logInfo = sentryLogger('kiloclaw-stripe', 'info');
 const logWarning = sentryLogger('kiloclaw-stripe', 'warning');
-const logError = sentryLogger('kiloclaw-stripe', 'error');
 
 type KiloClawSubscriptionMetadata = {
   type: 'kiloclaw';
@@ -83,52 +78,6 @@ const STRIPE_TO_CLAW_STATUS: Record<string, KiloClawSubscriptionStatus> = {
 function mapStripeStatus(stripeStatus: string): KiloClawSubscriptionStatus {
   if (stripeStatus === 'trialing') return 'active';
   return STRIPE_TO_CLAW_STATUS[stripeStatus] ?? 'active';
-}
-
-/**
- * If the user was suspended, try to start their instance and clear suspension state.
- */
-async function autoResumeIfSuspended(kiloUserId: string): Promise<void> {
-  const [activeInstance] = await db
-    .select({ id: kiloclaw_instances.id })
-    .from(kiloclaw_instances)
-    .where(and(eq(kiloclaw_instances.user_id, kiloUserId), isNull(kiloclaw_instances.destroyed_at)))
-    .limit(1);
-
-  if (activeInstance) {
-    try {
-      const client = new KiloClawInternalClient();
-      await client.start(kiloUserId);
-    } catch (startError) {
-      logError('Failed to auto-resume instance', {
-        user_id: kiloUserId,
-        error: startError instanceof Error ? startError.message : String(startError),
-      });
-    }
-  }
-
-  // Clear suspension/destruction cycle emails so they can fire again in a future cycle.
-  // Trial and earlybird warnings are one-time events and must NOT be cleared.
-  const resettableEmailTypes = [
-    'claw_suspended_trial',
-    'claw_suspended_subscription',
-    'claw_suspended_payment',
-    'claw_destruction_warning',
-    'claw_instance_destroyed',
-  ];
-  await db
-    .delete(kiloclaw_email_log)
-    .where(
-      and(
-        eq(kiloclaw_email_log.user_id, kiloUserId),
-        inArray(kiloclaw_email_log.email_type, resettableEmailTypes)
-      )
-    );
-
-  await db
-    .update(kiloclaw_subscriptions)
-    .set({ suspended_at: null, destruction_deadline: null })
-    .where(eq(kiloclaw_subscriptions.user_id, kiloUserId));
 }
 
 /**
@@ -227,6 +176,7 @@ export async function handleKiloClawSubscriptionCreated(params: {
         stripe_subscription_id: subscription.id,
         plan,
         status,
+        payment_source: 'stripe',
         cancel_at_period_end: subscription.cancel_at_period_end,
         current_period_start: periods.current_period_start,
         current_period_end: periods.current_period_end,
@@ -238,6 +188,7 @@ export async function handleKiloClawSubscriptionCreated(params: {
           stripe_subscription_id: subscription.id,
           plan,
           status,
+          payment_source: 'stripe',
           cancel_at_period_end: subscription.cancel_at_period_end,
           current_period_start: periods.current_period_start,
           current_period_end: periods.current_period_end,
@@ -310,6 +261,7 @@ export async function handleKiloClawSubscriptionUpdated(params: {
     .set({
       status,
       plan,
+      payment_source: 'stripe',
       cancel_at_period_end: subscription.cancel_at_period_end,
       current_period_start: periods.current_period_start,
       current_period_end: periods.current_period_end,

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -45,7 +45,10 @@ import { getStripePriceIdForClawPlan } from '@/lib/kiloclaw/stripe-price-ids.ser
 import {
   KILOCLAW_EARLYBIRD_EXPIRY_DATE,
   KILOCLAW_TRIAL_DURATION_DAYS,
+  KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS,
+  KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS,
 } from '@/lib/kiloclaw/constants';
+import { enrollWithCredits } from '@/lib/kiloclaw/credit-billing';
 import type { ClawBillingStatus } from '@/app/(app)/claw/components/billing/billing-types';
 
 /**
@@ -1105,7 +1108,10 @@ export const kiloclawRouter = createTRPCRouter({
         : null;
 
     const subscriptionData =
-      sub && sub.plan !== 'trial' && sub.status !== 'trialing' && sub.stripe_subscription_id
+      sub &&
+      sub.plan !== 'trial' &&
+      sub.status !== 'trialing' &&
+      (sub.stripe_subscription_id || sub.payment_source === 'credits')
         ? {
             plan: sub.plan,
             status: sub.status,
@@ -1114,6 +1120,14 @@ export const kiloclawRouter = createTRPCRouter({
             commitEndsAt: sub.commit_ends_at,
             scheduledPlan: sub.scheduled_plan,
             scheduledBy: sub.scheduled_by,
+            paymentSource: sub.payment_source ?? null,
+            creditRenewalAt: sub.credit_renewal_at ?? null,
+            renewalCostMicrodollars:
+              sub.payment_source === 'credits'
+                ? sub.plan === 'commit'
+                  ? KILOCLAW_COMMIT_SIXMONTH_MICRODOLLARS
+                  : KILOCLAW_STANDARD_MONTHLY_MICRODOLLARS
+                : null,
           }
         : null;
 
@@ -1261,6 +1275,12 @@ export const kiloclawRouter = createTRPCRouter({
       return { url: typeof session.url === 'string' ? session.url : null };
     }),
 
+  enrollWithCredits: baseProcedure
+    .input(z.object({ plan: z.enum(['commit', 'standard']) }))
+    .mutation(async ({ ctx, input }) => {
+      await enrollWithCredits(ctx.user.id, input.plan);
+    }),
+
   cancelSubscription: baseProcedure.mutation(async ({ ctx }) => {
     const [sub] = await db
       .select()
@@ -1268,7 +1288,7 @@ export const kiloclawRouter = createTRPCRouter({
       .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
       .limit(1);
 
-    if (!sub?.stripe_subscription_id || sub.status !== 'active') {
+    if (!sub || sub.status !== 'active') {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to cancel.' });
     }
 
@@ -1277,6 +1297,23 @@ export const kiloclawRouter = createTRPCRouter({
         code: 'BAD_REQUEST',
         message: 'Subscription is already set to cancel.',
       });
+    }
+
+    // Credit-funded subscriptions: update local DB only, no Stripe calls.
+    if (sub.payment_source === 'credits') {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({
+          cancel_at_period_end: true,
+          ...(sub.scheduled_plan ? { scheduled_plan: null, scheduled_by: null } : {}),
+        })
+        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+      return { success: true };
+    }
+
+    if (!sub.stripe_subscription_id) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to cancel.' });
     }
 
     // If there's a pending schedule, release it first.
@@ -1332,7 +1369,24 @@ export const kiloclawRouter = createTRPCRouter({
       .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
       .limit(1);
 
-    if (!sub?.stripe_subscription_id || !sub.cancel_at_period_end) {
+    if (!sub?.cancel_at_period_end) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'No pending cancellation to reactivate.',
+      });
+    }
+
+    // Credit-funded subscriptions: update local DB only, no Stripe calls.
+    if (sub.payment_source === 'credits') {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ cancel_at_period_end: false })
+        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+      return { success: true };
+    }
+
+    if (!sub.stripe_subscription_id) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
         message: 'No pending cancellation to reactivate.',
@@ -1357,7 +1411,7 @@ export const kiloclawRouter = createTRPCRouter({
         .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
         .limit(1);
 
-      if (!sub?.stripe_subscription_id || sub.status !== 'active') {
+      if (!sub || sub.status !== 'active') {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to switch.' });
       }
 
@@ -1369,11 +1423,28 @@ export const kiloclawRouter = createTRPCRouter({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot switch from a trial plan.' });
       }
 
-      if (sub.stripe_schedule_id) {
+      if (sub.scheduled_plan) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'A plan switch is already pending. Cancel it before requesting a new one.',
         });
+      }
+
+      // Credit-funded subscriptions: record schedule locally only, no Stripe calls.
+      if (sub.payment_source === 'credits') {
+        await db
+          .update(kiloclaw_subscriptions)
+          .set({
+            scheduled_plan: input.toPlan,
+            scheduled_by: 'user',
+          })
+          .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+        return { success: true };
+      }
+
+      if (!sub.stripe_subscription_id) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to switch.' });
       }
 
       const targetPriceId = getStripePriceIdForClawPlan(input.toPlan);
@@ -1431,7 +1502,7 @@ export const kiloclawRouter = createTRPCRouter({
       .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
       .limit(1);
 
-    if (!sub?.stripe_schedule_id) {
+    if (!sub?.scheduled_plan) {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'No pending plan switch to cancel.' });
     }
 
@@ -1441,6 +1512,20 @@ export const kiloclawRouter = createTRPCRouter({
         code: 'BAD_REQUEST',
         message: 'No user-initiated plan switch to cancel.',
       });
+    }
+
+    // Credit-funded subscriptions: clear schedule locally only, no Stripe calls.
+    if (sub.payment_source === 'credits') {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ scheduled_plan: null, scheduled_by: null })
+        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+      return { success: true };
+    }
+
+    if (!sub.stripe_schedule_id) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'No pending plan switch to cancel.' });
     }
 
     await stripe.subscriptionSchedules.release(sub.stripe_schedule_id);
@@ -1453,6 +1538,19 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   createBillingPortalSession: baseProcedure.mutation(async ({ ctx }) => {
+    const [creditSub] = await db
+      .select({ payment_source: kiloclaw_subscriptions.payment_source })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
+      .limit(1);
+
+    if (creditSub?.payment_source === 'credits') {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Billing portal is not available for credit-funded subscriptions',
+      });
+    }
+
     const stripeCustomerId = ctx.user.stripe_customer_id;
     if (!stripeCustomerId) {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer.' });


### PR DESCRIPTION
## Summary

Add support for paying KiloClaw subscriptions with Kilo credits as an alternative to Stripe, implementing the credit-funded billing rules from the updated spec.

**Key architectural changes:**

- **New `payment_source` column** on `kiloclaw_subscriptions` (`stripe` | `credits`) with `credit_renewal_at` and `auto_top_up_triggered_for_period` timestamps for credit lifecycle tracking
- **New `credit-billing.ts` module** — core credit enrollment and renewal sweep logic, including:
  - `enrollWithCredits()` — atomic credit deduction + subscription upsert in a single transaction with idempotent category keys
  - `runCreditRenewalSweep()` — periodic sweep handling active renewals, cancel-at-period-end, plan switches, insufficient balance (with auto top-up fire-and-skip), past-due marking, and recovery paths (grace-period + suspended)
  - `autoResumeIfSuspended()` — extracted from `stripe-handlers.ts` and extended to also clear `credit-renewal-failed` email log entries
- **New `kilo-pass-integration.ts` module** — projects and awards Kilo Pass bonus credits for KiloClaw deductions
- **Router updates** — `cancelSubscription`, `reactivateSubscription`, `switchPlan`, and `cancelPlanSwitch` now branch on `payment_source` to handle credit-funded subs with local DB updates only (no Stripe API calls); new `enrollWithCredits` mutation
- **Billing status API** — returns `paymentSource`, `creditRenewalAt`, and `renewalCostMicrodollars` for credit-funded subscriptions
- **Billing portal** — blocks access for credit-funded subscriptions per spec
- **Auto top-up integration** — `triggerAutoTopUpForKiloClaw()` with deterministic Stripe idempotency keys derived from user ID + renewal timestamp
- **Email** — new `clawCreditRenewalFailed` notification type
- **Billing lifecycle cron** — credit renewal sweep runs before all other sweeps; interrupted auto-resume detection retries on next cron run
- **Stripe webhook handlers** — now set `payment_source: 'stripe'` on all subscription upserts to distinguish from credit-funded subscriptions

**Spec changes** (commits 1–4): Updated `.specs/kiloclaw-billing.md` with comprehensive rules for credit enrollment, credit renewal, auto top-up integration, plan switching, cancellation/reactivation, and payment source constraints.

## Verification

- Tests: `src/lib/kiloclaw/credit-billing.test.ts` (1196 lines) covers enrollment, renewal sweep, cancellation, plan switches, auto top-up integration, and recovery paths
- Staged, unstaged, and untracked changes implement the full spec; the 4 pushed commits are spec documentation

## Visual Changes

N/A

## Reviewer Notes

- `autoResumeIfSuspended` was moved from `stripe-handlers.ts` to `credit-billing.ts` so it can be shared by both Stripe webhook recovery and credit renewal recovery paths. The Stripe handler now imports from the new location.
- The credit renewal sweep intentionally advances by at most one billing period per run (even if multiple periods are overdue) to ensure each period gets a distinct idempotency key.
- Effective balance for enrollment/renewal checks includes projected Kilo Pass bonus credits (conservative estimate — under-projects rather than over-projects).
- The `auto_top_up_triggered_for_period` marker is persisted *before* the Stripe invoice is created to prevent duplicate top-ups if the process crashes after invoice creation but before the marker write.
- Cross-payment-source switching (credits↔Stripe) is explicitly deferred to a future phase per spec; users must cancel and re-enroll.