### PR TITLE
fix(billing): move auto-intro metadata from schedule create to update

### DIFF
--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -297,7 +297,6 @@ async function createAutoIntroSchedule(
   try {
     newSchedule = await stripe.subscriptionSchedules.create({
       from_subscription: stripeSubscriptionId,
-      metadata: { origin: 'auto-intro' },
     });
   } catch (error) {
     await handleAutoIntroCreateRace(error, stripeSubscriptionId, userId);
@@ -317,19 +316,31 @@ async function createAutoIntroSchedule(
     return;
   }
 
-  await stripe.subscriptionSchedules.update(newSchedule.id, {
-    phases: [
-      {
-        items: [{ price: phase1Price }],
-        start_date: currentPhase.start_date,
-        end_date: currentPhase.end_date,
-      },
-      {
-        items: [{ price: getStripePriceIdForClawPlan('standard') }],
-      },
-    ],
-    end_behavior: 'release',
-  });
+  try {
+    await stripe.subscriptionSchedules.update(newSchedule.id, {
+      metadata: { origin: 'auto-intro' },
+      phases: [
+        {
+          items: [{ price: phase1Price }],
+          start_date: currentPhase.start_date,
+          end_date: currentPhase.end_date,
+        },
+        {
+          items: [{ price: getStripePriceIdForClawPlan('standard') }],
+        },
+      ],
+      end_behavior: 'release',
+    });
+  } catch (error) {
+    // Release the half-created schedule so retry can start fresh — without
+    // metadata, recovery paths cannot identify it as auto-intro.
+    try {
+      await stripe.subscriptionSchedules.release(newSchedule.id);
+    } catch {
+      // best-effort cleanup
+    }
+    throw error;
+  }
 
   await persistAutoIntroSchedule(newSchedule.id, userId);
 }

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -247,7 +247,20 @@ export async function ensureAutoIntroSchedule(
     if (!scheduleId) return;
     const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
 
-    if (schedule.metadata?.origin === 'auto-intro') {
+    const isAutoIntro = schedule.metadata?.origin === 'auto-intro';
+
+    // A schedule created via from_subscription without metadata is likely a
+    // half-created auto-intro schedule (create succeeded but the subsequent
+    // update that sets metadata + phases hasn't run yet, or the worker died
+    // before it could). Claim it by tagging it before attempting repair.
+    const isUntagged = !schedule.metadata?.origin;
+    if (isUntagged) {
+      await stripe.subscriptionSchedules.update(schedule.id, {
+        metadata: { origin: 'auto-intro' },
+      });
+    }
+
+    if (isAutoIntro || isUntagged) {
       const valid = await validateOrRepairAutoIntroSchedule(schedule, stripeSubscriptionId, userId);
       if (!valid) {
         logError('Auto-intro schedule is unrecoverable, skipping', {
@@ -373,7 +386,19 @@ async function handleAutoIntroCreateRace(
   });
 
   const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
-  if (existingSchedule.metadata?.origin === 'auto-intro') {
+
+  // The race winner may not have tagged the schedule yet (metadata is set in
+  // a separate update call). Treat untagged schedules as auto-intro since
+  // only auto-intro setup creates schedules via from_subscription.
+  const isAutoIntro = existingSchedule.metadata?.origin === 'auto-intro';
+  const isUntagged = !existingSchedule.metadata?.origin;
+  if (isUntagged) {
+    await stripe.subscriptionSchedules.update(existingSchedule.id, {
+      metadata: { origin: 'auto-intro' },
+    });
+  }
+
+  if (isAutoIntro || isUntagged) {
     const valid = await validateOrRepairAutoIntroSchedule(
       existingSchedule,
       stripeSubscriptionId,

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -249,11 +249,15 @@ export async function ensureAutoIntroSchedule(
 
     const isAutoIntro = schedule.metadata?.origin === 'auto-intro';
 
-    // A schedule created via from_subscription without metadata is likely a
-    // half-created auto-intro schedule (create succeeded but the subsequent
-    // update that sets metadata + phases hasn't run yet, or the worker died
-    // before it could). Claim it by tagging it before attempting repair.
-    const isUntagged = !schedule.metadata?.origin;
+    // A schedule created via from_subscription without metadata AND with only
+    // 1 phase is likely a half-created auto-intro schedule (create succeeded
+    // but the subsequent update that sets metadata + phases hasn't run yet, or
+    // the worker died before it could). We require exactly 1 phase because
+    // createAutoIntroSchedule sets metadata and phases in the same update call
+    // — so a fully-updated schedule always has both. User-initiated plan
+    // switches and kilo-pass changes also create untagged schedules but their
+    // update writes 2+ phases, so the phase-count guard avoids claiming them.
+    const isUntagged = !schedule.metadata?.origin && schedule.phases.length === 1;
     if (isUntagged) {
       await stripe.subscriptionSchedules.update(schedule.id, {
         metadata: { origin: 'auto-intro' },
@@ -388,10 +392,12 @@ async function handleAutoIntroCreateRace(
   const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
 
   // The race winner may not have tagged the schedule yet (metadata is set in
-  // a separate update call). Treat untagged schedules as auto-intro since
-  // only auto-intro setup creates schedules via from_subscription.
+  // a separate update call). Only claim untagged schedules that still have a
+  // single phase — the from_subscription default. Schedules with 2+ phases
+  // were already fully configured by another code path (user plan switch,
+  // kilo-pass) and must not be claimed.
   const isAutoIntro = existingSchedule.metadata?.origin === 'auto-intro';
-  const isUntagged = !existingSchedule.metadata?.origin;
+  const isUntagged = !existingSchedule.metadata?.origin && existingSchedule.phases.length === 1;
   if (isUntagged) {
     await stripe.subscriptionSchedules.update(existingSchedule.id, {
       metadata: { origin: 'auto-intro' },

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -164,6 +164,28 @@ async function persistAutoIntroSchedule(scheduleId: string, userId: string): Pro
 }
 
 /**
+ * Determine whether a schedule is auto-intro (already tagged) or a claimable
+ * orphan (untagged, single-phase — likely a half-created auto-intro where
+ * create succeeded but the update that sets metadata + phases never ran).
+ * If orphaned, tags it as auto-intro before returning. Returns true when the
+ * schedule should be treated as auto-intro, false otherwise.
+ */
+async function claimIfAutoIntro(schedule: Stripe.SubscriptionSchedule): Promise<boolean> {
+  if (schedule.metadata?.origin === 'auto-intro') return true;
+
+  // Only claim untagged schedules with a single phase (the from_subscription
+  // default). Schedules with 2+ phases were already configured by another code
+  // path (user plan switch, kilo-pass) and must not be claimed.
+  const isOrphan = !schedule.metadata?.origin && schedule.phases.length === 1;
+  if (!isOrphan) return false;
+
+  await stripe.subscriptionSchedules.update(schedule.id, {
+    metadata: { origin: 'auto-intro' },
+  });
+  return true;
+}
+
+/**
  * Validate that an auto-intro schedule has the expected 2-phase structure
  * (phase 1 = current price, phase 2 = regular standard price). If the schedule
  * is half-configured (e.g., created from_subscription but the 2-phase rewrite
@@ -247,24 +269,7 @@ export async function ensureAutoIntroSchedule(
     if (!scheduleId) return;
     const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
 
-    const isAutoIntro = schedule.metadata?.origin === 'auto-intro';
-
-    // A schedule created via from_subscription without metadata AND with only
-    // 1 phase is likely a half-created auto-intro schedule (create succeeded
-    // but the subsequent update that sets metadata + phases hasn't run yet, or
-    // the worker died before it could). We require exactly 1 phase because
-    // createAutoIntroSchedule sets metadata and phases in the same update call
-    // — so a fully-updated schedule always has both. User-initiated plan
-    // switches and kilo-pass changes also create untagged schedules but their
-    // update writes 2+ phases, so the phase-count guard avoids claiming them.
-    const isUntagged = !schedule.metadata?.origin && schedule.phases.length === 1;
-    if (isUntagged) {
-      await stripe.subscriptionSchedules.update(schedule.id, {
-        metadata: { origin: 'auto-intro' },
-      });
-    }
-
-    if (isAutoIntro || isUntagged) {
+    if (await claimIfAutoIntro(schedule)) {
       const valid = await validateOrRepairAutoIntroSchedule(schedule, stripeSubscriptionId, userId);
       if (!valid) {
         logError('Auto-intro schedule is unrecoverable, skipping', {
@@ -391,20 +396,7 @@ async function handleAutoIntroCreateRace(
 
   const existingSchedule = await stripe.subscriptionSchedules.retrieve(refetchedScheduleId);
 
-  // The race winner may not have tagged the schedule yet (metadata is set in
-  // a separate update call). Only claim untagged schedules that still have a
-  // single phase — the from_subscription default. Schedules with 2+ phases
-  // were already fully configured by another code path (user plan switch,
-  // kilo-pass) and must not be claimed.
-  const isAutoIntro = existingSchedule.metadata?.origin === 'auto-intro';
-  const isUntagged = !existingSchedule.metadata?.origin && existingSchedule.phases.length === 1;
-  if (isUntagged) {
-    await stripe.subscriptionSchedules.update(existingSchedule.id, {
-      metadata: { origin: 'auto-intro' },
-    });
-  }
-
-  if (isAutoIntro || isUntagged) {
+  if (await claimIfAutoIntro(existingSchedule)) {
     const valid = await validateOrRepairAutoIntroSchedule(
       existingSchedule,
       stripeSubscriptionId,

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -824,6 +824,7 @@ export const kiloPassRouter = createTRPCRouter({
         }
 
         const updatedSchedule = await stripe.subscriptionSchedules.update(schedule.id, {
+          metadata: { origin: 'kilo-pass-switch' },
           // We want the subscription to continue normally after the final phase starts.
           // Without this, Stripe may require the last phase to specify `duration`/`end_date`.
           end_behavior: 'release',

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1476,6 +1476,7 @@ export const kiloclawRouter = createTRPCRouter({
         }
 
         await stripe.subscriptionSchedules.update(schedule.id, {
+          metadata: { origin: 'user-switch' },
           end_behavior: 'release',
           phases: [
             {


### PR DESCRIPTION
## Summary

### Problem

`createAutoIntroSchedule` passes `metadata: { origin: 'auto-intro' }` alongside `from_subscription` in `stripe.subscriptionSchedules.create()`. Stripe rejects this combination with HTTP 400, causing 100% failure on auto-intro schedule creation since commit df6ff4c0 (PR #1362). Affected intro-priced subscriptions never get the scheduled transition to the regular standard price.

### Solution

- Removed `metadata` from the `subscriptionSchedules.create()` call where Stripe forbids it alongside `from_subscription`.
- Added `metadata: { origin: 'auto-intro' }` to the subsequent `subscriptionSchedules.update()` call, which already sets phases and end behavior.
- Wrapped the `update` call in error recovery: if it fails, the half-created schedule is released so retry paths (Sweep 5 cron) can start fresh instead of encountering an untagged schedule they cannot identify.
- Added race recovery: `ensureAutoIntroSchedule` and `handleAutoIntroCreateRace` now detect and claim untagged orphan schedules (create succeeded, update never ran) by tagging them as `auto-intro` and running repair.
- Added a `phases.length === 1` guard to the untagged-schedule claiming logic to avoid incorrectly claiming user-initiated plan switches or kilo-pass changes, which also create `from_subscription` schedules without `metadata.origin` but always have 2+ phases after their update completes.

### Why this approach

The metadata must live on the schedule for downstream code to distinguish auto-intro schedules from user-initiated plan switches. Moving it to the `update` call is the minimal fix — the only alternative would be two separate `update` calls (one for metadata, one for phases), which doubles API calls for no benefit since both fields can be set atomically in one `update`.

### Related issues

- Introduced in PR #1362 (`feat(billing): replace coupon with intro pricing and enable promo codes`)

## Verification

- [x] `pnpm typecheck` — pass
- [x] `pnpm test -- src/routers/kiloclaw-billing-router.test.ts` — 59/59 pass
- [x] Six-agent code review (security, logic, types, data, resources, style) — all clean after fixing the one WARNING
- [x] Pre-push hooks (format, lint, typecheck) — pass

## Visual Changes

N/A

## Reviewer Notes

- **Risk area:** The window between `create` and `update` where the schedule exists without metadata. Three layers of mitigation: (1) release on update failure, (2) race recovery paths claim untagged orphans, (3) `phases.length === 1` guard prevents incorrectly claiming user-initiated schedules.
- **Self-healing:** After deploy, the next billing lifecycle cron run (Sweep 5) will automatically repair the 3 stranded subscriptions by calling `ensureAutoIntroSchedule`, which invokes the now-fixed `createAutoIntroSchedule`.
- **Rollback:** Simple revert; no migrations or config changes.