### PR TITLE
fix(gastown): skip container_status events for running containers

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2891,10 +2891,16 @@ export class TownDO extends DurableObject<Env> {
               townId,
               row.bead_id
             );
-            events.upsertContainerStatus(this.sql, row.bead_id, {
-              status: containerInfo.status,
-              exit_reason: containerInfo.exitReason,
-            });
+            // Skip inserting events for 'running' — it's the steady-state and
+            // a no-op in applyEvent, so recording it just bloats the event table
+            // (~720 events/hour/agent). Non-running statuses (stopped, error,
+            // unknown) still get inserted so the reconciler can detect and handle them.
+            if (containerInfo.status !== 'running') {
+              events.upsertContainerStatus(this.sql, row.bead_id, {
+                status: containerInfo.status,
+                exit_reason: containerInfo.exitReason,
+              });
+            }
           } catch (err) {
             console.warn(
               `${TOWN_LOG} alarm: container status check failed for agent=${row.bead_id}`,


### PR DESCRIPTION
## Summary

Skip inserting `container_status` events when the container reports `running` status. Running is the steady-state for healthy agents and is a no-op in `applyEvent()` (the reconciler only acts on `exited` or `not_found`). This eliminates ~720 no-op events/hour/agent from the `town_events` table. Non-running statuses (`stopped`, `error`, `unknown`, `exited`, `not_found`) continue to generate events for reconciler detection.

## Verification

- [x] Typecheck (`pnpm typecheck`) — pass (per polecat)
- [x] oxlint — pass (per polecat)
- [x] Format — pass (per polecat)
- [x] Code review — confirmed `applyEvent` only acts on `exited`/`not_found`, so filtering `running` is safe

## Visual Changes

N/A

## Reviewer Notes

- The existing dedup logic in `upsertContainerStatus()` (`events.ts:75-139`) already mitigated the volume problem by bumping timestamps instead of inserting new rows for same-status repeats. This change goes further by not calling `upsertContainerStatus()` at all for `running`, avoiding even the SELECT+UPDATE overhead.
- The comment mentions "stopped, error, unknown" as non-running statuses that still get inserted. The reconciler currently only handles `exited` and `not_found` — the others are also no-ops in `applyEvent` today but are preserved as audit trail for non-steady-state conditions.