### PR TITLE
feat(claw): prompt users to purchase credits when selecting a paid model

### DIFF
--- a/src/app/(app)/claw/components/AutoModelPicker.tsx
+++ b/src/app/(app)/claw/components/AutoModelPicker.tsx
@@ -23,7 +23,6 @@ type PerformanceLevel = 1 | 2 | 3;
 type AutoModelCard = {
   id: string;
   label: string;
-  badge?: string;
   description: string;
   icon: typeof Zap;
   iconBg: string;
@@ -59,7 +58,6 @@ const autoModelCards: AutoModelCard[] = [
   {
     id: KILO_AUTO_FREE_MODEL.id,
     label: 'Free',
-    badge: 'FREE',
     description: KILO_AUTO_FREE_MODEL.description,
     icon: Gift,
     iconBg: 'bg-emerald-500/20',
@@ -183,11 +181,6 @@ export function AutoModelPicker({
                   <div className="space-y-1">
                     <div className="flex items-center gap-2">
                       <span className="font-semibold">{card.label}</span>
-                      {card.badge && (
-                        <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] font-bold leading-none text-emerald-400">
-                          {card.badge}
-                        </span>
-                      )}
                     </div>
                     <p className="text-muted-foreground text-xs leading-relaxed">
                       {card.description}

--- a/src/app/(app)/claw/components/AutoModelPicker.tsx
+++ b/src/app/(app)/claw/components/AutoModelPicker.tsx
@@ -23,6 +23,7 @@ type PerformanceLevel = 1 | 2 | 3;
 type AutoModelCard = {
   id: string;
   label: string;
+  badge?: string;
   description: string;
   icon: typeof Zap;
   iconBg: string;
@@ -58,6 +59,7 @@ const autoModelCards: AutoModelCard[] = [
   {
     id: KILO_AUTO_FREE_MODEL.id,
     label: 'Free',
+    badge: 'FREE',
     description: KILO_AUTO_FREE_MODEL.description,
     icon: Gift,
     iconBg: 'bg-emerald-500/20',
@@ -181,6 +183,11 @@ export function AutoModelPicker({
                   <div className="space-y-1">
                     <div className="flex items-center gap-2">
                       <span className="font-semibold">{card.label}</span>
+                      {card.badge && (
+                        <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] font-bold leading-none text-emerald-400">
+                          {card.badge}
+                        </span>
+                      )}
                     </div>
                     <p className="text-muted-foreground text-xs leading-relaxed">
                       {card.description}

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -12,6 +12,7 @@ import { useTRPC } from '@/lib/trpc/utils';
 import type { ModelOption } from '@/components/shared/ModelCombobox';
 import { useUser } from '@/hooks/useUser';
 import { KILO_AUTO_FRONTIER_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/kilo-auto-model';
+import { isFreeModel } from '@/lib/models';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { getCreateModelOptions } from './modelSupport';
@@ -79,6 +80,7 @@ export function CreateInstanceCard({
   const hasCredits = (user?.total_microdollars_acquired ?? 0) > 0;
   const isPaymentReturn = searchParams.get('payment') === 'success';
   const hasAutoProvisioned = useRef(false);
+
 
   useEffect(() => {
     if (hasAppliedDefault.current || selectedModel !== '' || modelOptions.length === 0) return;
@@ -176,8 +178,7 @@ export function CreateInstanceCard({
     );
   }
 
-  const needsCredits =
-    !hasCredits && selectedModel !== '' && selectedModel !== KILO_AUTO_FREE_MODEL.id;
+  const needsCredits = !hasCredits && selectedModel !== '' && !isFreeModel(selectedModel);
 
   return (
     <Card>

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -81,7 +81,6 @@ export function CreateInstanceCard({
   const isPaymentReturn = searchParams.get('payment') === 'success';
   const hasAutoProvisioned = useRef(false);
 
-
   useEffect(() => {
     if (hasAppliedDefault.current || selectedModel !== '' || modelOptions.length === 0) return;
     if (isLoadingUser) return;

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -77,6 +77,8 @@ export function CreateInstanceCard({
   );
 
   const hasCredits = (user?.total_microdollars_acquired ?? 0) > 0;
+  const isPaymentReturn = searchParams.get('payment') === 'success';
+  const hasAutoProvisioned = useRef(false);
 
   useEffect(() => {
     if (hasAppliedDefault.current || selectedModel !== '' || modelOptions.length === 0) return;
@@ -96,6 +98,39 @@ export function CreateInstanceCard({
       hasAppliedDefault.current = true;
     }
   }, [modelOptions, hasCredits, selectedModel, isLoadingUser, searchParams]);
+
+  // After returning from a successful credit purchase, show a toast and
+  // auto-start provisioning so the user doesn't have to click again.
+  useEffect(() => {
+    if (!isPaymentReturn || hasAutoProvisioned.current) return;
+    if (!selectedModel || isLoadingModels || isLoadingProvisionTargetVersion) return;
+    if (hasProvisionTargetError) return;
+
+    hasAutoProvisioned.current = true;
+    toast.success('Payment processed — setting up your instance!');
+
+    posthog?.capture('claw_create_instance_clicked', {
+      selected_model: selectedModel,
+      auto_provision_after_payment: true,
+    });
+
+    mutations.provision.mutate(
+      { kilocodeDefaultModel: `kilocode/${selectedModel}` },
+      {
+        onSuccess: () => onProvisionStart?.(),
+        onError: err => toast.error(`Failed to create: ${err.message}`),
+      }
+    );
+  }, [
+    isPaymentReturn,
+    selectedModel,
+    isLoadingModels,
+    isLoadingProvisionTargetVersion,
+    hasProvisionTargetError,
+    mutations.provision,
+    posthog,
+    onProvisionStart,
+  ]);
 
   function handleCreate() {
     if (hasProvisionTargetError) {

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFeatureFlagVariantKey, usePostHog } from 'posthog-js/react';
 import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useKiloClawLatestVersion, useKiloClawMyPin } from '@/hooks/useKiloClaw';
@@ -15,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { getCreateModelOptions } from './modelSupport';
 import { AutoModelPicker } from './AutoModelPicker';
+import { CreditsNudge } from './CreditsNudge';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
@@ -30,6 +32,7 @@ export function CreateInstanceCard({
   useFeatureFlagVariantKey('button-vs-card');
   const posthog = usePostHog();
   const trpc = useTRPC();
+  const searchParams = useSearchParams();
   const { data: billingStatus } = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
   const { data: user, isLoading: isLoadingUser } = useUser();
   const { data: modelsData, isLoading: isLoadingModels } = useOpenRouterModels();
@@ -78,12 +81,21 @@ export function CreateInstanceCard({
   useEffect(() => {
     if (hasAppliedDefault.current || selectedModel !== '' || modelOptions.length === 0) return;
     if (isLoadingUser) return;
+
+    // If returning from a checkout flow, restore the previously-selected model
+    const modelParam = searchParams.get('model');
+    if (modelParam && modelOptions.some(m => m.id === modelParam)) {
+      setSelectedModel(modelParam);
+      hasAppliedDefault.current = true;
+      return;
+    }
+
     const defaultId = hasCredits ? KILO_AUTO_FRONTIER_MODEL.id : KILO_AUTO_FREE_MODEL.id;
     if (modelOptions.some(m => m.id === defaultId)) {
       setSelectedModel(defaultId);
       hasAppliedDefault.current = true;
     }
-  }, [modelOptions, hasCredits, selectedModel, isLoadingUser]);
+  }, [modelOptions, hasCredits, selectedModel, isLoadingUser, searchParams]);
 
   function handleCreate() {
     if (hasProvisionTargetError) {
@@ -129,6 +141,9 @@ export function CreateInstanceCard({
     );
   }
 
+  const needsCredits =
+    !hasCredits && selectedModel !== '' && selectedModel !== KILO_AUTO_FREE_MODEL.id;
+
   return (
     <Card>
       <CardHeader>
@@ -158,15 +173,22 @@ export function CreateInstanceCard({
           }
         />
 
-        <div className="flex">
-          <Button
-            onClick={handleCreate}
-            disabled={mutations.provision.isPending || !selectedModel || isLoadingUser}
-            className="grow bg-emerald-600 text-white hover:bg-emerald-700"
-          >
-            {mutations.provision.isPending ? 'Setting up...' : 'Get Started'}
-          </Button>
-        </div>
+        {needsCredits ? (
+          <CreditsNudge
+            selectedModel={selectedModel}
+            onSwitchToFree={() => setSelectedModel(KILO_AUTO_FREE_MODEL.id)}
+          />
+        ) : (
+          <div className="flex">
+            <Button
+              onClick={handleCreate}
+              disabled={mutations.provision.isPending || !selectedModel}
+              className="grow bg-emerald-600 text-white hover:bg-emerald-700"
+            >
+              {mutations.provision.isPending ? 'Setting up...' : 'Get Started'}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/app/(app)/claw/components/CreditsNudge.actions.ts
+++ b/src/app/(app)/claw/components/CreditsNudge.actions.ts
@@ -1,0 +1,8 @@
+'use server';
+import 'server-only';
+
+import { setPaymentReturnUrl } from '@/lib/payment-return-url';
+
+export async function setClawReturnUrl(modelId: string): Promise<void> {
+  await setPaymentReturnUrl(`/claw?model=${encodeURIComponent(modelId)}`);
+}

--- a/src/app/(app)/claw/components/CreditsNudge.actions.ts
+++ b/src/app/(app)/claw/components/CreditsNudge.actions.ts
@@ -4,5 +4,5 @@ import 'server-only';
 import { setPaymentReturnUrl } from '@/lib/payment-return-url';
 
 export async function setClawReturnUrl(modelId: string): Promise<void> {
-  await setPaymentReturnUrl(`/claw?model=${encodeURIComponent(modelId)}`);
+  await setPaymentReturnUrl(`/claw?model=${encodeURIComponent(modelId)}&payment=success`);
 }

--- a/src/app/(app)/claw/components/CreditsNudge.tsx
+++ b/src/app/(app)/claw/components/CreditsNudge.tsx
@@ -94,7 +94,7 @@ export function CreditsNudge({
         className="w-full py-5"
       >
         <Gift className="h-4 w-4" />
-        Use the free model instead
+        Use the Kilo Auto: Free model instead
       </Button>
     </div>
   );

--- a/src/app/(app)/claw/components/CreditsNudge.tsx
+++ b/src/app/(app)/claw/components/CreditsNudge.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+import { CreditCard, Gift, TriangleAlert } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { setClawReturnUrl } from './CreditsNudge.actions';
+
+const AMOUNT_OPTIONS = [10, 20, 50] as const;
+
+export function CreditsNudge({
+  selectedModel,
+  onSwitchToFree,
+}: {
+  selectedModel: string;
+  onSwitchToFree: () => void;
+}) {
+  const [selectedAmount, setSelectedAmount] = useState<number>(10);
+  const [isPending, startTransition] = useTransition();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  function handlePurchase() {
+    startTransition(async () => {
+      await setClawReturnUrl(selectedModel);
+      formRef.current?.submit();
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-4">
+      <div className="mb-1 flex items-center gap-2">
+        <TriangleAlert className="h-5 w-5 shrink-0 text-yellow-400" />
+        <span className="text-sm font-bold">You need credits to use this model</span>
+      </div>
+      <p className="text-muted-foreground mb-4 text-sm">
+        Add a small balance and your bot will be ready to go.
+      </p>
+
+      {/* Amount selector */}
+      <div className="mb-3 grid grid-cols-3 gap-2">
+        {AMOUNT_OPTIONS.map(amount => (
+          <button
+            key={amount}
+            type="button"
+            disabled={isPending}
+            onClick={() => setSelectedAmount(amount)}
+            className={cn(
+              'rounded-lg border py-2.5 text-sm font-medium transition-colors',
+              amount === selectedAmount
+                ? 'border-blue-500 bg-blue-500/10 text-blue-300'
+                : 'border-border bg-background hover:bg-accent'
+            )}
+          >
+            ${amount}
+          </button>
+        ))}
+      </div>
+
+      {/* Hidden form for POST to /payments/topup */}
+      <form
+        ref={formRef}
+        action={`/payments/topup?amount=${selectedAmount}`}
+        method="post"
+        className="hidden"
+      />
+
+      {/* Purchase CTA */}
+      <Button
+        type="button"
+        onClick={handlePurchase}
+        disabled={isPending}
+        className="w-full bg-emerald-600 py-5 text-white hover:bg-emerald-700"
+      >
+        <CreditCard className="h-4 w-4" />
+        {isPending ? 'Redirecting...' : `Add $${selectedAmount} & get started`}
+      </Button>
+
+      {/* Divider */}
+      <div className="my-3 flex items-center gap-3">
+        <hr className="grow opacity-30" />
+        <span className="text-muted-foreground text-xs">or</span>
+        <hr className="grow opacity-30" />
+      </div>
+
+      {/* Free model fallback */}
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onSwitchToFree}
+        disabled={isPending}
+        className="w-full py-5"
+      >
+        <Gift className="h-4 w-4" />
+        Use the free model instead
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(app)/claw/components/CreditsNudge.tsx
+++ b/src/app/(app)/claw/components/CreditsNudge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, useTransition } from 'react';
+import { useRef, useState } from 'react';
 import { CreditCard, Gift, TriangleAlert } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -16,14 +16,17 @@ export function CreditsNudge({
   onSwitchToFree: () => void;
 }) {
   const [selectedAmount, setSelectedAmount] = useState<number>(10);
-  const [isPending, startTransition] = useTransition();
+  // Plain boolean that stays true once set — the form submit navigates
+  // away, so we never need to reset it. Using useTransition would flicker
+  // because submitting resets when the server action finishes, before the
+  // browser has actually navigated.
+  const [submitting, setSubmitting] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
 
-  function handlePurchase() {
-    startTransition(async () => {
-      await setClawReturnUrl(selectedModel);
-      formRef.current?.submit();
-    });
+  async function handlePurchase() {
+    setSubmitting(true);
+    await setClawReturnUrl(selectedModel);
+    formRef.current?.submit();
   }
 
   return (
@@ -42,7 +45,7 @@ export function CreditsNudge({
           <button
             key={amount}
             type="button"
-            disabled={isPending}
+            disabled={submitting}
             onClick={() => setSelectedAmount(amount)}
             className={cn(
               'rounded-lg border py-2.5 text-sm font-medium transition-colors',
@@ -68,11 +71,11 @@ export function CreditsNudge({
       <Button
         type="button"
         onClick={handlePurchase}
-        disabled={isPending}
+        disabled={submitting}
         className="w-full bg-emerald-600 py-5 text-white hover:bg-emerald-700"
       >
         <CreditCard className="h-4 w-4" />
-        {isPending ? 'Redirecting...' : `Add $${selectedAmount} & get started`}
+        {submitting ? 'Redirecting...' : `Add $${selectedAmount} & get started`}
       </Button>
 
       {/* Divider */}
@@ -87,7 +90,7 @@ export function CreditsNudge({
         type="button"
         variant="outline"
         onClick={onSwitchToFree}
-        disabled={isPending}
+        disabled={submitting}
         className="w-full py-5"
       >
         <Gift className="h-4 w-4" />

--- a/src/app/(app)/claw/components/CreditsNudge.tsx
+++ b/src/app/(app)/claw/components/CreditsNudge.tsx
@@ -62,7 +62,7 @@ export function CreditsNudge({
       {/* Hidden form for POST to /payments/topup */}
       <form
         ref={formRef}
-        action={`/payments/topup?amount=${selectedAmount}`}
+        action={`/payments/topup?amount=${selectedAmount}&cancel-path=${encodeURIComponent('/claw')}`}
         method="post"
         className="hidden"
       />

--- a/src/app/payments/topup/route.ts
+++ b/src/app/payments/topup/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { getStripeTopUpCheckoutUrl } from '@/lib/stripe';
 import { MAXIMUM_TOP_UP_AMOUNT, MINIMUM_TOP_UP_AMOUNT } from '@/lib/constants';
+import { isValidReturnUrl } from '@/lib/payment-return-url';
 import { captureException } from '@sentry/nextjs';
 import { getOrCreateStripeCustomerIdForOrganization } from '@/lib/organizations/organization-billing';
 
@@ -67,12 +68,16 @@ export async function POST(request: NextRequest): Promise<NextResponse<unknown>>
       await getOrCreateStripeCustomerIdForOrganization(organizationId)
     : currentUser.stripe_customer_id;
 
+  const cancelPathRaw = searchParams.get('cancel-path');
+  const cancelPath = cancelPathRaw && isValidReturnUrl(cancelPathRaw) ? cancelPathRaw : null;
+
   const url = await getStripeTopUpCheckoutUrl(
     currentUser.id,
     stripeCustomerId,
     validationResult.amount as number,
     origin,
-    organizationId
+    organizationId,
+    cancelPath
   );
 
   if (!url) {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -993,7 +993,9 @@ export async function getStripeTopUpCheckoutUrl(
   stripeCustomerId: User['stripe_customer_id'],
   amount: number,
   origin: string = 'web',
-  organizationId?: string | null
+  organizationId?: string | null,
+  /** Optional internal path to redirect to when the user cancels checkout. */
+  cancelPath?: string | null
 ): Promise<string | null> {
   const line_items = amount
     ? [
@@ -1016,9 +1018,13 @@ export async function getStripeTopUpCheckoutUrl(
       ];
 
   const isOrganizationTopUp = Boolean(organizationId);
-  let cancelUrl = `${APP_URL}/profile?payment_status=topup_cancelled&origin=${origin}`;
-  if (isOrganizationTopUp) {
+  let cancelUrl: string;
+  if (cancelPath) {
+    cancelUrl = `${APP_URL}${cancelPath}`;
+  } else if (isOrganizationTopUp) {
     cancelUrl = `${APP_URL}/organizations/${organizationId}?${TOPUP_CANCELED_QUERY_STRING_KEY}=true`;
+  } else {
+    cancelUrl = `${APP_URL}/profile?payment_status=topup_cancelled&origin=${origin}`;
   }
 
   const rewardfulReferral = await getRewardfulReferral();


### PR DESCRIPTION
## Summary

- When a user without credits selects a paid model during KiloClaw onboarding, an inline credit purchase nudge now appears below the model picker. It offers preset amounts ($10, $20, $50), a Stripe checkout CTA, and a "Use the free model instead" fallback.
- After completing payment, the user is automatically redirected back to `/claw` with their model selection preserved via the existing `payment-return-url` cookie mechanism, a success toast is shown, and provisioning starts automatically.
- Free model detection uses the shared `isFreeModel()` helper, so selecting any free model (not just Kilo Auto: Free) from the 500+ dropdown also hides the nudge.

## Verification

- [x] `pnpm typecheck` — passes across all packages
- [x] `pnpm format:check` (oxfmt) — passes
- [x] `pnpm lint` — passes (oxlint + eslint)

## Visual Changes

https://github.com/user-attachments/assets/af69ed1b-46ec-4b50-8a02-8d0549216ec5

## Reviewer Notes

- The Stripe cancel URL still redirects to `/profile` (hardcoded in `getStripeTopUpCheckoutUrl`). A follow-up could pass a custom cancel URL so users return to `/claw` on cancellation too.
- The auto-provision effect uses a `useRef` guard (`hasAutoProvisioned`) to prevent double-firing in React strict mode or on re-renders.