### PR TITLE
feat(admin): add stopped status to KiloClaw instances view

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -48,7 +48,7 @@ import {
 
 type SortField = 'created_at' | 'destroyed_at';
 type SortOrder = 'asc' | 'desc';
-type StatusFilter = 'all' | 'active' | 'destroyed';
+type StatusFilter = 'all' | 'active' | 'stopped' | 'destroyed';
 
 function toSortedSearchParams(obj: Record<string, unknown>): URLSearchParams {
   const params = new URLSearchParams();
@@ -77,6 +77,7 @@ function formatLifespan(minutes: number | null): string {
 type OverviewData = {
   totalInstances: number;
   activeInstances: number;
+  stoppedInstances: number;
   destroyedInstances: number;
   uniqueUsers: number;
   last24hCreated: number;
@@ -87,7 +88,7 @@ type OverviewData = {
 
 function OverviewStatsCards({ data }: { data: OverviewData }) {
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium">Total Instances</CardTitle>
@@ -109,6 +110,16 @@ function OverviewStatsCards({ data }: { data: OverviewData }) {
           <p className="text-muted-foreground text-xs">
             {data.destroyedInstances.toLocaleString()} destroyed
           </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Stopped Instances</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{data.stoppedInstances.toLocaleString()}</div>
+          <p className="text-muted-foreground text-xs">Suspended by billing lifecycle</p>
         </CardContent>
       </Card>
 
@@ -445,6 +456,7 @@ export function KiloclawInstancesPage() {
           <SelectContent>
             <SelectItem value="all">All Instances</SelectItem>
             <SelectItem value="active">Active Only</SelectItem>
+            <SelectItem value="stopped">Stopped Only</SelectItem>
             <SelectItem value="destroyed">Destroyed Only</SelectItem>
           </SelectContent>
         </Select>
@@ -527,12 +539,14 @@ export function KiloclawInstancesPage() {
                     </span>
                   </TableCell>
                   <TableCell>
-                    {instance.destroyed_at === null ? (
+                    {instance.destroyed_at !== null ? (
+                      <Badge variant="secondary">Destroyed</Badge>
+                    ) : instance.suspended_at !== null ? (
+                      <Badge className="bg-amber-600">Stopped</Badge>
+                    ) : (
                       <Badge variant="default" className="bg-green-600">
                         Active
                       </Badge>
-                    ) : (
-                      <Badge variant="secondary">Destroyed</Badge>
                     )}
                   </TableCell>
                   <TableCell

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -48,7 +48,7 @@ import {
 
 type SortField = 'created_at' | 'destroyed_at';
 type SortOrder = 'asc' | 'desc';
-type StatusFilter = 'all' | 'active' | 'stopped' | 'destroyed';
+type StatusFilter = 'all' | 'active' | 'suspended' | 'destroyed';
 
 function toSortedSearchParams(obj: Record<string, unknown>): URLSearchParams {
   const params = new URLSearchParams();
@@ -77,7 +77,7 @@ function formatLifespan(minutes: number | null): string {
 type OverviewData = {
   totalInstances: number;
   activeInstances: number;
-  stoppedInstances: number;
+  suspendedInstances: number;
   destroyedInstances: number;
   uniqueUsers: number;
   last24hCreated: number;
@@ -115,10 +115,10 @@ function OverviewStatsCards({ data }: { data: OverviewData }) {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">Stopped Instances</CardTitle>
+          <CardTitle className="text-sm font-medium">Suspended Instances</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{data.stoppedInstances.toLocaleString()}</div>
+          <div className="text-2xl font-bold">{data.suspendedInstances.toLocaleString()}</div>
           <p className="text-muted-foreground text-xs">Suspended by billing lifecycle</p>
         </CardContent>
       </Card>
@@ -456,7 +456,7 @@ export function KiloclawInstancesPage() {
           <SelectContent>
             <SelectItem value="all">All Instances</SelectItem>
             <SelectItem value="active">Active Only</SelectItem>
-            <SelectItem value="stopped">Stopped Only</SelectItem>
+            <SelectItem value="suspended">Suspended Only</SelectItem>
             <SelectItem value="destroyed">Destroyed Only</SelectItem>
           </SelectContent>
         </Select>
@@ -542,7 +542,7 @@ export function KiloclawInstancesPage() {
                     {instance.destroyed_at !== null ? (
                       <Badge variant="secondary">Destroyed</Badge>
                     ) : instance.suspended_at !== null ? (
-                      <Badge className="bg-amber-600">Stopped</Badge>
+                      <Badge className="bg-amber-600">Suspended</Badge>
                     ) : (
                       <Badge variant="default" className="bg-green-600">
                         Active

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -29,7 +29,7 @@ const ListInstancesSchema = z.object({
   sortBy: z.enum(['created_at', 'destroyed_at']).default('created_at'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
   search: z.string().optional(),
-  status: z.enum(['all', 'active', 'stopped', 'destroyed']).default('all'),
+  status: z.enum(['all', 'active', 'suspended', 'destroyed']).default('all'),
 });
 
 const GetInstanceSchema = z.object({
@@ -220,7 +220,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     if (status === 'active') {
       conditions.push(isNull(kiloclaw_instances.destroyed_at));
       conditions.push(isNull(kiloclaw_subscriptions.suspended_at));
-    } else if (status === 'stopped') {
+    } else if (status === 'suspended') {
       conditions.push(isNull(kiloclaw_instances.destroyed_at));
       conditions.push(isNotNull(kiloclaw_subscriptions.suspended_at));
     } else if (status === 'destroyed') {
@@ -286,12 +286,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
   stats: adminProcedure.input(StatsSchema).query(async ({ input }) => {
     const { days } = input;
 
-    // Overview counts (join subscriptions to derive stopped state)
+    // Overview counts (join subscriptions to derive suspended state)
     const [overview] = await db
       .select({
         total_instances: sql<number>`COUNT(*)::int`,
         active_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL AND ${kiloclaw_subscriptions.suspended_at} IS NULL THEN 1 END)::int`,
-        stopped_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL AND ${kiloclaw_subscriptions.suspended_at} IS NOT NULL THEN 1 END)::int`,
+        suspended_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL AND ${kiloclaw_subscriptions.suspended_at} IS NOT NULL THEN 1 END)::int`,
         destroyed_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NOT NULL THEN 1 END)::int`,
         unique_users: sql<number>`COUNT(DISTINCT ${kiloclaw_instances.user_id})::int`,
       })
@@ -378,7 +378,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       overview: {
         totalInstances: overview?.total_instances ?? 0,
         activeInstances: overview?.active_instances ?? 0,
-        stoppedInstances: overview?.stopped_instances ?? 0,
+        suspendedInstances: overview?.suspended_instances ?? 0,
         destroyedInstances: overview?.destroyed_instances ?? 0,
         uniqueUsers: overview?.unique_users ?? 0,
         last24hCreated: last24h?.count ?? 0,

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,6 +1,6 @@
 import { adminProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
-import { kiloclaw_instances, kilocode_users } from '@kilocode/db/schema';
+import { kiloclaw_instances, kiloclaw_subscriptions, kilocode_users } from '@kilocode/db/schema';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import {
@@ -29,7 +29,7 @@ const ListInstancesSchema = z.object({
   sortBy: z.enum(['created_at', 'destroyed_at']).default('created_at'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
   search: z.string().optional(),
-  status: z.enum(['all', 'active', 'destroyed']).default('all'),
+  status: z.enum(['all', 'active', 'stopped', 'destroyed']).default('all'),
 });
 
 const GetInstanceSchema = z.object({
@@ -123,6 +123,7 @@ export type AdminKiloclawInstance = {
   sandbox_id: string;
   created_at: string;
   destroyed_at: string | null;
+  suspended_at: string | null;
   user_email: string | null;
 };
 
@@ -138,9 +139,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       .select({
         instance: kiloclaw_instances,
         user_email: kilocode_users.google_user_email,
+        suspended_at: kiloclaw_subscriptions.suspended_at,
       })
       .from(kiloclaw_instances)
       .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
+      .leftJoin(
+        kiloclaw_subscriptions,
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+      )
       .where(eq(kiloclaw_instances.id, input.id))
       .limit(1);
 
@@ -154,6 +160,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       sandbox_id: result.instance.sandbox_id,
       created_at: result.instance.created_at,
       destroyed_at: result.instance.destroyed_at,
+      suspended_at: result.suspended_at ?? null,
       user_email: result.user_email,
     };
 
@@ -212,6 +219,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
 
     if (status === 'active') {
       conditions.push(isNull(kiloclaw_instances.destroyed_at));
+      conditions.push(isNull(kiloclaw_subscriptions.suspended_at));
+    } else if (status === 'stopped') {
+      conditions.push(isNull(kiloclaw_instances.destroyed_at));
+      conditions.push(isNotNull(kiloclaw_subscriptions.suspended_at));
     } else if (status === 'destroyed') {
       conditions.push(isNotNull(kiloclaw_instances.destroyed_at));
     }
@@ -225,9 +236,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       .select({
         instance: kiloclaw_instances,
         user_email: kilocode_users.google_user_email,
+        suspended_at: kiloclaw_subscriptions.suspended_at,
       })
       .from(kiloclaw_instances)
       .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
+      .leftJoin(
+        kiloclaw_subscriptions,
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+      )
       .where(whereCondition)
       .orderBy(orderCondition)
       .limit(limit)
@@ -237,6 +253,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(kiloclaw_instances)
       .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
+      .leftJoin(
+        kiloclaw_subscriptions,
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+      )
       .where(whereCondition);
 
     const totalCount = totalCountResult[0]?.count || 0;
@@ -248,6 +268,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       sandbox_id: row.instance.sandbox_id,
       created_at: row.instance.created_at,
       destroyed_at: row.instance.destroyed_at,
+      suspended_at: row.suspended_at ?? null,
       user_email: row.user_email,
     }));
 
@@ -265,15 +286,20 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
   stats: adminProcedure.input(StatsSchema).query(async ({ input }) => {
     const { days } = input;
 
-    // Overview counts
+    // Overview counts (join subscriptions to derive stopped state)
     const [overview] = await db
       .select({
         total_instances: sql<number>`COUNT(*)::int`,
-        active_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL THEN 1 END)::int`,
+        active_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL AND ${kiloclaw_subscriptions.suspended_at} IS NULL THEN 1 END)::int`,
+        stopped_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NULL AND ${kiloclaw_subscriptions.suspended_at} IS NOT NULL THEN 1 END)::int`,
         destroyed_instances: sql<number>`COUNT(CASE WHEN ${kiloclaw_instances.destroyed_at} IS NOT NULL THEN 1 END)::int`,
         unique_users: sql<number>`COUNT(DISTINCT ${kiloclaw_instances.user_id})::int`,
       })
-      .from(kiloclaw_instances);
+      .from(kiloclaw_instances)
+      .leftJoin(
+        kiloclaw_subscriptions,
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+      );
 
     // Time-windowed counts
     const [last24h] = await db
@@ -352,6 +378,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       overview: {
         totalInstances: overview?.total_instances ?? 0,
         activeInstances: overview?.active_instances ?? 0,
+        stoppedInstances: overview?.stopped_instances ?? 0,
         destroyedInstances: overview?.destroyed_instances ?? 0,
         uniqueUsers: overview?.unique_users ?? 0,
         last24hCreated: last24h?.count ?? 0,


### PR DESCRIPTION
## Summary

### Problem

The KiloClaw admin dashboard at `/admin/kiloclaw` only showed two instance states: Active and Destroyed. When the billing lifecycle cron stops a machine (trial expiry, subscription cancellation, past-due), the instance enters an invisible limbo — still marked "active" in the DB but with its machine stopped and subscription suspended. Admins had no way to distinguish these from truly running instances.

### Solution

- Joined `kiloclaw_subscriptions` in the admin `list`, `get`, and `stats` endpoints to surface `suspended_at` alongside instance data.
- Added a tri-state status badge: **Active** (green), **Suspended** (amber), **Destroyed** (grey) — derived from `destroyed_at` and `suspended_at`.
- Added a "Suspended Only" filter option to the status dropdown.
- Added a "Suspended Instances" stats card to the overview dashboard.
- Narrowed the "Active" filter/count to exclude suspended instances (`destroyed_at IS NULL AND suspended_at IS NULL`).
- **Architecture:** No schema migration needed — `suspended_at` already exists on `kiloclaw_subscriptions` with a unique constraint on `user_id`, making the LEFT JOIN 1:1 and safe.

### Why this approach

The alternative was adding an explicit `status` column to `kiloclaw_instances`, but that would require a migration, backfill, and keeping it in sync with the billing lifecycle cron that already manages `suspended_at` on the subscription table. Deriving the state from a JOIN avoids data duplication and is consistent with how the billing system already models suspension.

## Verification

- [x] `pnpm typecheck` — passed (all 30 workspace projects)
- [x] `pnpm lint` (via pre-commit hook) — passed
- [x] `pnpm format:check` (via pre-commit hook) — passed
- [x] Six-agent code review (security, types, logic, data, resources, style) — 0 findings

## Visual Changes

All changes are on the `/admin/kiloclaw` page:

**Overview stats cards (top of page)**
- Previously: 4-card grid — Total Instances, Active Instances, Unique Users, Avg Lifespan.
- Now: 5-card grid — Total Instances, Active Instances, **Suspended Instances** (new), Unique Users, Avg Lifespan.
- The new "Suspended Instances" card shows the count of instances where `suspended_at IS NOT NULL` and subtitle "Suspended by billing lifecycle".
- The "Active Instances" count now excludes suspended instances (previously it included them).

**Status filter dropdown**
- Previously: All Instances, Active Only, Destroyed Only.
- Now: All Instances, Active Only, **Suspended Only** (new), Destroyed Only.

**Instance table status badge**
- Previously: binary — green "Active" badge or grey "Destroyed" badge.
- Now: tri-state — green "Active", **amber "Suspended"** (new), or grey "Destroyed".
- An instance shows "Suspended" when `destroyed_at` is null but the subscription's `suspended_at` is set (billing lifecycle has stopped the machine).

## Reviewer Notes

- The `kiloclaw_subscriptions.user_id` column has a UNIQUE constraint, so the LEFT JOIN cannot produce duplicate rows. If the future multi-instance-per-user model changes this, the join will need to be updated.
- Instances without a subscription row get `suspended_at = null` from the LEFT JOIN, correctly mapping to "Active" status.
- The `active` filter now excludes suspended instances — this is a behavioral change for anyone relying on the "Active Only" filter to include suspended instances.