### PR TITLE
fix(cloud-agent): return 4xx for branch-not-found instead of 500

### DIFF
--- a/cloud-agent-next/src/kilo/client.ts
+++ b/cloud-agent-next/src/kilo/client.ts
@@ -1,5 +1,6 @@
 import type { ExecutionSession } from '../types.js';
 import { logger } from '../logger.js';
+import { shellQuote } from '../utils/shell.js';
 import {
   KiloClientError,
   KiloApiError,
@@ -250,7 +251,7 @@ export class KiloClient {
       curlArgs.push('--data-binary', `@${tempFile}`);
     }
 
-    const quotedUrl = `'${url.replace(/'/g, "'\\''")}'`;
+    const quotedUrl = shellQuote(url);
     curlArgs.push(quotedUrl);
 
     const command = curlArgs.join(' ');

--- a/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -11,6 +11,7 @@ import { logger } from '../logger.js';
 import { findWrapperForSession, getWrapperSessionMarker } from './wrapper-manager.js';
 import { randomPort } from './ports.js';
 import { WRAPPER_VERSION } from '../shared/wrapper-version.js';
+import { shellQuote } from '../utils/shell.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -149,16 +150,12 @@ export class WrapperClient {
   private readonly port: number;
   private readonly baseUrl: string;
 
-  private shellQuote(value: string): string {
-    return `'${value.replace(/'/g, "'\\''")}'`;
-  }
-
   private async runPreflightChecks(options: {
     wrapperPath: string;
     workspacePath: string;
   }): Promise<void> {
     const { wrapperPath, workspacePath } = options;
-    const quotedWrapperPath = this.shellQuote(wrapperPath);
+    const quotedWrapperPath = shellQuote(wrapperPath);
 
     // Verify bun runtime and wrapper binary before the full start+waitForPort loop.
     // A fast `bun --version` catches SIGILL (exit 132) on hosts whose CPU lacks
@@ -249,11 +246,11 @@ export class WrapperClient {
 
     if (body) {
       // Escape single quotes in JSON
-      const json = this.shellQuote(JSON.stringify(body));
+      const json = shellQuote(JSON.stringify(body));
       command += ` -d ${json}`;
     }
 
-    command += ` ${this.shellQuote(url)}`;
+    command += ` ${shellQuote(url)}`;
 
     // Execute curl in the container
     const result = await this.session.exec(command);
@@ -335,12 +332,12 @@ export class WrapperClient {
       `WORKSPACE_PATH=${workspacePath}`,
       `WRAPPER_LOG_PATH=${wrapperLogPath}`,
     ];
-    const argParts = [`--user-id ${this.shellQuote(userId)}`];
+    const argParts = [`--user-id ${shellQuote(userId)}`];
     if (sessionId) {
-      argParts.push(`--session-id ${this.shellQuote(sessionId)}`);
+      argParts.push(`--session-id ${shellQuote(sessionId)}`);
     }
 
-    const command = `${envParts.join(' ')} bun run ${this.shellQuote(wrapperPath)} ${sessionMarker} ${argParts.join(' ')}`;
+    const command = `${envParts.join(' ')} bun run ${shellQuote(wrapperPath)} ${sessionMarker} ${argParts.join(' ')}`;
 
     logger.debug('WrapperClient: starting wrapper process', {
       command,

--- a/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/cloud-agent-next/src/persistence/async-preparation.ts
@@ -6,6 +6,7 @@ import { GitHubTokenService } from '../services/github-token-service.js';
 import { InstallationLookupService } from '../services/installation-lookup-service.js';
 import { getSandbox } from '@cloudflare/sandbox';
 import {
+  buildAuthenticatedGitUrl,
   checkDiskAndCleanBeforeSetup,
   setupWorkspace,
   cloneGitHubRepo,
@@ -140,14 +141,12 @@ export async function executePreparationSteps(
 
   const cloneOptions = input.shallow ? { shallow: true } : undefined;
   if (input.gitUrl) {
-    await cloneGitRepo(
-      session,
-      workspacePath,
+    const authenticatedGitUrl = buildAuthenticatedGitUrl(
       input.gitUrl,
       input.gitToken,
-      undefined,
-      cloneOptions
+      input.platform
     );
+    await cloneGitRepo(session, workspacePath, authenticatedGitUrl, undefined, cloneOptions);
   } else if (input.githubRepo) {
     await cloneGitHubRepo(
       session,

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -21,10 +21,10 @@ import { generateSandboxId, getSandboxNamespace } from '../../sandbox-id.js';
 import {
   checkDiskAndCleanBeforeSetup,
   setupWorkspace,
-  cloneGitHubRepo,
   cloneGitRepo,
   manageBranch,
   validateUpstreamBranchExists,
+  buildAuthenticatedGitUrl,
   BranchNotFoundError,
 } from '../../workspace.js';
 import { WrapperClient } from '../../kilo/wrapper-client.js';
@@ -361,24 +361,37 @@ const prepareSessionHandler = internalApiProtectedProcedure
         input.mcpServers
       );
 
-      // 7. Clone repository
+      // 7. Build authenticated git URL once for both validation and clone
       const cloneOptions = input.shallow ? { shallow: true } : undefined;
-      logger.info('Cloning repository');
+      let authenticatedGitUrl: string;
+      let gitAuthor: { name: string; email: string } | undefined;
+
+      if (input.gitUrl) {
+        authenticatedGitUrl = buildAuthenticatedGitUrl(
+          input.gitUrl,
+          input.gitToken,
+          input.platform
+        );
+      } else if (input.githubRepo) {
+        const gitUrl = `https://github.com/${input.githubRepo}.git`;
+        authenticatedGitUrl = buildAuthenticatedGitUrl(gitUrl, resolvedGithubToken);
+        if (ctx.env.GITHUB_APP_SLUG && ctx.env.GITHUB_APP_BOT_USER_ID) {
+          gitAuthor = {
+            name: `${ctx.env.GITHUB_APP_SLUG}[bot]`,
+            email: `${ctx.env.GITHUB_APP_BOT_USER_ID}+${ctx.env.GITHUB_APP_SLUG}[bot]@users.noreply.github.com`,
+          };
+        }
+      } else {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Either githubRepo or gitUrl must be provided',
+        });
+      }
+
       // Pre-validate upstream branch exists before cloning (saves 30-120s of wasted compute)
       if (input.upstreamBranch) {
-        const repo = input.gitUrl
-          ? { gitUrl: input.gitUrl, gitToken: input.gitToken, platform: input.platform }
-          : input.githubRepo
-            ? { githubRepo: input.githubRepo, githubToken: resolvedGithubToken }
-            : undefined;
-        if (!repo) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'Either githubRepo or gitUrl must be provided',
-          });
-        }
         try {
-          await validateUpstreamBranchExists(session, repo, input.upstreamBranch);
+          await validateUpstreamBranchExists(session, authenticatedGitUrl, input.upstreamBranch);
         } catch (err) {
           if (err instanceof BranchNotFoundError) {
             throw new TRPCError({ code: 'BAD_REQUEST', message: err.message });
@@ -387,33 +400,8 @@ const prepareSessionHandler = internalApiProtectedProcedure
         }
       }
 
-      if (input.gitUrl) {
-        await cloneGitRepo(
-          session,
-          workspacePath,
-          input.gitUrl,
-          input.gitToken,
-          undefined,
-          cloneOptions
-        );
-      } else if (input.githubRepo) {
-        await cloneGitHubRepo(
-          session,
-          workspacePath,
-          input.githubRepo,
-          resolvedGithubToken,
-          {
-            GITHUB_APP_SLUG: ctx.env.GITHUB_APP_SLUG,
-            GITHUB_APP_BOT_USER_ID: ctx.env.GITHUB_APP_BOT_USER_ID,
-          },
-          cloneOptions
-        );
-      } else {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Either githubRepo or gitUrl must be provided',
-        });
-      }
+      logger.info('Cloning repository');
+      await cloneGitRepo(session, workspacePath, authenticatedGitUrl, gitAuthor, cloneOptions);
 
       // 8. Branch management
       logger

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -24,6 +24,8 @@ import {
   cloneGitHubRepo,
   cloneGitRepo,
   manageBranch,
+  validateUpstreamBranchExists,
+  BranchNotFoundError,
 } from '../../workspace.js';
 import { WrapperClient } from '../../kilo/wrapper-client.js';
 import { withDORetry } from '../../utils/do-retry.js';
@@ -362,6 +364,29 @@ const prepareSessionHandler = internalApiProtectedProcedure
       // 7. Clone repository
       const cloneOptions = input.shallow ? { shallow: true } : undefined;
       logger.info('Cloning repository');
+      // Pre-validate upstream branch exists before cloning (saves 30-120s of wasted compute)
+      if (input.upstreamBranch) {
+        const repo = input.gitUrl
+          ? { gitUrl: input.gitUrl, gitToken: input.gitToken, platform: input.platform }
+          : input.githubRepo
+            ? { githubRepo: input.githubRepo, githubToken: resolvedGithubToken }
+            : undefined;
+        if (!repo) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Either githubRepo or gitUrl must be provided',
+          });
+        }
+        try {
+          await validateUpstreamBranchExists(session, repo, input.upstreamBranch);
+        } catch (err) {
+          if (err instanceof BranchNotFoundError) {
+            throw new TRPCError({ code: 'BAD_REQUEST', message: err.message });
+          }
+          throw err;
+        }
+      }
+
       if (input.gitUrl) {
         await cloneGitRepo(
           session,
@@ -396,7 +421,17 @@ const prepareSessionHandler = internalApiProtectedProcedure
         .info('Managing branch');
       if (input.upstreamBranch) {
         // For upstream branches, use manageBranch (verifies exists remotely)
-        await manageBranch(session, workspacePath, branchName, true);
+        try {
+          await manageBranch(session, workspacePath, branchName, true);
+        } catch (err) {
+          if (err instanceof BranchNotFoundError) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: err.message,
+            });
+          }
+          throw err;
+        }
       } else {
         // For session branches, create directly (can't exist remotely with UUID-based name)
         const result = await session.exec(`cd ${workspacePath} && git checkout -b '${branchName}'`);

--- a/cloud-agent-next/src/session-prepare.test.ts
+++ b/cloud-agent-next/src/session-prepare.test.ts
@@ -35,16 +35,28 @@ vi.mock('@cloudflare/sandbox', () => ({
 }));
 
 // Mock workspace functions
-vi.mock('./workspace.js', () => ({
-  checkDiskAndCleanBeforeSetup: vi.fn().mockResolvedValue(undefined),
-  setupWorkspace: vi.fn().mockResolvedValue({
-    workspacePath: '/workspace/test',
-    sessionHome: '/home/test',
-  }),
-  cloneGitHubRepo: vi.fn().mockResolvedValue(undefined),
-  cloneGitRepo: vi.fn().mockResolvedValue(undefined),
-  manageBranch: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('./workspace.js', () => {
+  class BranchNotFoundError extends Error {
+    constructor(branchName: string) {
+      super(
+        `Branch "${branchName}" not found in repository. Please ensure the branch exists remotely.`
+      );
+      this.name = 'BranchNotFoundError';
+    }
+  }
+  return {
+    checkDiskAndCleanBeforeSetup: vi.fn().mockResolvedValue(undefined),
+    setupWorkspace: vi.fn().mockResolvedValue({
+      workspacePath: '/workspace/test',
+      sessionHome: '/home/test',
+    }),
+    cloneGitHubRepo: vi.fn().mockResolvedValue(undefined),
+    cloneGitRepo: vi.fn().mockResolvedValue(undefined),
+    manageBranch: vi.fn().mockResolvedValue(undefined),
+    validateUpstreamBranchExists: vi.fn().mockResolvedValue(undefined),
+    BranchNotFoundError,
+  };
+});
 
 // Mock WrapperClient.ensureWrapper (wrapper now starts kilo server in-process)
 vi.mock('./kilo/wrapper-client.js', () => ({

--- a/cloud-agent-next/src/session-prepare.test.ts
+++ b/cloud-agent-next/src/session-prepare.test.ts
@@ -44,13 +44,26 @@ vi.mock('./workspace.js', () => {
       this.name = 'BranchNotFoundError';
     }
   }
+
+  function buildAuthenticatedGitUrl(
+    gitUrl: string,
+    gitToken?: string,
+    platform?: 'github' | 'gitlab'
+  ): string {
+    if (!gitToken) return gitUrl;
+    const url = new URL(gitUrl);
+    url.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
+    url.password = gitToken;
+    return url.toString();
+  }
+
   return {
+    buildAuthenticatedGitUrl,
     checkDiskAndCleanBeforeSetup: vi.fn().mockResolvedValue(undefined),
     setupWorkspace: vi.fn().mockResolvedValue({
       workspacePath: '/workspace/test',
       sessionHome: '/home/test',
     }),
-    cloneGitHubRepo: vi.fn().mockResolvedValue(undefined),
     cloneGitRepo: vi.fn().mockResolvedValue(undefined),
     manageBranch: vi.fn().mockResolvedValue(undefined),
     validateUpstreamBranchExists: vi.fn().mockResolvedValue(undefined),

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -5,6 +5,18 @@ vi.mock('@cloudflare/sandbox', () => ({
 }));
 
 vi.mock('./workspace.js', () => {
+  function buildAuthenticatedGitUrl(
+    gitUrl: string,
+    gitToken?: string,
+    platform?: 'github' | 'gitlab'
+  ): string {
+    if (!gitToken) return gitUrl;
+    const url = new URL(gitUrl);
+    url.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
+    url.password = gitToken;
+    return url.toString();
+  }
+
   const setupWorkspace = vi.fn();
   const cloneGitHubRepo = vi.fn();
   const cloneGitRepo = vi.fn();
@@ -14,6 +26,7 @@ vi.mock('./workspace.js', () => {
   const cleanupWorkspace = vi.fn().mockResolvedValue(undefined);
 
   return {
+    buildAuthenticatedGitUrl,
     setupWorkspace,
     cloneGitHubRepo,
     cloneGitRepo,

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -10,6 +10,7 @@ import type {
 import type { ExecutionParams as _ExecutionParams } from './schema.js';
 import { generateSandboxId } from './sandbox-id.js';
 import {
+  buildAuthenticatedGitUrl,
   checkDiskAndCleanBeforeSetup,
   cloneGitHubRepo,
   cloneGitRepo,
@@ -869,10 +870,8 @@ export class SessionService {
     // Shallow clone (depth: 1) can be enabled for faster checkout and reduced disk usage
     const cloneOptions = shallow ? { shallow: true } : undefined;
     if (gitUrl) {
-      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, {
-        ...cloneOptions,
-        platform: context.platform,
-      });
+      const authenticatedGitUrl = buildAuthenticatedGitUrl(gitUrl, gitToken, context.platform);
+      await cloneGitRepo(session, workspacePath, authenticatedGitUrl, undefined, cloneOptions);
     } else if (githubRepo) {
       await cloneGitHubRepo(
         session,
@@ -1037,9 +1036,8 @@ export class SessionService {
 
     // Clone repository using appropriate method
     if (gitUrl) {
-      await cloneGitRepo(session, workspacePath, gitUrl, gitToken, undefined, {
-        platform: context.platform,
-      });
+      const authenticatedGitUrl = buildAuthenticatedGitUrl(gitUrl, gitToken, context.platform);
+      await cloneGitRepo(session, workspacePath, authenticatedGitUrl);
     } else if (githubRepo) {
       await cloneGitHubRepo(
         session,

--- a/cloud-agent-next/src/utils/shell.ts
+++ b/cloud-agent-next/src/utils/shell.ts
@@ -1,0 +1,4 @@
+/** POSIX single-quote escaping: wraps `value` in single quotes, escaping any embedded single quotes. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/cloud-agent-next/src/workspace.test.ts
+++ b/cloud-agent-next/src/workspace.test.ts
@@ -8,6 +8,10 @@ import {
   checkDiskAndCleanBeforeSetup,
   cleanupStaleWorkspaces,
   createSandboxUsageEvent,
+  buildAuthenticatedGitUrl,
+  branchExistsOnRemote,
+  validateUpstreamBranchExists,
+  BranchNotFoundError,
   LOW_DISK_THRESHOLD_MB,
   STALE_DIR_MIN_AGE_SECONDS,
 } from './workspace';
@@ -110,6 +114,108 @@ describe('manageBranch', () => {
       });
     });
 
+    describe('validateUpstreamBranchExists', () => {
+      let fakeSession: ExecutionSession;
+      let mockExec: ReturnType<typeof vi.fn>;
+
+      beforeEach(() => {
+        mockExec = vi.fn();
+        fakeSession = {
+          exec: mockExec,
+        } as unknown as ExecutionSession;
+      });
+
+      it('skips validation for GitHub pull refs', async () => {
+        await validateUpstreamBranchExists(
+          fakeSession,
+          { gitUrl: 'https://github.com/org/repo.git', gitToken: 'tok' },
+          'refs/pull/42/head'
+        );
+        expect(mockExec).not.toHaveBeenCalled();
+      });
+
+      it('resolves when branch exists on remote with gitUrl repo', async () => {
+        mockExec.mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'abc123\trefs/heads/main\n',
+          stderr: '',
+        });
+
+        await expect(
+          validateUpstreamBranchExists(
+            fakeSession,
+            { gitUrl: 'https://github.com/org/repo.git', gitToken: 'tok', platform: 'github' },
+            'main'
+          )
+        ).resolves.toBeUndefined();
+      });
+
+      it('resolves when branch exists on remote with githubRepo', async () => {
+        mockExec.mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'abc123\trefs/heads/feature\n',
+          stderr: '',
+        });
+
+        await expect(
+          validateUpstreamBranchExists(
+            fakeSession,
+            { githubRepo: 'org/repo', githubToken: 'tok' },
+            'feature'
+          )
+        ).resolves.toBeUndefined();
+      });
+
+      it('throws BranchNotFoundError when branch does not exist', async () => {
+        mockExec.mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        });
+
+        await expect(
+          validateUpstreamBranchExists(
+            fakeSession,
+            { gitUrl: 'https://github.com/org/repo.git' },
+            'nonexistent'
+          )
+        ).rejects.toThrow(BranchNotFoundError);
+      });
+
+      it('resolves (does not throw) when ls-remote fails — lets clone surface the error', async () => {
+        mockExec.mockResolvedValueOnce({
+          exitCode: 128,
+          stdout: '',
+          stderr: 'fatal: could not read from remote',
+        });
+
+        await expect(
+          validateUpstreamBranchExists(
+            fakeSession,
+            { gitUrl: 'https://github.com/org/repo.git', gitToken: 'tok' },
+            'main'
+          )
+        ).resolves.toBeUndefined();
+      });
+
+      it('passes platform to git URL for gitlab repos', async () => {
+        mockExec.mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: 'abc123\trefs/heads/main\n',
+          stderr: '',
+        });
+
+        await validateUpstreamBranchExists(
+          fakeSession,
+          { gitUrl: 'https://gitlab.com/org/repo.git', gitToken: 'tok', platform: 'gitlab' },
+          'main'
+        );
+
+        const cmd = mockExec.mock.calls[0][0] as string;
+        expect(cmd).toContain('oauth2:');
+      });
+    });
+
     describe('and it is an upstream branch', () => {
       it('should fetch and checkout GitHub pull refs', async () => {
         mockExec
@@ -149,6 +255,118 @@ describe('manageBranch', () => {
           'Branch "main" not found in repository'
         );
       });
+    });
+  });
+
+  describe('buildAuthenticatedGitUrl', () => {
+    it('returns URL unchanged when no token is provided', () => {
+      const url = 'https://github.com/org/repo.git';
+      expect(buildAuthenticatedGitUrl(url)).toBe(url);
+      expect(buildAuthenticatedGitUrl(url, undefined)).toBe(url);
+      expect(buildAuthenticatedGitUrl(url, '')).toBe(url);
+    });
+
+    it('embeds token with x-access-token username by default', () => {
+      const result = buildAuthenticatedGitUrl('https://github.com/org/repo.git', 'ghp_abc123');
+      const parsed = new URL(result);
+      expect(parsed.username).toBe('x-access-token');
+      expect(parsed.password).toBe('ghp_abc123');
+      expect(parsed.hostname).toBe('github.com');
+      expect(parsed.pathname).toBe('/org/repo.git');
+    });
+
+    it('embeds token with x-access-token username for github platform', () => {
+      const result = buildAuthenticatedGitUrl(
+        'https://github.com/org/repo.git',
+        'ghp_abc123',
+        'github'
+      );
+      const parsed = new URL(result);
+      expect(parsed.username).toBe('x-access-token');
+      expect(parsed.password).toBe('ghp_abc123');
+    });
+
+    it('uses oauth2 username when platform is gitlab', () => {
+      const result = buildAuthenticatedGitUrl(
+        'https://gitlab.com/org/repo.git',
+        'glpat-xyz789',
+        'gitlab'
+      );
+      const parsed = new URL(result);
+      expect(parsed.username).toBe('oauth2');
+      expect(parsed.password).toBe('glpat-xyz789');
+      expect(parsed.hostname).toBe('gitlab.com');
+    });
+
+    it('percent-encodes special characters in token', () => {
+      const token = 'tok/en@with:special#chars';
+      const result = buildAuthenticatedGitUrl('https://github.com/org/repo.git', token);
+      // The raw URL string should NOT contain the unencoded token
+      expect(result).not.toContain(`:${token}@`);
+      // Parsing the result back should preserve the encoded password
+      const parsed = new URL(result);
+      expect(parsed.username).toBe('x-access-token');
+      // URL.password returns the percent-encoded form
+      expect(decodeURIComponent(parsed.password)).toBe(token);
+      expect(parsed.hostname).toBe('github.com');
+    });
+  });
+
+  describe('branchExistsOnRemote', () => {
+    let mockExec: ReturnType<typeof vi.fn>;
+    let fakeSession: ExecutionSession;
+
+    beforeEach(() => {
+      mockExec = vi.fn();
+      fakeSession = { exec: mockExec } as unknown as ExecutionSession;
+    });
+
+    it('returns true when branch is found in ls-remote output', async () => {
+      mockExec.mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'abc123def456\trefs/heads/my-branch\n',
+        stderr: '',
+      });
+
+      const result = await branchExistsOnRemote(
+        fakeSession,
+        'https://github.com/org/repo.git',
+        'my-branch'
+      );
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith(
+        "git ls-remote --heads 'https://github.com/org/repo.git' 'my-branch'"
+      );
+    });
+
+    it('returns false when branch is not found', async () => {
+      mockExec.mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      const result = await branchExistsOnRemote(
+        fakeSession,
+        'https://github.com/org/repo.git',
+        'nonexistent-branch'
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns true as fallback when ls-remote fails', async () => {
+      mockExec.mockResolvedValueOnce({
+        exitCode: 128,
+        stdout: '',
+        stderr: 'fatal: could not read from remote repository',
+      });
+
+      const result = await branchExistsOnRemote(
+        fakeSession,
+        'https://github.com/org/repo.git',
+        'some-branch'
+      );
+      expect(result).toBe(true);
     });
   });
 

--- a/cloud-agent-next/src/workspace.test.ts
+++ b/cloud-agent-next/src/workspace.test.ts
@@ -128,13 +128,13 @@ describe('manageBranch', () => {
       it('skips validation for GitHub pull refs', async () => {
         await validateUpstreamBranchExists(
           fakeSession,
-          { gitUrl: 'https://github.com/org/repo.git', gitToken: 'tok' },
+          'https://x-access-token:tok@github.com/org/repo.git',
           'refs/pull/42/head'
         );
         expect(mockExec).not.toHaveBeenCalled();
       });
 
-      it('resolves when branch exists on remote with gitUrl repo', async () => {
+      it('resolves when branch exists on remote', async () => {
         mockExec.mockResolvedValueOnce({
           exitCode: 0,
           stdout: 'abc123\trefs/heads/main\n',
@@ -144,24 +144,8 @@ describe('manageBranch', () => {
         await expect(
           validateUpstreamBranchExists(
             fakeSession,
-            { gitUrl: 'https://github.com/org/repo.git', gitToken: 'tok', platform: 'github' },
+            buildAuthenticatedGitUrl('https://github.com/org/repo.git', 'tok', 'github'),
             'main'
-          )
-        ).resolves.toBeUndefined();
-      });
-
-      it('resolves when branch exists on remote with githubRepo', async () => {
-        mockExec.mockResolvedValueOnce({
-          exitCode: 0,
-          stdout: 'abc123\trefs/heads/feature\n',
-          stderr: '',
-        });
-
-        await expect(
-          validateUpstreamBranchExists(
-            fakeSession,
-            { githubRepo: 'org/repo', githubToken: 'tok' },
-            'feature'
           )
         ).resolves.toBeUndefined();
       });
@@ -176,7 +160,7 @@ describe('manageBranch', () => {
         await expect(
           validateUpstreamBranchExists(
             fakeSession,
-            { gitUrl: 'https://github.com/org/repo.git' },
+            'https://github.com/org/repo.git',
             'nonexistent'
           )
         ).rejects.toThrow(BranchNotFoundError);
@@ -192,24 +176,25 @@ describe('manageBranch', () => {
         await expect(
           validateUpstreamBranchExists(
             fakeSession,
-            { gitUrl: 'https://github.com/org/repo.git', gitToken: 'tok' },
+            buildAuthenticatedGitUrl('https://github.com/org/repo.git', 'tok'),
             'main'
           )
         ).resolves.toBeUndefined();
       });
 
-      it('passes platform to git URL for gitlab repos', async () => {
+      it('uses the pre-built authenticated URL as-is', async () => {
         mockExec.mockResolvedValueOnce({
           exitCode: 0,
           stdout: 'abc123\trefs/heads/main\n',
           stderr: '',
         });
 
-        await validateUpstreamBranchExists(
-          fakeSession,
-          { gitUrl: 'https://gitlab.com/org/repo.git', gitToken: 'tok', platform: 'gitlab' },
-          'main'
+        const authenticatedUrl = buildAuthenticatedGitUrl(
+          'https://gitlab.com/org/repo.git',
+          'tok',
+          'gitlab'
         );
+        await validateUpstreamBranchExists(fakeSession, authenticatedUrl, 'main');
 
         const cmd = mockExec.mock.calls[0][0] as string;
         expect(cmd).toContain('oauth2:');
@@ -629,12 +614,11 @@ describe('disk space checking', () => {
   });
 
   describe('cloneGitRepo', () => {
-    it('should clone repository (disk space check is separate)', async () => {
+    it('should clone repository with plain URL (no credentials)', async () => {
       mockExec
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
 
-      // Mock gitCheckout to succeed
       mockGitCheckout.mockResolvedValue({
         success: true,
         exitCode: 0,
@@ -642,31 +626,32 @@ describe('disk space checking', () => {
 
       await cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git');
 
-      // Verify clone was called
       expect(mockGitCheckout).toHaveBeenCalled();
     });
 
-    it('should include token in URL when provided', async () => {
+    it('should pass pre-built authenticated URL directly to gitCheckout', async () => {
       mockExec
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
 
-      // Mock gitCheckout to succeed
       mockGitCheckout.mockResolvedValue({
         success: true,
         exitCode: 0,
       });
 
-      await cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git', 'test-token');
+      const authenticatedUrl = buildAuthenticatedGitUrl(
+        'https://example.com/repo.git',
+        'test-token'
+      );
+      await cloneGitRepo(fakeSession, '/workspace', authenticatedUrl);
 
-      // Verify gitCheckout was called with URL containing token
       expect(mockGitCheckout).toHaveBeenCalledWith(
         expect.stringContaining('x-access-token:test-token'),
         expect.any(Object)
       );
     });
 
-    it('should use oauth2 username for gitlab platform', async () => {
+    it('should pass gitlab authenticated URL directly to gitCheckout', async () => {
       mockExec
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
@@ -676,64 +661,15 @@ describe('disk space checking', () => {
         exitCode: 0,
       });
 
-      await cloneGitRepo(
-        fakeSession,
-        '/workspace',
+      const authenticatedUrl = buildAuthenticatedGitUrl(
         'https://gitlab.com/repo.git',
         'test-token',
-        undefined,
-        {
-          platform: 'gitlab',
-        }
+        'gitlab'
       );
+      await cloneGitRepo(fakeSession, '/workspace', authenticatedUrl);
 
       expect(mockGitCheckout).toHaveBeenCalledWith(
         expect.stringContaining('oauth2:test-token'),
-        expect.any(Object)
-      );
-    });
-
-    it('should use x-access-token username for github platform', async () => {
-      mockExec
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
-
-      mockGitCheckout.mockResolvedValue({
-        success: true,
-        exitCode: 0,
-      });
-
-      await cloneGitRepo(
-        fakeSession,
-        '/workspace',
-        'https://example.com/repo.git',
-        'test-token',
-        undefined,
-        {
-          platform: 'github',
-        }
-      );
-
-      expect(mockGitCheckout).toHaveBeenCalledWith(
-        expect.stringContaining('x-access-token:test-token'),
-        expect.any(Object)
-      );
-    });
-
-    it('should use x-access-token username when platform is undefined', async () => {
-      mockExec
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // git config user.name
-        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // git config user.email
-
-      mockGitCheckout.mockResolvedValue({
-        success: true,
-        exitCode: 0,
-      });
-
-      await cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git', 'test-token');
-
-      expect(mockGitCheckout).toHaveBeenCalledWith(
-        expect.stringContaining('x-access-token:test-token'),
         expect.any(Object)
       );
     });

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -415,6 +415,67 @@ export async function createSandboxUsageEvent(
   };
 }
 
+export class BranchNotFoundError extends Error {
+  constructor(branchName: string) {
+    super(
+      `Branch "${branchName}" not found in repository. Please ensure the branch exists remotely.`
+    );
+    this.name = 'BranchNotFoundError';
+  }
+}
+
+export function buildAuthenticatedGitUrl(
+  gitUrl: string,
+  gitToken?: string,
+  platform?: 'github' | 'gitlab'
+): string {
+  if (!gitToken) return gitUrl;
+  const url = new URL(gitUrl);
+  url.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
+  url.password = gitToken;
+  return url.toString();
+}
+
+export async function branchExistsOnRemote(
+  session: ExecutionSession,
+  repoUrl: string,
+  branchName: string
+): Promise<boolean> {
+  const result = await session.exec(`git ls-remote --heads '${repoUrl}' '${branchName}'`);
+  if (result.exitCode !== 0) {
+    // ls-remote itself failed (network, auth) — don't treat as "branch missing",
+    // let the clone path handle the real error
+    return true;
+  }
+  return result.stdout.trim().length > 0;
+}
+
+/**
+ * Pre-validate that an upstream branch exists on the remote before cloning.
+ * Skips validation for GitHub pull refs (e.g. refs/pull/123/head).
+ * Returns silently when the branch exists or when ls-remote fails (letting the clone path surface the real error).
+ * Throws BranchNotFoundError when the branch is confirmed missing.
+ */
+export async function validateUpstreamBranchExists(
+  session: ExecutionSession,
+  repo:
+    | { gitUrl: string; gitToken?: string; platform?: 'github' | 'gitlab' }
+    | { githubRepo: string; githubToken?: string },
+  branchName: string
+): Promise<void> {
+  if (GITHUB_PULL_REF_PATTERN.test(branchName)) return;
+
+  const authenticatedUrl =
+    'gitUrl' in repo
+      ? buildAuthenticatedGitUrl(repo.gitUrl, repo.gitToken, repo.platform)
+      : buildAuthenticatedGitUrl(`https://github.com/${repo.githubRepo}.git`, repo.githubToken);
+
+  const exists = await branchExistsOnRemote(session, authenticatedUrl, branchName);
+  if (!exists) {
+    throw new BranchNotFoundError(branchName);
+  }
+}
+
 export async function cloneGitHubRepo(
   session: ExecutionSession,
   workspacePath: string,
@@ -446,15 +507,7 @@ export async function cloneGitRepo(
   gitAuthor?: GitAuthorConfig,
   options?: { shallow?: boolean; platform?: 'github' | 'gitlab' }
 ): Promise<void> {
-  // Build URL with token if available (for private repos)
-  // GitLab OAuth tokens require username 'oauth2'; all other providers use 'x-access-token'
-  let repoUrl = gitUrl;
-  if (gitToken) {
-    const url = new URL(gitUrl);
-    url.username = options?.platform === 'gitlab' ? 'oauth2' : 'x-access-token';
-    url.password = gitToken;
-    repoUrl = url.toString();
-  }
+  const repoUrl = buildAuthenticatedGitUrl(gitUrl, gitToken, options?.platform);
 
   const sanitizedGitUrl = sanitizeGitUrlForLogging(gitUrl);
   const shallow = options?.shallow ?? false;
@@ -658,7 +711,7 @@ async function createNewBranch(
   }
 }
 
-const GITHUB_PULL_REF_PATTERN = /^refs\/pull\/\d+\/head$/;
+export const GITHUB_PULL_REF_PATTERN = /^refs\/pull\/\d+\/head$/;
 
 async function fetchPullRefAndCheckout(
   session: ExecutionSession,
@@ -750,9 +803,7 @@ export async function manageBranch(
         return branchName;
       }
 
-      throw new Error(
-        `Branch "${branchName}" not found in repository. Please ensure the branch exists remotely.`
-      );
+      throw new BranchNotFoundError(branchName);
     }
     await createNewBranch(session, workspacePath, branchName);
   }

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -461,19 +461,12 @@ export async function branchExistsOnRemote(
  */
 export async function validateUpstreamBranchExists(
   session: ExecutionSession,
-  repo:
-    | { gitUrl: string; gitToken?: string; platform?: 'github' | 'gitlab' }
-    | { githubRepo: string; githubToken?: string },
+  authenticatedGitUrl: string,
   branchName: string
 ): Promise<void> {
   if (GITHUB_PULL_REF_PATTERN.test(branchName)) return;
 
-  const authenticatedUrl =
-    'gitUrl' in repo
-      ? buildAuthenticatedGitUrl(repo.gitUrl, repo.gitToken, repo.platform)
-      : buildAuthenticatedGitUrl(`https://github.com/${repo.githubRepo}.git`, repo.githubToken);
-
-  const exists = await branchExistsOnRemote(session, authenticatedUrl, branchName);
+  const exists = await branchExistsOnRemote(session, authenticatedGitUrl, branchName);
   if (!exists) {
     throw new BranchNotFoundError(branchName);
   }
@@ -487,10 +480,9 @@ export async function cloneGitHubRepo(
   env?: { GITHUB_APP_SLUG?: string; GITHUB_APP_BOT_USER_ID?: string },
   options?: { shallow?: boolean }
 ): Promise<void> {
-  // Convert GitHub repo format (org/repo) to full HTTPS URL and delegate to cloneGitRepo
   const gitUrl = `https://github.com/${githubRepo}.git`;
+  const authenticatedGitUrl = buildAuthenticatedGitUrl(gitUrl, githubToken);
 
-  // Build git author config from GitHub App environment variables
   let gitAuthor: GitAuthorConfig | undefined;
   if (env?.GITHUB_APP_SLUG && env?.GITHUB_APP_BOT_USER_ID) {
     gitAuthor = {
@@ -499,20 +491,17 @@ export async function cloneGitHubRepo(
     };
   }
 
-  await cloneGitRepo(session, workspacePath, gitUrl, githubToken, gitAuthor, options);
+  await cloneGitRepo(session, workspacePath, authenticatedGitUrl, gitAuthor, options);
 }
 
 export async function cloneGitRepo(
   session: ExecutionSession,
   workspacePath: string,
-  gitUrl: string,
-  gitToken?: string,
+  authenticatedGitUrl: string,
   gitAuthor?: GitAuthorConfig,
-  options?: { shallow?: boolean; platform?: 'github' | 'gitlab' }
+  options?: { shallow?: boolean }
 ): Promise<void> {
-  const repoUrl = buildAuthenticatedGitUrl(gitUrl, gitToken, options?.platform);
-
-  const sanitizedGitUrl = sanitizeGitUrlForLogging(gitUrl);
+  const sanitizedGitUrl = sanitizeGitUrlForLogging(authenticatedGitUrl);
   const shallow = options?.shallow ?? false;
   logger.setTags({ gitUrl: sanitizedGitUrl, workspacePath, shallow });
   logger.info('Cloning generic git repository');
@@ -521,7 +510,7 @@ export async function cloneGitRepo(
     // Git clone with 2-minute timeout to prevent indefinite hangs
     const CLONE_TIMEOUT_MS = 120_000; // 2 minutes
     const result = await withTimeout(
-      session.gitCheckout(repoUrl, {
+      session.gitCheckout(authenticatedGitUrl, {
         targetDir: workspacePath,
         // Use depth: 1 for shallow clones (faster, less disk space)
         ...(shallow && { depth: 1 }),
@@ -569,9 +558,12 @@ export async function restoreWorkspace(
   options: RestoreWorkspaceOptions
 ): Promise<void> {
   if (options.gitUrl) {
-    await cloneGitRepo(session, workspacePath, options.gitUrl, options.gitToken, undefined, {
-      platform: options.platform,
-    });
+    const authenticatedGitUrl = buildAuthenticatedGitUrl(
+      options.gitUrl,
+      options.gitToken,
+      options.platform
+    );
+    await cloneGitRepo(session, workspacePath, authenticatedGitUrl);
   } else if (options.githubRepo) {
     await cloneGitHubRepo(
       session,
@@ -605,17 +597,14 @@ export async function updateGitRemoteToken(
   gitToken: string,
   platform?: 'github' | 'gitlab'
 ): Promise<void> {
-  // Build new URL with token embedded (GitLab uses 'oauth2', others use 'x-access-token')
-  const newUrl = new URL(gitUrl);
-  newUrl.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
-  newUrl.password = gitToken;
+  const newUrl = buildAuthenticatedGitUrl(gitUrl, gitToken, platform);
 
   const sanitizedGitUrl = sanitizeGitUrlForLogging(gitUrl);
   logger.setTags({ workspacePath, gitUrl: sanitizedGitUrl });
   logger.info('Updating git remote URL with new token');
 
   const result = await session.exec(
-    `cd '${workspacePath}' && git remote set-url origin '${newUrl.toString()}'`
+    `cd '${workspacePath}' && git remote set-url origin '${newUrl}'`
   );
 
   if (result.exitCode !== 0) {

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -3,6 +3,7 @@ import type { ExecResult, ExecOptions } from '@cloudflare/sandbox';
 import { logger } from './logger.js';
 import { findWrapperForSessionInProcesses } from './kilo/wrapper-manager.js';
 import { withTimeout } from '@kilocode/worker-utils';
+import { shellQuote } from './utils/shell.js';
 
 /**
  * Minimal interface for running shell commands.
@@ -434,10 +435,6 @@ export function buildAuthenticatedGitUrl(
   url.username = platform === 'gitlab' ? 'oauth2' : 'x-access-token';
   url.password = gitToken;
   return url.toString();
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 export async function branchExistsOnRemote(

--- a/cloud-agent-next/src/workspace.ts
+++ b/cloud-agent-next/src/workspace.ts
@@ -436,12 +436,18 @@ export function buildAuthenticatedGitUrl(
   return url.toString();
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 export async function branchExistsOnRemote(
   session: ExecutionSession,
   repoUrl: string,
   branchName: string
 ): Promise<boolean> {
-  const result = await session.exec(`git ls-remote --heads '${repoUrl}' '${branchName}'`);
+  const result = await session.exec(
+    `git ls-remote --heads ${shellQuote(repoUrl)} ${shellQuote(branchName)}`
+  );
   if (result.exitCode !== 0) {
     // ls-remote itself failed (network, auth) — don't treat as "branch missing",
     // let the clone path handle the real error


### PR DESCRIPTION
## Summary

Return a `BAD_REQUEST` (4xx) instead of an internal server error (500) when an upstream branch does not exist during session preparation. Before this change, `manageBranch` threw a plain `Error` that propagated as a 500; now it throws a typed `BranchNotFoundError` that `session-prepare` catches and converts to a `TRPCError({ code: 'BAD_REQUEST' })`.

Additionally, a `git ls-remote` pre-validation step runs *before* cloning when `upstreamBranch` is set, failing fast (saving 30–120s of wasted clone time) when the branch is confirmed missing. The pre-check is purely additive — if `ls-remote` itself fails (network, auth), it silently passes and lets the clone path surface the real error.

Key extraction: `buildAuthenticatedGitUrl` was factored out of `cloneGitRepo` so it can be reused by the new `branchExistsOnRemote` helper.

## Verification

- [x] `pnpm format` — passed (auto-fixed 3 files)
- [x] `pnpm lint` — passed (0 warnings, 0 errors across all workspaces)
- [x] `pnpm typecheck` — passed (all workspace projects)

## Visual Changes

N/A

## Reviewer Notes

- PR ref branches (`refs/pull/N/head`) are intentionally skipped in the pre-validation — they aren't regular branches and `ls-remote --heads` won't find them.
- `branchExistsOnRemote` returns `true` on ls-remote failure to keep the check purely additive; the clone/checkout path already handles auth and network errors with better context.
- `GITHUB_PULL_REF_PATTERN` was made `export` so the pre-validation can reuse it.