### PR TITLE
feat(gastown): add POST /debug/reconcile-dry-run endpoint

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -30,7 +30,7 @@ import * as scheduling from './town/scheduling';
 import * as events from './town/events';
 import * as reconciler from './town/reconciler';
 import { applyAction } from './town/actions';
-import type { ApplyActionContext } from './town/actions';
+import type { Action, ApplyActionContext } from './town/actions';
 import { buildRefinerySystemPrompt } from '../prompts/refinery-system.prompt';
 import { GitHubPRStatusSchema, GitLabMRStatusSchema } from '../util/platform-pr.util';
 
@@ -3681,6 +3681,31 @@ export class TownDO extends DurableObject<Env> {
       },
       reconciler: this._lastReconcilerMetrics,
       recentEvents,
+    };
+  }
+
+  // DEBUG: dry-run the reconciler against current state, returning actions
+  // it would emit without applying them. Side-effect-free — reconcile()
+  // only reads SQLite state; applyAction() is never called.
+  async debugDryRun(): Promise<{
+    actions: Action[];
+    metrics: Pick<
+      reconciler.ReconcilerMetrics,
+      'actionsEmitted' | 'actionsByType' | 'pendingEventCount'
+    >;
+  }> {
+    const actions = reconciler.reconcile(this.sql);
+    const actionsByType: Record<string, number> = {};
+    for (const a of actions) {
+      actionsByType[a.type] = (actionsByType[a.type] ?? 0) + 1;
+    }
+    return {
+      actions,
+      metrics: {
+        actionsEmitted: actions.length,
+        actionsByType,
+        pendingEventCount: events.pendingEventCount(this.sql),
+      },
     };
   }
 

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -206,6 +206,14 @@ app.get('/debug/towns/:townId/status', async c => {
   return c.json({ alarmStatus, agentMeta, beadSummary });
 });
 
+app.post('/debug/towns/:townId/reconcile-dry-run', async c => {
+  const townId = c.req.param('townId');
+  const town = getTownDOStub(c.env, townId);
+  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
+  const result = await town.debugDryRun();
+  return c.json(result);
+});
+
 // ── Town ID + Auth ──────────────────────────────────────────────────────
 // All rig routes live under /api/towns/:townId/rigs/:rigId so the townId
 // is always available from the URL path.


### PR DESCRIPTION
## Summary

Add a debug endpoint (`POST /debug/towns/:townId/reconcile-dry-run`) that runs the reconciler against current live state and returns the actions it would emit without applying them. The `debugDryRun()` method on TownDO calls `reconciler.reconcile(this.sql)` — which is side-effect-free (only SELECTs) — then returns the actions array along with metrics (`actionsEmitted`, `actionsByType`, `pendingEventCount`). The route follows the same unauthenticated debug pattern as the existing `GET /debug/towns/:townId/status` endpoint.

## Verification

- No quality gates configured for this convoy branch
- Code review: verified `reconciler.reconcile()` is side-effect-free (only SELECT queries, returns `Action[]`)
- Verified `events.pendingEventCount()` is a read-only COUNT query
- Verified `Action` type import is correct (from `./town/actions`)
- Verified route follows the existing debug endpoint pattern exactly
- Polecat reports typecheck, oxlint, and format all pass

## Visual Changes

N/A

## Reviewer Notes

- The `/debug/` endpoints are unauthenticated by design (temporary debug tooling, marked for removal). This matches the existing pattern.
- POST is used instead of GET since the endpoint runs the full reconciler and could be expensive — callers should be intentional about invoking it.
- The `Pick<ReconcilerMetrics, ...>` type on the return value keeps the contract explicit without duplicating the metric type definitions.