### PR TITLE
feat(claw): mention YOLO mode in never-ask permission description

### DIFF
--- a/src/app/(app)/claw/components/PermissionStep.tsx
+++ b/src/app/(app)/claw/components/PermissionStep.tsx
@@ -40,7 +40,7 @@ export function PermissionStep({
             icon={<ShieldAlert className="h-5 w-5 text-amber-400" />}
             iconBg="bg-amber-900/50"
             title="Allow everything"
-            description="The bot acts immediately without asking. Best for autonomous workflows, but review what it can access first."
+            description="The bot acts immediately without asking — a.k.a. YOLO mode. Best for autonomous workflows, but review what it can access first."
             caution="Use with caution"
           />
           <PresetCard


### PR DESCRIPTION
## Summary

Add a subtle "a.k.a. YOLO mode" callout to the "Allow everything" (never-ask) preset description on the KiloClaw permissions screen, aligning the UI copy with how the feature is referred to across the platform.

## Verification

- [x] `pnpm format:check` — passed (ran by pre-push hook)
- [x] `pnpm lint` — passed (ran by pre-push hook)
- [x] `pnpm typecheck` — passed (ran by pre-push hook)

## Visual Changes

N/A — text-only change to a description string.

## Reviewer Notes

Single-line copy change in `PermissionStep.tsx`. No logic or behavior changes.