### PR TITLE
ci(actions): migrate workflows to Blacksmith

### DIFF
--- a/.github/workflows/bump-openclaw.yml
+++ b/.github/workflows/bump-openclaw.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           sparse-checkout: kiloclaw/Dockerfile
           sparse-checkout-cone-mode: false

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   playwright:
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
 
     services:
       postgres:
@@ -41,7 +41,7 @@ jobs:
       DOTENV_PRIVATE_KEY_DEVELOPMENT: ${{ secrets.DOTENV_PRIVATE_KEY_DEVELOPMENT }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
           fetch-depth: 0
@@ -79,12 +79,12 @@ jobs:
 
   chromatic:
     needs: playwright
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     if: always() # Run even if playwright job fails
     continue-on-error: true # Make this check optional - don't block PR merges
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           lfs: true
           fetch-depth: 0
@@ -134,6 +134,7 @@ jobs:
           pnpm build-storybook
 
       - name: Run Chromatic
+        id: chromatic
         uses: chromaui/action@latest
         continue-on-error: true
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ permissions:
   contents: read
   pull-requests: read
 
+# Optional repo/org variables for runner migration:
+# - RUNNER_DEFAULT_LABEL=blacksmith-2vcpu-ubuntu-2404
+# - RUNNER_LARGE_LABEL=blacksmith-8vcpu-ubuntu-2404
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     outputs:
       cloud_agent: ${{ steps.filter.outputs.cloud_agent }}
       cloud_agent_next: ${{ steps.filter.outputs.cloud_agent_next }}
@@ -26,7 +29,7 @@ jobs:
       kiloclaw: ${{ steps.filter.outputs.kiloclaw }}
       app_builder: ${{ steps.filter.outputs.app_builder }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 
@@ -49,9 +52,9 @@ jobs:
               - 'cloudflare-app-builder/**'
 
   typecheck:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -74,9 +77,9 @@ jobs:
         run: pnpm run typecheck
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -99,9 +102,9 @@ jobs:
         run: pnpm run lint
 
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -128,9 +131,9 @@ jobs:
           }
 
   dependency-cycle-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -153,7 +156,7 @@ jobs:
         run: pnpm run dependency-cycle-check
 
   test:
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
 
     services:
       postgres:
@@ -176,7 +179,7 @@ jobs:
       JEST_MAX_WORKERS: 4
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -199,9 +202,9 @@ jobs:
         run: pnpm run test
 
   build:
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -246,9 +249,9 @@ jobs:
   cloud-agent:
     needs: changes
     if: needs.changes.outputs.cloud_agent == 'true'
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -288,9 +291,9 @@ jobs:
   cloud-agent-next:
     needs: changes
     if: needs.changes.outputs.cloud_agent_next == 'true'
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
           ref: ${{ github.head_ref }}
@@ -331,9 +334,9 @@ jobs:
   webhook-agent:
     needs: changes
     if: needs.changes.outputs.webhook_agent == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -364,9 +367,9 @@ jobs:
   security-auto-analysis:
     needs: changes
     if: needs.changes.outputs.security_auto_analysis == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -394,9 +397,9 @@ jobs:
   kiloclaw:
     needs: changes
     if: needs.changes.outputs.kiloclaw == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -433,9 +436,9 @@ jobs:
   app-builder:
     needs: changes
     if: needs.changes.outputs.app_builder == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -472,9 +475,9 @@ jobs:
           - name: code-review
             filter: kilo-code-review-worker
     name: cloudflare-${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           lfs: true
 

--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -6,12 +6,14 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     name: Deploy KiloClaw
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
+        with:
+          dissociate: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -80,7 +82,7 @@ jobs:
       # ── Docker setup ────────────────────────────────────────────
       # Always set up Docker + login so we can check the registry.
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Login to Fly Registry
         uses: docker/login-action@v3
@@ -119,7 +121,7 @@ jobs:
       - name: Build and push Docker image
         id: docker-build
         if: steps.check-image.outputs.exists != 'true'
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: kiloclaw
           file: kiloclaw/Dockerfile
@@ -130,8 +132,6 @@ jobs:
             registry.fly.io/kiloclaw-machines:latest
           build-args: |
             CONTROLLER_COMMIT=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       # ── Resolve image digest ────────────────────────────────────
       # Gets the Docker digest from whichever source is available:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,12 +10,12 @@ concurrency:
 
 jobs:
   run-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     environment: production
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -42,7 +42,7 @@ jobs:
         run: NODE_ENV=production pnpm run drizzle migrate
 
   deploy-app:
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     needs: run-migrations
     environment: production
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -97,7 +97,7 @@ jobs:
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
   deploy-global-app:
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     needs: run-migrations
     environment: production
 
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -154,7 +154,7 @@ jobs:
   deploy-gateway:
     # Disabled: R2_ACCOUNT_ID env var is missing, causing deploy failures
     if: false
-    runs-on: ubuntu-24.04-8core
+    runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     needs: run-migrations
     environment: production
 
@@ -164,7 +164,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           lfs: true
 
@@ -209,12 +209,12 @@ jobs:
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
   check-kiloclaw-changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     outputs:
       changed: ${{ steps.changes.outputs.kiloclaw }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -38,11 +38,11 @@ jobs:
   # ── Manual dispatch: deploy a single specified worker ──────────────────────
   deploy-manual:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     name: Deploy ${{ inputs.worker }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -68,12 +68,12 @@ jobs:
   # ── Push to main: detect changed workers, deploy each one ─────────────────
   detect-changes:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 
@@ -127,7 +127,7 @@ jobs:
   deploy-changed:
     needs: detect-changes
     if: needs.detect-changes.outputs.matrix != '[]' && needs.detect-changes.outputs.matrix != ''
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +135,7 @@ jobs:
     name: Deploy ${{ matrix.worker }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/stale-prs.yaml
+++ b/.github/workflows/stale-prs.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,10 +11,10 @@ permissions:
 
 jobs:
   trufflehog:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
       - name: Secret Scanning


### PR DESCRIPTION
## Summary
- migrate all GitHub Actions workflows to repo-wide Blacksmith runner variables using `RUNNER_DEFAULT_LABEL` and `RUNNER_LARGE_LABEL`, while preserving GitHub-hosted fallbacks for rollback
- replace all workflow checkout steps with `useblacksmith/checkout@v1`, preserving existing checkout options like `fetch-depth`, `lfs`, `ref`, and sparse checkout configuration
- switch `deploy-kiloclaw` to Blacksmith's Docker builder actions and keep the existing content-hash, registry-login, and digest-resolution flow intact
- add a missing `id` to the Chromatic action step so its later output references are valid under `actionlint`

## Verification
- `ruby -e 'Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "ok #{f}" }' -ryaml` (pass)
- `actionlint .github/workflows/*.{yml,yaml}` (warns only on the pre-existing disabled `deploy-gateway` job using `if: false` in `.github/workflows/deploy-production.yml`)
- `rg -n "actions/checkout@v4|docker/setup-buildx-action@v3|docker/build-push-action@v6|useblacksmith/build-push-action@v1|CI_DEFAULT_RUNNER|CI_LARGE_RUNNER" .github/workflows -S` (no matches)
- `rg -n "runs-on:\\s+ubuntu-(latest|24\\.04-8core)$" .github/workflows -S` (no matches)

## Visual Changes
N/A

## Reviewer Notes
- this depends on Blacksmith being installed and on repo/org variables `RUNNER_DEFAULT_LABEL=blacksmith-2vcpu-ubuntu-2404` and `RUNNER_LARGE_LABEL=blacksmith-8vcpu-ubuntu-2404` being set before merge
- `deploy-kiloclaw` uses `useblacksmith/build-push-action@v2` because Blacksmith's current Docker build docs deprecate `v1`
- the only remaining `actionlint` warning is unrelated to this migration: the existing disabled `deploy-gateway` job is still guarded by `if: false`
