### PR TITLE
fix(dev-cli): handle non-compose infra services in logs command

### DIFF
--- a/dev/cli/src/commands/logs.ts
+++ b/dev/cli/src/commands/logs.ts
@@ -18,12 +18,16 @@ export async function logs(args: string[], root: string) {
     return;
   }
 
-  if (svc.type === 'infra') {
+  if (svc.type === 'infra' && svc.devCommand?.startsWith('docker compose')) {
     const proc = Bun.spawn(
       ['docker', 'compose', '-f', 'dev/docker-compose.yml', 'logs', '-f', svc.name],
       { stdout: 'inherit', stderr: 'inherit', cwd: root }
     );
     await proc.exited;
+  } else if (svc.type === 'infra') {
+    ui.warn(
+      `"${svc.name}" is not a Docker Compose service (runs: ${svc.devCommand ?? 'n/a'}).\n  It does not produce persistent logs that can be tailed.`
+    );
   } else {
     ui.warn(
       `Log tailing for running dev servers is not yet supported.\n  Start the service with 'pnpm kilo dev up ${name}' to see its output.`

--- a/dev/cli/test/logs.test.ts
+++ b/dev/cli/test/logs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { services } from '../src/services/registry';
+
+/**
+ * The `logs` command tails `docker compose logs -f <name>` for infra services.
+ * Only infra services whose devCommand starts with "docker compose" actually
+ * exist in docker-compose.yml. Non-compose infra services (e.g. migrations)
+ * must NOT be passed to `docker compose logs` — they'd fail silently or error.
+ *
+ * These tests validate the invariants that the logs command relies on.
+ */
+describe('logs command invariants', () => {
+  const infraServices = services.filter(s => s.type === 'infra');
+  const composeInfra = infraServices.filter(s => s.devCommand?.startsWith('docker compose'));
+  const nonComposeInfra = infraServices.filter(s => !s.devCommand?.startsWith('docker compose'));
+
+  test('migrations is an infra service with a non-compose devCommand', () => {
+    const migrations = services.find(s => s.name === 'migrations');
+    expect(migrations).toBeDefined();
+    expect(migrations!.type).toBe('infra');
+    expect(migrations!.devCommand).toBe('pnpm drizzle migrate');
+    expect(migrations!.devCommand!.startsWith('docker compose')).toBe(false);
+  });
+
+  test('postgres and redis are infra services with docker compose devCommands', () => {
+    for (const name of ['postgres', 'redis']) {
+      const svc = services.find(s => s.name === name);
+      expect(svc).toBeDefined();
+      expect(svc!.type).toBe('infra');
+      expect(svc!.devCommand!.startsWith('docker compose')).toBe(true);
+    }
+  });
+
+  test('at least one infra service is non-compose (guard against regression)', () => {
+    expect(nonComposeInfra.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('compose infra services have names matching docker-compose service names', () => {
+    // The logs command uses svc.name as the compose service name.
+    // Compose infra devCommands should contain `-d <name>` referencing the same service.
+    for (const svc of composeInfra) {
+      expect(svc.devCommand).toContain(svc.name);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The `logs` command assumes all `infra` services are Docker Compose services and unconditionally runs `docker compose -f dev/docker-compose.yml logs -f <name>` for them.

However, `migrations` is registered as an `infra` service with `devCommand: "pnpm drizzle migrate"` — it is **not** a Docker Compose service. The `docker-compose.yml` only defines `postgres` and `redis`.

Running `pnpm kilo logs migrations` executes `docker compose ... logs -f migrations`, which fails immediately because no such compose service exists.

## Proof the issue is real

1. **Registry:** `migrations` has `type: "infra"` and `devCommand: "pnpm drizzle migrate"` ([registry.ts](../blob/improvement/kiloclaw-dev-cli/dev/cli/src/services/registry.ts#L32-L38))
2. **docker-compose.yml:** Only defines `postgres` and `redis` — no `migrations` service ([docker-compose.yml](../blob/improvement/kiloclaw-dev-cli/dev/docker-compose.yml))
3. **logs.ts (before fix):** Line 21 checks `svc.type === "infra"` and runs `docker compose logs -f` with the service name — this sends `migrations` to docker compose, which fails

## Proof this is not a band-aid

The root issue is in `logs.ts` itself: it incorrectly equates "infra service" with "Docker Compose service". The `migrations` service is correctly categorized as `infra` (it is infrastructure — DB migrations must run before app services). The registry is correct. The fix belongs in the `logs` command.

## Changes

**`dev/cli/src/commands/logs.ts`:**
- Added a check: only run `docker compose logs` for infra services whose `devCommand` starts with `"docker compose"`
- Non-compose infra services (like `migrations`) now show a helpful warning explaining that the service is not a Docker Compose service and does not produce persistent logs

**`dev/cli/test/logs.test.ts`** (new):
- 4 tests validating the invariants the logs command relies on:
  - `migrations` is infra with a non-compose devCommand
  - `postgres`/`redis` are infra with compose devCommands
  - At least one non-compose infra service exists (regression guard)
  - Compose infra service names match their docker-compose service names

All 19 tests pass (15 existing + 4 new).

Fixes review comment: https://github.com/Kilo-Org/cloud/pull/1142#discussion_r2942776818