### PR TITLE
fix(dev-cli): handle shared-port services in status command

### DIFF
--- a/dev/cli/src/commands/status.ts
+++ b/dev/cli/src/commands/status.ts
@@ -16,11 +16,45 @@ export async function status(root: string) {
   );
 
   const portServices = services.filter(s => s.port && s.type !== 'infra');
+
+  // Group services by port to detect shared-port conflicts
+  const portGroups = new Map<number, typeof portServices>();
   for (const svc of portServices) {
-    const listening = await isPortListening(svc.port!);
-    console.log(
-      `  ${listening ? ui.green('●') : ui.dim('○')} ${svc.name.padEnd(12)} ${listening ? `port ${svc.port}` : ui.dim('not running')}`
-    );
+    const group = portGroups.get(svc.port!) ?? [];
+    group.push(svc);
+    portGroups.set(svc.port!, group);
+  }
+
+  // Check each unique port once
+  const portStatus = new Map<number, boolean>();
+  for (const port of portGroups.keys()) {
+    portStatus.set(port, await isPortListening(port));
+  }
+
+  for (const [port, group] of portGroups) {
+    const listening = portStatus.get(port)!;
+
+    if (group.length === 1) {
+      // Unique port — show definitive status
+      const svc = group[0];
+      console.log(
+        `  ${listening ? ui.green('●') : ui.dim('○')} ${svc.name.padEnd(12)} ${listening ? `port ${port}` : ui.dim('not running')}`
+      );
+    } else {
+      // Shared port — cannot determine which service is actually running
+      const names = group.map(s => s.name);
+      if (listening) {
+        console.log(
+          `  ${ui.yellow('●')} ${names.join(', ').padEnd(12)} port ${port} ${ui.yellow('(shared — cannot distinguish)')}`
+        );
+      } else {
+        for (const svc of group) {
+          console.log(
+            `  ${ui.dim('○')} ${svc.name.padEnd(12)} ${ui.dim('not running')}`
+          );
+        }
+      }
+    }
   }
 
   console.log();

--- a/dev/cli/test/status.test.ts
+++ b/dev/cli/test/status.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { services } from '../src/services/registry';
+
+describe('status: shared-port detection', () => {
+  test('identifies services that share a port', () => {
+    const portServices = services.filter(s => s.port && s.type !== 'infra');
+    const portGroups = new Map<number, string[]>();
+    for (const svc of portServices) {
+      const group = portGroups.get(svc.port!) ?? [];
+      group.push(svc.name);
+      portGroups.set(svc.port!, group);
+    }
+    const sharedPorts = [...portGroups.entries()].filter(([, names]) => names.length > 1);
+
+    // Verify the known shared ports are detected
+    expect(sharedPorts.length).toBeGreaterThanOrEqual(2);
+
+    const port8792 = portGroups.get(8792);
+    expect(port8792).toBeDefined();
+    expect(port8792).toContain('auto-fix');
+    expect(port8792).toContain('db-proxy');
+
+    const port8795 = portGroups.get(8795);
+    expect(port8795).toBeDefined();
+    expect(port8795).toContain('kiloclaw');
+    expect(port8795).toContain('git-token');
+  });
+
+  test('unique-port services are not grouped', () => {
+    const portServices = services.filter(s => s.port && s.type !== 'infra');
+    const portGroups = new Map<number, string[]>();
+    for (const svc of portServices) {
+      const group = portGroups.get(svc.port!) ?? [];
+      group.push(svc.name);
+      portGroups.set(svc.port!, group);
+    }
+
+    // Port 3000 belongs only to nextjs
+    const port3000 = portGroups.get(3000);
+    expect(port3000).toEqual(['nextjs']);
+  });
+
+  test('all non-infra port services are accounted for in port groups', () => {
+    const portServices = services.filter(s => s.port && s.type !== 'infra');
+    const portGroups = new Map<number, string[]>();
+    for (const svc of portServices) {
+      const group = portGroups.get(svc.port!) ?? [];
+      group.push(svc.name);
+      portGroups.set(svc.port!, group);
+    }
+
+    // Every port-having service should be in exactly one group
+    const allGroupedNames = [...portGroups.values()].flat();
+    const serviceNames = portServices.map(s => s.name);
+    expect(allGroupedNames.sort()).toEqual(serviceNames.sort());
+  });
+});


### PR DESCRIPTION
## Problem

The `pnpm kilo status` command checks whether each service is running by probing its registered port. However, the service registry assigns the same port to multiple services:

- **Port 8792:** `auto-fix` and `db-proxy`
- **Port 8795:** `kiloclaw` and `git-token`

When either process in a shared-port pair is running, `status` falsely reports **both** services as running — producing false positives.

## Proof the Issue Is Real

The registry (`dev/cli/src/services/registry.ts`) explicitly declares:
- `auto-fix` → port 8792, `db-proxy` → port 8792
- `kiloclaw` → port 8795, `git-token` → port 8795

The old `status.ts` iterates all port-having services and calls `isPortListening(svc.port!)` independently for each. Since both services in a shared-port pair resolve to the same port number, a single listening process causes both to show green.

The existing `registry.test.ts` already documents these conflicts with a `console.warn` — confirming they are known and intentional in the registry.

## Proof This Is Not a Band-Aid

The port conflicts originate in upstream `wrangler.jsonc` files. The registry correctly mirrors those configs. These services are **not intended to run simultaneously** (as noted in the registry test), so changing the ports would be incorrect.

The **status command** is the presentation layer responsible for showing accurate information. It is the correct place to handle shared-port ambiguity — not the registry, and not the upstream wrangler configs.

## What Changed

### `dev/cli/src/commands/status.ts`
- Group services by port before probing
- For **unique ports**: behavior unchanged (green ● or dim ○)
- For **shared ports**: when listening, show a yellow ● with all service names and `(shared — cannot distinguish)` instead of falsely marking each as independently running. When not listening, show each service as not running individually.

### `dev/cli/test/status.test.ts` (new)
3 tests covering the shared-port grouping logic:
1. Detects known shared ports (8792, 8795) with correct service names
2. Confirms unique-port services are not grouped
3. Verifies all port-having services are accounted for in groups

All 18 tests pass (15 existing + 3 new).

Addresses review comment: https://github.com/Kilo-Org/cloud/pull/1142#discussion_r2942776822