### PR TITLE
chore(gastown): bump TownContainerDO max_instances from 100 to 500

### DIFF
--- a/cloudflare-gastown/wrangler.jsonc
+++ b/cloudflare-gastown/wrangler.jsonc
@@ -35,7 +35,7 @@
       "class_name": "TownContainerDO",
       "image": "./container/Dockerfile",
       "instance_type": "standard-4",
-      "max_instances": 100,
+      "max_instances": 500,
     },
   ],
 


### PR DESCRIPTION
## Summary

Bump `max_instances` on the `TownContainerDO` Durable Object container class from 100 to 500 to support more concurrent towns ahead of soft launch.

Previously bumped from 20 to 100 in PR #1232. With increased user load expected, 100 is no longer sufficient.

Closes #1448

## Verification

- [x] Verified the change is a single-line config update in `cloudflare-gastown/wrangler.jsonc`
- [x] No code logic changes — only deployment configuration

## Visual Changes

N/A

## Reviewer Notes

This is a deployment config change only. The `max_instances` field controls the maximum number of container instances Cloudflare will spin up for the `TownContainerDO` class. No code changes are required.