### PR TITLE
fix(ci): use actions/checkout@v4 in TruffleHog workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: useblacksmith/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Secret Scanning


### PR DESCRIPTION
## Summary

Replace `useblacksmith/checkout@v1` with `actions/checkout@v4` in the TruffleHog secret scanning workflow. The third-party checkout fork was causing Git clone errors ("unable to normalize alternate") that prevented TruffleHog from scanning.

## Verification

- [x] `pnpm lint` — passed (ran via pre-push hook)
- [x] `pnpm typecheck` — passed (ran via pre-push hook)

## Visual Changes

N/A

## Reviewer Notes

Single-line change. The `fetch-depth: 0` setting is preserved — only the action reference changed. This should resolve the "BASE and HEAD commits are the same" and Git clone failures reported in the TruffleHog CI job.