### PR TITLE
fix(auth): pass callbackPath through magic link sign-in flow

### DIFF
--- a/src/hooks/useSignInFlow.ts
+++ b/src/hooks/useSignInFlow.ts
@@ -383,7 +383,8 @@ export function useSignInFlow({
     }
 
     try {
-      const result = await sendMagicLink(email);
+      const callbackUrl = getSignInCallbackUrl(params);
+      const result = await sendMagicLink(email, callbackUrl);
       if (result.success) {
         saveHint({
           lastEmail: email,
@@ -401,7 +402,7 @@ export function useSignInFlow({
       });
       setError('Failed to send magic link. Please try again.');
     }
-  }, [email, saveHint]);
+  }, [email, params, saveHint]);
 
   const handleTurnstileSuccess = useCallback(
     async (token: string) => {

--- a/src/lib/auth/send-magic-link.ts
+++ b/src/lib/auth/send-magic-link.ts
@@ -7,14 +7,18 @@ export type SendMagicLinkResult = { success: true } | { success: false; error: s
  * Uses the Turnstile JWT cookie (from previous verification) for authentication.
  *
  * @param email - The email address to send the magic link to
+ * @param callbackUrl - Optional post-sign-in redirect URL (e.g. from getSignInCallbackUrl)
  * @returns Promise resolving to success/error result
  */
-export async function sendMagicLink(email: string): Promise<SendMagicLinkResult> {
+export async function sendMagicLink(
+  email: string,
+  callbackUrl?: string
+): Promise<SendMagicLinkResult> {
   try {
     const response = await fetch('/api/auth/magic-link', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email }),
+      body: JSON.stringify({ email, callbackUrl }),
     });
 
     const result = await response.json();


### PR DESCRIPTION
## Summary

- Fix `callbackPath` being dropped when users sign in via the magic link method. OAuth flows (Google, GitHub, WorkOS, etc.) correctly threaded `callbackPath` through `getSignInCallbackUrl(params)`, but `handleSendMagicLink` only sent the email address — ignoring `params` entirely.
- The backend already fully supported `callbackUrl` end-to-end (API route zod schema, email builder, magic link URL generator, verify-magic-link page). The only gap was the frontend never sending the value. This two-file change closes that gap.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` (via pre-commit hook) — passed
- [x] `pnpm format:check` (via pre-commit hook) — passed
- [x] Manual browser test: navigated to `/users/sign_in?callbackPath=/organizations/new`, clicked "Continue with Email", confirmed flow reaches Turnstile with callbackPath still in the URL context (Turnstile challenge blocked full end-to-end automated test)

## Visual Changes

N/A

## Reviewer Notes

- The fix mirrors exactly how every OAuth provider in `useSignInFlow.ts` handles `callbackPath` — via `getSignInCallbackUrl(params)`.
- Zero backend changes: the API route (`/api/auth/magic-link`), `sendMagicLinkEmail`, `getMagicLinkUrl`, and `verify-magic-link` page all already accepted and forwarded `callbackUrl`. Only the client-side call site was missing it.
- `params` was added to the `useCallback` dependency array for `handleSendMagicLink` since it now reads from it.