### PR TITLE
feat(admin): add KiloClaw subscription controls

### DIFF
--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -151,6 +151,7 @@ export type KiloClawSubscriptionStatus =
 // NOTE: Do not change these action names. Use present tense for consistency.
 export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.volume.reassociate',
+  'kiloclaw.subscription.update_trial_end',
   'kiloclaw.machine.start',
   'kiloclaw.machine.stop',
   'kiloclaw.instance.destroy',

--- a/src/app/admin/components/UserAdmin/UserAdminDashboard.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminDashboard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/breadcrumb';
 import { UserAdminOrganizations } from '@/app/admin/components/UserAdmin/UserAdminOrganizations';
 import { UserAdminKiloPass } from '@/app/admin/components/UserAdmin/UserAdminKiloPass';
+import { UserAdminKiloClaw } from '@/app/admin/components/UserAdmin/UserAdminKiloClaw';
 import { UserAdminGastown } from '@/app/admin/components/UserAdmin/UserAdminGastown';
 
 export function UserAdminDashboard({ ...user }: UserDetailProps) {
@@ -49,6 +50,7 @@ export function UserAdminDashboard({ ...user }: UserDetailProps) {
           <UserAdminNotes {...user} />
           <UserAdminGdprRemoval {...user} />
           <UserAdminKiloPass userId={user.id} />
+          <UserAdminKiloClaw userId={user.id} />
           <UserAdminUsageBilling {...user} />
           <UserAdminCreditGrant
             {...user}

--- a/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useTRPC } from '@/lib/trpc/utils';
+import { formatDate } from '@/lib/admin-utils';
+import { toast } from 'sonner';
+
+function formatDateOrDash(date: string | null): string {
+  return date ? formatDate(date) : '—';
+}
+
+function toLocalDateInputValue(date: string): string {
+  const parsed = new Date(date);
+  const year = parsed.getFullYear();
+  const month = String(parsed.getMonth() + 1).padStart(2, '0');
+  const day = String(parsed.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function localDateInputToEndOfDayIso(date: string): string {
+  const [year, month, day] = date.split('-').map(Number);
+  return new Date(year, month - 1, day, 23, 59, 59, 0).toISOString();
+}
+
+function getAccessBadgeClass(hasAccess: boolean) {
+  return hasAccess ? 'bg-green-900/20 text-green-400' : 'bg-red-900/20 text-red-400';
+}
+
+function getSubscriptionStatusBadgeClass(status: string) {
+  switch (status) {
+    case 'active':
+      return 'bg-green-900/20 text-green-400';
+    case 'trialing':
+      return 'bg-blue-900/20 text-blue-400';
+    case 'past_due':
+    case 'unpaid':
+      return 'bg-yellow-900/20 text-yellow-400';
+    case 'canceled':
+      return 'bg-red-900/20 text-red-400';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+export function UserAdminKiloClaw({ userId }: { userId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState('');
+
+  const { data, isLoading, error } = useQuery(
+    trpc.admin.users.getKiloClawState.queryOptions({ userId })
+  );
+
+  useEffect(() => {
+    if (!dialogOpen) return;
+
+    const currentTrialEndAt = data?.subscription?.trial_ends_at;
+    setSelectedDate(currentTrialEndAt ? toLocalDateInputValue(currentTrialEndAt) : '');
+  }, [data?.subscription?.trial_ends_at, dialogOpen]);
+
+  const updateTrialEndAt = useMutation(
+    trpc.admin.users.updateKiloClawTrialEndAt.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.admin.users.getKiloClawState.queryKey({ userId }),
+        });
+        setDialogOpen(false);
+        toast.success('KiloClaw trial end date updated');
+      },
+      onError: mutationError => {
+        toast.error(mutationError.message || 'Failed to update KiloClaw trial end date');
+      },
+    })
+  );
+
+  const handleSave = () => {
+    if (!selectedDate) {
+      toast.error('Select a trial end date');
+      return;
+    }
+
+    const trialEndsAt = localDateInputToEndOfDayIso(selectedDate);
+    updateTrialEndAt.mutate({
+      userId,
+      trial_ends_at: trialEndsAt,
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>KiloClaw</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">Loading...</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>KiloClaw</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-red-400">Failed to load KiloClaw state</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data?.subscription) {
+    return (
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <CardTitle>KiloClaw</CardTitle>
+          <CardDescription>No KiloClaw subscription</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {data?.earlybird ? (
+            <div className="rounded-lg border p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-sm font-medium">Earlybird Access</span>
+                <Badge className={getAccessBadgeClass(data.hasAccess)}>
+                  {data.hasAccess ? 'has access' : 'no access'}
+                </Badge>
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <span className="text-muted-foreground">Expires</span>
+                  <p>{formatDate(data.earlybird.expiresAt)}</p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Days remaining</span>
+                  <p>{data.earlybird.daysRemaining}</p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              This user does not have a KiloClaw subscription row.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { subscription } = data;
+  const canEditTrialEnd = subscription.status === 'trialing';
+
+  return (
+    <>
+      <Card className="lg:col-span-2">
+        <CardHeader>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <CardTitle>KiloClaw</CardTitle>
+              <CardDescription>KiloClaw subscription and trial status</CardDescription>
+            </div>
+            {canEditTrialEnd && (
+              <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
+                Edit Trial End
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Access</h4>
+              <Badge className={getAccessBadgeClass(data.hasAccess)}>
+                {data.hasAccess ? 'has access' : 'no access'}
+              </Badge>
+              {data.accessReason ? (
+                <p className="text-muted-foreground mt-1 text-xs">{data.accessReason}</p>
+              ) : null}
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Status</h4>
+              <Badge className={getSubscriptionStatusBadgeClass(subscription.status)}>
+                {subscription.status}
+              </Badge>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Plan</h4>
+              <p className="text-sm font-semibold">{subscription.plan}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Trial Started</h4>
+              <p className="text-sm">{formatDateOrDash(subscription.trial_started_at)}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Trial Ends</h4>
+              <p className="text-sm">{formatDateOrDash(subscription.trial_ends_at)}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Current Period End</h4>
+              <p className="text-sm">{formatDateOrDash(subscription.current_period_end)}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Commit Ends</h4>
+              <p className="text-sm">{formatDateOrDash(subscription.commit_ends_at)}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Scheduled Plan</h4>
+              <p className="text-sm">{subscription.scheduled_plan ?? '—'}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Scheduled By</h4>
+              <p className="text-sm">{subscription.scheduled_by ?? '—'}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Suspended At</h4>
+              <p className="text-sm">{formatDateOrDash(subscription.suspended_at)}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Destruction Deadline</h4>
+              <p className="text-sm">{formatDateOrDash(subscription.destruction_deadline)}</p>
+            </div>
+            <div>
+              <h4 className="text-muted-foreground text-xs font-medium">Updated</h4>
+              <p className="text-sm">{formatDate(subscription.updated_at)}</p>
+            </div>
+          </div>
+
+          {data.earlybird ? (
+            <div className="rounded-lg border p-3">
+              <h4 className="mb-2 text-sm font-medium">Earlybird</h4>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <span className="text-muted-foreground">Expires</span>
+                  <p>{formatDate(data.earlybird.expiresAt)}</p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Days remaining</span>
+                  <p>{data.earlybird.daysRemaining}</p>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit KiloClaw Trial End Date</DialogTitle>
+            <DialogDescription>
+              Set the day this user&apos;s KiloClaw trial ends. The trial will end at the end of the
+              selected day.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-4">
+            <Label htmlFor="kiloclaw-trial-end-date">Trial End Date</Label>
+            <Input
+              id="kiloclaw-trial-end-date"
+              type="date"
+              value={selectedDate}
+              onChange={event => setSelectedDate(event.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={updateTrialEndAt.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={updateTrialEndAt.isPending || !selectedDate}>
+              {updateTrialEndAt.isPending ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/src/routers/admin-kiloclaw-user-router.test.ts
@@ -14,6 +14,12 @@ let adminUser: User;
 let targetUser: User;
 const expectedAccessWithoutEntitlement = !KILOCLAW_BILLING_ENFORCEMENT;
 
+function expectSameInstant(actual: string | null | undefined, expected: string) {
+  expect(actual).not.toBeNull();
+  expect(actual).toBeDefined();
+  expect(new Date(actual as string).toISOString()).toBe(new Date(expected).toISOString());
+}
+
 beforeEach(async () => {
   await cleanupDbForTest();
 
@@ -83,7 +89,7 @@ describe('admin.users.getKiloClawState', () => {
     const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
 
     expect(result.subscription?.status).toBe('trialing');
-    expect(result.subscription?.trial_ends_at).toBe(futureTrialEnd);
+    expectSameInstant(result.subscription?.trial_ends_at, futureTrialEnd);
     expect(result.hasAccess).toBe(true);
     expect(result.accessReason).toBe('trial');
   });
@@ -102,7 +108,7 @@ describe('admin.users.getKiloClawState', () => {
     const caller = await createCallerForUser(adminUser.id);
     const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
 
-    expect(result.subscription?.trial_ends_at).toBe(expiredTrialEnd);
+    expectSameInstant(result.subscription?.trial_ends_at, expiredTrialEnd);
     expect(result.hasAccess).toBe(expectedAccessWithoutEntitlement);
     expect(result.accessReason).toBeNull();
   });
@@ -153,7 +159,7 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     const updatedSubscription = await db.query.kiloclaw_subscriptions.findFirst({
       where: eq(kiloclaw_subscriptions.user_id, targetUser.id),
     });
-    expect(updatedSubscription?.trial_ends_at).toBe(newTrialEndsAt);
+    expectSameInstant(updatedSubscription?.trial_ends_at, newTrialEndsAt);
 
     const [auditLog] = await db
       .select()

--- a/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/src/routers/admin-kiloclaw-user-router.test.ts
@@ -173,12 +173,15 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
         actor_email: adminUser.google_user_email,
         actor_name: adminUser.google_user_name,
         target_user_id: targetUser.id,
-        metadata: {
-          previousTrialEndsAt,
-          newTrialEndsAt,
-        },
       })
     );
+    expect(auditLog.message).toContain('KiloClaw trial end updated from');
+    expect(auditLog.message).toContain(newTrialEndsAt);
+    expectSameInstant(
+      auditLog.metadata?.previousTrialEndsAt as string | undefined,
+      previousTrialEndsAt
+    );
+    expect(auditLog.metadata?.newTrialEndsAt).toBe(newTrialEndsAt);
   });
 
   it('rejects unknown users', async () => {

--- a/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/src/routers/admin-kiloclaw-user-router.test.ts
@@ -1,0 +1,217 @@
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import { KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  kiloclaw_admin_audit_logs,
+  kiloclaw_earlybird_purchases,
+  kiloclaw_subscriptions,
+} from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import type { User } from '@kilocode/db/schema';
+
+let adminUser: User;
+let targetUser: User;
+const expectedAccessWithoutEntitlement = !KILOCLAW_BILLING_ENFORCEMENT;
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+
+  adminUser = await insertTestUser({
+    google_user_email: 'admin-kiloclaw-user-router@example.com',
+    google_user_name: 'Admin User',
+    is_admin: true,
+  });
+
+  targetUser = await insertTestUser({
+    google_user_email: 'target-kiloclaw-user-router@example.com',
+    google_user_name: 'Target User',
+  });
+});
+
+afterAll(async () => {
+  try {
+    await cleanupDbForTest();
+  } catch {
+    // Database may already be torn down by the test runner.
+  }
+});
+
+describe('admin.users.getKiloClawState', () => {
+  it('returns an empty state when the user has no KiloClaw subscription', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result).toEqual({
+      subscription: null,
+      hasAccess: expectedAccessWithoutEntitlement,
+      accessReason: null,
+      earlybird: null,
+    });
+  });
+
+  it('returns subscription access for active subscriptions', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'standard',
+      status: 'active',
+      stripe_subscription_id: 'sub_admin_kiloclaw_active',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription?.status).toBe('active');
+    expect(result.subscription?.plan).toBe('standard');
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('subscription');
+    expect(result.earlybird).toBeNull();
+  });
+
+  it('returns trial access for future trial end dates', async () => {
+    const futureTrialEnd = new Date(Date.now() + 5 * 86_400_000).toISOString();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'trial',
+      status: 'trialing',
+      trial_started_at: new Date().toISOString(),
+      trial_ends_at: futureTrialEnd,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription?.status).toBe('trialing');
+    expect(result.subscription?.trial_ends_at).toBe(futureTrialEnd);
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('trial');
+  });
+
+  it('shows expired trial rows without trial access', async () => {
+    const expiredTrialEnd = new Date(Date.now() - 2 * 86_400_000).toISOString();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'trial',
+      status: 'trialing',
+      trial_started_at: new Date(Date.now() - 10 * 86_400_000).toISOString(),
+      trial_ends_at: expiredTrialEnd,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription?.trial_ends_at).toBe(expiredTrialEnd);
+    expect(result.hasAccess).toBe(expectedAccessWithoutEntitlement);
+    expect(result.accessReason).toBeNull();
+  });
+
+  it('returns earlybird access when no subscription row exists', async () => {
+    await db.insert(kiloclaw_earlybird_purchases).values({
+      user_id: targetUser.id,
+      amount_cents: 2500,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription).toBeNull();
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('earlybird');
+    expect(result.earlybird).toEqual(
+      expect.objectContaining({
+        purchased: true,
+        expiresAt: expect.any(String),
+        daysRemaining: expect.any(Number),
+      })
+    );
+  });
+});
+
+describe('admin.users.updateKiloClawTrialEndAt', () => {
+  it('updates the trial end date and writes an admin audit log entry', async () => {
+    const previousTrialEndsAt = '2026-03-20T23:59:59.000Z';
+    const newTrialEndsAt = '2026-03-25T23:59:59.000Z';
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'trial',
+      status: 'trialing',
+      trial_started_at: '2026-03-13T12:00:00.000Z',
+      trial_ends_at: previousTrialEndsAt,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.updateKiloClawTrialEndAt({
+      userId: targetUser.id,
+      trial_ends_at: newTrialEndsAt,
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const updatedSubscription = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.user_id, targetUser.id),
+    });
+    expect(updatedSubscription?.trial_ends_at).toBe(newTrialEndsAt);
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+
+    expect(auditLog).toEqual(
+      expect.objectContaining({
+        action: 'kiloclaw.subscription.update_trial_end',
+        actor_id: adminUser.id,
+        actor_email: adminUser.google_user_email,
+        actor_name: adminUser.google_user_name,
+        target_user_id: targetUser.id,
+        metadata: {
+          previousTrialEndsAt,
+          newTrialEndsAt,
+        },
+      })
+    );
+  });
+
+  it('rejects unknown users', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.updateKiloClawTrialEndAt({
+        userId: 'missing-user',
+        trial_ends_at: '2026-03-25T23:59:59.000Z',
+      })
+    ).rejects.toThrow('User not found');
+  });
+
+  it('rejects users without a KiloClaw subscription row', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.updateKiloClawTrialEndAt({
+        userId: targetUser.id,
+        trial_ends_at: '2026-03-25T23:59:59.000Z',
+      })
+    ).rejects.toThrow('No KiloClaw subscription found for this user');
+  });
+
+  it('rejects non-trialing subscription rows', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'standard',
+      status: 'active',
+      stripe_subscription_id: 'sub_admin_kiloclaw_non_trial',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.updateKiloClawTrialEndAt({
+        userId: targetUser.id,
+        trial_ends_at: '2026-03-25T23:59:59.000Z',
+      })
+    ).rejects.toThrow('Only trialing KiloClaw subscriptions can have their trial end date edited');
+  });
+});

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -11,6 +11,8 @@ import {
   cliSessions,
   cli_sessions_v2,
   credit_transactions,
+  kiloclaw_subscriptions,
+  kiloclaw_earlybird_purchases,
 } from '@kilocode/db/schema';
 import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { fetchSessionSnapshot, type SessionMessage } from '@/lib/session-ingest-client';
@@ -45,7 +47,7 @@ import {
 import { KiloPassIssuanceItemKind } from '@/lib/kilo-pass/enums';
 import { fromMicrodollars } from '@/lib/utils';
 import { sum } from 'drizzle-orm';
-import { CRON_SECRET } from '@/lib/config.server';
+import { CRON_SECRET, KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
 import { APP_URL } from '@/lib/constants';
 import { revalidatePath } from 'next/cache';
 import { recomputeUserBalances } from '@/lib/recomputeUserBalances';
@@ -53,6 +55,8 @@ import { getStripeInvoices } from '@/lib/stripe';
 import { client as stripeClient } from '@/lib/stripe-client';
 import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
 import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
+import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
 import {
   getKilocodeRepoOpenPullRequestCounts,
   getKilocodeRepoOpenPullRequestsSummary,
@@ -156,6 +160,15 @@ const GetUserInvoicesSchema = z.object({
 const CancelAndRefundKiloPassSchema = z.object({
   userId: z.string(),
   reason: z.string().min(1, 'Reason is required').trim(),
+});
+
+const GetKiloClawStateSchema = z.object({
+  userId: z.string(),
+});
+
+const UpdateKiloClawTrialEndAtSchema = z.object({
+  userId: z.string(),
+  trial_ends_at: z.string().datetime(),
 });
 
 export const adminRouter = createTRPCRouter({
@@ -441,6 +454,126 @@ export const adminRouter = createTRPCRouter({
             bonusUnlocked: user.kilo_pass_threshold === null,
           },
         };
+      }),
+
+    getKiloClawState: adminProcedure.input(GetKiloClawStateSchema).query(async ({ input }) => {
+      const user = await db.query.kilocode_users.findFirst({
+        columns: { id: true },
+        where: eq(kilocode_users.id, input.userId),
+      });
+
+      if (!user) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      }
+
+      const [subscription, earlybird] = await Promise.all([
+        db.query.kiloclaw_subscriptions.findFirst({
+          where: eq(kiloclaw_subscriptions.user_id, input.userId),
+        }),
+        db.query.kiloclaw_earlybird_purchases.findFirst({
+          columns: { id: true },
+          where: eq(kiloclaw_earlybird_purchases.user_id, input.userId),
+        }),
+      ]);
+
+      const now = new Date();
+      const earlybirdDaysRemaining = earlybird
+        ? Math.ceil(
+            (new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE).getTime() - now.getTime()) / 86_400_000
+          )
+        : 0;
+
+      let hasAccess = !KILOCLAW_BILLING_ENFORCEMENT;
+      let accessReason: 'trial' | 'subscription' | 'earlybird' | null = null;
+
+      if (
+        subscription?.status === 'active' ||
+        (subscription?.status === 'past_due' && !subscription.suspended_at)
+      ) {
+        hasAccess = true;
+        accessReason = 'subscription';
+      } else if (
+        subscription?.status === 'trialing' &&
+        subscription.trial_ends_at &&
+        new Date(subscription.trial_ends_at) > now
+      ) {
+        hasAccess = true;
+        accessReason = 'trial';
+      } else if (earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now) {
+        hasAccess = true;
+        accessReason = 'earlybird';
+      }
+
+      return {
+        subscription: subscription ?? null,
+        hasAccess,
+        accessReason,
+        earlybird: earlybird
+          ? {
+              purchased: true,
+              expiresAt: KILOCLAW_EARLYBIRD_EXPIRY_DATE,
+              daysRemaining: earlybirdDaysRemaining,
+            }
+          : null,
+      };
+    }),
+
+    updateKiloClawTrialEndAt: adminProcedure
+      .input(UpdateKiloClawTrialEndAtSchema)
+      .mutation(async ({ input, ctx }) => {
+        const user = await db.query.kilocode_users.findFirst({
+          columns: { id: true },
+          where: eq(kilocode_users.id, input.userId),
+        });
+
+        if (!user) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+        }
+
+        const subscription = await db.query.kiloclaw_subscriptions.findFirst({
+          where: eq(kiloclaw_subscriptions.user_id, input.userId),
+        });
+
+        if (!subscription) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'No KiloClaw subscription found for this user',
+          });
+        }
+
+        if (subscription.status !== 'trialing') {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Only trialing KiloClaw subscriptions can have their trial end date edited',
+          });
+        }
+
+        const previousTrialEndsAt = subscription.trial_ends_at;
+
+        await db.transaction(async tx => {
+          await tx
+            .update(kiloclaw_subscriptions)
+            .set({ trial_ends_at: input.trial_ends_at })
+            .where(eq(kiloclaw_subscriptions.user_id, input.userId));
+
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.subscription.update_trial_end',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `KiloClaw trial end updated from ${
+              previousTrialEndsAt ?? 'unset'
+            } to ${input.trial_ends_at}`,
+            metadata: {
+              previousTrialEndsAt,
+              newTrialEndsAt: input.trial_ends_at,
+            },
+            tx,
+          });
+        });
+
+        return successResult();
       }),
 
     getInvoices: adminProcedure.input(GetUserInvoicesSchema).query(async ({ input }) => {


### PR DESCRIPTION
## Summary

Add KiloClaw subscription management to the admin user detail page so admins can inspect a user's KiloClaw subscription state and edit the KiloClaw trial expiration date without leaving `/admin/users/[id]`.

This adds admin tRPC read/write endpoints for KiloClaw subscription state, records trial-date edits in the KiloClaw admin audit log, and adds a dedicated KiloClaw card in the existing admin user dashboard. The trial date editor now preserves the admin's local calendar date when reopening and saving a value.

## Verification

- [x] `pnpm exec tsc -p tsconfig.json --noEmit --pretty false --incremental false`
- [x] `git push -u origin kiloclaw-billing-admin` (pre-push hooks ran `pnpm run format:check`, `pnpm run lint`, and `pnpm run typecheck` successfully)
- [ ] `pnpm test -- src/routers/admin-kiloclaw-user-router.test.ts` could not complete in this environment because the test Postgres setup was unavailable

## Visual Changes

| Before | After |
| ------ | ----- |
| Not captured | Not captured |

## Reviewer Notes

Admin trial-date editing is intentionally limited to existing `trialing` KiloClaw subscription rows. The organization trial editor appears to use the older UTC/local date pattern too, but this PR only fixes the KiloClaw admin flow.
