### PR TITLE
feat(container): install git-lfs in Dockerfile and Dockerfile.dev

### DIFF
--- a/cloudflare-gastown/container/Dockerfile
+++ b/cloudflare-gastown/container/Dockerfile
@@ -2,7 +2,7 @@ FROM oven/bun:1-slim
 
 # Install git, gh CLI, and Node.js (required by @kilocode/cli which uses #!/usr/bin/env node)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl ca-certificates && \
+    apt-get install -y --no-install-recommends git git-lfs curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -13,6 +13,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN git lfs install
 
 # Install Kilo CLI globally via npm (needs real Node.js runtime).
 # npm's global install does not resolve optionalDependencies, so we must

--- a/cloudflare-gastown/container/Dockerfile
+++ b/cloudflare-gastown/container/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git lfs install
+RUN git lfs install --system
 
 # Install Kilo CLI globally via npm (needs real Node.js runtime).
 # npm's global install does not resolve optionalDependencies, so we must

--- a/cloudflare-gastown/container/Dockerfile.dev
+++ b/cloudflare-gastown/container/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM --platform=linux/arm64 oven/bun:1-slim
 
 # Install git, gh CLI, and Node.js (required by @kilocode/cli which uses #!/usr/bin/env node)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl ca-certificates && \
+    apt-get install -y --no-install-recommends git git-lfs curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -13,6 +13,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN git lfs install
 
 # Install Kilo CLI globally via npm (needs real Node.js runtime).
 # npm's global install does not resolve optionalDependencies, so we must

--- a/cloudflare-gastown/container/Dockerfile.dev
+++ b/cloudflare-gastown/container/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git lfs install
+RUN git lfs install --system
 
 # Install Kilo CLI globally via npm (needs real Node.js runtime).
 # npm's global install does not resolve optionalDependencies, so we must


### PR DESCRIPTION
## Summary

- Install `git-lfs` package in both `Dockerfile` and `Dockerfile.dev` for the gastown container, and run `git lfs install` to initialize the LFS filter in the container environment.
- This enables the container to clone and work with repositories that use Git LFS for large file storage.

## Verification

- Verified Dockerfile syntax is correct by inspecting the diff.
- No automated tests to run for Dockerfile changes.

## Visual Changes

N/A

## Reviewer Notes

- The `git-lfs` package is added to the existing `apt-get install` line to avoid creating an extra image layer.
- `git lfs install` is run as a separate `RUN` step after the apt cleanup to configure the LFS smudge/clean filters globally in the container.