### PR TITLE
fix(code-reviews): fix incremental review flag and add logging

### DIFF
--- a/src/lib/code-reviews/prompts/generate-prompt.ts
+++ b/src/lib/code-reviews/prompts/generate-prompt.ts
@@ -273,8 +273,22 @@ export async function generateReviewPrompt(
       .replace(/{PREVIOUS_SUMMARY}/g, existingReviewState.summaryComment.body)
       .replace(/{ACTIVE_COMMENT_COUNT}/g, String(activeCount));
     prompt += replacePlaceholders(incrementalWorkflow) + '\n\n';
+    logExceptInTest('[generateReviewPrompt] Using incremental workflow', {
+      reviewId,
+      previousHeadSha: previousHeadSha.substring(0, 8),
+    });
   } else {
     prompt += replacePlaceholders(template.workflow) + '\n\n';
+    if (previousHeadSha) {
+      logExceptInTest(
+        '[generateReviewPrompt] Falling back to full workflow despite previousHeadSha',
+        {
+          reviewId,
+          hasIncrementalTemplate: !!template.incrementalReviewWorkflow,
+          hasSummaryComment: !!existingReviewState?.summaryComment,
+        }
+      );
+    }
   }
 
   // 6. What to review

--- a/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -322,7 +322,10 @@ export async function prepareReviewPayload(
     // continuation) are derived from the same review row to avoid mismatches.
     let previousHeadSha: string | null = null;
     let previousCloudAgentSessionId: string | undefined;
-    const incrementalEnabled = await isFeatureFlagEnabled(FEATURE_FLAG_INCREMENTAL_REVIEW);
+    const incrementalEnabled = await isFeatureFlagEnabled(
+      FEATURE_FLAG_INCREMENTAL_REVIEW,
+      owner.userId
+    );
 
     if (incrementalEnabled) {
       try {

--- a/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -327,6 +327,12 @@ export async function prepareReviewPayload(
       owner.userId
     );
 
+    logExceptInTest('[prepareReviewPayload] Incremental review flag evaluated', {
+      reviewId,
+      incrementalEnabled,
+      ownerId: owner.userId,
+    });
+
     if (incrementalEnabled) {
       try {
         const previousReview = await findPreviousCompletedReview(
@@ -347,6 +353,11 @@ export async function prepareReviewPayload(
               currentHeadSha: review.head_sha.substring(0, 8),
               previousCloudAgentSessionId,
             }
+          );
+        } else {
+          logExceptInTest(
+            '[prepareReviewPayload] No previous completed review found, using full review',
+            { reviewId }
           );
         }
       } catch (error) {


### PR DESCRIPTION
## Summary

Follow-up for https://github.com/Kilo-Org/cloud/pull/927

The incremental review feature flag was evaluated with a hardcoded `'server-config-fetch'` distinctId instead of the actual owner's userId, making per-user/org targeting in PostHog non-functional. This meant the flag always resolved the same way regardless of which user or org triggered the review. Additionally, the entire incremental review decision path had zero logging, making it impossible to debug from Axiom why a review used full mode instead of incremental.

This PR passes `owner.userId` to the flag evaluation (matching the pattern already used for the PR gate flag in the same file) and adds log lines at each decision point: flag evaluation result, previous review lookup outcome, and the prompt workflow gate that selects incremental vs full mode.

## Verification

- [x] `pnpm typecheck` — passes cleanly across all workspace projects

## Visual Changes

N/A

## Reviewer Notes

- The flag fix on line 325 mirrors the existing correct pattern at line 410 (`isFeatureFlagEnabled('code-review-pr-gate', owner.userId)`).
- `owner.userId` is always present — it's a required field in both variants of the `OwnerSchema` discriminated union. For orgs, it's a synthetic bot ID like `'bot-code-review-{orgId}'`.
- Logging uses `logExceptInTest` consistently and truncates SHAs to 8 characters, matching existing conventions.
- Issue #3 from the investigation (rapid push cancellation preventing incremental base) is intentionally not addressed here — it's an architectural design constraint that needs product discussion.