### PR TITLE
chore(gastown): increase TownContainerDO max_instances from 20 to 100

### DIFF
--- a/cloudflare-gastown/wrangler.jsonc
+++ b/cloudflare-gastown/wrangler.jsonc
@@ -21,7 +21,7 @@
       "class_name": "TownContainerDO",
       "image": "./container/Dockerfile",
       "instance_type": "standard-4",
-      "max_instances": 20,
+      "max_instances": 100,
     },
   ],
 


### PR DESCRIPTION
## Summary

Increases the `max_instances` limit for `TownContainerDO` in the gastown wrangler config from 20 to 100 to allow more concurrent container instances.

## Verification

- Reviewed the single-line config change in `cloudflare-gastown/wrangler.jsonc`
- No code logic changes; config-only update

## Visual Changes

N/A

## Reviewer Notes

N/A