### PR TITLE
fix(claw): allow instance destroy without active subscription

### DIFF
--- a/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
+++ b/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Lock, CreditCard } from 'lucide-react';
+import { Lock, CreditCard, Trash2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -17,6 +18,8 @@ type AccessLockedDialogProps = {
   reason: ClawLockReason;
   onSubscribeClick: () => void;
   onUpdatePaymentClick: () => void;
+  onDestroyClick: () => void;
+  isDestroying?: boolean;
 };
 
 function getLockContent(reason: ClawLockReason) {
@@ -101,12 +104,20 @@ function getInfoBoxMessage(reason: ClawLockReason): string {
   return 'Your KiloClaw will resume automatically once you subscribe.';
 }
 
+const INSTANCE_ALIVE_REASONS = new Set<ClawLockReason>([
+  'trial_expired_instance_alive',
+  'subscription_expired_instance_alive',
+]);
+
 export function AccessLockedDialog({
   reason,
   onSubscribeClick,
   onUpdatePaymentClick,
+  onDestroyClick,
+  isDestroying,
 }: AccessLockedDialogProps) {
   const router = useRouter();
+  const [confirmDestroy, setConfirmDestroy] = useState(false);
 
   if (!reason) return null;
 
@@ -114,6 +125,7 @@ export function AccessLockedDialog({
   if (!content) return null;
 
   const Icon = content.icon;
+  const canDestroy = INSTANCE_ALIVE_REASONS.has(reason);
 
   function handleCta() {
     if (content?.action === 'update_payment') {
@@ -158,6 +170,38 @@ export function AccessLockedDialog({
               ? "You'll be redirected to Stripe to update your payment method"
               : "You'll be redirected to Stripe to complete your purchase"}
           </p>
+
+          {canDestroy &&
+            (confirmDestroy ? (
+              <div className="flex w-full gap-2">
+                <Button
+                  variant="destructive"
+                  className="flex-1"
+                  disabled={isDestroying}
+                  onClick={onDestroyClick}
+                >
+                  <Trash2 className="mr-1.5 h-4 w-4" />
+                  {isDestroying ? 'Destroying...' : 'Yes, destroy'}
+                </Button>
+                <Button
+                  variant="outline"
+                  className="flex-1"
+                  disabled={isDestroying}
+                  onClick={() => setConfirmDestroy(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button
+                variant="link"
+                onClick={() => setConfirmDestroy(true)}
+                className="text-muted-foreground hover:text-destructive w-full"
+              >
+                Destroy Instance
+              </Button>
+            ))}
+
           <Button
             variant="link"
             onClick={handleDismiss}

--- a/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
 import { BillingBanner } from './BillingBanner';
@@ -51,6 +52,16 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
 
   const reactivate = useMutation(trpc.kiloclaw.reactivateSubscription.mutationOptions());
   const billingPortal = useMutation(trpc.kiloclaw.createBillingPortalSession.mutationOptions());
+  const destroy = useMutation(
+    trpc.kiloclaw.destroy.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
+        });
+      },
+    })
+  );
 
   if (!billing) {
     return <>{children}</>;
@@ -104,6 +115,13 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
         reason={lockReason}
         onSubscribeClick={handleSubscribe}
         onUpdatePaymentClick={handleUpdatePayment}
+        onDestroyClick={() =>
+          destroy.mutate(undefined, {
+            onSuccess: () => toast.success('Instance destroyed'),
+            onError: err => toast.error(err.message),
+          })
+        }
+        isDestroying={destroy.isPending}
       />
 
       {/* Dashboard content */}

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -399,11 +399,18 @@ export const kiloclawRouter = createTRPCRouter({
     return client.stop(ctx.user.id);
   }),
 
-  destroy: clawAccessProcedure.mutation(async ({ ctx }) => {
+  destroy: baseProcedure.mutation(async ({ ctx }) => {
     const destroyedRow = await markActiveInstanceDestroyed(ctx.user.id);
     const client = new KiloClawInternalClient();
     try {
-      return await client.destroy(ctx.user.id);
+      const result = await client.destroy(ctx.user.id);
+      // Clear the destruction lifecycle so the billing cron doesn't
+      // send warning emails or attempt a redundant destroy.
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ suspended_at: null, destruction_deadline: null })
+        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+      return result;
     } catch (error) {
       if (destroyedRow) {
         await restoreDestroyedInstance(destroyedRow.id);

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -406,9 +406,22 @@ export const kiloclawRouter = createTRPCRouter({
       const result = await client.destroy(ctx.user.id);
       // Clear the destruction lifecycle so the billing cron doesn't
       // send warning emails or attempt a redundant destroy.
+      // Only clear suspended_at for non-past_due subscriptions — nulling it
+      // on a past_due row would re-enable access without fixing payment.
+      const [sub] = await db
+        .select({ status: kiloclaw_subscriptions.status })
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
+        .limit(1);
+      const clearFields: { suspended_at?: null; destruction_deadline: null } = {
+        destruction_deadline: null,
+      };
+      if (sub && sub.status !== 'past_due') {
+        clearFields.suspended_at = null;
+      }
       await db
         .update(kiloclaw_subscriptions)
-        .set({ suspended_at: null, destruction_deadline: null })
+        .set(clearFields)
         .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
       return result;
     } catch (error) {


### PR DESCRIPTION
## Summary

Users whose trial or subscription has expired but whose KiloClaw instance is still alive were unable to destroy their instance — the `destroy` endpoint required `clawAccessProcedure`, which gates on active billing. This change:

- Downgrades `destroy` from `clawAccessProcedure` to `baseProcedure` so any authenticated user can destroy their instance regardless of billing state.
- Adds a two-step "Destroy Instance" confirmation flow to the `AccessLockedDialog` for `trial_expired_instance_alive` and `subscription_expired_instance_alive` lock states.
- Clears `suspended_at` and `destruction_deadline` on the subscription row after a successful destroy, preventing the billing cron from sending redundant destruction-warning emails or attempting a duplicate destroy.

## Verification

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass (via pre-push hook)
- [x] `pnpm format:check` — pass (via pre-push hook)

## Visual Changes

> Screenshots could not be captured automatically: the AccessLockedDialog only renders when the user has an expired trial/subscription with a live instance, a billing state that cannot be reproduced via simple dev-server navigation.

The dialog change adds a "Destroy Instance" link button below the subscribe/payment CTA. Clicking it reveals a two-step confirmation with a red "Yes, destroy" button and a "Cancel" button. The destroy button shows a loading state while the mutation is in-flight.

| Before | After |
| ------ | ----- |
| No destroy option in lock dialog | "Destroy Instance" link with two-step confirm flow |

## Reviewer Notes

- The `destroy` endpoint now uses `baseProcedure` (auth-only, no billing gate). This is intentional — users should always be able to tear down their own instance. The `markActiveInstanceDestroyed` / `restoreDestroyedInstance` rollback pattern is preserved.
- The subscription field cleanup (`suspended_at`, `destruction_deadline`) after destroy prevents the billing lifecycle cron from racing against the user-initiated destroy.