### PR TITLE
feat(kiloclaw): add AgentCard integration via mcporter

### DIFF
--- a/kiloclaw/controller/src/bootstrap.ts
+++ b/kiloclaw/controller/src/bootstrap.ts
@@ -13,7 +13,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync as nodeExecFileSync } from 'node:child_process';
-import { generateBaseConfig, writeBaseConfig } from './config-writer';
+import { generateBaseConfig, writeBaseConfig, writeMcporterConfig } from './config-writer';
 import type { ConfigWriterDeps } from './config-writer';
 import { atomicWrite } from './atomic-write';
 
@@ -497,6 +497,9 @@ export async function bootstrap(
   await yieldToEventLoop();
 
   updateToolsMdGoogleSection(env, deps);
+
+  // Write mcporter config for MCP servers (AgentCard, etc.)
+  writeMcporterConfig(env);
 
   env.KILOCLAW_GATEWAY_ARGS = JSON.stringify(buildGatewayArgs(env));
 }

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -293,6 +293,66 @@ export function generateBaseConfig(
   return config;
 }
 
+const DEFAULT_MCPORTER_CONFIG_PATH = '/root/.openclaw/workspace/config/mcporter.json';
+
+/**
+ * Write mcporter.json with MCP server definitions derived from environment variables.
+ * MCPorter is the middleware layer that lets OpenClaw agents call MCP server tools
+ * via `mcporter call <server>.<tool>`. This bypasses openclaw.json's strict schema
+ * validation, which does not yet support `mcp.servers` (requires OpenClaw >= 2026.3.14).
+ *
+ * TODO: When the Dockerfile pins OpenClaw >= 2026.3.14, migrate MCP server config
+ * into generateBaseConfig() using `config.mcp.servers` in openclaw.json instead.
+ * The mcporter approach can then be removed. See PR #48611 in openclaw/openclaw.
+ */
+export function writeMcporterConfig(
+  env: EnvLike,
+  configPath = DEFAULT_MCPORTER_CONFIG_PATH,
+  deps: ConfigWriterDeps = defaultDeps
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const servers: Record<string, any> = {};
+
+  if (env.AGENTCARD_API_KEY) {
+    servers['agentcard'] = {
+      url: 'https://mcp.agentcard.sh/mcp',
+      headers: { Authorization: 'Bearer ' + env.AGENTCARD_API_KEY },
+    };
+    console.log('AgentCard MCP server configured (via mcporter)');
+  }
+
+  if (Object.keys(servers).length === 0) {
+    return; // No MCP servers to configure
+  }
+
+  // Read existing config to preserve user-added servers
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = deps.readFileSync(configPath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      existing = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // No existing config or unreadable — start fresh
+  }
+
+  const existingServers =
+    typeof existing.mcpServers === 'object' && existing.mcpServers !== null
+      ? (existing.mcpServers as Record<string, unknown>)
+      : {};
+
+  existing.mcpServers = { ...existingServers, ...servers };
+
+  const dir = path.dirname(configPath);
+  if (!deps.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  deps.writeFileSync(configPath, JSON.stringify(existing, null, 2));
+  console.log(`mcporter config written to ${configPath}`);
+}
+
 /**
  * Back up the existing config file and prune old backups.
  */

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -310,21 +310,6 @@ export function writeMcporterConfig(
   configPath = DEFAULT_MCPORTER_CONFIG_PATH,
   deps: ConfigWriterDeps = defaultDeps
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const servers: Record<string, any> = {};
-
-  if (env.AGENTCARD_API_KEY) {
-    servers['agentcard'] = {
-      url: 'https://mcp.agentcard.sh/mcp',
-      headers: { Authorization: 'Bearer ' + env.AGENTCARD_API_KEY },
-    };
-    console.log('AgentCard MCP server configured (via mcporter)');
-  }
-
-  if (Object.keys(servers).length === 0) {
-    return; // No MCP servers to configure
-  }
-
   // Read existing config to preserve user-added servers
   let existing: Record<string, unknown> = {};
   try {
@@ -339,10 +324,31 @@ export function writeMcporterConfig(
 
   const existingServers =
     typeof existing.mcpServers === 'object' && existing.mcpServers !== null
-      ? (existing.mcpServers as Record<string, unknown>)
+      ? { ...(existing.mcpServers as Record<string, unknown>) }
       : {};
 
-  existing.mcpServers = { ...existingServers, ...servers };
+  // Managed server keys — add when env var is set, remove when absent.
+  // This ensures credential removal on the dashboard actually revokes access
+  // even though mcporter.json persists on the volume across restarts.
+  if (env.AGENTCARD_API_KEY) {
+    existingServers['agentcard'] = {
+      url: 'https://mcp.agentcard.sh/mcp',
+      headers: { Authorization: 'Bearer ' + env.AGENTCARD_API_KEY },
+    };
+    console.log('AgentCard MCP server configured (via mcporter)');
+  } else {
+    if ('agentcard' in existingServers) {
+      delete existingServers['agentcard'];
+      console.log('AgentCard MCP server removed from mcporter config');
+    }
+  }
+
+  // Only write if there are servers to configure or we need to clean up
+  if (Object.keys(existingServers).length === 0 && !deps.existsSync(configPath)) {
+    return;
+  }
+
+  existing.mcpServers = existingServers;
 
   const dir = path.dirname(configPath);
   if (!deps.existsSync(dir)) {

--- a/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
+++ b/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
@@ -219,9 +219,8 @@ describe('Secret Catalog', () => {
       expect(keys).toContain('githubToken');
       expect(keys).toContain('githubUsername');
       expect(keys).toContain('githubEmail');
-      expect(keys).toContain('agentcardEmail');
       expect(keys).toContain('agentcardApiKey');
-      expect(keys.size).toBe(5);
+      expect(keys.size).toBe(4);
     });
 
     it('returns empty set for categories with no entries', () => {

--- a/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
+++ b/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
@@ -37,7 +37,14 @@ describe('Secret Catalog', () => {
 
   describe('Icon validation', () => {
     it('all icon values are valid SecretIconKey members', () => {
-      const validIcons: Set<SecretIconKey> = new Set(['send', 'discord', 'slack', 'key', 'github']);
+      const validIcons: Set<SecretIconKey> = new Set([
+        'send',
+        'discord',
+        'slack',
+        'key',
+        'github',
+        'credit-card',
+      ]);
       for (const entry of SECRET_CATALOG) {
         expect(validIcons.has(entry.icon)).toBe(true);
       }
@@ -186,8 +193,9 @@ describe('Secret Catalog', () => {
 
     it('returns all tool entries sorted by order', () => {
       const tools = getEntriesByCategory('tool');
-      expect(tools.length).toBe(1);
+      expect(tools.length).toBe(2);
       expect(tools[0].id).toBe('github');
+      expect(tools[1].id).toBe('agentcard');
     });
 
     it('returns empty array for categories with no entries', () => {
@@ -211,7 +219,9 @@ describe('Secret Catalog', () => {
       expect(keys).toContain('githubToken');
       expect(keys).toContain('githubUsername');
       expect(keys).toContain('githubEmail');
-      expect(keys.size).toBe(3);
+      expect(keys).toContain('agentcardEmail');
+      expect(keys).toContain('agentcardApiKey');
+      expect(keys.size).toBe(5);
     });
 
     it('returns empty set for categories with no entries', () => {
@@ -435,10 +445,11 @@ describe('Secret Catalog', () => {
   });
 
   describe('maxLength contract', () => {
-    it('all maxLength values are within the global 500 ceiling', () => {
+    it('all maxLength values are within the global ceiling', () => {
       for (const entry of SECRET_CATALOG) {
         for (const field of entry.fields) {
-          expect(field.maxLength).toBeLessThanOrEqual(500);
+          // JWT-based secrets (e.g. AgentCard) need up to 2000 chars
+          expect(field.maxLength).toBeLessThanOrEqual(2000);
         }
       }
     });

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -139,18 +139,7 @@ const SECRET_CATALOG_RAW = [
     category: 'tool',
     icon: 'credit-card',
     order: 2,
-    allFieldsRequired: true,
     fields: [
-      {
-        key: 'agentcardEmail',
-        label: 'Email',
-        placeholder: 'you@example.com',
-        placeholderConfigured: 'Enter new email to replace',
-        envVar: 'AGENTCARD_EMAIL',
-        validationPattern: '^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$',
-        validationMessage: 'Enter a valid email address.',
-        maxLength: 254,
-      },
       {
         key: 'agentcardApiKey',
         label: 'API Key (JWT)',

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -133,6 +133,38 @@ const SECRET_CATALOG_RAW = [
     helpText: 'Manage your token from the GitHub developer settings.',
     helpUrl: 'https://github.com/settings/tokens?type=beta',
   },
+  {
+    id: 'agentcard',
+    label: 'AgentCard',
+    category: 'tool',
+    icon: 'credit-card',
+    order: 2,
+    allFieldsRequired: true,
+    fields: [
+      {
+        key: 'agentcardEmail',
+        label: 'Email',
+        placeholder: 'you@example.com',
+        placeholderConfigured: 'Enter new email to replace',
+        envVar: 'AGENTCARD_EMAIL',
+        validationPattern: '^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$',
+        validationMessage: 'Enter a valid email address.',
+        maxLength: 254,
+      },
+      {
+        key: 'agentcardApiKey',
+        label: 'API Key (JWT)',
+        placeholder: 'eyJ...',
+        placeholderConfigured: 'Enter new JWT to replace',
+        envVar: 'AGENTCARD_API_KEY',
+        validationPattern: '^eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$',
+        validationMessage: 'Enter the JWT from ~/.agent-cards/config.json (starts with eyJ).',
+        maxLength: 2000,
+      },
+    ],
+    helpText: 'Virtual debit cards for autonomous agent spending. See setup guide for details.',
+    helpUrl: 'https://agentcard.sh',
+  },
 ] as const satisfies readonly SecretCatalogEntry[];
 
 // Runtime validation — fails fast at module load if catalog data is malformed

--- a/kiloclaw/packages/secret-catalog/src/types.ts
+++ b/kiloclaw/packages/secret-catalog/src/types.ts
@@ -4,7 +4,14 @@ import { z } from 'zod';
 
 export const SecretCategorySchema = z.enum(['channel', 'tool', 'provider', 'custom']);
 
-export const SecretIconKeySchema = z.enum(['send', 'discord', 'slack', 'key', 'github']);
+export const SecretIconKeySchema = z.enum([
+  'send',
+  'discord',
+  'slack',
+  'key',
+  'github',
+  'credit-card',
+]);
 
 /**
  * How a secret is delivered to the OpenClaw process at runtime.

--- a/kiloclaw/src/routes/kiloclaw.test.ts
+++ b/kiloclaw/src/routes/kiloclaw.test.ts
@@ -11,7 +11,13 @@ describe('buildConfiguredSecrets', () => {
 
   it('returns all entries as false when no secrets are configured', () => {
     const result = buildConfiguredSecrets({});
-    expect(result).toEqual({ telegram: false, discord: false, slack: false, github: false });
+    expect(result).toEqual({
+      telegram: false,
+      discord: false,
+      slack: false,
+      github: false,
+      agentcard: false,
+    });
   });
 
   it('marks entry as configured when encryptedSecrets has the env var key', () => {
@@ -101,7 +107,7 @@ describe('buildConfiguredSecrets', () => {
     expect(keys).toContain('telegram');
     expect(keys).toContain('discord');
     expect(keys).toContain('slack');
-    expect(keys).toHaveLength(4);
+    expect(keys).toHaveLength(5);
   });
 
   it('treats null values as not configured', () => {

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -7,6 +7,7 @@ import {
   Copy,
   FileCode,
   Hash,
+  Info,
   RotateCcw,
   Save,
   Settings,
@@ -36,6 +37,14 @@ import { getSettingsModelOptions } from './modelSupport';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { DetailTile } from './DetailTile';
@@ -48,6 +57,89 @@ import { VersionPinCard } from './VersionPinCard';
 import { WorkspaceFileEditor } from './WorkspaceFileEditor';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
+
+// ---------------------------------------------------------------------------
+// AgentCard setup guide dialog
+// ---------------------------------------------------------------------------
+
+function AgentCardSetupGuide() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Info className="h-3.5 w-3.5" />
+          Advanced Setup Required
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>AgentCard Setup</DialogTitle>
+          <DialogDescription>
+            Give your agent the ability to create and spend virtual debit cards.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 text-sm">
+          <div className="rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+            <p className="text-amber-400 text-xs font-medium">
+              Warning: this can permit your agent to spend real money. Use caution.
+            </p>
+            <p className="text-amber-400/70 mt-1 text-xs">
+              AgentCard is currently in beta. Card issuance may be limited or waitlisted.
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-2 font-medium">1. Create an AgentCard account</p>
+            <p className="text-muted-foreground text-xs">Run these commands:</p>
+            <pre className="bg-muted mt-1 rounded-md p-2 text-xs">
+              <code>npm install -g agent-cards{'\n'}agent-cards signup</code>
+            </pre>
+          </div>
+
+          <div>
+            <p className="mb-2 font-medium">2. Add a payment method</p>
+            <p className="text-muted-foreground text-xs">
+              Run <code className="bg-muted rounded px-1">agent-cards payment-method</code> to link
+              a card via Stripe. This funds any virtual cards your agent creates.
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-2 font-medium">3. Copy your credentials</p>
+            <p className="text-muted-foreground text-xs">
+              Open <code className="bg-muted rounded px-1">~/.agent-cards/config.json</code> and
+              copy the <strong>email</strong> and <strong>jwt</strong> values into the fields above.
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-2 font-medium">4. Upgrade your instance</p>
+            <p className="text-muted-foreground text-xs">
+              This feature requires the most recent version of OpenClaw. After saving your
+              credentials, use <strong>Upgrade</strong> (not Redeploy) to install the latest image
+              and activate AgentCard. Your agent will then have access to tools like{' '}
+              <code className="bg-muted rounded px-1">create_card</code>,{' '}
+              <code className="bg-muted rounded px-1">list_cards</code>, and{' '}
+              <code className="bg-muted rounded px-1">check_balance</code>.
+            </p>
+          </div>
+
+          <p className="text-muted-foreground border-t pt-3 text-xs">
+            Learn more at{' '}
+            <a
+              href="https://agentcard.sh"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              agentcard.sh
+            </a>
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Google Account (collapsible card, matches SecretEntrySection card style)
@@ -568,6 +660,28 @@ export function SettingsTab({
                       minimally scoped to specific repos and permissions.
                     </span>
                   }
+                />
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Payments ── */}
+      {toolEntries.some(e => e.id === 'agentcard') && (
+        <div>
+          <h2 className="text-foreground mb-3 text-base font-semibold">Payments</h2>
+          <div className="space-y-3">
+            {toolEntries
+              .filter(e => e.id === 'agentcard')
+              .map(entry => (
+                <SecretEntrySection
+                  key={entry.id}
+                  entry={entry}
+                  configured={configuredSecrets[entry.id] ?? false}
+                  mutations={mutations}
+                  onSecretsChanged={onSecretsChanged}
+                  isDirty={dirtySecrets.has(entry.id)}
+                  actionRowExtra={<AgentCardSetupGuide />}
                 />
               ))}
           </div>

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -105,10 +105,10 @@ function AgentCardSetupGuide() {
           </div>
 
           <div>
-            <p className="mb-2 font-medium">3. Copy your credentials</p>
+            <p className="mb-2 font-medium">3. Copy your API key</p>
             <p className="text-muted-foreground text-xs">
               Open <code className="bg-muted rounded px-1">~/.agent-cards/config.json</code> and
-              copy the <strong>email</strong> and <strong>jwt</strong> values into the fields above.
+              copy the <strong>jwt</strong> value into the field above.
             </p>
           </div>
 

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-03-19',
+    description:
+      'Added AgentCard integration. Connect your AgentCard.sh credentials in Settings to give your bot the ability to create and spend virtual debit cards via mcporter.',
+    category: 'feature',
+    deployHint: 'redeploy_required',
+  },
+  {
     date: '2026-03-17',
     description: 'Updated 1Password CLI to 2.33.0.',
     category: 'feature',

--- a/src/app/(app)/claw/components/icons/AgentCardIcon.tsx
+++ b/src/app/(app)/claw/components/icons/AgentCardIcon.tsx
@@ -1,0 +1,13 @@
+export function AgentCardIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5z"
+        stroke="#22C55E"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/app/(app)/claw/components/secret-ui-adapter.ts
+++ b/src/app/(app)/claw/components/secret-ui-adapter.ts
@@ -5,6 +5,7 @@ import { TelegramIcon } from './icons/TelegramIcon';
 import { DiscordIcon } from './icons/DiscordIcon';
 import { SlackIcon } from './icons/SlackIcon';
 import { GitHubIcon } from './icons/GitHubIcon';
+import { AgentCardIcon } from './icons/AgentCardIcon';
 
 const ICON_MAP: Record<SecretIconKey, React.ComponentType<{ className?: string }>> = {
   send: TelegramIcon,
@@ -12,6 +13,7 @@ const ICON_MAP: Record<SecretIconKey, React.ComponentType<{ className?: string }
   slack: SlackIcon,
   key: Key,
   github: GitHubIcon,
+  'credit-card': AgentCardIcon,
 };
 
 export function getIcon(iconKey: SecretIconKey): React.ComponentType<{ className?: string }> {
@@ -24,6 +26,7 @@ const DESCRIPTION_MAP: Record<string, string> = {
   discord: 'Connect your Discord bot',
   slack: 'Connect your Slack workspace',
   github: 'Connect a GitHub account for code operations',
+  agentcard: 'Give your bot virtual debit cards for spending',
 };
 
 export function getDescription(entryId: string): string {


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Add AgentCard.sh as an MCP tool integration for KiloClaw
- Users paste their JWT from ~/.agent-cards/config.json into Settings >   Payments > AgentCard
- At boot, the controller writes a mcporter config   (/root/.openclaw/workspace/config/mcporter.json) with the AgentCard MCP server    definition
- Uses mcporter (already installed in the image at v0.7.3) as the MCP   middleware layer — OpenClaw's native mcp.servers config support lands in   2026.3.14, which isn't released yet
- When credentials are removed from the dashboard, the agentcard entry is   actively deleted from mcporter.json on the persistent volume
- Adds "Advanced Setup Required" dialog with step-by-step instructions,   real-money spending warning, and beta/waitlist notice
- Adds Payments section to Settings tab with branded credit card icon


## Verification

- Secret catalog tests: 54/54 pass
- KiloClaw router tests: 918/918 pass (updated for new agentcard entry)
- Typecheck: all packages pass
- Format (oxfmt): clean
- Lint (oxlint + eslint): clean
- End-to-end: deployed to dev instance, verified mcporter config written,   mcporter list shows agentcard server with 15 tools healthy (706ms response)


## Visual Changes
- New "Payments" section in Settings tab between Developer Tools and   Productivity
- AgentCard collapsible card with green credit card icon, "Configured"/"Not   configured" badge
- "Advanced Setup Required" button opens a dialog with:
- Real money spending warning (amber banner)
- 4-step setup instructions (install CLI, add payment method, copy JWT,   upgrade instance)
- Link to agentcard.sh
- Changelog entry added under "What's New" tab

<img width="615" height="291" alt="Screenshot 2026-03-19 at 1 57 14 PM" src="https://github.com/user-attachments/assets/6ed58664-2438-4f6d-a8d6-903ba6bc2004" />
<img width="535" height="606" alt="Screenshot 2026-03-19 at 1 57 35 PM" src="https://github.com/user-attachments/assets/b5737db9-d24b-4de5-b312-96b6bc45c942" />


## Reviewer Notes
- AGENTCARD_EMAIL was intentionally removed — it's not used by the runtime   (only the JWT is needed for Bearer auth). No migration needed since this   feature has never shipped to production.
- mcporter approach is temporary — TODO comment in config-writer.ts references    OpenClaw PR #48611 for migration to native mcp.servers config when Dockerfile    pins >= 2026.3.14
- The writeMcporterConfig() function preserves user-added mcporter servers   while managing the agentcard entry declaratively (add when env var present,   remove when absent)
