### PR TITLE
feat(topbar): extract TopBarContext and TopBar component

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,27 +1,25 @@
-import { AnimatedLogo } from '@/components/AnimatedLogo';
 import AppSidebar from './components/AppSidebar';
-import { SidebarProvider, SidebarTrigger, SidebarInset } from '@/components/ui/sidebar';
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { RoleTestingProvider } from '@/contexts/RoleTestingContext';
 import { AdminOmnibox } from '@/components/admin-omnibox';
 import { PrefetchedOrganizations } from './components/PrefetchedOrganizations';
+import { TopBarProvider, TopBar } from '@/components/TopBar';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <RoleTestingProvider>
       <SidebarProvider>
         <PrefetchedOrganizations>
-          <div className="flex min-h-screen w-full">
-            <AppSidebar />
-            <SidebarInset>
-              {/* Mobile header with sidebar trigger */}
-              <header className="bg-background sticky top-0 z-10 flex h-18 items-center justify-between gap-4 border-b p-4 md:hidden">
-                <AnimatedLogo />
-                <SidebarTrigger />
-              </header>
-              {/* Main content */}
-              <main className="bg-background w-full flex-1">{children}</main>
-            </SidebarInset>
-          </div>
+          <TopBarProvider>
+            <div className="flex min-h-screen w-full">
+              <AppSidebar />
+              <SidebarInset>
+                <TopBar />
+                {/* Main content */}
+                <main className="bg-background w-full flex-1">{children}</main>
+              </SidebarInset>
+            </div>
+          </TopBarProvider>
         </PrefetchedOrganizations>
       </SidebarProvider>
       <AdminOmnibox />

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import type { ReactNode } from 'react';
 import { PageContainer } from './layouts/PageContainer';
+import { useSetTopBarTitle } from '@/components/TopBar';
 
 type PageLayoutProps = {
   title: ReactNode;
@@ -9,12 +12,15 @@ type PageLayoutProps = {
 };
 
 export function PageLayout({ title, subtitle, children, headerActions }: PageLayoutProps) {
+  // Push string titles into the topbar; ReactNode titles stay in-page only.
+  useSetTopBarTitle(typeof title === 'string' ? title : null);
+
   return (
     <PageContainer>
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2">
           {typeof title === 'string' ? (
-            <h1 className="text-foreground text-3xl font-bold">{title}</h1>
+            <h1 className="text-foreground text-3xl font-bold md:hidden">{title}</h1>
           ) : (
             title
           )}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useLayoutEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import { AnimatedLogo } from '@/components/AnimatedLogo';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+type TopBarContextValue = {
+  title: string | null;
+  setTitle: (title: string | null) => void;
+  /** Slot for extra elements rendered on the right side of the topbar (e.g. notification bell). */
+  rightSlot: ReactNode;
+  setRightSlot: (node: ReactNode) => void;
+};
+
+const TopBarContext = createContext<TopBarContextValue | null>(null);
+
+export function TopBarProvider({ children }: { children: ReactNode }) {
+  const [title, setTitle] = useState<string | null>(null);
+  const [rightSlot, setRightSlot] = useState<ReactNode>(null);
+
+  return (
+    <TopBarContext.Provider value={{ title, setTitle, rightSlot, setRightSlot }}>
+      {children}
+    </TopBarContext.Provider>
+  );
+}
+
+function useTopBarContext() {
+  const ctx = useContext(TopBarContext);
+  if (!ctx) throw new Error('useTopBarContext must be used within <TopBarProvider>');
+  return ctx;
+}
+
+/**
+ * Sets the topbar title for the lifetime of the calling component.
+ * Cleans up on unmount so navigating away resets the title.
+ */
+export function useSetTopBarTitle(title: string | null) {
+  const { setTitle } = useTopBarContext();
+  useLayoutEffect(() => {
+    setTitle(title);
+    return () => setTitle(null);
+  }, [title, setTitle]);
+}
+
+/**
+ * Returns a stable setter to place arbitrary content in the topbar's right slot.
+ * Intended for the notification bell (wired in a later PR).
+ */
+export function useSetTopBarRightSlot() {
+  const { setRightSlot } = useTopBarContext();
+  return useCallback(
+    (node: ReactNode) => {
+      setRightSlot(node);
+    },
+    [setRightSlot]
+  );
+}
+
+// ── TopBar UI ────────────────────────────────────────────────────────────────
+
+export function TopBar() {
+  const { title, rightSlot } = useTopBarContext();
+
+  return (
+    <header className="bg-background sticky top-0 z-10 flex h-12 shrink-0 items-center justify-between gap-4 border-b px-4">
+      {/* Left: logo + sidebar trigger on mobile, page title on desktop */}
+      <div className="flex items-center gap-3">
+        <div className="md:hidden">
+          <AnimatedLogo />
+        </div>
+        {title && (
+          <h1 className="text-foreground hidden truncate text-lg font-semibold md:block">
+            {title}
+          </h1>
+        )}
+      </div>
+
+      {/* Right: notification slot + sidebar trigger (mobile only) */}
+      <div className="flex items-center gap-2">
+        {rightSlot}
+        <SidebarTrigger className="md:hidden" />
+      </div>
+    </header>
+  );
+}

--- a/src/components/organizations/OrganizationPageHeader.tsx
+++ b/src/components/organizations/OrganizationPageHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { BackButton } from '@/components/BackButton';
+import { useSetTopBarTitle } from '@/components/TopBar';
 import type { ReactNode } from 'react';
 
 type OrganizationPageHeaderProps = {
@@ -28,6 +29,9 @@ export function OrganizationPageHeader({
   const finalTitle =
     typeof title === 'string' ? title.replace('<org name>', organizationName) : title;
 
+  // Push resolved string titles into the topbar
+  useSetTopBarTitle(typeof finalTitle === 'string' ? finalTitle : null);
+
   return (
     <div className="flex w-full flex-col gap-y-4">
       {showBackButton && (
@@ -36,7 +40,7 @@ export function OrganizationPageHeader({
         </div>
       )}
       <div className="flex items-center gap-3">
-        <h1 className="text-3xl font-bold">{finalTitle}</h1>
+        <h1 className="text-3xl font-bold md:hidden">{finalTitle}</h1>
         {badge}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Replace the mobile-only header in the app layout with a universal `TopBar` component backed by a `TopBarContext`. On desktop, the topbar displays the page title in a slim `h-12` bar; on mobile, it shows the animated logo and sidebar trigger (same as before).

- **`TopBarProvider` + `TopBar`** (`src/components/TopBar.tsx`): React context with `useSetTopBarTitle` and `useSetTopBarRightSlot` hooks. The right slot is a placeholder for the notification bell (wired in a follow-up PR).
- **`PageLayout`**: Now calls `useSetTopBarTitle` for string titles. The in-page `<h1>` is hidden on desktop (`md:hidden`) to avoid duplication.
- **`OrganizationPageHeader`**: Same pattern — resolved title (after org name substitution) is pushed to the topbar.
- Pages with custom headers (Cloud Chat, App Builder, etc.) are unaffected — they don't use these components, so the topbar just shows no title.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm format` — no changes needed
- [x] `pnpm lint` (via pre-push hook) — passes
- [x] Reviewed that all ~60 `PageLayout` consumers continue to work (server component pages rendering a `'use client'` component is standard Next.js)

## Visual Changes

| Before | After |
| ------ | ----- |
| No desktop header bar; mobile has logo + sidebar trigger in `h-18` header | Universal `h-12` topbar: desktop shows page title, mobile shows logo + sidebar trigger. Right-side slot reserved for notification bell |

## Reviewer Notes

- `PageLayout` gained a `'use client'` directive since it now uses `useSetTopBarTitle`. Server component pages that import it (e.g. `/organizations`, `/learn`, `/install`) treat it as a client boundary — standard Next.js pattern, no behavior change.
- The `useLayoutEffect` in `useSetTopBarTitle` minimizes title flash during navigation. Cleanup on unmount resets the title to `null`.
- `useSetTopBarRightSlot` is exported but not wired yet — that happens in PR 3 (notification bell).