### PR TITLE
refactor(kiloclaw): replace react-rewards with canvas-confetti

### DIFF
--- a/components.json
+++ b/components.json
@@ -10,6 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
+  "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
@@ -17,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "registries": {
+    "@magicui": "https://magicui.design/r/{name}"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@trpc/client": "^11.13.0",
     "@trpc/server": "^11.13.0",
     "@trpc/tanstack-react-query": "^11.13.0",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/js-cookie": "^3.0.6",
     "@types/js-yaml": "^4.0.9",
     "@types/mdx": "^2.0.13",
@@ -102,6 +103,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.116",
+    "canvas-confetti": "^1.9.4",
     "chat": "^4.20.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -205,7 +207,8 @@
       "qs": ">=6.14.1",
       "serialize-javascript": ">=7.0.3",
       "hono": "^4.12.7",
-      "undici@^6": "^6.24.1"
+      "undici@^6": "^6.24.1",
+      "@types/pg": "^8.18.0"
     },
     "patchedDependencies": {
       "@storybook/nextjs@9.1.20": "patches/@storybook__nextjs@9.1.20.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,7 @@ overrides:
   serialize-javascript: '>=7.0.3'
   hono: ^4.12.7
   undici@^6: ^6.24.1
+  '@types/pg': ^8.18.0
 
 patchedDependencies:
   '@storybook/nextjs@9.1.20':
@@ -248,6 +249,9 @@ importers:
       '@trpc/tanstack-react-query':
         specifier: ^11.13.0
         version: 11.13.0(@tanstack/react-query@5.90.21(react@19.2.4))(@trpc/client@11.13.0(@trpc/server@11.13.0(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.0(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
+      '@types/canvas-confetti':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
@@ -278,6 +282,9 @@ importers:
       ai:
         specifier: ^6.0.116
         version: 6.0.116(zod@4.3.6)
+      canvas-confetti:
+        specifier: ^1.9.4
+        version: 1.9.4
       chat:
         specifier: ^4.20.1
         version: 4.20.1
@@ -310,7 +317,7 @@ importers:
         version: 14.25.1
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       event-source-polyfill:
         specifier: ^1.0.31
         version: 1.0.31
@@ -557,7 +564,7 @@ importers:
         version: 11.13.0(typescript@5.9.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
@@ -630,7 +637,7 @@ importers:
         version: 11.13.0(typescript@5.9.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -692,7 +699,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.10
+        version: 1.3.11
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
@@ -707,7 +714,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.10
+        version: 1.3.11
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
@@ -725,7 +732,7 @@ importers:
         version: link:../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -774,7 +781,7 @@ importers:
         version: 8.0.3
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
@@ -1087,7 +1094,7 @@ importers:
         version: 11.13.0(typescript@5.9.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1182,7 +1189,7 @@ importers:
         version: 8.2.0
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1290,7 +1297,7 @@ importers:
         version: link:../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1333,7 +1340,7 @@ importers:
         version: link:../packages/db
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       workers-tagged-logger:
         specifier: 'catalog:'
         version: 1.0.0
@@ -1367,7 +1374,7 @@ importers:
         version: link:../packages/db
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1401,7 +1408,7 @@ importers:
         version: 0.0.22
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1456,7 +1463,7 @@ importers:
         version: link:../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1514,7 +1521,7 @@ importers:
         version: link:../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1570,7 +1577,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -6361,6 +6368,12 @@ packages:
   '@types/bun@1.3.10':
     resolution: {integrity: sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==}
 
+  '@types/bun@1.3.11':
+    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+
+  '@types/canvas-confetti@1.9.0':
+    resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -6477,9 +6490,6 @@ packages:
 
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
-
-  '@types/pg@8.15.6':
-    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/pg@8.18.0':
     resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
@@ -7414,6 +7424,9 @@ packages:
   bun-types@1.3.10:
     resolution: {integrity: sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg==}
 
+  bun-types@1.3.11:
+    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -7455,6 +7468,9 @@ packages:
 
   caniuse-lite@1.0.30001779:
     resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
+
+  canvas-confetti@1.9.4:
+    resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -8123,7 +8139,7 @@ packages:
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
-      '@types/pg': '*'
+      '@types/pg': ^8.18.0
       '@types/sql.js': '*'
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
@@ -15502,7 +15518,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
-      '@types/pg': 8.15.6
+      '@types/pg': 8.18.0
       '@types/pg-pool': 2.0.7
     transitivePeerDependencies:
       - supports-color
@@ -18076,6 +18092,12 @@ snapshots:
     dependencies:
       bun-types: 1.3.10
 
+  '@types/bun@1.3.11':
+    dependencies:
+      bun-types: 1.3.11
+
+  '@types/canvas-confetti@1.9.0': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -18202,13 +18224,7 @@ snapshots:
 
   '@types/pg-pool@2.0.7':
     dependencies:
-      '@types/pg': 8.15.6
-
-  '@types/pg@8.15.6':
-    dependencies:
-      '@types/node': 22.19.15
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
+      '@types/pg': 8.18.0
 
   '@types/pg@8.18.0':
     dependencies:
@@ -19255,6 +19271,10 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  bun-types@1.3.11:
+    dependencies:
+      '@types/node': 25.5.0
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -19295,6 +19315,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001779: {}
+
+  canvas-confetti@1.9.4: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 
@@ -19974,12 +19996,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.10)(pg@8.20.0):
+  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260313.1
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.18.0
-      bun-types: 1.3.10
+      bun-types: 1.3.11
       pg: 8.20.0
 
   dset@3.1.4: {}

--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import { Check, Sparkles, TriangleAlert, X, Zap } from 'lucide-react';
+import { Sparkles, TriangleAlert, Zap } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import {
   useKiloClawGatewayStatus,
@@ -9,7 +9,6 @@ import {
   useKiloClawServiceDegraded,
 } from '@/hooks/useKiloClaw';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useGatewayUrl } from '../hooks/useGatewayUrl';
@@ -17,10 +16,10 @@ import { ClawHeader } from './ClawHeader';
 import { CreateInstanceCard } from './CreateInstanceCard';
 import { InstanceControls } from './InstanceControls';
 import { InstanceTab } from './InstanceTab';
-import { OpenClawButton } from './OpenClawButton';
 import { SettingsTab } from './SettingsTab';
 import { ChangelogTab } from './ChangelogTab';
 import { ChannelSelectionStepView } from './ChannelSelectionStep';
+import { CompletionStep } from './CompletionStep';
 import { PermissionStep } from './PermissionStep';
 import { ProvisioningStep } from './ProvisioningStep';
 import type { ExecPreset } from './claw.types';
@@ -174,61 +173,12 @@ export function ClawDashboard({
             onComplete={() => setOnboardingStep('done')}
           />
         ) : isNewSetup ? (
-          <Card className="mt-6 overflow-hidden">
-            <CardContent className="flex flex-col items-center justify-center gap-6 pt-12">
-              <div className="relative">
-                <div className="flex h-20 w-20 items-center justify-center rounded-2xl border border-emerald-700/30 bg-emerald-900/50">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-emerald-500">
-                    <Check className="h-6 w-6 text-emerald-500" />
-                  </div>
-                </div>
-                <div className="absolute -top-3 -right-3 flex h-6 w-6 items-center justify-center rounded-full bg-[#09090b] text-amber-400">
-                  <Sparkles className="h-4 w-4" />
-                </div>
-              </div>
-
-              <div className="flex flex-col items-center gap-2">
-                <h2 className="text-2xl font-bold">Your instance is ready!</h2>
-                <p className="text-muted-foreground max-w-md text-center">
-                  KiloClaw has been provisioned and configured with your settings. You&apos;re all
-                  set to start.
-                </p>
-              </div>
-
-              {instanceStatus?.flyRegion && (
-                <div className="border-border/50 flex items-center gap-2 rounded-full border px-4 py-2">
-                  <span className="relative flex h-1.5 w-1.5">
-                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
-                    <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                  </span>
-                  <span className="text-muted-foreground flex items-center gap-2 text-sm">
-                    Active ·{' '}
-                    <span className="text-foreground font-bold">
-                      {instanceStatus.flyRegion.toUpperCase()}
-                    </span>{' '}
-                    region
-                  </span>
-                </div>
-              )}
-              <div className="flex w-full flex-col gap-3">
-                <OpenClawButton
-                  canShow={gatewayStatus?.state === 'running'}
-                  gatewayUrl={gatewayUrl}
-                  look="hero"
-                  label="Open KiloClaw"
-                  className="w-full py-6 text-base"
-                />
-                <Button
-                  className="w-full py-6 text-base"
-                  variant="outline"
-                  onClick={() => onNewSetupChange(false)}
-                >
-                  <X className="mr-2 h-4 w-4" />
-                  Close Wizard
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
+          <CompletionStep
+            flyRegion={instanceStatus?.flyRegion ?? null}
+            canOpenClaw={gatewayStatus?.state === 'running'}
+            gatewayUrl={gatewayUrl}
+            onClose={() => onNewSetupChange(false)}
+          />
         ) : (
           <Card className="mt-6">
             <CardContent className="border-b p-5">

--- a/src/app/(app)/claw/components/CompletionStep.tsx
+++ b/src/app/(app)/claw/components/CompletionStep.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Check, Sparkles, X } from 'lucide-react';
+import confetti from 'canvas-confetti';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { OpenClawButton } from './OpenClawButton';
+
+type CompletionStepProps = {
+  flyRegion: string | null;
+  canOpenClaw: boolean;
+  gatewayUrl: string;
+  onClose: () => void;
+};
+
+export function CompletionStep({
+  flyRegion,
+  canOpenClaw,
+  gatewayUrl,
+  onClose,
+}: CompletionStepProps) {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const confettiStarted = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (confettiStarted.current) return;
+
+    const timer = setTimeout(() => {
+      const end = Date.now() + 3 * 1000; // 3 seconds
+      const colors = ['#a786ff', '#fd8bbc', '#eca184', '#f8deb1'];
+      const frame = () => {
+        if (Date.now() > end) return;
+        void confetti({
+          particleCount: 2,
+          angle: 60,
+          spread: 55,
+          startVelocity: 60,
+          origin: { x: 0, y: 1 },
+          colors: colors,
+        });
+        void confetti({
+          particleCount: 2,
+          angle: 120,
+          spread: 55,
+          startVelocity: 60,
+          origin: { x: 1, y: 1 },
+          colors: colors,
+        });
+        requestAnimationFrame(frame);
+      };
+      frame();
+      confettiStarted.current = true;
+    }, 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <Card className="mt-6 overflow-hidden">
+      <CardContent className="flex flex-col items-center justify-center gap-6 pt-12">
+        <div className="relative">
+          <div className="flex h-20 w-20 items-center justify-center rounded-2xl border border-emerald-700/30 bg-emerald-900/50">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-emerald-500">
+              <Check className="h-6 w-6 text-emerald-500" />
+            </div>
+          </div>
+          <div className="absolute -top-3 -right-3 flex h-6 w-6 items-center justify-center rounded-full bg-[#09090b] text-amber-400">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <span
+            ref={anchorRef}
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+          />
+        </div>
+
+        <div className="flex flex-col items-center gap-2">
+          <h2 className="text-2xl font-bold">Your instance is ready!</h2>
+          <p className="text-muted-foreground max-w-md text-center">
+            KiloClaw has been provisioned and configured with your settings. You&apos;re all set to
+            start.
+          </p>
+        </div>
+
+        {flyRegion && (
+          <div className="border-border/50 flex items-center gap-2 rounded-full border px-4 py-2">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            </span>
+            <span className="text-muted-foreground flex items-center gap-2 text-sm">
+              Active &middot;{' '}
+              <span className="text-foreground font-bold">{flyRegion.toUpperCase()}</span> region
+            </span>
+          </div>
+        )}
+        <div className="flex w-full flex-col gap-3">
+          <OpenClawButton
+            canShow={canOpenClaw}
+            gatewayUrl={gatewayUrl}
+            look="hero"
+            label="Open KiloClaw"
+            className="w-full py-6 text-base"
+          />
+          <Button className="w-full py-6 text-base" variant="outline" onClick={onClose}>
+            <X className="mr-2 h-4 w-4" />
+            Close Wizard
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/magicui/confetti.tsx
+++ b/src/components/magicui/confetti.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import React, {
+  createContext,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
+import type {
+  GlobalOptions as ConfettiGlobalOptions,
+  CreateTypes as ConfettiInstance,
+  Options as ConfettiOptions,
+} from 'canvas-confetti';
+import confetti from 'canvas-confetti';
+
+import { Button } from '@/components/ui/button';
+
+type Api = {
+  fire: (options?: ConfettiOptions) => void;
+};
+
+type Props = React.ComponentPropsWithRef<'canvas'> & {
+  options?: ConfettiOptions;
+  globalOptions?: ConfettiGlobalOptions;
+  manualstart?: boolean;
+  children?: ReactNode;
+};
+
+export type ConfettiRef = Api | null;
+
+const ConfettiContext = createContext<Api>({} as Api);
+
+// Define component first
+const ConfettiComponent = forwardRef<ConfettiRef, Props>((props, ref) => {
+  const {
+    options,
+    globalOptions = { resize: true, useWorker: true },
+    manualstart = false,
+    children,
+    ...rest
+  } = props;
+  const instanceRef = useRef<ConfettiInstance | null>(null);
+
+  const canvasRef = useCallback(
+    (node: HTMLCanvasElement) => {
+      if (node !== null) {
+        if (instanceRef.current) return;
+        instanceRef.current = confetti.create(node, {
+          ...globalOptions,
+          resize: true,
+        });
+      } else {
+        if (instanceRef.current) {
+          instanceRef.current.reset();
+          instanceRef.current = null;
+        }
+      }
+    },
+    [globalOptions]
+  );
+
+  const fire = useCallback(
+    async (opts = {}) => {
+      try {
+        await instanceRef.current?.({ ...options, ...opts });
+      } catch (error) {
+        console.error('Confetti error:', error);
+      }
+    },
+    [options]
+  );
+
+  const api = useMemo(
+    () => ({
+      fire,
+    }),
+    [fire]
+  );
+
+  useImperativeHandle(ref, () => api, [api]);
+
+  useEffect(() => {
+    if (!manualstart) {
+      void fire();
+    }
+  }, [manualstart, fire]);
+
+  return (
+    <ConfettiContext.Provider value={api}>
+      <canvas ref={canvasRef} {...rest} />
+      {children}
+    </ConfettiContext.Provider>
+  );
+});
+
+// Set display name immediately
+ConfettiComponent.displayName = 'Confetti';
+
+// Export as Confetti
+export const Confetti = ConfettiComponent;
+
+interface ConfettiButtonProps extends React.ComponentProps<'button'> {
+  options?: ConfettiOptions & ConfettiGlobalOptions & { canvas?: HTMLCanvasElement };
+}
+
+const ConfettiButtonComponent = ({ options, children, ...props }: ConfettiButtonProps) => {
+  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    try {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      await confetti({
+        ...options,
+        origin: {
+          x: x / window.innerWidth,
+          y: y / window.innerHeight,
+        },
+      });
+    } catch (error) {
+      console.error('Confetti button error:', error);
+    }
+  };
+
+  return (
+    <Button onClick={handleClick} {...props}>
+      {children}
+    </Button>
+  );
+};
+
+ConfettiButtonComponent.displayName = 'ConfettiButton';
+
+export const ConfettiButton = ConfettiButtonComponent;

--- a/storybook/stories/claw/CompletionStep.stories.tsx
+++ b/storybook/stories/claw/CompletionStep.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { CompletionStep } from '@/app/(app)/claw/components/CompletionStep';
+
+const meta: Meta<typeof CompletionStep> = {
+  title: 'Claw/CompletionStep',
+  component: CompletionStep,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="mx-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    flyRegion: 'sfo',
+  },
+};
+
+export const NoRegion: Story = {
+  args: {
+    flyRegion: null,
+  },
+};


### PR DESCRIPTION
## Summary

- Replace `react-rewards` with `canvas-confetti` for the KiloClaw completion step animation
- Extract the inline completion UI from `ClawDashboard.tsx` into a dedicated `CompletionStep` component
- Add the Magic UI confetti component (`src/components/magicui/confetti.tsx`) via the shadcn registry for future reuse
- Register the `@magicui` registry in `components.json`
- Remove `react-rewards` dependency (only consumer was CompletionStep)
- Add `canvas-confetti` + `@types/canvas-confetti` as replacements
- Add pnpm override for `@types/pg@^8.18.0` to prevent duplicate drizzle-orm resolutions
- Add a Storybook story for the new `CompletionStep` component

## Verification

- [x] `pnpm typecheck` -- passes (fixed duplicate drizzle-orm resolution via `@types/pg` override)
- [x] `oxfmt --list-different .` -- passes
- [x] `oxlint` + `eslint` -- passes

## Visual Changes

<!-- Attach video here -->

## Reviewer Notes

The confetti animation style changed from emoji-based (crab emojis from center) to a side-cannons effect (colorful confetti from bottom corners for 3 seconds). The `@magicui/confetti` component was installed but `CompletionStep` uses `canvas-confetti` directly since the side-cannons pattern doesn't need the wrapper component -- the component is available for other future uses.

Adding `canvas-confetti` caused `@opentelemetry/instrumentation-pg` to pull in `@types/pg@8.15.6` alongside the existing `@types/pg@8.18.0`, which created a second drizzle-orm instance with incompatible private types. The pnpm override for `@types/pg@^8.18.0` forces a single resolution.