### PR TITLE
fix(app-builder): resolve stuck streaming UI on disconnect

### DIFF
--- a/src/components/app-builder/project-manager/sessions/v2/streaming.ts
+++ b/src/components/app-builder/project-manager/sessions/v2/streaming.ts
@@ -235,6 +235,8 @@ export function createV2StreamingCoordinator(config: V2StreamingConfig): V2Strea
   function updateConnectionState(state: ConnectionState): void {
     connectionState = state;
     if (state.status === 'error' || state.status === 'disconnected') {
+      // Force-complete all in-flight messages so they don't appear stuck in streaming state
+      processor?.forceCompleteAll();
       store.setState({ isStreaming: false });
       if (state.status === 'disconnected') {
         onStreamComplete?.();

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -1479,6 +1479,59 @@ describe('createEventProcessor', () => {
       if (erroredPart.state.status !== 'error') throw new Error('Expected error status');
       expect(erroredPart.state.error).toBe('original error');
     });
+
+    it('should force-complete stuck tool parts on already-completed messages via onMessageUpdated', () => {
+      let updatedMessage: ProcessedMessage | undefined;
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn((_, __, message) => {
+          updatedMessage = message;
+        }),
+        onMessageCompleted: jest.fn(),
+        onPartUpdated: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      // Create an assistant message that is already completed (server sent time.completed)
+      processor.processEvent(
+        createKilocodeEvent('message.updated', {
+          info: createAssistantInfo('msg-1', 'session-123', Date.now()),
+        })
+      );
+
+      // Add a tool part still in running state (arrived after message completion)
+      processor.processEvent(
+        createKilocodeEvent('message.part.updated', {
+          part: {
+            id: 'tool-1',
+            sessionID: 'session-123',
+            messageID: 'msg-1',
+            type: 'tool',
+            callID: 'call-1',
+            tool: 'some_tool',
+            state: { status: 'running', input: { arg: 'value' }, time: { start: 2000 } },
+          },
+        })
+      );
+
+      // onMessageCompleted already fired from message.updated
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+      (callbacks.onMessageUpdated as jest.Mock).mockClear();
+
+      processor.forceCompleteAll();
+
+      // Should NOT re-fire onMessageCompleted for already-completed message
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+
+      // Should fire onMessageUpdated so the UI re-renders cleaned-up parts
+      expect(callbacks.onMessageUpdated).toHaveBeenCalledTimes(1);
+
+      const toolPart = updatedMessage?.parts.find(p => p.type === 'tool');
+      if (!toolPart || toolPart.type !== 'tool') throw new Error('Expected tool part');
+      expect(toolPart.state.status).toBe('error');
+      if (toolPart.state.status !== 'error') throw new Error('Expected error status');
+      expect(toolPart.state.error).toBe('Connection lost');
+      expect(toolPart.state.time.start).toBe(2000);
+    });
   });
 
   describe('question events', () => {

--- a/src/lib/cloud-agent-next/processor/event-processor.test.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.test.ts
@@ -1317,6 +1317,168 @@ describe('createEventProcessor', () => {
 
       expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
     });
+
+    it('should force-complete running tool parts to error state preserving time.start', () => {
+      let completedMessage: ProcessedMessage | undefined;
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onPartUpdated: jest.fn(),
+        onMessageCompleted: jest.fn((_, __, message) => {
+          completedMessage = message;
+        }),
+        onStreamingChanged: jest.fn(),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('session.status', {
+          sessionID: 'session-123',
+          status: { type: 'busy' },
+        })
+      );
+
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      processor.processEvent(
+        createKilocodeEvent('message.part.updated', {
+          part: {
+            id: 'tool-1',
+            sessionID: 'session-123',
+            messageID: 'msg-1',
+            type: 'tool',
+            callID: 'call-1',
+            tool: 'some_tool',
+            state: { status: 'running', input: { arg: 'value' }, time: { start: 1000 } },
+          },
+        })
+      );
+
+      processor.forceCompleteAll();
+
+      expect(callbacks.onMessageCompleted).toHaveBeenCalledTimes(1);
+      const toolPart = completedMessage?.parts.find(p => p.type === 'tool');
+      if (!toolPart || toolPart.type !== 'tool') throw new Error('Expected tool part');
+      expect(toolPart.state.status).toBe('error');
+      if (toolPart.state.status !== 'error') throw new Error('Expected error status');
+      expect(toolPart.state.error).toBe('Connection lost');
+      expect(toolPart.state.time.start).toBe(1000);
+    });
+
+    it('should force-complete pending tool parts to error state', () => {
+      let completedMessage: ProcessedMessage | undefined;
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onPartUpdated: jest.fn(),
+        onMessageCompleted: jest.fn((_, __, message) => {
+          completedMessage = message;
+        }),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      processor.processEvent(
+        createKilocodeEvent('message.part.updated', {
+          part: {
+            id: 'tool-1',
+            sessionID: 'session-123',
+            messageID: 'msg-1',
+            type: 'tool',
+            callID: 'call-1',
+            tool: 'some_tool',
+            state: { status: 'pending', input: { x: 1 }, raw: '{}' },
+          },
+        })
+      );
+
+      processor.forceCompleteAll();
+
+      const toolPart = completedMessage?.parts.find(p => p.type === 'tool');
+      if (!toolPart || toolPart.type !== 'tool') throw new Error('Expected tool part');
+      expect(toolPart.state.status).toBe('error');
+      if (toolPart.state.status !== 'error') throw new Error('Expected error status');
+      expect(toolPart.state.error).toBe('Connection lost');
+    });
+
+    it('should not modify already-completed or errored tool parts', () => {
+      let completedMessage: ProcessedMessage | undefined;
+      const callbacks: EventProcessorCallbacks = {
+        onMessageUpdated: jest.fn(),
+        onPartUpdated: jest.fn(),
+        onMessageCompleted: jest.fn((_, __, message) => {
+          completedMessage = message;
+        }),
+      };
+      const processor = createEventProcessor({ callbacks });
+
+      processor.processEvent(
+        createKilocodeEvent('message.updated', { info: createAssistantInfo('msg-1') })
+      );
+
+      // Add a completed tool part
+      processor.processEvent(
+        createKilocodeEvent('message.part.updated', {
+          part: {
+            id: 'tool-done',
+            sessionID: 'session-123',
+            messageID: 'msg-1',
+            type: 'tool',
+            callID: 'call-done',
+            tool: 'done_tool',
+            state: {
+              status: 'completed',
+              input: {},
+              output: 'ok',
+              title: 'Done',
+              metadata: {},
+              time: { start: 500, end: 600 },
+            },
+          },
+        })
+      );
+
+      // Add an already-errored tool part
+      processor.processEvent(
+        createKilocodeEvent('message.part.updated', {
+          part: {
+            id: 'tool-err',
+            sessionID: 'session-123',
+            messageID: 'msg-1',
+            type: 'tool',
+            callID: 'call-err',
+            tool: 'err_tool',
+            state: {
+              status: 'error',
+              input: {},
+              error: 'original error',
+              time: { start: 700, end: 800 },
+            },
+          },
+        })
+      );
+
+      processor.forceCompleteAll();
+
+      const completedPart = completedMessage?.parts.find(
+        p => p.type === 'tool' && p.id === 'tool-done'
+      );
+      const erroredPart = completedMessage?.parts.find(
+        p => p.type === 'tool' && p.id === 'tool-err'
+      );
+
+      // Completed part should remain completed
+      if (!completedPart || completedPart.type !== 'tool') throw new Error('Expected tool part');
+      expect(completedPart.state.status).toBe('completed');
+      // Errored part should keep original error
+      if (!erroredPart || erroredPart.type !== 'tool') throw new Error('Expected tool part');
+      expect(erroredPart.state.status).toBe('error');
+      if (erroredPart.state.status !== 'error') throw new Error('Expected error status');
+      expect(erroredPart.state.error).toBe('original error');
+    });
   });
 
   describe('question events', () => {

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -433,7 +433,12 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
   function forceCompleteAllMessages(skipStreamingToggle = false): void {
     const now = Date.now();
     for (const [key, message] of messagesMap) {
-      if (isAssistantMessage(message.info) && !isAssistantMessageComplete(message)) {
+      if (!isAssistantMessage(message.info)) continue;
+
+      const [sessionId, messageId] = key.split(':');
+      const parentSessionId = getParentSessionId(sessionId);
+
+      if (!isAssistantMessageComplete(message)) {
         message.info = {
           ...message.info,
           time: { ...message.info.time, completed: now },
@@ -442,10 +447,13 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
         // Force-complete any in-flight tool parts so their spinners stop
         forceCompleteToolParts(message, now);
 
-        const [sessionId, messageId] = key.split(':');
-        const parentSessionId = getParentSessionId(sessionId);
         callbacks.onMessageCompleted?.(sessionId, messageId, message, parentSessionId);
         completedMessages.add(key);
+      } else if (forceCompleteToolParts(message, now)) {
+        // Already-completed messages can still have stuck tool parts when the
+        // server sent time.completed before all part updates arrived.
+        // Notify the UI so it re-renders the cleaned-up parts.
+        callbacks.onMessageUpdated?.(sessionId, messageId, message, parentSessionId);
       }
     }
 
@@ -461,8 +469,10 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
    * Force-complete tool parts that are stuck in pending/running state.
    * Transitions them to error state with a synthetic timestamp so the UI
    * stops showing a spinner.
+   * Returns true if any parts were modified.
    */
-  function forceCompleteToolParts(message: ProcessedMessage, now: number): void {
+  function forceCompleteToolParts(message: ProcessedMessage, now: number): boolean {
+    let modified = false;
     for (let i = 0; i < message.parts.length; i++) {
       const part = message.parts[i];
       if (!isToolPart(part)) continue;
@@ -478,7 +488,9 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
           time: { start, end: now },
         },
       };
+      modified = true;
     }
+    return modified;
   }
 
   /**

--- a/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -23,6 +23,7 @@ import {
   stripPartContentIfFile,
   isUserMessage,
   isAssistantMessage,
+  isToolPart,
   type EventMessageUpdated,
   type EventMessagePartUpdated,
   type EventMessagePartRemoved,
@@ -438,6 +439,9 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
           time: { ...message.info.time, completed: now },
         };
 
+        // Force-complete any in-flight tool parts so their spinners stop
+        forceCompleteToolParts(message, now);
+
         const [sessionId, messageId] = key.split(':');
         const parentSessionId = getParentSessionId(sessionId);
         callbacks.onMessageCompleted?.(sessionId, messageId, message, parentSessionId);
@@ -450,6 +454,30 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
     if (!skipStreamingToggle && streaming) {
       streaming = false;
       callbacks.onStreamingChanged?.(false);
+    }
+  }
+
+  /**
+   * Force-complete tool parts that are stuck in pending/running state.
+   * Transitions them to error state with a synthetic timestamp so the UI
+   * stops showing a spinner.
+   */
+  function forceCompleteToolParts(message: ProcessedMessage, now: number): void {
+    for (let i = 0; i < message.parts.length; i++) {
+      const part = message.parts[i];
+      if (!isToolPart(part)) continue;
+      if (part.state.status === 'completed' || part.state.status === 'error') continue;
+
+      const start = part.state.status === 'running' ? part.state.time.start : now;
+      message.parts[i] = {
+        ...part,
+        state: {
+          status: 'error',
+          input: part.state.input,
+          error: 'Connection lost',
+          time: { start, end: now },
+        },
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

Fix the bug where app builder messages and tool parts appear permanently stuck in "Streaming..." state when the sandbox dies or the WebSocket disconnects.

**Streaming fix (two layers):**
- **Message-level** (`streaming.ts`): Call `processor.forceCompleteAll()` in `updateConnectionState()` before clearing the streaming flag, so all in-flight messages get `time.completed` set and their bubble spinners stop.
- **Part-level** (`event-processor.ts`): Add `forceCompleteToolParts()` to transition stuck tool parts (pending/running) to `error` state with a "Connection lost" message, stopping their individual tool card spinners.

**Also includes** structured JSON logging for KiloClaw DO modules — replaces ~46 ad-hoc `console.error`/`console.warn` calls with `doError()`/`doWarn()` helpers that emit JSON with full instance context (userId, sandboxId, flyMachineId, flyRegion, flyAppName). Adds `RequestContext` threading to `KiloClawInternalClient` and `KiloClawUserClient` so HTTP error logs include userId.

## Verification

- [x] `prettier --check` — passed (pre-push hook)
- [x] `eslint` — passed across all workspace projects (pre-push hook)
- [x] `typecheck` — passed across all workspace projects (pre-push hook)
- [x] `pnpm test` — event-processor tests including 3 new test cases for force-completing tool parts (running→error, pending→error, already-completed/errored parts unchanged)
- [x] Manual: trigger disconnect while tools are streaming, verify spinners resolve to error state

## Visual Changes

N/A

## Reviewer Notes

- Only the app builder streaming path (`streaming.ts`) is patched. The same bug exists in `useCloudAgentStream.ts` (Cloud Agent UI) but is deferred to a later refactor.
- Tool parts stuck in pending/running transition to `error` (not `completed`) with "Connection lost" — this is more accurate than pretending they succeeded.
- The kiloclaw structured logging changes are logically separate but were committed to this branch.