### PR TITLE
refactor(claw): extract shared OnboardingStepView component

### DIFF
--- a/src/app/(app)/claw/components/ChannelSelectionStep.tsx
+++ b/src/app/(app)/claw/components/ChannelSelectionStep.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import { ChevronRight, ExternalLink, PlayCircle } from 'lucide-react';
 import { validateFieldValue } from '@kilocode/kiloclaw-secret-catalog';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+import { OnboardingStepView } from './OnboardingStepView';
 import { DiscordIcon } from './icons/DiscordIcon';
 import { ChannelTokenInput } from './ChannelTokenInput';
 import { SlackIcon } from './icons/SlackIcon';
@@ -95,10 +95,12 @@ function pickChannelTokens(
 }
 
 export function ChannelSelectionStepView({
+  instanceRunning,
   onSelect,
   onSkip,
   defaultSelected = null,
 }: {
+  instanceRunning?: boolean;
   onSelect?: (channelId: ChannelId, tokens: Record<string, string>) => void;
   onSkip?: () => void;
   defaultSelected?: ChannelId | null;
@@ -137,72 +139,57 @@ export function ChannelSelectionStepView({
   };
 
   return (
-    <Card className="mt-6">
-      <CardContent className="flex flex-col gap-6 p-6 sm:p-8">
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-              Step 3 of 4
-            </span>
-            <div className="flex gap-1">
-              <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-              <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-              <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-              <span className="bg-muted h-1.5 w-6 rounded-full" />
-            </div>
-          </div>
-          <h2 className="text-foreground text-2xl font-bold">Where do you want to chat?</h2>
-          <p className="text-muted-foreground text-sm">
-            Pick where you&apos;d like to talk to your KiloClaw bot. You can add more channels any
-            time from settings.
-          </p>
-        </div>
+    <OnboardingStepView
+      currentStep={3}
+      totalSteps={4}
+      title="Where do you want to chat?"
+      description="Pick where you'd like to talk to your KiloClaw bot. You can add more channels any time from settings."
+      showProvisioningBanner={instanceRunning === false}
+    >
+      {telegram && (
+        <ChannelCard
+          option={telegram}
+          isSelected={selected === telegram.id}
+          onSelect={() => setSelected(telegram.id)}
+          expandedContent={expandedSections[telegram.id]}
+        />
+      )}
 
-        {telegram && (
-          <ChannelCard
-            option={telegram}
-            isSelected={selected === telegram.id}
-            onSelect={() => setSelected(telegram.id)}
-            expandedContent={expandedSections[telegram.id]}
-          />
-        )}
+      <div className="flex items-center gap-3">
+        <div className="border-border flex-1 border-t" />
+        <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+          Other options
+        </span>
+        <div className="border-border flex-1 border-t" />
+      </div>
 
-        <div className="flex items-center gap-3">
-          <div className="border-border flex-1 border-t" />
-          <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-            Other options
-          </span>
-          <div className="border-border flex-1 border-t" />
-        </div>
+      {others.map(option => (
+        <ChannelCard
+          key={option.id}
+          option={option}
+          isSelected={selected === option.id}
+          onSelect={() => setSelected(option.id)}
+          expandedContent={expandedSections[option.id]}
+        />
+      ))}
 
-        {others.map(option => (
-          <ChannelCard
-            key={option.id}
-            option={option}
-            isSelected={selected === option.id}
-            onSelect={() => setSelected(option.id)}
-            expandedContent={expandedSections[option.id]}
-          />
-        ))}
+      <Button
+        className="w-full bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
+        disabled={!isChannelValid(selected, tokens)}
+        onClick={() => selected && onSelect?.(selected, pickChannelTokens(selected, tokens))}
+      >
+        Continue
+        <ChevronRight className="ml-1 h-5 w-5" />
+      </Button>
 
-        <Button
-          className="w-full bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
-          disabled={!isChannelValid(selected, tokens)}
-          onClick={() => selected && onSelect?.(selected, pickChannelTokens(selected, tokens))}
-        >
-          Continue
-          <ChevronRight className="ml-1 h-5 w-5" />
-        </Button>
-
-        <button
-          type="button"
-          className="text-muted-foreground hover:text-foreground mx-auto text-sm transition-colors"
-          onClick={() => onSkip?.()}
-        >
-          Skip for now
-        </button>
-      </CardContent>
-    </Card>
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground mx-auto text-sm transition-colors"
+        onClick={() => onSkip?.()}
+      >
+        Skip for now
+      </button>
+    </OnboardingStepView>
   );
 }
 

--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -158,6 +158,7 @@ export function ClawDashboard({
           />
         ) : isNewSetup && onboardingStep === 'channels' ? (
           <ChannelSelectionStepView
+            instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             onSelect={(_channelId, tokens) => {
               setChannelTokens(tokens);
               setOnboardingStep('provisioning');

--- a/src/app/(app)/claw/components/OnboardingStepView.tsx
+++ b/src/app/(app)/claw/components/OnboardingStepView.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type OnboardingStepIndicatorProps = {
+  currentStep: number;
+  totalSteps: number;
+  label?: string;
+};
+
+export function OnboardingStepIndicator({
+  currentStep,
+  totalSteps,
+  label,
+}: OnboardingStepIndicatorProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex gap-1">
+        {Array.from({ length: totalSteps }, (_, i) => (
+          <span
+            key={i}
+            className={cn('h-1.5 w-6 rounded-full', i < currentStep ? 'bg-blue-500' : 'bg-muted')}
+          />
+        ))}
+      </div>
+      <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+        {label ?? `Step ${currentStep} of ${totalSteps}`}
+      </span>
+    </div>
+  );
+}
+
+export function ProvisioningBanner() {
+  return (
+    <div className="border-border flex w-full items-center gap-3 rounded-lg border p-4">
+      <span className="relative flex h-2 w-2 shrink-0">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+      </span>
+      <div>
+        <p className="text-sm font-semibold">Setting up your instance</p>
+        <p className="text-muted-foreground text-xs">
+          This happens in the background — keep going while we get things ready.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type OnboardingStepViewProps = {
+  currentStep: number;
+  totalSteps: number;
+  stepLabel?: string;
+  title?: string;
+  description?: string;
+  showProvisioningBanner?: boolean;
+  contentClassName?: string;
+  children: React.ReactNode;
+};
+
+export function OnboardingStepView({
+  currentStep,
+  totalSteps,
+  stepLabel,
+  title,
+  description,
+  showProvisioningBanner,
+  contentClassName,
+  children,
+}: OnboardingStepViewProps) {
+  const indicator = (
+    <OnboardingStepIndicator currentStep={currentStep} totalSteps={totalSteps} label={stepLabel} />
+  );
+
+  return (
+    <Card className="mt-6">
+      <CardContent className={cn('flex flex-col gap-6 p-6 sm:p-8', contentClassName)}>
+        {title || description ? (
+          <div className="flex flex-col gap-3">
+            {indicator}
+            {title && <h2 className="text-foreground text-2xl font-bold">{title}</h2>}
+            {description && <p className="text-muted-foreground text-sm">{description}</p>}
+          </div>
+        ) : (
+          <div className="self-start">{indicator}</div>
+        )}
+
+        {children}
+
+        {showProvisioningBanner && <ProvisioningBanner />}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/claw/components/PermissionStep.tsx
+++ b/src/app/(app)/claw/components/PermissionStep.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { AlertCircle, ShieldAlert, ShieldCheck } from 'lucide-react';
-import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import type { ExecPreset } from './claw.types';
+import { OnboardingStepView } from './OnboardingStepView';
 
 export function PermissionStep({
   instanceRunning,
@@ -13,64 +13,32 @@ export function PermissionStep({
   onSelect: (preset: ExecPreset) => void;
 }) {
   return (
-    <Card className="mt-6">
-      <CardContent className="flex flex-col gap-6 p-6 sm:p-8">
-        {/* Step indicator */}
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-              Step 2 of 4
-            </span>
-            <div className="flex gap-1">
-              <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-              <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-              <span className="bg-muted h-1.5 w-6 rounded-full" />
-              <span className="bg-muted h-1.5 w-6 rounded-full" />
-            </div>
-          </div>
-          <h2 className="text-foreground text-2xl font-bold">Set Bot Permissions</h2>
-          <p className="text-muted-foreground text-sm">
-            Choose how your KiloClaw bot handles actions on your behalf.
-          </p>
-        </div>
-
-        {/* Permission cards */}
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <PresetCard
-            onClick={() => onSelect('never-ask')}
-            icon={<ShieldAlert className="h-5 w-5 text-amber-400" />}
-            iconBg="bg-amber-900/50"
-            title="Allow everything"
-            description="The bot acts immediately without asking — a.k.a. YOLO mode. Best for autonomous workflows, but review what it can access first."
-            caution="Use with caution"
-          />
-          <PresetCard
-            onClick={() => onSelect('always-ask')}
-            icon={<ShieldCheck className="h-5 w-5 text-emerald-400" />}
-            iconBg="bg-emerald-900/50"
-            title="Ask for permission"
-            description="The bot pauses and asks you before taking any action. Best when you want full control over what it does."
-            badge="Recommended"
-          />
-        </div>
-
-        {/* Provisioning status banner */}
-        {!instanceRunning && (
-          <div className="border-border flex w-full items-center gap-3 rounded-lg border p-4">
-            <span className="relative flex h-2 w-2 shrink-0">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
-            </span>
-            <div>
-              <p className="text-sm font-semibold">Setting up your instance</p>
-              <p className="text-muted-foreground text-xs">
-                This happens in the background — keep going while we get things ready.
-              </p>
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    <OnboardingStepView
+      currentStep={2}
+      totalSteps={4}
+      title="Set Bot Permissions"
+      description="Choose how your KiloClaw bot handles actions on your behalf."
+      showProvisioningBanner={!instanceRunning}
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <PresetCard
+          onClick={() => onSelect('never-ask')}
+          icon={<ShieldAlert className="h-5 w-5 text-amber-400" />}
+          iconBg="bg-amber-900/50"
+          title="Allow everything"
+          description="The bot acts immediately without asking — a.k.a. YOLO mode. Best for autonomous workflows, but review what it can access first."
+          caution="Use with caution"
+        />
+        <PresetCard
+          onClick={() => onSelect('always-ask')}
+          icon={<ShieldCheck className="h-5 w-5 text-emerald-400" />}
+          iconBg="bg-emerald-900/50"
+          title="Ask for permission"
+          description="The bot pauses and asks you before taking any action. Best when you want full control over what it does."
+          badge="Recommended"
+        />
+      </div>
+    </OnboardingStepView>
   );
 }
 

--- a/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -4,13 +4,13 @@ import { useEffect, useRef } from 'react';
 import { Volume2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import {
   type ExecPreset,
   type ClawMutations,
   execPresetToConfig,
   channelTokensToConfigPatch,
 } from './claw.types';
+import { OnboardingStepView } from './OnboardingStepView';
 
 /** Play a short chime via the Web Audio API. */
 function playChime() {
@@ -116,79 +116,69 @@ export function ProvisioningStep({
 /** Pure visual shell — extracted so Storybook can render it without wiring up mutations. */
 export function ProvisioningStepView() {
   return (
-    <Card className="mt-6">
-      <CardContent className="flex flex-col items-center gap-8 p-6 pt-10 sm:p-10 sm:pt-12">
-        {/* Step indicator */}
-        <div className="flex items-center gap-2 self-start">
-          <span className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-            Almost there...
-          </span>
-          <div className="flex gap-1">
-            <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-            <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-            <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-            <span className="h-1.5 w-6 rounded-full bg-blue-500" />
-          </div>
-        </div>
+    <OnboardingStepView
+      currentStep={4}
+      totalSteps={4}
+      stepLabel="Almost there..."
+      contentClassName="items-center gap-8"
+    >
+      {/* Spinner */}
+      <div className="provisioning-spinner relative h-24 w-24">
+        <svg className="h-full w-full" viewBox="0 0 96 96">
+          {/* Gray track */}
+          <circle
+            cx="48"
+            cy="48"
+            r="42"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="4"
+            className="text-muted/40"
+          />
+          {/* Blue arc */}
+          <circle
+            cx="48"
+            cy="48"
+            r="42"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="4"
+            strokeLinecap="round"
+            strokeDasharray="132 264"
+            className="provisioning-spinner-arc text-blue-500"
+          />
+        </svg>
+        {/* Pulsing center dot */}
+        <span className="absolute inset-0 m-auto h-2.5 w-2.5 animate-pulse rounded-full bg-blue-500" />
+        <style>{`
+          .provisioning-spinner svg {
+            animation: provisioning-rotate 1.4s linear infinite;
+          }
+          @keyframes provisioning-rotate {
+            to { transform: rotate(360deg); }
+          }
+        `}</style>
+      </div>
 
-        {/* Spinner */}
-        <div className="provisioning-spinner relative h-24 w-24">
-          <svg className="h-full w-full" viewBox="0 0 96 96">
-            {/* Gray track */}
-            <circle
-              cx="48"
-              cy="48"
-              r="42"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="4"
-              className="text-muted/40"
-            />
-            {/* Blue arc */}
-            <circle
-              cx="48"
-              cy="48"
-              r="42"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="4"
-              strokeLinecap="round"
-              strokeDasharray="132 264"
-              className="provisioning-spinner-arc text-blue-500"
-            />
-          </svg>
-          {/* Pulsing center dot */}
-          <span className="absolute inset-0 m-auto h-2.5 w-2.5 animate-pulse rounded-full bg-blue-500" />
-          <style>{`
-            .provisioning-spinner svg {
-              animation: provisioning-rotate 1.4s linear infinite;
-            }
-            @keyframes provisioning-rotate {
-              to { transform: rotate(360deg); }
-            }
-          `}</style>
-        </div>
+      {/* Heading + subtitle */}
+      <div className="flex flex-col items-center gap-2 text-center">
+        <h2 className="text-foreground text-2xl font-bold">Setting up your instance</h2>
+        <p className="text-muted-foreground max-w-md text-sm leading-relaxed">
+          This usually takes a minute or two. Feel free to keep this tab open and step away &mdash;
+          we&apos;ll play a sound as soon as it&apos;s ready.
+        </p>
+      </div>
 
-        {/* Heading + subtitle */}
-        <div className="flex flex-col items-center gap-2 text-center">
-          <h2 className="text-foreground text-2xl font-bold">Setting up your instance</h2>
-          <p className="text-muted-foreground max-w-md text-sm leading-relaxed">
-            This usually takes a minute or two. Feel free to keep this tab open and step away
-            &mdash; we&apos;ll play a sound as soon as it&apos;s ready.
-          </p>
-        </div>
-
-        {/* Sound banner */}
-        <div className="border-border flex w-full items-center gap-3 rounded-lg border p-4">
-          <Volume2 className="text-muted-foreground h-5 w-5 shrink-0" />
-          <span className="text-muted-foreground flex-1 text-sm">
-            You&apos;ll hear a chime when your instance is ready.
-          </span>
-          <Button variant="ghost" size="sm" onClick={playChime}>
-            Play test sound
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+      {/* Sound banner */}
+      <div className="border-border flex w-full items-center gap-3 rounded-lg border p-4">
+        <Volume2 className="text-muted-foreground h-5 w-5 shrink-0" />
+        <span className="text-muted-foreground flex-1 text-sm">
+          You&apos;ll hear a chime when your instance is ready.
+        </span>
+        <Button variant="ghost" size="sm" onClick={playChime}>
+          Play test sound
+        </Button>
+      </div>
+    </OnboardingStepView>
   );
 }

--- a/storybook/stories/claw/AutoModelPicker.stories.tsx
+++ b/storybook/stories/claw/AutoModelPicker.stories.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { AutoModelPicker } from '@/app/(app)/claw/components/AutoModelPicker';
+import type { ModelOption } from '@/components/shared/ModelCombobox';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+const SAMPLE_MODELS: ModelOption[] = [
+  { id: 'kilo-auto/frontier', name: 'Kilo Auto Frontier' },
+  { id: 'kilo-auto/balanced', name: 'Kilo Auto Balanced' },
+  { id: 'kilo-auto/free', name: 'Kilo Auto Free' },
+  { id: 'anthropic/claude-opus-4.6', name: 'Anthropic: Claude Opus 4.6' },
+  { id: 'anthropic/claude-sonnet-4.5', name: 'Anthropic: Claude Sonnet 4.5' },
+  { id: 'openai/gpt-5.2', name: 'OpenAI: GPT-5.2' },
+  { id: 'google/gemini-3-pro-preview', name: 'Google: Gemini 3 Pro Preview' },
+  { id: 'google/gemini-3-flash-preview', name: 'Google: Gemini 3 Flash Preview' },
+];
+
+const meta: Meta<typeof AutoModelPicker> = {
+  title: 'Claw/AutoModelPicker',
+  component: AutoModelPicker,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    models: SAMPLE_MODELS,
+    value: 'kilo-auto/frontier',
+  },
+  decorators: [
+    Story => (
+      <div className="mx-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Get Started with KiloClaw</CardTitle>
+            <CardDescription>
+              Choose a default model to provision your first KiloClaw instance.
+              <br />
+              7-day free trial, no credit card required
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="mt-4 space-y-6">
+            <Story />
+          </CardContent>
+        </Card>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FrontierSelected: Story = {
+  args: {
+    value: 'kilo-auto/frontier',
+  },
+};
+
+export const BalancedSelected: Story = {
+  args: {
+    value: 'kilo-auto/balanced',
+  },
+};
+
+export const FreeSelected: Story = {
+  args: {
+    value: 'kilo-auto/free',
+  },
+};
+
+export const NoSelection: Story = {
+  args: {
+    value: '',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    models: [],
+    value: '',
+    isLoading: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    value: '',
+  },
+  render: function InteractivePicker(args) {
+    const [value, setValue] = useState(args.value);
+    return <AutoModelPicker {...args} value={value} onValueChange={setValue} />;
+  },
+};

--- a/storybook/stories/claw/ChannelSelectionStep.stories.tsx
+++ b/storybook/stories/claw/ChannelSelectionStep.stories.tsx
@@ -38,3 +38,9 @@ export const SlackSelected: Story = {
     defaultSelected: 'slack',
   },
 };
+
+export const WithProvisioningBanner: Story = {
+  args: {
+    instanceRunning: false,
+  },
+};

--- a/storybook/stories/claw/PermissionStep.stories.tsx
+++ b/storybook/stories/claw/PermissionStep.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { PermissionStep } from '@/app/(app)/claw/components/PermissionStep';
+
+const meta: Meta<typeof PermissionStep> = {
+  title: 'Claw/PermissionStep',
+  component: PermissionStep,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="mx-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    instanceRunning: true,
+  },
+};
+
+export const WithProvisioningBanner: Story = {
+  args: {
+    instanceRunning: false,
+  },
+};


### PR DESCRIPTION
## Summary

I noticed some discrepancies in the styling of the onboarding steps, so this PR unifies the logic into shared components.

- Extract duplicated onboarding step indicator (progress bars + label), Card wrapper, and provisioning banner into a shared `OnboardingStepView` component in `src/app/(app)/claw/components/OnboardingStepView.tsx`.
- Refactor `PermissionStep`, `ChannelSelectionStep`, and `ProvisioningStep` to use `OnboardingStepView`, reducing boilerplate across all three steps.
- Add the provisioning banner to `ChannelSelectionStep` (step 3), which previously lacked it — now users see the "Setting up your instance" indicator while configuring channels.
- Add Storybook stories for `PermissionStep` and `AutoModelPicker`.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (via pre-push hook)
- [x] `pnpm format:check` — passes (via pre-push hook)
- [x] Visual verification in browser at `http://localhost:3000/claw` — walked through all onboarding steps
- [x] Storybook stories render correctly for PermissionStep, ChannelSelectionStep, ProvisioningStep, and AutoModelPicker

## Visual Changes

https://github.com/user-attachments/assets/1d62d474-b6f1-4eb9-aefd-3c4c11756210

## Reviewer Notes

- `instanceRunning` on `ChannelSelectionStepView` is typed as `instanceRunning?: boolean` to avoid breaking existing Storybook stories that don't pass it. The banner check uses `instanceRunning === false` (strict equality) rather than `!instanceRunning` to avoid showing the banner when the prop is `undefined`.
- `ProvisioningStepView` is a zero-prop component — it uses `OnboardingStepView` with `stepLabel="Almost there..."` and `contentClassName="items-center gap-8"` instead of title/description.
- The original `ProvisioningStep` had extra `pt-10 sm:pt-12` padding that was removed during refactoring to keep step indicator alignment consistent across all steps.