### PR TITLE
feat(ui): update Gastown branding to Gas Town

### DIFF
--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -151,7 +151,7 @@ export default function OrganizationAppSidebar({
     ...(currentRole !== 'billing_manager'
       ? [
           {
-            title: 'Gastown',
+            title: 'Gas Town',
             icon: Bot,
             url: `/organizations/${organizationId}/gastown`,
           },

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -129,7 +129,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     ...(isGastownEnabled || isDevelopment
       ? [
           {
-            title: 'Gastown',
+            title: 'Gas Town',
             icon: Factory,
             url: '/gastown',
           },

--- a/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/src/app/(app)/gastown/TownListPageClient.tsx
@@ -42,7 +42,7 @@ export function TownListPageClient() {
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="flex items-center gap-3">
-                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gastown</h1>
+                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gas Town</h1>
                 <Badge variant="beta">beta</Badge>
               </div>
               <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">

--- a/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
@@ -81,7 +81,7 @@ export function OrgTownListPageClient({ organizationId, role }: OrgTownListPageC
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="flex items-center gap-3">
-                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gastown</h1>
+                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gas Town</h1>
                 <Badge variant="beta">beta</Badge>
               </div>
               <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">

--- a/src/app/admin/components/AppSidebar.tsx
+++ b/src/app/admin/components/AppSidebar.tsx
@@ -146,7 +146,7 @@ const productEngineeringItems: MenuItem[] = [
     icon: () => <Database />,
   },
   {
-    title: () => 'Gastown',
+    title: () => 'Gas Town',
     url: '/admin/gastown',
     icon: () => <Network />,
   },

--- a/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
@@ -152,7 +152,7 @@ export function UserAdminGastown({ userId }: { userId: string }) {
   return (
     <Card className="col-span-1 lg:col-span-4">
       <CardHeader>
-        <CardTitle>Gastown</CardTitle>
+        <CardTitle>Gas Town</CardTitle>
         <CardDescription>Towns and rigs owned by this user</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">

--- a/src/app/admin/gastown/page.tsx
+++ b/src/app/admin/gastown/page.tsx
@@ -507,7 +507,7 @@ export default function GastownAnalyticsPage() {
     <AdminPage
       breadcrumbs={
         <BreadcrumbItem>
-          <BreadcrumbLink href="/admin/gastown">Gastown Analytics</BreadcrumbLink>
+          <BreadcrumbLink href="/admin/gastown">Gas Town Analytics</BreadcrumbLink>
         </BreadcrumbItem>
       }
       buttons={

--- a/src/app/admin/gastown/towns/[townId]/agents/[agentId]/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/agents/[agentId]/page.tsx
@@ -17,7 +17,7 @@ export default async function AgentInspectorPage({
   const breadcrumbs = (
     <>
       <BreadcrumbItem>
-        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+        <BreadcrumbLink href="/admin/gastown">Gas Town</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbSeparator />
       <BreadcrumbItem>

--- a/src/app/admin/gastown/towns/[townId]/audit/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/audit/page.tsx
@@ -13,7 +13,7 @@ export default async function AuditLogPage({ params }: { params: Promise<{ townI
   const breadcrumbs = (
     <>
       <BreadcrumbItem>
-        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+        <BreadcrumbLink href="/admin/gastown">Gas Town</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbSeparator />
       <BreadcrumbItem>

--- a/src/app/admin/gastown/towns/[townId]/beads/[beadId]/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/beads/[beadId]/page.tsx
@@ -17,7 +17,7 @@ export default async function BeadInspectorPage({
   const breadcrumbs = (
     <>
       <BreadcrumbItem>
-        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+        <BreadcrumbLink href="/admin/gastown">Gas Town</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbSeparator />
       <BreadcrumbItem>

--- a/src/app/admin/gastown/towns/[townId]/page.tsx
+++ b/src/app/admin/gastown/towns/[townId]/page.tsx
@@ -17,7 +17,7 @@ export default async function TownInspectorPage({
   const breadcrumbs = (
     <>
       <BreadcrumbItem>
-        <BreadcrumbLink href="/admin/gastown">Gastown</BreadcrumbLink>
+        <BreadcrumbLink href="/admin/gastown">Gas Town</BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbSeparator />
       <BreadcrumbItem>


### PR DESCRIPTION
## Summary

Updated all user-facing text from "Gastown" to "Gas Town" across the application UI:
- Navigation sidebars (personal, organization, admin)
- Page headings and main titles
- Breadcrumb navigation
- Admin panel card titles

This is a purely cosmetic branding update that preserves all underlying functionality and URL structure.

## Verification

- ✅ Verified all 11 UI text occurrences were updated consistently
- ✅ Confirmed no functional code was modified
- ✅ URL paths and routing remain unchanged

## Visual Changes

Before: UI displayed "Gastown" in navigation and page titles
After: UI displays "Gas Town" in navigation and page titles

## Reviewer Notes

This is a straightforward branding update with no functional changes. All modifications are simple string replacements in user-facing text.