### PR TITLE
fix(kiloclaw): remove duplicate metadata recovery from Postgres restore

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1744,6 +1744,54 @@ describe('start: metadata recovery re-arms alarm', () => {
 });
 
 // ============================================================================
+// start: Postgres restore + metadata recovery cooldown interaction
+// ============================================================================
+
+describe('start: Postgres restore does not poison metadata recovery cooldown', () => {
+  it('starts successfully when DO is wiped, Postgres has a record, and Fly has no machines', async () => {
+    // Simulate a wiped DO: empty storage (no seedProvisioned), but Postgres has the record.
+    // This is the DO-eviction or local-dev-restart scenario for a user who provisioned
+    // but has never had a Fly machine created yet.
+    const appStubWithGetName = {
+      ...createFakeAppStub(),
+      getAppName: vi.fn().mockResolvedValue(null), // falls back to appNameFromUserId
+    };
+    const env = {
+      ...createFakeEnv(),
+      KILOCLAW_APP: {
+        idFromName: vi.fn().mockReturnValue('fake-do-id'),
+        get: vi.fn().mockReturnValue(appStubWithGetName),
+      } as unknown,
+    };
+
+    (db.getWorkerDb as Mock).mockReturnValue({});
+    (db.getActiveInstance as Mock).mockResolvedValue({ sandboxId: 'sandbox-1' });
+
+    // Explicitly reset listMachines — previous tests may have overridden the default.
+    (flyClient.listMachines as Mock).mockResolvedValue([]);
+    // restoreFromPostgres restores flyVolumeId=null, so ensureVolume creates one.
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-new',
+      region: 'iad',
+    });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'new-machine', region: 'iad' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    const { instance } = createInstance(undefined, env); // empty storage = DO wipe
+
+    // Bug: restoreFromPostgres calls attemptMetadataRecovery (setting cooldown),
+    // then _startInner calls it again immediately → cooldown → returns false → throws.
+    // Fix: remove attemptMetadataRecovery from restoreFromPostgres; let _startInner handle it.
+    await expect(instance.start('user-1')).resolves.toBeUndefined();
+
+    // Machine was created (not blocked by false "Metadata recovery failed" error).
+    expect(flyClient.createMachine).toHaveBeenCalledOnce();
+    // listMachines called exactly once — from _startInner's attemptMetadataRecovery only.
+    expect(flyClient.listMachines).toHaveBeenCalledOnce();
+  });
+});
+
+// ============================================================================
 // updateChannels
 // ============================================================================
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
@@ -62,6 +62,7 @@ export async function restoreFromPostgres(
         pendingDestroyMachineId: null,
         pendingDestroyVolumeId: null,
         pendingPostgresMarkOnFinalize: false,
+        lastMetadataRecoveryAt: null,
         openclawVersion: null,
         imageVariant: null,
         trackedImageTag: null,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
@@ -3,9 +3,7 @@ import type { EncryptedEnvelope } from '../../schemas/instance-config';
 import { getWorkerDb, getActiveInstance, markInstanceDestroyed } from '../../db';
 import { appNameFromUserId } from '../../fly/apps';
 import type { InstanceMutableState } from './types';
-import { getFlyConfig } from './types';
 import { storageUpdate } from './state';
-import { attemptMetadataRecovery } from './reconcile';
 import { doError, doWarn, toLoggable } from './log';
 
 /**
@@ -99,15 +97,10 @@ export async function restoreFromPostgres(
 
     console.log('[DO] Restored from Postgres: sandboxId =', instance.sandboxId);
 
-    // Attempt to recover machine/volume IDs via Fly metadata.
-    try {
-      const flyConfig = getFlyConfig(env, state);
-      await attemptMetadataRecovery(flyConfig, ctx, state, 'postgres_restore');
-    } catch (err) {
-      doWarn(state, 'Metadata recovery after Postgres restore failed', {
-        error: toLoggable(err),
-      });
-    }
+    // Machine/volume recovery is intentionally NOT done here.
+    // The caller (_startInner) already calls attemptMetadataRecovery after restore.
+    // Calling it here too would set the recovery cooldown, causing the caller's
+    // attempt to short-circuit and incorrectly abort machine creation.
   } catch (err) {
     doError(state, 'Postgres restore failed', { error: toLoggable(err) });
   }


### PR DESCRIPTION
## Summary

This issue occurs frequently when attempting to start new instances of KiloClaw in the local development environment.

- **Bug**: `restoreFromPostgres` called `attemptMetadataRecovery`, setting a cooldown timestamp. When `_startInner` subsequently called the same function, the cooldown caused it to short-circuit and return `false`, throwing a "Metadata recovery failed" error on start for users whose DO state had been evicted.
- **Fix**: Remove the redundant `attemptMetadataRecovery` call from `restoreFromPostgres` — `_startInner` already handles metadata recovery after restore.
- Add a regression test covering the DO-wipe + Postgres-restore + no-existing-machines path.

## Example Console Output

> [wrangler:info] GET /api/platform/gateway-token 200 OK (1ms)
> [REQ] POST /api/platform/start
> ✘ [ERROR] Uncaught Error: Metadata recovery failed; aborting start to avoid creating a duplicate machine Error
> 
>       at _startInner
>   (/cloud/.worktrees/controller-pairing/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts:637:15)
> 
> 
> ▲ [WARNING] [do-retry] Non-retryable error {
> 
>     operation: 'start',
>     attempt: 1,
>     error: 'Metadata recovery failed; aborting start to avoid creating a
>   duplicate machine',
>     retryable: false
>   }
> 
> 
> ✘ [ERROR] [platform] start failed: Metadata recovery failed; aborting start to avoid creating a duplicate machine
> 
> 
> [wrangler:info] POST /api/platform/start 500 Internal Server Error (3ms)
> [REQ] POST /api/platform/start
> ✘ [ERROR] Uncaught Error: Metadata recovery failed; aborting start to avoid creating a duplicate machine Error
> 
>       at _startInner
>   (/cloud/.worktrees/controller-pairing/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts:637:15)
> 
> 
> ▲ [WARNING] [do-retry] Non-retryable error {
> 
>     operation: 'start',
>     attempt: 1,
>     error: 'Metadata recovery failed; aborting start to avoid creating a
>   duplicate machine',
>     retryable: false
>   }
> 
> 
> ✘ [ERROR] [platform] start failed: Metadata recovery failed; aborting start to avoid creating a duplicate machine
> 
> 
> [wrangler:info] POST /api/platform/start 500 Internal Server Error (3ms)

## Test plan

- [x] New test: "starts successfully when DO is wiped, Postgres has a record, and Fly has no machines"
- [x] Verified locally