### PR TITLE
feat(cloud-agent): distinguish cloud-agent-web sessions from cloud-agent

### DIFF
--- a/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
+++ b/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
@@ -79,7 +79,12 @@ export function SessionsPageContent() {
       limit: 50,
       orderBy: 'updated_at',
       organizationId: organizationId ?? null,
-      createdOnPlatform: platformFilter === 'all' ? undefined : platformFilter,
+      createdOnPlatform:
+        platformFilter === 'all'
+          ? undefined
+          : platformFilter === 'cloud-agent'
+            ? ['cloud-agent', 'cloud-agent-web']
+            : platformFilter,
       includeSubSessions,
     })
   );
@@ -91,7 +96,12 @@ export function SessionsPageContent() {
       limit: 50,
       offset: 0,
       organizationId: organizationId ?? null,
-      createdOnPlatform: platformFilter === 'all' ? undefined : platformFilter,
+      createdOnPlatform:
+        platformFilter === 'all'
+          ? undefined
+          : platformFilter === 'cloud-agent'
+            ? ['cloud-agent', 'cloud-agent-web']
+            : platformFilter,
       includeSubSessions,
     }),
     enabled: isSearching,

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -423,7 +423,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
       void queryClient.invalidateQueries({
         queryKey: trpc.unifiedSessions.list.queryKey({
           limit: 3,
-          createdOnPlatform: 'cloud-agent',
+          createdOnPlatform: ['cloud-agent', 'cloud-agent-web'],
           orderBy: 'updated_at',
           organizationId: organizationId ?? null,
         }),

--- a/src/components/cloud-agent-next/SessionsList.tsx
+++ b/src/components/cloud-agent-next/SessionsList.tsx
@@ -48,7 +48,7 @@ export function SessionsList({ sessions, organizationId, onSessionClick }: Sessi
         const platform = session.createdOnPlatform;
         let badge: React.ReactNode;
 
-        if (platform === 'cloud-agent') {
+        if (platform === 'cloud-agent' || platform === 'cloud-agent-web') {
           badge = (
             <span className="inline-flex shrink-0 items-center gap-1 rounded bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-400">
               <Cloud className="h-3 w-3" />

--- a/src/components/cloud-agent-next/store/db-session-atoms.test.ts
+++ b/src/components/cloud-agent-next/store/db-session-atoms.test.ts
@@ -646,7 +646,7 @@ describe('New Session Creation Logic', () => {
       title,
       git_url: repository ? `https://github.com/${repository}` : null,
       cloud_agent_session_id: cloudAgentSessionId,
-      created_on_platform: 'cloud-agent',
+      created_on_platform: 'cloud-agent-web',
       created_at: now,
       updated_at: now,
     };

--- a/src/components/cloud-agent-next/store/db-session-atoms.ts
+++ b/src/components/cloud-agent-next/store/db-session-atoms.ts
@@ -600,7 +600,7 @@ export const createNewSessionInIndexedDbAtom = atom(
       title,
       git_url: null,
       cloud_agent_session_id: cloudAgentSessionId,
-      created_on_platform: 'cloud-agent',
+      created_on_platform: 'cloud-agent-web',
       created_at: nowDate,
       updated_at: nowDate,
       last_mode: mode ?? null,

--- a/src/components/cloud-agent/CloudSessionsPage.tsx
+++ b/src/components/cloud-agent/CloudSessionsPage.tsx
@@ -455,7 +455,7 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
       void queryClient.invalidateQueries({
         queryKey: trpc.unifiedSessions.list.queryKey({
           limit: 3,
-          createdOnPlatform: 'cloud-agent',
+          createdOnPlatform: ['cloud-agent', 'cloud-agent-web'],
           orderBy: 'updated_at',
           organizationId: organizationId ?? null,
         }),

--- a/src/components/cloud-agent/SessionsList.tsx
+++ b/src/components/cloud-agent/SessionsList.tsx
@@ -50,7 +50,7 @@ export function SessionsList<T extends SessionsListItem>({
         const platform = session.createdOnPlatform;
         let badge: React.ReactNode;
 
-        if (platform === 'cloud-agent') {
+        if (platform === 'cloud-agent' || platform === 'cloud-agent-web') {
           badge = (
             <span className="inline-flex shrink-0 items-center gap-1 rounded bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-400">
               <Cloud className="h-3 w-3" />

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -127,7 +127,7 @@ const cloudAgentSessionIdField = z.string().min(1).max(255);
 const ListSessionsInputSchema = z.object({
   cursor: z.iso.datetime().optional(),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
-  createdOnPlatform: z.union([z.string(), z.array(z.string())]).optional(),
+  createdOnPlatform: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
   organizationId: z.uuid().nullable().optional(),
 });
@@ -136,7 +136,7 @@ const SearchInputSchema = z.object({
   search_string: z.string().min(1),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   offset: z.number().min(0).optional().default(0),
-  createdOnPlatform: z.union([z.string(), z.array(z.string())]).optional(),
+  createdOnPlatform: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   organizationId: z.uuid().nullable().optional(),
 });
 

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -2,7 +2,19 @@ import 'server-only';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import * as z from 'zod';
 import { db } from '@/lib/drizzle';
-import { eq, and, desc, lt, or, ilike, sql, isNull, notInArray, type SQL } from 'drizzle-orm';
+import {
+  eq,
+  and,
+  desc,
+  lt,
+  or,
+  ilike,
+  sql,
+  isNull,
+  notInArray,
+  inArray,
+  type SQL,
+} from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { cliSessions, sharedCliSessions } from '@kilocode/db/schema';
 import { CliSessionSharedState } from '@/types/cli-session-shared-state';
@@ -28,7 +40,13 @@ export const BLOB_TYPES = [
 ] as const satisfies readonly FileName[];
 
 /** Known platform values that have dedicated filters. "Extension" is everything else. */
-export const KNOWN_PLATFORMS = ['cloud-agent', 'cli', 'agent-manager', 'app-builder'] as const;
+export const KNOWN_PLATFORMS = [
+  'cloud-agent',
+  'cloud-agent-web',
+  'cli',
+  'agent-manager',
+  'app-builder',
+] as const;
 
 const PAGE_SIZE = 10;
 
@@ -109,7 +127,7 @@ const cloudAgentSessionIdField = z.string().min(1).max(255);
 const ListSessionsInputSchema = z.object({
   cursor: z.iso.datetime().optional(),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
-  createdOnPlatform: z.string().optional(),
+  createdOnPlatform: z.union([z.string(), z.array(z.string())]).optional(),
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
   organizationId: z.uuid().nullable().optional(),
 });
@@ -118,7 +136,7 @@ const SearchInputSchema = z.object({
   search_string: z.string().min(1),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   offset: z.number().min(0).optional().default(0),
-  createdOnPlatform: z.string().optional(),
+  createdOnPlatform: z.union([z.string(), z.array(z.string())]).optional(),
   organizationId: z.uuid().nullable().optional(),
 });
 
@@ -281,17 +299,23 @@ async function getForkableSession(
  * Used by both list and search procedures to ensure consistent filtering.
  */
 function buildScopeConditions(opts: {
-  createdOnPlatform?: string;
+  createdOnPlatform?: string | string[];
   organizationId?: string | null;
 }): SQL[] {
   const conditions: SQL[] = [];
 
   if (opts.createdOnPlatform) {
-    if (opts.createdOnPlatform === 'extension') {
+    const platforms = Array.isArray(opts.createdOnPlatform)
+      ? opts.createdOnPlatform
+      : [opts.createdOnPlatform];
+
+    if (platforms.length === 1 && platforms[0] === 'extension') {
       // "Extension" means everything NOT in the known platforms list
       conditions.push(notInArray(cliSessions.created_on_platform, [...KNOWN_PLATFORMS]));
+    } else if (platforms.length === 1) {
+      conditions.push(eq(cliSessions.created_on_platform, platforms[0]));
     } else {
-      conditions.push(eq(cliSessions.created_on_platform, opts.createdOnPlatform));
+      conditions.push(inArray(cliSessions.created_on_platform, platforms));
     }
   }
 

--- a/src/routers/cloud-agent-next-router.ts
+++ b/src/routers/cloud-agent-next-router.ts
@@ -100,6 +100,7 @@ export const cloudAgentNextRouter = createTRPCRouter({
         const result = await client.prepareSession({
           ...restInput,
           ...gitParams,
+          createdOnPlatform: 'cloud-agent-web',
           envVars: merged.envVars,
           encryptedSecrets: merged.encryptedSecrets,
           setupCommands: merged.setupCommands,

--- a/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -149,6 +149,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
         const result = await client.prepareSession({
           ...restInput,
           ...gitParams,
+          createdOnPlatform: 'cloud-agent-web',
           kilocodeOrganizationId: organizationId,
           envVars: merged.envVars,
           encryptedSecrets: merged.encryptedSecrets,

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -31,7 +31,7 @@ const createdOnPlatformField = z.string().min(1).max(100);
 const ListSessionsInputSchema = z.object({
   cursor: z.iso.datetime().optional(),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
-  createdOnPlatform: createdOnPlatformField.optional(),
+  createdOnPlatform: z.union([createdOnPlatformField, z.array(createdOnPlatformField)]).optional(),
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
@@ -41,7 +41,7 @@ const SearchInputSchema = z.object({
   search_string: z.string().min(1),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   offset: z.number().min(0).optional().default(0),
-  createdOnPlatform: createdOnPlatformField.optional(),
+  createdOnPlatform: z.union([createdOnPlatformField, z.array(createdOnPlatformField)]).optional(),
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
 });
@@ -54,7 +54,7 @@ function buildScopeFragments(
   tableName: 'cli_sessions' | 'cli_sessions_v2',
   opts: {
     userId: string;
-    createdOnPlatform?: string;
+    createdOnPlatform?: string | string[];
     organizationId?: string | null;
     includeSubSessions?: boolean;
   }
@@ -64,15 +64,26 @@ function buildScopeFragments(
   const fragments: SQL[] = [sql`${table.kilo_user_id} = ${opts.userId}`];
 
   if (opts.createdOnPlatform) {
-    if (opts.createdOnPlatform === 'extension') {
+    const platforms = Array.isArray(opts.createdOnPlatform)
+      ? opts.createdOnPlatform
+      : [opts.createdOnPlatform];
+
+    if (platforms.length === 1 && platforms[0] === 'extension') {
       fragments.push(
         sql`${table.created_on_platform} NOT IN (${sql.join(
           KNOWN_PLATFORMS.map(p => sql`${p}`),
           sql`, `
         )})`
       );
+    } else if (platforms.length === 1) {
+      fragments.push(sql`${table.created_on_platform} = ${platforms[0]}`);
     } else {
-      fragments.push(sql`${table.created_on_platform} = ${opts.createdOnPlatform}`);
+      fragments.push(
+        sql`${table.created_on_platform} IN (${sql.join(
+          platforms.map(p => sql`${p}`),
+          sql`, `
+        )})`
+      );
     }
   }
 

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -31,7 +31,9 @@ const createdOnPlatformField = z.string().min(1).max(100);
 const ListSessionsInputSchema = z.object({
   cursor: z.iso.datetime().optional(),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
-  createdOnPlatform: z.union([createdOnPlatformField, z.array(createdOnPlatformField)]).optional(),
+  createdOnPlatform: z
+    .union([createdOnPlatformField, z.array(createdOnPlatformField).min(1)])
+    .optional(),
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
@@ -41,7 +43,9 @@ const SearchInputSchema = z.object({
   search_string: z.string().min(1),
   limit: z.number().min(1).max(50).optional().default(PAGE_SIZE),
   offset: z.number().min(0).optional().default(0),
-  createdOnPlatform: z.union([createdOnPlatformField, z.array(createdOnPlatformField)]).optional(),
+  createdOnPlatform: z
+    .union([createdOnPlatformField, z.array(createdOnPlatformField).min(1)])
+    .optional(),
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
 });


### PR DESCRIPTION
## Summary

Sessions created via the cloud-agent-next web UI are now tagged as `cloud-agent-web` instead of `cloud-agent`, giving each platform an explicit identity. The `createdOnPlatform` filter in both `cli-sessions-router` and `unified-sessions-router` now accepts `string | string[]`, enabling multi-platform queries with `IN` clauses. Frontend query invalidations and badge rendering treat both `cloud-agent` and `cloud-agent-web` identically so the user experience is unchanged.

Key changes:
- `cloud-agent-next-router` and `organization-cloud-agent-next-router` pass `createdOnPlatform: 'cloud-agent-web'` when preparing sessions.
- `KNOWN_PLATFORMS` includes `cloud-agent-web` so it is not lumped into the "extension" fallback bucket.
- `buildScopeConditions` / `buildScopeFragments` handle array inputs via `inArray` / `IN`.
- Session list pages query for `['cloud-agent', 'cloud-agent-web']` to show both.

## Verification

- [x] `pnpm lint` — passed
- [x] `pnpm typecheck` — passed

## Visual Changes

N/A

## Reviewer Notes

- The `buildScopeConditions` (drizzle ORM) and `buildScopeFragments` (raw SQL) diverge in style because the two routers use different query strategies — both were updated consistently.
- `db-session-atoms.test.ts` expectation updated to assert `cloud-agent-web` for new sessions created in the web UI.