### PR TITLE
Increase rollout active grace period to 1800 seconds

### DIFF
--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -140,7 +140,7 @@
         "KILOCODE_CLI_VERSION": "7.0.50",
       },
       "max_instances": 150,
-      "rollout_active_grace_period": 120,
+      "rollout_active_grace_period": 1800,
     },
     {
       "class_name": "SandboxSmall",
@@ -150,7 +150,7 @@
         "KILOCODE_CLI_VERSION": "7.0.50",
       },
       "max_instances": 100,
-      "rollout_active_grace_period": 120,
+      "rollout_active_grace_period": 1800,
     },
   ],
   "durable_objects": {


### PR DESCRIPTION
When redeploying cloudflare will wait 30 min before killing a container