### PR TITLE
feat(claw): persist exec permissions preset across machine restarts

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -401,6 +401,28 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.presets).toEqual(['gmail']);
     expect(config.hooks.token).toBe('new-token');
   });
+
+  it('reads exec security and ask from env vars', () => {
+    const { deps } = fakeDeps();
+    const env = {
+      ...minimalEnv(),
+      KILOCLAW_EXEC_SECURITY: 'full',
+      KILOCLAW_EXEC_ASK: 'off',
+    };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.tools.exec.host).toBe('gateway');
+    expect(config.tools.exec.security).toBe('full');
+    expect(config.tools.exec.ask).toBe('off');
+  });
+
+  it('falls back to defaults when exec env vars are not set', () => {
+    const { deps } = fakeDeps();
+    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
+
+    expect(config.tools.exec.security).toBe('allowlist');
+    expect(config.tools.exec.ask).toBe('on-miss');
+  });
 });
 
 describe('backupConfigFile', () => {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -204,12 +204,13 @@ export function generateBaseConfig(
   }
 
   // Exec: KiloClaw machines have no Docker sandbox, so exec must target the
-  // gateway host directly. Allowlist mode gates unknown commands via the
-  // Control UI approval dialog; safe bins auto-allow without approval.
+  // gateway host directly. Security and ask are user-configurable via the
+  // provisioning preset, persisted in DO state and transported as env vars.
+  // Defaults match the 'always-ask' preset (allowlist + on-miss).
   config.tools.exec = config.tools.exec ?? {};
   config.tools.exec.host = 'gateway';
-  config.tools.exec.security = 'allowlist';
-  config.tools.exec.ask = 'on-miss';
+  config.tools.exec.security = env.KILOCLAW_EXEC_SECURITY || 'allowlist';
+  config.tools.exec.ask = env.KILOCLAW_EXEC_ASK || 'on-miss';
 
   // Browser: headless Chromium for the browser tool in Docker.
   // OpenClaw auto-detects /usr/bin/chromium and adds --disable-dev-shm-usage on Linux.

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5408,3 +5408,41 @@ describe('reassociateVolume', () => {
     expect(storage._store.get('flyRegion')).toBe('lax');
   });
 });
+
+// ============================================================================
+// updateExecPreset
+// ============================================================================
+
+describe('updateExecPreset', () => {
+  it('persists exec security and ask to DO storage', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+
+    const result = await instance.updateExecPreset({ security: 'full', ask: 'off' });
+
+    expect(result.execSecurity).toBe('full');
+    expect(result.execAsk).toBe('off');
+    expect(storage._store.get('execSecurity')).toBe('full');
+    expect(storage._store.get('execAsk')).toBe('off');
+  });
+
+  it('updates only the fields that are provided', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+
+    await instance.updateExecPreset({ security: 'full' });
+
+    expect(storage._store.get('execSecurity')).toBe('full');
+    expect(storage._store.get('execAsk')).toBeUndefined();
+  });
+
+  it('returns current state when no fields are provided', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { execSecurity: 'full', execAsk: 'off' });
+
+    const result = await instance.updateExecPreset({});
+
+    expect(result.execSecurity).toBe('full');
+    expect(result.execAsk).toBe('off');
+  });
+});

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -144,6 +144,8 @@ export async function buildUserEnvVars(
       channels: state.channels ?? undefined,
       googleCredentials: state.googleCredentials ?? undefined,
       instanceFeatures: state.instanceFeatures,
+      execSecurity: state.execSecurity ?? undefined,
+      execAsk: state.execAsk ?? undefined,
     }
   );
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -344,6 +344,33 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     };
   }
 
+  async updateExecPreset(patch: {
+    security?: string;
+    ask?: string;
+  }): Promise<{ execSecurity: string | null; execAsk: string | null }> {
+    await this.loadState();
+
+    const pending: Partial<PersistedState> = {};
+
+    if (patch.security !== undefined) {
+      this.s.execSecurity = patch.security;
+      pending.execSecurity = patch.security;
+    }
+    if (patch.ask !== undefined) {
+      this.s.execAsk = patch.ask;
+      pending.execAsk = patch.ask;
+    }
+
+    if (Object.keys(pending).length > 0) {
+      await this.ctx.storage.put(pending);
+    }
+
+    return {
+      execSecurity: this.s.execSecurity,
+      execAsk: this.s.execAsk,
+    };
+  }
+
   async updateChannels(patch: {
     telegramBotToken?: EncryptedEnvelope | null;
     discordBotToken?: EncryptedEnvelope | null;

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -70,6 +70,8 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.gmailNotificationsEnabled = d.gmailNotificationsEnabled;
     s.gmailLastHistoryId = d.gmailLastHistoryId;
     s.gmailPushOidcEmail = d.gmailPushOidcEmail;
+    s.execSecurity = d.execSecurity;
+    s.execAsk = d.execAsk;
   } else {
     const hasAnyData = entries.size > 0;
     if (hasAnyData) {
@@ -130,6 +132,8 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.gmailNotificationsEnabled = false;
   s.gmailLastHistoryId = null;
   s.gmailPushOidcEmail = null;
+  s.execSecurity = null;
+  s.execAsk = null;
   s.lastLiveCheckAt = null;
   s.restartingAt = null;
   s.loaded = false;
@@ -184,6 +188,8 @@ export function createMutableState(): InstanceMutableState {
     gmailNotificationsEnabled: false,
     gmailLastHistoryId: null,
     gmailPushOidcEmail: null,
+    execSecurity: null,
+    execAsk: null,
     lastLiveCheckAt: null,
   };
 }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -82,6 +82,8 @@ export type InstanceMutableState = {
   gmailNotificationsEnabled: boolean;
   gmailLastHistoryId: string | null;
   gmailPushOidcEmail: string | null;
+  execSecurity: string | null;
+  execAsk: string | null;
   /** In-memory only — throttles live Fly checks in getStatus(). */
   lastLiveCheckAt: number | null;
 };

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -451,4 +451,36 @@ describe('buildEnvVars', () => {
       ).toBeDefined();
     }
   });
+
+  // ─── Exec preset env vars ─────────────────────────────────────────────
+
+  it('passes KILOCLAW_EXEC_SECURITY and KILOCLAW_EXEC_ASK in env when set', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      execSecurity: 'full',
+      execAsk: 'off',
+    });
+
+    expect(result.env.KILOCLAW_EXEC_SECURITY).toBe('full');
+    expect(result.env.KILOCLAW_EXEC_ASK).toBe('off');
+  });
+
+  it('does not set exec env vars when execSecurity and execAsk are null', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      execSecurity: null,
+      execAsk: null,
+    });
+
+    expect(result.env.KILOCLAW_EXEC_SECURITY).toBeUndefined();
+    expect(result.env.KILOCLAW_EXEC_ASK).toBeUndefined();
+  });
+
+  it('does not set exec env vars when not provided in userConfig', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {});
+
+    expect(result.env.KILOCLAW_EXEC_SECURITY).toBeUndefined();
+    expect(result.env.KILOCLAW_EXEC_ASK).toBeUndefined();
+  });
 });

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -28,6 +28,8 @@ export type UserConfig = {
   channels?: EncryptedChannelTokens;
   googleCredentials?: GoogleCredentials;
   instanceFeatures?: string[];
+  execSecurity?: string | null;
+  execAsk?: string | null;
 };
 
 /**
@@ -193,6 +195,10 @@ export async function buildEnvVars(
   // Layer 5: Reserved system vars (cannot be overridden by any user config)
   sensitive.OPENCLAW_GATEWAY_TOKEN = await deriveGatewayToken(sandboxId, gatewayTokenSecret);
   plainEnv.AUTO_APPROVE_DEVICES = 'true';
+
+  // User-selected exec permissions preset (non-sensitive, survives restarts).
+  if (userConfig?.execSecurity) plainEnv.KILOCLAW_EXEC_SECURITY = userConfig.execSecurity;
+  if (userConfig?.execAsk) plainEnv.KILOCLAW_EXEC_ASK = userConfig.execAsk;
 
   // Instance feature flags → env vars (non-sensitive, not user-overridable).
   // Applied after user env vars so users cannot suppress features via envVars config.

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -264,6 +264,32 @@ platform.patch('/channels', async c => {
   }
 });
 
+// PATCH /api/platform/exec-preset
+const ExecPresetPatchSchema = z.object({
+  userId: z.string().min(1),
+  security: z.string().optional(),
+  ask: z.string().optional(),
+});
+
+platform.patch('/exec-preset', async c => {
+  const result = await parseBody(c, ExecPresetPatchSchema);
+  if ('error' in result) return result.error;
+
+  const { userId, security, ask } = result.data;
+
+  try {
+    const updated = await withDORetry(
+      instanceStubFactory(c.env, userId),
+      stub => stub.updateExecPreset({ security, ask }),
+      'updateExecPreset'
+    );
+    return c.json(updated, 200);
+  } catch (err) {
+    const { message, status } = sanitizeError(err, 'exec-preset patch');
+    return jsonError(message, status);
+  }
+});
+
 // POST /api/platform/google-credentials
 const GoogleCredentialsPatchSchema = z.object({
   userId: z.string().min(1),

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -182,6 +182,10 @@ export const PersistedStateSchema = z.object({
   gmailNotificationsEnabled: z.boolean().default(false),
   gmailLastHistoryId: z.string().nullable().default(null),
   gmailPushOidcEmail: z.string().nullable().default(null),
+  // User-selected exec permissions preset (persisted so it survives restarts).
+  // null = use defaults (security: 'allowlist', ask: 'on-miss').
+  execSecurity: z.string().nullable().default(null),
+  execAsk: z.string().nullable().default(null),
 });
 
 export type PersistedState = z.infer<typeof PersistedStateSchema>;

--- a/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -54,6 +54,8 @@ export function ProvisioningStep({
   patchOpenclawConfigRef.current = mutations.patchOpenclawConfig.mutate;
   const patchChannelsRef = useRef(mutations.patchChannels.mutate);
   patchChannelsRef.current = mutations.patchChannels.mutate;
+  const patchExecPresetRef = useRef(mutations.patchExecPreset.mutate);
+  patchExecPresetRef.current = mutations.patchExecPreset.mutate;
   const channelTokensRef = useRef(channelTokens);
   channelTokensRef.current = channelTokens;
 
@@ -78,6 +80,13 @@ export function ProvisioningStep({
     const tokens = channelTokensRef.current;
     if (tokens && Object.keys(tokens).length > 0) {
       patchChannelsRef.current(tokens);
+    }
+
+    // Persist exec permissions preset to durable storage so it survives
+    // machine restarts/redeploys. Fire-and-forget — same pattern as channels.
+    if (preset !== 'always-ask') {
+      const { security, ask } = execPresetToConfig(preset);
+      patchExecPresetRef.current({ security, ask });
     }
 
     if (Object.keys(configPatch).length === 0) {

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -222,6 +222,7 @@ export function useKiloClawMutations() {
         },
       })
     ),
+    patchExecPreset: useMutation(trpc.kiloclaw.patchExecPreset.mutationOptions()),
     patchOpenclawConfig: useMutation(trpc.kiloclaw.patchOpenclawConfig.mutationOptions()),
     disconnectGoogle: useMutation(
       trpc.kiloclaw.disconnectGoogle.mutationOptions({ onSuccess: invalidateStatus })

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -199,6 +199,20 @@ export class KiloClawInternalClient {
     );
   }
 
+  async patchExecPreset(
+    userId: string,
+    patch: { security?: string; ask?: string }
+  ): Promise<{ execSecurity: string | null; execAsk: string | null }> {
+    return this.request(
+      '/api/platform/exec-preset',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ userId, ...patch }),
+      },
+      { userId }
+    );
+  }
+
   async patchSecrets(userId: string, input: SecretsPatchInput): Promise<SecretsPatchResponse> {
     return this.request(
       '/api/platform/secrets',

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -444,6 +444,13 @@ export const kiloclawRouter = createTRPCRouter({
     });
   }),
 
+  patchExecPreset: clawAccessProcedure
+    .input(z.object({ security: z.string().optional(), ask: z.string().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      const client = new KiloClawInternalClient();
+      return client.patchExecPreset(ctx.user.id, input);
+    }),
+
   /**
    * Generic secret patch — catalog-driven replacement for patchChannels.
    * Validates keys against the secret catalog, enforces allFieldsRequired,


### PR DESCRIPTION
## Summary

- User-selected exec permissions preset (e.g. "never-ask" → `security: full`, `ask: off`) was only applied to the live config file via `patchOpenclawConfig`. On machine restart/redeploy, `generateBaseConfig()` unconditionally overwrote exec settings to hardcoded defaults, losing the user's choice.
- Follows the established `kilocodeDefaultModel` pattern: persist to DO durable storage, transport via env vars (`KILOCLAW_EXEC_SECURITY`, `KILOCLAW_EXEC_ASK`), and read in `generateBaseConfig()` with the current values as fallback defaults.
- Adds a new `PATCH /api/platform/exec-preset` route, tRPC mutation, and fire-and-forget call in `ProvisioningStep` alongside the existing channel persistence pattern.

## Verification

- [x] `pnpm typecheck` — passes across all 30 workspace packages
- [x] `pnpm --filter kiloclaw test` — all 944 tests pass (42 test files)
- [x] Pre-push hooks (format, lint, typecheck) — all pass
- [x] Manual test: provisioned with "never-ask", confirmed preset persists after redeploy

## Visual Changes

N/A

## Reviewer Notes

- The `'always-ask'` preset maps to `{ security: 'allowlist', ask: 'on-miss' }` which matches the hardcoded defaults, so `null` values in DO storage fall through correctly — only non-default presets actually need storage.
- `config.tools.exec.host = 'gateway'` remains hardcoded (line 210) as KiloClaw machines always require gateway host.
- The new `ExecPresetPatchSchema` route uses the same `withDORetry` + `parseBody` pattern as the channels route but avoids the legacy `ChannelsPatchSchema` TODO debt.