### PR TITLE
fix(ui): guard chat input keydown handlers against IME composition

### DIFF
--- a/src/components/app-builder/PromptInput.tsx
+++ b/src/components/app-builder/PromptInput.tsx
@@ -265,7 +265,7 @@ export function PromptInput({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       // Ignore keyboard events during IME composition (Chinese, Japanese, Korean input)
-      if (e.nativeEvent.isComposing) return;
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
 
       if (isLanding) {
         // Landing: Cmd/Ctrl+Enter to submit

--- a/src/components/app-builder/PromptInput.tsx
+++ b/src/components/app-builder/PromptInput.tsx
@@ -264,6 +264,9 @@ export function PromptInput({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Ignore keyboard events during IME composition (Chinese, Japanese, Korean input)
+      if (e.nativeEvent.isComposing) return;
+
       if (isLanding) {
         // Landing: Cmd/Ctrl+Enter to submit
         if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {

--- a/src/components/cloud-agent-next/ChatInput.tsx
+++ b/src/components/cloud-agent-next/ChatInput.tsx
@@ -152,7 +152,7 @@ export function ChatInput({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     // Ignore keyboard events during IME composition (Chinese, Japanese, Korean input)
-    if (e.nativeEvent.isComposing) return;
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
 
     if (showAutocomplete && filteredCommands.length > 0) {
       switch (e.key) {

--- a/src/components/cloud-agent-next/ChatInput.tsx
+++ b/src/components/cloud-agent-next/ChatInput.tsx
@@ -151,6 +151,9 @@ export function ChatInput({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ignore keyboard events during IME composition (Chinese, Japanese, Korean input)
+    if (e.nativeEvent.isComposing) return;
+
     if (showAutocomplete && filteredCommands.length > 0) {
       switch (e.key) {
         case 'ArrowDown':

--- a/src/components/cloud-agent/ChatInput.tsx
+++ b/src/components/cloud-agent/ChatInput.tsx
@@ -139,6 +139,9 @@ export function ChatInput({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ignore keyboard events during IME composition (Chinese, Japanese, Korean input)
+    if (e.nativeEvent.isComposing) return;
+
     if (showAutocomplete && filteredCommands.length > 0) {
       switch (e.key) {
         case 'ArrowDown':

--- a/src/components/cloud-agent/ChatInput.tsx
+++ b/src/components/cloud-agent/ChatInput.tsx
@@ -140,7 +140,7 @@ export function ChatInput({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     // Ignore keyboard events during IME composition (Chinese, Japanese, Korean input)
-    if (e.nativeEvent.isComposing) return;
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
 
     if (showAutocomplete && filteredCommands.length > 0) {
       switch (e.key) {


### PR DESCRIPTION
## Summary

Fixes #1442. Chinese/Japanese/Korean input methods (IME) use a composition phase where Enter selects a candidate character rather than confirming input. Without checking `isComposing`, the `onKeyDown` Enter-to-submit handler fires during composition, submitting partial pinyin text or interfering with character selection.

Added `e.nativeEvent.isComposing` early-return guard at the top of `handleKeyDown` in all three chat input components:
- `src/components/cloud-agent/ChatInput.tsx`
- `src/components/cloud-agent-next/ChatInput.tsx`
- `src/components/app-builder/PromptInput.tsx`

The xterm.js terminal (`useXtermPty.ts`) was also investigated but xterm.js v6 handles IME composition internally — no changes needed there.

## Verification

- `pnpm typecheck` — all packages pass with zero errors
- Manual review of all `handleKeyDown` handlers in the codebase to confirm no other chat inputs are affected

## Visual Changes

N/A

## Reviewer Notes

The guard uses `e.nativeEvent.isComposing` (accessing the native DOM `KeyboardEvent.isComposing`) rather than React's synthetic event, since React's `KeyboardEvent` type doesn't expose `isComposing` directly. This is the standard approach for IME-safe keyboard handling in React and is supported in all modern browsers.