### PR TITLE
feat(gastown): sort agent lists by status with active agents at top

### DIFF
--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { sortAgentsByStatus } from '@/lib/gastown/sort-agents';
 import { Button } from '@/components/Button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateRigDialog } from '@/components/gastown/CreateRigDialog';
@@ -188,13 +189,7 @@ export function TownOverviewPageClient({
         }
       }
     }
-    // Sort by last_activity_at descending, then by created_at
-    agents.sort((a, b) => {
-      const aTime = a.last_activity_at ?? a.created_at;
-      const bTime = b.last_activity_at ?? b.created_at;
-      return new Date(bTime).getTime() - new Date(aTime).getTime();
-    });
-    return agents.slice(0, 5);
+    return sortAgentsByStatus(agents).slice(0, 5);
   }, [agentsByRig, rigs]);
 
   const deleteRig = useMutation(

--- a/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { sortAgentsByStatus } from '@/lib/gastown/sort-agents';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Bot, Crown, Shield, Eye, Clock, Hexagon, MessageSquare } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
@@ -50,7 +51,7 @@ export function AgentsPageClient({ townId }: { townId: string }) {
         }
       }
     });
-    return agents;
+    return sortAgentsByStatus(agents);
   }, [rigAgentData, rigs]);
 
   return (

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { sortAgentsByStatus } from '@/lib/gastown/sort-agents';
 import { toast } from 'sonner';
 import { Button } from '@/components/Button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -90,7 +91,7 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
   );
 
   const beads = beadsQuery.data ?? [];
-  const agents = agentsQuery.data ?? [];
+  const agents = useMemo(() => sortAgentsByStatus(agentsQuery.data ?? []), [agentsQuery.data]);
 
   // Filter convoys to those with at least one bead in this rig
   const rigBeadIds = useMemo(() => new Set(beads.map(b => b.bead_id)), [beads]);

--- a/src/lib/gastown/sort-agents.ts
+++ b/src/lib/gastown/sort-agents.ts
@@ -1,0 +1,24 @@
+const AGENT_STATUS_PRIORITY: Record<string, number> = {
+  working: 0,
+  starting: 1,
+  active: 2,
+  idle: 3,
+  stalled: 4,
+  blocked: 4,
+  exited: 5,
+  failed: 5,
+  dead: 5,
+};
+
+export function sortAgentsByStatus<
+  T extends { status: string; last_activity_at: string | null; created_at: string },
+>(agents: T[]): T[] {
+  return [...agents].sort((a, b) => {
+    const aPri = AGENT_STATUS_PRIORITY[a.status] ?? 6;
+    const bPri = AGENT_STATUS_PRIORITY[b.status] ?? 6;
+    if (aPri !== bPri) return aPri - bPri;
+    const aTime = new Date(a.last_activity_at ?? a.created_at).getTime();
+    const bTime = new Date(b.last_activity_at ?? b.created_at).getTime();
+    return bTime - aTime;
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/gastown/sort-agents.ts` with a `sortAgentsByStatus()` utility that sorts agents by status priority (working > starting > active > idle > stalled/blocked > exited/failed/dead) with a secondary sort by `last_activity_at` descending.
- Applied to three pages: `RigDetailPageClient` (wrapped in `useMemo`), `TownOverviewPageClient` (replaced the prior time-only sort in the `recentAgents` memo), and `AgentsPageClient` (added sort to flat-map result).

## Verification

- Code review: logic is correct, non-mutating sort, generic constraint is minimal and appropriate, unknown statuses gracefully fall to lowest priority.
- TypeScript: no type errors introduced; generic `<T extends { status: string; last_activity_at: string | null; created_at: string }>` ensures compatibility with all three call sites.

## Visual Changes

N/A

## Reviewer Notes

The `RigDetailPageClient` previously had no memoization for the agents list at all — the `useMemo` wrap is a minor perf improvement on top of the sort. All three usages are consistent and no existing behaviour is broken (sort is stable for same-priority agents via the time tiebreak).