### PR TITLE
feat(admin): allow resetting canceled KiloClaw subscriptions to trial

### DIFF
--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -152,6 +152,7 @@ export type KiloClawSubscriptionStatus =
 export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.volume.reassociate',
   'kiloclaw.subscription.update_trial_end',
+  'kiloclaw.subscription.reset_trial',
   'kiloclaw.machine.start',
   'kiloclaw.machine.stop',
   'kiloclaw.instance.destroy',

--- a/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -19,6 +19,8 @@ import { useTRPC } from '@/lib/trpc/utils';
 import { formatDate } from '@/lib/admin-utils';
 import { toast } from 'sonner';
 
+const DEFAULT_TRIAL_DAYS = 7;
+
 function formatDateOrDash(date: string | null): string {
   return date ? formatDate(date) : '—';
 }
@@ -70,8 +72,14 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
     if (!dialogOpen) return;
 
     const currentTrialEndAt = data?.subscription?.trial_ends_at;
-    setSelectedDate(currentTrialEndAt ? toLocalDateInputValue(currentTrialEndAt) : '');
-  }, [data?.subscription?.trial_ends_at, dialogOpen]);
+    if (currentTrialEndAt && data?.subscription?.status !== 'canceled') {
+      setSelectedDate(toLocalDateInputValue(currentTrialEndAt));
+    } else {
+      const defaultTrialEnd = new Date();
+      defaultTrialEnd.setDate(defaultTrialEnd.getDate() + DEFAULT_TRIAL_DAYS);
+      setSelectedDate(toLocalDateInputValue(defaultTrialEnd.toISOString()));
+    }
+  }, [data?.subscription?.trial_ends_at, data?.subscription?.status, dialogOpen]);
 
   const updateTrialEndAt = useMutation(
     trpc.admin.users.updateKiloClawTrialEndAt.mutationOptions({
@@ -165,7 +173,8 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
   }
 
   const { subscription } = data;
-  const canEditTrialEnd = subscription.status === 'trialing';
+  const canEditTrialEnd = subscription.status === 'trialing' || subscription.status === 'canceled';
+  const isTrialReset = subscription.status === 'canceled';
 
   return (
     <>
@@ -178,7 +187,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
             </div>
             {canEditTrialEnd && (
               <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
-                Edit Trial End
+                {isTrialReset ? 'Reset Trial' : 'Edit Trial End'}
               </Button>
             )}
           </div>
@@ -263,10 +272,13 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Edit KiloClaw Trial End Date</DialogTitle>
+            <DialogTitle>
+              {isTrialReset ? 'Reset KiloClaw Trial' : 'Edit KiloClaw Trial End Date'}
+            </DialogTitle>
             <DialogDescription>
-              Set the day this user&apos;s KiloClaw trial ends. The trial will end at the end of the
-              selected day.
+              {isTrialReset
+                ? 'Reset this canceled subscription to a new trial. This will restore access, clear suspension state, and attempt to restart the instance.'
+                : "Set the day this user's KiloClaw trial ends. The trial will end at the end of the selected day."}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2 py-4">

--- a/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/src/routers/admin-kiloclaw-user-router.test.ts
@@ -206,7 +206,7 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     ).rejects.toThrow('No KiloClaw subscription found for this user');
   });
 
-  it('rejects non-trialing subscription rows', async () => {
+  it('rejects non-trialing and non-canceled subscription rows', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: targetUser.id,
       plan: 'standard',
@@ -221,6 +221,59 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
         userId: targetUser.id,
         trial_ends_at: '2026-03-25T23:59:59.000Z',
       })
-    ).rejects.toThrow('Only trialing KiloClaw subscriptions can have their trial end date edited');
+    ).rejects.toThrow(
+      'Only trialing or canceled KiloClaw subscriptions can have their trial end date edited'
+    );
+  });
+
+  it('resets a canceled subscription to a new trial', async () => {
+    const previousTrialEndsAt = '2026-03-15T23:59:59.000Z';
+    const newTrialEndsAt = '2026-04-01T23:59:59.000Z';
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'trial',
+      status: 'canceled',
+      trial_started_at: '2026-03-08T12:00:00.000Z',
+      trial_ends_at: previousTrialEndsAt,
+      suspended_at: '2026-03-16T00:00:00.000Z',
+      destruction_deadline: '2026-03-23T00:00:00.000Z',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.updateKiloClawTrialEndAt({
+      userId: targetUser.id,
+      trial_ends_at: newTrialEndsAt,
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const updatedSubscription = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.user_id, targetUser.id),
+    });
+    expect(updatedSubscription?.status).toBe('trialing');
+    expect(updatedSubscription?.plan).toBe('trial');
+    expectSameInstant(updatedSubscription?.trial_ends_at, newTrialEndsAt);
+    expect(updatedSubscription?.trial_started_at).not.toBeNull();
+    expect(updatedSubscription?.suspended_at).toBeNull();
+    expect(updatedSubscription?.destruction_deadline).toBeNull();
+    expect(updatedSubscription?.stripe_subscription_id).toBeNull();
+    expect(updatedSubscription?.cancel_at_period_end).toBe(false);
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+
+    expect(auditLog).toEqual(
+      expect.objectContaining({
+        action: 'kiloclaw.subscription.reset_trial',
+        actor_id: adminUser.id,
+        target_user_id: targetUser.id,
+      })
+    );
+    expect(auditLog.message).toContain('reset from canceled to trialing');
+    expect(auditLog.metadata?.isReset).toBe(true);
+    expect(auditLog.metadata?.previousStatus).toBe('canceled');
   });
 });

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -13,6 +13,8 @@ import {
   credit_transactions,
   kiloclaw_subscriptions,
   kiloclaw_earlybird_purchases,
+  kiloclaw_email_log,
+  kiloclaw_instances,
 } from '@kilocode/db/schema';
 import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { fetchSessionSnapshot, type SessionMessage } from '@/lib/session-ingest-client';
@@ -31,7 +33,7 @@ import { adminWebhookTriggersRouter } from '@/routers/admin-webhook-triggers-rou
 import { adminAlertingRouter } from '@/routers/admin-alerting-router';
 import { adminBotRequestsRouter } from '@/routers/admin-bot-requests-router';
 import * as z from 'zod';
-import { eq, and, ne, or, ilike, desc, asc, sql, isNull } from 'drizzle-orm';
+import { eq, and, ne, or, ilike, desc, asc, sql, isNull, inArray } from 'drizzle-orm';
 import { findUsersByIds, findUserById } from '@/lib/user';
 import { getBlobContent } from '@/lib/r2/cli-sessions';
 import { toNonNullish } from '@/lib/utils';
@@ -57,6 +59,7 @@ import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled
 import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
+import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import {
   getKilocodeRepoOpenPullRequestCounts,
   getKilocodeRepoOpenPullRequestsSummary,
@@ -541,37 +544,112 @@ export const adminRouter = createTRPCRouter({
           });
         }
 
-        if (subscription.status !== 'trialing') {
+        if (subscription.status !== 'trialing' && subscription.status !== 'canceled') {
           throw new TRPCError({
             code: 'BAD_REQUEST',
-            message: 'Only trialing KiloClaw subscriptions can have their trial end date edited',
+            message:
+              'Only trialing or canceled KiloClaw subscriptions can have their trial end date edited',
           });
         }
 
+        const isReset = subscription.status === 'canceled';
         const previousTrialEndsAt = subscription.trial_ends_at;
 
         await db.transaction(async tx => {
-          await tx
-            .update(kiloclaw_subscriptions)
-            .set({ trial_ends_at: input.trial_ends_at })
-            .where(eq(kiloclaw_subscriptions.user_id, input.userId));
+          if (isReset) {
+            // Reset canceled subscription to a new trial
+            await tx
+              .update(kiloclaw_subscriptions)
+              .set({
+                status: 'trialing',
+                plan: 'trial',
+                trial_started_at: new Date().toISOString(),
+                trial_ends_at: input.trial_ends_at,
+                stripe_subscription_id: null,
+                stripe_schedule_id: null,
+                scheduled_plan: null,
+                scheduled_by: null,
+                cancel_at_period_end: false,
+                current_period_start: null,
+                current_period_end: null,
+                commit_ends_at: null,
+                past_due_since: null,
+                suspended_at: null,
+                destruction_deadline: null,
+              })
+              .where(eq(kiloclaw_subscriptions.user_id, input.userId));
+
+            // Clear email logs so notifications can fire again for the new trial.
+            // Unlike autoResumeIfSuspended (which preserves trial warnings as one-time events),
+            // an admin reset creates a genuinely new trial, so trial warnings should repeat.
+            const emailTypesToClearOnTrialReset = [
+              'claw_trial_1d',
+              'claw_trial_5d',
+              'claw_suspended_trial',
+              'claw_suspended_subscription',
+              'claw_suspended_payment',
+              'claw_destruction_warning',
+              'claw_instance_destroyed',
+            ];
+            await tx
+              .delete(kiloclaw_email_log)
+              .where(
+                and(
+                  eq(kiloclaw_email_log.user_id, input.userId),
+                  inArray(kiloclaw_email_log.email_type, emailTypesToClearOnTrialReset)
+                )
+              );
+          } else {
+            // Just update the trial end date for an active trial
+            await tx
+              .update(kiloclaw_subscriptions)
+              .set({ trial_ends_at: input.trial_ends_at })
+              .where(eq(kiloclaw_subscriptions.user_id, input.userId));
+          }
 
           await createKiloClawAdminAuditLog({
-            action: 'kiloclaw.subscription.update_trial_end',
+            action: isReset
+              ? 'kiloclaw.subscription.reset_trial'
+              : 'kiloclaw.subscription.update_trial_end',
             actor_id: ctx.user.id,
             actor_email: ctx.user.google_user_email,
             actor_name: ctx.user.google_user_name,
             target_user_id: input.userId,
-            message: `KiloClaw trial end updated from ${
-              previousTrialEndsAt ?? 'unset'
-            } to ${input.trial_ends_at}`,
+            message: isReset
+              ? `KiloClaw subscription reset from canceled to trialing, trial ends ${input.trial_ends_at}`
+              : `KiloClaw trial end updated from ${previousTrialEndsAt ?? 'unset'} to ${input.trial_ends_at}`,
             metadata: {
+              isReset,
+              previousStatus: subscription.status,
               previousTrialEndsAt,
               newTrialEndsAt: input.trial_ends_at,
             },
             tx,
           });
         });
+
+        // For resets, attempt to start the instance (best effort, outside transaction)
+        if (isReset) {
+          const [activeInstance] = await db
+            .select({ id: kiloclaw_instances.id })
+            .from(kiloclaw_instances)
+            .where(
+              and(
+                eq(kiloclaw_instances.user_id, input.userId),
+                isNull(kiloclaw_instances.destroyed_at)
+              )
+            )
+            .limit(1);
+
+          if (activeInstance) {
+            try {
+              const client = new KiloClawInternalClient();
+              await client.start(input.userId);
+            } catch {
+              // Best effort — instance will be startable by the user from the dashboard
+            }
+          }
+        }
 
         return successResult();
       }),


### PR DESCRIPTION
## Summary

### Problem

Admins cannot reset a canceled KiloClaw subscription back to a trial. The "Edit Trial End" button only appears when the subscription status is `trialing`, leaving no admin UI action for users whose trial expired and subscription was canceled.

### Solution

- The admin KiloClaw card now shows a **"Reset Trial"** button when a subscription is in `canceled` status, alongside the existing "Edit Trial End" for `trialing` subscriptions.
- Clicking "Reset Trial" resets the subscription row to `trialing`/`trial` with a fresh `trial_started_at`, clears all billing fields (Stripe IDs, schedule, period dates, suspension state), and clears email notification logs so trial warnings and lifecycle notifications fire again for the new trial.
- After the DB transaction, the mutation makes a best-effort attempt to restart the user's KiloClaw instance.
- The dialog title, description, and default date (7 days from now) adapt based on whether the action is a reset or a trial-end edit.
- A new `kiloclaw.subscription.reset_trial` audit action distinguishes resets from trial-end edits in the audit log.

### Why this approach

The alternative was a separate mutation for resets, but the existing `updateKiloClawTrialEndAt` already takes the same inputs (`userId` + `trial_ends_at`) and both operations share validation and audit logging. Branching on `isReset` within the same mutation avoids API surface duplication while keeping the two code paths clearly separated. Trial warning email logs are intentionally cleared (unlike `autoResumeIfSuspended`, which preserves them as one-time events) because an admin reset creates a genuinely new trial.

## Verification

- [x] `pnpm typecheck` — pass
- [x] `npx jest src/routers/admin-kiloclaw-user-router.test.ts` — 10/10 pass (includes new `resets a canceled subscription to a new trial` test)
- [x] Pre-push hooks (format, lint, typecheck) — pass
- [x] Automated six-agent code review — 0 CRITICAL, 0 unresolved WARNING

## Visual Changes

The KiloClaw subscription card on the admin user detail page (`/admin/users/[id]`) now shows a "Reset Trial" button when the subscription status is `canceled`. The dialog adapts its title and description for the reset context.

> Screenshots were not captured (admin page requires a real user with a canceled subscription in the dev database).

## Reviewer Notes

- **Email log clearing divergence**: The reset path clears trial warning emails (`claw_trial_1d`, `claw_trial_5d`) in addition to suspension/destruction emails. This intentionally diverges from `autoResumeIfSuspended` (which preserves trial warnings). The rationale is documented in a code comment at the clearing site.
- **Introductory pricing**: Resetting sets `plan: 'trial'`, so the checkout intro-pricing check (`hadPaidSubscription = existing?.status === 'canceled' && existing.plan !== 'trial'`) correctly evaluates to `false` — a reset trial is not treated as a prior paid subscription.
- **Instance restart**: Best-effort, outside the transaction. If it fails (or the instance was destroyed), the user can re-provision from their dashboard.