### PR TITLE
fix(kiloclaw): treat analytics event timestamps as UTC

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -68,13 +68,25 @@ import {
   type KiloclawEventRow,
 } from '@/app/admin/api/kiloclaw-analytics/hooks';
 
+function parseTimestamp(timestamp: string): Date {
+  const normalized = timestamp.includes('T') ? timestamp : timestamp.replace(' ', 'T');
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalized);
+  const parsed = new Date(hasTimezone ? normalized : `${normalized}Z`);
+
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed;
+  }
+
+  return new Date(timestamp);
+}
+
 function formatRelativeTime(timestamp: string | null): string {
   if (!timestamp) return '—';
-  return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+  return formatDistanceToNow(parseTimestamp(timestamp), { addSuffix: true });
 }
 
 function formatAbsoluteTime(timestamp: string): string {
-  return new Date(timestamp).toLocaleString();
+  return parseTimestamp(timestamp).toLocaleString();
 }
 
 function formatEpochTime(epoch: number | null): string {
@@ -924,51 +936,54 @@ function InstanceEventsCard({ sandboxId }: { sandboxId: string }) {
                 </tr>
               </thead>
               <tbody>
-                {data.data.map((row: KiloclawEventRow, i: number) => (
-                  <tr key={`${row.timestamp}-${i}`} className="border-b last:border-0">
-                    <td className="py-2 pr-4 whitespace-nowrap">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="text-xs">
-                            {formatDistanceToNow(new Date(row.timestamp), { addSuffix: true })}
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>{new Date(row.timestamp).toLocaleString()}</TooltipContent>
-                      </Tooltip>
-                    </td>
-                    <td className="py-2 pr-4">
-                      <code className="text-xs">{row.event}</code>
-                    </td>
-                    <td className="py-2 pr-4">
-                      <DeliveryBadge delivery={row.delivery} />
-                    </td>
-                    <td className="py-2 pr-4">
-                      <span className="text-xs">{row.status || '—'}</span>
-                    </td>
-                    <td className="py-2 pr-4">
-                      <span className="text-xs">{row.label || '—'}</span>
-                    </td>
-                    <td className="py-2 pr-4 whitespace-nowrap">
-                      <span className="text-xs">{formatDuration(row.duration_ms)}</span>
-                    </td>
-                    <td className="py-2">
-                      {row.error ? (
+                {data.data.map((row: KiloclawEventRow, i: number) => {
+                  const eventTimestamp = parseTimestamp(row.timestamp);
+                  return (
+                    <tr key={`${row.timestamp}-${i}`} className="border-b last:border-0">
+                      <td className="py-2 pr-4 whitespace-nowrap">
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span className="text-destructive block max-w-[200px] truncate text-xs">
-                              {row.error}
+                            <span className="text-xs">
+                              {formatDistanceToNow(eventTimestamp, { addSuffix: true })}
                             </span>
                           </TooltipTrigger>
-                          <TooltipContent className="max-w-[400px]">
-                            <p className="break-words text-xs">{row.error}</p>
-                          </TooltipContent>
+                          <TooltipContent>{eventTimestamp.toLocaleString()}</TooltipContent>
                         </Tooltip>
-                      ) : (
-                        <span className="text-muted-foreground text-xs">—</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <code className="text-xs">{row.event}</code>
+                      </td>
+                      <td className="py-2 pr-4">
+                        <DeliveryBadge delivery={row.delivery} />
+                      </td>
+                      <td className="py-2 pr-4">
+                        <span className="text-xs">{row.status || '—'}</span>
+                      </td>
+                      <td className="py-2 pr-4">
+                        <span className="text-xs">{row.label || '—'}</span>
+                      </td>
+                      <td className="py-2 pr-4 whitespace-nowrap">
+                        <span className="text-xs">{formatDuration(row.duration_ms)}</span>
+                      </td>
+                      <td className="py-2">
+                        {row.error ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-destructive block max-w-[200px] truncate text-xs">
+                                {row.error}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[400px]">
+                              <p className="break-words text-xs">{row.error}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <span className="text-muted-foreground text-xs">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary

- Fixes admin KiloClaw instance event times showing in the future by normalizing Analytics Engine timestamps before display.
- Adds `parseTimestamp` in the instance detail view so timestamps without an explicit timezone are interpreted as UTC, then reuses that parsed value for both relative and absolute rendering.
- Keeps the change scoped to the admin UI event table (`DO & Reconcile Events`) with no backend or data model changes.

## Verification

- Pre-push hook checks triggered on `git push`:
- `pnpm format:check` ✅ pass
- `pnpm lint` ✅ pass
- [ ] Additional verification details from reviewer/author

## Visual Changes

| Before | After |
| ------ | ----- |
| DO & Reconcile Events shows future relative times (e.g., `in about 4 hours`) for recent rows. | DO & Reconcile Events shows correct past relative times (e.g., `about 2 minutes ago`) for the same rows. |

## Reviewer Notes

- Risk is low and isolated to timestamp parsing in one admin component.
- Parsing logic intentionally handles both explicit-timezone timestamps and timezone-less SQL-style timestamps to avoid regressions across data sources.