### PR TITLE
fix(kilo-app): prevent flash of home screen before auth redirect

### DIFF
--- a/kilo-app/src/app/_layout.tsx
+++ b/kilo-app/src/app/_layout.tsx
@@ -19,21 +19,22 @@ function RootLayoutNav() {
   const segments = useSegments();
   const router = useRouter();
 
+  const inAuthGroup = segments[0] === '(auth)';
+  const needsRedirect = !isLoading && ((!token && !inAuthGroup) || (token && inAuthGroup));
+
   useEffect(() => {
     if (isLoading) return;
-
-    const inAuthGroup = segments[0] === '(auth)';
 
     if (!token && !inAuthGroup) {
       router.replace('/(auth)/login');
     } else if (token && inAuthGroup) {
       router.replace('/(app)');
+    } else {
+      void SplashScreen.hideAsync();
     }
+  }, [token, isLoading, inAuthGroup, router]);
 
-    void SplashScreen.hideAsync();
-  }, [token, isLoading, segments, router]);
-
-  if (isLoading) {
+  if (isLoading || needsRedirect) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Fixed splash screen flash showing "Welcome to Kilo!" before redirecting anonymous users to the login screen
- Root cause: `<Slot />` rendered the `(app)` route and `SplashScreen.hideAsync()` fired while `router.replace` to login was still in flight
- Fix: compute redirect need synchronously, gate `<Slot />` rendering on it, and only hide splash screen once the user is on the correct route group

## Test plan
- [x] Open app as anonymous user — should see splash screen then login, no flash of home screen
- [x] Open app as authenticated user — should see splash screen then home screen directly
- [x] Sign out — should redirect to login without flash
- [x] Sign in — should redirect to home without flash