### PR TITLE
fix(gastown): add dispatch attempt limit and cooldown to refinery re-dispatch (Rule 6)

### DIFF
--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -368,12 +368,20 @@ async function handleIdleEvent(agent: ManagedAgent, onExit: () => void): Promise
     return;
   }
 
-  // No nudges (or fetch error) — (re)start the idle timeout
+  // No nudges (or fetch error) — (re)start the idle timeout.
+  // Refineries get a longer timeout because their workflow is multi-step
+  // (diff → analyze → decide → merge/rework). The 2-min default kills the
+  // session between LLM turns when the refinery responds with text before
+  // issuing a tool call. See #1342.
   clearIdleTimer(agentId);
   const timeoutMs =
-    process.env.AGENT_IDLE_TIMEOUT_MS !== undefined
-      ? Number(process.env.AGENT_IDLE_TIMEOUT_MS)
-      : 120_000;
+    agent.role === 'refinery'
+      ? process.env.REFINERY_IDLE_TIMEOUT_MS !== undefined
+        ? Number(process.env.REFINERY_IDLE_TIMEOUT_MS)
+        : 600_000
+      : process.env.AGENT_IDLE_TIMEOUT_MS !== undefined
+        ? Number(process.env.AGENT_IDLE_TIMEOUT_MS)
+        : 120_000;
 
   console.log(
     `${MANAGER_LOG} handleIdleEvent: no nudges for ${agentId}, idle timeout in ${timeoutMs}ms`

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1103,6 +1103,24 @@ export class TownDO extends DurableObject<Env> {
     this.broadcastAgentStatus(agentId, message);
   }
 
+  /** Test-only: directly set dispatch_attempts (and optionally last_activity_at) for an agent. */
+  async setAgentDispatchAttempts(
+    agentId: string,
+    attempts: number,
+    lastActivityAt?: string
+  ): Promise<void> {
+    query(
+      this.sql,
+      /* sql */ `
+        UPDATE ${agent_metadata}
+        SET ${agent_metadata.columns.dispatch_attempts} = ?,
+            ${agent_metadata.columns.last_activity_at} = COALESCE(?, ${agent_metadata.columns.last_activity_at})
+        WHERE ${agent_metadata.bead_id} = ?
+      `,
+      [attempts, lastActivityAt ?? null, agentId]
+    );
+  }
+
   // ══════════════════════════════════════════════════════════════════
   // Mail
   // ══════════════════════════════════════════════════════════════════

--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -969,6 +969,27 @@ export function reconcileReviewQueue(sql: SqlStorage): Action[] {
   for (const ref of idleRefineries) {
     if (!ref.current_hook_bead_id) continue;
 
+    // Cooldown: skip if last activity is too recent (#1342)
+    if (!staleMs(ref.last_activity_at, DISPATCH_COOLDOWN_MS)) continue;
+
+    // Circuit-breaker: fail the MR bead after too many attempts (#1342)
+    if (ref.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS) {
+      actions.push({
+        type: 'transition_bead',
+        bead_id: ref.current_hook_bead_id,
+        from: null,
+        to: 'failed',
+        reason: 'refinery max dispatch attempts exceeded',
+        actor: 'system',
+      });
+      actions.push({
+        type: 'unhook_agent',
+        agent_id: ref.bead_id,
+        reason: 'max dispatch attempts',
+      });
+      continue;
+    }
+
     const mrRows = z
       .object({ status: z.string(), type: z.string(), rig_id: z.string().nullable() })
       .array()

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -722,13 +722,20 @@ export function agentCompleted(
     }
   }
 
-  // Mark agent idle
+  // Mark agent idle.
+  // For refineries, preserve dispatch_attempts so Rule 6's circuit-breaker
+  // can track cumulative re-dispatch attempts across idle→dispatch cycles.
+  // Resetting to 0 here was enabling infinite loops (#1342). Non-refineries
+  // reset to 0 because they unhook above and get a fresh counter on hookBead.
   query(
     sql,
     /* sql */ `
       UPDATE ${agent_metadata}
       SET ${agent_metadata.columns.status} = 'idle',
-          ${agent_metadata.columns.dispatch_attempts} = 0
+          ${agent_metadata.columns.dispatch_attempts} = CASE
+            WHEN ${agent_metadata.columns.role} = 'refinery' THEN ${agent_metadata.columns.dispatch_attempts}
+            ELSE 0
+          END
       WHERE ${agent_metadata.bead_id} = ?
     `,
     [agentId]

--- a/cloudflare-gastown/src/dos/town/scheduling.ts
+++ b/cloudflare-gastown/src/dos/town/scheduling.ts
@@ -133,16 +133,21 @@ export async function dispatchAgent(
     });
 
     if (started) {
-      // Best-effort: may be dropped if I/O gate is closed
-      query(
-        ctx.sql,
-        /* sql */ `
-          UPDATE ${agent_metadata}
-          SET ${agent_metadata.columns.dispatch_attempts} = 0
-          WHERE ${agent_metadata.bead_id} = ?
-        `,
-        [agent.id]
-      );
+      // Reset dispatch_attempts on successful start — but NOT for refineries.
+      // Refineries can loop (idle-timeout → re-dispatch) many times on the
+      // same MR bead, so we keep the counter monotonically increasing until
+      // the bead is closed or the agent hooks a new bead (#1342).
+      if (agent.role !== 'refinery') {
+        query(
+          ctx.sql,
+          /* sql */ `
+            UPDATE ${agent_metadata}
+            SET ${agent_metadata.columns.dispatch_attempts} = 0
+            WHERE ${agent_metadata.bead_id} = ?
+          `,
+          [agent.id]
+        );
+      }
       console.log(`${LOG} dispatchAgent: started agent=${agent.name}(${agent.id})`);
       ctx.emitEvent({
         event: 'agent.spawned',

--- a/cloudflare-gastown/test/integration/reconciler.test.ts
+++ b/cloudflare-gastown/test/integration/reconciler.test.ts
@@ -214,6 +214,67 @@ describe('Reconciler', () => {
     });
   });
 
+  // ── reconcileReviewQueue Rule 6: Refinery re-dispatch limits (#1342) ─
+
+  describe('reconcileReviewQueue Rule 6: refinery re-dispatch limits', () => {
+    it('should fail MR bead after refinery exceeds max dispatch attempts', async () => {
+      const result = await town.slingConvoy({
+        rigId: 'rig-1',
+        convoyTitle: 'Rule 6 limit test',
+        tasks: [{ title: 'Dispatch limit test' }],
+      });
+
+      const beadId = result.beads[0].bead.bead_id;
+
+      // Assign agent and dispatch
+      await runDurableObjectAlarm(town);
+
+      const assigned = await town.getBeadAsync(beadId);
+      const agentId = assigned?.assignee_agent_bead_id!;
+      expect(agentId).toBeTruthy();
+
+      // Agent finishes work → creates MR bead
+      await town.agentDone(agentId, {
+        branch: 'gt/polecat/test-rule6',
+        summary: 'Ready for review',
+      });
+      await runDurableObjectAlarm(town);
+
+      // Find the MR bead and its refinery
+      const mrBeads = await town.listBeads({ type: 'merge_request' });
+      const mrBead = mrBeads.find(b => b.metadata?.source_bead_id === beadId);
+      expect(mrBead).toBeTruthy();
+
+      // Run alarm to dispatch the refinery
+      await runDurableObjectAlarm(town);
+
+      const refineries = await town.listAgents({ role: 'refinery' });
+      expect(refineries.length).toBeGreaterThan(0);
+      const refinery = refineries[0];
+
+      // Simulate repeated idle→re-dispatch cycles by setting dispatch_attempts
+      // past the limit (MAX_DISPATCH_ATTEMPTS = 20) and backdating last_activity_at
+      // so the DISPATCH_COOLDOWN_MS check passes.
+      const pastTimestamp = new Date(Date.now() - 5 * 60_000).toISOString();
+      await town.setAgentDispatchAttempts(refinery.id, 25, pastTimestamp);
+
+      // Set agent to idle (simulating agentCompleted) and ensure MR is in_progress
+      await town.updateAgentStatus(refinery.id, 'idle');
+      const mrBefore = await town.getBeadAsync(mrBead!.bead_id);
+      expect(mrBefore?.status).toBe('in_progress');
+
+      // Run alarm — Rule 6 should see dispatch_attempts >= 20 and fail the MR bead
+      await runDurableObjectAlarm(town);
+
+      const mrAfter = await town.getBeadAsync(mrBead!.bead_id);
+      expect(mrAfter?.status).toBe('failed');
+
+      // Refinery should be unhooked
+      const refineryAfter = await town.getAgentAsync(refinery.id);
+      expect(refineryAfter?.current_hook_bead_id).toBeNull();
+    });
+  });
+
   // ── reconcileConvoys: Auto-close ────────────────────────────────────
 
   describe('reconcileConvoys: progress and auto-close', () => {


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that caused the refinery to enter an infinite review loop on MR beads (52+ dispatch attempts observed on bead `4395c769` in town `be5bb063`):

1. **Idle timer kills refinery between LLM turns** — The 2-minute default idle timeout fires when the refinery responds with text (no tool call). Extended to 10 minutes for refineries via `REFINERY_IDLE_TIMEOUT_MS` (configurable).

2. **Rule 6 has no dispatch limits** — `reconcileReviewQueue` Rule 6 (idle refinery hooked to in-progress MR → re-dispatch) had no `DISPATCH_COOLDOWN_MS` or `MAX_DISPATCH_ATTEMPTS` checks, unlike Rule 2. Now applies both guards; exceeding the limit fails the MR bead and unhooks the refinery.

3. **`dispatch_attempts` counter reset on every cycle** — `agentCompleted` unconditionally reset `dispatch_attempts` to 0 when marking the agent idle, and `dispatchAgent` reset to 0 on successful container start. Both resets made the `MAX_DISPATCH_ATTEMPTS` circuit-breaker ineffective for refineries. Now preserved for refineries across idle→dispatch cycles (only reset on new bead hook via `hookBead`).

## Verification

- [x] `pnpm typecheck` — passes (all workspace packages)
- [x] `pnpm test` (unit tests) — 118/118 pass
- [x] `pnpm test:integration` — 96/120 pass (same 10 pre-existing failures as main, 0 new)
- [x] New integration test for Rule 6 dispatch limits passes (`reconciler.test.ts`)
- [x] `pnpm oxfmt --list-different .` — no formatting issues
- [x] Pre-push hooks (format, lint, typecheck) — all pass

## Visual Changes

N/A

## Reviewer Notes

- The `setAgentDispatchAttempts` RPC method on `TownDO` is test-only infrastructure for setting up the Rule 6 circuit-breaker test scenario.
- The `dispatch_attempts` counter increments in two places per dispatch cycle (`actions.ts` line 515 and `scheduling.ts` line 107). With `MAX_DISPATCH_ATTEMPTS = 20`, this gives ~10 full dispatch cycles before the circuit-breaker trips — reasonable for transient failures.
- Part C of the issue (investigate `agentCompleted('failed')` bead reset for refineries) was analyzed: the refinery path in `agentCompleted` is correctly a no-op on the bead. The earlier `in_progress → open` cycling seen in production logs was likely Rule 3 ("abandoned MR", 2-min timeout) firing in the gap between `agentCompleted` and Rule 6 re-dispatch. The cooldown guard added here prevents that race.

Closes #1342