### PR TITLE
feat(billing): replace coupon with intro pricing and enable promo codes

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -4,6 +4,7 @@
 
 Draft -- generated from branch `jdp/kiloclaw-billing` on 2026-03-13.
 Updated 2026-03-19 -- pricing and trial duration changes.
+Updated 2026-03-20 -- promotional codes and introductory pricing.
 
 ## Conventions
 
@@ -41,6 +42,21 @@ lapses, with email notifications at each stage.
    MUST NOT independently validate or enforce specific price amounts.
 7. The system MUST fail with an error at checkout time if a required
    plan price identifier is not configured.
+
+### Standard Plan Introductory Pricing
+
+1. New standard plan subscribers who do not have a prior canceled
+   subscription MUST receive an introductory price for their first
+   billing period. Returning subscribers with a previously canceled
+   subscription MUST receive the regular standard price.
+2. The system MUST automatically transition introductory-price
+   subscribers to the regular standard price at the end of the
+   introductory billing period.
+3. The automatic price transition MUST be transparent to the user: it
+   MUST NOT appear as a pending plan switch in billing status and MUST
+   NOT prevent the user from initiating a plan switch or canceling.
+4. Failure to set up the automatic price transition during subscription
+   creation MUST NOT block checkout completion.
 
 ### Trial Eligibility and Creation
 
@@ -85,9 +101,11 @@ lapses, with email notifications at each stage.
    customer before creating a new checkout session, to guard against
    concurrent checkouts. This check does not cover provider-side
    subscriptions in past-due status.
-4. The system MUST NOT allow promotional codes for either plan.
-5. The system MUST apply a provider-configured first-month discount
-   coupon when creating a standard plan checkout session.
+4. The system MUST allow promotional codes on checkout for both plans.
+5. For standard plan checkout, the system MUST use the introductory
+   price when the user has no prior canceled subscription, and the
+   regular price when the user has a previously canceled subscription
+   (see Standard Plan Introductory Pricing).
 6. When a configurable billing start date is set and is in the future,
    the system MUST create the subscription with a delayed billing period
    that begins on that date.
@@ -145,6 +163,15 @@ lapses, with email notifications at each stage.
    the commit-period end date to six calendar months from the
    transition date.
 8. The system MUST allow cancellation of user-initiated plan switches.
+9. The system MUST reject a plan switch if a user-initiated plan switch
+   is already pending.
+10. If an automatic price transition is pending when the user requests a
+    plan switch, the system MUST replace the automatic transition with
+    the user's requested switch.
+11. After canceling a user-initiated plan switch, if the subscription is
+    still on the introductory price, the system MUST restore the
+    automatic price transition. Failure to restore the transition MUST
+    NOT prevent the switch cancellation from succeeding.
 
 ### Cancellation and Reactivation
 
@@ -152,14 +179,19 @@ lapses, with email notifications at each stage.
    subscription with a payment provider ID exists.
 2. The system MUST reject a cancellation request if cancellation is
    already pending.
-3. When canceling a subscription that has a pending schedule, the system
-   MUST release the schedule before setting the cancel-at-period-end
-   flag.
+3. When canceling a subscription that has a pending schedule — whether
+   a user-initiated plan switch or an automatic price transition — the
+   system MUST release the schedule before setting the
+   cancel-at-period-end flag.
 4. Cancellation MUST NOT terminate access immediately; access MUST
    continue until the current billing period ends.
 5. The system MUST allow reactivation of a subscription that is pending
    cancellation.
 6. On reactivation, the system MUST clear the cancel-at-period-end flag.
+7. On reactivation, if the subscription is still on the introductory
+   price, the system MUST restore the automatic price transition.
+   Failure to restore the transition MUST NOT prevent the reactivation
+   from succeeding.
 
 ### Billing Lifecycle Background Job
 
@@ -169,6 +201,9 @@ lapses, with email notifications at each stage.
 2. Each sweep in the background job MUST process users independently;
    a failure for one user MUST NOT prevent processing of other users.
 3. All errors during sweep processing MUST be captured for monitoring.
+4. The background job MUST detect active subscriptions on the
+   introductory price that have no automatic price transition pending
+   and MUST set up the missing transition.
 
 ### Trial Expiry Warnings
 
@@ -298,6 +333,19 @@ lapses, with email notifications at each stage.
    notification log entries for that user.
 
 ### Changelog
+
+#### 2026-03-20 -- Promotional codes and introductory pricing
+
+Previous values:
+
+- Standard plan first-month discount: coupon applied at checkout
+- Promotional codes: not allowed on either plan
+
+New values:
+
+- Standard plan first-month discount: introductory price with automatic
+  transition to regular price at period end
+- Promotional codes: allowed on both plans at checkout
 
 #### 2026-03-19 -- Pricing and trial changes
 

--- a/plans/kiloclaw-billing-promo-codes.md
+++ b/plans/kiloclaw-billing-promo-codes.md
@@ -1,0 +1,312 @@
+# Rewardful Promo Codes for KiloClaw Checkout
+
+## Goal
+
+Enable Rewardful affiliate promo code entry on Stripe-hosted checkout for both KiloClaw plans. Preserve the automated $4 first month for new Standard subscribers by encoding it as an intro Stripe Price rather than a coupon, avoiding the `discounts` / `allow_promotion_codes` mutual exclusivity.
+
+## Background
+
+Stripe Checkout's `discounts` parameter (used today for the Standard first-month coupon) and `allow_promotion_codes` are mutually exclusive on a session. The intro-price approach eliminates the coupon entirely, freeing `allow_promotion_codes` for Rewardful promo codes on all checkouts.
+
+No DB schema migration is needed — `scheduled_by = 'auto'` already exists in `packages/db/src/schema-types.ts:133`.
+
+## Step 1: Stripe Configuration (Manual, Pre-Deploy)
+
+- Create a new Stripe Price on the Standard product: **$4/month**, recurring monthly. This is the **intro price**.
+- Set the new price ID in env var `STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID`.
+- Existing `STRIPE_KILOCLAW_STANDARD_PRICE_ID` remains as the regular $9/month price.
+- Configure Rewardful campaign promotion codes to be valid on all KiloClaw price IDs (intro, regular, commit).
+- **Promo discount duration**: Verify that all Rewardful promo codes are configured in Stripe as **one-time** (or first-invoice-only) discounts, not recurring. The auto intro→standard schedule rewrite (Step 4) and `switchPlan` schedule rewrite (Step 7) specify only `items: [{ price: ... }]` and timing fields in phase definitions — any active `discounts` on the subscription are not carried into the rewritten phases. If recurring promo discounts are needed in the future, Steps 4 and 7 must be updated to read and forward `discounts` from the current phase into both phases of the rewritten schedule.
+- `STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID` can be removed from environment after deploy.
+
+## Step 2: Config & Price ID Module
+
+### `src/lib/config.server.ts`
+
+- Add `STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID` export.
+- Remove `STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID` export (line 186–188).
+
+### `src/lib/kiloclaw/stripe-price-ids.server.ts`
+
+- Add the intro price to `getPriceIdMetadata()` mapping it to `'standard'`. Both intro and regular prices resolve to `plan = 'standard'`. This means `detectPlanFromSubscription` in `stripe-handlers.ts:59` works without changes.
+- Add a new export `getStripePriceIdForClawPlanIntro(plan)` that returns the intro price for `'standard'` and falls through to the regular price for `'commit'` (commit has no intro).
+- Add a new export `isIntroPriceId(priceId: string): boolean` for use in reactivation/switch logic.
+
+### `src/lib/kiloclaw/stripe-invoice-classifier.server.ts`
+
+No code changes needed. `getKnownStripePriceIdsForKiloClaw()` already returns all keys from `getPriceIdMetadata()`, so the intro price is automatically included.
+
+## Step 3: Checkout Flow — `src/routers/kiloclaw-router.ts`
+
+In `createSubscriptionCheckout` (line 1152):
+
+- Remove the `shouldApplyStandardPlanDiscount` / `standardPlanDiscount` / `discounts` logic (lines 1223–1238).
+- Remove the import of the coupon config constant.
+- Add `allow_promotion_codes: true` to the checkout session params for **both** plans.
+- Price selection: for new Standard subscribers (`input.plan === 'standard'` and `existing?.status !== 'canceled'`), use the intro price via `getStripePriceIdForClawPlanIntro('standard')`. For returning canceled Standard subscribers and all Commit subscribers, use `getStripePriceIdForClawPlan(input.plan)` (regular price).
+
+## Step 4: Shared Helper & Auto-Schedule Creation
+
+### `ensureAutoIntroSchedule` helper — `src/lib/kiloclaw/stripe-handlers.ts`
+
+Extract a shared idempotent helper that Steps 4, 6, and 8 all call. This helper encapsulates schedule creation, the idempotency guard, and partial-failure semantics in one place.
+
+Signature: `ensureAutoIntroSchedule(stripeSubscriptionId: string, userId: string): Promise<void>`
+
+Behavior:
+
+1. **Live Stripe fetch** (single source of truth): Call `stripe.subscriptions.retrieve(stripeSubscriptionId)`. This is the authoritative check — all subsequent decisions derive from this response, including both the price gate and the schedule-existence check.
+2. **Price gate**: Read `items.data[0].price.id` from the live fetch and check via `isIntroPriceId()`. If the subscription is **not** on the intro price, no-op and return. This prevents creating an intro-anchored schedule on a subscription that has already rolled to the regular price, even if the caller's earlier check (webhook payload, prior retrieve) said otherwise.
+3. **Schedule already attached in Stripe**: If the live subscription's `.schedule` is non-null, the schedule already exists. Retrieve it via `subscriptionSchedules.retrieve` and check `metadata.origin`. If it equals `'auto-intro'`, persist the schedule ID with `scheduled_by: 'auto'`, `scheduled_plan: 'standard'` on the DB row (in case the DB is stale or was never written) and return. If the metadata does not match (e.g., it is a user-initiated switch schedule), **do not relabel it** — log a warning and return without persisting. This prevents a retried `subscription.created` or a race between `cancelPlanSwitch` and a concurrent `switchPlan` from converting a user schedule into an auto schedule, which would hide the "Cancel Switch" button (since `SubscriptionCard.tsx:35` checks `scheduledBy === 'user'`) and cause `cancelPlanSwitch` to reject the cancel.
+4. **DB reconciliation**: Read the row's `stripe_schedule_id`. If it is set but Stripe says `.schedule` is null (stale local pointer — e.g., a prior cancel released the Stripe schedule but DB clear failed), clear the stale pointer before proceeding. Do **not** early-return based on the DB value alone.
+5. **Create the 2-phase schedule**:
+   - `subscriptionSchedules.create({ from_subscription: stripeSubscriptionId })`
+   - Read the current phase from the newly created schedule. Use its existing price (as set by `from_subscription`) for phase 1 — do **not** hardcode the intro price ID. `from_subscription` mirrors the subscription's current state, so if the subscription is still on the intro price (confirmed by step 2), phase 1 will naturally use it. Copy `start_date` and `end_date` from the current phase.
+   - Set phase 2 = regular Standard price, open-ended with `end_behavior: 'release'`.
+   - **Schedule metadata**: Set `metadata: { origin: 'auto-intro' }` on the schedule at creation time. This tag is the authoritative marker for distinguishing auto schedules from user schedules — all classification logic (Steps 4, 7, 8) checks `metadata.origin === 'auto-intro'` instead of inferring origin from phase structure. Stripe subscription schedules support arbitrary metadata.
+   - **Discount passthrough**: Phase definitions do not carry forward subscription-level discounts. This is safe because Rewardful promo codes are configured as one-time discounts (see Step 1). If this assumption changes, both phases must explicitly forward `discounts` from the current phase.
+6. **Race guard**: If `subscriptionSchedules.create` throws because a schedule was attached between the fetch and the create call (narrow race), catch the error, live-fetch the subscription again, persist the existing schedule ID, and return.
+7. **Persist** `stripe_schedule_id`, `scheduled_plan: 'standard'`, `scheduled_by: 'auto'` on the DB row.
+
+The helper is idempotent: calling it multiple times for the same subscription produces the same result. The live Stripe fetch is the single source of truth — neither stale webhook payloads nor stale DB pointers can cause incorrect schedule creation.
+
+### Failure modes
+
+The helper can fail at two points with distinct consequences:
+
+- **Before Stripe schedule creation** (steps 1–4): No Stripe-side state was created. The subscription remains on the intro price with no schedule. Callers can safely retry by re-invoking the helper.
+- **After Stripe schedule creation but before DB persist** (between steps 5 and 7): A Stripe schedule exists but the DB has no `stripe_schedule_id` pointer. This is the **hidden-schedule state**. The helper handles this on re-invocation (step 3 persists the existing schedule ID). However, other router flows that key off the DB pointer (`cancelSubscription`, `switchPlan`) must also handle this state — see Steps 5 and 7.
+
+### Webhook invocation — `src/lib/kiloclaw/stripe-handlers.ts`
+
+In `handleKiloClawSubscriptionCreated` (line 140), after the upsert at line 223:
+
+- **Stale-event guard**: The existing stale-subscription guard at line 181 `return`s from inside the transaction callback, not from the outer function — post-transaction work (like `autoResumeIfSuspended`) still executes. Follow the existing `wasSuspended` pattern: declare a `let didProcess = false` before the transaction, set `didProcess = true` after the upsert inside the transaction (but inside the non-stale branch), and gate the `ensureAutoIntroSchedule` call on `didProcess`. Without this, a retried/stale `subscription.created` carrying an old subscription ID would cause the helper to live-fetch and schedule against the wrong subscription, then persist that schedule ID to the user's current DB row.
+- Call `ensureAutoIntroSchedule(subscription.id, kiloUserId)` only when `didProcess` is true. The helper performs its own live price check internally, so the caller does not need to pre-check the price. The stale webhook payload (`event.data.object`) is used only for the DB upsert; the helper fetches live state from Stripe.
+
+Update the handler's doc comment (line 134) to reflect that it now creates auto intro→regular schedules, not just persisting subscription data.
+
+## Step 5: Cancel Flow — `src/routers/kiloclaw-router.ts`
+
+The current `cancelSubscription` (line 1264) releases any schedule when `sub.stripe_schedule_id` is set (line 1285), then sets `cancel_at_period_end`. This works for all cases where the DB pointer is accurate. However, after this change, the **hidden-schedule state** is possible (Stripe has an attached schedule but the DB pointer is null — see Step 4 failure modes).
+
+Add a reconciliation step before the existing schedule-release logic: live-fetch the subscription (`stripe.subscriptions.retrieve`) and check `.schedule`. If Stripe has an attached schedule but `sub.stripe_schedule_id` is null, release the Stripe schedule before proceeding. Cancel always releases any attached schedule regardless of origin (auto or user), so no phase inspection is needed here — this is safe for both hidden auto schedules and hidden user schedules.
+
+The existing defensive try/catch at lines 1285–1306 already handles already-released schedules, so the reconciliation only needs to fill in the missing schedule ID for the release call. The rest of the cancel flow (setting `cancel_at_period_end`, clearing DB fields) remains unchanged.
+
+## Step 6: Reactivation Flow — `src/routers/kiloclaw-router.ts`
+
+In `reactivateSubscription` (line 1328), after unsetting `cancel_at_period_end`:
+
+- Call `ensureAutoIntroSchedule(sub.stripe_subscription_id, ctx.user.id)`. The helper performs its own live price check — if the subscription has already rolled to the regular price, it no-ops. No external price check needed.
+
+### Partial-failure recovery
+
+The primary operation — unsetting `cancel_at_period_end` in Stripe (line 1342) — has already succeeded before the schedule recreation attempt. If `ensureAutoIntroSchedule` throws, the mutation should **log the error but not throw to the caller**. The user's subscription is reactivated (correct), but left in one of two degraded states depending on where the helper failed (see Step 4 failure modes):
+
+- **Before Stripe schedule creation**: intro price, no schedule anywhere. Re-invoking the helper repairs it. The billing lifecycle cron (Step 11) also detects and repairs this state on its next run, so the subscription does not stay stranded indefinitely. Emit a structured log/metric on suppressed failures so ops can monitor frequency.
+- **After Stripe schedule creation but before DB persist**: Stripe has a live schedule but the DB has no pointer (hidden-schedule state). This state is self-healing — the Stripe schedule fires on its own, `subscription.updated` picks up the price change via `detectPlanFromSubscription`, and the `released` event clears tracking fields. The helper also repairs this on re-invocation (step 3 persists the existing schedule ID). Other flows (cancel, switchPlan) handle this via their own live-fetch reconciliation (Steps 5 and 7).
+
+Both states are preferable to failing the entire reactivation.
+
+## Step 7: Switch Plan Flow — `src/routers/kiloclaw-router.ts`
+
+In `switchPlan` (line 1351):
+
+- Remove the hard rejection at line 1373–1377 when `stripe_schedule_id` exists.
+- Replace with: if `scheduled_by === 'user'`, keep the current rejection ("cancel it first"). If `scheduled_by === 'auto'`, attempt to update the existing auto schedule in place.
+
+### Reconciliation for hidden schedules
+
+Before branching on `scheduled_by`, live-fetch the subscription (`stripe.subscriptions.retrieve`) to detect the hidden-schedule state (Stripe has `.schedule` but DB has no `stripe_schedule_id`).
+
+A hidden schedule can originate from either an auto intro→regular creation (Step 4) or a prior user-initiated switchPlan (line 1385–1421) where the DB persist failed after the Stripe schedule was created. These two cases require different handling — blindly rewriting an orphaned user schedule is unsafe because it could discard a user's intended plan switch. To distinguish them, retrieve the hidden schedule from Stripe (`subscriptionSchedules.retrieve`) and check `metadata.origin`:
+
+- **Auto schedule** (`metadata.origin === 'auto-intro'`): Safe to update in place with the new target plan, same as the `scheduled_by === 'auto'` path below.
+- **User schedule or no metadata**: Treat conservatively — release it first (with the defensive try/catch from `cancelSubscription:1285`), then fall through to fresh schedule creation. This is equivalent to the user having manually canceled their prior switch, which is the safest fallback when the intent is ambiguous.
+
+This same live fetch also provides the actual current price ID from `items.data[0].price.id`, which is needed for phase 1 (see below). Do not use `getStripePriceIdForClawPlan(sub.plan)`, which is now ambiguous for Standard (could be intro or regular).
+
+### Updating the auto schedule
+
+Retrieve the schedule from Stripe to get the current phase. Phase 1 must remain byte-for-byte aligned with the current billing period — copy `start_date` and `end_date` from the existing current phase (same pattern as line 1405–1409 in the current user-switch code). Use the current phase's existing price for phase 1 (do not hardcode the intro price). Rewrite phase 2's price to the target plan's price (e.g., commit price). Set `end_behavior: 'release'`.
+
+### Stale schedule handling
+
+Wrap the schedule update in a try/catch mirroring the defensive pattern from `cancelSubscription` at lines 1285–1306. If the auto schedule is already released/canceled/completed (Stripe returns a 400 with "not active"), catch the error, clear the stale local pointer (`stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null`), then fall through to fresh schedule creation via `subscriptionSchedules.create({ from_subscription })`, using the live subscription's current price for phase 1.
+
+After updating or creating the schedule, persist `stripe_schedule_id`, `scheduled_plan: input.toPlan`, `scheduled_by: 'user'`.
+
+## Step 8: Cancel Plan Switch — `src/routers/kiloclaw-router.ts`
+
+In `cancelPlanSwitch` (line 1427):
+
+- Keep the existing check: `scheduled_by !== 'user'` → reject (line 1445). This correctly prevents users from canceling auto schedules directly.
+- **Release the user's schedule**: Wrap the release call (line 1449) in a try/catch mirroring `cancelSubscription`'s defensive pattern at lines 1285–1306. If the schedule is already released/inactive, swallow the error and proceed to clear local state. If it's a genuine failure, throw.
+- Clear the DB schedule fields (existing behavior at line 1450–1452).
+- **Restore auto schedule if on intro price**: Call `ensureAutoIntroSchedule(sub.stripe_subscription_id, ctx.user.id)`. The helper performs its own live price check and schedule-existence check — if the subscription has already rolled to the regular price, it no-ops. No external price check needed.
+
+### Partial-failure recovery
+
+The primary operation — releasing the user's switch schedule — has already succeeded before the auto-schedule restoration attempt. If `ensureAutoIntroSchedule` throws, the mutation should **log the error but not throw to the caller**. The user's switch is canceled (correct), but the subscription is left in one of the two degraded states described in Step 6's partial-failure recovery. The same repair paths apply: the post-create (hidden-schedule) state is self-healing via the Stripe schedule firing on its own, and the pre-create state is repaired by the billing lifecycle cron (Step 11). Emit a structured log/metric on suppressed failures.
+
+## Step 9: Frontend — `src/app/(app)/claw/components/billing/SubscriptionCard.tsx`
+
+At line 98, the current condition `!sub.scheduledPlan` hides the switch button when any schedule exists, including auto. An internal auto schedule would therefore hide "Switch to Commit" unless this changes. Update the button rendering logic so that auto schedules are transparent to the user:
+
+```tsx
+{
+  hasUserRequestedSwitch ? (
+    <Button variant="outline" size="sm" onClick={handleCancelSwitch}>
+      Cancel Switch
+    </Button>
+  ) : (
+    <Button variant="outline" size="sm" onClick={handleSwitchPlan}>
+      Switch to {otherPlan}
+    </Button>
+  );
+}
+```
+
+Since `hasUserRequestedSwitch` is already `sub.scheduledBy === 'user'` (line 35), reaching the else branch means either no schedule or an auto schedule — both cases where the user should be able to initiate a switch.
+
+## Step 10: Schedule Handler — `src/lib/kiloclaw/stripe-handlers.ts`
+
+In `handleKiloClawScheduleEvent` (line 419):
+
+- Update the doc comment to reflect auto intro→regular schedules (no longer "only created by user-initiated plan switches").
+- No behavioral changes needed. The handler already processes `completed`/`released`/`canceled` generically. Auto intro→regular schedules use `end_behavior: 'release'`, so the natural transition fires as `released` (not `completed`), matching the existing behavior documented at line 454–460. On `released`, the handler clears the three schedule tracking fields. The actual plan update (intro → regular Standard) is handled by the `subscription.updated` webhook via `detectPlanFromSubscription` (line 59), which reads the new price from the live subscription. The `completed` branch at line 461 remains as a safety net but is not the primary path for `end_behavior: 'release'` schedules.
+
+## Step 11: Reconciliation Sweep — `src/lib/kiloclaw/billing-lifecycle-cron.ts`
+
+Add a new sweep to `runKiloClawBillingLifecycleCron` that repairs stranded intro-price subscriptions (the pre-create failure mode from Step 4).
+
+**Query**: Find `kiloclaw_subscriptions` rows where:
+
+- `status = 'active'`
+- `stripe_schedule_id IS NULL`
+- `stripe_subscription_id IS NOT NULL`
+- `cancel_at_period_end = false`
+
+For each matching row, call `stripe.subscriptions.retrieve` and check if `isIntroPriceId(items.data[0].price.id)`. If true and `.schedule` is null, call `ensureAutoIntroSchedule`. If false (already on regular price), no action needed — the subscription rolled over naturally or was never on the intro price.
+
+**Frequency**: This runs on the existing cron cadence. The query is lightweight (indexed columns, small result set) and the Stripe calls are bounded by the number of stranded subscriptions (expected to be near zero under normal operation).
+
+**Logging**: Log each repaired subscription as a structured event. Emit a count metric for alerting — a sustained non-zero count indicates a systemic issue with schedule creation in `handleKiloClawSubscriptionCreated`.
+
+## Step 12: Cleanup
+
+- Remove `STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID` from `src/lib/config.server.ts:186–188`.
+- Remove the env var from `src/routers/kiloclaw-billing-router.test.ts:4–5`.
+- Remove the import of the coupon config in `kiloclaw-router.ts`.
+
+## Step 13: Tests — `src/routers/kiloclaw-billing-router.test.ts`
+
+### Test harness updates (required before any new tests)
+
+The existing test file's setup and mocks must be updated for the new exports, or tests will fail during module initialization.
+
+**Env var setup** (top of file, line 1–6):
+
+- Add `process.env.STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID ||= 'price_standard_intro';`
+- Remove `process.env.STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID ||= 'coupon_test_kiloclaw_standard_first_month';` (line 4–5).
+
+**Jest mock for `@/lib/kiloclaw/stripe-price-ids.server`** (line 51–58):
+
+- Add `getStripePriceIdForClawPlanIntro: jest.fn((plan: string) => plan === 'standard' ? 'price_standard_intro' : 'price_commit')` to the mock exports.
+- Add `isIntroPriceId: jest.fn((priceId: string) => priceId === 'price_standard_intro')` to the mock exports.
+
+**Stripe mock** (line 34–45):
+
+- Add `subscriptions: { retrieve: jest.fn(), ... }` — the existing mock already has `retrieve` on `subscriptions` (line 38), so verify it is reset in `beforeEach` and returns a sensible default (e.g., `{ schedule: null, items: { data: [{ price: { id: 'price_standard' } }] } }`).
+- Add `subscriptionSchedules: { retrieve: jest.fn(), ... }` — new code paths in `ensureAutoIntroSchedule` (step 3) and `switchPlan` (hidden-schedule reconciliation) call `subscriptionSchedules.retrieve` to read schedule metadata and phase data. The mock should return a sensible default (e.g., `{ id: 'sub_sched_test', metadata: {}, phases: [], end_behavior: 'release', status: 'active' }`) and be configurable per-test for auto-intro metadata (`{ metadata: { origin: 'auto-intro' } }`) and phase structures.
+
+### Checkout tests (update existing at line 242)
+
+- Standard first-time checkout uses the intro price and `allow_promotion_codes: true`; no `discounts`.
+- Standard returning-canceled checkout uses the regular price and `allow_promotion_codes: true`.
+- Commit checkout uses `allow_promotion_codes: true`; no `discounts`.
+- Rewardful `client_reference_id` still passes through when the referral cookie exists.
+
+### `ensureAutoIntroSchedule` helper tests (new)
+
+- Creates a schedule and persists `scheduled_by: 'auto'`, `scheduled_plan: 'standard'` when no schedule exists and subscription is on the intro price.
+- Price gate: if `subscriptions.retrieve` returns a non-intro price, no-ops without creating a schedule — even if the caller previously believed it was on the intro price.
+- Idempotency (Stripe): if `subscriptions.retrieve` returns a non-null `.schedule`, persists the existing schedule ID without calling `subscriptionSchedules.create`.
+- Stale DB pointer: if the DB row has `stripe_schedule_id` set but `subscriptions.retrieve` returns `.schedule: null`, clears the stale pointer and creates a new schedule.
+- Race: if `subscriptionSchedules.create` fails because a schedule was attached concurrently, recovers by fetching and persisting the existing schedule.
+- Phase 1 price is derived from the schedule created by `from_subscription`, not hardcoded to the intro price ID.
+
+### Auto-schedule lifecycle tests (new)
+
+- `handleKiloClawSubscriptionCreated` with an intro-price subscription calls `ensureAutoIntroSchedule` and persists the schedule.
+- `handleKiloClawSubscriptionCreated` with a regular-price subscription (returning subscriber) does not call `ensureAutoIntroSchedule`.
+- Schedule `released` event clears DB fields without surfacing a user-visible plan switch.
+
+### Cancel / reactivate during intro month (new)
+
+- Cancel releases the auto schedule, sets `cancel_at_period_end`, clears schedule fields.
+- Reactivate during intro month recreates the auto schedule.
+- Reactivate after intro month (regular price) does not recreate a schedule.
+- Partial failure (pre-create): if `ensureAutoIntroSchedule` throws before Stripe schedule creation, the mutation still succeeds (cancel_at_period_end is unset), logs the error, and leaves no schedule anywhere.
+- Partial failure (post-create): if `ensureAutoIntroSchedule` throws after Stripe schedule creation but before DB persist, the mutation still succeeds, logs the error, and leaves a hidden schedule that subsequent flows or re-invocation can reconcile.
+
+### switchPlan during intro month (new)
+
+- Switch from Standard (intro) to Commit updates the auto schedule in place, preserving phase 1 timing and price, sets `scheduled_by: 'user'`, `scheduled_plan: 'commit'`.
+- Switch when auto schedule is stale/released: clears local pointer and falls through to fresh schedule creation.
+- Switch when no schedule exists (regular price) creates a new user schedule (existing behavior preserved).
+- Hidden auto schedule: DB has no `stripe_schedule_id` but Stripe has an attached schedule with `metadata.origin === 'auto-intro'`. switchPlan detects it via live fetch, identifies it as auto by metadata, and updates it in place.
+- Hidden user schedule: DB has no `stripe_schedule_id` but Stripe has an attached schedule without auto-intro metadata. switchPlan detects it via live fetch, releases it conservatively, and creates a fresh schedule.
+
+### Cancel / switchPlan with hidden schedule (new)
+
+- Cancel when DB has no `stripe_schedule_id` but Stripe has an attached schedule (auto or user): live-fetch detects it, releases the hidden schedule, then proceeds with `cancel_at_period_end`.
+- switchPlan with hidden auto schedule: detected via live fetch, identified by `metadata.origin === 'auto-intro'`, updated in place.
+- switchPlan with hidden user schedule: detected via live fetch, no auto-intro metadata, released conservatively then fresh schedule created.
+
+### cancelPlanSwitch during intro month (new)
+
+- Cancel a user switch while on intro price restores the auto intro→regular schedule.
+- Cancel a user switch while on regular price just clears fields (existing behavior).
+- Cancel a user switch when the schedule is already released/inactive: swallows error, clears fields, still restores auto schedule if on intro price.
+- Partial failure (pre-create): if `ensureAutoIntroSchedule` throws before Stripe schedule creation, the mutation still succeeds (user switch is canceled), logs the error, and leaves no schedule anywhere.
+- Partial failure (post-create): if `ensureAutoIntroSchedule` throws after Stripe schedule creation but before DB persist, the mutation still succeeds, logs the error, and leaves a hidden schedule that subsequent flows or re-invocation can reconcile.
+
+### Schedule metadata (new)
+
+- `ensureAutoIntroSchedule` sets `metadata: { origin: 'auto-intro' }` on created schedules.
+- Idempotency check uses `metadata.origin === 'auto-intro'` to identify auto schedules, not phase structure.
+- switchPlan hidden-schedule reconciliation uses `metadata.origin` to classify hidden schedules.
+
+### Reconciliation sweep (new)
+
+- Cron sweep finds an active intro-price subscription with no schedule and calls `ensureAutoIntroSchedule`, repairing the stranded state.
+- Cron sweep skips active subscriptions on the regular price (no repair needed).
+- Cron sweep skips subscriptions that already have a `stripe_schedule_id`.
+- Cron sweep skips canceled subscriptions and subscriptions with `cancel_at_period_end`.
+
+### Invoice classification (new)
+
+- Intro-price invoices are recognized as KiloClaw by `invoiceLooksLikeKiloClawByPriceId`.
+
+## Assumptions
+
+- Rollout lands after March 23, 2026 — no need to handle the `trial_end` launch-gating path.
+- Rewardful promo codes apply only on initial KiloClaw checkout, not plan switches or billing-portal actions. Stripe promotion code restrictions (first-time orders, new customers only) enforce this.
+- `allow_promotion_codes: true` enables a promo code input on Stripe's hosted checkout. No KiloClaw-side promo input needed.
+- Existing Rewardful link-based attribution via `client_reference_id` continues unchanged. Rewardful's first-affiliate-wins attribution model means entering a different affiliate's promo code doesn't override prior link attribution.
+- The auto-schedule creation pattern follows the same `subscriptionSchedules.create({ from_subscription })` → `subscriptionSchedules.update()` two-step as the existing `switchPlan` implementation.
+- The price migration script (`src/scripts/d2026-03-19_migrate-kiloclaw-prices.ts`) and helper (`src/lib/kiloclaw/price-migration.ts`) assume one canonical price ID per plan (`Record<ClawPlan, string>`). After this change, Standard has two live prices (intro and regular). These scripts are not in the runtime path and do not need updating for this deploy, but **any future price migration must account for the intro price** — either by extending `newPriceIds` to include it or by ensuring the migration only targets subscriptions on the regular price. Without this, a migration run against an intro-month subscriber would swap their intro price for the new regular price, breaking the intro→regular schedule.
+
+## Files Changed
+
+| File                                                         | Change                                                                                                                                                                                                                |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/config.server.ts`                                   | Add intro price env var, remove coupon env var                                                                                                                                                                        |
+| `src/lib/kiloclaw/stripe-price-ids.server.ts`                | Add intro price to metadata map, new `getStripePriceIdForClawPlanIntro`, new `isIntroPriceId`                                                                                                                         |
+| `src/routers/kiloclaw-router.ts`                             | Checkout: intro price + `allow_promotion_codes`. switchPlan: handle auto schedule with stale-schedule defense. cancelPlanSwitch: restore auto schedule on intro price. reactivateSubscription: recreate auto schedule |
+| `src/lib/kiloclaw/stripe-handlers.ts`                        | New `ensureAutoIntroSchedule` shared idempotent helper (DB + live Stripe fetch guard). Called from `handleKiloClawSubscriptionCreated`, `reactivateSubscription`, and `cancelPlanSwitch`. Update comments             |
+| `src/lib/kiloclaw/billing-lifecycle-cron.ts`                 | New sweep: detect and repair stranded intro-price subscriptions with no attached schedule                                                                                                                             |
+| `src/app/(app)/claw/components/billing/SubscriptionCard.tsx` | Gate switch button on `scheduledBy === 'user'` not `scheduledPlan` presence                                                                                                                                           |
+| `src/routers/kiloclaw-billing-router.test.ts`                | Update checkout assertions, add lifecycle tests for auto-schedule, cancel/reactivate, switchPlan, cancelPlanSwitch, invoice classification, reconciliation sweep                                                      |

--- a/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
+++ b/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
@@ -100,7 +100,7 @@ function ActiveSubscriptionCard({
           >
             Cancel Switch
           </Button>
-        ) : !sub.scheduledPlan ? (
+        ) : (
           <Button
             variant="outline"
             size="sm"
@@ -109,7 +109,7 @@ function ActiveSubscriptionCard({
           >
             Switch to {otherPlan}
           </Button>
-        ) : null}
+        )}
         <Button variant="outline" size="sm" onClick={onCancelClick}>
           Cancel
         </Button>
@@ -217,9 +217,6 @@ export function SubscriptionCard({ billing, onCancelClick }: SubscriptionCardPro
     window.location.href = result.url;
   }
 
-  // Trial is handled by BillingBanner — no card needed here
-
-  // Active subscription
   if (billing.subscription) {
     if (billing.subscription.status === 'past_due' || billing.subscription.status === 'unpaid') {
       return (

--- a/src/lib/config.server.ts
+++ b/src/lib/config.server.ts
@@ -183,8 +183,8 @@ export const STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID = getEnvVariable(
 export const STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID = getEnvVariable(
   'STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID'
 );
-export const STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID = getEnvVariable(
-  'STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID'
+export const STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID = getEnvVariable(
+  'STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID'
 );
 
 // KiloClaw Billing — ISO 8601 date after which new checkouts are billed immediately

--- a/src/lib/kiloclaw/billing-lifecycle-cron.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.ts
@@ -16,6 +16,9 @@ import { format } from 'date-fns';
 import type { TemplateName } from '@/lib/email';
 import { send as sendEmail } from '@/lib/email';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { ensureAutoIntroSchedule } from '@/lib/kiloclaw/stripe-handlers';
+import { isIntroPriceId } from '@/lib/kiloclaw/stripe-price-ids.server';
+import { client as stripe } from '@/lib/stripe-client';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import { NEXTAUTH_URL, KILOCLAW_BILLING_ENFORCEMENT } from '@/lib/config.server';
 import { sentryLogger } from '@/lib/utils.server';
@@ -42,6 +45,7 @@ type CronSummary = {
   destruction_warnings: number;
   sweep3_instance_destruction: number;
   sweep4_past_due_cleanup: number;
+  sweep5_intro_schedules_repaired: number;
   emails_sent: number;
   emails_skipped: number;
   errors: number;
@@ -104,6 +108,7 @@ export async function runKiloClawBillingLifecycleCron(
     destruction_warnings: 0,
     sweep3_instance_destruction: 0,
     sweep4_past_due_cleanup: 0,
+    sweep5_intro_schedules_repaired: 0,
     emails_sent: 0,
     emails_skipped: 0,
     errors: 0,
@@ -571,6 +576,47 @@ export async function runKiloClawBillingLifecycleCron(
       summary.errors++;
       captureException(error);
       logError('Sweep 4 (past-due cleanup) failed for user', {
+        user_id: row.user_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // ── Sweep 5: Repair stranded intro-price subscriptions ─────────────
+  const strandedIntroRows = await database
+    .select({
+      user_id: kiloclaw_subscriptions.user_id,
+      stripe_subscription_id: kiloclaw_subscriptions.stripe_subscription_id,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.status, 'active'),
+        isNull(kiloclaw_subscriptions.stripe_schedule_id),
+        isNotNull(kiloclaw_subscriptions.stripe_subscription_id),
+        eq(kiloclaw_subscriptions.cancel_at_period_end, false)
+      )
+    );
+
+  for (const row of strandedIntroRows) {
+    try {
+      const stripeSubId = row.stripe_subscription_id;
+      if (!stripeSubId) continue;
+      const liveSub = await stripe.subscriptions.retrieve(stripeSubId);
+      const priceId = liveSub.items.data[0]?.price?.id;
+      if (!priceId || !isIntroPriceId(priceId)) continue;
+      if (liveSub.schedule) continue;
+
+      await ensureAutoIntroSchedule(stripeSubId, row.user_id);
+      summary.sweep5_intro_schedules_repaired++;
+      logInfo('Sweep 5: repaired stranded intro-price subscription', {
+        user_id: row.user_id,
+        stripe_subscription_id: row.stripe_subscription_id,
+      });
+    } catch (error) {
+      summary.errors++;
+      captureException(error);
+      logError('Sweep 5 (intro schedule repair) failed for user', {
         user_id: row.user_id,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -11,9 +11,14 @@ import {
   kiloclaw_email_log,
 } from '@kilocode/db/schema';
 import type { KiloClawSubscriptionStatus } from '@kilocode/db/schema-types';
-import { getClawPlanForStripePriceId } from '@/lib/kiloclaw/stripe-price-ids.server';
+import {
+  getClawPlanForStripePriceId,
+  getStripePriceIdForClawPlan,
+  isIntroPriceId,
+} from '@/lib/kiloclaw/stripe-price-ids.server';
 import { sentryLogger } from '@/lib/utils.server';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { client as stripe } from '@/lib/stripe-client';
 
 const logInfo = sentryLogger('kiloclaw-stripe', 'info');
 const logWarning = sentryLogger('kiloclaw-stripe', 'warning');
@@ -131,11 +136,145 @@ async function autoResumeIfSuspended(kiloUserId: string): Promise<void> {
     .where(eq(kiloclaw_subscriptions.user_id, kiloUserId));
 }
 
+function resolveScheduleId(
+  schedule: string | Stripe.SubscriptionSchedule | null | undefined
+): string | null {
+  if (!schedule) return null;
+  return typeof schedule === 'string' ? schedule : schedule.id;
+}
+
+function resolvePhasePrice(phase: Stripe.SubscriptionSchedule.Phase): string | null {
+  const priceRef = phase.items[0]?.price;
+  if (!priceRef) return null;
+  return typeof priceRef === 'string' ? priceRef : (priceRef.id ?? null);
+}
+
+async function persistAutoIntroSchedule(scheduleId: string, userId: string): Promise<void> {
+  await db
+    .update(kiloclaw_subscriptions)
+    .set({
+      stripe_schedule_id: scheduleId,
+      scheduled_plan: 'standard',
+      scheduled_by: 'auto',
+    })
+    .where(eq(kiloclaw_subscriptions.user_id, userId));
+}
+
+/**
+ * Ensure an intro-price subscription has a 2-phase schedule that automatically
+ * transitions to the regular standard price at the end of the intro period.
+ *
+ * No-ops if the subscription is not on an intro price or already has a valid
+ * auto-intro schedule attached.
+ */
+export async function ensureAutoIntroSchedule(
+  stripeSubscriptionId: string,
+  userId: string
+): Promise<void> {
+  const liveSub = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+
+  const priceId = liveSub.items.data[0]?.price?.id;
+  if (!priceId || !isIntroPriceId(priceId)) return;
+
+  // Schedule already attached — persist if auto-intro, skip otherwise
+  if (liveSub.schedule) {
+    const scheduleId = resolveScheduleId(liveSub.schedule);
+    if (!scheduleId) return;
+    const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+
+    if (schedule.metadata?.origin === 'auto-intro') {
+      await persistAutoIntroSchedule(schedule.id, userId);
+      return;
+    }
+
+    logWarning('Subscription has non-auto-intro schedule attached, skipping auto schedule', {
+      stripe_subscription_id: stripeSubscriptionId,
+      user_id: userId,
+      schedule_id: schedule.id,
+    });
+    return;
+  }
+
+  // Clear stale schedule pointer if Stripe says no schedule
+  const [existingRow] = await db
+    .select({ stripe_schedule_id: kiloclaw_subscriptions.stripe_schedule_id })
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.user_id, userId))
+    .limit(1);
+
+  if (existingRow?.stripe_schedule_id) {
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
+      .where(eq(kiloclaw_subscriptions.user_id, userId));
+  }
+
+  // Create the 2-phase schedule (intro → regular standard)
+  let newSchedule: Stripe.SubscriptionSchedule;
+  try {
+    newSchedule = await stripe.subscriptionSchedules.create({
+      from_subscription: stripeSubscriptionId,
+      metadata: { origin: 'auto-intro' },
+    });
+  } catch (error) {
+    // Race guard: a schedule was attached concurrently
+    logWarning('Race creating auto-intro schedule, re-checking subscription', {
+      stripe_subscription_id: stripeSubscriptionId,
+      user_id: userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    const refetched = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+    const refetchedScheduleId = resolveScheduleId(refetched.schedule);
+    if (refetchedScheduleId) {
+      const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
+      if (existingSchedule.metadata?.origin === 'auto-intro') {
+        await persistAutoIntroSchedule(existingSchedule.id, userId);
+      }
+    }
+    return;
+  }
+
+  const currentPhase = newSchedule.phases[0];
+  if (!currentPhase) {
+    logError('Auto-intro schedule created with no phases', {
+      stripe_subscription_id: stripeSubscriptionId,
+      schedule_id: newSchedule.id,
+      user_id: userId,
+    });
+    return;
+  }
+
+  const phase1Price = resolvePhasePrice(currentPhase);
+  if (!phase1Price) {
+    logError('Auto-intro schedule current phase has no price', {
+      stripe_subscription_id: stripeSubscriptionId,
+      schedule_id: newSchedule.id,
+      user_id: userId,
+    });
+    return;
+  }
+
+  await stripe.subscriptionSchedules.update(newSchedule.id, {
+    phases: [
+      {
+        items: [{ price: phase1Price }],
+        start_date: currentPhase.start_date,
+        end_date: currentPhase.end_date,
+      },
+      {
+        items: [{ price: getStripePriceIdForClawPlan('standard') }],
+      },
+    ],
+    end_behavior: 'release',
+  });
+
+  await persistAutoIntroSchedule(newSchedule.id, userId);
+}
+
 /**
  * Handle customer.subscription.created for KiloClaw subscriptions.
- *
- * Stripe propagates subscription_data.metadata from the checkout session
- * to the subscription object, so we can read kiloUserId and plan from metadata.
+ * After persisting, creates an auto intro→regular schedule if on an intro price.
  */
 export async function handleKiloClawSubscriptionCreated(params: {
   eventId: string;
@@ -157,9 +296,8 @@ export async function handleKiloClawSubscriptionCreated(params: {
   const periods = getSubscriptionPeriods(subscription, kiloUserId);
   const status = mapStripeStatus(subscription.status);
 
-  // Capture suspension state before the upsert clears it, so auto-resume
-  // can fire for re-subscribing users who were previously suspended.
   let wasSuspended = false;
+  let didProcess = false;
 
   await db.transaction(async tx => {
     // Guard against stale subscription.created retries: if the user already has
@@ -195,8 +333,7 @@ export async function handleKiloClawSubscriptionCreated(params: {
       return;
     }
 
-    // Set wasSuspended only after passing the stale guard — stale events
-    // must not trigger auto-resume for the current subscription.
+    // Captured after the stale guard so stale events don't auto-resume
     wasSuspended = !!existingRow?.suspended_at;
 
     // For commit plans, derive commit_ends_at. If the subscription has a
@@ -249,13 +386,16 @@ export async function handleKiloClawSubscriptionCreated(params: {
           destruction_deadline: null,
         },
       });
+
+    didProcess = true;
   });
 
-  // Auto-resume: if user was suspended before this re-subscription, start their
-  // instance and clear suspension cycle emails. wasSuspended was captured inside
-  // the transaction before the upsert cleared suspended_at.
   if (wasSuspended) {
     await autoResumeIfSuspended(kiloUserId);
+  }
+
+  if (didProcess) {
+    await ensureAutoIntroSchedule(subscription.id, kiloUserId);
   }
 
   logInfo('KiloClaw subscription.created processed', {
@@ -412,9 +552,8 @@ export async function handleKiloClawSubscriptionDeleted(params: {
 
 /**
  * Handle subscription_schedule.updated for KiloClaw subscriptions.
- * Schedules are only created by user-initiated plan switches.
- * When a schedule completes: apply the scheduled plan transition.
- * When released/canceled: clear schedule tracking fields without changing plan.
+ * On completed: apply the scheduled plan transition.
+ * On released/canceled: clear schedule tracking fields without changing plan.
  */
 export async function handleKiloClawScheduleEvent(params: {
   eventId: string;

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -172,6 +172,19 @@ async function validateOrRepairAutoIntroSchedule(
   stripeSubscriptionId: string,
   userId: string
 ): Promise<boolean> {
+  // If the user has repurposed this schedule via switchPlan (scheduled_by = 'user'),
+  // do not overwrite their pending plan switch. switchPlan reuses the auto-intro
+  // schedule but doesn't change metadata.origin, so it still reads as 'auto-intro'.
+  const [dbRow] = await db
+    .select({ scheduled_by: kiloclaw_subscriptions.scheduled_by })
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.user_id, userId))
+    .limit(1);
+
+  if (dbRow?.scheduled_by === 'user') {
+    return true;
+  }
+
   const regularPriceId = getStripePriceIdForClawPlan('standard');
   const phase2Price = schedule.phases[1] ? resolvePhasePrice(schedule.phases[1]) : null;
 
@@ -266,20 +279,31 @@ export async function ensureAutoIntroSchedule(
       metadata: { origin: 'auto-intro' },
     });
   } catch (error) {
-    // Race guard: a schedule was attached concurrently
+    // Race guard: if a schedule was attached concurrently, the create fails
+    // because Stripe only allows one schedule per subscription. Re-fetch to
+    // check whether a concurrent caller won the race.
+    const refetched = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+    const refetchedScheduleId = resolveScheduleId(refetched.schedule);
+    if (!refetchedScheduleId) {
+      // No concurrent schedule — this was a transient Stripe/API error, not a
+      // race. Re-throw so callers can observe the failure and retry.
+      logError('Failed to create auto-intro schedule (non-race error)', {
+        stripe_subscription_id: stripeSubscriptionId,
+        user_id: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+
     logWarning('Race creating auto-intro schedule, re-checking subscription', {
       stripe_subscription_id: stripeSubscriptionId,
       user_id: userId,
       error: error instanceof Error ? error.message : String(error),
     });
 
-    const refetched = await stripe.subscriptions.retrieve(stripeSubscriptionId);
-    const refetchedScheduleId = resolveScheduleId(refetched.schedule);
-    if (refetchedScheduleId) {
-      const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
-      if (existingSchedule.metadata?.origin === 'auto-intro') {
-        await validateOrRepairAutoIntroSchedule(existingSchedule, stripeSubscriptionId, userId);
-      }
+    const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
+    if (existingSchedule.metadata?.origin === 'auto-intro') {
+      await validateOrRepairAutoIntroSchedule(existingSchedule, stripeSubscriptionId, userId);
     }
     return;
   }

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -161,6 +161,55 @@ async function persistAutoIntroSchedule(scheduleId: string, userId: string): Pro
 }
 
 /**
+ * Validate that an auto-intro schedule has the expected 2-phase structure
+ * (phase 1 = current price, phase 2 = regular standard price). If the schedule
+ * is half-configured (e.g., created from_subscription but the 2-phase rewrite
+ * never completed), rewrite it now and persist. Returns true if the schedule
+ * is valid (or was repaired), false if unrecoverable.
+ */
+async function validateOrRepairAutoIntroSchedule(
+  schedule: Stripe.SubscriptionSchedule,
+  stripeSubscriptionId: string,
+  userId: string
+): Promise<boolean> {
+  const regularPriceId = getStripePriceIdForClawPlan('standard');
+  const phase2Price = schedule.phases[1] ? resolvePhasePrice(schedule.phases[1]) : null;
+
+  if (schedule.phases.length >= 2 && phase2Price === regularPriceId) {
+    await persistAutoIntroSchedule(schedule.id, userId);
+    return true;
+  }
+
+  // Half-configured: rewrite to add the regular-price phase
+  const existingPhase = schedule.phases[0];
+  const existingPhasePrice = existingPhase ? resolvePhasePrice(existingPhase) : null;
+  if (!existingPhase || !existingPhasePrice) {
+    logError('Half-configured auto-intro schedule has no usable phase', {
+      stripe_subscription_id: stripeSubscriptionId,
+      schedule_id: schedule.id,
+      user_id: userId,
+    });
+    return false;
+  }
+
+  await stripe.subscriptionSchedules.update(schedule.id, {
+    phases: [
+      {
+        items: [{ price: existingPhasePrice }],
+        start_date: existingPhase.start_date,
+        end_date: existingPhase.end_date,
+      },
+      {
+        items: [{ price: regularPriceId }],
+      },
+    ],
+    end_behavior: 'release',
+  });
+  await persistAutoIntroSchedule(schedule.id, userId);
+  return true;
+}
+
+/**
  * Ensure an intro-price subscription has a 2-phase schedule that automatically
  * transitions to the regular standard price at the end of the intro period.
  *
@@ -183,7 +232,7 @@ export async function ensureAutoIntroSchedule(
     const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
 
     if (schedule.metadata?.origin === 'auto-intro') {
-      await persistAutoIntroSchedule(schedule.id, userId);
+      await validateOrRepairAutoIntroSchedule(schedule, stripeSubscriptionId, userId);
       return;
     }
 
@@ -229,7 +278,7 @@ export async function ensureAutoIntroSchedule(
     if (refetchedScheduleId) {
       const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
       if (existingSchedule.metadata?.origin === 'auto-intro') {
-        await persistAutoIntroSchedule(existingSchedule.id, userId);
+        await validateOrRepairAutoIntroSchedule(existingSchedule, stripeSubscriptionId, userId);
       }
     }
     return;

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -143,7 +143,7 @@ function resolveScheduleId(
   return typeof schedule === 'string' ? schedule : schedule.id;
 }
 
-function resolvePhasePrice(phase: Stripe.SubscriptionSchedule.Phase): string | null {
+export function resolvePhasePrice(phase: Stripe.SubscriptionSchedule.Phase): string | null {
   const priceRef = phase.items[0]?.price;
   if (!priceRef) return null;
   return typeof priceRef === 'string' ? priceRef : (priceRef.id ?? null);
@@ -245,7 +245,14 @@ export async function ensureAutoIntroSchedule(
     const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
 
     if (schedule.metadata?.origin === 'auto-intro') {
-      await validateOrRepairAutoIntroSchedule(schedule, stripeSubscriptionId, userId);
+      const valid = await validateOrRepairAutoIntroSchedule(schedule, stripeSubscriptionId, userId);
+      if (!valid) {
+        logError('Auto-intro schedule is unrecoverable, skipping', {
+          stripe_subscription_id: stripeSubscriptionId,
+          schedule_id: schedule.id,
+          user_id: userId,
+        });
+      }
       return;
     }
 
@@ -271,7 +278,18 @@ export async function ensureAutoIntroSchedule(
       .where(eq(kiloclaw_subscriptions.user_id, userId));
   }
 
-  // Create the 2-phase schedule (intro → regular standard)
+  await createAutoIntroSchedule(stripeSubscriptionId, userId);
+}
+
+/**
+ * Create a new 2-phase auto-intro schedule (intro → regular standard) for a
+ * subscription. Handles the race where a concurrent caller attaches a schedule
+ * between our check and the create call.
+ */
+async function createAutoIntroSchedule(
+  stripeSubscriptionId: string,
+  userId: string
+): Promise<void> {
   let newSchedule: Stripe.SubscriptionSchedule;
   try {
     newSchedule = await stripe.subscriptionSchedules.create({
@@ -279,51 +297,19 @@ export async function ensureAutoIntroSchedule(
       metadata: { origin: 'auto-intro' },
     });
   } catch (error) {
-    // Race guard: if a schedule was attached concurrently, the create fails
-    // because Stripe only allows one schedule per subscription. Re-fetch to
-    // check whether a concurrent caller won the race.
-    const refetched = await stripe.subscriptions.retrieve(stripeSubscriptionId);
-    const refetchedScheduleId = resolveScheduleId(refetched.schedule);
-    if (!refetchedScheduleId) {
-      // No concurrent schedule — this was a transient Stripe/API error, not a
-      // race. Re-throw so callers can observe the failure and retry.
-      logError('Failed to create auto-intro schedule (non-race error)', {
-        stripe_subscription_id: stripeSubscriptionId,
-        user_id: userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
-
-    logWarning('Race creating auto-intro schedule, re-checking subscription', {
-      stripe_subscription_id: stripeSubscriptionId,
-      user_id: userId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
-    const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
-    if (existingSchedule.metadata?.origin === 'auto-intro') {
-      await validateOrRepairAutoIntroSchedule(existingSchedule, stripeSubscriptionId, userId);
-    }
+    await handleAutoIntroCreateRace(error, stripeSubscriptionId, userId);
     return;
   }
 
   const currentPhase = newSchedule.phases[0];
-  if (!currentPhase) {
-    logError('Auto-intro schedule created with no phases', {
+  const phase1Price = currentPhase ? resolvePhasePrice(currentPhase) : null;
+  if (!currentPhase || !phase1Price) {
+    logError('Auto-intro schedule created with unusable phase', {
       stripe_subscription_id: stripeSubscriptionId,
       schedule_id: newSchedule.id,
       user_id: userId,
-    });
-    return;
-  }
-
-  const phase1Price = resolvePhasePrice(currentPhase);
-  if (!phase1Price) {
-    logError('Auto-intro schedule current phase has no price', {
-      stripe_subscription_id: stripeSubscriptionId,
-      schedule_id: newSchedule.id,
-      user_id: userId,
+      has_phase: !!currentPhase,
+      has_price: !!phase1Price,
     });
     return;
   }
@@ -343,6 +329,50 @@ export async function ensureAutoIntroSchedule(
   });
 
   await persistAutoIntroSchedule(newSchedule.id, userId);
+}
+
+/**
+ * Handle a failed subscriptionSchedules.create call during auto-intro setup.
+ * If the failure was a race (another caller attached a schedule concurrently),
+ * validate/repair the winning schedule. Otherwise re-throw.
+ */
+async function handleAutoIntroCreateRace(
+  error: unknown,
+  stripeSubscriptionId: string,
+  userId: string
+): Promise<void> {
+  const refetched = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+  const refetchedScheduleId = resolveScheduleId(refetched.schedule);
+  if (!refetchedScheduleId) {
+    logError('Failed to create auto-intro schedule (non-race error)', {
+      stripe_subscription_id: stripeSubscriptionId,
+      user_id: userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+
+  logWarning('Race creating auto-intro schedule, re-checking subscription', {
+    stripe_subscription_id: stripeSubscriptionId,
+    user_id: userId,
+    error: error instanceof Error ? error.message : String(error),
+  });
+
+  const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
+  if (existingSchedule.metadata?.origin === 'auto-intro') {
+    const valid = await validateOrRepairAutoIntroSchedule(
+      existingSchedule,
+      stripeSubscriptionId,
+      userId
+    );
+    if (!valid) {
+      logError('Race-recovered auto-intro schedule is unrecoverable', {
+        stripe_subscription_id: stripeSubscriptionId,
+        schedule_id: existingSchedule.id,
+        user_id: userId,
+      });
+    }
+  }
 }
 
 /**

--- a/src/lib/kiloclaw/stripe-price-ids.server.ts
+++ b/src/lib/kiloclaw/stripe-price-ids.server.ts
@@ -19,6 +19,7 @@ function getPriceIdMetadata(): Record<string, ClawPlan> {
     cachedPriceIdMetadata = {
       [requireEnvVariable('STRIPE_KILOCLAW_COMMIT_PRICE_ID')]: 'commit',
       [requireEnvVariable('STRIPE_KILOCLAW_STANDARD_PRICE_ID')]: 'standard',
+      [requireEnvVariable('STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID')]: 'standard',
     };
   }
   return cachedPriceIdMetadata;
@@ -40,6 +41,17 @@ export function getStripePriceIdForClawPlan(plan: ClawPlan): string {
   if (plan === 'standard') {
     return requireEnvVariable('STRIPE_KILOCLAW_STANDARD_PRICE_ID');
   }
-  // Exhaustive guard
   throw new Error(`Unsupported KiloClaw plan: ${plan satisfies never}`);
+}
+
+export function getStripePriceIdForClawPlanIntro(plan: ClawPlan): string {
+  if (plan === 'standard') {
+    return requireEnvVariable('STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID');
+  }
+  // Commit has no intro price — fall through to regular price
+  return getStripePriceIdForClawPlan(plan);
+}
+
+export function isIntroPriceId(priceId: string): boolean {
+  return priceId === requireEnvVariable('STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID');
 }

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -743,6 +743,60 @@ describe('handleKiloClawSubscriptionCreated', () => {
     expect(row.scheduled_by).toBe('auto');
   });
 
+  it('repairs half-configured auto-intro schedule on retry', async () => {
+    // Simulate: first attempt created the schedule (from_subscription) and tagged
+    // it auto-intro, but the 2-phase rewrite never completed. On retry, the
+    // subscription has a schedule attached with auto-intro metadata but only 1 phase.
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_half',
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: 'sched_half',
+      metadata: { origin: 'auto-intro' },
+      // Only 1 phase — the 2-phase rewrite never completed
+      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      status: 'active',
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const subscription = makeStripeSubscription({
+      id: 'sub_half_repair',
+      metadata: { type: 'kiloclaw', plan: 'standard', kiloUserId: user.id },
+      status: 'active',
+      priceId: 'price_standard_intro',
+    });
+
+    await handleKiloClawSubscriptionCreated({
+      eventId: 'evt_half_repair',
+      subscription,
+    });
+
+    // Should have rewritten the schedule with 2 phases
+    expect(stripeMock.subscriptionSchedules.update).toHaveBeenCalledWith(
+      'sched_half',
+      expect.objectContaining({
+        end_behavior: 'release',
+        phases: expect.arrayContaining([
+          expect.objectContaining({
+            items: [{ price: 'price_standard_intro' }],
+          }),
+          expect.objectContaining({
+            items: [{ price: 'price_test_kiloclaw' }],
+          }),
+        ]),
+      })
+    );
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    expect(row.stripe_schedule_id).toBe('sched_half');
+    expect(row.scheduled_by).toBe('auto');
+  });
+
   it('does not create auto schedule for regular-price subscription (returning subscriber)', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1189,6 +1243,68 @@ describe('switchPlan', () => {
     await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
       'Already on this plan'
     );
+  });
+
+  it('aborts when releasing hidden non-auto schedule fails with transient error', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_hidden_fail',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_hidden_transient',
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+    stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: 'sched_hidden_transient',
+      metadata: {},
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      status: 'active',
+    });
+    // Transient error — not "not active" or "released" or "canceled"
+    stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe API timeout'));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'commit' })).rejects.toThrow(
+      'Unable to switch plan: failed to release existing schedule'
+    );
+  });
+
+  it('derives phase-1 price from the newly created schedule, not the stale live fetch', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_fresh_price',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    // Live fetch returns the old intro price (stale by the time the schedule is created)
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    // But from_subscription mirrors the subscription's current state at create time,
+    // which has already rolled over to the regular price
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sched_fresh_price',
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    // Phase 1 should use the fresh price from the schedule ('price_standard'),
+    // not the stale intro price from the earlier subscriptions.retrieve()
+    const updateArgs = stripeMock.subscriptionSchedules.update.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    const phases = updateArgs.phases as Array<{ items: Array<{ price: string }> }>;
+    expect(phases[0].items[0].price).toBe('price_standard');
   });
 });
 

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -1820,7 +1820,7 @@ describe('cancelPlanSwitch', () => {
     expect(row.scheduled_plan).toBeNull();
   });
 
-  it('proceeds to clear DB state when schedule release fails with a non-recognized error', async () => {
+  it('rethrows non-already-released Stripe errors', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       stripe_subscription_id: 'sub_stripe_fail',
@@ -1834,18 +1834,17 @@ describe('cancelPlanSwitch', () => {
     stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe network timeout'));
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.cancelPlanSwitch();
+    await expect(caller.kiloclaw.cancelPlanSwitch()).rejects.toThrow(
+      'Failed to release pending plan schedule'
+    );
 
-    expect(result).toEqual({ success: true });
-
-    // DB should still be cleared so the user isn't stuck
+    // DB should NOT have been cleared since Stripe failed
     const [row] = await db
       .select()
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.user_id, user.id))
       .limit(1);
 
-    expect(row.stripe_schedule_id).toBeNull();
-    expect(row.scheduled_plan).toBeNull();
+    expect(row.stripe_schedule_id).toBe('sub_sched_fail');
   });
 });

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -343,48 +343,6 @@ describe('createSubscriptionCheckout', () => {
       })
     );
   });
-
-  it('sets trial_end in subscription_data when before March 23', async () => {
-    // Today (March 12, 2026) is before March 23 — no fake timers needed
-    stripeMock.checkout.sessions.create.mockResolvedValue({
-      url: 'https://checkout.stripe.com/test',
-    });
-
-    const caller = await createCallerForUser(user.id);
-    await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
-
-    const callArgs = stripeMock.checkout.sessions.create.mock.calls[0]?.[0] as Record<
-      string,
-      unknown
-    >;
-    const subscriptionData = callArgs.subscription_data as Record<string, unknown>;
-    const expectedTrialEnd = Math.floor(new Date('2026-03-23T00:00:00Z').getTime() / 1000);
-    expect(subscriptionData.trial_end).toBe(expectedTrialEnd);
-  });
-
-  it('does not set trial_end when after March 23', async () => {
-    // Temporarily override Date.now to simulate being after March 23
-    const realDateNow = Date.now;
-    Date.now = () => new Date('2026-04-01T00:00:00Z').getTime();
-
-    try {
-      stripeMock.checkout.sessions.create.mockResolvedValue({
-        url: 'https://checkout.stripe.com/test',
-      });
-
-      const caller = await createCallerForUser(user.id);
-      await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
-
-      const callArgs = stripeMock.checkout.sessions.create.mock.calls[0]?.[0] as Record<
-        string,
-        unknown
-      >;
-      const subscriptionData = callArgs.subscription_data as Record<string, unknown>;
-      expect(subscriptionData.trial_end).toBeUndefined();
-    } finally {
-      Date.now = realDateNow;
-    }
-  });
 });
 
 describe('handleKiloClawSubscriptionUpdated', () => {

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -1,8 +1,7 @@
 // Set stripe price env vars before any module loads
 process.env.STRIPE_KILOCLAW_COMMIT_PRICE_ID ||= 'price_commit';
 process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID ||= 'price_standard';
-process.env.STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID ||=
-  'coupon_test_kiloclaw_standard_first_month';
+process.env.STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID ||= 'price_standard_intro';
 process.env.STRIPE_KILOCLAW_BILLING_START ||= '2026-03-23T00:00:00Z';
 
 import {
@@ -36,7 +35,12 @@ jest.mock('@/lib/stripe-client', () => {
   const { errors } = require('stripe').default ?? require('stripe');
   const stripeMock = {
     subscriptions: { retrieve: jest.fn(), update: jest.fn(), list: jest.fn() },
-    subscriptionSchedules: { create: jest.fn(), update: jest.fn(), release: jest.fn() },
+    subscriptionSchedules: {
+      create: jest.fn(),
+      update: jest.fn(),
+      release: jest.fn(),
+      retrieve: jest.fn(),
+    },
     checkout: { sessions: { create: jest.fn(), list: jest.fn(), expire: jest.fn() } },
     billingPortal: { sessions: { create: jest.fn() } },
     errors,
@@ -50,11 +54,16 @@ jest.mock('@/lib/rewardful', () => ({
 
 jest.mock('@/lib/kiloclaw/stripe-price-ids.server', () => ({
   getStripePriceIdForClawPlan: jest.fn(() => 'price_test_kiloclaw'),
+  getStripePriceIdForClawPlanIntro: jest.fn((plan: string) =>
+    plan === 'standard' ? 'price_standard_intro' : 'price_commit'
+  ),
   getClawPlanForStripePriceId: jest.fn((priceId: string) => {
     if (priceId === 'price_commit') return 'commit';
     if (priceId === 'price_standard') return 'standard';
+    if (priceId === 'price_standard_intro') return 'standard';
     return null;
   }),
+  isIntroPriceId: jest.fn((priceId: string) => priceId === 'price_standard_intro'),
 }));
 
 jest.mock('next/headers', () => {
@@ -95,7 +104,7 @@ type StripeMockShape = {
   checkout: { sessions: { create: AnyMock; list: AnyMock; expire: AnyMock } };
   billingPortal: { sessions: { create: AnyMock } };
   subscriptions: { retrieve: AnyMock; update: AnyMock; list: AnyMock };
-  subscriptionSchedules: { create: AnyMock; update: AnyMock; release: AnyMock };
+  subscriptionSchedules: { create: AnyMock; update: AnyMock; release: AnyMock; retrieve: AnyMock };
   errors: Stripe['errors'];
 };
 
@@ -132,6 +141,20 @@ beforeEach(async () => {
   stripeMock.subscriptionSchedules.create.mockReset();
   stripeMock.subscriptionSchedules.update.mockReset();
   stripeMock.subscriptionSchedules.release.mockReset();
+  stripeMock.subscriptionSchedules.retrieve.mockReset();
+
+  // Default mock returns for live-fetch calls
+  stripeMock.subscriptions.retrieve.mockResolvedValue({
+    schedule: null,
+    items: { data: [{ price: { id: 'price_standard' } }] },
+  });
+  stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+    id: 'sub_sched_test',
+    metadata: {},
+    phases: [],
+    end_behavior: 'release',
+    status: 'active',
+  });
 
   // Reset rewardful mock
   const { getRewardfulReferral } = jest.requireMock<{
@@ -240,7 +263,7 @@ describe('getBillingStatus', () => {
 });
 
 describe('createSubscriptionCheckout', () => {
-  it('applies the configured first-month coupon for standard plan', async () => {
+  it('uses the intro price and allow_promotion_codes for new standard subscribers', async () => {
     stripeMock.checkout.sessions.create.mockResolvedValue({
       url: 'https://checkout.stripe.com/test',
     });
@@ -252,27 +275,15 @@ describe('createSubscriptionCheckout', () => {
       string,
       unknown
     >;
-    expect(callArgs.discounts).toEqual([{ coupon: 'coupon_test_kiloclaw_standard_first_month' }]);
-    expect(callArgs.allow_promotion_codes).toBeUndefined();
-  });
-
-  it('does not set discounts or promotion codes for commit plan', async () => {
-    stripeMock.checkout.sessions.create.mockResolvedValue({
-      url: 'https://checkout.stripe.com/test',
-    });
-
-    const caller = await createCallerForUser(user.id);
-    await caller.kiloclaw.createSubscriptionCheckout({ plan: 'commit' });
-
-    const callArgs = stripeMock.checkout.sessions.create.mock.calls[0]?.[0] as Record<
-      string,
-      unknown
-    >;
+    // Should use intro price
+    expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
+    // Should allow promotion codes (for Rewardful promo codes)
+    expect(callArgs.allow_promotion_codes).toBe(true);
+    // Should NOT have discounts (coupon removed)
     expect(callArgs.discounts).toBeUndefined();
-    expect(callArgs.allow_promotion_codes).toBeUndefined();
   });
 
-  it('does not apply the first-month coupon for returning canceled subscribers', async () => {
+  it('uses the regular price for returning canceled standard subscribers', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       plan: 'standard',
@@ -291,8 +302,26 @@ describe('createSubscriptionCheckout', () => {
       string,
       unknown
     >;
+    // Should use regular price (via getStripePriceIdForClawPlan mock which returns 'price_test_kiloclaw')
+    expect(callArgs.line_items).toEqual([{ price: 'price_test_kiloclaw', quantity: 1 }]);
+    expect(callArgs.allow_promotion_codes).toBe(true);
     expect(callArgs.discounts).toBeUndefined();
-    expect(callArgs.allow_promotion_codes).toBeUndefined();
+  });
+
+  it('uses allow_promotion_codes for commit plan', async () => {
+    stripeMock.checkout.sessions.create.mockResolvedValue({
+      url: 'https://checkout.stripe.com/test',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await caller.kiloclaw.createSubscriptionCheckout({ plan: 'commit' });
+
+    const callArgs = stripeMock.checkout.sessions.create.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs.allow_promotion_codes).toBe(true);
+    expect(callArgs.discounts).toBeUndefined();
   });
 
   it('includes client_reference_id when rewardful cookie is set', async () => {
@@ -674,6 +703,75 @@ describe('handleKiloClawSubscriptionCreated', () => {
     expect(row.stripe_subscription_id).toBe('sub_current');
     expect(row.plan).toBe('standard');
   });
+
+  it('calls ensureAutoIntroSchedule for intro-price subscription', async () => {
+    // Set up stripe.subscriptions.retrieve to return intro price
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_auto',
+      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const subscription = makeStripeSubscription({
+      id: 'sub_intro',
+      metadata: { type: 'kiloclaw', plan: 'standard', kiloUserId: user.id },
+      status: 'active',
+      priceId: 'price_standard_intro',
+    });
+
+    await handleKiloClawSubscriptionCreated({
+      eventId: 'evt_intro_created',
+      subscription,
+    });
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_subscription_id).toBe('sub_intro');
+    expect(row.plan).toBe('standard');
+    // ensureAutoIntroSchedule should have been invoked
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
+    expect(row.stripe_schedule_id).toBe('sub_sched_auto');
+    expect(row.scheduled_plan).toBe('standard');
+    expect(row.scheduled_by).toBe('auto');
+  });
+
+  it('does not create auto schedule for regular-price subscription (returning subscriber)', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      plan: 'standard',
+      status: 'canceled',
+      stripe_subscription_id: 'sub_old_canceled',
+    });
+
+    // Regular price — isIntroPriceId returns false
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const subscription = makeStripeSubscription({
+      id: 'sub_regular_return',
+      metadata: { type: 'kiloclaw', plan: 'standard', kiloUserId: user.id },
+      status: 'active',
+      priceId: 'price_standard',
+    });
+
+    await handleKiloClawSubscriptionCreated({
+      eventId: 'evt_regular_created',
+      subscription,
+    });
+
+    // Should NOT create a schedule
+    expect(stripeMock.subscriptionSchedules.create).not.toHaveBeenCalled();
+  });
 });
 
 describe('cancelSubscription', () => {
@@ -685,6 +783,7 @@ describe('cancelSubscription', () => {
       status: 'active',
     });
 
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
     const caller = await createCallerForUser(user.id);
@@ -716,6 +815,7 @@ describe('cancelSubscription', () => {
       scheduled_by: 'user',
     });
 
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
     stripeMock.subscriptionSchedules.release.mockResolvedValue({});
     stripeMock.subscriptions.update.mockResolvedValue({});
 
@@ -747,6 +847,7 @@ describe('cancelSubscription', () => {
       scheduled_by: 'user',
     });
 
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
     stripeMock.subscriptionSchedules.release.mockRejectedValue(
       new Error('This schedule is not active and cannot be released')
     );
@@ -769,6 +870,7 @@ describe('cancelSubscription', () => {
       scheduled_by: 'user',
     });
 
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
     stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe API timeout'));
 
     const caller = await createCallerForUser(user.id);
@@ -785,6 +887,28 @@ describe('cancelSubscription', () => {
 
     expect(row.stripe_schedule_id).toBe('sched_fail');
     expect(row.cancel_at_period_end).toBe(false);
+  });
+
+  it('detects and releases hidden schedule when DB has no pointer but Stripe has schedule', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_hidden_sched',
+      plan: 'standard',
+      status: 'active',
+      // No stripe_schedule_id in DB
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_hidden',
+    });
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    stripeMock.subscriptions.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelSubscription();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sched_hidden');
   });
 });
 
@@ -821,6 +945,369 @@ describe('reactivateSubscription', () => {
     expect(row.cancel_at_period_end).toBe(false);
     // commit_ends_at preserved (compare as dates to avoid format mismatch)
     expect(new Date(row.commit_ends_at!).getTime()).toBe(new Date(futureCommitEnd).getTime());
+  });
+
+  it('restores auto intro schedule after reactivating a standard intro-price subscription', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_reactivate_intro',
+      plan: 'standard',
+      status: 'active',
+      cancel_at_period_end: true,
+    });
+
+    stripeMock.subscriptions.update.mockResolvedValue({});
+    // ensureAutoIntroSchedule will call stripe.subscriptions.retrieve
+    // Return intro price to trigger schedule creation
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_restored',
+      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.reactivateSubscription();
+
+    expect(result).toEqual({ success: true });
+    // Schedule should have been created
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
+  });
+
+  it('succeeds even if ensureAutoIntroSchedule throws after reactivation', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_reactivate_fail',
+      plan: 'standard',
+      status: 'active',
+      cancel_at_period_end: true,
+    });
+
+    stripeMock.subscriptions.update.mockResolvedValue({});
+    // Make ensureAutoIntroSchedule fail
+    stripeMock.subscriptions.retrieve.mockRejectedValue(new Error('Stripe timeout'));
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.reactivateSubscription();
+
+    // Should still succeed — reactivation is the primary operation
+    expect(result).toEqual({ success: true });
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    expect(row.cancel_at_period_end).toBe(false);
+  });
+});
+
+describe('switchPlan', () => {
+  it('creates a fresh schedule when switching standard to commit with no existing schedule', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_switch',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_new',
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
+    expect(stripeMock.subscriptionSchedules.update).toHaveBeenCalled();
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    expect(dbRow.stripe_schedule_id).toBe('sub_sched_new');
+    expect(dbRow.scheduled_plan).toBe('commit');
+    expect(dbRow.scheduled_by).toBe('user');
+  });
+
+  it('rejects switch when user-initiated schedule already exists', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_switch_reject',
+      plan: 'standard',
+      status: 'active',
+      stripe_schedule_id: 'sched_user_pending',
+      scheduled_plan: 'commit',
+      scheduled_by: 'user',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_user_pending',
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'commit' })).rejects.toThrow(
+      'A plan switch is already pending'
+    );
+  });
+
+  it('updates auto schedule in place when switching standard (intro) to commit', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_switch_auto',
+      plan: 'standard',
+      status: 'active',
+      stripe_schedule_id: 'sched_auto',
+      scheduled_plan: 'standard',
+      scheduled_by: 'auto',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_auto',
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: 'sched_auto',
+      metadata: { origin: 'auto-intro' },
+      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      status: 'active',
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    // Should update existing schedule, not create a new one
+    expect(stripeMock.subscriptionSchedules.create).not.toHaveBeenCalled();
+    expect(stripeMock.subscriptionSchedules.update).toHaveBeenCalledWith(
+      'sched_auto',
+      expect.objectContaining({
+        end_behavior: 'release',
+      })
+    );
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    expect(row.stripe_schedule_id).toBe('sched_auto');
+    expect(row.scheduled_plan).toBe('commit');
+    expect(row.scheduled_by).toBe('user');
+  });
+
+  it('detects hidden auto schedule via live fetch and updates it in place', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_hidden_auto',
+      plan: 'standard',
+      status: 'active',
+      // No stripe_schedule_id in DB
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_hidden_auto',
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: 'sched_hidden_auto',
+      metadata: { origin: 'auto-intro' },
+      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      status: 'active',
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.create).not.toHaveBeenCalled();
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    expect(row.scheduled_by).toBe('user');
+    expect(row.scheduled_plan).toBe('commit');
+  });
+
+  it('releases hidden non-auto schedule and creates fresh schedule', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_hidden_user',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: 'sched_hidden_user',
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+    stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: 'sched_hidden_user',
+      metadata: {},
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      status: 'active',
+    });
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sched_fresh',
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sched_hidden_user');
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
+  });
+
+  it('rejects switch to same plan', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_same',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
+      'Already on this plan'
+    );
+  });
+});
+
+describe('cancelPlanSwitch', () => {
+  it('releases user schedule and clears DB fields', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_cancel_switch',
+      plan: 'standard',
+      status: 'active',
+      stripe_schedule_id: 'sched_user_switch',
+      scheduled_plan: 'commit',
+      scheduled_by: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    // ensureAutoIntroSchedule will check price — return regular price so it no-ops
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sched_user_switch');
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    expect(row.stripe_schedule_id).toBeNull();
+    expect(row.scheduled_plan).toBeNull();
+    expect(row.scheduled_by).toBeNull();
+  });
+
+  it('restores auto schedule when canceling switch during intro month', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_cancel_switch_intro',
+      plan: 'standard',
+      status: 'active',
+      stripe_schedule_id: 'sched_user_intro',
+      scheduled_plan: 'commit',
+      scheduled_by: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    // Return intro price so ensureAutoIntroSchedule creates a schedule
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard_intro' } }] },
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sched_auto_restored',
+      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+    // Should have restored the auto schedule
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+    // After ensureAutoIntroSchedule, DB should have the restored schedule
+    expect(row.stripe_schedule_id).toBe('sched_auto_restored');
+    expect(row.scheduled_plan).toBe('standard');
+    expect(row.scheduled_by).toBe('auto');
+  });
+
+  it('rejects when no user-initiated schedule exists', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_no_switch',
+      plan: 'standard',
+      status: 'active',
+      stripe_schedule_id: 'sched_auto_only',
+      scheduled_plan: 'standard',
+      scheduled_by: 'auto',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelPlanSwitch()).rejects.toThrow(
+      'No user-initiated plan switch to cancel'
+    );
+  });
+
+  it('succeeds when schedule is already released', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_already_released',
+      plan: 'standard',
+      status: 'active',
+      stripe_schedule_id: 'sched_gone',
+      scheduled_plan: 'commit',
+      scheduled_by: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockRejectedValue(
+      new Error('This schedule is not active and cannot be released')
+    );
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
   });
 });
 

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -1463,7 +1463,9 @@ describe('switchPlan', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_new',
-      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+      phases: [
+        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({
       id: 'sub_sched_new',
@@ -1568,7 +1570,7 @@ describe('switchPlan', () => {
 
     const caller = await createCallerForUser(user.id);
     await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
-      'Stripe network timeout'
+      'Unable to switch plan: failed to release existing schedule'
     );
 
     // Should NOT have attempted to create a new schedule
@@ -1592,7 +1594,9 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.release.mockResolvedValue({});
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_new',
-      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+      phases: [
+        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({
       id: 'sub_sched_new',
@@ -1615,7 +1619,9 @@ describe('switchPlan', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_orphan',
-      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+      phases: [
+        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockRejectedValue(new Error('Stripe update failed'));
     stripeMock.subscriptionSchedules.release.mockResolvedValue({});
@@ -1647,7 +1653,9 @@ describe('switchPlan', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_race',
-      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+      phases: [
+        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+      ],
     });
     // Simulate a concurrent request writing a schedule to the DB while our
     // Stripe schedule update is in-flight — after the DB guard passed but
@@ -1812,7 +1820,7 @@ describe('cancelPlanSwitch', () => {
     expect(row.scheduled_plan).toBeNull();
   });
 
-  it('rethrows non-already-released Stripe errors', async () => {
+  it('proceeds to clear DB state when schedule release fails with a non-recognized error', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       stripe_subscription_id: 'sub_stripe_fail',
@@ -1826,15 +1834,18 @@ describe('cancelPlanSwitch', () => {
     stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe network timeout'));
 
     const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.cancelPlanSwitch()).rejects.toThrow('Stripe network timeout');
+    const result = await caller.kiloclaw.cancelPlanSwitch();
 
-    // DB should NOT have been cleared since Stripe failed
+    expect(result).toEqual({ success: true });
+
+    // DB should still be cleared so the user isn't stuck
     const [row] = await db
       .select()
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.user_id, user.id))
       .limit(1);
 
-    expect(row.stripe_schedule_id).toBe('sub_sched_fail');
+    expect(row.stripe_schedule_id).toBeNull();
+    expect(row.scheduled_plan).toBeNull();
   });
 });

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -44,7 +44,7 @@ import {
   getStripePriceIdForClawPlan,
   getStripePriceIdForClawPlanIntro,
 } from '@/lib/kiloclaw/stripe-price-ids.server';
-import { ensureAutoIntroSchedule } from '@/lib/kiloclaw/stripe-handlers';
+import { ensureAutoIntroSchedule, resolvePhasePrice } from '@/lib/kiloclaw/stripe-handlers';
 import {
   KILOCLAW_EARLYBIRD_EXPIRY_DATE,
   KILOCLAW_TRIAL_DURATION_DAYS,
@@ -1404,12 +1404,7 @@ export const kiloclawRouter = createTRPCRouter({
         try {
           const existingSchedule = await stripe.subscriptionSchedules.retrieve(effectiveScheduleId);
           const autoCurrentPhase = existingSchedule.phases[0];
-          const phase1PriceRef = autoCurrentPhase?.items[0]?.price;
-          const phase1Price = phase1PriceRef
-            ? typeof phase1PriceRef === 'string'
-              ? phase1PriceRef
-              : phase1PriceRef.id
-            : null;
+          const phase1Price = autoCurrentPhase ? resolvePhasePrice(autoCurrentPhase) : null;
 
           if (!autoCurrentPhase || !phase1Price) {
             throw new TRPCError({
@@ -1470,12 +1465,7 @@ export const kiloclawRouter = createTRPCRouter({
           });
         }
 
-        const freshPhase1PriceRef = currentPhase.items[0]?.price;
-        const freshPhase1Price = freshPhase1PriceRef
-          ? typeof freshPhase1PriceRef === 'string'
-            ? freshPhase1PriceRef
-            : freshPhase1PriceRef.id
-          : null;
+        const freshPhase1Price = resolvePhasePrice(currentPhase);
         if (!freshPhase1Price) {
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
@@ -1557,9 +1547,12 @@ export const kiloclawRouter = createTRPCRouter({
 
     const released = await releaseScheduleIfActive(sub.stripe_schedule_id);
     if (!released) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to release pending plan schedule. Please try again.',
+      // Schedule release failed with a non-recognized error. Proceed to clear
+      // DB state anyway so the user isn't stuck — the schedule may have been
+      // completed or is in an unexpected terminal state.
+      console.error('Failed to release schedule during cancelPlanSwitch, clearing local state', {
+        userId: ctx.user.id,
+        stripeScheduleId: sub.stripe_schedule_id,
       });
     }
 

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -17,7 +17,6 @@ import {
   KILOCLAW_API_URL,
   STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID,
   STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID,
-  STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID,
   STRIPE_KILOCLAW_BILLING_START,
   KILOCLAW_BILLING_ENFORCEMENT,
 } from '@/lib/config.server';
@@ -41,7 +40,11 @@ import { client as stripe } from '@/lib/stripe-client';
 import { APP_URL } from '@/lib/constants';
 import { getRewardfulReferral } from '@/lib/rewardful';
 import { clawAccessProcedure } from '@/lib/kiloclaw/access-gate';
-import { getStripePriceIdForClawPlan } from '@/lib/kiloclaw/stripe-price-ids.server';
+import {
+  getStripePriceIdForClawPlan,
+  getStripePriceIdForClawPlanIntro,
+} from '@/lib/kiloclaw/stripe-price-ids.server';
+import { ensureAutoIntroSchedule } from '@/lib/kiloclaw/stripe-handlers';
 import {
   KILOCLAW_EARLYBIRD_EXPIRY_DATE,
   KILOCLAW_TRIAL_DURATION_DAYS,
@@ -272,6 +275,32 @@ const STATUS_PAGE_TIMEOUT_MS = 5_000;
 
 const logStatusPageWarning = sentryLogger('kiloclaw-status-page', 'warning');
 const logBillingError = sentryLogger('kiloclaw-billing', 'error');
+
+/** Returns true if a Stripe error indicates the schedule is already released/canceled. */
+function isScheduleAlreadyInactive(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes('not active') || msg.includes('released') || msg.includes('canceled');
+}
+
+/**
+ * Release a Stripe schedule, tolerating already-released/canceled states.
+ * Returns true if the schedule was released (or was already inactive).
+ * Returns false if the release failed with a transient error.
+ */
+async function releaseScheduleIfActive(scheduleId: string): Promise<boolean> {
+  try {
+    await stripe.subscriptionSchedules.release(scheduleId);
+    return true;
+  } catch (error) {
+    return isScheduleAlreadyInactive(error);
+  }
+}
+
+/** Resolve a Stripe schedule reference (string ID or expanded object) to its ID. */
+function resolveScheduleId(schedule: string | { id: string } | null | undefined): string | null {
+  if (!schedule) return null;
+  return typeof schedule === 'string' ? schedule : schedule.id;
+}
 
 async function fetchKiloClawServiceDegraded(): Promise<boolean> {
   try {
@@ -1172,14 +1201,8 @@ export const kiloclawRouter = createTRPCRouter({
         });
       }
 
-      // Guard against duplicate Stripe subscriptions from concurrent checkouts.
-      // The local DB check above exempts trialing rows, so a user could open
-      // multiple Checkout Sessions before the first webhook flips the row to active.
-      // We check for both completed subscriptions and open checkout sessions:
-      // - Active/trialing subscriptions catch the case where a prior checkout completed.
-      // - Open checkout sessions catch the race where a parallel request just
-      //   created a session but the user hasn't completed it yet, preventing
-      //   multiple pending sessions from leading to duplicate subscriptions.
+      // Guard against duplicate Stripe subscriptions: the DB check above exempts
+      // trialing rows, so also verify against live Stripe state.
       const [activeSubs, trialingSubs, openSessions] = await Promise.all([
         stripe.subscriptions.list({ customer: stripeCustomerId, status: 'active', limit: 10 }),
         stripe.subscriptions.list({ customer: stripeCustomerId, status: 'trialing', limit: 10 }),
@@ -1194,48 +1217,22 @@ export const kiloclawRouter = createTRPCRouter({
           message: 'You already have an active subscription.',
         });
       }
-      // Best-effort cleanup: expire stale open checkout sessions so the user
-      // can start fresh (e.g. they started checkout, closed the tab, and came
-      // back to retry). Errors are swallowed because a session may already be
-      // expired or completed by the time we call expire() — either way the
-      // stale session is no longer open, which is the goal.
-      //
-      // NOTE: This does not prevent two concurrent requests from both reaching
-      // sessions.create(). That race is inherent to any read-then-write
-      // pattern against the Stripe API and cannot be closed without an
-      // external lock. Duplicate open checkout sessions are tolerable: each
-      // requires independent user action to complete, and the subscription-
-      // level guard above (hasActiveKiloClawSub) prevents the real harm —
-      // duplicate subscriptions.
+      // Best-effort: expire stale open checkout sessions so the user can retry.
+      // Concurrent duplicates are tolerable — hasActiveKiloClawSub prevents
+      // duplicate subscriptions, which is what actually matters.
       const staleKiloClawSessions = openSessions.data.filter(s => s.metadata?.type === 'kiloclaw');
       await Promise.all(
-        staleKiloClawSessions.map(s =>
-          stripe.checkout.sessions.expire(s.id).catch(() => {
-            // Swallow — session is already expired, completed, or otherwise
-            // no longer open. The goal (clearing stale sessions) is met.
-          })
-        )
+        staleKiloClawSessions.map(s => stripe.checkout.sessions.expire(s.id).catch(() => {}))
       );
 
-      const priceId = getStripePriceIdForClawPlan(input.plan);
+      // New standard subscribers get the intro price; returning (canceled) standard
+      // subscribers and all commit subscribers get the regular price.
+      const priceId =
+        input.plan === 'standard' && existing?.status !== 'canceled'
+          ? getStripePriceIdForClawPlanIntro('standard')
+          : getStripePriceIdForClawPlan(input.plan);
 
       const rewardfulReferral = await getRewardfulReferral();
-      const shouldApplyStandardPlanDiscount =
-        input.plan === 'standard' && existing?.status !== 'canceled';
-      const standardPlanDiscount = shouldApplyStandardPlanDiscount
-        ? (() => {
-            if (!STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID) {
-              throw new TRPCError({
-                code: 'INTERNAL_SERVER_ERROR',
-                message: 'Standard plan first-month discount is not configured.',
-              });
-            }
-
-            return {
-              discounts: [{ coupon: STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID }],
-            };
-          })()
-        : {};
 
       const session = await stripe.checkout.sessions.create({
         mode: 'subscription',
@@ -1243,7 +1240,7 @@ export const kiloclawRouter = createTRPCRouter({
         ...(rewardfulReferral && { client_reference_id: rewardfulReferral }),
         billing_address_collection: 'required',
         line_items: [{ price: priceId, quantity: 1 }],
-        ...standardPlanDiscount,
+        allow_promotion_codes: true,
         customer_update: { name: 'auto', address: 'auto' },
         tax_id_collection: { enabled: true, required: 'never' },
         success_url: `${APP_URL}/payments/kiloclaw/success?session_id={CHECKOUT_SESSION_ID}`,
@@ -1279,44 +1276,32 @@ export const kiloclawRouter = createTRPCRouter({
       });
     }
 
-    // If there's a pending schedule, release it first.
-    // Only clear the local pointer after release succeeds or the schedule is
-    // already released/canceled, so Stripe and local state stay in sync.
-    if (sub.stripe_schedule_id) {
-      try {
-        await stripe.subscriptionSchedules.release(sub.stripe_schedule_id);
-      } catch (releaseError) {
-        // If the schedule was already released/canceled, Stripe returns an error
-        // with status 400 and a message about the schedule not being active.
-        // In that case we should still clear our local pointer.
-        const msg = releaseError instanceof Error ? releaseError.message : String(releaseError);
-        const alreadyInactive =
-          msg.includes('not active') || msg.includes('released') || msg.includes('canceled');
-        if (!alreadyInactive) {
-          logBillingError('Failed to release subscription schedule — aborting cancellation', {
-            user_id: ctx.user.id,
-            schedule_id: sub.stripe_schedule_id,
-            error: msg,
-          });
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: 'Unable to cancel: failed to release pending plan schedule. Please try again.',
-          });
-        }
+    // Reconcile hidden-schedule state: Stripe may have an attached schedule
+    // that the DB doesn't know about.
+    const liveSub = await stripe.subscriptions.retrieve(sub.stripe_subscription_id);
+    const scheduleIdToRelease = sub.stripe_schedule_id ?? resolveScheduleId(liveSub.schedule);
+
+    if (scheduleIdToRelease) {
+      const released = await releaseScheduleIfActive(scheduleIdToRelease);
+      if (!released) {
+        logBillingError('Failed to release subscription schedule — aborting cancellation', {
+          user_id: ctx.user.id,
+          schedule_id: scheduleIdToRelease,
+        });
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Unable to cancel: failed to release pending plan schedule. Please try again.',
+        });
       }
     }
 
-    // Set cancel_at_period_end in Stripe BEFORE clearing local schedule fields.
-    // If this Stripe call fails, the schedule was already released in Stripe but
-    // local state still references it, so reactivateSubscription can recreate it.
     await stripe.subscriptions.update(sub.stripe_subscription_id, { cancel_at_period_end: true });
 
-    // Both Stripe calls succeeded — now persist all local changes together.
     await db
       .update(kiloclaw_subscriptions)
       .set({
         cancel_at_period_end: true,
-        ...(sub.stripe_schedule_id
+        ...(scheduleIdToRelease
           ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
           : {}),
       })
@@ -1345,6 +1330,16 @@ export const kiloclawRouter = createTRPCRouter({
       .set({ cancel_at_period_end: false })
       .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
 
+    // Best-effort: restore the auto intro→regular schedule if on an intro price
+    try {
+      await ensureAutoIntroSchedule(sub.stripe_subscription_id, ctx.user.id);
+    } catch (err) {
+      console.error('Failed to restore auto intro schedule after reactivation', {
+        userId: ctx.user.id,
+        error: err,
+      });
+    }
+
     return { success: true };
   }),
 
@@ -1369,47 +1364,93 @@ export const kiloclawRouter = createTRPCRouter({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot switch from a trial plan.' });
       }
 
-      // Reject if the DB already tracks a legitimate pending switch.
-      if (sub.stripe_schedule_id) {
+      // Reconcile hidden-schedule state: Stripe may have an attached schedule
+      // that the DB doesn't know about.
+      const liveSub = await stripe.subscriptions.retrieve(sub.stripe_subscription_id);
+      const effectiveScheduleId = sub.stripe_schedule_id ?? resolveScheduleId(liveSub.schedule);
+
+      let effectiveScheduledBy = sub.scheduled_by;
+      if (!sub.stripe_schedule_id && effectiveScheduleId) {
+        const hiddenSchedule = await stripe.subscriptionSchedules.retrieve(effectiveScheduleId);
+        if (hiddenSchedule.metadata?.origin === 'auto-intro') {
+          effectiveScheduledBy = 'auto';
+        } else {
+          await releaseScheduleIfActive(effectiveScheduleId);
+          effectiveScheduledBy = null;
+        }
+      }
+
+      if (effectiveScheduledBy === 'user') {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'A plan switch is already pending. Cancel it before requesting a new one.',
         });
       }
 
-      // Release any orphaned Stripe schedule not tracked in the DB.
-      // This handles the race condition where a concurrent request created a schedule
-      // on Stripe but crashed before writing it to the DB.
-      const stripeSub = await stripe.subscriptions.retrieve(sub.stripe_subscription_id);
-      const existingScheduleId =
-        typeof stripeSub.schedule === 'string'
-          ? stripeSub.schedule
-          : (stripeSub.schedule?.id ?? null);
+      const targetPriceId = getStripePriceIdForClawPlan(input.toPlan);
 
-      if (existingScheduleId) {
+      // If an auto schedule exists, update it in place for the user's plan switch.
+      if (effectiveScheduledBy === 'auto' && effectiveScheduleId) {
         try {
-          await stripe.subscriptionSchedules.release(existingScheduleId);
-        } catch (error) {
-          // Only ignore errors that mean the schedule is already gone
-          // (released, canceled, not found). Transient failures (network,
-          // rate-limit) must abort so we don't try to create() while a
-          // schedule is still attached.
-          if (
-            error instanceof stripe.errors.StripeInvalidRequestError &&
-            /already|released|canceled|not_found|does not exist/.test(error.message)
-          ) {
-            // safe to proceed
-          } else {
-            throw error;
+          const existingSchedule = await stripe.subscriptionSchedules.retrieve(effectiveScheduleId);
+          const autoCurrentPhase = existingSchedule.phases[0];
+          const phase1PriceRef = autoCurrentPhase?.items[0]?.price;
+          const phase1Price = phase1PriceRef
+            ? typeof phase1PriceRef === 'string'
+              ? phase1PriceRef
+              : phase1PriceRef.id
+            : null;
+
+          if (!autoCurrentPhase || !phase1Price) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: 'Cannot determine current phase price from schedule.',
+            });
           }
+
+          await stripe.subscriptionSchedules.update(effectiveScheduleId, {
+            end_behavior: 'release',
+            phases: [
+              {
+                items: [{ price: phase1Price }],
+                start_date: autoCurrentPhase.start_date,
+                end_date: autoCurrentPhase.end_date,
+              },
+              { items: [{ price: targetPriceId }] },
+            ],
+          });
+
+          await db
+            .update(kiloclaw_subscriptions)
+            .set({
+              stripe_schedule_id: effectiveScheduleId,
+              scheduled_plan: input.toPlan,
+              scheduled_by: 'user',
+            })
+            .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+          return { success: true };
+        } catch (err) {
+          // Stale schedule — clear pointer and fall through to fresh creation
+          if (!isScheduleAlreadyInactive(err)) throw err;
+
+          await db
+            .update(kiloclaw_subscriptions)
+            .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
+            .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
         }
       }
 
-      const targetPriceId = getStripePriceIdForClawPlan(input.toPlan);
-      const currentPriceId = getStripePriceIdForClawPlan(sub.plan);
+      // Fresh schedule creation: no existing schedule (or stale one was cleared above)
+      const liveCurrentPriceId = liveSub.items.data[0]?.price?.id;
+      if (!liveCurrentPriceId) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Cannot determine current subscription price.',
+        });
+      }
 
-      // Create schedule for plan transition at period end.
-      // from_subscription creates a schedule with one phase matching the current billing period.
+      // from_subscription creates one phase matching the current billing period.
       // We must preserve that phase's start/end dates so the switch happens at renewal, not immediately.
       let stripeScheduleId: string | null = null;
       try {
@@ -1426,17 +1467,11 @@ export const kiloclawRouter = createTRPCRouter({
           });
         }
 
-        // Both directions use a 2-phase schedule: current plan until period end,
-        // then the target plan (open-ended, end_behavior: 'release'). When the
-        // final phase starts, Stripe releases the schedule and the subscription
-        // continues on the new price. The plan change is picked up by
-        // subscription.updated via detectPlanFromSubscription, and the schedule
-        // release event clears the tracking fields.
         await stripe.subscriptionSchedules.update(schedule.id, {
           end_behavior: 'release',
           phases: [
             {
-              items: [{ price: currentPriceId }],
+              items: [{ price: liveCurrentPriceId }],
               start_date: currentPhase.start_date,
               end_date: currentPhase.end_date,
             },
@@ -1504,25 +1539,30 @@ export const kiloclawRouter = createTRPCRouter({
       });
     }
 
-    try {
-      await stripe.subscriptionSchedules.release(sub.stripe_schedule_id);
-    } catch (error) {
-      // If Stripe says the schedule is already released/canceled/not found,
-      // proceed to clear the DB so the user isn't stuck.
-      if (
-        error instanceof stripe.errors.StripeInvalidRequestError &&
-        /already|released|canceled|not_found|does not exist/.test(error.message)
-      ) {
-        // fall through to clear DB
-      } else {
-        throw error;
-      }
+    const released = await releaseScheduleIfActive(sub.stripe_schedule_id);
+    if (!released) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to release pending plan schedule. Please try again.',
+      });
     }
 
     await db
       .update(kiloclaw_subscriptions)
       .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
       .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+    // Best-effort: restore the auto intro→regular schedule if on an intro price
+    try {
+      if (sub.stripe_subscription_id) {
+        await ensureAutoIntroSchedule(sub.stripe_subscription_id, ctx.user.id);
+      }
+    } catch (err) {
+      console.error('Failed to restore auto intro schedule after cancel plan switch', {
+        userId: ctx.user.id,
+        error: err,
+      });
+    }
 
     return { success: true };
   }),

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1375,7 +1375,17 @@ export const kiloclawRouter = createTRPCRouter({
         if (hiddenSchedule.metadata?.origin === 'auto-intro') {
           effectiveScheduledBy = 'auto';
         } else {
-          await releaseScheduleIfActive(effectiveScheduleId);
+          // Hidden non-auto schedule — must release before creating a fresh one,
+          // otherwise Stripe rejects the create because the subscription is still
+          // attached to the old schedule.
+          const released = await releaseScheduleIfActive(effectiveScheduleId);
+          if (!released) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message:
+                'Unable to switch plan: failed to release existing schedule. Please try again.',
+            });
+          }
           effectiveScheduledBy = null;
         }
       }
@@ -1441,17 +1451,10 @@ export const kiloclawRouter = createTRPCRouter({
         }
       }
 
-      // Fresh schedule creation: no existing schedule (or stale one was cleared above)
-      const liveCurrentPriceId = liveSub.items.data[0]?.price?.id;
-      if (!liveCurrentPriceId) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Cannot determine current subscription price.',
-        });
-      }
-
-      // from_subscription creates one phase matching the current billing period.
-      // We must preserve that phase's start/end dates so the switch happens at renewal, not immediately.
+      // Fresh schedule creation: no existing schedule (or stale one was cleared above).
+      // from_subscription mirrors the subscription's current state at create-time,
+      // so the phase price reflects the actual current price even if a schedule
+      // released at a billing boundary since our earlier subscriptions.retrieve().
       let stripeScheduleId: string | null = null;
       try {
         const schedule = await stripe.subscriptionSchedules.create({
@@ -1467,11 +1470,24 @@ export const kiloclawRouter = createTRPCRouter({
           });
         }
 
+        const freshPhase1PriceRef = currentPhase.items[0]?.price;
+        const freshPhase1Price = freshPhase1PriceRef
+          ? typeof freshPhase1PriceRef === 'string'
+            ? freshPhase1PriceRef
+            : freshPhase1PriceRef.id
+          : null;
+        if (!freshPhase1Price) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Cannot determine current subscription price from schedule.',
+          });
+        }
+
         await stripe.subscriptionSchedules.update(schedule.id, {
           end_behavior: 'release',
           phases: [
             {
-              items: [{ price: liveCurrentPriceId }],
+              items: [{ price: freshPhase1Price }],
               start_date: currentPhase.start_date,
               end_date: currentPhase.end_date,
             },

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -276,10 +276,15 @@ const STATUS_PAGE_TIMEOUT_MS = 5_000;
 const logStatusPageWarning = sentryLogger('kiloclaw-status-page', 'warning');
 const logBillingError = sentryLogger('kiloclaw-billing', 'error');
 
-/** Returns true if a Stripe error indicates the schedule is already released/canceled. */
+/** Returns true if a Stripe error indicates the schedule is already in a terminal state. */
 function isScheduleAlreadyInactive(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
-  return msg.includes('not active') || msg.includes('released') || msg.includes('canceled');
+  return (
+    msg.includes('not active') ||
+    msg.includes('released') ||
+    msg.includes('canceled') ||
+    msg.includes('completed')
+  );
 }
 
 /**
@@ -1547,12 +1552,9 @@ export const kiloclawRouter = createTRPCRouter({
 
     const released = await releaseScheduleIfActive(sub.stripe_schedule_id);
     if (!released) {
-      // Schedule release failed with a non-recognized error. Proceed to clear
-      // DB state anyway so the user isn't stuck — the schedule may have been
-      // completed or is in an unexpected terminal state.
-      console.error('Failed to release schedule during cancelPlanSwitch, clearing local state', {
-        userId: ctx.user.id,
-        stripeScheduleId: sub.stripe_schedule_id,
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to release pending plan schedule. Please try again.',
       });
     }
 


### PR DESCRIPTION
## Summary

- Replace the Stripe coupon-based first-month discount for Standard plan with an introductory price approach (`STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID`), enabling `allow_promotion_codes: true` on all KiloClaw checkout sessions (both Standard and Commit plans). This unblocks Rewardful affiliate promo code entry, which was previously blocked by Stripe's mutual exclusivity between `discounts` and `allow_promotion_codes`.
- New `ensureAutoIntroSchedule` idempotent helper creates a 2-phase Stripe subscription schedule (intro → regular standard price) with `end_behavior: 'release'`, called from `subscription.created` webhook, reactivation, and cancel-plan-switch flows. Auto schedules are tagged with `metadata.origin: 'auto-intro'` to distinguish them from user-initiated plan switches.
- All billing flows (cancel, reactivate, switchPlan, cancelPlanSwitch) updated to handle auto schedules transparently — live-fetch reconciliation detects "hidden schedules" (Stripe has schedule but DB pointer is null) and handles them correctly. Auto schedules are invisible in the UI; users can still switch plans or cancel without interference.
- New billing lifecycle cron sweep repairs stranded intro-price subscriptions that are missing their auto schedule (e.g., due to partial failure during schedule creation).

## Verification

- [x] `pnpm typecheck` — passed (all packages)
- [x] `pnpm jest src/routers/kiloclaw-billing-router.test.ts` — 42 tests passed
- [x] `pnpm run format:check` — passed
- [x] `pnpm run lint` — passed (0 warnings, 0 errors)
- [x] Pre-push hooks (format, lint, typecheck) — all passed
- [x] Spec verification: all 12 relevant spec rules verified as PASS against implementation

## Visual Changes

N/A

## Reviewer Notes

- **Pre-deploy manual step**: Create a new Stripe Price for Standard at the intro amount (recurring monthly), set its ID in `STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID`. After deploy, `STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID` can be removed from environment.
- **Key architectural pattern**: `ensureAutoIntroSchedule` uses a live Stripe fetch as single source of truth — it never trusts stale webhook payloads or DB state for schedule decisions. Race guards handle concurrent schedule creation. Partial failures are tolerated: the cron sweep (sweep 5) repairs stranded subscriptions on subsequent runs.
- **Hidden-schedule reconciliation** in cancel/switchPlan flows ensures that even if the DB loses its schedule pointer (e.g., Stripe schedule created but DB persist failed), the schedule is still detected and handled correctly via live fetch.
- **`as` casts minimized**: Stripe schedule/price references use `typeof` checks with `.id` fallback instead of `as string` casts, per coding style rules.
- **Assumption**: Rewardful promo codes are configured as one-time (first-invoice-only) discounts. If recurring promo discounts are needed, schedule phase definitions must forward `discounts` from the current phase.