### PR TITLE
feat(gastown): add GitHub OAuth Device Flow backend support

### DIFF
--- a/cloudflare-gastown/src/handlers/town-config.handler.ts
+++ b/cloudflare-gastown/src/handlers/town-config.handler.ts
@@ -70,6 +70,7 @@ function maskSensitiveValues(config: TownConfig): TownConfig {
   return {
     ...config,
     kilocode_token: maskToken(config.kilocode_token),
+    github_cli_pat: maskToken(config.github_cli_pat),
     env_vars: envVars,
     git_auth: {
       ...config.git_auth,

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -859,6 +859,190 @@ export const gastownRouter = router({
       await townStub.forceRefreshContainerToken();
     }),
 
+  // ── GitHub OAuth Device Flow ────────────────────────────────────────
+
+  githubOAuthDeviceCode: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const clientId = ctx.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub OAuth is not configured (missing GITHUB_OAUTH_CLIENT_ID)',
+        });
+      }
+
+      const response = await fetch('https://github.com/login/device/code', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          scope: 'repo read:user user:email',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub device code request failed: ${response.status}`,
+        });
+      }
+
+      const DeviceCodeResponse = z.object({
+        device_code: z.string(),
+        user_code: z.string(),
+        verification_uri: z.string(),
+        expires_in: z.number(),
+        interval: z.number(),
+      });
+      const raw: unknown = await response.json();
+      const data = DeviceCodeResponse.parse(raw);
+
+      return {
+        userCode: data.user_code,
+        verificationUri: data.verification_uri,
+        deviceCode: data.device_code,
+        expiresIn: data.expires_in,
+        interval: data.interval,
+      };
+    }),
+
+  githubOAuthPoll: gastownProcedure
+    .input(z.object({ townId: z.string().uuid(), deviceCode: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const clientId = ctx.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub OAuth is not configured (missing GITHUB_OAUTH_CLIENT_ID)',
+        });
+      }
+
+      const response = await fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          device_code: input.deviceCode,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub token exchange failed: ${response.status}`,
+        });
+      }
+
+      const TokenResponse = z.object({
+        access_token: z.string().optional(),
+        token_type: z.string().optional(),
+        scope: z.string().optional(),
+        error: z.string().optional(),
+        error_description: z.string().optional(),
+      });
+      const raw: unknown = await response.json();
+      const data = TokenResponse.parse(raw);
+
+      if (data.error === 'authorization_pending' || data.error === 'slow_down') {
+        return { status: 'pending' as const };
+      }
+
+      if (data.error) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: data.error_description ?? data.error,
+        });
+      }
+
+      if (!data.access_token) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'GitHub returned no access token',
+        });
+      }
+
+      // Fetch the authenticated GitHub user
+      const userResponse = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${data.access_token}`,
+          Accept: 'application/json',
+          'User-Agent': 'Kilo-Gastown',
+        },
+      });
+
+      if (!userResponse.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub user lookup failed: ${userResponse.status}`,
+        });
+      }
+
+      const GitHubUser = z.object({
+        login: z.string(),
+        avatar_url: z.string(),
+      });
+      const userRaw: unknown = await userResponse.json();
+      const user = GitHubUser.parse(userRaw);
+
+      // Store the token and OAuth metadata
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.updateTownConfig({
+        github_cli_pat: data.access_token,
+        github_cli_oauth_username: user.login,
+        github_cli_oauth_connected_at: new Date().toISOString(),
+      });
+
+      return {
+        status: 'complete' as const,
+        username: user.login,
+        avatarUrl: user.avatar_url,
+      };
+    }),
+
+  githubOAuthDisconnect: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.updateTownConfig({
+        github_cli_pat: '',
+        github_cli_oauth_username: '',
+        github_cli_oauth_connected_at: '',
+      });
+    }),
+
+  githubOAuthStatus: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const config = await townStub.getTownConfig();
+
+      if (config.github_cli_oauth_username && config.github_cli_pat) {
+        return {
+          connected: true as const,
+          username: config.github_cli_oauth_username,
+          connectedAt: config.github_cli_oauth_connected_at,
+        };
+      }
+
+      return { connected: false as const };
+    }),
+
   // ── Events ──────────────────────────────────────────────────────────
 
   getBeadEvents: gastownProcedure

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -271,6 +271,12 @@ export const TownConfigSchema = z.object({
    *  Git clone/push still uses the integration token from git_auth. */
   github_cli_pat: z.string().optional(),
 
+  /** GitHub username resolved from OAuth Device Flow (display only). */
+  github_cli_oauth_username: z.string().optional(),
+
+  /** ISO timestamp of when GitHub was connected via OAuth. */
+  github_cli_oauth_connected_at: z.string().optional(),
+
   /** Custom git commit author name. When set, the user becomes the primary author
    *  and the AI agent is added as co-author (unless disable_ai_coauthor is true). */
   git_author_name: z.string().optional(),
@@ -327,6 +333,8 @@ export const TownConfigUpdateSchema = z.object({
     .optional(),
   staged_convoys_default: z.boolean().optional(),
   github_cli_pat: z.string().optional(),
+  github_cli_oauth_username: z.string().optional(),
+  github_cli_oauth_connected_at: z.string().optional(),
   git_author_name: z.string().optional(),
   git_author_email: z.string().optional(),
   disable_ai_coauthor: z.boolean().optional(),

--- a/cloudflare-gastown/worker-configuration.d.ts
+++ b/cloudflare-gastown/worker-configuration.d.ts
@@ -60,6 +60,7 @@ declare namespace Cloudflare {
 		CF_VERSION_METADATA?: WorkerVersionMetadata;
 		SENTRY_DSN?: string; // worker secret
 		SENTRY_RELEASE?: string; // deploy-time --var
+		GITHUB_OAUTH_CLIENT_ID?: string;
 	}
 }
 interface Env extends Cloudflare.Env {}


### PR DESCRIPTION
## Summary

Adds backend support for GitHub OAuth Device Flow to enable users to connect their GitHub account via the settings UI instead of manually pasting a PAT. Changes include:

- **TownConfig schema**: Added `github_cli_oauth_username` and `github_cli_oauth_connected_at` fields to both `TownConfigSchema` and `TownConfigUpdateSchema` for storing OAuth connection metadata.
- **Four tRPC procedures**: `githubOAuthDeviceCode` (initiates device flow), `githubOAuthPoll` (polls for token completion and fetches GitHub user), `githubOAuthDisconnect` (clears token and metadata), `githubOAuthStatus` (returns connected state without exposing the token).
- **Security fix**: `github_cli_pat` is now masked in `maskSensitiveValues` — it was previously returned unmasked via `getTownConfig`.
- **Env type**: `GITHUB_OAUTH_CLIENT_ID` added to the Cloudflare worker `Env` type.

All IO boundaries are validated with Zod schemas. All endpoints verify town ownership before proceeding.

## Verification

- [x] Code review: correctness, security, style consistency, IO validation
- [x] Verified ownership checks on all four new endpoints
- [x] Verified token masking in `maskSensitiveValues`
- [x] Verified Zod schema consistency between `TownConfigSchema` and `TownConfigUpdateSchema`

## Visual Changes

N/A

## Reviewer Notes

- The `slow_down` response from GitHub's device flow is treated as `pending` — the frontend (separate bead) can handle interval backoff client-side.
- No tests added — these are tRPC procedures wrapping external GitHub API calls, and the codebase style guidelines discourage mocking.
- The `github_cli_oauth_username` is a public GitHub username stored in DO SQLite (TownConfig), not the main Postgres DB, so the GDPR `softDeleteUser` flow is not directly applicable.