### PR TITLE
chore(kiloclaw): bump 1Password CLI to 2.33.0

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
     && curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
        | gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg \
     && apt-get update \
-    && apt-get install -y --no-install-recommends gh 1password-cli=2.32.1-1 \
+    && apt-get install -y --no-install-recommends gh 1password-cli=2.33.0-1 \
     && apt-get purge -y xz-utils \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -12,6 +12,12 @@ export type ChangelogEntry = {
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-03-17',
+    description: 'Updated 1Password CLI to 2.33.0.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
+    date: '2026-03-17',
     description:
       'Reduced OpenClaw startup overhead by disabling unnecessary CLI self-respawn, enabled Node compile cache for faster repeated CLI runs, and tightened state directory permissions.',
     category: 'feature',


### PR DESCRIPTION
## Summary

Bump 1Password CLI from 2.32.1 to 2.33.0 in the KiloClaw Dockerfile and add a corresponding changelog entry.

## Verification

- [x] `pnpm format:check` — passed (ran as pre-push hook)
- [x] `pnpm lint` — passed (ran as pre-push hook)
- [x] `pnpm typecheck` — passed (ran as pre-push hook)

## Visual Changes

N/A

## Reviewer Notes

Version-only change; no logic or config changes.