### PR TITLE
fix(dev-cli): address review comments — env banner, logs, status, log dirs

### DIFF
--- a/dev/cli/src/commands/env.ts
+++ b/dev/cli/src/commands/env.ts
@@ -6,12 +6,15 @@ import { join } from 'path';
 export async function envCheck(root: string) {
   ui.header('Environment Variable Check');
 
+  let allGood = true;
+
   const envLocalPath = join(root, '.env.local');
   const envLocalExists = await Bun.file(envLocalPath).exists();
   if (envLocalExists) {
     ui.success('.env.local exists');
   } else {
     ui.error('.env.local missing — run: vercel env pull');
+    allGood = false;
   }
 
   const vercelProjectPath = join(root, '.vercel', 'project.json');
@@ -20,10 +23,10 @@ export async function envCheck(root: string) {
     ui.success('Vercel project linked');
   } else {
     ui.warn('Vercel project not linked — run: vercel link --project kilocode-app');
+    allGood = false;
   }
 
   const servicesWithEnv = services.filter(s => s.envFile);
-  let allGood = true;
 
   for (const svc of servicesWithEnv) {
     const examplePath = join(root, svc.dir, svc.envFile!);

--- a/dev/cli/src/commands/logs.ts
+++ b/dev/cli/src/commands/logs.ts
@@ -18,12 +18,21 @@ export async function logs(args: string[], root: string) {
     return;
   }
 
-  if (svc.type === 'infra') {
+  // Only docker compose services support `docker compose logs`.
+  // Infra services like 'migrations' use non-docker commands (e.g. pnpm drizzle migrate)
+  // and have no persistent container to tail.
+  const dockerComposeServices = new Set(['postgres', 'redis']);
+
+  if (svc.type === 'infra' && dockerComposeServices.has(svc.name)) {
     const proc = Bun.spawn(
       ['docker', 'compose', '-f', 'dev/docker-compose.yml', 'logs', '-f', svc.name],
       { stdout: 'inherit', stderr: 'inherit', cwd: root }
     );
     await proc.exited;
+  } else if (svc.type === 'infra') {
+    ui.warn(
+      `"${svc.name}" is not a Docker Compose service — no logs to tail.\n  It runs: ${svc.devCommand ?? 'n/a'}`
+    );
   } else {
     ui.warn(
       `Log tailing for running dev servers is not yet supported.\n  Start the service with 'pnpm kilo dev up ${name}' to see its output.`

--- a/dev/cli/src/commands/status.ts
+++ b/dev/cli/src/commands/status.ts
@@ -16,11 +16,42 @@ export async function status(root: string) {
   );
 
   const portServices = services.filter(s => s.port && s.type !== 'infra');
+
+  // Group services by port to detect shared ports
+  const portToServices = new Map<number, string[]>();
   for (const svc of portServices) {
-    const listening = await isPortListening(svc.port!);
-    console.log(
-      `  ${listening ? ui.green('●') : ui.dim('○')} ${svc.name.padEnd(12)} ${listening ? `port ${svc.port}` : ui.dim('not running')}`
-    );
+    const list = portToServices.get(svc.port!) ?? [];
+    list.push(svc.name);
+    portToServices.set(svc.port!, list);
+  }
+
+  // Track ports we've already checked to avoid duplicate probes
+  const checkedPorts = new Set<number>();
+
+  for (const svc of portServices) {
+    const port = svc.port!;
+    const sharesPort = portToServices.get(port)!;
+
+    if (checkedPorts.has(port)) {
+      // Already reported for this port — skip duplicate probe
+      continue;
+    }
+    checkedPorts.add(port);
+
+    const listening = await isPortListening(port);
+
+    if (sharesPort.length > 1) {
+      // Multiple services claim this port — show them together with a note
+      const names = sharesPort.join(' / ');
+      const ambiguityNote = ui.dim('(shared port — cannot distinguish)');
+      console.log(
+        `  ${listening ? ui.green('●') : ui.dim('○')} ${names.padEnd(24)} ${listening ? `port ${port} ${ambiguityNote}` : ui.dim('not running')}`
+      );
+    } else {
+      console.log(
+        `  ${listening ? ui.green('●') : ui.dim('○')} ${svc.name.padEnd(12)} ${listening ? `port ${port}` : ui.dim('not running')}`
+      );
+    }
   }
 
   console.log();

--- a/dev/cli/src/projects/auto-fix.ts
+++ b/dev/cli/src/projects/auto-fix.ts
@@ -2,6 +2,7 @@ import type { ProjectDef } from './types';
 import { spawnService, run } from '../utils/process';
 import * as ui from '../utils/ui';
 import { join } from 'path';
+import { mkdir } from 'fs/promises';
 import { createHmac, randomUUID } from 'crypto';
 
 const GENERIC_BODY = JSON.stringify(
@@ -50,6 +51,7 @@ async function upCommand(args: string[], root: string): Promise<void> {
   const skipRoot = args.includes('--no-root');
 
   const logDir = join(root, 'dev', '.dev-logs', 'auto-fix');
+  await mkdir(logDir, { recursive: true });
   await Bun.write(join(logDir, '.gitkeep'), '');
 
   ui.header('Kilo Cloud Dev Services — Auto Fix');

--- a/dev/cli/src/projects/code-review.ts
+++ b/dev/cli/src/projects/code-review.ts
@@ -2,6 +2,7 @@ import type { ProjectDef } from './types';
 import { spawnService, run } from '../utils/process';
 import * as ui from '../utils/ui';
 import { join } from 'path';
+import { mkdir } from 'fs/promises';
 import { createHmac, randomUUID } from 'crypto';
 
 const GENERIC_BODY = JSON.stringify(
@@ -48,6 +49,7 @@ async function upCommand(args: string[], root: string): Promise<void> {
   const skipRoot = args.includes('--no-root');
 
   const logDir = join(root, 'dev', '.dev-logs', 'review');
+  await mkdir(logDir, { recursive: true });
   await Bun.write(join(logDir, '.gitkeep'), '');
 
   ui.header('Kilo Cloud Dev Services — Code Review');


### PR DESCRIPTION
Fixes all 5 review comments from kilo-code-bot on #1142:

1. **env.ts** — `allGood` now tracks `.env.local` and Vercel project checks, not just the per-service loop. Final banner no longer lies.
2. **logs.ts** — `migrations` (non-docker infra) no longer crashes with `docker compose logs`. Shows helpful message instead.
3. **status.ts** — Services sharing a port (auto-fix/db-proxy on 8792, kiloclaw/git-token on 8795) are grouped with a shared-port note. Port only probed once.
4. **code-review.ts** — Added `mkdir(logDir, { recursive: true })` before `Bun.write()` so it works on fresh checkouts.
5. **auto-fix.ts** — Same mkdir fix as #4.

All 15/15 unit tests pass.

Addresses review comments on #1142.