### PR TITLE
feat(admin): add Create Machine button for unallocated instances

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -155,7 +155,10 @@ export async function buildUserEnvVars(
   }
 
   // Get the env encryption key from the App DO, creating it if needed.
+  // Call ensureApp first so the App DO has its flyAppName persisted — required
+  // by ensureEnvKey to set the Fly secret.
   const appStub = env.KILOCLAW_APP.get(env.KILOCLAW_APP.idFromName(state.userId));
+  await appStub.ensureApp(state.userId);
   const { key: envKey, secretsVersion } = await appStub.ensureEnvKey(state.userId);
 
   // Encrypt sensitive values and prefix their names with KILOCLAW_ENC_

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -653,7 +653,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
-  async start(userId?: string): Promise<void> {
+  async start(userId?: string, opts?: { skipRecovery?: boolean; imageTag?: string }): Promise<void> {
     // Guard against concurrent start() calls — two overlapping invocations
     // (e.g. startAsync via waitUntil + a direct RPC start) can both see
     // flyMachineId as null and each create a Fly machine, orphaning one.
@@ -664,13 +664,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.startInProgress = true;
 
     try {
-      await this._startInner(userId);
+      await this._startInner(userId, opts);
     } finally {
       this.startInProgress = false;
     }
   }
 
-  private async _startInner(userId?: string): Promise<void> {
+  private async _startInner(userId?: string, opts?: { skipRecovery?: boolean; imageTag?: string }): Promise<void> {
     await this.loadState();
 
     if (this.s.status === 'destroying') {
@@ -697,7 +697,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // If the DO has identity but lost its machine ID, try to recover it
     // from Fly metadata before creating a duplicate machine.
-    if (!this.s.flyMachineId) {
+    if (!this.s.flyMachineId && !opts?.skipRecovery) {
       const recovered = await attemptMetadataRecovery(
         flyConfig,
         this.ctx,
@@ -760,7 +760,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
     const guest = guestFromSize(this.s.machineSize);
-    const imageTag = resolveImageTag(this.s, this.env);
+    const imageTag = opts?.imageTag ?? resolveImageTag(this.s, this.env);
     console.log(
       '[DO] startGateway: deploying with imageTag:',
       imageTag,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -771,7 +771,15 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
     const guest = guestFromSize(this.s.machineSize);
-    const imageTag = opts?.imageTag ?? resolveImageTag(this.s, this.env);
+
+    // If an explicit imageTag was passed (e.g. from admin machineCreate with a
+    // version pin), persist it so subsequent restarts keep the same image.
+    if (opts?.imageTag && opts.imageTag !== this.s.trackedImageTag) {
+      this.s.trackedImageTag = opts.imageTag;
+      await this.persist({ trackedImageTag: opts.imageTag });
+    }
+
+    const imageTag = resolveImageTag(this.s, this.env);
     console.log(
       '[DO] startGateway: deploying with imageTag:',
       imageTag,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -697,6 +697,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     // If the DO has identity but lost its machine ID, try to recover it
     // from Fly metadata before creating a duplicate machine.
+    if (!this.s.flyMachineId && opts?.skipRecovery) {
+      console.warn('[DO] start: skipRecovery=true — bypassing metadata recovery, will create new machine');
+    }
     if (!this.s.flyMachineId && !opts?.skipRecovery) {
       const recovered = await attemptMetadataRecovery(
         flyConfig,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -653,7 +653,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
-  async start(userId?: string, opts?: { skipRecovery?: boolean; imageTag?: string }): Promise<void> {
+  async start(
+    userId?: string,
+    opts?: { skipRecovery?: boolean; imageTag?: string }
+  ): Promise<void> {
     // Guard against concurrent start() calls — two overlapping invocations
     // (e.g. startAsync via waitUntil + a direct RPC start) can both see
     // flyMachineId as null and each create a Fly machine, orphaning one.
@@ -670,7 +673,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
   }
 
-  private async _startInner(userId?: string, opts?: { skipRecovery?: boolean; imageTag?: string }): Promise<void> {
+  private async _startInner(
+    userId?: string,
+    opts?: { skipRecovery?: boolean; imageTag?: string }
+  ): Promise<void> {
     await this.loadState();
 
     if (this.s.status === 'destroying') {
@@ -698,7 +704,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     // If the DO has identity but lost its machine ID, try to recover it
     // from Fly metadata before creating a duplicate machine.
     if (!this.s.flyMachineId && opts?.skipRecovery) {
-      console.warn('[DO] start: skipRecovery=true — bypassing metadata recovery, will create new machine');
+      console.warn(
+        '[DO] start: skipRecovery=true — bypassing metadata recovery, will create new machine'
+      );
     }
     if (!this.s.flyMachineId && !opts?.skipRecovery) {
       const recovered = await attemptMetadataRecovery(

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -913,19 +913,18 @@ platform.post('/doctor', async c => {
 // POST /api/platform/start
 const StartRequestSchema = UserIdRequestSchema.extend({
   skipRecovery: z.boolean().optional(),
-  imageTag: z.string().optional(),
+  imageTag: z.string().min(1).optional(),
 });
 platform.post('/start', async c => {
   const result = await parseBody(c, StartRequestSchema);
   if ('error' in result) return result.error;
 
   try {
-    const opts: { skipRecovery?: boolean; imageTag?: string } = {};
-    if (result.data.skipRecovery) opts.skipRecovery = true;
-    if (result.data.imageTag) opts.imageTag = result.data.imageTag;
+    const { skipRecovery, imageTag } = result.data;
+    const opts = skipRecovery || imageTag ? { skipRecovery, imageTag } : undefined;
     await withDORetry(
       instanceStubFactory(c.env, result.data.userId),
-      stub => stub.start(result.data.userId, Object.keys(opts).length ? opts : undefined),
+      stub => stub.start(result.data.userId, opts),
       'start'
     );
     return c.json({ ok: true });

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -911,14 +911,21 @@ platform.post('/doctor', async c => {
 });
 
 // POST /api/platform/start
+const StartRequestSchema = UserIdRequestSchema.extend({
+  skipRecovery: z.boolean().optional(),
+  imageTag: z.string().optional(),
+});
 platform.post('/start', async c => {
-  const result = await parseBody(c, UserIdRequestSchema);
+  const result = await parseBody(c, StartRequestSchema);
   if ('error' in result) return result.error;
 
   try {
+    const opts: { skipRecovery?: boolean; imageTag?: string } = {};
+    if (result.data.skipRecovery) opts.skipRecovery = true;
+    if (result.data.imageTag) opts.imageTag = result.data.imageTag;
     await withDORetry(
       instanceStubFactory(c.env, result.data.userId),
-      stub => stub.start(result.data.userId),
+      stub => stub.start(result.data.userId, Object.keys(opts).length ? opts : undefined),
       'start'
     );
     return c.json({ ok: true });

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -913,7 +913,12 @@ platform.post('/doctor', async c => {
 // POST /api/platform/start
 const StartRequestSchema = UserIdRequestSchema.extend({
   skipRecovery: z.boolean().optional(),
-  imageTag: z.string().min(1).optional(),
+  imageTag: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/)
+    .optional(),
 });
 platform.post('/start', async c => {
   const result = await parseBody(c, StartRequestSchema);

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1622,7 +1622,9 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       size="sm"
                       variant="outline"
                       disabled={machineActionPending || machineRestartBlocked}
-                      onClick={() => void machineRedeploy({ instanceId: data.id, imageTag: undefined })}
+                      onClick={() =>
+                        void machineRedeploy({ instanceId: data.id, imageTag: undefined })
+                      }
                     >
                       {isMachineRedeploying ? (
                         <Loader2 className="mr-1 h-4 w-4 animate-spin" />
@@ -1635,7 +1637,9 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       size="sm"
                       variant="outline"
                       disabled={machineActionPending || machineRestartBlocked}
-                      onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
+                      onClick={() =>
+                        void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })
+                      }
                     >
                       {isMachineUpgrading ? (
                         <Loader2 className="mr-1 h-4 w-4 animate-spin" />

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1094,7 +1094,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
   };
 
-  const machineControlsEnabled = data?.destroyed_at === null && !!data?.workerStatus?.flyMachineId;
+  const machineControlsEnabled = data?.destroyed_at === null;
+  const hasMachine = !!data?.workerStatus?.flyMachineId;
 
   const invalidateMachineQueries = () => {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
@@ -1108,6 +1109,18 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
       },
       onError: err => {
         toast.error(`Failed to start machine: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: machineCreate, isPending: isMachineCreating } = useMutation(
+    trpc.admin.kiloclawInstances.machineCreate.mutationOptions({
+      onSuccess: () => {
+        toast.success('Machine create requested');
+        invalidateMachineQueries();
+      },
+      onError: err => {
+        toast.error(`Failed to create machine: ${err.message}`);
       },
     })
   );
@@ -1259,7 +1272,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     machineStatus === 'starting' ||
     machineStatus === 'restarting';
   const machineActionPending =
-    isMachineStarting || isMachineStopping || isMachineRedeploying || isMachineUpgrading;
+    isMachineStarting ||
+    isMachineCreating ||
+    isMachineStopping ||
+    isMachineRedeploying ||
+    isMachineUpgrading;
   const gatewayActionPending =
     isGatewayStarting ||
     isGatewayStopping ||
@@ -1573,58 +1590,76 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             </CardHeader>
             <CardContent>
               <div className="flex flex-wrap gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={machineActionPending}
-                  onClick={() => void machineStart({ userId: data.user_id })}
-                >
-                  {isMachineStarting ? (
-                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Play className="mr-1 h-4 w-4" />
-                  )}
-                  Start Machine
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={machineActionPending}
-                  onClick={() => void machineStop({ userId: data.user_id })}
-                >
-                  {isMachineStopping ? (
-                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Square className="mr-1 h-4 w-4" />
-                  )}
-                  Stop Machine
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={machineActionPending || machineRestartBlocked}
-                  onClick={() => void machineRedeploy({ instanceId: data.id, imageTag: undefined })}
-                >
-                  {isMachineRedeploying ? (
-                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                  ) : (
-                    <RotateCw className="mr-1 h-4 w-4" />
-                  )}
-                  Redeploy
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={machineActionPending || machineRestartBlocked}
-                  onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
-                >
-                  {isMachineUpgrading ? (
-                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                  ) : (
-                    <ArrowUpCircle className="mr-1 h-4 w-4" />
-                  )}
-                  Upgrade to Latest
-                </Button>
+                {hasMachine ? (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={machineActionPending}
+                      onClick={() => void machineStart({ userId: data.user_id })}
+                    >
+                      {isMachineStarting ? (
+                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Play className="mr-1 h-4 w-4" />
+                      )}
+                      Start Machine
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={machineActionPending}
+                      onClick={() => void machineStop({ userId: data.user_id })}
+                    >
+                      {isMachineStopping ? (
+                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Square className="mr-1 h-4 w-4" />
+                      )}
+                      Stop Machine
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={machineActionPending || machineRestartBlocked}
+                      onClick={() => void machineRedeploy({ instanceId: data.id, imageTag: undefined })}
+                    >
+                      {isMachineRedeploying ? (
+                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                      ) : (
+                        <RotateCw className="mr-1 h-4 w-4" />
+                      )}
+                      Redeploy
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={machineActionPending || machineRestartBlocked}
+                      onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
+                    >
+                      {isMachineUpgrading ? (
+                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                      ) : (
+                        <ArrowUpCircle className="mr-1 h-4 w-4" />
+                      )}
+                      Upgrade to Latest
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={machineActionPending}
+                    onClick={() => void machineCreate({ userId: data.user_id })}
+                  >
+                    {isMachineCreating ? (
+                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Play className="mr-1 h-4 w-4" />
+                    )}
+                    Create Machine
+                  </Button>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -127,12 +127,12 @@ export class KiloClawInternalClient {
     );
   }
 
-  async start(userId: string): Promise<{ ok: true }> {
+  async start(userId: string, opts?: { skipRecovery?: boolean; imageTag?: string }): Promise<{ ok: true }> {
     return this.request(
       '/api/platform/start',
       {
         method: 'POST',
-        body: JSON.stringify({ userId }),
+        body: JSON.stringify({ userId, ...opts }),
       },
       { userId }
     );

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -127,7 +127,10 @@ export class KiloClawInternalClient {
     );
   }
 
-  async start(userId: string, opts?: { skipRecovery?: boolean; imageTag?: string }): Promise<{ ok: true }> {
+  async start(
+    userId: string,
+    opts?: { skipRecovery?: boolean; imageTag?: string }
+  ): Promise<{ ok: true }> {
     return this.request(
       '/api/platform/start',
       {

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -523,19 +523,25 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
   }),
 
   machineCreate: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
-    const fallbackMessage = 'Failed to create machine';
+    // Look up any version pin so the new machine uses it (non-fatal).
+    let imageTag: string | undefined;
     try {
-      // Look up any version pin for this user so the new machine uses it.
       const [pin] = await db
         .select({ image_tag: kiloclaw_version_pins.image_tag })
         .from(kiloclaw_version_pins)
         .where(eq(kiloclaw_version_pins.user_id, input.userId))
         .limit(1);
+      imageTag = pin?.image_tag || undefined;
+    } catch (err) {
+      console.error('Failed to look up version pin for user:', input.userId, err);
+    }
 
+    const fallbackMessage = 'Failed to create machine';
+    try {
       const client = new KiloClawInternalClient();
       return await client.start(input.userId, {
         skipRecovery: true,
-        imageTag: pin?.image_tag ?? undefined,
+        imageTag,
       });
     } catch (err) {
       console.error('Failed to create machine for user:', input.userId, err);

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -523,25 +523,20 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
   }),
 
   machineCreate: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
-    // Look up any version pin so the new machine uses it (non-fatal).
-    let imageTag: string | undefined;
+    const fallbackMessage = 'Failed to create machine';
     try {
+      // Look up any version pin so the new machine uses the pinned tag.
+      // Fatal if DB fails — deploying the wrong version is worse than failing.
       const [pin] = await db
         .select({ image_tag: kiloclaw_version_pins.image_tag })
         .from(kiloclaw_version_pins)
         .where(eq(kiloclaw_version_pins.user_id, input.userId))
         .limit(1);
-      imageTag = pin?.image_tag || undefined;
-    } catch (err) {
-      console.error('Failed to look up version pin for user:', input.userId, err);
-    }
 
-    const fallbackMessage = 'Failed to create machine';
-    try {
       const client = new KiloClawInternalClient();
       return await client.start(input.userId, {
         skipRecovery: true,
-        imageTag,
+        imageTag: pin?.image_tag || undefined,
       });
     } catch (err) {
       console.error('Failed to create machine for user:', input.userId, err);

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,6 +1,6 @@
 import { adminProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
-import { kiloclaw_instances, kilocode_users } from '@kilocode/db/schema';
+import { kiloclaw_instances, kiloclaw_version_pins, kilocode_users } from '@kilocode/db/schema';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import {
@@ -518,6 +518,27 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       return await client.start(input.userId);
     } catch (err) {
       console.error('Failed to start machine for user:', input.userId, err);
+      throwKiloclawAdminError(err, fallbackMessage);
+    }
+  }),
+
+  machineCreate: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
+    const fallbackMessage = 'Failed to create machine';
+    try {
+      // Look up any version pin for this user so the new machine uses it.
+      const [pin] = await db
+        .select({ image_tag: kiloclaw_version_pins.image_tag })
+        .from(kiloclaw_version_pins)
+        .where(eq(kiloclaw_version_pins.user_id, input.userId))
+        .limit(1);
+
+      const client = new KiloClawInternalClient();
+      return await client.start(input.userId, {
+        skipRecovery: true,
+        imageTag: pin?.image_tag ?? undefined,
+      });
+    } catch (err) {
+      console.error('Failed to create machine for user:', input.userId, err);
       throwKiloclawAdminError(err, fallbackMessage);
     }
   }),


### PR DESCRIPTION
## Summary
- Adds a "Create Machine" button in the admin KiloClaw instance detail for instances that have lost their `flyMachineId` (e.g. after DO state loss)
- The button calls `start()` with `skipRecovery: true` to bypass metadata recovery (which may fail due to cooldown/missing Fly app) and directly create a new Fly machine
- Looks up any version pin from Postgres so the new machine uses the pinned image tag instead of falling back to `latest`
- Calls `ensureApp` in `buildUserEnvVars` before `ensureEnvKey` so the App DO's state is recovered when its storage was wiped

## Loom — Kilo team only
https://www.loom.com/share/a2c0872adb3f477383b45215d5b4ff71

## Changes
- **DO `start()`/`_startInner()`**: Accept `opts?: { skipRecovery?: boolean; imageTag?: string }` — skip metadata recovery and/or override image tag
- **Platform `/start` route**: Extended schema with `skipRecovery` and validated `imageTag` (max 128 chars, Docker tag regex)
- **Internal client**: Thread `opts` through to platform route
- **Admin TRPC**: New `machineCreate` mutation — looks up version pin, calls `start` with `skipRecovery: true`
- **Frontend**: Show "Create Machine" button when `flyMachineId` is null, existing Start/Stop/Redeploy/Upgrade when it exists
- **`buildUserEnvVars`**: Call `ensureApp` on App DO before `ensureEnvKey` to handle missing App DO state

## Test plan
- [ ] Navigate to an admin instance detail with no `flyMachineId` — verify "Create Machine" button appears
- [ ] Click "Create Machine" — verify machine is created with the pinned image tag
- [ ] Navigate to an instance with a `flyMachineId` — verify normal Start/Stop/Redeploy/Upgrade buttons appear
- [ ] Verify destroyed instances don't show machine controls