### PR TITLE
feat(ui): add sessions view to Usage page

### DIFF
--- a/apps/web/src/app/(app)/usage/page.tsx
+++ b/apps/web/src/app/(app)/usage/page.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   formatDollars,
   formatIsoDateString_UsaDateOnlyFormat,
@@ -19,12 +19,15 @@ import {
   formatLargeNumber,
 } from '@/lib/utils';
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import { StreakCalendar } from '@/components/profile/StreakCalendar';
 import { UsageWarning } from '@/components/usage/UsageWarning';
 import type { UsageTableColumn, UsageTableRow } from '@/components/usage/UsageTableBase';
 import { UsageTableBase } from '@/components/usage/UsageTableBase';
 import { PageLayout } from '@/components/PageLayout';
+import { extractRepoFromGitUrl } from '@/components/cloud-agent/utils/git-utils';
+import { formatDate, formatRelativeTime } from '@/lib/admin-utils';
 
 import { useTRPC } from '@/lib/trpc/utils';
 
@@ -44,6 +47,92 @@ type UsageData = {
 type UsageResponse = {
   usage: UsageData[];
 };
+
+type UsageTab = 'overview' | 'sessions';
+
+type SessionUsageTableRow = UsageTableRow & {
+  id: string;
+  sessionId: string | null;
+  source: string | null;
+  lastUsedAt: string;
+  title: string | null;
+  createdOnPlatform: string | null;
+  gitUrl: string | null;
+  organizationId: string | null;
+  cost: number;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheHits: number;
+};
+
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
+function isSessionUsageTableRow(row: UsageTableRow): row is SessionUsageTableRow {
+  return (
+    typeof row.id === 'string' &&
+    'sessionId' in row &&
+    (typeof row.sessionId === 'string' || row.sessionId === null) &&
+    'source' in row &&
+    (typeof row.source === 'string' || row.source === null) &&
+    typeof row.lastUsedAt === 'string'
+  );
+}
+
+function formatUsageSource(source: string | null): string {
+  if (source === null) {
+    return 'Unknown Source';
+  }
+
+  switch (source) {
+    case 'slack':
+      return 'Slack';
+    case 'discord':
+      return 'Discord';
+    case 'security-agent':
+      return 'Security Agent';
+    case 'embeddings':
+      return 'Embeddings';
+    case 'direct-gateway':
+      return 'Direct Gateway';
+    case 'bot':
+      return 'Bot';
+    default:
+      return source
+        .split('-')
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+  }
+}
+
+function formatSessionPlatform(createdOnPlatform: string | null): string | null {
+  if (createdOnPlatform === null) {
+    return null;
+  }
+
+  switch (createdOnPlatform) {
+    case 'cloud-agent':
+      return 'Cloud';
+    case 'cli':
+      return 'CLI';
+    case 'agent-manager':
+      return 'Agent Manager';
+    case 'slack':
+      return 'Slack';
+    default:
+      return createdOnPlatform;
+  }
+}
+
+function getSessionChatHref(sessionId: string, organizationId: string | null): string {
+  const sessionIdParam = encodeURIComponent(sessionId);
+  if (organizationId) {
+    return `/organizations/${organizationId}/cloud/chat?sessionId=${sessionIdParam}`;
+  }
+
+  return `/cloud/chat?sessionId=${sessionIdParam}`;
+}
 
 async function fetchUsageData(
   groupByModel: boolean,
@@ -149,9 +238,29 @@ const PERIOD_LABELS: Record<Period, string> = {
 export default function UsagePage() {
   const router = useRouter();
   const trpc = useTRPC();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [groupByModel, setGroupByModel] = useState(false);
   const [viewType, setViewType] = useState<string>('personal');
   const [period, setPeriod] = useState<Period>('week');
+  const tabParam = searchParams.get('tab');
+  const activeTab: UsageTab = tabParam === 'sessions' ? 'sessions' : 'overview';
+  const [sessionsPage, setSessionsPage] = useState<number>(1);
+
+  const handleTabChange = (nextTab: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (nextTab === 'overview') {
+      params.delete('tab');
+    } else {
+      params.set('tab', nextTab);
+    }
+
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  };
 
   const {
     data: usageData,
@@ -168,6 +277,24 @@ export default function UsagePage() {
   );
 
   const { data: organizations } = useQuery(trpc.organizations.list.queryOptions());
+
+  const {
+    data: sessionUsageHistory,
+    isLoading: isLoadingSessionUsageHistory,
+    error: sessionUsageHistoryError,
+  } = useQuery({
+    ...trpc.user.getSessionUsageHistory.queryOptions({
+      viewType,
+      period,
+      page: sessionsPage,
+      limit: 100,
+    }),
+    enabled: activeTab === 'sessions',
+  });
+
+  useEffect(() => {
+    setSessionsPage(1);
+  }, [viewType, period]);
 
   // Redirect to sign-in page if user is not authenticated
   useEffect(() => {
@@ -423,6 +550,145 @@ export default function UsagePage() {
     cacheHits: item.total_cache_hit_tokens,
   }));
 
+  const renderViewTypeSelector = () => {
+    if (!organizations || organizations.length === 0) {
+      return null;
+    }
+
+    return (
+      <Select value={viewType} onValueChange={setViewType}>
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="personal">Personal Only</SelectItem>
+          <SelectItem value="all">All Usage</SelectItem>
+          {organizations.map(org => (
+            <SelectItem key={org.organizationId} value={org.organizationId}>
+              {org.organizationName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  };
+
+  const sessionTableColumns: UsageTableColumn[] = [
+    {
+      key: 'lastUsedAt',
+      label: 'Last Used',
+      render: value => {
+        if (typeof value !== 'string') {
+          return '—';
+        }
+
+        return (
+          <div className="flex flex-col">
+            <span>{formatRelativeTime(value)}</span>
+            <span className="text-muted-foreground text-xs">{formatDate(value)}</span>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'sessionId',
+      label: 'Session',
+      render: (_value, row) => {
+        if (!isSessionUsageTableRow(row)) {
+          return 'Unknown Session';
+        }
+
+        if (row.sessionId === null) {
+          return (
+            <div className="min-w-[260px] max-w-[360px]">
+              <div className="text-foreground font-medium">{formatUsageSource(row.source)}</div>
+              <div className="text-muted-foreground mt-1 text-xs">Source-backed usage</div>
+            </div>
+          );
+        }
+
+        const repository = extractRepoFromGitUrl(row.gitUrl);
+        const platformLabel = formatSessionPlatform(row.createdOnPlatform);
+        const metadataParts: string[] = [];
+
+        if (repository) {
+          metadataParts.push(repository);
+        }
+
+        if (platformLabel) {
+          metadataParts.push(platformLabel);
+        }
+
+        const title = row.title?.trim() ? row.title : 'Untitled Session';
+        const sessionHref = getSessionChatHref(row.sessionId, row.organizationId);
+
+        return (
+          <div className="min-w-[260px] max-w-[360px]">
+            <Link href={sessionHref} className="text-foreground font-medium hover:underline">
+              {title}
+            </Link>
+            <div className="text-muted-foreground mt-1 font-mono text-xs">ID: {row.sessionId}</div>
+            {metadataParts.length > 0 && (
+              <div className="text-muted-foreground mt-1 text-xs">{metadataParts.join(' • ')}</div>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      key: 'cost',
+      label: 'Cost',
+      render: value =>
+        typeof value === 'number' ? formatDollars(fromMicrodollars(value)) : formatDollars(0),
+    },
+    {
+      key: 'requests',
+      label: 'Requests',
+      render: value => (typeof value === 'number' ? value.toLocaleString() : '0'),
+    },
+    {
+      key: 'inputTokens',
+      label: 'Input Tokens',
+      render: value => (typeof value === 'number' ? formatLargeNumber(value, true) : '0'),
+    },
+    {
+      key: 'outputTokens',
+      label: 'Output Tokens',
+      render: value => (typeof value === 'number' ? formatLargeNumber(value, true) : '0'),
+    },
+    {
+      key: 'cacheHits',
+      label: 'Cache Hits',
+      render: value => (typeof value === 'number' ? formatLargeNumber(value, true) : '0'),
+    },
+  ];
+
+  const sessionTableData: UsageTableRow[] =
+    sessionUsageHistory?.sessions.map((session, index) => ({
+      id: session.sessionId ?? `${session.source ?? 'source'}-${session.lastUsedAt}-${index}`,
+      sessionId: session.sessionId,
+      source: session.source,
+      lastUsedAt: session.lastUsedAt,
+      title: session.title,
+      createdOnPlatform: session.createdOnPlatform,
+      gitUrl: session.gitUrl,
+      organizationId: session.organizationId,
+      cost: session.totalCost,
+      requests: session.requestCount,
+      inputTokens: session.totalInputTokens,
+      outputTokens: session.totalOutputTokens,
+      cacheHits: session.totalCacheHitTokens,
+    })) ?? [];
+
+  const sessionsEmptyMessage =
+    sessionUsageHistoryError instanceof Error
+      ? sessionUsageHistoryError.message
+      : isLoadingSessionUsageHistory
+        ? 'Loading session usage history...'
+        : 'No usage found with a recorded session or source';
+
+  const sessionsPagination = sessionUsageHistory?.pagination;
+
   return (
     <PageLayout
       title="Usage"
@@ -542,47 +808,96 @@ export default function UsagePage() {
         </div>
       </div>
 
-      <UsageTableBase
-        title="Usage Overview"
-        columns={tableColumns}
-        data={tableData}
-        emptyMessage="No usage data found"
-        headerContent={<UsageWarning />}
-        headerActions={
-          <div className="flex items-center gap-2">
-            {organizations && organizations.length > 0 && (
-              <Select value={viewType} onValueChange={setViewType}>
-                <SelectTrigger size="sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="personal">Personal Only</SelectItem>
-                  <SelectItem value="all">All Usage</SelectItem>
-                  {organizations.map(org => (
-                    <SelectItem key={org.organizationId} value={org.organizationId}>
-                      {org.organizationName}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            <Button
-              variant={groupByModel ? 'outline' : 'default'}
-              size="sm"
-              onClick={() => setGroupByModel(false)}
-            >
-              By Day
-            </Button>
-            <Button
-              variant={groupByModel ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setGroupByModel(true)}
-            >
-              By Model & Day
-            </Button>
-          </div>
-        }
-      />
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+          <TabsTrigger value="overview" className={tabTriggerClass}>
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="sessions" className={tabTriggerClass}>
+            Sessions
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="mt-4">
+          <UsageTableBase
+            title="Usage Overview"
+            columns={tableColumns}
+            data={tableData}
+            emptyMessage="No usage data found"
+            headerContent={<UsageWarning />}
+            headerActions={
+              <div className="flex items-center gap-2">
+                {organizations && organizations.length > 0 && (
+                  <Select value={viewType} onValueChange={setViewType}>
+                    <SelectTrigger size="sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="personal">Personal Only</SelectItem>
+                      <SelectItem value="all">All Usage</SelectItem>
+                      {organizations.map(org => (
+                        <SelectItem key={org.organizationId} value={org.organizationId}>
+                          {org.organizationName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <Button
+                  variant={groupByModel ? 'outline' : 'default'}
+                  size="sm"
+                  onClick={() => setGroupByModel(false)}
+                >
+                  By Day
+                </Button>
+                <Button
+                  variant={groupByModel ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setGroupByModel(true)}
+                >
+                  By Model & Day
+                </Button>
+              </div>
+            }
+          />
+        </TabsContent>
+
+        <TabsContent value="sessions" className="mt-4">
+          <UsageTableBase
+            title="Session Usage"
+            columns={sessionTableColumns}
+            data={sessionTableData}
+            emptyMessage={sessionsEmptyMessage}
+            headerActions={
+              <div className="flex items-center gap-2">{renderViewTypeSelector()}</div>
+            }
+          />
+
+          {activeTab === 'sessions' && sessionsPagination && sessionsPagination.totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-end gap-3">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSessionsPage(page => Math.max(1, page - 1))}
+                disabled={isLoadingSessionUsageHistory || !sessionsPagination.hasPreviousPage}
+              >
+                Previous
+              </Button>
+              <div className="text-muted-foreground text-sm">
+                Page {sessionsPagination.page} of {sessionsPagination.totalPages}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSessionsPage(page => page + 1)}
+                disabled={isLoadingSessionUsageHistory || !sessionsPagination.hasNextPage}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
     </PageLayout>
   );
 }

--- a/apps/web/src/routers/user-router.test.ts
+++ b/apps/web/src/routers/user-router.test.ts
@@ -1,9 +1,17 @@
 import { createCallerForUser } from '@/routers/test-utils';
 import { db } from '@/lib/drizzle';
-import { kilocode_users } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import {
+  kilocode_users,
+  microdollar_usage,
+  microdollar_usage_metadata,
+  cli_sessions_v2,
+} from '@kilocode/db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import type { User } from '@kilocode/db/schema';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { defineMicrodollarUsage } from '@/tests/helpers/microdollar-usage.helper';
+import { insertUsageRecord } from '@/lib/ai-gateway/processUsage';
+import type { User, Organization } from '@kilocode/db/schema';
 
 let testUser: User;
 let surveyTestUser: User;
@@ -148,7 +156,9 @@ describe('user router - submitCustomerSource', () => {
 
   it('saves the customer source to the database', async () => {
     const caller = await createCallerForUser(surveyTestUser.id);
-    const result = await caller.user.submitCustomerSource({ source: 'A YouTube video' });
+    const result = await caller.user.submitCustomerSource({
+      source: 'A YouTube video',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -187,7 +197,9 @@ describe('user router - submitCustomerSource', () => {
     const caller = await createCallerForUser(surveyTestUser.id);
     const maxString = 'a'.repeat(1000);
 
-    const result = await caller.user.submitCustomerSource({ source: maxString });
+    const result = await caller.user.submitCustomerSource({
+      source: maxString,
+    });
     expect(result).toEqual({ success: true });
 
     const updated = await db.query.kilocode_users.findFirst({
@@ -211,7 +223,9 @@ describe('user router - submitCustomerSource', () => {
   it('accepts 1000 chars of content with leading/trailing spaces (validates post-trim)', async () => {
     const caller = await createCallerForUser(surveyTestUser.id);
     const content = 'a'.repeat(1000);
-    const result = await caller.user.submitCustomerSource({ source: `  ${content}  ` });
+    const result = await caller.user.submitCustomerSource({
+      source: `  ${content}  `,
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -250,7 +264,9 @@ describe('user router - submitCustomerSource', () => {
   describe('whitespace trimming on valid input', () => {
     it('trims leading and trailing whitespace before storing', async () => {
       const caller = await createCallerForUser(surveyTestUser.id);
-      const result = await caller.user.submitCustomerSource({ source: '  hello  ' });
+      const result = await caller.user.submitCustomerSource({
+        source: '  hello  ',
+      });
 
       expect(result).toEqual({ success: true });
 
@@ -262,7 +278,9 @@ describe('user router - submitCustomerSource', () => {
 
     it('preserves internal whitespace in stored value', async () => {
       const caller = await createCallerForUser(surveyTestUser.id);
-      const result = await caller.user.submitCustomerSource({ source: 'a YouTube video' });
+      const result = await caller.user.submitCustomerSource({
+        source: 'a YouTube video',
+      });
 
       expect(result).toEqual({ success: true });
 
@@ -324,7 +342,9 @@ describe('user router - skipCustomerSource', () => {
   it('does NOT overwrite a real answer when skipCustomerSource is called after submitCustomerSource', async () => {
     const caller = await createCallerForUser(skipTestUser.id);
 
-    await caller.user.submitCustomerSource({ source: 'Found it on Hacker News' });
+    await caller.user.submitCustomerSource({
+      source: 'Found it on Hacker News',
+    });
     await caller.user.skipCustomerSource();
 
     const updated = await db.query.kilocode_users.findFirst({
@@ -336,7 +356,9 @@ describe('user router - skipCustomerSource', () => {
   it('allows a real answer to overwrite a previous skip', async () => {
     const caller = await createCallerForUser(skipTestUser.id);
     await caller.user.skipCustomerSource();
-    await caller.user.submitCustomerSource({ source: 'Changed my mind — Reddit' });
+    await caller.user.submitCustomerSource({
+      source: 'Changed my mind — Reddit',
+    });
 
     const updated = await db.query.kilocode_users.findFirst({
       where: eq(kilocode_users.id, skipTestUser.id),
@@ -414,5 +436,555 @@ describe('session and API token reset mutations', () => {
     expect(updated.web_session_pepper).toEqual(expect.any(String));
     expect(updated.web_session_pepper).not.toBe('web-session-pepper-before');
     expect(updated.api_token_pepper).toBe('api-pepper-before');
+  });
+});
+
+describe('user router - getSessionUsageHistory', () => {
+  let sessionUsageUser: User;
+  let sessionUsageOrg: Organization;
+  const insertedUsageIds: string[] = [];
+  const insertedSessionIds: string[] = [];
+
+  const insertSessionUsage = async ({
+    sessionId,
+    feature,
+    createdAt,
+    organizationId,
+    cost,
+    inputTokens,
+    outputTokens,
+    cacheHitTokens,
+    cacheWriteTokens,
+  }: {
+    sessionId: string | null;
+    feature?: string | null;
+    createdAt: string;
+    organizationId: string | null;
+    cost: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheHitTokens: number;
+    cacheWriteTokens: number;
+  }) => {
+    const { core, metadata } = defineMicrodollarUsage();
+
+    await insertUsageRecord(
+      {
+        ...core,
+        kilo_user_id: sessionUsageUser.id,
+        organization_id: organizationId,
+        created_at: createdAt,
+        cost,
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_hit_tokens: cacheHitTokens,
+        cache_write_tokens: cacheWriteTokens,
+      },
+      {
+        ...metadata,
+        created_at: createdAt,
+        message_id: `user-router-session-history-${core.id}`,
+        session_id: sessionId,
+        feature: feature ?? null,
+      }
+    );
+
+    insertedUsageIds.push(core.id);
+  };
+
+  const insertSession = async ({
+    sessionId,
+    title,
+    createdOnPlatform,
+    gitUrl,
+    organizationId,
+  }: {
+    sessionId: string;
+    title: string;
+    createdOnPlatform: string;
+    gitUrl: string | null;
+    organizationId: string | null;
+  }) => {
+    await db.insert(cli_sessions_v2).values({
+      session_id: sessionId,
+      kilo_user_id: sessionUsageUser.id,
+      title,
+      created_on_platform: createdOnPlatform,
+      git_url: gitUrl,
+      organization_id: organizationId,
+    });
+
+    insertedSessionIds.push(sessionId);
+  };
+
+  beforeAll(async () => {
+    sessionUsageUser = await insertTestUser({
+      google_user_email: 'session-usage-history@example.com',
+      google_user_name: 'Session Usage History User',
+    });
+
+    sessionUsageOrg = await createTestOrganization(
+      'Session Usage History Org',
+      sessionUsageUser.id,
+      0
+    );
+  });
+
+  afterEach(async () => {
+    if (insertedSessionIds.length > 0) {
+      await db
+        .delete(cli_sessions_v2)
+        .where(
+          and(
+            eq(cli_sessions_v2.kilo_user_id, sessionUsageUser.id),
+            inArray(cli_sessions_v2.session_id, insertedSessionIds)
+          )
+        );
+      insertedSessionIds.length = 0;
+    }
+
+    if (insertedUsageIds.length > 0) {
+      await db
+        .delete(microdollar_usage_metadata)
+        .where(inArray(microdollar_usage_metadata.id, insertedUsageIds));
+      await db.delete(microdollar_usage).where(inArray(microdollar_usage.id, insertedUsageIds));
+      insertedUsageIds.length = 0;
+    }
+  });
+
+  it('returns newest sessions first with usage aggregation and session enrichment', async () => {
+    await insertSession({
+      sessionId: 'ses-usage-newest',
+      title: 'Newest Session',
+      createdOnPlatform: 'cli',
+      gitUrl: 'https://github.com/kilo/newest-repo.git',
+      organizationId: null,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-usage-newest',
+      createdAt: '2026-01-10T10:00:00.000Z',
+      organizationId: null,
+      cost: 1_000,
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheHitTokens: 10,
+      cacheWriteTokens: 5,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-usage-middle',
+      createdAt: '2026-01-11T10:00:00.000Z',
+      organizationId: null,
+      cost: 500,
+      inputTokens: 80,
+      outputTokens: 40,
+      cacheHitTokens: 8,
+      cacheWriteTokens: 4,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-usage-newest',
+      createdAt: '2026-01-12T10:00:00.000Z',
+      organizationId: null,
+      cost: 2_000,
+      inputTokens: 200,
+      outputTokens: 75,
+      cacheHitTokens: 20,
+      cacheWriteTokens: 10,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+    const result = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+
+    expect(result.sessions.map(session => session.sessionId)).toEqual([
+      'ses-usage-newest',
+      'ses-usage-middle',
+    ]);
+
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'ses-usage-newest',
+      totalCost: 3_000,
+      requestCount: 2,
+      totalInputTokens: 300,
+      totalOutputTokens: 125,
+      totalCacheHitTokens: 30,
+      totalCacheWriteTokens: 15,
+      title: 'Newest Session',
+      createdOnPlatform: 'cli',
+      gitUrl: 'https://github.com/kilo/newest-repo.git',
+      organizationId: null,
+    });
+
+    expect(new Date(result.sessions[0].lastUsedAt).toISOString()).toBe('2026-01-12T10:00:00.000Z');
+    expect(result.pagination).toMatchObject({
+      page: 1,
+      limit: 100,
+      totalCount: 2,
+      totalPages: 1,
+      hasPreviousPage: false,
+      hasNextPage: false,
+    });
+  });
+
+  it('applies personal, organization, and all usage scoping', async () => {
+    await insertSessionUsage({
+      sessionId: 'ses-scope-personal',
+      createdAt: '2026-02-01T10:00:00.000Z',
+      organizationId: null,
+      cost: 700,
+      inputTokens: 70,
+      outputTokens: 35,
+      cacheHitTokens: 7,
+      cacheWriteTokens: 3,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-scope-org',
+      createdAt: '2026-02-02T10:00:00.000Z',
+      organizationId: sessionUsageOrg.id,
+      cost: 900,
+      inputTokens: 90,
+      outputTokens: 45,
+      cacheHitTokens: 9,
+      cacheWriteTokens: 4,
+    });
+
+    await insertSessionUsage({
+      sessionId: null,
+      createdAt: '2026-02-03T10:00:00.000Z',
+      organizationId: null,
+      cost: 400,
+      inputTokens: 40,
+      outputTokens: 20,
+      cacheHitTokens: 4,
+      cacheWriteTokens: 2,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+
+    const personalResult = await caller.user.getSessionUsageHistory({
+      viewType: 'personal',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+    expect(personalResult.sessions.map(session => session.sessionId)).toEqual([
+      'ses-scope-personal',
+    ]);
+
+    const orgResult = await caller.user.getSessionUsageHistory({
+      viewType: sessionUsageOrg.id,
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+    expect(orgResult.sessions.map(session => session.sessionId)).toEqual(['ses-scope-org']);
+    expect(orgResult.sessions[0]?.organizationId).toBe(sessionUsageOrg.id);
+
+    const allResult = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+    expect(allResult.sessions.map(session => session.sessionId)).toEqual([
+      'ses-scope-org',
+      'ses-scope-personal',
+    ]);
+  });
+
+  it('includes sessionless usage rows when feature is recorded', async () => {
+    await insertSessionUsage({
+      sessionId: null,
+      feature: 'slack',
+      createdAt: '2026-02-05T10:00:00.000Z',
+      organizationId: null,
+      cost: 1_200,
+      inputTokens: 120,
+      outputTokens: 60,
+      cacheHitTokens: 12,
+      cacheWriteTokens: 6,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+    const result = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: null,
+      source: 'slack',
+      totalCost: 1_200,
+      requestCount: 1,
+      totalInputTokens: 120,
+      totalOutputTokens: 60,
+      totalCacheHitTokens: 12,
+      totalCacheWriteTokens: 6,
+      title: null,
+      createdOnPlatform: null,
+      gitUrl: null,
+      organizationId: null,
+    });
+  });
+
+  it('does not group sessionless rows together when feature matches', async () => {
+    await insertSessionUsage({
+      sessionId: null,
+      feature: 'discord',
+      createdAt: '2026-02-06T10:00:00.000Z',
+      organizationId: null,
+      cost: 600,
+      inputTokens: 60,
+      outputTokens: 30,
+      cacheHitTokens: 6,
+      cacheWriteTokens: 3,
+    });
+
+    await insertSessionUsage({
+      sessionId: null,
+      feature: 'discord',
+      createdAt: '2026-02-07T10:00:00.000Z',
+      organizationId: null,
+      cost: 900,
+      inputTokens: 90,
+      outputTokens: 45,
+      cacheHitTokens: 9,
+      cacheWriteTokens: 4,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+    const result = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions.map(session => session.source)).toEqual(['discord', 'discord']);
+    expect(result.sessions.map(session => session.totalCost)).toEqual([900, 600]);
+    expect(result.sessions.map(session => session.requestCount)).toEqual([1, 1]);
+    expect(result.pagination.totalCount).toBe(2);
+  });
+
+  it('excludes rows without both session id and feature', async () => {
+    await insertSessionUsage({
+      sessionId: null,
+      createdAt: '2026-02-08T10:00:00.000Z',
+      organizationId: null,
+      cost: 500,
+      inputTokens: 50,
+      outputTokens: 25,
+      cacheHitTokens: 5,
+      cacheWriteTokens: 2,
+    });
+
+    await insertSessionUsage({
+      sessionId: null,
+      feature: 'bot',
+      createdAt: '2026-02-09T10:00:00.000Z',
+      organizationId: null,
+      cost: 700,
+      inputTokens: 70,
+      outputTokens: 35,
+      cacheHitTokens: 7,
+      cacheWriteTokens: 3,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+    const result = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: null,
+      source: 'bot',
+      totalCost: 700,
+      requestCount: 1,
+    });
+  });
+
+  it('applies period filtering to session and source-only rows', async () => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    const now = Date.now();
+
+    await insertSessionUsage({
+      sessionId: 'ses-period-recent',
+      createdAt: new Date(now - 2 * dayMs).toISOString(),
+      organizationId: null,
+      cost: 1_000,
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheHitTokens: 10,
+      cacheWriteTokens: 5,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-period-old',
+      createdAt: new Date(now - 15 * dayMs).toISOString(),
+      organizationId: null,
+      cost: 1_100,
+      inputTokens: 110,
+      outputTokens: 55,
+      cacheHitTokens: 11,
+      cacheWriteTokens: 5,
+    });
+
+    await insertSessionUsage({
+      sessionId: null,
+      feature: 'embeddings',
+      createdAt: new Date(now - dayMs).toISOString(),
+      organizationId: null,
+      cost: 800,
+      inputTokens: 80,
+      outputTokens: 40,
+      cacheHitTokens: 8,
+      cacheWriteTokens: 4,
+    });
+
+    await insertSessionUsage({
+      sessionId: null,
+      feature: 'slack',
+      createdAt: new Date(now - 20 * dayMs).toISOString(),
+      organizationId: null,
+      cost: 900,
+      inputTokens: 90,
+      outputTokens: 45,
+      cacheHitTokens: 9,
+      cacheWriteTokens: 4,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+
+    const weeklyResult = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'week',
+      page: 1,
+      limit: 100,
+    });
+
+    expect(weeklyResult.sessions).toHaveLength(2);
+    expect(
+      weeklyResult.sessions.find(session => session.sessionId === 'ses-period-recent')
+    ).toMatchObject({
+      source: null,
+      totalCost: 1_000,
+    });
+    expect(weeklyResult.sessions.find(session => session.sessionId === null)).toMatchObject({
+      source: 'embeddings',
+      totalCost: 800,
+    });
+    expect(weeklyResult.sessions.some(session => session.sessionId === 'ses-period-old')).toBe(
+      false
+    );
+    expect(weeklyResult.sessions.some(session => session.source === 'slack')).toBe(false);
+
+    const allTimeResult = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 100,
+    });
+
+    expect(allTimeResult.sessions).toHaveLength(4);
+  });
+
+  it('returns expected pagination metadata and slices', async () => {
+    await insertSessionUsage({
+      sessionId: 'ses-page-1',
+      createdAt: '2026-03-01T10:00:00.000Z',
+      organizationId: null,
+      cost: 100,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheHitTokens: 1,
+      cacheWriteTokens: 1,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-page-2',
+      createdAt: '2026-03-02T10:00:00.000Z',
+      organizationId: null,
+      cost: 100,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheHitTokens: 1,
+      cacheWriteTokens: 1,
+    });
+
+    await insertSessionUsage({
+      sessionId: 'ses-page-3',
+      createdAt: '2026-03-03T10:00:00.000Z',
+      organizationId: null,
+      cost: 100,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheHitTokens: 1,
+      cacheWriteTokens: 1,
+    });
+
+    const caller = await createCallerForUser(sessionUsageUser.id);
+
+    const page1 = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 1,
+      limit: 1,
+    });
+    expect(page1.sessions[0]?.sessionId).toBe('ses-page-3');
+    expect(page1.pagination).toMatchObject({
+      page: 1,
+      limit: 1,
+      totalCount: 3,
+      totalPages: 3,
+      hasPreviousPage: false,
+      hasNextPage: true,
+    });
+
+    const page2 = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 2,
+      limit: 1,
+    });
+    expect(page2.sessions[0]?.sessionId).toBe('ses-page-2');
+    expect(page2.pagination).toMatchObject({
+      page: 2,
+      limit: 1,
+      totalCount: 3,
+      totalPages: 3,
+      hasPreviousPage: true,
+      hasNextPage: true,
+    });
+
+    const page3 = await caller.user.getSessionUsageHistory({
+      viewType: 'all',
+      period: 'all',
+      page: 3,
+      limit: 1,
+    });
+    expect(page3.sessions[0]?.sessionId).toBe('ses-page-1');
+    expect(page3.pagination).toMatchObject({
+      page: 3,
+      limit: 1,
+      totalCount: 3,
+      totalPages: 3,
+      hasPreviousPage: true,
+      hasNextPage: false,
+    });
   });
 });

--- a/apps/web/src/routers/user-router.ts
+++ b/apps/web/src/routers/user-router.ts
@@ -14,14 +14,18 @@ import { timedUsageQuery } from '@/lib/usage-query';
 import {
   kilocode_users,
   microdollar_usage,
+  microdollar_usage_metadata,
   credit_transactions,
   auto_top_up_configs,
   user_auth_provider,
   kiloclaw_instances,
   kiloclaw_subscriptions,
   user_push_tokens,
+  cliSessions,
+  cli_sessions_v2,
+  feature,
 } from '@kilocode/db/schema';
-import { eq, and, isNull, inArray, sql, gte } from 'drizzle-orm';
+import { eq, and, or, isNull, isNotNull, inArray, sql, gte, desc } from 'drizzle-orm';
 import crypto from 'crypto';
 import { checkDiscordGuildMembership } from '@/lib/integrations/discord-guild-membership';
 import { AuthProviderIdSchema } from '@/lib/auth/provider-metadata';
@@ -73,6 +77,41 @@ const AutocompleteMetricsOutputSchema = z.object({
   cost: z.number(),
   requests: z.number(),
   tokens: z.number(),
+});
+
+const SessionUsageHistoryInputSchema = z.object({
+  viewType: ViewTypeSchema.default('personal'),
+  period: PeriodSchema.default('week'),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(100),
+});
+
+const SessionUsageHistoryRowSchema = z.object({
+  sessionId: z.string().nullable(),
+  source: z.string().nullable(),
+  lastUsedAt: z.string(),
+  totalCost: z.number(),
+  requestCount: z.number(),
+  totalInputTokens: z.number(),
+  totalOutputTokens: z.number(),
+  totalCacheWriteTokens: z.number(),
+  totalCacheHitTokens: z.number(),
+  title: z.string().nullable(),
+  createdOnPlatform: z.string().nullable(),
+  gitUrl: z.string().nullable(),
+  organizationId: z.string().nullable(),
+});
+
+const SessionUsageHistoryOutputSchema = z.object({
+  sessions: z.array(SessionUsageHistoryRowSchema),
+  pagination: z.object({
+    page: z.number(),
+    limit: z.number(),
+    totalCount: z.number(),
+    totalPages: z.number(),
+    hasPreviousPage: z.boolean(),
+    hasNextPage: z.boolean(),
+  }),
 });
 
 const LinkAuthProviderInputSchema = z.object({
@@ -415,6 +454,159 @@ export const userRouter = createTRPCRouter({
       };
     }),
 
+  getSessionUsageHistory: baseProcedure
+    .input(SessionUsageHistoryInputSchema)
+    .output(SessionUsageHistoryOutputSchema)
+    .query(async ({ ctx, input }) => {
+      const { viewType, period, page, limit } = input;
+      const userId = ctx.user.id;
+
+      if (viewType !== 'personal' && viewType !== 'all') {
+        await ensureOrganizationAccess(ctx, viewType);
+      }
+
+      const dateThreshold = getDateThreshold(period);
+
+      let whereClause;
+      if (viewType === 'personal') {
+        whereClause = and(
+          eq(microdollar_usage.kilo_user_id, userId),
+          isNull(microdollar_usage.organization_id)
+        );
+      } else if (viewType === 'all') {
+        whereClause = eq(microdollar_usage.kilo_user_id, userId);
+      } else {
+        whereClause = and(
+          eq(microdollar_usage.kilo_user_id, userId),
+          eq(microdollar_usage.organization_id, viewType)
+        );
+      }
+
+      const offset = (page - 1) * limit;
+      const usageWhereClause = dateThreshold
+        ? and(
+            whereClause,
+            or(isNotNull(microdollar_usage_metadata.session_id), isNotNull(feature.feature)),
+            gte(microdollar_usage.created_at, dateThreshold)
+          )
+        : and(
+            whereClause,
+            or(isNotNull(microdollar_usage_metadata.session_id), isNotNull(feature.feature))
+          );
+      const usageGroupingKey = sql<string>`COALESCE(${microdollar_usage_metadata.session_id}, ${microdollar_usage.id}::text)`;
+
+      const result = await timedUsageQuery(
+        {
+          db: readDb,
+          route: 'user.getSessionUsageHistory',
+          queryLabel: 'user_session_usage_history',
+          scope: 'user',
+          period,
+        },
+        async tx => {
+          const [sessions, countRows] = await Promise.all([
+            tx
+              .select({
+                session_id: sql<string | null>`MAX(${microdollar_usage_metadata.session_id})`,
+                source: sql<string | null>`MAX(${feature.feature})`,
+                last_used_at: sql<string>`MAX(${microdollar_usage.created_at})`,
+                total_cost: sql<number>`COALESCE(SUM(${microdollar_usage.cost}), 0)::float`,
+                request_count: sql<number>`COUNT(*)::int`,
+                total_input_tokens: sql<number>`COALESCE(SUM(${microdollar_usage.input_tokens}), 0)::float`,
+                total_output_tokens: sql<number>`COALESCE(SUM(${microdollar_usage.output_tokens}), 0)::float`,
+                total_cache_write_tokens: sql<number>`COALESCE(SUM(${microdollar_usage.cache_write_tokens}), 0)::float`,
+                total_cache_hit_tokens: sql<number>`COALESCE(SUM(${microdollar_usage.cache_hit_tokens}), 0)::float`,
+                title: sql<
+                  string | null
+                >`COALESCE(MAX(${cliSessions.title}), MAX(${cli_sessions_v2.title}))`,
+                created_on_platform: sql<
+                  string | null
+                >`COALESCE(MAX(${cliSessions.created_on_platform}), MAX(${cli_sessions_v2.created_on_platform}))`,
+                git_url: sql<
+                  string | null
+                >`COALESCE(MAX(${cliSessions.git_url}), MAX(${cli_sessions_v2.git_url}))`,
+                organization_id: sql<
+                  string | null
+                >`COALESCE(MAX(${cliSessions.organization_id}::text), MAX(${cli_sessions_v2.organization_id}::text), MAX(${microdollar_usage.organization_id}::text))`,
+              })
+              .from(microdollar_usage)
+              .innerJoin(
+                microdollar_usage_metadata,
+                eq(microdollar_usage.id, microdollar_usage_metadata.id)
+              )
+              .leftJoin(feature, eq(microdollar_usage_metadata.feature_id, feature.feature_id))
+              .leftJoin(
+                cliSessions,
+                and(
+                  sql`${cliSessions.session_id}::text = ${microdollar_usage_metadata.session_id}`,
+                  eq(cliSessions.kilo_user_id, userId)
+                )
+              )
+              .leftJoin(
+                cli_sessions_v2,
+                and(
+                  eq(cli_sessions_v2.session_id, microdollar_usage_metadata.session_id),
+                  eq(cli_sessions_v2.kilo_user_id, userId)
+                )
+              )
+              .where(usageWhereClause)
+              .groupBy(usageGroupingKey)
+              .orderBy(desc(sql`MAX(${microdollar_usage.created_at})`))
+              .offset(offset)
+              .limit(limit),
+            tx
+              .select({
+                count: sql<number>`COUNT(DISTINCT ${usageGroupingKey})::int`,
+              })
+              .from(microdollar_usage)
+              .innerJoin(
+                microdollar_usage_metadata,
+                eq(microdollar_usage.id, microdollar_usage_metadata.id)
+              )
+              .leftJoin(feature, eq(microdollar_usage_metadata.feature_id, feature.feature_id))
+              .where(usageWhereClause),
+          ]);
+
+          return {
+            sessions,
+            totalCount: countRows[0]?.count ?? 0,
+          };
+        }
+      );
+
+      const totalPages = Math.ceil(result.totalCount / limit);
+
+      return {
+        sessions: result.sessions.map(row => {
+          const hasSessionId = row.session_id !== null;
+
+          return {
+            sessionId: row.session_id,
+            source: row.source,
+            lastUsedAt: row.last_used_at,
+            totalCost: row.total_cost,
+            requestCount: row.request_count,
+            totalInputTokens: row.total_input_tokens,
+            totalOutputTokens: row.total_output_tokens,
+            totalCacheWriteTokens: row.total_cache_write_tokens,
+            totalCacheHitTokens: row.total_cache_hit_tokens,
+            title: hasSessionId ? row.title : null,
+            createdOnPlatform: hasSessionId ? row.created_on_platform : null,
+            gitUrl: hasSessionId ? row.git_url : null,
+            organizationId: row.organization_id,
+          };
+        }),
+        pagination: {
+          page,
+          limit,
+          totalCount: result.totalCount,
+          totalPages,
+          hasPreviousPage: page > 1,
+          hasNextPage: page < totalPages,
+        },
+      };
+    }),
+
   toggleAutoTopUp: baseProcedure
     .input(
       z.object({
@@ -692,7 +884,11 @@ export const userRouter = createTRPCRouter({
         })
         .onConflictDoUpdate({
           target: [user_push_tokens.token],
-          set: { user_id: ctx.user.id, platform: input.platform, updated_at: sql`now()` },
+          set: {
+            user_id: ctx.user.id,
+            platform: input.platform,
+            updated_at: sql`now()`,
+          },
         });
       return { success: true };
     }),


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
This adds a view to the Usage page to allow users to see a list of each
individual session's spending and token count. The default is to show
the most recent 100 sessions, sorted by most recent. Time period filters also apply.
Pagination at the bottom will allow users to view older sesions.

## Verification

- Navigate to the Usage page
- Click the new Sessions tab

## Visual Changes

<img width="1126" height="364" alt="image" src="https://github.com/user-attachments/assets/ee818f9d-7ee5-4d2b-8d27-4c13db922bc5" />