### PR TITLE
fix(cloud-agent-next): start wrapper outside workspace directory

### DIFF
--- a/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -873,7 +873,7 @@ describe('WrapperClient', () => {
         expect.stringMatching(
           /^WRAPPER_PORT=5000 WORKSPACE_PATH=\/workspace\/test WRAPPER_LOG_PATH=\/tmp\/kilocode-wrapper-test-session-\d+\.log bun run '\.\/wrapper'\\''s folder\/wrapper\.js; touch \/tmp\/pwned' --agent-session test-session --user-id 'test-user'$/
         ),
-        expect.objectContaining({ cwd: '/workspace/test' })
+        expect.objectContaining({ cwd: '/workspace' })
       );
     });
   });

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -5,6 +5,7 @@
  * running inside the sandbox container via HTTP.
  */
 
+import { dirname } from 'node:path';
 import type { ExecutionSession, SandboxInstance } from '../types.js';
 import { logger } from '../logger.js';
 import { findWrapperForSession, getWrapperSessionMarker } from './wrapper-manager.js';
@@ -350,7 +351,7 @@ export class WrapperClient {
 
     try {
       proc = await this.session.startProcess(command, {
-        cwd: workspacePath,
+        cwd: dirname(workspacePath),
       });
 
       // Wait for wrapper to become healthy via port check.

--- a/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/cloud-agent-next/src/persistence/async-preparation.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path';
 import { logger } from '../logger.js';
 import { SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
 import { generateSandboxId, getSandboxNamespace } from '../sandbox-id.js';
@@ -196,7 +197,8 @@ export async function executePreparationSteps(
     const escapedId = input.kiloSessionId.replaceAll("'", "'\\''");
     const escapedWorkspace = workspacePath.replaceAll("'", "'\\''");
     const restoreResult = await session.exec(
-      `bun /usr/local/bin/kilo-restore-session.js --file '${escapedFile}' '${escapedId}' '${escapedWorkspace}'`
+      `bun /usr/local/bin/kilo-restore-session.js --file '${escapedFile}' '${escapedId}' '${escapedWorkspace}'`,
+      { cwd: dirname(workspacePath) }
     );
     if (restoreResult.exitCode !== 0) {
       const stdout = restoreResult.stdout?.trim() ?? '';

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path';
 import type {
   ExecutionSession,
   SandboxInstance,
@@ -1310,7 +1311,8 @@ export class SessionService {
       const escapedId = metadata.kiloSessionId.replaceAll("'", "'\\''");
       const escapedWorkspace = context.workspacePath.replaceAll("'", "'\\''");
       const restoreResult = await session.exec(
-        `bun /usr/local/bin/kilo-restore-session.js '${escapedId}' '${escapedWorkspace}'`
+        `bun /usr/local/bin/kilo-restore-session.js '${escapedId}' '${escapedWorkspace}'`,
+        { cwd: dirname(context.workspacePath) }
       );
 
       if (restoreResult.exitCode !== 0) {

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -141,6 +141,11 @@ async function main() {
     failStartup(`Invalid agent session ID: ${agentSessionId}`);
   }
 
+  // The wrapper process is started with cwd outside the workspace so bun
+  // doesn't auto-load the repo's .env files. Switch into the workspace now
+  // so the kilo server (started in-process) sees the correct project root.
+  process.chdir(workspacePath);
+
   // Set log path if not already set
   if (!process.env.WRAPPER_LOG_PATH) {
     process.env.WRAPPER_LOG_PATH = `/tmp/kilocode-wrapper-${Date.now()}.log`;

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -141,9 +141,9 @@ async function main() {
     failStartup(`Invalid agent session ID: ${agentSessionId}`);
   }
 
-  // The wrapper process is started with cwd outside the workspace so bun
-  // doesn't auto-load the repo's .env files. Switch into the workspace now
-  // so the kilo server (started in-process) sees the correct project root.
+  // The wrapper process is started with cwd outside the workspace. 
+  // Switch into the workspace now so the kilo server (started in-process) sees the correct project root.
+  // This is an attempt to fix an issue where bun process crashes in some repos
   process.chdir(workspacePath);
 
   // Set log path if not already set

--- a/cloud-agent-next/wrapper/src/main.ts
+++ b/cloud-agent-next/wrapper/src/main.ts
@@ -141,9 +141,10 @@ async function main() {
     failStartup(`Invalid agent session ID: ${agentSessionId}`);
   }
 
-  // The wrapper process is started with cwd outside the workspace. 
-  // Switch into the workspace now so the kilo server (started in-process) sees the correct project root.
-  // This is an attempt to fix an issue where bun process crashes in some repos
+  // The wrapper process is started with cwd outside the workspace.
+  // Switch into the workspace now so the kilo server (started in-process)
+  // sees the correct project root. This is an attempt to fix an issue where
+  // the bun process crashes in some repos but not others.
   process.chdir(workspacePath);
 
   // Set log path if not already set

--- a/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/cloud-agent-next/wrapper/src/restore-session.ts
@@ -139,6 +139,7 @@ export async function restoreSession(
     const importProc = Bun.spawn(['kilo', 'import', tmpPath], {
       stdout: 'pipe',
       stderr: 'pipe',
+      cwd: workspacePath,
       env: process.env,
     });
     const exitCode = await importProc.exited;


### PR DESCRIPTION
## Summary

- Start the wrapper process and restore-session scripts with `cwd` set to the parent of the workspace directory (`dirname(workspacePath)`) instead of inside the workspace itself
- The wrapper's `main.ts` then calls `process.chdir(workspacePath)` once the process is running, so the kilo server still sees the correct project root
- The `kilo import` subprocess in `restore-session.ts` explicitly gets `cwd: workspacePath` since it needs to operate inside the workspace
- This addresses an intermittent issue where the wrapper/restore scripts fail on some repositories but work fine on others — starting the process outside the repo isolates startup from repo-specific interference

## Verification

- [x] `pnpm --filter cloud-agent-next test` — 657 tests passed across 26 test files
- [x] Unit test in `wrapper-client.test.ts` updated to reflect new `cwd` expectation (`/workspace` instead of `/workspace/test`)
- [x] Manual verification

## Visual Changes

N/A

## Reviewer Notes

- The key pattern is a two-phase cwd strategy: start outside the workspace (`dirname(workspacePath)`) to avoid repo-level interference during process startup, then `chdir` into the workspace once running
- All four call sites that launch processes in the sandbox are updated consistently: `wrapper-client.ts`, `async-preparation.ts`, `session-service.ts`, and `wrapper/src/main.ts`
- `restore-session.ts` does the inverse — it explicitly passes `cwd: workspacePath` to the `kilo import` subprocess since that command needs to run inside the workspace