### PR TITLE
feat(kiloclaw): emit instance.restarting analytics event

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1431,6 +1431,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
       await this.scheduleAlarm();
 
+      this.emitEvent({
+        event: 'instance.restarting',
+        status: 'restarting',
+        label: action,
+      });
+
       this.ctx.waitUntil(this.restartMachineInBackground());
       return { success: true };
     } catch (err) {

--- a/kiloclaw/src/utils/analytics.ts
+++ b/kiloclaw/src/utils/analytics.ts
@@ -35,6 +35,7 @@ export type KiloClawEventName =
   | 'instance.provisioned'
   | 'instance.started'
   | 'instance.stopped'
+  | 'instance.restarting'
   | 'instance.destroy_started'
   // Reconcile events (emitted via ReconcileContext.log as `reconcile.{action}`)
   // All reconcileLog actions are automatically prefixed — see log.ts.


### PR DESCRIPTION
## Summary

The restart lifecycle was the only DO operation without an Analytics Engine event at initiation time. `start`, `stop`, `destroy`, and `provision` all emit DO-level events (`instance.started`, `instance.stopped`, `instance.destroy_started`, `instance.provisioned`), but `restartMachine()` only produced an HTTP middleware event and a reconcile-layer completion event (`reconcile.restart_self_healed`).

This adds an `instance.restarting` event emitted from the DO when a restart is initiated, carrying full machine context (flyAppName, machineId, sandboxId, imageTag, etc.) and the action type (`redeploy-same-image`, `upgrade-to-latest`, `pin-to-tag:{tag}`) as the `label` dimension.

## Verification

- [x] `pnpm typecheck` — passed (tsgo, all workspace projects)
- [x] `pnpm test` — 42 test files, 944 tests passed
- [x] `pnpm lint` — passed (oxlint + eslint, all workspace projects)
- [x] Pre-push hooks (format, lint, typecheck) — passed

## Visual Changes

N/A

## Reviewer Notes

Two-line change. The event is emitted after status is persisted as `'restarting'` and the alarm is scheduled, right before `waitUntil(restartMachineInBackground())`. Same fire-and-forget pattern as other `emitEvent` calls — never throws.