### PR TITLE
fix(kiloclaw): remove start-openclaw.sh from deploy workflow

### DIFF
--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -36,7 +36,6 @@ jobs:
       # Files included (must match what the Dockerfile COPYs):
       #   - Dockerfile itself (base image, apt packages, npm versions)
       #   - controller/        (COPY controller/ → compiled to controller.js)
-      #   - start-openclaw.sh  (COPY → entrypoint script)
       #   - openclaw-pairing-list.js, openclaw-device-pairing-list.js (COPY)
       #   - skills/            (COPY skills/ → /root/clawd/skills/)
       #
@@ -49,7 +48,7 @@ jobs:
         working-directory: kiloclaw
         run: |
           # Validate all expected paths exist before hashing
-          for path in Dockerfile start-openclaw.sh controller skills \
+          for path in Dockerfile controller skills \
                       openclaw-pairing-list.js openclaw-device-pairing-list.js; do
             if [ ! -e "$path" ]; then
               echo "::error::Required path not found: $path"
@@ -58,7 +57,7 @@ jobs:
           done
 
           CONTENT_HASH=$(
-            find Dockerfile start-openclaw.sh controller/ skills/ \
+            find Dockerfile controller/ skills/ \
               openclaw-pairing-list.js openclaw-device-pairing-list.js \
               -type f \
               | sort \

--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -36,6 +36,7 @@ jobs:
       # Files included (must match what the Dockerfile COPYs):
       #   - Dockerfile itself (base image, apt packages, npm versions)
       #   - controller/        (COPY controller/ → compiled to controller.js)
+      #   - container/         (COPY container/TOOLS.md → /usr/local/share/kiloclaw/)
       #   - openclaw-pairing-list.js, openclaw-device-pairing-list.js (COPY)
       #   - skills/            (COPY skills/ → /root/clawd/skills/)
       #
@@ -48,7 +49,7 @@ jobs:
         working-directory: kiloclaw
         run: |
           # Validate all expected paths exist before hashing
-          for path in Dockerfile controller skills \
+          for path in Dockerfile controller container skills \
                       openclaw-pairing-list.js openclaw-device-pairing-list.js; do
             if [ ! -e "$path" ]; then
               echo "::error::Required path not found: $path"
@@ -57,7 +58,7 @@ jobs:
           done
 
           CONTENT_HASH=$(
-            find Dockerfile controller/ skills/ \
+            find Dockerfile controller/ container/ skills/ \
               openclaw-pairing-list.js openclaw-device-pairing-list.js \
               -type f \
               | sort \

--- a/kiloclaw/AGENTS.md
+++ b/kiloclaw/AGENTS.md
@@ -273,8 +273,25 @@ OpenClaw has strict config validation. Common gotchas:
 The Dockerfile is based on `debian:bookworm-slim` and installs Node.js 22 + OpenClaw.
 The image is pushed to Fly's registry (`registry.fly.io/{FLY_APP_NAME}`) via CI.
 
-The Dockerfile includes a cache bust comment for the controller build layer. Use
-`--build-arg CONTROLLER_CACHE_BUST=$(date +%s)` to force a controller rebuild.
+The Dockerfile has two cache bust mechanisms:
+
+- **Controller build layer**: Use `--build-arg CONTROLLER_CACHE_BUST=$(date +%s)` to force a controller rebuild.
+- **COPY layers** (helper scripts, skills, etc.): Increment the number in the `RUN echo "N"` line and update the adjacent `# Build cache bust:` comment. This invalidates Docker's layer cache for all subsequent COPY instructions.
+
+### Files COPYed into the image
+
+These files are COPYed by the Dockerfile and hashed by CI (`deploy-kiloclaw.yml`) to
+produce the content-hash image tag. If you add or remove a COPY in the Dockerfile,
+update the `find` command in the workflow's "Compute source content hash" step to match.
+
+| Path                              | Purpose                                           |
+| --------------------------------- | ------------------------------------------------- |
+| `Dockerfile`                      | Base image, apt packages, npm versions (hashed)   |
+| `controller/`                     | Compiled to `kiloclaw-controller.js` (entrypoint) |
+| `openclaw-pairing-list.js`        | Helper script used at runtime by controller       |
+| `openclaw-device-pairing-list.js` | Helper script used at runtime by controller       |
+| `skills/`                         | Custom skills copied to `/root/clawd/skills/`     |
+| `container/TOOLS.md`              | Staged to `/usr/local/share/kiloclaw/TOOLS.md`    |
 
 ## Fly Machine Lifecycle
 

--- a/kiloclaw/AGENTS.md
+++ b/kiloclaw/AGENTS.md
@@ -284,14 +284,14 @@ These files are COPYed by the Dockerfile and hashed by CI (`deploy-kiloclaw.yml`
 produce the content-hash image tag. If you add or remove a COPY in the Dockerfile,
 update the `find` command in the workflow's "Compute source content hash" step to match.
 
-| Path                              | Purpose                                           |
-| --------------------------------- | ------------------------------------------------- |
-| `Dockerfile`                      | Base image, apt packages, npm versions (hashed)   |
-| `controller/`                     | Compiled to `kiloclaw-controller.js` (entrypoint) |
-| `openclaw-pairing-list.js`        | Helper script used at runtime by controller       |
-| `openclaw-device-pairing-list.js` | Helper script used at runtime by controller       |
-| `skills/`                         | Custom skills copied to `/root/clawd/skills/`     |
-| `container/TOOLS.md`              | Staged to `/usr/local/share/kiloclaw/TOOLS.md`    |
+| Path                              | Purpose                                                 |
+| --------------------------------- | ------------------------------------------------------- |
+| `Dockerfile`                      | Base image, apt packages, npm versions                  |
+| `controller/`                     | Compiled to `kiloclaw-controller.js` (entrypoint)       |
+| `container/`                      | Runtime assets (e.g. `TOOLS.md`) staged outside `/root` |
+| `openclaw-pairing-list.js`        | Helper script used at runtime by controller             |
+| `openclaw-device-pairing-list.js` | Helper script used at runtime by controller             |
+| `skills/`                         | Custom skills copied to `/root/clawd/skills/`           |
 
 ## Fly Machine Lifecycle
 


### PR DESCRIPTION
## Summary

Remove references to `start-openclaw.sh` from the deploy workflow's content-hash step. The script was removed in #1193 (controller refactor) but the workflow still validated its existence and included it in the `find` hash, which would fail every deploy with `Required path not found: start-openclaw.sh`.

Also documents the Dockerfile's COPYed files and both cache bust mechanisms in `kiloclaw/AGENTS.md`.

## Verification

- [x] Verified `start-openclaw.sh` does not exist in the repo
- [x] Verified the Dockerfile no longer references it (entrypoint is `node kiloclaw-controller.js`)
- [x] Confirmed all three references removed from workflow (validation loop, find command, comment)
- [x] Pre-push hooks passed (format, lint)

## Visual Changes

N/A

## Reviewer Notes
