### PR TITLE
fix(dev): keep non-production DB reads on primary

### DIFF
--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -16,6 +16,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    // Use a fake token for non-production environments as recommended by PostHog
     const token = isProduction ? key : 'fake-token';
 
     posthog.init(token, {
@@ -27,12 +28,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       disable_session_recording: !isProduction,
       opt_out_capturing_by_default: !isProduction,
       advanced_disable_flags: !isProduction,
-      internal_or_test_user_hostname: 'localhost',
     });
     window.posthog = posthog; // Reveal PostHog object globally
-    if (!isProduction) {
-      console.log('PostHog network disabled in non-production environment');
-    }
     if (process.env.NEXT_PUBLIC_POSTHOG_DEBUG) {
       posthog.debug(true);
     } else if (localStorage.getItem('ph_debug')) {
@@ -55,8 +52,6 @@ function PostHogPageView() {
   const posthog = usePostHog();
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') return;
-
     if (pathname && posthog) {
       let url = window.origin + pathname;
       const search = searchParams.toString();
@@ -84,8 +79,6 @@ function IdentifyUser() {
   const previousStatusRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') return;
-
     // Check if posthog is loaded before using it
     if (!posthog || !posthog.__loaded) return;
 

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -16,23 +16,18 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // Use a fake token for non-production environments as recommended by PostHog
-    const token = isProduction ? key : 'fake-token';
+    if (!isProduction) {
+      window.posthog = posthog;
+      console.log('PostHog disabled in non-production environment');
+      return;
+    }
 
-    posthog.init(token, {
+    posthog.init(key, {
       api_host: '/ingest',
       ui_host: 'https://us.posthog.com',
       disable_web_experiments: false,
       capture_pageview: false, // We capture pageviews manually
       capture_pageleave: true, // Enable pageleave capture
-      loaded: function (ph) {
-        if (!isProduction) {
-          // Opt out of capturing in non-production environments
-          ph.opt_out_capturing();
-          ph.set_config({ disable_session_recording: true });
-          console.log('PostHog capturing disabled in non-production environment');
-        }
-      },
     });
     window.posthog = posthog; // Reveal PostHog object globally
     if (process.env.NEXT_PUBLIC_POSTHOG_DEBUG) {

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -25,9 +25,14 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       disable_web_experiments: false,
       capture_pageview: false, // We capture pageviews manually
       capture_pageleave: true, // Enable pageleave capture
-      disable_session_recording: !isProduction,
-      opt_out_capturing_by_default: !isProduction,
-      advanced_disable_flags: !isProduction,
+      loaded: function (ph) {
+        if (!isProduction) {
+          // Opt out of capturing in non-production environments
+          ph.opt_out_capturing();
+          ph.set_config({ disable_session_recording: true });
+          console.log('PostHog capturing disabled in non-production environment');
+        }
+      },
     });
     window.posthog = posthog; // Reveal PostHog object globally
     if (process.env.NEXT_PUBLIC_POSTHOG_DEBUG) {

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -16,20 +16,23 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    if (!isProduction) {
-      window.posthog = posthog;
-      console.log('PostHog disabled in non-production environment');
-      return;
-    }
+    const token = isProduction ? key : 'fake-token';
 
-    posthog.init(key, {
+    posthog.init(token, {
       api_host: '/ingest',
       ui_host: 'https://us.posthog.com',
       disable_web_experiments: false,
       capture_pageview: false, // We capture pageviews manually
       capture_pageleave: true, // Enable pageleave capture
+      disable_session_recording: !isProduction,
+      opt_out_capturing_by_default: !isProduction,
+      advanced_disable_flags: !isProduction,
+      internal_or_test_user_hostname: 'localhost',
     });
     window.posthog = posthog; // Reveal PostHog object globally
+    if (!isProduction) {
+      console.log('PostHog network disabled in non-production environment');
+    }
     if (process.env.NEXT_PUBLIC_POSTHOG_DEBUG) {
       posthog.debug(true);
     } else if (localStorage.getItem('ph_debug')) {
@@ -52,6 +55,8 @@ function PostHogPageView() {
   const posthog = usePostHog();
 
   useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+
     if (pathname && posthog) {
       let url = window.origin + pathname;
       const search = searchParams.toString();
@@ -79,6 +84,8 @@ function IdentifyUser() {
   const previousStatusRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+
     // Check if posthog is loaded before using it
     if (!posthog || !posthog.__loaded) return;
 

--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -52,6 +52,12 @@ export function isUSRegion(): boolean {
  * - Falls back to primary if no replica URL is configured for the region
  */
 function getReplicaUrl(): string {
+  // Only use read replicas in production deployments. Local dev and preview
+  // should stay on the primary URL to avoid depending on remote Supabase hosts.
+  if (VERCEL_ENV !== 'production') {
+    return postgresUrl;
+  }
+
   if (isUSRegion()) {
     const usReplica = getEnvVariable('POSTGRES_REPLICA_US_URL');
     if (usReplica) return usReplica;


### PR DESCRIPTION
## Summary

Keep non-production database reads on the primary Postgres URL instead of using configured read replicas.

This prevents local development from depending on remote Supabase replica hosts when `.env.local` includes `POSTGRES_REPLICA_*` settings, which was causing `next dev` database requests to hang or time out.

## Verification

- [x] `pnpm exec oxfmt src/lib/drizzle.ts`
- [x] `pnpm exec tsgo --noEmit --incremental false`
- [x] `pnpm test`
- [x] Pre-push hooks passed: `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`

## Visual Changes

N/A

## Reviewer Notes

The functional change is limited to `getReplicaUrl()` in `drizzle.ts`. Non-production environments now always use the primary/local Postgres URL, even if replica env vars are present.
