### PR TITLE
feat(kiloclaw): record Rewardful lead when affiliate-referred user starts trial

### DIFF
--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -102,6 +102,10 @@ export function CreateInstanceCard({
       selected_model: selectedModel,
     });
 
+    // Capture email before the async mutation so the onSuccess closure
+    // doesn't depend on the useUser query still being resolved.
+    const email = user?.google_user_email;
+
     mutations.provision.mutate(
       {
         kilocodeDefaultModel: `kilocode/${selectedModel}`,
@@ -109,6 +113,11 @@ export function CreateInstanceCard({
       {
         onSuccess: () => {
           onProvisionStart?.();
+          // Record a Rewardful lead when an affiliate-referred user starts a trial.
+          // No-op if the visitor is not a referral or rw.js didn't load.
+          if (email && typeof window.rewardful === 'function') {
+            window.rewardful('convert', { email });
+          }
         },
         onError: err => {
           toast.error(`Failed to create: ${err.message}`);
@@ -149,7 +158,7 @@ export function CreateInstanceCard({
         <div className="flex">
           <Button
             onClick={handleCreate}
-            disabled={mutations.provision.isPending || !selectedModel}
+            disabled={mutations.provision.isPending || !selectedModel || isLoadingUser}
             className="grow bg-emerald-600 text-white hover:bg-emerald-700"
           >
             {mutations.provision.isPending ? 'Setting up...' : 'Get Started'}

--- a/src/types/rewardful.d.ts
+++ b/src/types/rewardful.d.ts
@@ -1,0 +1,7 @@
+// Extend the Window interface to include the Rewardful tracking function.
+// Loaded conditionally by rw.js when NEXT_PUBLIC_REWARDFUL_ID is set.
+declare global {
+  interface Window {
+    rewardful?: (...args: unknown[]) => void;
+  }
+}


### PR DESCRIPTION
## Summary

- When an affiliate-referred user starts a KiloClaw trial, call `rewardful('convert', { email })` client-side to record the referral as a **Lead** in Rewardful
- Previously, Rewardful attribution only happened at Stripe checkout (via `client_reference_id`), so trial users were never recorded — affiliates had no visibility into referred users until they paid
- The `rewardful('convert')` call is a no-op if the visitor has no referral cookie or if `rw.js` didn't load (e.g., local dev without `NEXT_PUBLIC_REWARDFUL_ID`)
- Added a global `Window.rewardful` type declaration following the existing pattern used for `datalayer` and `posthog`

## Verification

- [x] `pnpm typecheck` — passes across all workspace projects
- [x] `oxfmt` formatting check — no changes needed

## Visual Changes

N/A

## Reviewer Notes

- The `rewardful('convert')` function searches for the Stripe customer by email and associates it with the affiliate referral. Every user already has a `stripe_customer_id` (created eagerly at signup), so the customer will always exist in Stripe when this fires.
- Per Rewardful docs, a "Lead" becomes a "Conversion" only after a payment occurs — so this call correctly records a Lead (not a full Conversion) for trial users.
- The call fires in the `onSuccess` callback of `mutations.provision.mutate()` in `CreateInstanceCard.tsx`, which is the exact moment a trial row is inserted.