### PR TITLE
fix drizzle journal timestamps preventing new migrations

### DIFF
--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -376,7 +376,7 @@
     {
       "idx": 53,
       "version": "7",
-      "when": 1773847627452,
+      "when": 1773859539258,
       "tag": "0053_fine_stark_industries",
       "breakpoints": true
     }


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Timestamp from entry 052 to 053 was inverse, likely because the numbers got changed to fix merge conflict and the timestamps weren't updated. Drizzle is ignoring 53 because it had a timestamp prior to 52
