### PR TITLE
fix(payments): add org membership check to top-up checkout

### DIFF
--- a/src/app/payments/topup/route.ts
+++ b/src/app/payments/topup/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<unknown>>
 
   let stripeCustomerId: string | null | undefined;
   if (organizationId) {
-    const orgContext = await getAuthorizedOrgContext(organizationId);
+    const orgContext = await getAuthorizedOrgContext(organizationId, ['owner', 'billing_manager']);
     if (!orgContext.success) {
       return orgContext.nextResponse;
     }

--- a/src/app/payments/topup/route.ts
+++ b/src/app/payments/topup/route.ts
@@ -6,6 +6,7 @@ import { MAXIMUM_TOP_UP_AMOUNT, MINIMUM_TOP_UP_AMOUNT } from '@/lib/constants';
 import { isValidReturnUrl } from '@/lib/payment-return-url';
 import { captureException } from '@sentry/nextjs';
 import { getOrCreateStripeCustomerIdForOrganization } from '@/lib/organizations/organization-billing';
+import { getAuthorizedOrgContext } from '@/lib/organizations/organization-auth';
 
 /**
  * NOTE: Crypto payment support (Coinbase Commerce) was removed in January 2026.
@@ -63,10 +64,16 @@ export async function POST(request: NextRequest): Promise<NextResponse<unknown>>
     return NextResponse.json({ error: 'Invalid org id' }, { status: 400 });
   }
 
-  const stripeCustomerId = organizationId
-    ? // TODO(bmc): should we check user permission to organization here?
-      await getOrCreateStripeCustomerIdForOrganization(organizationId)
-    : currentUser.stripe_customer_id;
+  let stripeCustomerId: string | null | undefined;
+  if (organizationId) {
+    const orgContext = await getAuthorizedOrgContext(organizationId);
+    if (!orgContext.success) {
+      return orgContext.nextResponse;
+    }
+    stripeCustomerId = await getOrCreateStripeCustomerIdForOrganization(organizationId);
+  } else {
+    stripeCustomerId = currentUser.stripe_customer_id;
+  }
 
   const cancelPathRaw = searchParams.get('cancel-path');
   const cancelPath = cancelPathRaw && isValidReturnUrl(cancelPathRaw) ? cancelPathRaw : null;


### PR DESCRIPTION
## Summary
- Adds an organization authorization check to the top-up checkout route (`/payments/topup`)
- Previously, any authenticated user could initiate a checkout for any organization by passing an arbitrary `organization-id` query param
- Now uses `getAuthorizedOrgContext` to verify the user is a member of the org (or an admin) before creating/reusing the org's Stripe customer

## Test plan
- [ ] Verify top-up works normally for a user's own account (no `organization-id`)
- [ ] Verify top-up works for an org the user belongs to
- [ ] Verify top-up returns 404 when `organization-id` belongs to an org the user is not a member of
- [ ] Verify admin users can still top up any org