### PR TITLE
fix(admin-omnibox): point Admin Panel link to /admin/users

### DIFF
--- a/src/components/admin-omnibox/action-registry.ts
+++ b/src/components/admin-omnibox/action-registry.ts
@@ -78,7 +78,7 @@ export const createRoleTestingGroup = (
 export const createAdminLinks = (): OmniboxAdminLink[] => [
   {
     label: 'Admin Panel',
-    href: '/admin/organizations',
+    href: '/admin/users',
     icon: Building2,
   },
   {


### PR DESCRIPTION
## Summary

The "Admin Panel" link in the admin omnibox pointed to `/admin/organizations`, which was inconsistent with the admin root page (`/admin`) that redirects to `/admin/users`. This change updates the omnibox link to `/admin/users` so the entry point is consistent regardless of how the admin navigates there.

## Verification

- Reviewed the diff: single-line href change in `src/components/admin-omnibox/action-registry.ts:81`
- Confirmed `/admin/users` is a valid, widely-used route (37+ references across the codebase)
- Confirmed `/admin/page.tsx` already redirects to `/admin/users`, validating this as the correct default admin landing page
- No quality gates configured for this repo

## Visual Changes

N/A

## Reviewer Notes

- The `icon: Building2` on the "Admin Panel" link may be slightly misleading for a users-focused page, but that's pre-existing and outside the scope of this fix.