### PR TITLE
fix(claw): prevent double-tap race condition in switchPlan

### DIFF
--- a/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
+++ b/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
@@ -92,11 +92,21 @@ function ActiveSubscriptionCard({
 
       <div className="mt-4 flex flex-wrap gap-2">
         {hasUserRequestedSwitch ? (
-          <Button variant="outline" size="sm" onClick={handleCancelSwitch}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCancelSwitch}
+            disabled={cancelSwitchMutation.isPending}
+          >
             Cancel Switch
           </Button>
         ) : !sub.scheduledPlan ? (
-          <Button variant="outline" size="sm" onClick={handleSwitchPlan}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSwitchPlan}
+            disabled={switchPlanMutation.isPending}
+          >
             Switch to {otherPlan}
           </Button>
         ) : null}

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -880,3 +880,319 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
     );
   });
 });
+
+// ── switchPlan ─────────────────────────────────────────────────────────────
+
+describe('switchPlan', () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  function setupActiveSubscription(plan: 'commit' | 'standard') {
+    return db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_switch_test',
+      plan,
+      status: 'active',
+    });
+  }
+
+  function mockStripeForSwitchPlan(scheduleOnSub: string | null = null) {
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_switch_test',
+      schedule: scheduleOnSub,
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_new',
+      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({
+      id: 'sub_sched_new',
+      status: 'active',
+    });
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+  }
+
+  it('creates a schedule and writes it to the DB on happy path', async () => {
+    await setupActiveSubscription('commit');
+    mockStripeForSwitchPlan();
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'standard' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalledWith({
+      from_subscription: 'sub_switch_test',
+    });
+    expect(stripeMock.subscriptionSchedules.update).toHaveBeenCalledWith(
+      'sub_sched_new',
+      expect.objectContaining({ end_behavior: 'release' })
+    );
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBe('sub_sched_new');
+    expect(row.scheduled_plan).toBe('standard');
+    expect(row.scheduled_by).toBe('user');
+  });
+
+  it('rejects when user is already on the target plan', async () => {
+    await setupActiveSubscription('standard');
+    const caller = await createCallerForUser(user.id);
+
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
+      'Already on this plan'
+    );
+  });
+
+  it('rejects when subscription is not active', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_canceled',
+      plan: 'standard',
+      status: 'canceled',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'commit' })).rejects.toThrow(
+      'No active subscription to switch'
+    );
+  });
+
+  it('rejects when a pending plan switch already exists in the DB', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_switch_test',
+      plan: 'commit',
+      status: 'active',
+      stripe_schedule_id: 'sub_sched_existing',
+      scheduled_plan: 'standard',
+      scheduled_by: 'user',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
+      'A plan switch is already pending'
+    );
+
+    // Should NOT have created or released anything on Stripe
+    expect(stripeMock.subscriptionSchedules.create).not.toHaveBeenCalled();
+  });
+
+  it('releases an orphaned Stripe schedule not tracked in the DB', async () => {
+    await setupActiveSubscription('commit');
+    // DB has no stripe_schedule_id, but Stripe has an orphaned schedule attached
+    mockStripeForSwitchPlan('sub_sched_orphaned');
+
+    const caller = await createCallerForUser(user.id);
+    await caller.kiloclaw.switchPlan({ toPlan: 'standard' });
+
+    // Should have released the orphaned schedule first, then created a new one
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sub_sched_orphaned');
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalledWith({
+      from_subscription: 'sub_switch_test',
+    });
+  });
+
+  it('cleans up orphaned schedule when stripe schedule update fails', async () => {
+    await setupActiveSubscription('commit');
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_switch_test',
+      schedule: null,
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_orphan',
+      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockRejectedValue(new Error('Stripe update failed'));
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
+      'Stripe update failed'
+    );
+
+    // Best-effort cleanup should have released the orphaned schedule
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sub_sched_orphan');
+
+    // DB should NOT have been updated with the orphaned schedule
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBeNull();
+  });
+
+  it('uses optimistic concurrency to prevent double-write race', async () => {
+    await setupActiveSubscription('commit');
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_switch_test',
+      schedule: null,
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_race',
+      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+    });
+    // Simulate a concurrent request writing a schedule to the DB while our
+    // Stripe schedule update is in-flight — after the DB guard passed but
+    // before our optimistic DB write.
+    stripeMock.subscriptionSchedules.update.mockImplementation(async () => {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({
+          stripe_schedule_id: 'sub_sched_concurrent',
+          scheduled_plan: 'standard',
+          scheduled_by: 'user',
+        })
+        .where(eq(kiloclaw_subscriptions.user_id, user.id));
+      return { id: 'sub_sched_race', status: 'active' };
+    });
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
+      'A plan switch is already pending'
+    );
+
+    // Should have released the schedule it created since the DB write lost the race
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sub_sched_race');
+
+    // DB should still have the concurrent request's schedule
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBe('sub_sched_concurrent');
+  });
+});
+
+// ── cancelPlanSwitch ───────────────────────────────────────────────────────
+
+describe('cancelPlanSwitch', () => {
+  it('releases the schedule and clears DB fields on happy path', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_cancel_test',
+      plan: 'commit',
+      status: 'active',
+      stripe_schedule_id: 'sub_sched_cancel',
+      scheduled_plan: 'standard',
+      scheduled_by: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sub_sched_cancel');
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBeNull();
+    expect(row.scheduled_plan).toBeNull();
+    expect(row.scheduled_by).toBeNull();
+  });
+
+  it('rejects when no pending plan switch exists', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_no_schedule',
+      plan: 'commit',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelPlanSwitch()).rejects.toThrow(
+      'No pending plan switch to cancel'
+    );
+  });
+
+  it('rejects when the pending switch was not user-initiated', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_system_switch',
+      plan: 'commit',
+      status: 'active',
+      stripe_schedule_id: 'sub_sched_system',
+      scheduled_plan: 'standard',
+      scheduled_by: 'auto',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelPlanSwitch()).rejects.toThrow(
+      'No user-initiated plan switch to cancel'
+    );
+  });
+
+  it('clears DB when Stripe says schedule is already released', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_already_released',
+      plan: 'commit',
+      status: 'active',
+      stripe_schedule_id: 'sub_sched_gone',
+      scheduled_plan: 'standard',
+      scheduled_by: 'user',
+    });
+
+    const alreadyReleasedError = new stripeMock.errors.StripeInvalidRequestError({
+      message: 'This schedule has already been released',
+      type: 'invalid_request_error',
+    });
+    stripeMock.subscriptionSchedules.release.mockRejectedValue(alreadyReleasedError);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBeNull();
+    expect(row.scheduled_plan).toBeNull();
+  });
+
+  it('rethrows non-already-released Stripe errors', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_stripe_fail',
+      plan: 'commit',
+      status: 'active',
+      stripe_schedule_id: 'sub_sched_fail',
+      scheduled_plan: 'standard',
+      scheduled_by: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe network timeout'));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelPlanSwitch()).rejects.toThrow('Stripe network timeout');
+
+    // DB should NOT have been cleared since Stripe failed
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBe('sub_sched_fail');
+  });
+});

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -996,6 +996,55 @@ describe('switchPlan', () => {
     });
   });
 
+  it('aborts when orphaned schedule release fails with a transient error', async () => {
+    await setupActiveSubscription('commit');
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_switch_test',
+      schedule: 'sub_sched_orphaned',
+    });
+    stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe network timeout'));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.switchPlan({ toPlan: 'standard' })).rejects.toThrow(
+      'Stripe network timeout'
+    );
+
+    // Should NOT have attempted to create a new schedule
+    expect(stripeMock.subscriptionSchedules.create).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when orphaned schedule release says already released', async () => {
+    await setupActiveSubscription('commit');
+
+    const alreadyReleasedError = new stripeMock.errors.StripeInvalidRequestError({
+      message: 'This schedule has already been released',
+      type: 'invalid_request_error',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_switch_test',
+      schedule: 'sub_sched_orphaned',
+    });
+    stripeMock.subscriptionSchedules.release.mockRejectedValueOnce(alreadyReleasedError);
+    // Subsequent release calls (cleanup) succeed
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_new',
+      phases: [{ start_date: now, end_date: now + 86400 * 30 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({
+      id: 'sub_sched_new',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'standard' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
+  });
+
   it('cleans up orphaned schedule when stripe schedule update fails', async () => {
     await setupActiveSubscription('commit');
 
@@ -1154,6 +1203,38 @@ describe('cancelPlanSwitch', () => {
       type: 'invalid_request_error',
     });
     stripeMock.subscriptionSchedules.release.mockRejectedValue(alreadyReleasedError);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(row.stripe_schedule_id).toBeNull();
+    expect(row.scheduled_plan).toBeNull();
+  });
+
+  it('clears DB when Stripe says schedule is already canceled', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      stripe_subscription_id: 'sub_already_canceled',
+      plan: 'commit',
+      status: 'active',
+      stripe_schedule_id: 'sub_sched_canceled',
+      scheduled_plan: 'standard',
+      scheduled_by: 'user',
+    });
+
+    const alreadyCanceledError = new stripeMock.errors.StripeInvalidRequestError({
+      message: 'This schedule has already been canceled',
+      type: 'invalid_request_error',
+    });
+    stripeMock.subscriptionSchedules.release.mockRejectedValue(alreadyCanceledError);
 
     const caller = await createCallerForUser(user.id);
     const result = await caller.kiloclaw.cancelPlanSwitch();

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -29,7 +29,7 @@ import {
   kiloclaw_subscriptions,
   kiloclaw_instances,
 } from '@kilocode/db/schema';
-import { and, eq, desc, sql } from 'drizzle-orm';
+import { and, eq, desc, isNull, sql } from 'drizzle-orm';
 import { sentryLogger } from '@/lib/utils.server';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
 import {
@@ -1369,11 +1369,29 @@ export const kiloclawRouter = createTRPCRouter({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot switch from a trial plan.' });
       }
 
+      // Reject if the DB already tracks a legitimate pending switch.
       if (sub.stripe_schedule_id) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'A plan switch is already pending. Cancel it before requesting a new one.',
         });
+      }
+
+      // Release any orphaned Stripe schedule not tracked in the DB.
+      // This handles the race condition where a concurrent request created a schedule
+      // on Stripe but crashed before writing it to the DB.
+      const stripeSub = await stripe.subscriptions.retrieve(sub.stripe_subscription_id);
+      const existingScheduleId =
+        typeof stripeSub.schedule === 'string'
+          ? stripeSub.schedule
+          : (stripeSub.schedule?.id ?? null);
+
+      if (existingScheduleId) {
+        try {
+          await stripe.subscriptionSchedules.release(existingScheduleId);
+        } catch {
+          // Schedule may already be released/canceled — safe to proceed.
+        }
       }
 
       const targetPriceId = getStripePriceIdForClawPlan(input.toPlan);
@@ -1382,46 +1400,78 @@ export const kiloclawRouter = createTRPCRouter({
       // Create schedule for plan transition at period end.
       // from_subscription creates a schedule with one phase matching the current billing period.
       // We must preserve that phase's start/end dates so the switch happens at renewal, not immediately.
-      const schedule = await stripe.subscriptionSchedules.create({
-        from_subscription: sub.stripe_subscription_id,
-      });
-
-      const currentPhase = schedule.phases[0];
-      if (!currentPhase) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Stripe schedule has no current phase.',
+      let stripeScheduleId: string | null = null;
+      try {
+        const schedule = await stripe.subscriptionSchedules.create({
+          from_subscription: sub.stripe_subscription_id,
         });
+        stripeScheduleId = schedule.id;
+
+        const currentPhase = schedule.phases[0];
+        if (!currentPhase) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Stripe schedule has no current phase.',
+          });
+        }
+
+        // Both directions use a 2-phase schedule: current plan until period end,
+        // then the target plan (open-ended, end_behavior: 'release'). When the
+        // final phase starts, Stripe releases the schedule and the subscription
+        // continues on the new price. The plan change is picked up by
+        // subscription.updated via detectPlanFromSubscription, and the schedule
+        // release event clears the tracking fields.
+        await stripe.subscriptionSchedules.update(schedule.id, {
+          end_behavior: 'release',
+          phases: [
+            {
+              items: [{ price: currentPriceId }],
+              start_date: currentPhase.start_date,
+              end_date: currentPhase.end_date,
+            },
+            { items: [{ price: targetPriceId }] },
+          ],
+        });
+
+        // Optimistic concurrency: only write if no other request wrote a schedule first.
+        const updated = await db
+          .update(kiloclaw_subscriptions)
+          .set({
+            stripe_schedule_id: schedule.id,
+            scheduled_plan: input.toPlan,
+            scheduled_by: 'user',
+          })
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+              isNull(kiloclaw_subscriptions.stripe_schedule_id)
+            )
+          )
+          .returning({ id: kiloclaw_subscriptions.id });
+
+        if (updated.length === 0) {
+          // A concurrent request already wrote a schedule — release ours.
+          await stripe.subscriptionSchedules.release(schedule.id);
+          stripeScheduleId = null; // Already cleaned up; skip catch-block cleanup.
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'A plan switch is already pending. Cancel it before requesting a new one.',
+          });
+        }
+
+        return { success: true };
+      } catch (error) {
+        // Best-effort cleanup: if we created a schedule on Stripe but something
+        // failed afterward, release it so it doesn't become orphaned.
+        if (stripeScheduleId) {
+          try {
+            await stripe.subscriptionSchedules.release(stripeScheduleId);
+          } catch {
+            // Swallow cleanup errors — the original error is more important.
+          }
+        }
+        throw error;
       }
-
-      // Both directions use a 2-phase schedule: current plan until period end,
-      // then the target plan (open-ended, end_behavior: 'release'). When the
-      // final phase starts, Stripe releases the schedule and the subscription
-      // continues on the new price. The plan change is picked up by
-      // subscription.updated via detectPlanFromSubscription, and the schedule
-      // release event clears the tracking fields.
-      await stripe.subscriptionSchedules.update(schedule.id, {
-        end_behavior: 'release',
-        phases: [
-          {
-            items: [{ price: currentPriceId }],
-            start_date: currentPhase.start_date,
-            end_date: currentPhase.end_date,
-          },
-          { items: [{ price: targetPriceId }] },
-        ],
-      });
-
-      await db
-        .update(kiloclaw_subscriptions)
-        .set({
-          stripe_schedule_id: schedule.id,
-          scheduled_plan: input.toPlan,
-          scheduled_by: 'user',
-        })
-        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
-
-      return { success: true };
     }),
 
   cancelPlanSwitch: baseProcedure.mutation(async ({ ctx }) => {
@@ -1443,7 +1493,21 @@ export const kiloclawRouter = createTRPCRouter({
       });
     }
 
-    await stripe.subscriptionSchedules.release(sub.stripe_schedule_id);
+    try {
+      await stripe.subscriptionSchedules.release(sub.stripe_schedule_id);
+    } catch (error) {
+      // If Stripe says the schedule is already released/canceled/not found,
+      // proceed to clear the DB so the user isn't stuck.
+      if (
+        error instanceof stripe.errors.StripeInvalidRequestError &&
+        /already|released|not_found|does not exist/.test(error.message)
+      ) {
+        // fall through to clear DB
+      } else {
+        throw error;
+      }
+    }
+
     await db
       .update(kiloclaw_subscriptions)
       .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1389,8 +1389,19 @@ export const kiloclawRouter = createTRPCRouter({
       if (existingScheduleId) {
         try {
           await stripe.subscriptionSchedules.release(existingScheduleId);
-        } catch {
-          // Schedule may already be released/canceled — safe to proceed.
+        } catch (error) {
+          // Only ignore errors that mean the schedule is already gone
+          // (released, canceled, not found). Transient failures (network,
+          // rate-limit) must abort so we don't try to create() while a
+          // schedule is still attached.
+          if (
+            error instanceof stripe.errors.StripeInvalidRequestError &&
+            /already|released|canceled|not_found|does not exist/.test(error.message)
+          ) {
+            // safe to proceed
+          } else {
+            throw error;
+          }
         }
       }
 
@@ -1500,7 +1511,7 @@ export const kiloclawRouter = createTRPCRouter({
       // proceed to clear the DB so the user isn't stuck.
       if (
         error instanceof stripe.errors.StripeInvalidRequestError &&
-        /already|released|not_found|does not exist/.test(error.message)
+        /already|released|canceled|not_found|does not exist/.test(error.message)
       ) {
         // fall through to clear DB
       } else {


### PR DESCRIPTION
## Summary

- Fix a race condition in `kiloclaw.switchPlan` where concurrent requests (e.g. mobile double-tap) could both pass the DB guard and create duplicate Stripe subscription schedules, causing a 500 error on the second request.
- **Stripe-side pre-check**: Before creating a schedule, retrieve the subscription from Stripe and release any orphaned schedule (attached on Stripe but not tracked in DB) from prior failed/racing requests.
- **Optimistic concurrency**: The DB write uses `WHERE stripe_schedule_id IS NULL` so only the first concurrent request succeeds; losers release their schedule and return a CONFLICT error.
- **try/catch with cleanup**: Schedule creation is wrapped in try/catch — if any step fails after Stripe schedule creation, the orphaned schedule is released before rethrowing.
- **cancelPlanSwitch error handling**: Tolerates `StripeInvalidRequestError` when the schedule is already released, so users aren't stuck with stale DB state.
- **Client-side**: Disable "Switch to..." and "Cancel Switch" buttons during pending mutations to prevent double-tap at the UI level.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm jest src/routers/kiloclaw-billing-router.test.ts` — 39/39 passed (12 new tests for `switchPlan` and `cancelPlanSwitch` covering happy path, validation, orphan cleanup, optimistic concurrency race, and Stripe error tolerance)

## Visual Changes

N/A

## Reviewer Notes

- The optimistic concurrency test simulates a true in-flight race by injecting a concurrent DB write inside the `subscriptionSchedules.update` mock, so the handler's initial DB read sees no schedule but the conditional `UPDATE ... WHERE stripe_schedule_id IS NULL` returns 0 rows.
- The existing DB-level guard (`if (sub.stripe_schedule_id)`) is preserved for legitimate pending switches — only orphaned Stripe schedules (not tracked in DB) are auto-released.
- Affects Sentry issues KILOCODE-WEB-1G1M (server) and KILOCODE-WEB-1FZH (client), impacting 4 users with 8 error events since 2026-03-19.