### PR TITLE
fix(dev-cli): include prereq checks in envCheck allGood flag

### DIFF
--- a/dev/cli/src/commands/env.ts
+++ b/dev/cli/src/commands/env.ts
@@ -22,8 +22,9 @@ export async function envCheck(root: string) {
     ui.warn('Vercel project not linked — run: vercel link --project kilocode-app');
   }
 
+  let allGood = envLocalExists && vercelLinked;
+
   const servicesWithEnv = services.filter(s => s.envFile);
-  let allGood = true;
 
   for (const svc of servicesWithEnv) {
     const examplePath = join(root, svc.dir, svc.envFile!);

--- a/dev/cli/test/env-check.test.ts
+++ b/dev/cli/test/env-check.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Tests for envCheck that verify the final banner correctly reflects
+ * the state of ALL checks, including .env.local and .vercel/project.json.
+ *
+ * To isolate the pre-requisite checks from per-service env checks, we
+ * create all required service .dev.vars files (with valid content) in
+ * the temp tree so the service loop doesn't contribute failures.
+ */
+
+// Import services to know which dirs need .dev.vars
+import { services } from '../src/services/registry';
+import { envCheck } from '../src/commands/env';
+
+let root: string;
+let logs: string[];
+let errors: string[];
+let origLog: typeof console.log;
+let origError: typeof console.error;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'env-check-test-'));
+  logs = [];
+  errors = [];
+  origLog = console.log;
+  origError = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+  console.error = (...args: unknown[]) => errors.push(args.map(String).join(' '));
+});
+
+afterEach(async () => {
+  console.log = origLog;
+  console.error = origError;
+  await rm(root, { recursive: true, force: true });
+});
+
+function allOutput(): string {
+  return [...logs, ...errors].join('\n');
+}
+
+/**
+ * Creates all service .dev.vars AND their .dev.vars.example files so
+ * that the per-service loop produces no warnings. The .dev.vars files
+ * contain the same keys with non-placeholder values.
+ */
+async function createAllServiceEnvFiles() {
+  const servicesWithEnv = services.filter(s => s.envFile);
+  for (const svc of servicesWithEnv) {
+    const dir = join(root, svc.dir);
+    await mkdir(dir, { recursive: true });
+    // Create example file with a non-placeholder value
+    const exampleContent = 'SOME_KEY=real-value\n';
+    await writeFile(join(dir, svc.envFile!), exampleContent);
+    // Create actual .dev.vars with matching real value
+    await writeFile(join(dir, '.dev.vars'), 'SOME_KEY=real-value\n');
+  }
+}
+
+describe('envCheck final banner', () => {
+  test('missing .env.local → banner should say "needs attention", not "passed"', async () => {
+    // .env.local does NOT exist, .vercel/project.json DOES
+    await mkdir(join(root, '.vercel'), { recursive: true });
+    await writeFile(join(root, '.vercel', 'project.json'), '{}');
+    await createAllServiceEnvFiles();
+
+    await envCheck(root);
+
+    const output = allOutput();
+    expect(output).toContain('.env.local missing');
+    expect(output).not.toContain('All environment checks passed');
+    expect(output).toContain('Some checks need attention');
+  });
+
+  test('missing .vercel/project.json → banner should say "needs attention", not "passed"', async () => {
+    // .env.local EXISTS, .vercel/project.json does NOT
+    await writeFile(join(root, '.env.local'), 'KEY=value');
+    await createAllServiceEnvFiles();
+
+    await envCheck(root);
+
+    const output = allOutput();
+    expect(output).toContain('Vercel project not linked');
+    expect(output).not.toContain('All environment checks passed');
+    expect(output).toContain('Some checks need attention');
+  });
+
+  test('both prereqs missing → banner should say "needs attention"', async () => {
+    await createAllServiceEnvFiles();
+
+    await envCheck(root);
+
+    const output = allOutput();
+    expect(output).toContain('.env.local missing');
+    expect(output).toContain('Vercel project not linked');
+    expect(output).not.toContain('All environment checks passed');
+    expect(output).toContain('Some checks need attention');
+  });
+
+  test('all prereqs present + all service envs OK → banner says "passed"', async () => {
+    await writeFile(join(root, '.env.local'), 'KEY=value');
+    await mkdir(join(root, '.vercel'), { recursive: true });
+    await writeFile(join(root, '.vercel', 'project.json'), '{}');
+    await createAllServiceEnvFiles();
+
+    await envCheck(root);
+
+    const output = allOutput();
+    expect(output).toContain('All environment checks passed');
+    expect(output).not.toContain('Some checks need attention');
+  });
+});


### PR DESCRIPTION
## Problem

The `envCheck` function in `dev/cli/src/commands/env.ts` displays a false-positive success banner.

`allGood` is initialized to `true` (line 27) and only set to `false` inside the per-service `for` loop (lines 39, 49). The two prerequisite checks — `.env.local` existence and `.vercel/project.json` existence — print errors/warnings but **never flip `allGood` to `false`**.

### Proof the issue is real

When `.env.local` is missing, the function:
1. Prints `✗ .env.local missing — run: vercel env pull` via `ui.error()`
2. Proceeds through the service loop (which may find everything OK)
3. Reaches `allGood === true` and prints `All environment checks passed!`

Same for `.vercel/project.json`: `ui.warn()` fires but `allGood` stays `true`.

The new tests confirm this — they **fail on the original code** (3/4 fail) and **pass on the fixed code** (4/4 pass).

### Proof this is not a band-aid

The root cause is in `envCheck` itself: `allGood` is declared after the prereq checks and doesn't incorporate their results. There is no upstream caller or data source that should be responsible for this — the function owns both the checks and the banner, so the fix belongs here.

### What changed

**`dev/cli/src/commands/env.ts`:** Changed `let allGood = true` → `let allGood = envLocalExists && vercelLinked`, moved before the services filter. This ensures the final banner reflects all checks, not just the service loop.

**`dev/cli/test/env-check.test.ts`:** Added 4 integration tests that run `envCheck` against a temp directory tree with controlled filesystem state:
1. Missing `.env.local` → banner says "needs attention" (not "passed")
2. Missing `.vercel/project.json` → banner says "needs attention"
3. Both missing → banner says "needs attention"
4. All present + services OK → banner says "passed"

All 19 tests pass (15 existing + 4 new).

Fixes review comment: https://github.com/Kilo-Org/cloud/pull/1142#discussion_r2942776814