### PR TITLE
feat(session-ingest): add UserConnectionDO for CLI live session relay

### DIFF
--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -1,0 +1,975 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock cloudflare:workers before importing UserConnectionDO
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {
+    ctx: unknown;
+    env: unknown;
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  },
+}));
+
+import { UserConnectionDO } from './UserConnectionDO';
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+type MockWS = {
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+  _attachment: unknown;
+  _tags: string[];
+  serializeAttachment(att: unknown): void;
+  deserializeAttachment(): unknown;
+};
+
+function createMockWs(tags: string[] = [], attachment?: unknown): MockWS {
+  const ws: MockWS = {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    _attachment: attachment ?? null,
+    _tags: tags,
+    serializeAttachment(att: unknown) {
+      ws._attachment = att;
+    },
+    deserializeAttachment() {
+      return ws._attachment;
+    },
+  };
+  return ws;
+}
+
+// ---------------------------------------------------------------------------
+// Mock DurableObjectState (this.ctx)
+// ---------------------------------------------------------------------------
+
+function createMockCtx() {
+  const sockets: MockWS[] = [];
+  return {
+    sockets,
+    addSocket(ws: MockWS) {
+      sockets.push(ws);
+    },
+    removeSocket(ws: MockWS) {
+      const idx = sockets.indexOf(ws);
+      if (idx !== -1) sockets.splice(idx, 1);
+    },
+    // Builds the ctx object passed to the DO constructor
+    build() {
+      return {
+        getWebSockets(tag?: string): MockWS[] {
+          if (!tag) return [...sockets];
+          return sockets.filter(ws => ws._tags.includes(tag));
+        },
+        acceptWebSocket(ws: MockWS, tags: string[]) {
+          ws._tags = tags;
+          sockets.push(ws);
+        },
+        getTags(ws: MockWS) {
+          return ws._tags;
+        },
+        storage: {
+          setAlarm: vi.fn(),
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(id: string, status = 'busy', title = 'Test') {
+  return { id, status, title };
+}
+
+function parseSent(ws: MockWS, callIndex = 0): unknown {
+  const call = ws.send.mock.calls[callIndex];
+  if (!call) throw new Error(`No send call at index ${callIndex}`);
+  return JSON.parse(call[0] as string);
+}
+
+function allSent(ws: MockWS): unknown[] {
+  return ws.send.mock.calls.map(c => JSON.parse(c[0] as string));
+}
+
+/** Instantiate a fresh DO with a mock context. Returns the DO and helpers. */
+function setup() {
+  const mockCtx = createMockCtx();
+  const ctx = mockCtx.build();
+  const doInstance = new UserConnectionDO(ctx as never, {} as never);
+  return { doInstance, ctx, mockCtx };
+}
+
+/** Create a CLI WebSocket and add it to the context with proper attachment. */
+function addCliSocket(
+  mockCtx: ReturnType<typeof createMockCtx>,
+  connectionId: string,
+  sessions: Array<{ id: string; status: string; title: string }> = []
+): MockWS {
+  const attachment = { role: 'cli' as const, connectionId, sessions };
+  const ws = createMockWs(['cli'], attachment);
+  mockCtx.addSocket(ws);
+  return ws;
+}
+
+/** Create a web WebSocket and add it to the context. */
+function addWebSocket(
+  mockCtx: ReturnType<typeof createMockCtx>,
+  connectionId = 'web-1',
+  subscribedSessions: string[] = []
+): MockWS {
+  const attachment = { role: 'web' as const, connectionId, subscribedSessions };
+  const ws = createMockWs(['web'], attachment);
+  mockCtx.addSocket(ws);
+  return ws;
+}
+
+/** Send a heartbeat from a CLI ws */
+function sendHeartbeat(
+  doInstance: UserConnectionDO,
+  cliWs: MockWS,
+  sessions: Array<{ id: string; status: string; title: string }>
+) {
+  const msg = JSON.stringify({ type: 'heartbeat', sessions });
+  doInstance.webSocketMessage(cliWs as never, msg);
+}
+
+/** Send a subscribe from a web ws */
+function sendSubscribe(doInstance: UserConnectionDO, webWs: MockWS, sessionId: string) {
+  const msg = JSON.stringify({ type: 'subscribe', sessionId });
+  doInstance.webSocketMessage(webWs as never, msg);
+}
+
+/** Send an unsubscribe from a web ws */
+function sendUnsubscribe(doInstance: UserConnectionDO, webWs: MockWS, sessionId: string) {
+  const msg = JSON.stringify({ type: 'unsubscribe', sessionId });
+  doInstance.webSocketMessage(webWs as never, msg);
+}
+
+/** Send a command from a web ws */
+function sendCommand(
+  doInstance: UserConnectionDO,
+  webWs: MockWS,
+  opts: { id: string; command: string; sessionId?: string; connectionId?: string; data?: unknown }
+) {
+  const msg = JSON.stringify({ type: 'command', ...opts });
+  doInstance.webSocketMessage(webWs as never, msg);
+}
+
+/** Send a response from a CLI ws */
+function sendCliResponse(
+  doInstance: UserConnectionDO,
+  cliWs: MockWS,
+  opts: { id: string; result?: unknown; error?: unknown }
+) {
+  const msg = JSON.stringify({ type: 'response', ...opts });
+  doInstance.webSocketMessage(cliWs as never, msg);
+}
+
+/** Trigger CLI disconnect */
+function disconnectCli(doInstance: UserConnectionDO, cliWs: MockWS) {
+  doInstance.webSocketClose(cliWs as never, 0, '', false);
+}
+
+/** Trigger web disconnect */
+function disconnectWeb(doInstance: UserConnectionDO, webWs: MockWS) {
+  doInstance.webSocketClose(webWs as never, 0, '', false);
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe('UserConnectionDO', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Heartbeat processing
+  // -------------------------------------------------------------------------
+
+  describe('heartbeat processing', () => {
+    it('updates session ownership and broadcasts to web clients', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      const sessions = [makeSession('s1'), makeSession('s2')];
+      sendHeartbeat(doInstance, cliWs, sessions);
+
+      // Web should receive sessions.heartbeat system message
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      const sent = parseSent(webWs);
+      expect(sent).toEqual({
+        type: 'system',
+        event: 'sessions.heartbeat',
+        data: { connectionId: 'cli-1', sessions },
+      });
+
+      // CLI attachment updated with sessions
+      const att = cliWs.deserializeAttachment() as { sessions: unknown[] };
+      expect(att.sessions).toEqual(sessions);
+    });
+
+    it('removes session ownership when session disappears from heartbeat', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      addWebSocket(mockCtx, 'web-1');
+
+      // First heartbeat: owns s1 and s2
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1'), makeSession('s2')]);
+
+      // Second heartbeat: only s1
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      // Verify via command routing: command to s2 should fail (no owner)
+      const webWs2 = addWebSocket(mockCtx, 'web-2');
+      sendCommand(doInstance, webWs2, { id: 'cmd-1', command: 'test', sessionId: 's2' });
+      const resp = parseSent(webWs2);
+      expect(resp).toMatchObject({
+        type: 'response',
+        id: 'cmd-1',
+        error: 'Session owner not found',
+      });
+    });
+
+    it('schedules stale alarm on heartbeat', () => {
+      const { doInstance, mockCtx, ctx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      expect(ctx.storage.setAlarm).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stale connection eviction
+  // -------------------------------------------------------------------------
+
+  describe('stale connection eviction', () => {
+    it('closes stale connection after timeout', async () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      // Send heartbeat to register the connection and set lastHeartbeatAt
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      // Fast-forward time so the connection appears stale
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(Date.now() + 31_000) // for ensureState check
+        .mockReturnValue(Date.now() + 31_000); // for alarm's Date.now()
+
+      await doInstance.alarm();
+
+      expect(cliWs.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
+    });
+
+    it('reschedules alarm if other live connections remain', async () => {
+      const { doInstance, mockCtx, ctx } = setup();
+      const staleCli = addCliSocket(mockCtx, 'stale-1');
+      const freshCli = addCliSocket(mockCtx, 'fresh-1');
+
+      // Both send heartbeats
+      sendHeartbeat(doInstance, staleCli, [makeSession('s1')]);
+      sendHeartbeat(doInstance, freshCli, [makeSession('s2')]);
+
+      // Reset setAlarm call count
+      ctx.storage.setAlarm.mockClear();
+
+      // Make stale-1 appear stale but fresh-1 stays fresh
+      const now = Date.now();
+      const staleTime = now + 31_000;
+      vi.spyOn(Date, 'now').mockReturnValue(staleTime);
+
+      // Manually set lastHeartbeatAt for fresh-1 to "just now" (staleTime)
+      // by sending another heartbeat from fresh-1
+      sendHeartbeat(doInstance, freshCli, [makeSession('s2')]);
+      ctx.storage.setAlarm.mockClear();
+
+      await doInstance.alarm();
+
+      // Stale one closed
+      expect(staleCli.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
+      // Fresh one alive
+      expect(freshCli.close).not.toHaveBeenCalled();
+      // Alarm rescheduled because fresh-1 remains
+      expect(ctx.storage.setAlarm).toHaveBeenCalled();
+    });
+
+    it('does not evict connection with recent heartbeat', async () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      // Time is within timeout window
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 10_000);
+
+      await doInstance.alarm();
+
+      expect(cliWs.close).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Subscribe / Unsubscribe
+  // -------------------------------------------------------------------------
+
+  describe('subscribe/unsubscribe', () => {
+    it('sends subscribe to owning CLI when web subscribes', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      // CLI owns s1
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
+
+      sendSubscribe(doInstance, webWs, 's1');
+
+      // CLI should receive subscribe
+      expect(cliWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(cliWs)).toEqual({ type: 'subscribe', sessionId: 's1' });
+    });
+
+    it('broadcasts subscribe to all CLIs when no owner found', () => {
+      const { doInstance, mockCtx } = setup();
+      const cli1 = addCliSocket(mockCtx, 'cli-1');
+      const cli2 = addCliSocket(mockCtx, 'cli-2');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      // No heartbeat sent, so no owner for 's1'
+      // Trigger ensureState via a harmless message first
+      sendSubscribe(doInstance, webWs, 's1');
+
+      // Both CLIs should receive subscribe
+      expect(cli1.send).toHaveBeenCalled();
+      expect(cli2.send).toHaveBeenCalled();
+      expect(parseSent(cli1)).toEqual({ type: 'subscribe', sessionId: 's1' });
+      expect(parseSent(cli2)).toEqual({ type: 'subscribe', sessionId: 's1' });
+    });
+
+    it('duplicate subscribe is idempotent for attachment', () => {
+      const { doInstance, mockCtx } = setup();
+      addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendSubscribe(doInstance, webWs, 's1');
+      sendSubscribe(doInstance, webWs, 's1');
+
+      const att = webWs.deserializeAttachment() as { subscribedSessions: string[] };
+      expect(att.subscribedSessions).toEqual(['s1']);
+    });
+
+    it('unsubscribe sends to CLI when last subscriber leaves', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
+
+      sendSubscribe(doInstance, webWs, 's1');
+      cliWs.send.mockClear();
+
+      sendUnsubscribe(doInstance, webWs, 's1');
+
+      expect(cliWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(cliWs)).toEqual({ type: 'unsubscribe', sessionId: 's1' });
+    });
+
+    it('unsubscribe does not send to CLI when other subscribers remain', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const web1 = addWebSocket(mockCtx, 'web-1');
+      const web2 = addWebSocket(mockCtx, 'web-2');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
+
+      sendSubscribe(doInstance, web1, 's1');
+      sendSubscribe(doInstance, web2, 's1');
+      cliWs.send.mockClear();
+
+      // Unsubscribe first — CLI should NOT get unsubscribe
+      sendUnsubscribe(doInstance, web1, 's1');
+      expect(cliWs.send).not.toHaveBeenCalled();
+
+      // Unsubscribe second — CLI SHOULD get unsubscribe
+      sendUnsubscribe(doInstance, web2, 's1');
+      expect(cliWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(cliWs)).toEqual({ type: 'unsubscribe', sessionId: 's1' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // CLI disconnect
+  // -------------------------------------------------------------------------
+
+  describe('CLI disconnect', () => {
+    it('cleans up session ownership and broadcasts cli.disconnected', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      webWs.send.mockClear();
+
+      // Remove from sockets before disconnect (simulates runtime closing)
+      mockCtx.removeSocket(cliWs);
+      disconnectCli(doInstance, cliWs);
+
+      // Web receives cli.disconnected
+      expect(webWs.send).toHaveBeenCalled();
+      const msgs = allSent(webWs);
+      const disconnectMsg = msgs.find(
+        (m: any) => m.type === 'system' && m.event === 'cli.disconnected'
+      );
+      expect(disconnectMsg).toEqual({
+        type: 'system',
+        event: 'cli.disconnected',
+        data: { connectionId: 'cli-1' },
+      });
+
+      // Session no longer routable
+      const web2 = addWebSocket(mockCtx, 'web-2');
+      sendCommand(doInstance, web2, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+      expect(parseSent(web2)).toMatchObject({ type: 'response', error: 'Session owner not found' });
+    });
+
+    it('sends error responses for pending commands on disconnect', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      // Send command from web
+      sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+      webWs.send.mockClear();
+
+      // CLI disconnects
+      mockCtx.removeSocket(cliWs);
+      disconnectCli(doInstance, cliWs);
+
+      // Web receives error response
+      const msgs = allSent(webWs);
+      const errorResp = msgs.find((m: any) => m.type === 'response' && m.id === 'cmd-1');
+      expect(errorResp).toMatchObject({ type: 'response', id: 'cmd-1', error: 'CLI disconnected' });
+    });
+
+    it('reconnecting CLI — old socket close does not destroy state', () => {
+      const { doInstance, mockCtx } = setup();
+      const cli1 = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cli1, [makeSession('s1')]);
+
+      // CLI2 connects with same connectionId (simulates reconnect)
+      const cli2 = addCliSocket(mockCtx, 'cli-1');
+      sendHeartbeat(doInstance, cli2, [makeSession('s1')]);
+
+      // CLI1's close event fires (stale socket), but cli2 still holds the connectionId
+      // DON'T remove cli2 from sockets — cli2 is the replacement
+      // Just remove cli1 to simulate it being closed
+      mockCtx.removeSocket(cli1);
+      disconnectCli(doInstance, cli1);
+
+      // State should NOT be cleaned up — cli2 is live
+      // Verify by routing a command to s1 — should reach cli2
+      cli2.send.mockClear();
+      sendSubscribe(doInstance, webWs, 's1');
+      expect(cli2.send).toHaveBeenCalled();
+      expect(parseSent(cli2)).toEqual({ type: 'subscribe', sessionId: 's1' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Web disconnect
+  // -------------------------------------------------------------------------
+
+  describe('web disconnect', () => {
+    it('removes from all subscription sets', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1'), makeSession('s2')]);
+      sendSubscribe(doInstance, webWs, 's1');
+      sendSubscribe(doInstance, webWs, 's2');
+
+      mockCtx.removeSocket(webWs);
+      disconnectWeb(doInstance, webWs);
+
+      // Verify: CLI events for s1 and s2 go nowhere (no crash)
+      const cliEventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 's1',
+        event: 'message.updated',
+        data: {},
+      });
+      doInstance.webSocketMessage(cliWs as never, cliEventMsg);
+      // No web sockets to receive the event — no crash = success
+    });
+
+    it('sends unsubscribe to CLI when last subscriber leaves', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      sendSubscribe(doInstance, webWs, 's1');
+      cliWs.send.mockClear();
+
+      mockCtx.removeSocket(webWs);
+      disconnectWeb(doInstance, webWs);
+
+      // CLI should get unsubscribe for s1
+      const msgs = allSent(cliWs);
+      const unsub = msgs.find((m: any) => m.type === 'unsubscribe');
+      expect(unsub).toEqual({ type: 'unsubscribe', sessionId: 's1' });
+    });
+
+    it('cleans up pending commands from disconnecting web socket', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+
+      mockCtx.removeSocket(webWs);
+      disconnectWeb(doInstance, webWs);
+
+      // CLI sends response, but the pending command is gone — no crash
+      sendCliResponse(doInstance, cliWs, { id: 'cmd-1', result: 'ok' });
+      // webWs.send should NOT have been called after disconnect
+      // (all calls before disconnect are from subscription messages)
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Command routing
+  // -------------------------------------------------------------------------
+
+  describe('command routing', () => {
+    it('routes web command to correct CLI by sessionId', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
+
+      sendCommand(doInstance, webWs, {
+        id: 'cmd-1',
+        command: 'send_message',
+        sessionId: 's1',
+        data: { text: 'hello' },
+      });
+
+      expect(cliWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(cliWs)).toEqual({
+        type: 'command',
+        id: 'cmd-1',
+        command: 'send_message',
+        sessionId: 's1',
+        data: { text: 'hello' },
+      });
+    });
+
+    it('routes CLI response to correct web socket', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+      webWs.send.mockClear();
+
+      sendCliResponse(doInstance, cliWs, { id: 'cmd-1', result: { success: true } });
+
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(webWs)).toEqual({
+        type: 'response',
+        id: 'cmd-1',
+        result: { success: true },
+      });
+    });
+
+    it('returns error when CLI not found for session', () => {
+      const { doInstance, mockCtx } = setup();
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendCommand(doInstance, webWs, {
+        id: 'cmd-1',
+        command: 'test',
+        sessionId: 'unknown-session',
+      });
+
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(webWs)).toEqual({
+        type: 'response',
+        id: 'cmd-1',
+        error: 'Session owner not found',
+      });
+    });
+
+    it('routes command by connectionId to specific CLI', () => {
+      const { doInstance, mockCtx } = setup();
+      const cli1 = addCliSocket(mockCtx, 'cli-1');
+      const cli2 = addCliSocket(mockCtx, 'cli-2');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      // Trigger ensureState
+      sendHeartbeat(doInstance, cli1, []);
+      sendHeartbeat(doInstance, cli2, []);
+      cli1.send.mockClear();
+      cli2.send.mockClear();
+
+      sendCommand(doInstance, webWs, {
+        id: 'cmd-1',
+        command: 'test',
+        connectionId: 'cli-2',
+      });
+
+      expect(cli1.send).not.toHaveBeenCalled();
+      expect(cli2.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes to first CLI when no sessionId or connectionId given', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, []);
+      cliWs.send.mockClear();
+
+      sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test' });
+      expect(cliWs.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // CLI event forwarding
+  // -------------------------------------------------------------------------
+
+  describe('CLI event forwarding', () => {
+    it('forwards events to subscribed web sockets only', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const subWeb = addWebSocket(mockCtx, 'web-sub');
+      const otherWeb = addWebSocket(mockCtx, 'web-other');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      sendSubscribe(doInstance, subWeb, 's1');
+      subWeb.send.mockClear();
+      otherWeb.send.mockClear();
+
+      // CLI sends event for s1
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 's1',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      expect(subWeb.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(subWeb)).toEqual({
+        type: 'event',
+        sessionId: 's1',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      });
+      expect(otherWeb.send).not.toHaveBeenCalled();
+    });
+
+    it('routes child event to parent session subscribers via parentSessionId', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('parent-session')]);
+      sendSubscribe(doInstance, webWs, 'parent-session');
+      webWs.send.mockClear();
+
+      // CLI sends event for a child session with parentSessionId
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 'child-session-1',
+        parentSessionId: 'parent-session',
+        event: 'message.updated',
+        data: { id: 'msg-child-1' },
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(webWs)).toEqual({
+        type: 'event',
+        sessionId: 'child-session-1',
+        parentSessionId: 'parent-session',
+        event: 'message.updated',
+        data: { id: 'msg-child-1' },
+      });
+    });
+
+    it('drops child event when neither sessionId nor parentSessionId has subscribers', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('other-session')]);
+      sendSubscribe(doInstance, webWs, 'other-session');
+      webWs.send.mockClear();
+
+      // Child event with parent that nobody subscribes to
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 'child-session-1',
+        parentSessionId: 'unknown-parent',
+        event: 'message.updated',
+        data: { id: 'msg-child-1' },
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      expect(webWs.send).not.toHaveBeenCalled();
+    });
+
+    it('events without parentSessionId still route normally (backward compat)', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      sendSubscribe(doInstance, webWs, 's1');
+      webWs.send.mockClear();
+
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 's1',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(webWs)).toEqual({
+        type: 'event',
+        sessionId: 's1',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      });
+    });
+
+    it('child event does not include parentSessionId when not set', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      sendSubscribe(doInstance, webWs, 's1');
+      webWs.send.mockClear();
+
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 's1',
+        event: 'session.status',
+        data: {},
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      const sent = parseSent(webWs);
+      expect(sent).not.toHaveProperty('parentSessionId');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Broadcast resilience
+  // -------------------------------------------------------------------------
+
+  describe('broadcast resilience', () => {
+    it('one closed socket does not abort broadcast to others', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const failWeb = addWebSocket(mockCtx, 'web-fail');
+      const okWeb = addWebSocket(mockCtx, 'web-ok');
+
+      // Make failWeb throw on send
+      failWeb.send.mockImplementation(() => {
+        throw new Error('socket closed');
+      });
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      // okWeb should still receive the message
+      expect(okWeb.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(okWeb)).toMatchObject({
+        type: 'system',
+        event: 'sessions.heartbeat',
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Hibernation recovery (ensureState)
+  // -------------------------------------------------------------------------
+
+  describe('ensureState (hibernation recovery)', () => {
+    it('reconstructs sessionOwners and connectionSessions from CLI attachments', () => {
+      const { doInstance, mockCtx } = setup();
+
+      // Simulate hibernation: sockets exist with pre-set attachments
+      const sessions = [makeSession('s1'), makeSession('s2')];
+      addCliSocket(mockCtx, 'cli-1', sessions);
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      // Trigger ensureState by calling any method (e.g., webSocketMessage with subscribe)
+      sendSubscribe(doInstance, webWs, 's1');
+
+      // Verify state was reconstructed by routing a command
+      const web2 = addWebSocket(mockCtx, 'web-2');
+      sendCommand(doInstance, web2, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+
+      // Should route to cli-1 (not "Session owner not found")
+      const cliWs = mockCtx.sockets.find(s => s._tags.includes('cli'));
+      expect(cliWs?.send).toHaveBeenCalled();
+      const cliMsgs = allSent(cliWs!);
+      const cmdMsg = cliMsgs.find((m: any) => m.type === 'command');
+      expect(cmdMsg).toMatchObject({ type: 'command', id: 'cmd-1' });
+    });
+
+    it('reconstructs webSubscriptions from web attachments', () => {
+      const { doInstance, mockCtx } = setup();
+
+      const cliWs = addCliSocket(mockCtx, 'cli-1', [makeSession('s1')]);
+      // Web socket with pre-existing subscription (from hibernation)
+      const webWs = addWebSocket(mockCtx, 'web-1', ['s1']);
+
+      // Trigger ensureState by calling any method
+      const triggerMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 's1',
+        event: 'test',
+        data: {},
+      });
+      doInstance.webSocketMessage(cliWs as never, triggerMsg);
+
+      // webWs should have received the event because it was subscribed via attachment
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(webWs)).toMatchObject({
+        type: 'event',
+        sessionId: 's1',
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getActiveSessions RPC
+  // -------------------------------------------------------------------------
+
+  describe('getActiveSessions', () => {
+    it('returns sessions from live CLI connections', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      sendHeartbeat(doInstance, cliWs, [
+        makeSession('s1', 'busy', 'Fix bug'),
+        makeSession('s2', 'idle', 'Review PR'),
+      ]);
+
+      const result = doInstance.getActiveSessions();
+      expect(result).toEqual([
+        { id: 's1', status: 'busy', title: 'Fix bug', connectionId: 'cli-1' },
+        { id: 's2', status: 'idle', title: 'Review PR', connectionId: 'cli-1' },
+      ]);
+    });
+
+    it('excludes sessions from stale connections without live sockets', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      // Remove from sockets (simulates close)
+      mockCtx.removeSocket(cliWs);
+
+      const result = doInstance.getActiveSessions();
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  describe('edge cases', () => {
+    it('ignores non-JSON messages', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      // Should not throw
+      doInstance.webSocketMessage(cliWs as never, 'not-json');
+    });
+
+    it('ignores messages from socket with no attachment', () => {
+      const { doInstance, mockCtx } = setup();
+      const ws = createMockWs(['cli'], null);
+      mockCtx.addSocket(ws);
+
+      // Trigger ensureState first
+      doInstance.webSocketMessage(ws as never, JSON.stringify({ type: 'heartbeat', sessions: [] }));
+      // Should not throw
+    });
+
+    it('ignores messages that fail Zod validation', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      sendHeartbeat(doInstance, cliWs, []); // trigger ensureState
+
+      // Invalid CLI message
+      const badMsg = JSON.stringify({ type: 'invalid_type' });
+      doInstance.webSocketMessage(cliWs as never, badMsg);
+      // Should not throw
+
+      // Invalid web message
+      const webWs = addWebSocket(mockCtx, 'web-1');
+      doInstance.webSocketMessage(webWs as never, badMsg);
+      // Should not throw
+    });
+
+    it('webSocketError triggers webSocketClose', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      webWs.send.mockClear();
+
+      // Remove CLI so disconnect can clean up
+      mockCtx.removeSocket(cliWs);
+      doInstance.webSocketError(cliWs as never);
+
+      // Should broadcast cli.disconnected
+      const msgs = allSent(webWs);
+      expect(msgs.some((m: any) => m.event === 'cli.disconnected')).toBe(true);
+    });
+
+    it('CLI response for unknown correlation ID is a no-op', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      sendHeartbeat(doInstance, cliWs, []);
+
+      // Should not throw
+      sendCliResponse(doInstance, cliWs, { id: 'nonexistent', result: 'ok' });
+    });
+  });
+});

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -563,6 +563,37 @@ describe('UserConnectionDO', () => {
       expect(cli2.send).toHaveBeenCalled();
       expect(parseSent(cli2)).toEqual({ type: 'subscribe', sessionId: 's1' });
     });
+
+    it('reconnecting CLI — pending commands from old socket get error responses', () => {
+      const { doInstance, mockCtx } = setup();
+      const cli1 = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cli1, [makeSession('s1')]);
+
+      // Web sends a command that gets forwarded to cli1
+      sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+      webWs.send.mockClear();
+
+      // CLI2 connects with the same connectionId (reconnect)
+      const cli2 = addCliSocket(mockCtx, 'cli-1');
+      sendHeartbeat(doInstance, cli2, [makeSession('s1')]);
+
+      // cli1's close event fires — cmd-1 was sent on cli1's wire, cli2 never saw it
+      mockCtx.removeSocket(cli1);
+      disconnectCli(doInstance, cli1);
+
+      // Web should receive an error for the stranded command
+      const msgs = allSent(webWs);
+      const errorResp = msgs.find(
+        (m: Record<string, unknown>) => m.type === 'response' && m.id === 'cmd-1'
+      );
+      expect(errorResp).toMatchObject({
+        type: 'response',
+        id: 'cmd-1',
+        error: 'CLI disconnected',
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -261,6 +261,30 @@ describe('UserConnectionDO', () => {
       });
     });
 
+    it('replays existing web subscriptions when a session gets a new CLI owner', () => {
+      const { doInstance, mockCtx } = setup();
+      const cli1 = addCliSocket(mockCtx, 'cli-1');
+      const cli2 = addCliSocket(mockCtx, 'cli-2');
+      addWebSocket(mockCtx, 'web-1');
+
+      // cli1 owns s1
+      sendHeartbeat(doInstance, cli1, [makeSession('s1')]);
+
+      // web subscribes to s1 — subscribe sent to cli1 (the current owner)
+      const webWs = mockCtx.sockets.find(s => s._tags.includes('web'))!;
+      sendSubscribe(doInstance, webWs, 's1');
+
+      cli1.send.mockClear();
+      cli2.send.mockClear();
+
+      // cli2 now reports s1 — becomes new owner
+      sendHeartbeat(doInstance, cli2, [makeSession('s1')]);
+
+      // cli2 should have received the replayed subscribe for s1
+      const cli2Msgs = allSent(cli2);
+      expect(cli2Msgs).toContainEqual({ type: 'subscribe', sessionId: 's1' });
+    });
+
     it('schedules stale alarm on heartbeat', () => {
       const { doInstance, mockCtx, ctx } = setup();
       const cliWs = addCliSocket(mockCtx, 'cli-1');
@@ -562,6 +586,51 @@ describe('UserConnectionDO', () => {
       sendSubscribe(doInstance, webWs, 's1');
       expect(cli2.send).toHaveBeenCalled();
       expect(parseSent(cli2)).toEqual({ type: 'subscribe', sessionId: 's1' });
+    });
+
+    it('reconnecting CLI — commands sent to replacement socket are not spuriously failed', () => {
+      const { doInstance, mockCtx } = setup();
+      const cli1 = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cli1, [makeSession('s1')]);
+
+      // cli2 connects with the same connectionId (reconnect).
+      // In production, closeStaleSocket removes cli1 before cli2 is accepted.
+      // Simulate that by removing cli1 from the socket list first.
+      mockCtx.removeSocket(cli1);
+      const cli2 = addCliSocket(mockCtx, 'cli-1');
+      sendHeartbeat(doInstance, cli2, [makeSession('s1')]);
+
+      cli2.send.mockClear();
+      webWs.send.mockClear();
+
+      // Web sends a command targeting s1 — should route to cli2 (the replacement)
+      sendCommand(doInstance, webWs, { id: 'cmd-new', command: 'test', sessionId: 's1' });
+      expect(cli2.send).toHaveBeenCalled();
+      const correlationId = getCorrelationId(cli2);
+
+      webWs.send.mockClear();
+
+      // Now cli1's close event fires (stale socket teardown)
+      disconnectCli(doInstance, cli1);
+
+      // Web should NOT have received an error for cmd-new — it was sent to cli2, not cli1
+      const errorMsgs = allSent(webWs).filter(
+        m => m.type === 'response' && m.id === 'cmd-new' && m.error
+      );
+      expect(errorMsgs).toHaveLength(0);
+
+      // cli2 responds successfully
+      webWs.send.mockClear();
+      sendCliResponse(doInstance, cli2, { id: correlationId, result: 'ok' });
+
+      expect(webWs.send).toHaveBeenCalledTimes(1);
+      expect(parseSent(webWs)).toEqual({
+        type: 'response',
+        id: 'cmd-new',
+        result: 'ok',
+      });
     });
 
     it('reconnecting CLI — pending commands from old socket get error responses', () => {

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -110,6 +110,15 @@ function allSent(ws: MockWS): Record<string, unknown>[] {
   });
 }
 
+/** Extract the correlationId that was sent to CLI for a given command. */
+function getCorrelationId(cliWs: MockWS, callIndex = 0): string {
+  const msgs = allSent(cliWs);
+  const cmdMsgs = msgs.filter(m => m.type === 'command');
+  const msg = cmdMsgs[callIndex];
+  if (!msg) throw new Error(`No command call at index ${callIndex}`);
+  return msg.id as string;
+}
+
 /** Instantiate a fresh DO with a mock context. Returns the DO and helpers. */
 function setup() {
   const mockCtx = createMockCtx();
@@ -471,12 +480,63 @@ describe('UserConnectionDO', () => {
       mockCtx.removeSocket(cliWs);
       disconnectCli(doInstance, cliWs);
 
-      // Web receives error response
+      // Web receives error response with original id
       const msgs = allSent(webWs);
       const errorResp = msgs.find(
         (m: Record<string, unknown>) => m.type === 'response' && m.id === 'cmd-1'
       );
       expect(errorResp).toMatchObject({ type: 'response', id: 'cmd-1', error: 'CLI disconnected' });
+    });
+
+    it('sends error for connection-routed pending commands on CLI disconnect', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, []);
+
+      // Send command routed by connectionId (no sessionId)
+      sendCommand(doInstance, webWs, { id: 'cmd-conn', command: 'test', connectionId: 'cli-1' });
+      webWs.send.mockClear();
+
+      // CLI disconnects before responding
+      mockCtx.removeSocket(cliWs);
+      disconnectCli(doInstance, cliWs);
+
+      const msgs = allSent(webWs);
+      const errorResp = msgs.find(
+        (m: Record<string, unknown>) => m.type === 'response' && m.id === 'cmd-conn'
+      );
+      expect(errorResp).toMatchObject({
+        type: 'response',
+        id: 'cmd-conn',
+        error: 'CLI disconnected',
+      });
+    });
+
+    it('sends error for fallback-routed pending commands on CLI disconnect', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, []);
+
+      // Send command with no sessionId or connectionId (fallback routing)
+      sendCommand(doInstance, webWs, { id: 'cmd-fallback', command: 'test' });
+      webWs.send.mockClear();
+
+      mockCtx.removeSocket(cliWs);
+      disconnectCli(doInstance, cliWs);
+
+      const msgs = allSent(webWs);
+      const errorResp = msgs.find(
+        (m: Record<string, unknown>) => m.type === 'response' && m.id === 'cmd-fallback'
+      );
+      expect(errorResp).toMatchObject({
+        type: 'response',
+        id: 'cmd-fallback',
+        error: 'CLI disconnected',
+      });
     });
 
     it('reconnecting CLI — old socket close does not destroy state', () => {
@@ -557,15 +617,15 @@ describe('UserConnectionDO', () => {
       const webWs = addWebSocket(mockCtx, 'web-1');
 
       sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
       sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+      const correlationId = getCorrelationId(cliWs);
 
       mockCtx.removeSocket(webWs);
       disconnectWeb(doInstance, webWs);
 
-      // CLI sends response, but the pending command is gone — no crash
-      sendCliResponse(doInstance, cliWs, { id: 'cmd-1', result: 'ok' });
-      // webWs.send should NOT have been called after disconnect
-      // (all calls before disconnect are from subscription messages)
+      // CLI sends response with correlationId, but the pending command is gone — no crash
+      sendCliResponse(doInstance, cliWs, { id: correlationId, result: 'ok' });
     });
   });
 
@@ -590,25 +650,30 @@ describe('UserConnectionDO', () => {
       });
 
       expect(cliWs.send).toHaveBeenCalledTimes(1);
-      expect(parseSent(cliWs)).toEqual({
+      const sent = parseSent(cliWs) as Record<string, unknown>;
+      expect(sent).toMatchObject({
         type: 'command',
-        id: 'cmd-1',
         command: 'send_message',
         sessionId: 's1',
         data: { text: 'hello' },
       });
+      expect(typeof sent.id).toBe('string');
+      expect(sent.id).not.toBe('cmd-1');
     });
 
-    it('routes CLI response to correct web socket', () => {
+    it('routes CLI response to correct web socket with original id', () => {
       const { doInstance, mockCtx } = setup();
       const cliWs = addCliSocket(mockCtx, 'cli-1');
       const webWs = addWebSocket(mockCtx, 'web-1');
 
       sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
       sendCommand(doInstance, webWs, { id: 'cmd-1', command: 'test', sessionId: 's1' });
+
+      const correlationId = getCorrelationId(cliWs);
       webWs.send.mockClear();
 
-      sendCliResponse(doInstance, cliWs, { id: 'cmd-1', result: { success: true } });
+      sendCliResponse(doInstance, cliWs, { id: correlationId, result: { success: true } });
 
       expect(webWs.send).toHaveBeenCalledTimes(1);
       expect(parseSent(webWs)).toEqual({
@@ -658,6 +723,34 @@ describe('UserConnectionDO', () => {
       expect(cli2.send).toHaveBeenCalledTimes(1);
     });
 
+    it('two web sockets with the same command id each get the correct response', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const web1 = addWebSocket(mockCtx, 'web-1');
+      const web2 = addWebSocket(mockCtx, 'web-2');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      cliWs.send.mockClear();
+
+      // Both web sockets send commands with the same id
+      sendCommand(doInstance, web1, { id: 'dup-id', command: 'test', sessionId: 's1' });
+      const corr1 = getCorrelationId(cliWs, 0);
+
+      sendCommand(doInstance, web2, { id: 'dup-id', command: 'test', sessionId: 's1' });
+      const corr2 = getCorrelationId(cliWs, 1);
+
+      expect(corr1).not.toBe(corr2);
+
+      web1.send.mockClear();
+      web2.send.mockClear();
+
+      sendCliResponse(doInstance, cliWs, { id: corr1, result: 'result-1' });
+      sendCliResponse(doInstance, cliWs, { id: corr2, result: 'result-2' });
+
+      expect(parseSent(web1)).toEqual({ type: 'response', id: 'dup-id', result: 'result-1' });
+      expect(parseSent(web2)).toEqual({ type: 'response', id: 'dup-id', result: 'result-2' });
+    });
+
     it('routes to first CLI when no sessionId or connectionId given', () => {
       const { doInstance, mockCtx } = setup();
       const cliWs = addCliSocket(mockCtx, 'cli-1');
@@ -704,6 +797,63 @@ describe('UserConnectionDO', () => {
         data: { id: 'msg-1' },
       });
       expect(otherWeb.send).not.toHaveBeenCalled();
+    });
+
+    it('sends child events to both direct child subscribers and parent subscribers', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const parentWeb = addWebSocket(mockCtx, 'web-parent');
+      const childWeb = addWebSocket(mockCtx, 'web-child');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('parent-session')]);
+      sendSubscribe(doInstance, parentWeb, 'parent-session');
+      sendSubscribe(doInstance, childWeb, 'child-session-1');
+      parentWeb.send.mockClear();
+      childWeb.send.mockClear();
+
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 'child-session-1',
+        parentSessionId: 'parent-session',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      expect(parentWeb.send).toHaveBeenCalledTimes(1);
+      expect(childWeb.send).toHaveBeenCalledTimes(1);
+      const expected = {
+        type: 'event',
+        sessionId: 'child-session-1',
+        parentSessionId: 'parent-session',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      };
+      expect(parseSent(parentWeb)).toEqual(expected);
+      expect(parseSent(childWeb)).toEqual(expected);
+    });
+
+    it('deduplicates when same socket subscribes to both child and parent', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+      const webWs = addWebSocket(mockCtx, 'web-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('parent-session')]);
+      sendSubscribe(doInstance, webWs, 'parent-session');
+      sendSubscribe(doInstance, webWs, 'child-session-1');
+      webWs.send.mockClear();
+
+      const eventMsg = JSON.stringify({
+        type: 'event',
+        sessionId: 'child-session-1',
+        parentSessionId: 'parent-session',
+        event: 'message.updated',
+        data: { id: 'msg-1' },
+      });
+      doInstance.webSocketMessage(cliWs as never, eventMsg);
+
+      // Should only receive once despite subscribing to both
+      expect(webWs.send).toHaveBeenCalledTimes(1);
     });
 
     it('routes child event to parent session subscribers via parentSessionId', () => {
@@ -857,7 +1007,7 @@ describe('UserConnectionDO', () => {
       expect(cliWs?.send).toHaveBeenCalled();
       const cliMsgs = allSent(cliWs!);
       const cmdMsg = cliMsgs.find((m: Record<string, unknown>) => m.type === 'command');
-      expect(cmdMsg).toMatchObject({ type: 'command', id: 'cmd-1' });
+      expect(cmdMsg).toMatchObject({ type: 'command', command: 'test' });
     });
 
     it('reconstructs webSubscriptions from web attachments', () => {

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -96,8 +96,18 @@ function parseSent(ws: MockWS, callIndex = 0): unknown {
   return JSON.parse(call[0] as string);
 }
 
-function allSent(ws: MockWS): unknown[] {
-  return ws.send.mock.calls.map(c => JSON.parse(c[0] as string));
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function allSent(ws: MockWS): Record<string, unknown>[] {
+  return ws.send.mock.calls.map(c => {
+    const parsed: unknown = JSON.parse(String(c[0]));
+    if (!isRecord(parsed)) {
+      throw new Error(`Expected JSON object but got: ${String(c[0])}`);
+    }
+    return parsed;
+  });
 }
 
 /** Instantiate a fresh DO with a mock context. Returns the DO and helpers. */
@@ -432,7 +442,7 @@ describe('UserConnectionDO', () => {
       expect(webWs.send).toHaveBeenCalled();
       const msgs = allSent(webWs);
       const disconnectMsg = msgs.find(
-        (m: any) => m.type === 'system' && m.event === 'cli.disconnected'
+        (m: Record<string, unknown>) => m.type === 'system' && m.event === 'cli.disconnected'
       );
       expect(disconnectMsg).toEqual({
         type: 'system',
@@ -463,7 +473,9 @@ describe('UserConnectionDO', () => {
 
       // Web receives error response
       const msgs = allSent(webWs);
-      const errorResp = msgs.find((m: any) => m.type === 'response' && m.id === 'cmd-1');
+      const errorResp = msgs.find(
+        (m: Record<string, unknown>) => m.type === 'response' && m.id === 'cmd-1'
+      );
       expect(errorResp).toMatchObject({ type: 'response', id: 'cmd-1', error: 'CLI disconnected' });
     });
 
@@ -535,7 +547,7 @@ describe('UserConnectionDO', () => {
 
       // CLI should get unsubscribe for s1
       const msgs = allSent(cliWs);
-      const unsub = msgs.find((m: any) => m.type === 'unsubscribe');
+      const unsub = msgs.find((m: Record<string, unknown>) => m.type === 'unsubscribe');
       expect(unsub).toEqual({ type: 'unsubscribe', sessionId: 's1' });
     });
 
@@ -844,7 +856,7 @@ describe('UserConnectionDO', () => {
       const cliWs = mockCtx.sockets.find(s => s._tags.includes('cli'));
       expect(cliWs?.send).toHaveBeenCalled();
       const cliMsgs = allSent(cliWs!);
-      const cmdMsg = cliMsgs.find((m: any) => m.type === 'command');
+      const cmdMsg = cliMsgs.find((m: Record<string, unknown>) => m.type === 'command');
       expect(cmdMsg).toMatchObject({ type: 'command', id: 'cmd-1' });
     });
 
@@ -960,7 +972,7 @@ describe('UserConnectionDO', () => {
 
       // Should broadcast cli.disconnected
       const msgs = allSent(webWs);
-      expect(msgs.some((m: any) => m.event === 'cli.disconnected')).toBe(true);
+      expect(msgs.some((m: Record<string, unknown>) => m.event === 'cli.disconnected')).toBe(true);
     });
 
     it('CLI response for unknown correlation ID is a no-op', () => {

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -30,7 +30,10 @@ export class UserConnectionDO extends DurableObject<Env> {
   // Sessions per CLI connection (from heartbeat)
   private connectionSessions = new Map<string, HeartbeatSession[]>();
   // Pending command responses: correlationId → originating web socket
-  private pendingCommands = new Map<string, { ws: WebSocket; sessionId?: string }>();
+  private pendingCommands = new Map<
+    string,
+    { ws: WebSocket; sessionId?: string; originalId: string; targetConnectionId: string }
+  >();
   // Last heartbeat timestamp per CLI connectionId (for staleness eviction)
   private lastHeartbeatAt = new Map<string, number>();
 
@@ -293,10 +296,14 @@ export class UserConnectionDO extends DurableObject<Env> {
     event: string,
     data: unknown
   ): void {
-    const subscribers =
-      this.webSubscriptions.get(sessionId) ??
-      (parentSessionId ? this.webSubscriptions.get(parentSessionId) : undefined);
-    if (!subscribers) return;
+    const childSubs = this.webSubscriptions.get(sessionId);
+    const parentSubs = parentSessionId ? this.webSubscriptions.get(parentSessionId) : undefined;
+    if (!childSubs && !parentSubs) return;
+
+    const merged = new Set<WebSocket>();
+    if (childSubs) for (const ws of childSubs) merged.add(ws);
+    if (parentSubs) for (const ws of parentSubs) merged.add(ws);
+    if (merged.size === 0) return;
 
     const msg: WebInboundMessage = {
       type: 'event',
@@ -305,20 +312,19 @@ export class UserConnectionDO extends DurableObject<Env> {
       event,
       data,
     };
-    for (const ws of subscribers) {
+    for (const ws of merged) {
       this.sendToWeb(ws, msg);
     }
   }
 
   private handleCliResponse(id: string, result: unknown, error: unknown): void {
     const entry = this.pendingCommands.get(id);
-    const originWs = entry?.ws;
-    if (!originWs) return;
+    if (!entry) return;
     this.pendingCommands.delete(id);
 
-    this.sendToWeb(originWs, {
+    this.sendToWeb(entry.ws, {
       type: 'response',
-      id,
+      id: entry.originalId,
       ...(result !== undefined ? { result } : {}),
       ...(error !== undefined ? { error } : {}),
     });
@@ -444,11 +450,20 @@ export class UserConnectionDO extends DurableObject<Env> {
       return;
     }
 
-    this.pendingCommands.set(msg.id, { ws, sessionId: msg.sessionId });
+    const targetAtt = targetCli.deserializeAttachment() as WSAttachment | null;
+    const targetConnectionId = targetAtt?.role === 'cli' ? targetAtt.connectionId : 'unknown';
+
+    const correlationId = crypto.randomUUID();
+    this.pendingCommands.set(correlationId, {
+      ws,
+      sessionId: msg.sessionId,
+      originalId: msg.id,
+      targetConnectionId,
+    });
 
     this.sendToCli(targetCli, {
       type: 'command',
-      id: msg.id,
+      id: correlationId,
       command: msg.command,
       data: msg.data,
       ...(msg.sessionId ? { sessionId: msg.sessionId } : {}),
@@ -486,10 +501,13 @@ export class UserConnectionDO extends DurableObject<Env> {
     this.connectionSessions.delete(connectionId);
     this.lastHeartbeatAt.delete(connectionId);
 
-    // Clean up pending commands targeting sessions owned by the disconnecting CLI
     for (const [id, entry] of this.pendingCommands) {
-      if (entry.sessionId && ownedSessions.has(entry.sessionId)) {
-        this.sendToWeb(entry.ws, { type: 'response', id, error: 'CLI disconnected' });
+      if (entry.targetConnectionId === connectionId) {
+        this.sendToWeb(entry.ws, {
+          type: 'response',
+          id: entry.originalId,
+          error: 'CLI disconnected',
+        });
         this.pendingCommands.delete(id);
       }
     }

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -32,7 +32,7 @@ export class UserConnectionDO extends DurableObject<Env> {
   // Pending command responses: correlationId → originating web socket
   private pendingCommands = new Map<
     string,
-    { ws: WebSocket; sessionId?: string; originalId: string; targetConnectionId: string }
+    { ws: WebSocket; sessionId?: string; originalId: string; targetCliWs: WebSocket }
   >();
   // Last heartbeat timestamp per CLI connectionId (for staleness eviction)
   private lastHeartbeatAt = new Map<string, number>();
@@ -175,7 +175,7 @@ export class UserConnectionDO extends DurableObject<Env> {
     if (!attachment) return;
 
     if (attachment.role === 'cli') {
-      this.handleCliDisconnect(attachment);
+      this.handleCliDisconnect(ws, attachment);
     } else {
       this.handleWebDisconnect(ws);
     }
@@ -277,6 +277,14 @@ export class UserConnectionDO extends DurableObject<Env> {
     this.connectionSessions.set(connectionId, sessions);
     for (const session of sessions) {
       this.sessionOwners.set(session.id, connectionId);
+    }
+
+    // Replay existing subscriptions for sessions newly owned by this CLI
+    const previousIds = new Set(previousSessions.map(s => s.id));
+    for (const session of sessions) {
+      if (!previousIds.has(session.id) && this.webSubscriptions.has(session.id)) {
+        this.sendToCli(ws, { type: 'subscribe', sessionId: session.id });
+      }
     }
 
     // Persist to attachment for hibernation recovery
@@ -450,15 +458,12 @@ export class UserConnectionDO extends DurableObject<Env> {
       return;
     }
 
-    const targetAtt = targetCli.deserializeAttachment() as WSAttachment | null;
-    const targetConnectionId = targetAtt?.role === 'cli' ? targetAtt.connectionId : 'unknown';
-
     const correlationId = crypto.randomUUID();
     this.pendingCommands.set(correlationId, {
       ws,
       sessionId: msg.sessionId,
       originalId: msg.id,
-      targetConnectionId,
+      targetCliWs: targetCli,
     });
 
     this.sendToCli(targetCli, {
@@ -474,7 +479,10 @@ export class UserConnectionDO extends DurableObject<Env> {
   // Disconnect handling
   // ---------------------------------------------------------------------------
 
-  private handleCliDisconnect(attachment: WSAttachment & { role: 'cli' }): void {
+  private handleCliDisconnect(
+    disconnectedWs: WebSocket,
+    attachment: WSAttachment & { role: 'cli' }
+  ): void {
     const { connectionId } = attachment;
 
     // If another CLI socket already has this connectionId, this is a stale
@@ -484,9 +492,8 @@ export class UserConnectionDO extends DurableObject<Env> {
       return att?.role === 'cli' && att.connectionId === connectionId;
     });
 
-    // Fail pending commands that targeted this connection — even on reconnect,
-    // because the replacement socket never saw those correlation IDs.
-    this.failPendingCommandsForConnection(connectionId);
+    // Fail pending commands that targeted this specific socket
+    this.failPendingCommandsForSocket(disconnectedWs);
 
     if (replaced) {
       console.log('Stale CLI socket closed (already replaced)', { connectionId });
@@ -627,9 +634,9 @@ export class UserConnectionDO extends DurableObject<Env> {
     return undefined;
   }
 
-  private failPendingCommandsForConnection(connectionId: string): void {
+  private failPendingCommandsForSocket(targetWs: WebSocket): void {
     for (const [id, entry] of this.pendingCommands) {
-      if (entry.targetConnectionId === connectionId) {
+      if (entry.targetCliWs === targetWs) {
         this.sendToWeb(entry.ws, {
           type: 'response',
           id: entry.originalId,

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -484,6 +484,10 @@ export class UserConnectionDO extends DurableObject<Env> {
       return att?.role === 'cli' && att.connectionId === connectionId;
     });
 
+    // Fail pending commands that targeted this connection — even on reconnect,
+    // because the replacement socket never saw those correlation IDs.
+    this.failPendingCommandsForConnection(connectionId);
+
     if (replaced) {
       console.log('Stale CLI socket closed (already replaced)', { connectionId });
       return;
@@ -500,17 +504,6 @@ export class UserConnectionDO extends DurableObject<Env> {
     }
     this.connectionSessions.delete(connectionId);
     this.lastHeartbeatAt.delete(connectionId);
-
-    for (const [id, entry] of this.pendingCommands) {
-      if (entry.targetConnectionId === connectionId) {
-        this.sendToWeb(entry.ws, {
-          type: 'response',
-          id: entry.originalId,
-          error: 'CLI disconnected',
-        });
-        this.pendingCommands.delete(id);
-      }
-    }
 
     console.log('CLI socket disconnected', {
       connectionId,
@@ -632,6 +625,19 @@ export class UserConnectionDO extends DurableObject<Env> {
       }
     }
     return undefined;
+  }
+
+  private failPendingCommandsForConnection(connectionId: string): void {
+    for (const [id, entry] of this.pendingCommands) {
+      if (entry.targetConnectionId === connectionId) {
+        this.sendToWeb(entry.ws, {
+          type: 'response',
+          id: entry.originalId,
+          error: 'CLI disconnected',
+        });
+        this.pendingCommands.delete(id);
+      }
+    }
   }
 
   private scheduleStaleCheck(): void {

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -619,7 +619,7 @@ export class UserConnectionDO extends DurableObject<Env> {
   private scheduleStaleCheck(): void {
     // Schedule an alarm to run after the timeout period.
     // setAlarm is idempotent if one is already scheduled sooner.
-    this.ctx.storage.setAlarm(Date.now() + UserConnectionDO.HEARTBEAT_TIMEOUT_MS);
+    void this.ctx.storage.setAlarm(Date.now() + UserConnectionDO.HEARTBEAT_TIMEOUT_MS);
   }
 
   private aggregateSessions(): Array<HeartbeatSession & { connectionId: string }> {

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -1,0 +1,648 @@
+import { DurableObject } from 'cloudflare:workers';
+
+import type { Env } from '../env';
+import {
+  CLIOutboundMessageSchema,
+  type CLIInboundMessage,
+  type WebInboundMessage,
+  WebOutboundMessageSchema,
+} from '../types/user-connection-protocol';
+
+type HeartbeatSession = {
+  id: string;
+  status: string;
+  title: string;
+  gitUrl?: string;
+  gitBranch?: string;
+};
+
+type WSAttachment =
+  | { role: 'cli'; connectionId: string; sessions: HeartbeatSession[] }
+  | { role: 'web'; connectionId: string; subscribedSessions: string[] };
+
+export class UserConnectionDO extends DurableObject<Env> {
+  private static readonly HEARTBEAT_TIMEOUT_MS = 30_000;
+
+  // Which CLI connection owns each session
+  private sessionOwners = new Map<string, string>();
+  // Which web sockets want events for a session
+  private webSubscriptions = new Map<string, Set<WebSocket>>();
+  // Sessions per CLI connection (from heartbeat)
+  private connectionSessions = new Map<string, HeartbeatSession[]>();
+  // Pending command responses: correlationId → originating web socket
+  private pendingCommands = new Map<string, { ws: WebSocket; sessionId?: string }>();
+  // Last heartbeat timestamp per CLI connectionId (for staleness eviction)
+  private lastHeartbeatAt = new Map<string, number>();
+
+  private stateReconstructed = false;
+
+  private ensureState(): void {
+    if (this.stateReconstructed) return;
+
+    let cliCount = 0;
+    let webCount = 0;
+    let sessionCount = 0;
+
+    for (const ws of this.ctx.getWebSockets()) {
+      const attachment = ws.deserializeAttachment() as WSAttachment | null;
+      if (!attachment) continue;
+
+      if (attachment.role === 'cli') {
+        cliCount++;
+        const { connectionId, sessions } = attachment;
+        this.connectionSessions.set(connectionId, sessions);
+        sessionCount += sessions.length;
+        for (const session of sessions) {
+          this.sessionOwners.set(session.id, connectionId);
+        }
+        this.lastHeartbeatAt.set(connectionId, Date.now());
+      } else {
+        webCount++;
+        for (const sessionId of attachment.subscribedSessions) {
+          let subs = this.webSubscriptions.get(sessionId);
+          if (!subs) {
+            subs = new Set();
+            this.webSubscriptions.set(sessionId, subs);
+          }
+          subs.add(ws);
+        }
+      }
+    }
+
+    console.log('State reconstructed after hibernation', {
+      cliSockets: cliCount,
+      webSockets: webCount,
+      sessions: sessionCount,
+      subscriptions: this.webSubscriptions.size,
+    });
+
+    this.stateReconstructed = true;
+  }
+
+  fetch(request: Request): Response {
+    const upgradeHeader = request.headers.get('Upgrade');
+    if (upgradeHeader !== 'websocket') {
+      return new Response('Expected WebSocket upgrade', { status: 426 });
+    }
+
+    this.ensureState();
+
+    const url = new URL(request.url);
+    const role = url.pathname.endsWith('/cli') ? 'cli' : 'web';
+
+    const pair = new WebSocketPair();
+    const [client, server] = [pair[0], pair[1]];
+    const connectionId = url.searchParams.get('connectionId') ?? crypto.randomUUID();
+
+    if (role === 'cli') {
+      // Close any stale socket from a previous connection with the same ID (CLI reconnect)
+      const reconnect = this.closeStaleSocket(connectionId);
+
+      const attachment: WSAttachment = { role: 'cli', connectionId, sessions: [] };
+      this.ctx.acceptWebSocket(server, ['cli']);
+      server.serializeAttachment(attachment);
+      this.lastHeartbeatAt.set(connectionId, Date.now());
+      this.scheduleStaleCheck();
+
+      console.log('CLI socket connected', {
+        connectionId,
+        reconnect,
+        totalCliSockets: this.ctx.getWebSockets('cli').length,
+      });
+
+      if (!reconnect) {
+        this.broadcastToWeb({
+          type: 'system',
+          event: 'cli.connected',
+          data: { connectionId },
+        });
+      }
+    } else {
+      const attachment: WSAttachment = { role: 'web', connectionId, subscribedSessions: [] };
+      this.ctx.acceptWebSocket(server, ['web']);
+      server.serializeAttachment(attachment);
+
+      const sessions = this.aggregateSessions();
+
+      console.log('Web socket connected', {
+        connectionId,
+        totalWebSockets: this.ctx.getWebSockets('web').length,
+        activeSessions: sessions.length,
+      });
+
+      this.sendToWeb(server, {
+        type: 'system',
+        event: 'sessions.list',
+        data: { sessions },
+      });
+    }
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+    this.ensureState();
+
+    const raw = typeof message === 'string' ? message : new TextDecoder().decode(message);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      console.warn('Failed to parse WebSocket message as JSON');
+      return;
+    }
+
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    if (!attachment) {
+      console.warn('WebSocket message from socket with no attachment');
+      return;
+    }
+
+    if (attachment.role === 'cli') {
+      this.handleCliMessage(ws, attachment, parsed);
+    } else {
+      this.handleWebMessage(ws, attachment, parsed);
+    }
+  }
+
+  webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+    this.ensureState();
+
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    if (!attachment) return;
+
+    if (attachment.role === 'cli') {
+      this.handleCliDisconnect(attachment);
+    } else {
+      this.handleWebDisconnect(ws);
+    }
+  }
+
+  webSocketError(ws: WebSocket): void {
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    console.error('WebSocket error', {
+      role: attachment?.role ?? 'unknown',
+      connectionId: attachment?.connectionId ?? 'unknown',
+    });
+    this.webSocketClose(ws, 0, '', false);
+  }
+
+  async alarm(): Promise<void> {
+    this.ensureState();
+
+    const now = Date.now();
+    const staleConnectionIds: string[] = [];
+
+    for (const [connectionId, lastSeen] of this.lastHeartbeatAt) {
+      if (now - lastSeen > UserConnectionDO.HEARTBEAT_TIMEOUT_MS) {
+        staleConnectionIds.push(connectionId);
+      }
+    }
+
+    for (const connectionId of staleConnectionIds) {
+      // Find and close the stale CLI WebSocket
+      for (const ws of this.ctx.getWebSockets('cli')) {
+        const att = ws.deserializeAttachment() as WSAttachment | null;
+        if (att?.role === 'cli' && att.connectionId === connectionId) {
+          console.log('Closing stale CLI connection (heartbeat timeout)', { connectionId });
+          ws.close(4408, 'heartbeat timeout');
+          break;
+        }
+      }
+      // handleCliDisconnect will clean up connectionSessions/sessionOwners/lastHeartbeatAt
+      // via the webSocketClose callback
+    }
+
+    // If there are still active CLI connections, schedule another check
+    if (this.lastHeartbeatAt.size > staleConnectionIds.length) {
+      this.scheduleStaleCheck();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // CLI message handling
+  // ---------------------------------------------------------------------------
+
+  private handleCliMessage(
+    ws: WebSocket,
+    attachment: WSAttachment & { role: 'cli' },
+    parsed: unknown
+  ): void {
+    const result = CLIOutboundMessageSchema.safeParse(parsed);
+    if (!result.success) {
+      console.warn('CLI message parse failed', {
+        connectionId: attachment.connectionId,
+        errors: result.error.issues.map(i => i.message),
+        raw: JSON.stringify(parsed).slice(0, 500),
+      });
+      return;
+    }
+    const msg = result.data;
+
+    switch (msg.type) {
+      case 'heartbeat':
+        this.handleHeartbeat(ws, attachment, msg.sessions);
+        break;
+      case 'event':
+        this.handleCliEvent(msg.sessionId, msg.parentSessionId, msg.event, msg.data);
+        break;
+      case 'response':
+        this.handleCliResponse(msg.id, msg.result, msg.error);
+        break;
+    }
+  }
+
+  private handleHeartbeat(
+    ws: WebSocket,
+    attachment: WSAttachment & { role: 'cli' },
+    sessions: HeartbeatSession[]
+  ): void {
+    const { connectionId } = attachment;
+    this.lastHeartbeatAt.set(connectionId, Date.now());
+    this.scheduleStaleCheck();
+
+    // Remove sessions this connection previously owned but no longer reports
+    const previousSessions = this.connectionSessions.get(connectionId) ?? [];
+    const currentIds = new Set(sessions.map(s => s.id));
+    for (const prev of previousSessions) {
+      if (!currentIds.has(prev.id) && this.sessionOwners.get(prev.id) === connectionId) {
+        this.sessionOwners.delete(prev.id);
+      }
+    }
+
+    // Update ownership
+    this.connectionSessions.set(connectionId, sessions);
+    for (const session of sessions) {
+      this.sessionOwners.set(session.id, connectionId);
+    }
+
+    // Persist to attachment for hibernation recovery
+    const updatedAttachment: WSAttachment = { role: 'cli', connectionId, sessions };
+    ws.serializeAttachment(updatedAttachment);
+
+    this.broadcastToWeb({
+      type: 'system',
+      event: 'sessions.heartbeat',
+      data: { connectionId, sessions },
+    });
+  }
+
+  private handleCliEvent(
+    sessionId: string,
+    parentSessionId: string | undefined,
+    event: string,
+    data: unknown
+  ): void {
+    const subscribers =
+      this.webSubscriptions.get(sessionId) ??
+      (parentSessionId ? this.webSubscriptions.get(parentSessionId) : undefined);
+    if (!subscribers) return;
+
+    const msg: WebInboundMessage = {
+      type: 'event',
+      sessionId,
+      ...(parentSessionId ? { parentSessionId } : {}),
+      event,
+      data,
+    };
+    for (const ws of subscribers) {
+      this.sendToWeb(ws, msg);
+    }
+  }
+
+  private handleCliResponse(id: string, result: unknown, error: unknown): void {
+    const entry = this.pendingCommands.get(id);
+    const originWs = entry?.ws;
+    if (!originWs) return;
+    this.pendingCommands.delete(id);
+
+    this.sendToWeb(originWs, {
+      type: 'response',
+      id,
+      ...(result !== undefined ? { result } : {}),
+      ...(error !== undefined ? { error } : {}),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Web message handling
+  // ---------------------------------------------------------------------------
+
+  private handleWebMessage(
+    ws: WebSocket,
+    attachment: WSAttachment & { role: 'web' },
+    parsed: unknown
+  ): void {
+    const result = WebOutboundMessageSchema.safeParse(parsed);
+    if (!result.success) {
+      console.warn('Invalid web message', {
+        connectionId: attachment.connectionId,
+        errors: result.error.issues.map(i => i.message),
+      });
+      return;
+    }
+    const msg = result.data;
+
+    switch (msg.type) {
+      case 'subscribe':
+        this.handleWebSubscribe(ws, attachment, msg.sessionId);
+        break;
+      case 'unsubscribe':
+        this.handleWebUnsubscribe(ws, attachment, msg.sessionId);
+        break;
+      case 'command':
+        this.handleWebCommand(ws, msg);
+        break;
+    }
+  }
+
+  private handleWebSubscribe(
+    ws: WebSocket,
+    attachment: WSAttachment & { role: 'web' },
+    sessionId: string
+  ): void {
+    let subs = this.webSubscriptions.get(sessionId);
+    if (!subs) {
+      subs = new Set();
+      this.webSubscriptions.set(sessionId, subs);
+    }
+    subs.add(ws);
+
+    // Persist subscription in attachment for hibernation recovery
+    if (!attachment.subscribedSessions.includes(sessionId)) {
+      attachment.subscribedSessions.push(sessionId);
+      ws.serializeAttachment(attachment);
+    }
+
+    // Tell the owning CLI to start forwarding events for this session.
+    // If we know the owner (from heartbeats), send to that CLI only.
+    // Otherwise broadcast to all connected CLIs — the session may be idle
+    // so it wasn't reported in the most recent heartbeat.
+    const cliWs = this.findCliForSession(sessionId);
+    if (cliWs) {
+      this.sendToCli(cliWs, { type: 'subscribe', sessionId });
+    } else {
+      for (const ws of this.ctx.getWebSockets('cli')) {
+        this.sendToCli(ws, { type: 'subscribe', sessionId });
+      }
+    }
+  }
+
+  private handleWebUnsubscribe(
+    ws: WebSocket,
+    attachment: WSAttachment & { role: 'web' },
+    sessionId: string
+  ): void {
+    const subs = this.webSubscriptions.get(sessionId);
+    if (subs) {
+      subs.delete(ws);
+
+      // If no more subscribers, tell CLI to stop forwarding
+      if (subs.size === 0) {
+        this.webSubscriptions.delete(sessionId);
+        const cliWs = this.findCliForSession(sessionId);
+        if (cliWs) {
+          this.sendToCli(cliWs, { type: 'unsubscribe', sessionId });
+        }
+      }
+    }
+
+    // Update attachment
+    const idx = attachment.subscribedSessions.indexOf(sessionId);
+    if (idx !== -1) {
+      attachment.subscribedSessions.splice(idx, 1);
+      ws.serializeAttachment(attachment);
+    }
+  }
+
+  private handleWebCommand(
+    ws: WebSocket,
+    msg: { id: string; command: string; sessionId?: string; connectionId?: string; data?: unknown }
+  ): void {
+    // Find target CLI
+    let targetCli: WebSocket | undefined;
+
+    if (msg.connectionId) {
+      // Route to specific CLI by connectionId
+      for (const cliWs of this.ctx.getWebSockets('cli')) {
+        const att = cliWs.deserializeAttachment() as WSAttachment | null;
+        if (att?.role === 'cli' && att.connectionId === msg.connectionId) {
+          targetCli = cliWs;
+          break;
+        }
+      }
+    } else if (msg.sessionId) {
+      targetCli = this.findCliForSession(msg.sessionId);
+    } else {
+      // Fall back to first available CLI
+      const cliSockets = this.ctx.getWebSockets('cli');
+      targetCli = cliSockets[0];
+    }
+
+    if (!targetCli) {
+      this.sendToWeb(ws, { type: 'response', id: msg.id, error: 'Session owner not found' });
+      return;
+    }
+
+    this.pendingCommands.set(msg.id, { ws, sessionId: msg.sessionId });
+
+    this.sendToCli(targetCli, {
+      type: 'command',
+      id: msg.id,
+      command: msg.command,
+      data: msg.data,
+      ...(msg.sessionId ? { sessionId: msg.sessionId } : {}),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Disconnect handling
+  // ---------------------------------------------------------------------------
+
+  private handleCliDisconnect(attachment: WSAttachment & { role: 'cli' }): void {
+    const { connectionId } = attachment;
+
+    // If another CLI socket already has this connectionId, this is a stale
+    // close from a reconnect — the replacement socket is already active.
+    const replaced = this.ctx.getWebSockets('cli').some(ws => {
+      const att = ws.deserializeAttachment() as WSAttachment | null;
+      return att?.role === 'cli' && att.connectionId === connectionId;
+    });
+
+    if (replaced) {
+      console.log('Stale CLI socket closed (already replaced)', { connectionId });
+      return;
+    }
+
+    // Collect owned sessions before removing ownership
+    const sessions = this.connectionSessions.get(connectionId) ?? [];
+    const ownedSessions = new Set<string>();
+    for (const session of sessions) {
+      if (this.sessionOwners.get(session.id) === connectionId) {
+        ownedSessions.add(session.id);
+        this.sessionOwners.delete(session.id);
+      }
+    }
+    this.connectionSessions.delete(connectionId);
+    this.lastHeartbeatAt.delete(connectionId);
+
+    // Clean up pending commands targeting sessions owned by the disconnecting CLI
+    for (const [id, entry] of this.pendingCommands) {
+      if (entry.sessionId && ownedSessions.has(entry.sessionId)) {
+        this.sendToWeb(entry.ws, { type: 'response', id, error: 'CLI disconnected' });
+        this.pendingCommands.delete(id);
+      }
+    }
+
+    console.log('CLI socket disconnected', {
+      connectionId,
+      droppedSessions: ownedSessions.size,
+      remainingCliSockets: this.ctx.getWebSockets('cli').length,
+    });
+
+    // Leave webSubscriptions intact — a reconnecting CLI can resume
+
+    this.broadcastToWeb({
+      type: 'system',
+      event: 'cli.disconnected',
+      data: { connectionId },
+    });
+  }
+
+  private handleWebDisconnect(ws: WebSocket): void {
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    const connectionId = attachment?.role === 'web' ? attachment.connectionId : 'unknown';
+
+    // Remove from all subscription sets
+    let droppedSubscriptions = 0;
+    for (const [sessionId, subs] of this.webSubscriptions) {
+      if (!subs.has(ws)) continue;
+      subs.delete(ws);
+      droppedSubscriptions++;
+
+      if (subs.size === 0) {
+        this.webSubscriptions.delete(sessionId);
+        // Tell owning CLI to stop forwarding
+        const cliWs = this.findCliForSession(sessionId);
+        if (cliWs) {
+          this.sendToCli(cliWs, { type: 'unsubscribe', sessionId });
+        }
+      }
+    }
+
+    // Clean up any pending commands from this web socket
+    let droppedCommands = 0;
+    for (const [id, entry] of this.pendingCommands) {
+      if (entry.ws === ws) {
+        this.pendingCommands.delete(id);
+        droppedCommands++;
+      }
+    }
+
+    console.log('Web socket disconnected', {
+      connectionId,
+      droppedSubscriptions,
+      droppedCommands,
+      remainingWebSockets: this.ctx.getWebSockets('web').length,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // RPC
+  // ---------------------------------------------------------------------------
+
+  getActiveSessions(): Array<HeartbeatSession & { connectionId: string }> {
+    this.ensureState();
+    return this.aggregateSessions();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private sendToCli(ws: WebSocket, msg: CLIInboundMessage): void {
+    try {
+      ws.send(JSON.stringify(msg));
+    } catch (err) {
+      console.warn('sendToCli failed:', err);
+    }
+  }
+
+  private sendToWeb(ws: WebSocket, msg: WebInboundMessage): void {
+    try {
+      ws.send(JSON.stringify(msg));
+    } catch (err) {
+      console.warn('sendToWeb failed:', err);
+    }
+  }
+
+  private broadcastToWeb(msg: WebInboundMessage, exclude?: WebSocket): void {
+    const json = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets('web')) {
+      if (ws !== exclude) {
+        try {
+          ws.send(json);
+        } catch (err) {
+          console.warn('broadcastToWeb: skipping failed socket:', err);
+        }
+      }
+    }
+  }
+
+  /** Close a stale CLI socket that has the same connectionId (from a previous connection). Returns true if one was found. */
+  private closeStaleSocket(connectionId: string): boolean {
+    for (const ws of this.ctx.getWebSockets('cli')) {
+      const att = ws.deserializeAttachment() as WSAttachment | null;
+      if (att?.role === 'cli' && att.connectionId === connectionId) {
+        console.log('Closing stale CLI socket for reconnect', { connectionId });
+        // Preserve session ownership — the reconnecting CLI still owns these sessions
+        ws.close(1000, 'replaced by reconnect');
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private findCliForSession(sessionId: string): WebSocket | undefined {
+    const ownerConnectionId = this.sessionOwners.get(sessionId);
+    if (!ownerConnectionId) return undefined;
+
+    for (const ws of this.ctx.getWebSockets('cli')) {
+      const attachment = ws.deserializeAttachment() as WSAttachment | null;
+      if (attachment?.role === 'cli' && attachment.connectionId === ownerConnectionId) {
+        return ws;
+      }
+    }
+    return undefined;
+  }
+
+  private scheduleStaleCheck(): void {
+    // Schedule an alarm to run after the timeout period.
+    // setAlarm is idempotent if one is already scheduled sooner.
+    this.ctx.storage.setAlarm(Date.now() + UserConnectionDO.HEARTBEAT_TIMEOUT_MS);
+  }
+
+  private aggregateSessions(): Array<HeartbeatSession & { connectionId: string }> {
+    // Build set of connectionIds that still have a live CLI WebSocket.
+    // This guards against stale entries that persist if a close event is delayed.
+    const liveConnectionIds = new Set<string>();
+    for (const ws of this.ctx.getWebSockets('cli')) {
+      const att = ws.deserializeAttachment() as WSAttachment | null;
+      if (att?.role === 'cli') liveConnectionIds.add(att.connectionId);
+    }
+
+    const result: Array<HeartbeatSession & { connectionId: string }> = [];
+    for (const [connectionId, sessions] of this.connectionSessions) {
+      if (!liveConnectionIds.has(connectionId)) continue;
+      for (const session of sessions) {
+        result.push({ ...session, connectionId });
+      }
+    }
+    return result;
+  }
+}
+
+export function getUserConnectionDO(env: Env, params: { kiloUserId: string }) {
+  const id = env.USER_CONNECTION_DO.idFromName(params.kiloUserId);
+  return env.USER_CONNECTION_DO.get(id);
+}

--- a/cloudflare-session-ingest/src/index.ts
+++ b/cloudflare-session-ingest/src/index.ts
@@ -1,5 +1,6 @@
 export { SessionIngestDO } from './dos/SessionIngestDO';
 export { SessionAccessCacheDO } from './dos/SessionAccessCacheDO';
+export { UserConnectionDO } from './dos/UserConnectionDO';
 export { SessionIngestRPC } from './session-ingest-rpc';
 export { app } from './app';
 

--- a/cloudflare-session-ingest/src/middleware/kilo-jwt-auth.ts
+++ b/cloudflare-session-ingest/src/middleware/kilo-jwt-auth.ts
@@ -49,7 +49,11 @@ export const kiloJwtAuthMiddleware = createMiddleware<{
     user_id: string;
   };
 }>(async (c, next) => {
-  const token = extractBearerToken(c.req.header('Authorization'));
+  let token = extractBearerToken(c.req.header('Authorization'));
+  if (!token && c.req.header('Upgrade') === 'websocket') {
+    token = c.req.query('token') ?? null;
+  }
+
   if (!token) {
     return c.json({ success: false, error: 'Missing or malformed Authorization header' }, 401);
   }

--- a/cloudflare-session-ingest/src/routes/api.test.ts
+++ b/cloudflare-session-ingest/src/routes/api.test.ts
@@ -639,7 +639,7 @@ describe('api routes', () => {
 
     expect(stubFetch).toHaveBeenCalledTimes(1);
     expect(getUserConnectionDO).toHaveBeenCalledWith(expect.anything(), { kiloUserId: 'usr_test' });
-    const forwardedReq = stubFetch.mock.calls[0]![0];
+    const forwardedReq = stubFetch.mock.calls[0][0];
     const forwardedUrl = new URL(forwardedReq.url);
     expect(forwardedUrl.pathname).toBe('/cli');
   });
@@ -662,7 +662,7 @@ describe('api routes', () => {
 
     expect(stubFetch).toHaveBeenCalledTimes(1);
     expect(getUserConnectionDO).toHaveBeenCalledWith(expect.anything(), { kiloUserId: 'usr_test' });
-    const forwardedReq = stubFetch.mock.calls[0]![0];
+    const forwardedReq = stubFetch.mock.calls[0][0];
     const forwardedUrl = new URL(forwardedReq.url);
     expect(forwardedUrl.pathname).toBe('/web');
   });

--- a/cloudflare-session-ingest/src/routes/api.test.ts
+++ b/cloudflare-session-ingest/src/routes/api.test.ts
@@ -15,9 +15,14 @@ vi.mock('../dos/SessionAccessCacheDO', () => ({
   getSessionAccessCacheDO: vi.fn(),
 }));
 
+vi.mock('../dos/UserConnectionDO', () => ({
+  getUserConnectionDO: vi.fn(),
+}));
+
 import { getWorkerDb } from '@kilocode/db/client';
 import { getSessionIngestDO } from '../dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
+import { getUserConnectionDO } from '../dos/UserConnectionDO';
 
 type HyperdriveBinding = { connectionString: string };
 
@@ -537,5 +542,128 @@ describe('api routes', () => {
 
     expect(res.status).toBe(200);
     expect(fns.updateSet).toHaveBeenCalled();
+  });
+
+  it('GET /sessions/active returns sessions from UserConnectionDO', async () => {
+    const connectionStub = {
+      getActiveSessions: vi.fn(async () => [
+        {
+          id: 'ses_12345678901234567890123456',
+          status: 'active',
+          title: 'My Session',
+          connectionId: 'conn-1',
+        },
+      ]),
+    };
+    vi.mocked(getUserConnectionDO).mockReturnValue(
+      connectionStub as unknown as ReturnType<typeof getUserConnectionDO>
+    );
+
+    const app = makeApiApp();
+    const res = await app.fetch(new Request('http://local/sessions/active', { method: 'GET' }), {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(getUserConnectionDO).toHaveBeenCalledWith(expect.anything(), { kiloUserId: 'usr_test' });
+    expect(await res.json()).toEqual({
+      sessions: [
+        {
+          id: 'ses_12345678901234567890123456',
+          status: 'active',
+          title: 'My Session',
+          connectionId: 'conn-1',
+        },
+      ],
+    });
+  });
+
+  it('GET /sessions/active returns empty array when no sessions', async () => {
+    const connectionStub = {
+      getActiveSessions: vi.fn(async () => []),
+    };
+    vi.mocked(getUserConnectionDO).mockReturnValue(
+      connectionStub as unknown as ReturnType<typeof getUserConnectionDO>
+    );
+
+    const app = makeApiApp();
+    const res = await app.fetch(new Request('http://local/sessions/active', { method: 'GET' }), {
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sessions: [] });
+  });
+
+  it('GET /user/cli returns 426 without Upgrade header', async () => {
+    const app = makeApiApp();
+    const res = await app.fetch(
+      new Request('http://local/user/cli', {
+        method: 'GET',
+      }),
+      { HYPERDRIVE: { connectionString: 'postgres://test' } }
+    );
+
+    expect(res.status).toBe(426);
+    expect(await res.json()).toMatchObject({ error: 'Expected WebSocket upgrade' });
+  });
+
+  it('GET /user/web returns 426 without Upgrade header', async () => {
+    const app = makeApiApp();
+    const res = await app.fetch(
+      new Request('http://local/user/web', {
+        method: 'GET',
+      }),
+      { HYPERDRIVE: { connectionString: 'postgres://test' } }
+    );
+
+    expect(res.status).toBe(426);
+    expect(await res.json()).toMatchObject({ error: 'Expected WebSocket upgrade' });
+  });
+
+  it('GET /user/cli forwards to DO fetch with /cli path', async () => {
+    const stubFetch = vi.fn(async (_req: Request) => new Response(null, { status: 101 }));
+    const connectionStub = { fetch: stubFetch };
+    vi.mocked(getUserConnectionDO).mockReturnValue(
+      connectionStub as unknown as ReturnType<typeof getUserConnectionDO>
+    );
+
+    const app = makeApiApp();
+    await app.fetch(
+      new Request('http://local/user/cli', {
+        method: 'GET',
+        headers: { Upgrade: 'websocket' },
+      }),
+      { HYPERDRIVE: { connectionString: 'postgres://test' } }
+    );
+
+    expect(stubFetch).toHaveBeenCalledTimes(1);
+    expect(getUserConnectionDO).toHaveBeenCalledWith(expect.anything(), { kiloUserId: 'usr_test' });
+    const forwardedReq = stubFetch.mock.calls[0]![0];
+    const forwardedUrl = new URL(forwardedReq.url);
+    expect(forwardedUrl.pathname).toBe('/cli');
+  });
+
+  it('GET /user/web forwards to DO fetch with /web path', async () => {
+    const stubFetch = vi.fn(async (_req: Request) => new Response(null, { status: 101 }));
+    const connectionStub = { fetch: stubFetch };
+    vi.mocked(getUserConnectionDO).mockReturnValue(
+      connectionStub as unknown as ReturnType<typeof getUserConnectionDO>
+    );
+
+    const app = makeApiApp();
+    await app.fetch(
+      new Request('http://local/user/web', {
+        method: 'GET',
+        headers: { Upgrade: 'websocket' },
+      }),
+      { HYPERDRIVE: { connectionString: 'postgres://test' } }
+    );
+
+    expect(stubFetch).toHaveBeenCalledTimes(1);
+    expect(getUserConnectionDO).toHaveBeenCalledWith(expect.anything(), { kiloUserId: 'usr_test' });
+    const forwardedReq = stubFetch.mock.calls[0]![0];
+    const forwardedUrl = new URL(forwardedReq.url);
+    expect(forwardedUrl.pathname).toBe('/web');
   });
 });

--- a/cloudflare-session-ingest/src/routes/api.ts
+++ b/cloudflare-session-ingest/src/routes/api.ts
@@ -8,6 +8,7 @@ import type { Env } from '../env';
 import { zodJsonValidator, withDORetry } from '@kilocode/worker-utils';
 import { getSessionIngestDO } from '../dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
+import { getUserConnectionDO } from '../dos/UserConnectionDO';
 import { getSessionExport } from '../services/session-export';
 import type { IngestQueueMessage } from '../queue-consumer';
 
@@ -316,4 +317,39 @@ api.post('/session/:sessionId/unshare', async c => {
     );
 
   return c.json({ success: true }, 200);
+});
+
+api.get('/sessions/active', async c => {
+  const kiloUserId = c.get('user_id');
+  const stub = getUserConnectionDO(c.env, { kiloUserId });
+  const sessions = await stub.getActiveSessions();
+  return c.json({ sessions }, 200);
+});
+
+// CLI connects to /api/user/cli without userId in the path — userId comes from the JWT.
+api.get('/user/cli', async c => {
+  if (c.req.header('Upgrade') !== 'websocket') {
+    return c.json({ success: false, error: 'Expected WebSocket upgrade' }, 426);
+  }
+
+  const kiloUserId = c.get('user_id');
+  const stub = getUserConnectionDO(c.env, { kiloUserId });
+  const wsUrl = new URL(c.req.url);
+  wsUrl.pathname = '/cli';
+
+  return stub.fetch(new Request(wsUrl.toString(), c.req.raw));
+});
+
+// Web UI connects to /api/user/web without userId in the path — userId comes from the JWT.
+api.get('/user/web', async c => {
+  if (c.req.header('Upgrade') !== 'websocket') {
+    return c.json({ success: false, error: 'Expected WebSocket upgrade' }, 426);
+  }
+
+  const kiloUserId = c.get('user_id');
+  const stub = getUserConnectionDO(c.env, { kiloUserId });
+  const wsUrl = new URL(c.req.url);
+  wsUrl.pathname = '/web';
+
+  return stub.fetch(new Request(wsUrl.toString(), c.req.raw));
 });

--- a/cloudflare-session-ingest/src/types/user-connection-protocol.test.ts
+++ b/cloudflare-session-ingest/src/types/user-connection-protocol.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CLIOutboundMessageSchema,
+  CLIInboundMessageSchema,
+  WebOutboundMessageSchema,
+  WebInboundMessageSchema,
+} from './user-connection-protocol';
+
+const validSessionId = 'ses_12345678901234567890123456';
+
+describe('CLIOutboundMessageSchema', () => {
+  it('parses valid heartbeat', () => {
+    const msg = {
+      type: 'heartbeat',
+      sessions: [{ id: validSessionId, status: 'busy', title: 'Fix bug' }],
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses heartbeat with empty sessions', () => {
+    const msg = { type: 'heartbeat', sessions: [] };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects heartbeat with null title', () => {
+    const msg = {
+      type: 'heartbeat',
+      sessions: [{ id: validSessionId, status: 'busy', title: null }],
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+
+  it('parses valid event', () => {
+    const msg = {
+      type: 'event',
+      sessionId: validSessionId,
+      event: 'message.updated',
+      data: { id: 'msg_1' },
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid response', () => {
+    const msg = { type: 'response', id: 'req_abc', result: { ok: true } };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses response with error only', () => {
+    const msg = { type: 'response', id: 'req_err', error: 'not found' };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses event with parentSessionId', () => {
+    const msg = {
+      type: 'event',
+      sessionId: validSessionId,
+      parentSessionId: 'parent-ses-1',
+      event: 'message.updated',
+      data: { id: 'msg-1' },
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveProperty('parentSessionId', 'parent-ses-1');
+    }
+  });
+
+  it('parses event without parentSessionId (backward compat)', () => {
+    const msg = {
+      type: 'event',
+      sessionId: validSessionId,
+      event: 'message.updated',
+      data: { id: 'msg-1' },
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('parentSessionId');
+    }
+  });
+
+  it('rejects unknown type', () => {
+    const msg = { type: 'unknown' };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CLIInboundMessageSchema', () => {
+  it('parses valid subscribe', () => {
+    const msg = { type: 'subscribe', sessionId: validSessionId };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid unsubscribe', () => {
+    const msg = { type: 'unsubscribe', sessionId: validSessionId };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid command', () => {
+    const msg = {
+      type: 'command',
+      id: 'cmd_1',
+      command: 'send_message',
+      sessionId: validSessionId,
+      data: { text: 'hello' },
+    };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses command without sessionId', () => {
+    const msg = {
+      type: 'command',
+      id: 'cmd_2',
+      command: 'list_sessions',
+      data: null,
+    };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid system', () => {
+    const msg = { type: 'system', event: 'web.connected', data: {} };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects subscribe with missing sessionId', () => {
+    const msg = { type: 'subscribe' };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('WebOutboundMessageSchema', () => {
+  it('parses valid subscribe', () => {
+    const msg = { type: 'subscribe', sessionId: validSessionId };
+    const result = WebOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid unsubscribe', () => {
+    const msg = { type: 'unsubscribe', sessionId: validSessionId };
+    const result = WebOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid command', () => {
+    const msg = {
+      type: 'command',
+      id: 'req_1',
+      command: 'send_message',
+      sessionId: validSessionId,
+      data: { text: 'hi' },
+    };
+    const result = WebOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses command with connectionId', () => {
+    const msg = {
+      type: 'command',
+      id: 'req_2',
+      command: 'start_session',
+      connectionId: 'conn_1',
+      data: {},
+    };
+    const result = WebOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects command without id', () => {
+    const msg = { type: 'command', command: 'test', data: {} };
+    const result = WebOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('WebInboundMessageSchema', () => {
+  it('parses valid event', () => {
+    const msg = {
+      type: 'event',
+      sessionId: validSessionId,
+      event: 'session.updated',
+      data: {},
+    };
+    const result = WebInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid system', () => {
+    const msg = {
+      type: 'system',
+      event: 'cli.connected',
+      data: { connectionId: 'conn_1' },
+    };
+    const result = WebInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses valid response', () => {
+    const msg = { type: 'response', id: 'req_abc', result: { success: true } };
+    const result = WebInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses event with parentSessionId', () => {
+    const msg = {
+      type: 'event',
+      sessionId: validSessionId,
+      parentSessionId: 'parent-ses-1',
+      event: 'message.updated',
+      data: { id: 'msg-1' },
+    };
+    const result = WebInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveProperty('parentSessionId', 'parent-ses-1');
+    }
+  });
+
+  it('parses event without parentSessionId (backward compat)', () => {
+    const msg = {
+      type: 'event',
+      sessionId: validSessionId,
+      event: 'session.updated',
+      data: {},
+    };
+    const result = WebInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('parentSessionId');
+    }
+  });
+
+  it('rejects unknown type', () => {
+    const msg = { type: 'unknown', data: {} };
+    const result = WebInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('extra fields', () => {
+  it('strips unknown fields by default on strict objects', () => {
+    const msg = {
+      type: 'subscribe',
+      sessionId: validSessionId,
+      extra: 'should-be-stripped',
+    };
+    const result = WebOutboundMessageSchema.parse(msg);
+    expect(result).not.toHaveProperty('extra');
+  });
+});

--- a/cloudflare-session-ingest/src/types/user-connection-protocol.ts
+++ b/cloudflare-session-ingest/src/types/user-connection-protocol.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+
+// Use z.string() for session IDs (not the strict sessionIdSchema from ws-protocol)
+// because the CLI's remote-protocol.ts uses z.string() — the strict ses_ format
+// is enforced by the per-session SessionIngestDO path, not the UserConnectionDO path.
+
+// -- CLI → DO (CLIOutbound) ---------------------------------------------------
+
+export const CLIOutboundMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('heartbeat'),
+    sessions: z.array(
+      z.object({
+        id: z.string(),
+        status: z.string(),
+        title: z.string(),
+        gitUrl: z.string().optional(),
+        gitBranch: z.string().optional(),
+      })
+    ),
+  }),
+  z.object({
+    type: z.literal('event'),
+    sessionId: z.string(),
+    parentSessionId: z.string().optional(),
+    event: z.string(),
+    data: z.unknown(),
+  }),
+  z.object({
+    type: z.literal('response'),
+    id: z.string(),
+    result: z.unknown().optional(),
+    error: z.unknown().optional(),
+  }),
+]);
+
+// -- DO → CLI (CLIInbound) ----------------------------------------------------
+
+export const CLIInboundMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('subscribe'),
+    sessionId: z.string(),
+  }),
+  z.object({
+    type: z.literal('unsubscribe'),
+    sessionId: z.string(),
+  }),
+  z.object({
+    type: z.literal('command'),
+    id: z.string(),
+    command: z.string(),
+    sessionId: z.string().optional(),
+    data: z.unknown(),
+  }),
+  z.object({
+    type: z.literal('system'),
+    event: z.string(),
+    data: z.unknown(),
+  }),
+]);
+
+// -- Web UI → DO (WebOutbound) ------------------------------------------------
+
+export const WebOutboundMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('subscribe'),
+    sessionId: z.string(),
+  }),
+  z.object({
+    type: z.literal('unsubscribe'),
+    sessionId: z.string(),
+  }),
+  z.object({
+    type: z.literal('command'),
+    id: z.string(),
+    sessionId: z.string().optional(),
+    connectionId: z.string().optional(),
+    command: z.string(),
+    data: z.unknown(),
+  }),
+]);
+
+// -- DO → Web UI (WebInbound) -------------------------------------------------
+
+export const WebInboundMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('event'),
+    sessionId: z.string(),
+    parentSessionId: z.string().optional(),
+    event: z.string(),
+    data: z.unknown(),
+  }),
+  z.object({
+    type: z.literal('system'),
+    event: z.string(),
+    data: z.unknown(),
+  }),
+  z.object({
+    type: z.literal('response'),
+    id: z.string(),
+    result: z.unknown().optional(),
+    error: z.unknown().optional(),
+  }),
+]);
+
+// -- Inferred types -----------------------------------------------------------
+
+export type CLIOutboundMessage = z.infer<typeof CLIOutboundMessageSchema>;
+export type CLIInboundMessage = z.infer<typeof CLIInboundMessageSchema>;
+export type WebOutboundMessage = z.infer<typeof WebOutboundMessageSchema>;
+export type WebInboundMessage = z.infer<typeof WebInboundMessageSchema>;

--- a/cloudflare-session-ingest/src/types/ws-protocol.test.ts
+++ b/cloudflare-session-ingest/src/types/ws-protocol.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CLIWebSocketMessageSchema,
+  ServerToWebMessageSchema,
+  WebToServerMessageSchema,
+  ServerToCLIMessageSchema,
+} from './ws-protocol';
+
+const validSessionId = 'ses_12345678901234567890123456';
+
+describe('CLIWebSocketMessageSchema', () => {
+  it('parses a valid ingest message', () => {
+    const msg = {
+      type: 'ingest',
+      sessionId: validSessionId,
+      data: [{ type: 'session', data: { title: 'Hello' } }],
+    };
+    const result = CLIWebSocketMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid sessionId', () => {
+    const msg = {
+      type: 'ingest',
+      sessionId: 'bad_id',
+      data: [{ type: 'session', data: {} }],
+    };
+    const result = CLIWebSocketMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+
+  it('parses with an empty data array', () => {
+    const msg = {
+      type: 'ingest',
+      sessionId: validSessionId,
+      data: [],
+    };
+    const result = CLIWebSocketMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('ServerToWebMessageSchema', () => {
+  it('parses a valid catch_up message', () => {
+    const msg = {
+      type: 'catch_up',
+      items: [{ sessionId: 'ses_abc', itemId: 'i1', itemType: 'message', itemData: '{}' }],
+    };
+    const result = ServerToWebMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid events message', () => {
+    const msg = {
+      type: 'events',
+      sessionId: validSessionId,
+      data: [{ type: 'session', data: {} }],
+    };
+    const result = ServerToWebMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid cli_status message', () => {
+    const msg = { type: 'cli_status', connected: true };
+    const result = ServerToWebMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid type', () => {
+    const msg = { type: 'unknown_type', data: {} };
+    const result = ServerToWebMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('WebToServerMessageSchema', () => {
+  it('parses a valid command message', () => {
+    const msg = { type: 'command', command: 'approve', data: { id: 1 } };
+    const result = WebToServerMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a message with missing command', () => {
+    const msg = { type: 'command', data: {} };
+    const result = WebToServerMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ServerToCLIMessageSchema', () => {
+  it('parses a valid command message', () => {
+    const msg = { type: 'command', command: 'run', data: null };
+    const result = ServerToCLIMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('extra fields', () => {
+  it('strips unknown fields by default on strict objects', () => {
+    const msg = {
+      type: 'command',
+      command: 'test',
+      data: 'x',
+      extra: 'should-be-stripped',
+    };
+    const result = WebToServerMessageSchema.parse(msg);
+    expect(result).not.toHaveProperty('extra');
+  });
+});

--- a/cloudflare-session-ingest/src/types/ws-protocol.ts
+++ b/cloudflare-session-ingest/src/types/ws-protocol.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { SessionItemSchema } from './session-sync';
+
+export const sessionIdSchema = z.string().startsWith('ses_').length(30);
+
+export const CLIWebSocketMessageSchema = z.object({
+  type: z.literal('ingest'),
+  sessionId: sessionIdSchema,
+  data: z.array(SessionItemSchema),
+});
+
+export const ServerToWebMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('catch_up'),
+    items: z.array(
+      z.object({
+        sessionId: z.string(),
+        itemId: z.string(),
+        itemType: z.string(),
+        itemData: z.string(),
+      })
+    ),
+  }),
+  z.object({
+    type: z.literal('events'),
+    sessionId: sessionIdSchema,
+    data: z.array(SessionItemSchema),
+  }),
+  z.object({
+    type: z.literal('cli_status'),
+    connected: z.boolean(),
+  }),
+]);
+
+export const WebToServerMessageSchema = z.object({
+  type: z.literal('command'),
+  command: z.string().min(1),
+  data: z.unknown(),
+});
+
+export const ServerToCLIMessageSchema = z.object({
+  type: z.literal('command'),
+  command: z.string().min(1),
+  data: z.unknown(),
+});
+
+export type CLIWebSocketMessage = z.infer<typeof CLIWebSocketMessageSchema>;
+export type ServerToWebMessage = z.infer<typeof ServerToWebMessageSchema>;
+export type WebToServerMessage = z.infer<typeof WebToServerMessageSchema>;
+export type ServerToCLIMessage = z.infer<typeof ServerToCLIMessageSchema>;

--- a/cloudflare-session-ingest/worker-configuration.d.ts
+++ b/cloudflare-session-ingest/worker-configuration.d.ts
@@ -4,7 +4,7 @@
 declare namespace Cloudflare {
 	interface GlobalProps {
 		mainModule: typeof import("./src/index");
-		durableNamespaces: "SessionIngestDO" | "SessionAccessCacheDO";
+		durableNamespaces: "SessionIngestDO" | "SessionAccessCacheDO" | "UserConnectionDO";
 	}
 	interface Env {
 		USER_EXISTS_CACHE: KVNamespace;
@@ -15,6 +15,7 @@ declare namespace Cloudflare {
 		INTERNAL_API_SECRET_PROD: SecretsStoreSecret;
 		SESSION_INGEST_DO: DurableObjectNamespace<import("./src/index").SessionIngestDO>;
 		SESSION_ACCESS_CACHE_DO: DurableObjectNamespace<import("./src/index").SessionAccessCacheDO>;
+		USER_CONNECTION_DO: DurableObjectNamespace<import("./src/index").UserConnectionDO>;
 		O11Y: Fetcher /* o11y */;
 	}
 }

--- a/cloudflare-session-ingest/wrangler.jsonc
+++ b/cloudflare-session-ingest/wrangler.jsonc
@@ -53,12 +53,20 @@
         "name": "SESSION_ACCESS_CACHE_DO",
         "class_name": "SessionAccessCacheDO",
       },
+      {
+        "name": "USER_CONNECTION_DO",
+        "class_name": "UserConnectionDO",
+      },
     ],
   },
   "migrations": [
     {
       "tag": "v1",
       "new_sqlite_classes": ["SessionIngestDO", "SessionAccessCacheDO"],
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["UserConnectionDO"],
     },
   ],
   "r2_buckets": [


### PR DESCRIPTION
## Summary

Adds `UserConnectionDO` to the session-ingest Cloudflare Worker — a Durable Object that acts as a WebSocket relay between web UI clients and CLI sessions.

- **UserConnectionDO**: Manages per-user WebSocket connections with session subscription routing, command forwarding (chat, interrupt, permission responses), and multi-session multiplexing
- **Protocol types**: `user-connection-protocol.ts` defines the web↔DO message format (subscribe, unsubscribe, command, event routing); `ws-protocol.ts` defines the DO↔CLI WebSocket protocol
- **API routes**: `POST /api/user/web` for web client WebSocket upgrade, wired through `api.ts` router
- **Auth**: Updated `kilo-jwt-auth.ts` middleware for JWT-based user authentication on WebSocket upgrade
- **Wrangler config**: Added `UserConnectionDO` binding and migration tag

**This is PR 3 of 5** in a stacked series. Independent — no dependencies on other PRs.

## Verification

- [x] `pnpm test -- cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts` — 975 lines of tests passing
- [x] `pnpm test -- cloudflare-session-ingest/src/routes/api.test.ts` — passing
- [x] `pnpm test -- cloudflare-session-ingest/src/types/user-connection-protocol.test.ts` — passing
- [x] `pnpm test -- cloudflare-session-ingest/src/types/ws-protocol.test.ts` — passing

## Visual Changes

N/A

## Reviewer Notes

- The DO is keyed per-user — all sessions for a given user route through one DO instance
- Web clients subscribe to specific session IDs; the DO fans out events from CLI connections to subscribed web clients
- Command flow: web client → DO → CLI session (with correlation IDs for request/response)