### PR TITLE
feat(cloud-agent): set default session title on creation

### DIFF
--- a/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/cloud-agent-next/src/persistence/async-preparation.ts
@@ -179,13 +179,14 @@ export async function executePreparationSteps(
   if (input.kiloSessionId) {
     emitProgress('kilo_session', 'Importing session…');
     const now = Date.now();
+    const defaultTitle = 'New session - ' + new Date(now).toISOString();
     const minimalSessionJson = JSON.stringify({
       info: {
         id: input.kiloSessionId,
         slug: '',
         projectID: '',
         directory: '',
-        title: '',
+        title: defaultTitle,
         version: '2',
         time: { created: now, updated: now },
       },

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -208,13 +208,15 @@ const prepareSessionHandler = internalApiProtectedProcedure
         logger.setTags({ kiloSessionId });
 
         // Create cli_sessions_v2 record immediately (stream-ticket route needs it for ownership)
+        const defaultTitle = 'New session - ' + new Date().toISOString();
         await sessionService.createCliSessionViaSessionIngest(
           kiloSessionId,
           cloudAgentSessionId,
           ctx.userId,
           ctx.env,
           input.kilocodeOrganizationId,
-          input.createdOnPlatform ?? 'cloud-agent'
+          input.createdOnPlatform ?? 'cloud-agent',
+          defaultTitle
         );
 
         const rollbackCliSession = async () => {

--- a/cloud-agent-next/src/session-ingest-binding.ts
+++ b/cloud-agent-next/src/session-ingest-binding.ts
@@ -14,6 +14,7 @@ export type CreateSessionForCloudAgentParams = {
   cloudAgentSessionId: string;
   organizationId?: string;
   createdOnPlatform: string;
+  title?: string;
 };
 
 export type DeleteSessionForCloudAgentParams = {

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -1705,7 +1705,8 @@ export class SessionService {
     kiloUserId: string,
     env: PersistenceEnv,
     organizationId: string | undefined,
-    createdOnPlatform: string
+    createdOnPlatform: string,
+    title?: string
   ): Promise<void> {
     try {
       await env.SESSION_INGEST.createSessionForCloudAgent({
@@ -1714,6 +1715,7 @@ export class SessionService {
         cloudAgentSessionId,
         organizationId,
         createdOnPlatform,
+        title,
       });
     } catch (error) {
       logger

--- a/cloudflare-session-ingest/src/session-ingest-rpc.ts
+++ b/cloudflare-session-ingest/src/session-ingest-rpc.ts
@@ -32,6 +32,7 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> {
     cloudAgentSessionId: string;
     organizationId?: string;
     createdOnPlatform: string;
+    title?: string;
   }): Promise<void> {
     const parsed = z
       .object({
@@ -40,6 +41,7 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> {
         cloudAgentSessionId: z.string().min(1),
         organizationId: z.string().optional(),
         createdOnPlatform: z.string().min(1),
+        title: z.string().optional(),
       })
       .parse(params);
 
@@ -53,6 +55,7 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> {
         cloud_agent_session_id: parsed.cloudAgentSessionId,
         organization_id: parsed.organizationId ?? null,
         created_on_platform: parsed.createdOnPlatform,
+        ...(parsed.title !== undefined ? { title: parsed.title } : {}),
         version: 0,
       })
       .onConflictDoUpdate({


### PR DESCRIPTION
## Summary

Sets a default title (`"New session - <ISO timestamp>"`) when creating cloud agent sessions, replacing the previously blank/null title. The change threads an optional `title` parameter through the full session creation stack:

- **`async-preparation.ts`** — the minimal CLI SQLite session JSON now includes the timestamp title instead of an empty string
- **`session-prepare.ts`** — the fast path (autoInitiate=true) passes the default title to the session-ingest RPC
- **`session-service.ts`** / **`session-ingest-binding.ts`** — the service method and binding type accept the new optional parameter
- **`session-ingest-rpc.ts`** — the RPC handler validates via Zod and conditionally inserts the title into `cli_sessions_v2`

The slow path (non-autoInitiate) does not pass a title; those sessions continue to resolve as "Untitled" via the existing `COALESCE` at read time.

## Visual Changes

N/A

## Reviewer Notes

- The slow-path call at `session-prepare.ts:435` intentionally omits `title` — only the fast path (autoInitiate) sets a default.
- `onConflictDoUpdate` does not include `title`, so re-preparation won't overwrite an existing title. This preserves titles that may have already been set by user activity.