### PR TITLE
feat(gastown): add feature attribution for LLM usage tracking

### DIFF
--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -97,6 +97,7 @@ function buildAgentEnv(request: StartAgentRequest): Record<string, string> {
     GASTOWN_RIG_ID: request.rigId,
     GASTOWN_TOWN_ID: request.townId,
     GASTOWN_AGENT_ROLE: request.role,
+    KILOCODE_FEATURE: 'gastown',
 
     GIT_AUTHOR_NAME: authorName,
     GIT_AUTHOR_EMAIL: authorEmail,

--- a/src/lib/feature-detection.ts
+++ b/src/lib/feature-detection.ts
@@ -33,6 +33,7 @@ export const FEATURE_VALUES = [
   'direct-gateway',
   'embeddings',
   'openclaw-embedding',
+  'gastown',
 ] as const;
 
 const featureSchema = z.enum(FEATURE_VALUES);


### PR DESCRIPTION
## Summary

Adds `'gastown'` to the `FEATURE_VALUES` allowlist in `src/lib/feature-detection.ts` and sets `KILOCODE_FEATURE='gastown'` in the Gastown agent environment (`cloudflare-gastown/container/src/agent-runner.ts`). This ensures all Gastown agent LLM calls include the `X-KILOCODE-FEATURE: gastown` header, fixing the `NULL` `feature_id` in `microdollar_usage_metadata`.

Closes #1154.

## Verification

- [x] Code review: change follows the same pattern as `kiloclaw` and `cloud-agent` feature attribution
- [x] Confirmed `'gastown'` is a new, non-conflicting value in the FEATURE_VALUES enum
- [x] No build artifacts or secrets in the diff

## Visual Changes

N/A

## Reviewer Notes

Minimal change — two single-line additions. The pattern is identical to how `kiloclaw` sets `KILOCODE_FEATURE: 'kiloclaw'` in `kiloclaw/src/gateway/env.ts:99` and `cloud-agent` sets `KILOCODE_FEATURE: 'cloud-agent'` in `cloud-agent/src/session-service.ts:469`.