### PR TITLE
fix(db): route summarizeUserPayments reads to replica

### DIFF
--- a/src/lib/creditTransactions.ts
+++ b/src/lib/creditTransactions.ts
@@ -1,5 +1,5 @@
 import { eq, desc, and, isNull, gt, notExists } from 'drizzle-orm';
-import { db, sql } from './drizzle';
+import { db, readDb, sql } from './drizzle';
 import type { Organization } from '@kilocode/db/schema';
 import { credit_transactions, kilo_pass_issuance_items } from '@kilocode/db/schema';
 
@@ -42,9 +42,9 @@ export type CreditInfo = {
 };
 
 export type UserPaymentsSummary = Awaited<ReturnType<typeof summarizeUserPayments>>;
-export async function summarizeUserPayments(kiloUserId: string) {
+export async function summarizeUserPayments(kiloUserId: string, fromDb: typeof db = readDb) {
   return (
-    await db
+    await fromDb
       .select({
         payments_count: sql<number>`count(*)::int`,
         payments_total_microdollars: sql<number>`coalesce(sum(${credit_transactions.amount_microdollars}), 0)::float`,
@@ -56,7 +56,7 @@ export async function summarizeUserPayments(kiloUserId: string) {
           eq(credit_transactions.is_free, false),
           gt(credit_transactions.amount_microdollars, 0),
           notExists(
-            db
+            fromDb
               .select({ id: kilo_pass_issuance_items.id })
               .from(kilo_pass_issuance_items)
               .where(eq(kilo_pass_issuance_items.credit_transaction_id, credit_transactions.id))

--- a/src/lib/firstTopupBonus.ts
+++ b/src/lib/firstTopupBonus.ts
@@ -1,12 +1,14 @@
 import type { User } from '@kilocode/db/schema';
 import { grantCreditForCategory } from './promotionalCredits';
 import { summarizeUserPayments } from '@/lib/creditTransactions';
+import { db } from '@/lib/drizzle';
 import { FIRST_TOPUP_BONUS_AMOUNT } from '@/lib/constants';
 
 export async function processFirstTopupBonus(user: User) {
   // this is run after topping up, so a user which has done their first
   // topup will have exactly one topup
-  if ((await summarizeUserPayments(user.id)).payments_count !== 1) return;
+  // Uses primary db for read-after-write consistency (payment was just inserted)
+  if ((await summarizeUserPayments(user.id, db)).payments_count !== 1) return;
 
   await grantCreditForCategory(user, {
     credit_category: 'first-topup-bonus',


### PR DESCRIPTION
## Summary

Routes `summarizeUserPayments` queries to the read replica by default, reducing primary DB connection pressure. This function is called on every FIM 402 response (~273 req/s), notification generation, and profile page load — all pure reads that don't need primary consistency.

- Added `fromDb` parameter defaulting to `readDb` (replica) in `summarizeUserPayments`
- `firstTopupBonus.ts` explicitly passes primary `db` since it checks `payments_count === 1` immediately after inserting a payment (read-after-write consistency required)
- All other callers (FIM 402 path, notifications, customer info) use the new replica default with no code changes

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` — passed (via pre-push hook)
- [x] `pnpm format:check` — passed (via pre-push hook)
- [x] Manual review of all 4 call sites for read-after-write consistency requirements

## Visual Changes

N/A

## Reviewer Notes

- The `firstTopupBonus` caller is the only one requiring primary: it runs right after a Stripe webhook inserts a credit transaction and checks `payments_count === 1` to decide whether to grant the bonus. Replica lag could cause it to see 0 payments and skip the bonus.
- The other 3 callers (`llm-proxy-helpers.ts`, `notifications.ts`, `customerInfo.ts`) are all read-only with no preceding writes in their request paths, so replica lag is acceptable.