### PR TITLE
feat(admin): add dev-only nuke all button to KiloClaw admin page

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import {
   Table,
@@ -23,7 +23,17 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { ChevronLeft, ChevronRight, X, Bomb } from 'lucide-react';
 import Link from 'next/link';
 import { formatDistanceToNow, format, parseISO } from 'date-fns';
 import {
@@ -219,6 +229,66 @@ function DailyChart({ data }: { data: DailyChartData[] }) {
   );
 }
 
+// --- Dev Nuke All Button ---
+
+function DevNukeAllButton() {
+  if (process.env.NODE_ENV !== 'development') return null;
+
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+
+  const nukeAll = useMutation(
+    trpc.admin.kiloclawInstances.devNukeAll.mutationOptions({
+      onSuccess(data) {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.list.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.stats.queryKey(),
+        });
+        const errorSuffix =
+          data.errors.length > 0
+            ? `\n${data.errors.length} failed:\n${data.errors.map(e => `  ${e.userId}: ${e.error}`).join('\n')}`
+            : '';
+        alert(`Destroyed ${data.destroyed}/${data.total} instances${errorSuffix}`);
+      },
+    })
+  );
+
+  return (
+    <>
+      <Button variant="destructive" onClick={() => setOpen(true)} disabled={nukeAll.isPending}>
+        <Bomb className="mr-2 h-4 w-4" />
+        {nukeAll.isPending ? 'Nuking...' : 'Nuke All'}
+      </Button>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Nuke all KiloClaw instances?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will destroy every active KiloClaw instance. This action cannot be undone. Only
+              available in development mode.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                nukeAll.mutate();
+                setOpen(false);
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Nuke All
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
 // --- Main Page ---
 
 export function KiloclawInstancesPage() {
@@ -378,6 +448,8 @@ export function KiloclawInstancesPage() {
             <SelectItem value="destroyed">Destroyed Only</SelectItem>
           </SelectContent>
         </Select>
+
+        <DevNukeAllButton />
       </div>
 
       {/* Table */}

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -595,6 +595,51 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       }
     }),
 
+  devNukeAll: adminProcedure.mutation(async ({ ctx }) => {
+    if (process.env.NODE_ENV !== 'development') {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'This endpoint is only available in development mode',
+      });
+    }
+
+    const activeInstances = await db
+      .select({
+        id: kiloclaw_instances.id,
+        user_id: kiloclaw_instances.user_id,
+      })
+      .from(kiloclaw_instances)
+      .where(isNull(kiloclaw_instances.destroyed_at));
+
+    console.log(
+      `[admin-kiloclaw] DevNukeAll triggered by admin ${ctx.user.id} (${ctx.user.google_user_email}): ${activeInstances.length} active instances`
+    );
+
+    const client = new KiloClawInternalClient();
+    let destroyed = 0;
+    const errors: Array<{ userId: string; error: string }> = [];
+
+    for (const instance of activeInstances) {
+      const destroyedRow = await markActiveInstanceDestroyed(instance.user_id);
+      try {
+        await client.destroy(instance.user_id);
+        destroyed++;
+      } catch (err) {
+        if (destroyedRow) {
+          await restoreDestroyedInstance(destroyedRow.id);
+        }
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        errors.push({ userId: instance.user_id, error: message });
+        console.error(
+          `[admin-kiloclaw] DevNukeAll: failed to destroy instance ${instance.id} (user: ${instance.user_id}):`,
+          err
+        );
+      }
+    }
+
+    return { total: activeInstances.length, destroyed, errors };
+  }),
+
   reassociateVolume: adminProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary

Add a "Nuke All" button to the KiloClaw admin instances page that destroys all active KiloClaw instances, including their Fly machines via the worker. The button and its backend endpoint are both gated to development mode only (`process.env.NODE_ENV !== 'development'`).

- Backend: new `devNukeAll` mutation on `adminKiloclawInstancesRouter` that iterates active instances, marks each destroyed in Postgres, then calls `client.destroy()` on the worker. Uses the same mark-then-revert pattern as the existing single-instance `destroy` endpoint — if the worker call fails, the DB row is restored so state stays consistent.
- Frontend: `DevNukeAllButton` component renders `null` outside development mode. Shows a destructive button with confirmation dialog. Reports results including any partial failures.

## Verification

- [x] `pnpm typecheck` — 28 packages pass, 0 failures
- [x] `pnpm format` — no formatting issues
- [x] `git push` — pre-push hooks (format:check, lint, typecheck) all pass

## Visual Changes

N/A

## Reviewer Notes

- The button is tree-shaken from production builds via the `process.env.NODE_ENV !== 'development'` early return. The server endpoint also hard-gates with the same check and returns `FORBIDDEN`.
- The destroy loop is sequential per instance to avoid overwhelming the worker. Each instance is independently mark/destroy/revert so partial failures don't affect other instances.