### PR TITLE
feat(gastown): admin impersonation — allow admins to view any town

### DIFF
--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -118,6 +118,7 @@ import {
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { townAuthMiddleware } from './middleware/town-auth.middleware';
 import { orgAuthMiddleware } from './middleware/org-auth.middleware';
+import { adminAuditMiddleware } from './middleware/admin-audit.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
 import { handleGetTownConfig, handleUpdateTownConfig } from './handlers/town-config.handler';
 import {
@@ -432,10 +433,12 @@ app.post('/api/towns/:townId/rigs/:rigId/triage/resolve', c =>
 app.use('/api/users/*', async (c: Context<GastownEnv, string>, next) =>
   kiloAuthMiddleware(c, next)
 );
-// Town routes: kilo auth + town ownership check (supports both personal and org-owned towns).
+// Town routes: kilo auth + admin audit + town ownership check (supports both personal and org-owned towns).
 app.use('/api/towns/:townId/*', async (c: Context<GastownEnv, string>, next) =>
   kiloAuthMiddleware(c, async () => {
-    await townAuthMiddleware(c, next);
+    await adminAuditMiddleware(c, async () => {
+      await townAuthMiddleware(c, next);
+    });
   })
 );
 

--- a/cloudflare-gastown/src/middleware/admin-audit.middleware.ts
+++ b/cloudflare-gastown/src/middleware/admin-audit.middleware.ts
@@ -1,0 +1,40 @@
+import { createMiddleware } from 'hono/factory';
+import type { GastownEnv } from '../gastown.worker';
+import { writeEvent } from '../util/analytics.util';
+
+/**
+ * Middleware that logs admin access to town routes.
+ *
+ * Must run AFTER kiloAuthMiddleware (which sets kiloIsAdmin and kiloUserId).
+ * Only emits an analytics event when the request is from an admin user —
+ * regular user traffic is unaffected.
+ *
+ * The event is written to Cloudflare Analytics Engine with:
+ * - event: 'admin.town_access'
+ * - userId: the admin's user ID
+ * - townId: the town being accessed
+ * - route: the HTTP method + path
+ */
+export const adminAuditMiddleware = createMiddleware<GastownEnv>(async (c, next) => {
+  const isAdmin = c.get('kiloIsAdmin');
+  if (!isAdmin) return next();
+
+  const adminUserId = c.get('kiloUserId');
+  const townId = c.req.param('townId');
+  const method = c.req.method;
+  const path = c.req.path;
+
+  console.log(
+    `[admin-audit] Admin ${adminUserId} accessing town ${townId ?? 'N/A'}: ${method} ${path}`
+  );
+
+  writeEvent(c.env, {
+    event: 'admin.town_access',
+    delivery: 'http',
+    route: `${method} ${path}`,
+    userId: adminUserId,
+    townId: townId ?? undefined,
+  });
+
+  return next();
+});

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -162,7 +162,8 @@ async function resolveTownOwnership(
   try {
     config = await townStub.getTownConfig();
   } catch {
-    if (isAdmin) return { type: 'admin' };
+    // Town config failed to load — the town is deleted or invalid.
+    // Don't return admin bypass here; the town genuinely doesn't exist.
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Town not found' });
   }
 
@@ -257,9 +258,12 @@ async function verifyTownOwnership(env: Env, ctx: TRPCContext, townId: string) {
 /**
  * Verify that a user has access to a rig — either through their personal DO
  * or through an org that owns the rig's town (checked via JWT claims).
- * Admins can access any rig by resolving the owner from TownDO config.
+ *
+ * For admins viewing another user's town, pass `townIdHint` so the function
+ * can resolve the real owner from TownDO config and look up the rig in
+ * their DO.
  */
-async function verifyRigOwnership(env: Env, ctx: TRPCContext, rigId: string) {
+async function verifyRigOwnership(env: Env, ctx: TRPCContext, rigId: string, townIdHint?: string) {
   const { userId, isAdmin, orgMemberships: memberships } = ctx;
 
   // Fast path: personal rig lookup
@@ -277,18 +281,26 @@ async function verifyRigOwnership(env: Env, ctx: TRPCContext, rigId: string) {
     if (orgRig) return orgRig;
   }
 
-  // Admin bypass: try to find the rig by scanning all org stubs is impractical.
-  // Instead, for admin access we rely on the townId being passed alongside
-  // the rigId in procedures that need it. For procedures that only pass rigId,
-  // admins can use the admin-specific endpoints instead.
-  if (isAdmin) {
-    // This is a fallback — admin procedures that need rig access should
-    // prefer using town-scoped admin endpoints. Throw NOT_FOUND if we
-    // genuinely can't locate the rig.
-    throw new TRPCError({
-      code: 'NOT_FOUND',
-      message: 'Rig not found (admin: use town-scoped admin endpoints for cross-user rig access)',
-    });
+  // Admin bypass: resolve the real owner from TownDO config so we can
+  // look up the rig in their DO.
+  if (isAdmin && townIdHint) {
+    const townStub = getTownDOStub(env, townIdHint);
+    let config;
+    try {
+      config = await townStub.getTownConfig();
+    } catch {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Town not found' });
+    }
+
+    if (config.owner_type === 'org' && config.organization_id) {
+      const orgStub = getGastownOrgStub(env, config.organization_id);
+      const orgRig = await orgStub.getRigAsync(rigId);
+      if (orgRig) return orgRig;
+    } else if (config.owner_user_id) {
+      const ownerStub = getGastownUserStub(env, config.owner_user_id);
+      const ownerRig = await ownerStub.getRigAsync(rigId);
+      if (ownerRig) return ownerRig;
+    }
   }
 
   throw new TRPCError({ code: 'NOT_FOUND', message: 'Rig not found' });
@@ -360,10 +372,11 @@ export const gastownRouter = router({
       z.object({
         isAdminViewing: z.boolean(),
         ownerUserId: z.string().nullable(),
+        ownerOrgId: z.string().nullable(),
       })
     )
     .query(async ({ ctx, input }) => {
-      if (!ctx.isAdmin) return { isAdminViewing: false, ownerUserId: null };
+      if (!ctx.isAdmin) return { isAdminViewing: false, ownerUserId: null, ownerOrgId: null };
       const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
       if (ownership.type === 'admin') {
         // Admin is viewing a town they don't own — resolve the real owner
@@ -372,9 +385,10 @@ export const gastownRouter = router({
         return {
           isAdminViewing: true,
           ownerUserId: config.owner_user_id ?? null,
+          ownerOrgId: config.organization_id ?? null,
         };
       }
-      return { isAdminViewing: false, ownerUserId: null };
+      return { isAdminViewing: false, ownerUserId: null, ownerOrgId: null };
     }),
 
   deleteTown: gastownProcedure
@@ -519,10 +533,10 @@ export const gastownRouter = router({
     }),
 
   getRig: gastownProcedure
-    .input(z.object({ rigId: z.string().uuid() }))
+    .input(z.object({ rigId: z.string().uuid(), townId: z.string().uuid().optional() }))
     .output(RpcRigDetailOutput)
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
       const agentList = await townStub.listAgents({ rig_id: rig.id });
@@ -562,20 +576,27 @@ export const gastownRouter = router({
     .input(
       z.object({
         rigId: z.string().uuid(),
+        townId: z.string().uuid().optional(),
         status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']).optional(),
       })
     )
     .output(z.array(RpcBeadOutput))
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeads({ rig_id: rig.id, status: input.status });
     }),
 
   deleteBead: gastownProcedure
-    .input(z.object({ rigId: z.string().uuid(), beadId: z.string().uuid() }))
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        beadId: z.string().uuid(),
+        townId: z.string().uuid().optional(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteBead(input.beadId);
     }),
@@ -586,6 +607,7 @@ export const gastownRouter = router({
         .object({
           rigId: z.string().uuid(),
           beadId: z.string().uuid(),
+          townId: z.string().uuid().optional(),
           title: z.string().min(1).optional(),
           body: z.string().nullable().optional(),
           status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']).optional(),
@@ -610,7 +632,7 @@ export const gastownRouter = router({
     )
     .output(RpcBeadOutput)
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
 
       // Verify the bead belongs to this rig
@@ -622,25 +644,31 @@ export const gastownRouter = router({
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Bead does not belong to this rig' });
       }
 
-      const { rigId: _rigId, beadId, ...fields } = input;
+      const { rigId: _rigId, beadId, townId: _townId, ...fields } = input;
       return townStub.updateBead(beadId, fields, ctx.userId);
     }),
 
   // ── Agents ──────────────────────────────────────────────────────────
 
   listAgents: gastownProcedure
-    .input(z.object({ rigId: z.string().uuid() }))
+    .input(z.object({ rigId: z.string().uuid(), townId: z.string().uuid().optional() }))
     .output(z.array(RpcAgentOutput))
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listAgents({ rig_id: rig.id });
     }),
 
   deleteAgent: gastownProcedure
-    .input(z.object({ rigId: z.string().uuid(), agentId: z.string().uuid() }))
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        agentId: z.string().uuid(),
+        townId: z.string().uuid().optional(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteAgent(input.agentId);
     }),
@@ -959,7 +987,13 @@ export const gastownRouter = router({
   refreshContainerToken: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx, input.townId);
+      const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot refresh container tokens for towns they do not own',
+        });
+      }
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.forceRefreshContainerToken();
     }),
@@ -970,6 +1004,7 @@ export const gastownRouter = router({
     .input(
       z.object({
         rigId: z.string().uuid(),
+        townId: z.string().uuid().optional(),
         beadId: z.string().uuid().optional(),
         since: z.string().optional(),
         limit: z.number().int().positive().max(500).default(100),
@@ -977,7 +1012,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeadEvents({
         beadId: input.beadId,

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -114,16 +114,7 @@ type RigOwnerStub = {
   deleteTown(townId: string): Promise<boolean>;
 };
 
-/**
- * Core ownership resolution shared by resolveRigOwnerStub and verifyTownOwnership.
- * Returns the owning DO stub and, for personal towns, the town record.
- */
-async function resolveTownOwnership(
-  env: Env,
-  userId: string,
-  townId: string,
-  memberships: JwtOrgMembership[]
-): Promise<
+type TownOwnershipResult =
   | {
       type: 'user';
       stub: RigOwnerStub;
@@ -136,12 +127,30 @@ async function resolveTownOwnership(
       };
     }
   | { type: 'org'; stub: RigOwnerStub; orgId: string }
-> {
+  | { type: 'admin' };
+
+/**
+ * Core ownership resolution shared by resolveRigOwnerStub and verifyTownOwnership.
+ * Returns the owning DO stub and, for personal towns, the town record.
+ *
+ * Admins bypass ownership checks entirely — they can access any town for
+ * support/debugging purposes. The caller is responsible for restricting
+ * destructive mutations (delete, billing config) when the result type is 'admin'.
+ */
+async function resolveTownOwnership(
+  env: Env,
+  ctx: TRPCContext,
+  townId: string
+): Promise<TownOwnershipResult> {
+  const { userId, isAdmin, orgMemberships: memberships } = ctx;
+
   // Fast path: personal town lookup
   const userStub = getGastownUserStub(env, userId);
   const personalTown = await userStub.getTownAsync(townId);
   if (personalTown) {
     if (personalTown.owner_user_id !== userId) {
+      // Admin bypass: allow access without ownership
+      if (isAdmin) return { type: 'admin' };
       throw new TRPCError({ code: 'FORBIDDEN', message: 'Not your town' });
     }
     return { type: 'user', stub: userStub, town: personalTown };
@@ -153,12 +162,15 @@ async function resolveTownOwnership(
   try {
     config = await townStub.getTownConfig();
   } catch {
+    if (isAdmin) return { type: 'admin' };
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Town not found' });
   }
 
   if (config.owner_type === 'org' && config.organization_id) {
     const membership = getOrgMembership(memberships, config.organization_id);
     if (!membership || membership.role === 'billing_manager') {
+      // Admin bypass: allow access without org membership
+      if (isAdmin) return { type: 'admin' };
       throw new TRPCError({ code: 'FORBIDDEN', message: 'Not an org member' });
     }
     return {
@@ -168,17 +180,31 @@ async function resolveTownOwnership(
     };
   }
 
+  // No owner found — admins can still access the town for debugging
+  if (isAdmin) return { type: 'admin' };
   throw new TRPCError({ code: 'NOT_FOUND', message: 'Town not found' });
 }
 
 /** Resolve the DO stub that owns rigs/towns. Verifies access via JWT claims. */
 async function resolveRigOwnerStub(
   env: Env,
-  userId: string,
-  townId: string,
-  memberships: JwtOrgMembership[]
+  ctx: TRPCContext,
+  townId: string
 ): Promise<RigOwnerStub> {
-  const result = await resolveTownOwnership(env, userId, townId, memberships);
+  const result = await resolveTownOwnership(env, ctx, townId);
+  if (result.type === 'admin') {
+    // Admin doesn't own the town — resolve the real owner from TownDO config
+    // so we can still read rigs/towns from the correct DO.
+    const townStub = getTownDOStub(env, townId);
+    const config = await townStub.getTownConfig();
+    if (config.owner_type === 'org' && config.organization_id) {
+      return getGastownOrgStub(env, config.organization_id);
+    }
+    if (config.owner_user_id) {
+      return getGastownUserStub(env, config.owner_user_id);
+    }
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Town owner not found' });
+  }
   return result.stub;
 }
 
@@ -186,14 +212,35 @@ async function resolveRigOwnerStub(
  * Verify that a user has access to a town and return a record matching
  * RpcTownOutput (used by the getTown procedure).
  */
-async function verifyTownOwnership(
-  env: Env,
-  userId: string,
-  townId: string,
-  memberships: JwtOrgMembership[]
-) {
-  const result = await resolveTownOwnership(env, userId, townId, memberships);
+async function verifyTownOwnership(env: Env, ctx: TRPCContext, townId: string) {
+  const result = await resolveTownOwnership(env, ctx, townId);
   if (result.type === 'user') return result.town;
+
+  if (result.type === 'admin') {
+    // Admin bypass: resolve town metadata from TownDO config and the owner's DO
+    const townStub = getTownDOStub(env, townId);
+    const config = await townStub.getTownConfig();
+
+    // Try to look up the town name from the owner's DO
+    let name = townId;
+    if (config.owner_type === 'org' && config.organization_id) {
+      const orgStub = getGastownOrgStub(env, config.organization_id);
+      const orgTown = await orgStub.getTownAsync(townId);
+      if (orgTown) name = orgTown.name;
+    } else if (config.owner_user_id) {
+      const userStub = getGastownUserStub(env, config.owner_user_id);
+      const userTown = await userStub.getTownAsync(townId);
+      if (userTown) name = userTown.name;
+    }
+
+    return {
+      id: townId,
+      name,
+      owner_user_id: config.owner_user_id ?? ctx.userId,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+  }
 
   // Fetch the org town record for name/timestamps
   const orgStub = getGastownOrgStub(env, result.orgId);
@@ -201,7 +248,7 @@ async function verifyTownOwnership(
   return {
     id: townId,
     name: orgTown?.name ?? townId,
-    owner_user_id: orgTown?.created_by_user_id ?? userId,
+    owner_user_id: orgTown?.created_by_user_id ?? ctx.userId,
     created_at: orgTown?.created_at ?? new Date().toISOString(),
     updated_at: orgTown?.updated_at ?? new Date().toISOString(),
   };
@@ -210,13 +257,11 @@ async function verifyTownOwnership(
 /**
  * Verify that a user has access to a rig — either through their personal DO
  * or through an org that owns the rig's town (checked via JWT claims).
+ * Admins can access any rig by resolving the owner from TownDO config.
  */
-async function verifyRigOwnership(
-  env: Env,
-  userId: string,
-  rigId: string,
-  memberships: JwtOrgMembership[]
-) {
+async function verifyRigOwnership(env: Env, ctx: TRPCContext, rigId: string) {
+  const { userId, isAdmin, orgMemberships: memberships } = ctx;
+
   // Fast path: personal rig lookup
   const userStub = getGastownUserStub(env, userId);
   const personalRig = await userStub.getRigAsync(rigId);
@@ -230,6 +275,20 @@ async function verifyRigOwnership(
     );
     const orgRig = results.find(r => r !== null);
     if (orgRig) return orgRig;
+  }
+
+  // Admin bypass: try to find the rig by scanning all org stubs is impractical.
+  // Instead, for admin access we rely on the townId being passed alongside
+  // the rigId in procedures that need it. For procedures that only pass rigId,
+  // admins can use the admin-specific endpoints instead.
+  if (isAdmin) {
+    // This is a fallback — admin procedures that need rig access should
+    // prefer using town-scoped admin endpoints. Throw NOT_FOUND if we
+    // genuinely can't locate the rig.
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Rig not found (admin: use town-scoped admin endpoints for cross-user rig access)',
+    });
   }
 
   throw new TRPCError({ code: 'NOT_FOUND', message: 'Rig not found' });
@@ -288,23 +347,61 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcTownOutput)
     .query(async ({ ctx, input }) => {
-      return verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      return verifyTownOwnership(ctx.env, ctx, input.townId);
+    }),
+
+  /**
+   * Check whether the current user is an admin viewing a town they don't own.
+   * Used by the frontend to show an admin banner.
+   */
+  checkAdminAccess: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .output(
+      z.object({
+        isAdminViewing: z.boolean(),
+        ownerUserId: z.string().nullable(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      if (!ctx.isAdmin) return { isAdminViewing: false, ownerUserId: null };
+      const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
+      if (ownership.type === 'admin') {
+        // Admin is viewing a town they don't own — resolve the real owner
+        const townStub = getTownDOStub(ctx.env, input.townId);
+        const config = await townStub.getTownConfig();
+        return {
+          isAdminViewing: true,
+          ownerUserId: config.owner_user_id ?? null,
+        };
+      }
+      return { isAdminViewing: false, ownerUserId: null };
     }),
 
   deleteTown: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const ownership = await resolveTownOwnership(
-        ctx.env,
-        ctx.userId,
-        input.townId,
-        ctx.orgMemberships
-      );
+      // Admins cannot delete towns — they should use admin intervention endpoints
+      if (ctx.isAdmin) {
+        const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
+        if (ownership.type === 'admin') {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Admins cannot delete towns they do not own',
+          });
+        }
+      }
+      const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
       if (ownership.type === 'org') {
         const membership = getOrgMembership(ctx.orgMemberships, ownership.orgId);
         if (!membership || membership.role !== 'owner') {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Only org owners can delete towns' });
         }
+      }
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot delete towns they do not own',
+        });
       }
       const ownerStub = ownership.stub;
 
@@ -333,12 +430,13 @@ export const gastownRouter = router({
     .output(RpcRigOutput)
     .mutation(async ({ ctx, input }) => {
       const user = userFromCtx(ctx);
-      const ownership = await resolveTownOwnership(
-        ctx.env,
-        user.id,
-        input.townId,
-        ctx.orgMemberships
-      );
+      const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot create rigs on towns they do not own',
+        });
+      }
       const ownerStub = ownership.stub;
 
       const townStub = getTownDOStub(ctx.env, input.townId);
@@ -416,12 +514,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(z.array(RpcRigOutput))
     .query(async ({ ctx, input }) => {
-      const ownerStub = await resolveRigOwnerStub(
-        ctx.env,
-        ctx.userId,
-        input.townId,
-        ctx.orgMemberships
-      );
+      const ownerStub = await resolveRigOwnerStub(ctx.env, ctx, input.townId);
       return ownerStub.listRigs(input.townId);
     }),
 
@@ -429,7 +522,7 @@ export const gastownRouter = router({
     .input(z.object({ rigId: z.string().uuid() }))
     .output(RpcRigDetailOutput)
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
       const agentList = await townStub.listAgents({ rig_id: rig.id });
@@ -440,13 +533,14 @@ export const gastownRouter = router({
   deleteRig: gastownProcedure
     .input(z.object({ rigId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
-      const ownership = await resolveTownOwnership(
-        ctx.env,
-        ctx.userId,
-        rig.town_id,
-        ctx.orgMemberships
-      );
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
+      const ownership = await resolveTownOwnership(ctx.env, ctx, rig.town_id);
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot delete rigs on towns they do not own',
+        });
+      }
       if (ownership.type === 'org') {
         const membership = getOrgMembership(ctx.orgMemberships, ownership.orgId);
         if (!membership || membership.role !== 'owner') {
@@ -473,7 +567,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadOutput))
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeads({ rig_id: rig.id, status: input.status });
     }),
@@ -481,7 +575,7 @@ export const gastownRouter = router({
   deleteBead: gastownProcedure
     .input(z.object({ rigId: z.string().uuid(), beadId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteBead(input.beadId);
     }),
@@ -516,7 +610,7 @@ export const gastownRouter = router({
     )
     .output(RpcBeadOutput)
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
 
       // Verify the bead belongs to this rig
@@ -538,7 +632,7 @@ export const gastownRouter = router({
     .input(z.object({ rigId: z.string().uuid() }))
     .output(z.array(RpcAgentOutput))
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listAgents({ rig_id: rig.id });
     }),
@@ -546,7 +640,7 @@ export const gastownRouter = router({
   deleteAgent: gastownProcedure
     .input(z.object({ rigId: z.string().uuid(), agentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.deleteAgent(input.agentId);
     }),
@@ -565,7 +659,7 @@ export const gastownRouter = router({
     .output(RpcSlingResultOutput)
     .mutation(async ({ ctx, input }) => {
       const user = userFromCtx(ctx);
-      const rig = await verifyRigOwnership(ctx.env, user.id, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
 
       // Best-effort: refresh git credentials using the town owner's identity
       const townConfig = await getTownDOStub(ctx.env, rig.town_id).getTownConfig();
@@ -605,7 +699,7 @@ export const gastownRouter = router({
     )
     .output(RpcMayorSendResultOutput)
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
 
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.sendMayorMessage(input.message, input.model, input.uiContext);
@@ -615,7 +709,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcMayorStatusOutput)
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getMayorStatus();
     }),
@@ -624,7 +718,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcAlarmStatusOutput)
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getAlarmStatus();
     }),
@@ -633,12 +727,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcMayorSendResultOutput)
     .mutation(async ({ ctx, input }) => {
-      const ownerStub = await resolveRigOwnerStub(
-        ctx.env,
-        ctx.userId,
-        input.townId,
-        ctx.orgMemberships
-      );
+      const ownerStub = await resolveRigOwnerStub(ctx.env, ctx, input.townId);
 
       // Best-effort: refresh git credentials using the town owner's identity
       const townConfig = await getTownDOStub(ctx.env, input.townId).getTownConfig();
@@ -671,7 +760,7 @@ export const gastownRouter = router({
     .input(z.object({ agentId: z.string().uuid(), townId: z.string().uuid() }))
     .output(RpcStreamTicketOutput)
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
 
       // Proxy to container control server to get a stream ticket
       const containerStub = getTownContainerStub(ctx.env, input.townId);
@@ -701,7 +790,7 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid(), agentId: z.string().uuid() }))
     .output(RpcPtySessionOutput)
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
 
       // Proxy to container control server to create a PTY session
       const containerStub = getTownContainerStub(ctx.env, input.townId);
@@ -737,7 +826,7 @@ export const gastownRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
 
       const containerStub = getTownContainerStub(ctx.env, input.townId);
       const response = await containerStub.fetch(
@@ -762,14 +851,27 @@ export const gastownRouter = router({
     .input(z.object({ townId: z.string().uuid() }))
     .output(RpcTownConfigSchema)
     .query(async ({ ctx, input }) => {
-      const ownership = await resolveTownOwnership(
-        ctx.env,
-        ctx.userId,
-        input.townId,
-        ctx.orgMemberships
-      );
+      const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       const config = await townStub.getTownConfig();
+
+      // Admins see masked secrets (read-only access, no secret exposure)
+      if (ownership.type === 'admin') {
+        const mask = (s?: string) => (s ? '****' + s.slice(-4) : undefined);
+        return {
+          ...config,
+          kilocode_token: mask(config.kilocode_token),
+          github_cli_pat: mask(config.github_cli_pat),
+          git_auth: {
+            ...config.git_auth,
+            github_token: mask(config.git_auth?.github_token),
+            gitlab_token: mask(config.git_auth?.gitlab_token),
+          },
+          env_vars: Object.fromEntries(
+            Object.entries(config.env_vars).map(([k, v]) => [k, '****' + v.slice(-4)])
+          ),
+        };
+      }
 
       // Mask secrets for non-owner, non-creator org members
       if (ownership.type === 'org') {
@@ -806,12 +908,15 @@ export const gastownRouter = router({
     )
     .output(RpcTownConfigSchema)
     .mutation(async ({ ctx, input }) => {
-      const ownership = await resolveTownOwnership(
-        ctx.env,
-        ctx.userId,
-        input.townId,
-        ctx.orgMemberships
-      );
+      const ownership = await resolveTownOwnership(ctx.env, ctx, input.townId);
+
+      // Admins cannot modify town config via this endpoint (read-only access)
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot modify town configuration for towns they do not own',
+        });
+      }
 
       // Strip ownership fields — only the system (createTown flows) should set these
       const {
@@ -854,7 +959,7 @@ export const gastownRouter = router({
   refreshContainerToken: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.forceRefreshContainerToken();
     }),
@@ -872,7 +977,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      const rig = await verifyRigOwnership(ctx.env, ctx.userId, input.rigId, ctx.orgMemberships);
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       return townStub.listBeadEvents({
         beadId: input.beadId,
@@ -891,7 +996,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcBeadEventOutput))
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.listBeadEvents({
         since: input.since,
@@ -910,7 +1015,7 @@ export const gastownRouter = router({
     )
     .output(RpcMergeQueueDataOutput)
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getMergeQueueData({
         rigId: input.rigId,
@@ -927,7 +1032,7 @@ export const gastownRouter = router({
     )
     .output(z.array(RpcConvoyDetailOutput))
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.listConvoysDetailed();
     }),
@@ -941,7 +1046,7 @@ export const gastownRouter = router({
     )
     .output(RpcConvoyDetailOutput.nullable())
     .query(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getConvoyStatus(input.convoyId);
     }),
@@ -955,7 +1060,7 @@ export const gastownRouter = router({
     )
     .output(RpcConvoyDetailOutput.nullable())
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       const convoy = await townStub.closeConvoy(input.convoyId);
       if (!convoy) return null;
@@ -972,7 +1077,7 @@ export const gastownRouter = router({
     )
     .output(RpcConvoyDetailOutput.nullable())
     .mutation(async ({ ctx, input }) => {
-      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.startConvoy(input.convoyId);
       const status = await townStub.getConvoyStatus(input.convoyId);

--- a/cloudflare-gastown/test/unit/admin-access.test.ts
+++ b/cloudflare-gastown/test/unit/admin-access.test.ts
@@ -28,9 +28,7 @@ describe('adminAuditMiddleware', () => {
       return next();
     });
     app.use('/api/towns/:townId/*', adminAuditMiddleware);
-    app.get('/api/towns/:townId/config', c =>
-      c.json({ ok: true, townId: c.req.param('townId') })
-    );
+    app.get('/api/towns/:townId/config', c => c.json({ ok: true, townId: c.req.param('townId') }));
     return app;
   }
 

--- a/cloudflare-gastown/test/unit/admin-access.test.ts
+++ b/cloudflare-gastown/test/unit/admin-access.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { GastownEnv } from '../../src/gastown.worker';
+import { adminAuditMiddleware } from '../../src/middleware/admin-audit.middleware';
+
+// Minimal env stub for tests
+function testEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ENVIRONMENT: 'test',
+    GASTOWN_AE: {
+      writeDataPoint: vi.fn(),
+    },
+    ...overrides,
+  } as unknown as Env;
+}
+
+describe('adminAuditMiddleware', () => {
+  function createApp() {
+    const app = new Hono<GastownEnv>();
+    // Set up auth context variables before the audit middleware runs.
+    // In production, kiloAuthMiddleware does this.
+    app.use('/api/towns/:townId/*', async (c, next) => {
+      // Simulates kiloAuthMiddleware setting these values
+      const isAdmin = c.req.header('X-Test-Is-Admin') === 'true';
+      const userId = c.req.header('X-Test-User-Id') ?? 'unknown';
+      c.set('kiloIsAdmin', isAdmin);
+      c.set('kiloUserId', userId);
+      return next();
+    });
+    app.use('/api/towns/:townId/*', adminAuditMiddleware);
+    app.get('/api/towns/:townId/config', c =>
+      c.json({ ok: true, townId: c.req.param('townId') })
+    );
+    return app;
+  }
+
+  it('does not log for non-admin requests', async () => {
+    const app = createApp();
+    const env = testEnv();
+    const res = await app.request(
+      'http://localhost/api/towns/town-123/config',
+      {
+        headers: {
+          'X-Test-Is-Admin': 'false',
+          'X-Test-User-Id': 'user-1',
+        },
+      },
+      env
+    );
+    expect(res.status).toBe(200);
+    // @ts-expect-error -- mock function
+    expect(env.GASTOWN_AE.writeDataPoint).not.toHaveBeenCalled();
+  });
+
+  it('logs admin access with correct event data', async () => {
+    const app = createApp();
+    const env = testEnv();
+    const res = await app.request(
+      'http://localhost/api/towns/town-456/config',
+      {
+        headers: {
+          'X-Test-Is-Admin': 'true',
+          'X-Test-User-Id': 'admin-user-1',
+        },
+      },
+      env
+    );
+    expect(res.status).toBe(200);
+    // @ts-expect-error -- mock function
+    const writeDataPoint = env.GASTOWN_AE.writeDataPoint;
+    expect(writeDataPoint).toHaveBeenCalledOnce();
+
+    const call = writeDataPoint.mock.calls[0][0];
+    // blob1 = event name
+    expect(call.blobs[0]).toBe('admin.town_access');
+    // blob2 = userId
+    expect(call.blobs[1]).toBe('admin-user-1');
+    // blob3 = delivery
+    expect(call.blobs[2]).toBe('http');
+    // blob4 = route (method + path)
+    expect(call.blobs[3]).toContain('GET');
+    expect(call.blobs[3]).toContain('/api/towns/town-456/config');
+    // blob6 = townId
+    expect(call.blobs[5]).toBe('town-456');
+  });
+
+  it('passes through to the handler after logging', async () => {
+    const app = createApp();
+    const env = testEnv();
+    const res = await app.request(
+      'http://localhost/api/towns/my-town/config',
+      {
+        headers: {
+          'X-Test-Is-Admin': 'true',
+          'X-Test-User-Id': 'admin-user-2',
+        },
+      },
+      env
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, townId: 'my-town' });
+  });
+});
+
+// NOTE: Tests for townAuthMiddleware admin bypass require the Cloudflare
+// workers runtime (cloudflare:workers) and must be run in the integration
+// test environment (pnpm test:integration). The admin bypass is already
+// tested by the existing townAuthMiddleware implementation:
+// - townAuthMiddleware: if (c.get('kiloIsAdmin')) return next();
+// - townOwnershipMiddleware: if (c.get('kiloIsAdmin')) return next();

--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -3394,6 +3394,7 @@ type AdminKiloclawInstance = {
     sandbox_id: string;
     created_at: string;
     destroyed_at: string | null;
+    suspended_at: string | null;
     user_email: string | null;
 };
 
@@ -8068,6 +8069,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                         expiresAt: string;
                         daysRemaining: number;
                     } | null;
+                    activeInstanceId: string | null;
                 };
                 meta: object;
             }>;
@@ -9761,6 +9763,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     sandbox_id: string;
                     created_at: string;
                     destroyed_at: string | null;
+                    suspended_at: string | null;
                     user_email: string | null;
                 };
                 meta: object;
@@ -9772,7 +9775,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     sortBy?: "created_at" | "destroyed_at" | undefined;
                     sortOrder?: "asc" | "desc" | undefined;
                     search?: string | undefined;
-                    status?: "active" | "all" | "destroyed" | undefined;
+                    status?: "active" | "all" | "suspended" | "destroyed" | undefined;
                 };
                 output: {
                     instances: AdminKiloclawInstance[];
@@ -9793,6 +9796,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     overview: {
                         totalInstances: number;
                         activeInstances: number;
+                        suspendedInstances: number;
                         destroyedInstances: number;
                         uniqueUsers: number;
                         last24hCreated: number;
@@ -9941,7 +9945,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     message: string;
                     id: string;
                     created_at: string;
-                    action: "kiloclaw.volume.reassociate" | "kiloclaw.subscription.update_trial_end" | "kiloclaw.machine.start" | "kiloclaw.machine.stop" | "kiloclaw.instance.destroy" | "kiloclaw.gateway.start" | "kiloclaw.gateway.stop" | "kiloclaw.gateway.restart" | "kiloclaw.config.restore" | "kiloclaw.doctor.run";
+                    action: "kiloclaw.volume.reassociate" | "kiloclaw.subscription.update_trial_end" | "kiloclaw.subscription.reset_trial" | "kiloclaw.machine.start" | "kiloclaw.machine.stop" | "kiloclaw.instance.destroy" | "kiloclaw.gateway.start" | "kiloclaw.gateway.stop" | "kiloclaw.gateway.restart" | "kiloclaw.config.restore" | "kiloclaw.doctor.run";
                     actor_id: string | null;
                     actor_email: string | null;
                     actor_name: string | null;
@@ -10530,7 +10534,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             list: _trpc_server.TRPCQueryProcedure<{
                 input: {
                     page?: number | undefined;
-                    limit?: 10 | 100 | 50 | 25 | undefined;
+                    limit?: 100 | 50 | 10 | 25 | undefined;
                 };
                 output: {
                     requests: {
@@ -10545,7 +10549,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     }[];
                     pagination: {
                         page: number;
-                        limit: 10 | 100 | 50 | 25;
+                        limit: 100 | 50 | 10 | 25;
                         total: number;
                         totalPages: number;
                     };
@@ -11515,7 +11519,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             input: {
                 cursor?: string | undefined;
                 limit?: number | undefined;
-                createdOnPlatform?: string | undefined;
+                createdOnPlatform?: string | string[] | undefined;
                 orderBy?: "updated_at" | "created_at" | undefined;
                 organizationId?: string | null | undefined;
             };
@@ -11543,7 +11547,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                 search_string: string;
                 limit?: number | undefined;
                 offset?: number | undefined;
-                createdOnPlatform?: string | undefined;
+                createdOnPlatform?: string | string[] | undefined;
                 organizationId?: string | null | undefined;
             };
             output: {
@@ -15753,7 +15757,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             input: {
                 cursor?: string | undefined;
                 limit?: number | undefined;
-                createdOnPlatform?: string | undefined;
+                createdOnPlatform?: string | string[] | undefined;
                 orderBy?: "updated_at" | "created_at" | undefined;
                 organizationId?: string | null | undefined;
                 includeSubSessions?: boolean | undefined;
@@ -15784,7 +15788,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                 search_string: string;
                 limit?: number | undefined;
                 offset?: number | undefined;
-                createdOnPlatform?: string | undefined;
+                createdOnPlatform?: string | string[] | undefined;
                 organizationId?: string | null | undefined;
                 includeSubSessions?: boolean | undefined;
             };

--- a/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -34,6 +34,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { AreaChart, Area, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
+import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
 
 type Agent = GastownOutputs['gastown']['listAgents'][number];
 
@@ -211,6 +212,7 @@ export function TownOverviewPageClient({
 
   return (
     <div>
+      <AdminViewingBanner townId={townId} />
       {/* Top bar — sticky */}
       <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-3">

--- a/src/app/(app)/gastown/[townId]/agents/page.tsx
+++ b/src/app/(app)/gastown/[townId]/agents/page.tsx
@@ -8,6 +8,6 @@ export default async function AgentsPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/agents`
   );
-  if (!(await isGastownEnabled(user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) return notFound();
   return <AgentsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/beads/page.tsx
+++ b/src/app/(app)/gastown/[townId]/beads/page.tsx
@@ -8,6 +8,6 @@ export default async function BeadsPage({ params }: { params: Promise<{ townId: 
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/beads`
   );
-  if (!(await isGastownEnabled(user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) return notFound();
   return <BeadsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/mail/page.tsx
+++ b/src/app/(app)/gastown/[townId]/mail/page.tsx
@@ -8,6 +8,6 @@ export default async function MailPage({ params }: { params: Promise<{ townId: s
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/mail`
   );
-  if (!(await isGastownEnabled(user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) return notFound();
   return <MailPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/merges/page.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/page.tsx
@@ -8,6 +8,6 @@ export default async function MergesPage({ params }: { params: Promise<{ townId:
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/merges`
   );
-  if (!(await isGastownEnabled(user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) return notFound();
   return <MergesPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/observability/page.tsx
+++ b/src/app/(app)/gastown/[townId]/observability/page.tsx
@@ -12,6 +12,6 @@ export default async function ObservabilityPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/observability`
   );
-  if (!(await isGastownEnabled(user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) return notFound();
   return <ObservabilityPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/[townId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/page.tsx
@@ -11,7 +11,7 @@ export default async function TownOverviewPage({
   const { townId } = await params;
   const user = await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=/gastown/${townId}`);
 
-  if (!(await isGastownEnabled(user.id))) {
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/src/app/(app)/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -13,7 +13,7 @@ export default async function RigDetailPage({
     `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}`
   );
 
-  if (!(await isGastownEnabled(user.id))) {
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) {
     return notFound();
   }
 

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -29,6 +29,7 @@ import {
   Key,
 } from 'lucide-react';
 import { motion } from 'motion/react';
+import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
 
 type Props = { townId: string; readOnly?: boolean };
 
@@ -103,8 +104,12 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
 
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const configQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
+  const adminAccessQuery = useQuery(trpc.gastown.checkAdminAccess.queryOptions({ townId }));
 
-  const effectiveReadOnly = readOnly && currentUser?.id !== configQuery.data?.created_by_user_id;
+  // Admin viewing another user's town → force read-only
+  const isAdminViewing = adminAccessQuery.data?.isAdminViewing ?? false;
+  const effectiveReadOnly =
+    isAdminViewing || (readOnly && currentUser?.id !== configQuery.data?.created_by_user_id);
 
   const updateConfig = useMutation(
     trpc.gastown.updateTownConfig.mutationOptions({
@@ -245,6 +250,7 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
 
   return (
     <div>
+      <AdminViewingBanner townId={townId} />
       {/* Top bar */}
       <div
         id="settings-sticky-header"

--- a/src/app/(app)/gastown/[townId]/settings/page.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/page.tsx
@@ -12,6 +12,6 @@ export default async function TownSettingsPage({
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=/gastown/${townId}/settings`
   );
-  if (!(await isGastownEnabled(user.id))) return notFound();
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) return notFound();
   return <TownSettingsPageClient townId={townId} />;
 }

--- a/src/app/(app)/gastown/page.tsx
+++ b/src/app/(app)/gastown/page.tsx
@@ -6,7 +6,7 @@ import { TownListPageClient } from './TownListPageClient';
 export default async function GastownPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown');
 
-  if (!(await isGastownEnabled(user.id))) {
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) {
     return notFound();
   }
 

--- a/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
@@ -116,8 +116,13 @@ function TownRow({ town }: { town: { id: string; name: string; created_at: strin
       <TableCell>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" asChild>
-            <Link href={`/admin/gastown/towns/${town.id}`}>
+            <Link href={`/gastown/${town.id}`}>
               <ExternalLink className="mr-1 h-3 w-3" />
+              View Town
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/admin/gastown/towns/${town.id}`}>
               Inspect
             </Link>
           </Button>

--- a/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
+++ b/src/app/admin/components/UserAdmin/UserAdminGastown.tsx
@@ -122,9 +122,7 @@ function TownRow({ town }: { town: { id: string; name: string; created_at: strin
             </Link>
           </Button>
           <Button variant="outline" size="sm" asChild>
-            <Link href={`/admin/gastown/towns/${town.id}`}>
-              Inspect
-            </Link>
+            <Link href={`/admin/gastown/towns/${town.id}`}>Inspect</Link>
           </Button>
           <Button
             variant="outline"

--- a/src/app/admin/gastown/towns/[townId]/TownInspectorDashboard.tsx
+++ b/src/app/admin/gastown/towns/[townId]/TownInspectorDashboard.tsx
@@ -51,9 +51,14 @@ export function TownInspectorDashboard({ townId }: { townId: string }) {
           <h1 className="text-2xl font-semibold">Town Inspector</h1>
           <p className="text-muted-foreground font-mono text-sm">{townId}</p>
         </div>
-        <Button variant="outline" size="sm" asChild>
-          <Link href={`/admin/gastown/towns/${townId}/audit`}>Audit Log</Link>
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/gastown/${townId}`}>View Town UI</Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/admin/gastown/towns/${townId}/audit`}>Audit Log</Link>
+          </Button>
+        </div>
       </div>
 
       <Tabs value={activeTab} onValueChange={onTabChange}>

--- a/src/components/gastown/AdminViewingBanner.tsx
+++ b/src/components/gastown/AdminViewingBanner.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { ShieldAlert } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+/**
+ * Banner displayed when a Kilo admin is viewing a town they don't own.
+ * Fetches admin access status via the checkAdminAccess tRPC query.
+ * Renders nothing for non-admin users or when viewing their own town.
+ */
+export function AdminViewingBanner({ townId }: { townId: string }) {
+  const trpc = useGastownTRPC();
+  const { data } = useQuery(trpc.gastown.checkAdminAccess.queryOptions({ townId }));
+
+  if (!data?.isAdminViewing) return null;
+
+  return (
+    <Alert variant="warning" className="mb-4 border-amber-500/50 bg-amber-50 dark:bg-amber-950/20">
+      <ShieldAlert className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+      <AlertTitle className="text-amber-800 dark:text-amber-200">
+        Viewing as admin
+      </AlertTitle>
+      <AlertDescription className="text-amber-700 dark:text-amber-300">
+        This town belongs to user <code className="rounded bg-amber-100 px-1 py-0.5 text-xs dark:bg-amber-900/40">{data.ownerUserId}</code>.
+        Changes to settings and destructive actions are restricted.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/gastown/AdminViewingBanner.tsx
+++ b/src/components/gastown/AdminViewingBanner.tsx
@@ -19,12 +19,27 @@ export function AdminViewingBanner({ townId }: { townId: string }) {
   return (
     <Alert variant="warning" className="mb-4 border-amber-500/50 bg-amber-50 dark:bg-amber-950/20">
       <ShieldAlert className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-      <AlertTitle className="text-amber-800 dark:text-amber-200">
-        Viewing as admin
-      </AlertTitle>
+      <AlertTitle className="text-amber-800 dark:text-amber-200">Viewing as admin</AlertTitle>
       <AlertDescription className="text-amber-700 dark:text-amber-300">
-        This town belongs to user <code className="rounded bg-amber-100 px-1 py-0.5 text-xs dark:bg-amber-900/40">{data.ownerUserId}</code>.
-        Changes to settings and destructive actions are restricted.
+        This town belongs to{' '}
+        {data.ownerOrgId ? (
+          <>
+            org{' '}
+            <code className="rounded bg-amber-100 px-1 py-0.5 text-xs dark:bg-amber-900/40">
+              {data.ownerOrgId}
+            </code>
+          </>
+        ) : data.ownerUserId ? (
+          <>
+            user{' '}
+            <code className="rounded bg-amber-100 px-1 py-0.5 text-xs dark:bg-amber-900/40">
+              {data.ownerUserId}
+            </code>
+          </>
+        ) : (
+          'another user'
+        )}
+        . Changes to settings and destructive actions are restricted.
       </AlertDescription>
     </Alert>
   );

--- a/src/lib/gastown/feature-flags.ts
+++ b/src/lib/gastown/feature-flags.ts
@@ -11,9 +11,15 @@ const GASTOWN_ACCESS_FLAG = 'gastown-access';
  * (allowlists, percentage rollout, and kill-switch are managed in the
  * PostHog dashboard).
  *
+ * Kilo admins always have access regardless of the feature flag.
+ *
  * See #901 for details.
  */
-export async function isGastownEnabled(userId: string): Promise<boolean> {
+export async function isGastownEnabled(
+  userId: string,
+  opts?: { isAdmin?: boolean }
+): Promise<boolean> {
+  if (opts?.isAdmin) return true;
   if (process.env.NODE_ENV !== 'production') {
     return true;
   }

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,538 +1,758 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    createTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            name: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    createTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        name: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
     }>;
-    listTowns: import("@trpc/server").TRPCQueryProcedure<{
-        input: void;
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        }[];
-        meta: object;
+    listTowns: import('@trpc/server').TRPCQueryProcedure<{
+      input: void;
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
     }>;
-    getTown: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
+    getTown: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
     }>;
     /**
      * Check whether the current user is an admin viewing a town they don't own.
      * Used by the frontend to show an admin banner.
      */
-    checkAdminAccess: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            isAdminViewing: boolean;
-            ownerUserId: string | null;
-        };
-        meta: object;
+    checkAdminAccess: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        isAdminViewing: boolean;
+        ownerUserId: string | null;
+        ownerOrgId: string | null;
+      };
+      meta: object;
     }>;
-    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
+    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    createRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
+    createRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        name: string;
+        gitUrl: string;
+        defaultBranch?: string | undefined;
+        platformIntegrationId?: string | undefined;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
     }>;
-    listRigs: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
+    listRigs: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    getRig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        townId?: string | undefined;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+        agents: {
+          id: string;
+          rig_id: string | null;
+          role: string;
+          name: string;
+          identity: string;
+          status: string;
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+          agent_status_message: string | null;
+          agent_status_updated_at: string | null;
         }[];
-        meta: object;
-    }>;
-    getRig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-            agents: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
-            }[];
-            beads: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            }[];
-        };
-        meta: object;
-    }>;
-    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    listBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
+        beads: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-        };
-        output: void;
-        meta: object;
+    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+      };
+      output: void;
+      meta: object;
     }>;
-    updateBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            beadId: string;
-            title?: string | undefined;
-            body?: string | null | undefined;
-            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-            priority?: "critical" | "high" | "low" | "medium" | undefined;
-            labels?: string[] | undefined;
-            metadata?: Record<string, unknown> | undefined;
-            rig_id?: string | null | undefined;
-            parent_bead_id?: string | null | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
+    listBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        townId?: string | undefined;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
     }>;
-    listAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
+    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+        townId?: string | undefined;
+      };
+      output: void;
+      meta: object;
+    }>;
+    updateBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        beadId: string;
+        townId?: string | undefined;
+        title?: string | undefined;
+        body?: string | null | undefined;
+        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+        priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+        labels?: string[] | undefined;
+        metadata?: Record<string, unknown> | undefined;
+        rig_id?: string | null | undefined;
+        parent_bead_id?: string | null | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    listAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        townId?: string | undefined;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: string;
+        name: string;
+        identity: string;
+        status: string;
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+        agent_status_message: string | null;
+        agent_status_updated_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        agentId: string;
+        townId?: string | undefined;
+      };
+      output: void;
+      meta: object;
+    }>;
+    sling: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        title: string;
+        body?: string | undefined;
+        model?: string | undefined;
+      };
+      output: {
+        bead: {
+          bead_id: string;
+          type:
+            | 'agent'
+            | 'convoy'
+            | 'escalation'
+            | 'issue'
+            | 'merge_request'
+            | 'message'
+            | 'molecule';
+          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+          title: string;
+          body: string | null;
+          rig_id: string | null;
+          parent_bead_id: string | null;
+          assignee_agent_bead_id: string | null;
+          priority: 'critical' | 'high' | 'low' | 'medium';
+          labels: string[];
+          metadata: Record<string, unknown>;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+          closed_at: string | null;
         };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
+        agent: {
+          id: string;
+          rig_id: string | null;
+          role: string;
+          name: string;
+          identity: string;
+          status: string;
+          current_hook_bead_id: string | null;
+          dispatch_attempts: number;
+          last_activity_at: string | null;
+          checkpoint?: unknown;
+          created_at: string;
+          agent_status_message: string | null;
+          agent_status_updated_at: string | null;
+        };
+      };
+      meta: object;
+    }>;
+    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        message: string;
+        model?: string | undefined;
+        rigId?: string | undefined;
+        uiContext?: string | undefined;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
+    }>;
+    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        configured: boolean;
+        townId: string | null;
+        session: {
+          agentId: string;
+          sessionId: string;
+          status: 'active' | 'idle' | 'starting';
+          lastActivityAt: string;
+        } | null;
+      };
+      meta: object;
+    }>;
+    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
+        };
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
+        };
+        beads: {
+          open: number;
+          inProgress: number;
+          inReview: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            agentId: string;
-        };
-        output: void;
-        meta: object;
+    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        agentId: string;
+        sessionStatus: 'active' | 'idle' | 'starting';
+      };
+      meta: object;
     }>;
-    sling: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            rigId: string;
-            title: string;
-            body?: string | undefined;
-            model?: string | undefined;
+    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        agentId: string;
+        townId: string;
+      };
+      output: {
+        url: string;
+        ticket: string;
+      };
+      meta: object;
+    }>;
+    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: {
+        pty: {
+          [x: string]: unknown;
+          id: string;
         };
-        output: {
-            bead: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
+        wsUrl: string;
+      };
+      meta: object;
+    }>;
+    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+        ptyId: string;
+        cols: number;
+        rows: number;
+      };
+      output: void;
+      meta: object;
+    }>;
+    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
+        };
+        owner_user_id?: string | undefined;
+        owner_type: 'org' | 'user';
+        owner_id?: string | undefined;
+        created_by_user_id?: string | undefined;
+        organization_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+        staged_convoys_default: boolean;
+        github_cli_pat?: string | undefined;
+        git_author_name?: string | undefined;
+        git_author_email?: string | undefined;
+        disable_ai_coauthor: boolean;
+      };
+      meta: object;
+    }>;
+    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        config: {
+          env_vars?: Record<string, string> | undefined;
+          git_auth?:
+            | {
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
+              }
+            | undefined;
+          owner_user_id?: string | undefined;
+          owner_type?: 'org' | 'user' | undefined;
+          owner_id?: string | undefined;
+          created_by_user_id?: string | undefined;
+          organization_id?: string | undefined;
+          kilocode_token?: string | undefined;
+          default_model?: string | undefined;
+          small_model?: string | undefined;
+          max_polecats_per_rig?: number | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          refinery?:
+            | {
+                gates?: string[] | undefined;
+                auto_merge?: boolean | undefined;
+                require_clean_merge?: boolean | undefined;
+              }
+            | undefined;
+          alarm_interval_active?: number | undefined;
+          alarm_interval_idle?: number | undefined;
+          container?:
+            | {
+                sleep_after_minutes?: number | undefined;
+              }
+            | undefined;
+          staged_convoys_default?: boolean | undefined;
+          github_cli_pat?: string | undefined;
+          git_author_name?: string | undefined;
+          git_author_email?: string | undefined;
+          disable_ai_coauthor?: boolean | undefined;
+        };
+      };
+      output: {
+        env_vars: Record<string, string>;
+        git_auth: {
+          github_token?: string | undefined;
+          gitlab_token?: string | undefined;
+          gitlab_instance_url?: string | undefined;
+          platform_integration_id?: string | undefined;
+        };
+        owner_user_id?: string | undefined;
+        owner_type: 'org' | 'user';
+        owner_id?: string | undefined;
+        created_by_user_id?: string | undefined;
+        organization_id?: string | undefined;
+        kilocode_token?: string | undefined;
+        default_model?: string | undefined;
+        small_model?: string | undefined;
+        max_polecats_per_rig?: number | undefined;
+        merge_strategy: 'direct' | 'pr';
+        refinery?:
+          | {
+              gates: string[];
+              auto_merge: boolean;
+              require_clean_merge: boolean;
+            }
+          | undefined;
+        alarm_interval_active?: number | undefined;
+        alarm_interval_idle?: number | undefined;
+        container?:
+          | {
+              sleep_after_minutes?: number | undefined;
+            }
+          | undefined;
+        staged_convoys_default: boolean;
+        github_cli_pat?: string | undefined;
+        git_author_name?: string | undefined;
+        git_author_email?: string | undefined;
+        disable_ai_coauthor: boolean;
+      };
+      meta: object;
+    }>;
+    refreshContainerToken: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        rigId: string;
+        townId?: string | undefined;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    getMergeQueueData: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        rigId?: string | undefined;
+        limit?: number | undefined;
+        since?: string | undefined;
+      };
+      output: {
+        needsAttention: {
+          openPRs: {
+            mrBead: {
+              bead_id: string;
+              status: string;
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              created_at: string;
+              updated_at: string;
+              metadata: Record<string, unknown>;
             };
-            agent: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
+            reviewMetadata: {
+              branch: string;
+              target_branch: string;
+              merge_commit: string | null;
+              pr_url: string | null;
+              retry_count: number;
             };
-        };
-        meta: object;
-    }>;
-    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            message: string;
-            model?: string | undefined;
-            rigId?: string | undefined;
-            uiContext?: string | undefined;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            configured: boolean;
-            townId: string | null;
-            session: {
-                agentId: string;
-                sessionId: string;
-                status: "active" | "idle" | "starting";
-                lastActivityAt: string;
+            sourceBead: {
+              bead_id: string;
+              title: string;
+              status: string;
+              body: string | null;
             } | null;
-        };
-        meta: object;
-    }>;
-    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
+            convoy: {
+              convoy_id: string;
+              title: string;
+              total_beads: number;
+              closed_beads: number;
+              feature_branch: string | null;
+              merge_mode: string | null;
+            } | null;
+            agent: {
+              agent_id: string;
+              name: string;
+              role: string;
+            } | null;
+            rigName: string | null;
+            staleSince: string | null;
+            failureReason: string | null;
+          }[];
+          failedReviews: {
+            mrBead: {
+              bead_id: string;
+              status: string;
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              created_at: string;
+              updated_at: string;
+              metadata: Record<string, unknown>;
             };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
+            reviewMetadata: {
+              branch: string;
+              target_branch: string;
+              merge_commit: string | null;
+              pr_url: string | null;
+              retry_count: number;
             };
-            beads: {
-                open: number;
-                inProgress: number;
-                inReview: number;
-                failed: number;
-                triageRequests: number;
+            sourceBead: {
+              bead_id: string;
+              title: string;
+              status: string;
+              body: string | null;
+            } | null;
+            convoy: {
+              convoy_id: string;
+              title: string;
+              total_beads: number;
+              closed_beads: number;
+              feature_branch: string | null;
+              merge_mode: string | null;
+            } | null;
+            agent: {
+              agent_id: string;
+              name: string;
+              role: string;
+            } | null;
+            rigName: string | null;
+            staleSince: string | null;
+            failureReason: string | null;
+          }[];
+          stalePRs: {
+            mrBead: {
+              bead_id: string;
+              status: string;
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              created_at: string;
+              updated_at: string;
+              metadata: Record<string, unknown>;
             };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
+            reviewMetadata: {
+              branch: string;
+              target_branch: string;
+              merge_commit: string | null;
+              pr_url: string | null;
+              retry_count: number;
             };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
+            sourceBead: {
+              bead_id: string;
+              title: string;
+              status: string;
+              body: string | null;
+            } | null;
+            convoy: {
+              convoy_id: string;
+              title: string;
+              total_beads: number;
+              closed_beads: number;
+              feature_branch: string | null;
+              merge_mode: string | null;
+            } | null;
+            agent: {
+              agent_id: string;
+              name: string;
+              role: string;
+            } | null;
+            rigName: string | null;
+            staleSince: string | null;
+            failureReason: string | null;
+          }[];
         };
-        meta: object;
-    }>;
-    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            agentId: string;
-            sessionStatus: "active" | "idle" | "starting";
-        };
-        meta: object;
-    }>;
-    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            agentId: string;
-            townId: string;
-        };
-        output: {
-            url: string;
-            ticket: string;
-        };
-        meta: object;
-    }>;
-    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: {
-            pty: {
-                [x: string]: unknown;
-                id: string;
-            };
-            wsUrl: string;
-        };
-        meta: object;
-    }>;
-    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-            ptyId: string;
-            cols: number;
-            rows: number;
-        };
-        output: void;
-        meta: object;
-    }>;
-    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            owner_type: "org" | "user";
-            owner_id?: string | undefined;
-            created_by_user_id?: string | undefined;
-            organization_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
-                sleep_after_minutes?: number | undefined;
-            } | undefined;
-            staged_convoys_default: boolean;
-            github_cli_pat?: string | undefined;
-            git_author_name?: string | undefined;
-            git_author_email?: string | undefined;
-            disable_ai_coauthor: boolean;
-        };
-        meta: object;
-    }>;
-    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            config: {
-                env_vars?: Record<string, string> | undefined;
-                git_auth?: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                } | undefined;
-                owner_user_id?: string | undefined;
-                owner_type?: "org" | "user" | undefined;
-                owner_id?: string | undefined;
-                created_by_user_id?: string | undefined;
-                organization_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy?: "direct" | "pr" | undefined;
-                refinery?: {
-                    gates?: string[] | undefined;
-                    auto_merge?: boolean | undefined;
-                    require_clean_merge?: boolean | undefined;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-                staged_convoys_default?: boolean | undefined;
-                github_cli_pat?: string | undefined;
-                git_author_name?: string | undefined;
-                git_author_email?: string | undefined;
-                disable_ai_coauthor?: boolean | undefined;
-            };
-        };
-        output: {
-            env_vars: Record<string, string>;
-            git_auth: {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-            };
-            owner_user_id?: string | undefined;
-            owner_type: "org" | "user";
-            owner_id?: string | undefined;
-            created_by_user_id?: string | undefined;
-            organization_id?: string | undefined;
-            kilocode_token?: string | undefined;
-            default_model?: string | undefined;
-            small_model?: string | undefined;
-            max_polecats_per_rig?: number | undefined;
-            merge_strategy: "direct" | "pr";
-            refinery?: {
-                gates: string[];
-                auto_merge: boolean;
-                require_clean_merge: boolean;
-            } | undefined;
-            alarm_interval_active?: number | undefined;
-            alarm_interval_idle?: number | undefined;
-            container?: {
-                sleep_after_minutes?: number | undefined;
-            } | undefined;
-            staged_convoys_default: boolean;
-            github_cli_pat?: string | undefined;
-            git_author_name?: string | undefined;
-            git_author_email?: string | undefined;
-            disable_ai_coauthor: boolean;
-        };
-        meta: object;
-    }>;
-    refreshContainerToken: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            rigId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
+        activityLog: {
+          event: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -541,611 +761,480 @@ export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
             new_value: string | null;
             metadata: Record<string, unknown>;
             created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-        }[];
-        meta: object;
-    }>;
-    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
+          };
+          mrBead: {
             bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-        }[];
-        meta: object;
-    }>;
-    getMergeQueueData: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            rigId?: string | undefined;
-            limit?: number | undefined;
-            since?: string | undefined;
-        };
-        output: {
-            needsAttention: {
-                openPRs: {
-                    mrBead: {
-                        bead_id: string;
-                        status: string;
-                        title: string;
-                        body: string | null;
-                        rig_id: string | null;
-                        created_at: string;
-                        updated_at: string;
-                        metadata: Record<string, unknown>;
-                    };
-                    reviewMetadata: {
-                        branch: string;
-                        target_branch: string;
-                        merge_commit: string | null;
-                        pr_url: string | null;
-                        retry_count: number;
-                    };
-                    sourceBead: {
-                        bead_id: string;
-                        title: string;
-                        status: string;
-                        body: string | null;
-                    } | null;
-                    convoy: {
-                        convoy_id: string;
-                        title: string;
-                        total_beads: number;
-                        closed_beads: number;
-                        feature_branch: string | null;
-                        merge_mode: string | null;
-                    } | null;
-                    agent: {
-                        agent_id: string;
-                        name: string;
-                        role: string;
-                    } | null;
-                    rigName: string | null;
-                    staleSince: string | null;
-                    failureReason: string | null;
-                }[];
-                failedReviews: {
-                    mrBead: {
-                        bead_id: string;
-                        status: string;
-                        title: string;
-                        body: string | null;
-                        rig_id: string | null;
-                        created_at: string;
-                        updated_at: string;
-                        metadata: Record<string, unknown>;
-                    };
-                    reviewMetadata: {
-                        branch: string;
-                        target_branch: string;
-                        merge_commit: string | null;
-                        pr_url: string | null;
-                        retry_count: number;
-                    };
-                    sourceBead: {
-                        bead_id: string;
-                        title: string;
-                        status: string;
-                        body: string | null;
-                    } | null;
-                    convoy: {
-                        convoy_id: string;
-                        title: string;
-                        total_beads: number;
-                        closed_beads: number;
-                        feature_branch: string | null;
-                        merge_mode: string | null;
-                    } | null;
-                    agent: {
-                        agent_id: string;
-                        name: string;
-                        role: string;
-                    } | null;
-                    rigName: string | null;
-                    staleSince: string | null;
-                    failureReason: string | null;
-                }[];
-                stalePRs: {
-                    mrBead: {
-                        bead_id: string;
-                        status: string;
-                        title: string;
-                        body: string | null;
-                        rig_id: string | null;
-                        created_at: string;
-                        updated_at: string;
-                        metadata: Record<string, unknown>;
-                    };
-                    reviewMetadata: {
-                        branch: string;
-                        target_branch: string;
-                        merge_commit: string | null;
-                        pr_url: string | null;
-                        retry_count: number;
-                    };
-                    sourceBead: {
-                        bead_id: string;
-                        title: string;
-                        status: string;
-                        body: string | null;
-                    } | null;
-                    convoy: {
-                        convoy_id: string;
-                        title: string;
-                        total_beads: number;
-                        closed_beads: number;
-                        feature_branch: string | null;
-                        merge_mode: string | null;
-                    } | null;
-                    agent: {
-                        agent_id: string;
-                        name: string;
-                        role: string;
-                    } | null;
-                    rigName: string | null;
-                    staleSince: string | null;
-                    failureReason: string | null;
-                }[];
-            };
-            activityLog: {
-                event: {
-                    bead_event_id: string;
-                    bead_id: string;
-                    agent_id: string | null;
-                    event_type: string;
-                    old_value: string | null;
-                    new_value: string | null;
-                    metadata: Record<string, unknown>;
-                    created_at: string;
-                };
-                mrBead: {
-                    bead_id: string;
-                    title: string;
-                    type: string;
-                    status: string;
-                    rig_id: string | null;
-                    metadata: Record<string, unknown>;
-                } | null;
-                sourceBead: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                } | null;
-                convoy: {
-                    convoy_id: string;
-                    title: string;
-                    total_beads: number;
-                    closed_beads: number;
-                    feature_branch: string | null;
-                    merge_mode: string | null;
-                } | null;
-                agent: {
-                    agent_id: string;
-                    name: string;
-                    role: string;
-                } | null;
-                rigName: string | null;
-                reviewMetadata: {
-                    pr_url: string | null;
-                    branch: string | null;
-                    target_branch: string | null;
-                    merge_commit: string | null;
-                } | null;
-            }[];
-        };
-        meta: object;
-    }>;
-    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
             title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        }[];
-        meta: object;
-    }>;
-    getConvoy: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        } | null;
-        meta: object;
-    }>;
-    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        } | null;
-        meta: object;
-    }>;
-    startConvoy: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            convoyId: string;
-        };
-        output: {
-            id: string;
-            title: string;
-            status: "active" | "landed";
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-                bead_id: string;
-                title: string;
-                status: string;
-                rig_id: string | null;
-                assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-                bead_id: string;
-                depends_on_bead_id: string;
-            }[];
-        } | null;
-        meta: object;
-    }>;
-    listOrgTowns: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            organizationId: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_org_id: string;
-            created_by_user_id: string;
-            created_at: string;
-            updated_at: string;
-        }[];
-        meta: object;
-    }>;
-    createOrgTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            organizationId: string;
-            name: string;
-        };
-        output: {
-            id: string;
-            name: string;
-            owner_org_id: string;
-            created_by_user_id: string;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    deleteOrgTown: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            organizationId: string;
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    listOrgRigs: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            organizationId: string;
-            townId: string;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-        }[];
-        meta: object;
-    }>;
-    createOrgRig: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            organizationId: string;
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-        };
-        output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-        };
-        meta: object;
-    }>;
-    adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        }[];
-        meta: object;
-    }>;
-    adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
+            type: string;
             status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
+            rig_id: string | null;
+            metadata: Record<string, unknown>;
+          } | null;
+          sourceBead: {
+            bead_id: string;
+            title: string;
+            status: string;
+          } | null;
+          convoy: {
+            convoy_id: string;
+            title: string;
+            total_beads: number;
+            closed_beads: number;
+            feature_branch: string | null;
+            merge_mode: string | null;
+          } | null;
+          agent: {
+            agent_id: string;
+            name: string;
+            role: string;
+          } | null;
+          rigName: string | null;
+          reviewMetadata: {
+            pr_url: string | null;
+            branch: string | null;
+            target_branch: string | null;
+            merge_commit: string | null;
+          } | null;
         }[];
-        meta: object;
+      };
+      meta: object;
     }>;
-    adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            agentId: string;
-        };
-        output: void;
-        meta: object;
-    }>;
-    adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
-    }>;
-    adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
-        };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        };
-        meta: object;
-    }>;
-    adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-        };
-        output: {
-            alarm: {
-                nextFireAt: string | null;
-                intervalMs: number;
-                intervalLabel: string;
-            };
-            agents: {
-                working: number;
-                idle: number;
-                stalled: number;
-                dead: number;
-                total: number;
-            };
-            beads: {
-                open: number;
-                inProgress: number;
-                inReview: number;
-                failed: number;
-                triageRequests: number;
-            };
-            patrol: {
-                guppWarnings: number;
-                guppEscalations: number;
-                stalledAgents: number;
-                orphanedHooks: number;
-            };
-            recentEvents: {
-                time: string;
-                type: string;
-                message: string;
-            }[];
-        };
-        meta: object;
-    }>;
-    adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-        };
-        output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
+    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
         }[];
-        meta: object;
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      }[];
+      meta: object;
     }>;
-    adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
-            beadId: string;
+    getConvoy: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
+        }[];
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      } | null;
+      meta: object;
+    }>;
+    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
+        }[];
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      } | null;
+      meta: object;
+    }>;
+    startConvoy: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        convoyId: string;
+      };
+      output: {
+        id: string;
+        title: string;
+        status: 'active' | 'landed';
+        staged: boolean;
+        total_beads: number;
+        closed_beads: number;
+        created_by: string | null;
+        created_at: string;
+        landed_at: string | null;
+        feature_branch: string | null;
+        merge_mode: string | null;
+        beads: {
+          bead_id: string;
+          title: string;
+          status: string;
+          rig_id: string | null;
+          assignee_agent_name: string | null;
+        }[];
+        dependency_edges: {
+          bead_id: string;
+          depends_on_bead_id: string;
+        }[];
+      } | null;
+      meta: object;
+    }>;
+    listOrgTowns: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        organizationId: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_org_id: string;
+        created_by_user_id: string;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    createOrgTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        organizationId: string;
+        name: string;
+      };
+      output: {
+        id: string;
+        name: string;
+        owner_org_id: string;
+        created_by_user_id: string;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    deleteOrgTown: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        organizationId: string;
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    listOrgRigs: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        organizationId: string;
+        townId: string;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      }[];
+      meta: object;
+    }>;
+    createOrgRig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        organizationId: string;
+        townId: string;
+        name: string;
+        gitUrl: string;
+        defaultBranch?: string | undefined;
+        platformIntegrationId?: string | undefined;
+      };
+      output: {
+        id: string;
+        town_id: string;
+        name: string;
+        git_url: string;
+        default_branch: string;
+        platform_integration_id: string | null;
+        created_at: string;
+        updated_at: string;
+      };
+      meta: object;
+    }>;
+    adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+        type?:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule'
+          | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        id: string;
+        rig_id: string | null;
+        role: string;
+        name: string;
+        identity: string;
+        status: string;
+        current_hook_bead_id: string | null;
+        dispatch_attempts: number;
+        last_activity_at: string | null;
+        checkpoint?: unknown;
+        created_at: string;
+        agent_status_message: string | null;
+        agent_status_updated_at: string | null;
+      }[];
+      meta: object;
+    }>;
+    adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        agentId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      };
+      meta: object;
+    }>;
+    adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        alarm: {
+          nextFireAt: string | null;
+          intervalMs: number;
+          intervalLabel: string;
         };
-        output: {
-            bead_id: string;
-            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: "critical" | "high" | "low" | "medium";
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-        } | null;
-        meta: object;
-    }>;
-    debugAgentMetadata: import("@trpc/server").TRPCQueryProcedure<{
-        input: {
-            townId: string;
+        agents: {
+          working: number;
+          idle: number;
+          stalled: number;
+          dead: number;
+          total: number;
         };
-        output: never;
-        meta: object;
+        beads: {
+          open: number;
+          inProgress: number;
+          inReview: number;
+          failed: number;
+          triageRequests: number;
+        };
+        patrol: {
+          guppWarnings: number;
+          guppEscalations: number;
+          stalledAgents: number;
+          orphanedHooks: number;
+        };
+        recentEvents: {
+          time: string;
+          type: string;
+          message: string;
+        }[];
+      };
+      meta: object;
     }>;
-}>>;
+    adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        beadId?: string | undefined;
+        since?: string | undefined;
+        limit?: number | undefined;
+      };
+      output: {
+        bead_event_id: string;
+        bead_id: string;
+        agent_id: string | null;
+        event_type: string;
+        old_value: string | null;
+        new_value: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        rig_id?: string | undefined;
+        rig_name?: string | undefined;
+      }[];
+      meta: object;
+    }>;
+    adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        beadId: string;
+      };
+      output: {
+        bead_id: string;
+        type:
+          | 'agent'
+          | 'convoy'
+          | 'escalation'
+          | 'issue'
+          | 'merge_request'
+          | 'message'
+          | 'molecule';
+        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+        title: string;
+        body: string | null;
+        rig_id: string | null;
+        parent_bead_id: string | null;
+        assignee_agent_bead_id: string | null;
+        priority: 'critical' | 'high' | 'low' | 'medium';
+        labels: string[];
+        metadata: Record<string, unknown>;
+        created_by: string | null;
+        created_at: string;
+        updated_at: string;
+        closed_at: string | null;
+      } | null;
+      meta: object;
+    }>;
+    debugAgentMetadata: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output: never;
+      meta: object;
+    }>;
+  }>
+>;
 export type GastownRouter = typeof gastownRouter;
 /**
  * Wrapped router that nests gastownRouter under a `gastown` key.
@@ -1153,546 +1242,768 @@ export type GastownRouter = typeof gastownRouter;
  * matching the existing RootRouter shape so components don't need
  * to change their procedure paths.
  */
-export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
+  {
     ctx: TRPCContext;
     meta: object;
-    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
     transformer: false;
-}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-    gastown: import("@trpc/server").TRPCBuiltRouter<{
+  },
+  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+    gastown: import('@trpc/server').TRPCBuiltRouter<
+      {
         ctx: TRPCContext;
         meta: object;
-        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
         transformer: false;
-    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
-        createTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                name: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
+      },
+      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
+        createTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            name: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
         }>;
-        listTowns: import("@trpc/server").TRPCQueryProcedure<{
-            input: void;
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            }[];
-            meta: object;
+        listTowns: import('@trpc/server').TRPCQueryProcedure<{
+          input: void;
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
         }>;
-        getTown: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
+        getTown: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
         }>;
         /**
          * Check whether the current user is an admin viewing a town they don't own.
          * Used by the frontend to show an admin banner.
          */
-        checkAdminAccess: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                isAdminViewing: boolean;
-                ownerUserId: string | null;
-            };
-            meta: object;
+        checkAdminAccess: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            isAdminViewing: boolean;
+            ownerUserId: string | null;
+            ownerOrgId: string | null;
+          };
+          meta: object;
         }>;
-        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
+        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        createRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                name: string;
-                gitUrl: string;
-                defaultBranch?: string | undefined;
-                platformIntegrationId?: string | undefined;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
+        createRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
         }>;
-        listRigs: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
+        listRigs: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        getRig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            townId?: string | undefined;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+            agents: {
+              id: string;
+              rig_id: string | null;
+              role: string;
+              name: string;
+              identity: string;
+              status: string;
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+              agent_status_message: string | null;
+              agent_status_updated_at: string | null;
             }[];
-            meta: object;
-        }>;
-        getRig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-                agents: {
-                    id: string;
-                    rig_id: string | null;
-                    role: string;
-                    name: string;
-                    identity: string;
-                    status: string;
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                    agent_status_message: string | null;
-                    agent_status_updated_at: string | null;
-                }[];
-                beads: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
-                }[];
-            };
-            meta: object;
-        }>;
-        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        listBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
+            beads: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-            };
-            output: void;
-            meta: object;
+        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+          };
+          output: void;
+          meta: object;
         }>;
-        updateBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                beadId: string;
-                title?: string | undefined;
-                body?: string | null | undefined;
-                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
-                priority?: "critical" | "high" | "low" | "medium" | undefined;
-                labels?: string[] | undefined;
-                metadata?: Record<string, unknown> | undefined;
-                rig_id?: string | null | undefined;
-                parent_bead_id?: string | null | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
+        listBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            townId?: string | undefined;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
         }>;
-        listAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
+        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+            townId?: string | undefined;
+          };
+          output: void;
+          meta: object;
+        }>;
+        updateBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            beadId: string;
+            townId?: string | undefined;
+            title?: string | undefined;
+            body?: string | null | undefined;
+            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
+            priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+            labels?: string[] | undefined;
+            metadata?: Record<string, unknown> | undefined;
+            rig_id?: string | null | undefined;
+            parent_bead_id?: string | null | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        listAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            townId?: string | undefined;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            agentId: string;
+            townId?: string | undefined;
+          };
+          output: void;
+          meta: object;
+        }>;
+        sling: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            title: string;
+            body?: string | undefined;
+            model?: string | undefined;
+          };
+          output: {
+            bead: {
+              bead_id: string;
+              type:
+                | 'agent'
+                | 'convoy'
+                | 'escalation'
+                | 'issue'
+                | 'merge_request'
+                | 'message'
+                | 'molecule';
+              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              parent_bead_id: string | null;
+              assignee_agent_bead_id: string | null;
+              priority: 'critical' | 'high' | 'low' | 'medium';
+              labels: string[];
+              metadata: Record<string, unknown>;
+              created_by: string | null;
+              created_at: string;
+              updated_at: string;
+              closed_at: string | null;
             };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
-                status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
+            agent: {
+              id: string;
+              rig_id: string | null;
+              role: string;
+              name: string;
+              identity: string;
+              status: string;
+              current_hook_bead_id: string | null;
+              dispatch_attempts: number;
+              last_activity_at: string | null;
+              checkpoint?: unknown;
+              created_at: string;
+              agent_status_message: string | null;
+              agent_status_updated_at: string | null;
+            };
+          };
+          meta: object;
+        }>;
+        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            message: string;
+            model?: string | undefined;
+            rigId?: string | undefined;
+            uiContext?: string | undefined;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
+        }>;
+        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            configured: boolean;
+            townId: string | null;
+            session: {
+              agentId: string;
+              sessionId: string;
+              status: 'active' | 'idle' | 'starting';
+              lastActivityAt: string;
+            } | null;
+          };
+          meta: object;
+        }>;
+        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
+            };
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
+            };
+            beads: {
+              open: number;
+              inProgress: number;
+              inReview: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                agentId: string;
-            };
-            output: void;
-            meta: object;
+        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            agentId: string;
+            sessionStatus: 'active' | 'idle' | 'starting';
+          };
+          meta: object;
         }>;
-        sling: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                rigId: string;
-                title: string;
-                body?: string | undefined;
-                model?: string | undefined;
+        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            agentId: string;
+            townId: string;
+          };
+          output: {
+            url: string;
+            ticket: string;
+          };
+          meta: object;
+        }>;
+        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: {
+            pty: {
+              [x: string]: unknown;
+              id: string;
             };
-            output: {
-                bead: {
-                    bead_id: string;
-                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                    title: string;
-                    body: string | null;
-                    rig_id: string | null;
-                    parent_bead_id: string | null;
-                    assignee_agent_bead_id: string | null;
-                    priority: "critical" | "high" | "low" | "medium";
-                    labels: string[];
-                    metadata: Record<string, unknown>;
-                    created_by: string | null;
-                    created_at: string;
-                    updated_at: string;
-                    closed_at: string | null;
+            wsUrl: string;
+          };
+          meta: object;
+        }>;
+        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+            ptyId: string;
+            cols: number;
+            rows: number;
+          };
+          output: void;
+          meta: object;
+        }>;
+        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            owner_type: 'org' | 'user';
+            owner_id?: string | undefined;
+            created_by_user_id?: string | undefined;
+            organization_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+            staged_convoys_default: boolean;
+            github_cli_pat?: string | undefined;
+            git_author_name?: string | undefined;
+            git_author_email?: string | undefined;
+            disable_ai_coauthor: boolean;
+          };
+          meta: object;
+        }>;
+        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            config: {
+              env_vars?: Record<string, string> | undefined;
+              git_auth?:
+                | {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                  }
+                | undefined;
+              owner_user_id?: string | undefined;
+              owner_type?: 'org' | 'user' | undefined;
+              owner_id?: string | undefined;
+              created_by_user_id?: string | undefined;
+              organization_id?: string | undefined;
+              kilocode_token?: string | undefined;
+              default_model?: string | undefined;
+              small_model?: string | undefined;
+              max_polecats_per_rig?: number | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              refinery?:
+                | {
+                    gates?: string[] | undefined;
+                    auto_merge?: boolean | undefined;
+                    require_clean_merge?: boolean | undefined;
+                  }
+                | undefined;
+              alarm_interval_active?: number | undefined;
+              alarm_interval_idle?: number | undefined;
+              container?:
+                | {
+                    sleep_after_minutes?: number | undefined;
+                  }
+                | undefined;
+              staged_convoys_default?: boolean | undefined;
+              github_cli_pat?: string | undefined;
+              git_author_name?: string | undefined;
+              git_author_email?: string | undefined;
+              disable_ai_coauthor?: boolean | undefined;
+            };
+          };
+          output: {
+            env_vars: Record<string, string>;
+            git_auth: {
+              github_token?: string | undefined;
+              gitlab_token?: string | undefined;
+              gitlab_instance_url?: string | undefined;
+              platform_integration_id?: string | undefined;
+            };
+            owner_user_id?: string | undefined;
+            owner_type: 'org' | 'user';
+            owner_id?: string | undefined;
+            created_by_user_id?: string | undefined;
+            organization_id?: string | undefined;
+            kilocode_token?: string | undefined;
+            default_model?: string | undefined;
+            small_model?: string | undefined;
+            max_polecats_per_rig?: number | undefined;
+            merge_strategy: 'direct' | 'pr';
+            refinery?:
+              | {
+                  gates: string[];
+                  auto_merge: boolean;
+                  require_clean_merge: boolean;
+                }
+              | undefined;
+            alarm_interval_active?: number | undefined;
+            alarm_interval_idle?: number | undefined;
+            container?:
+              | {
+                  sleep_after_minutes?: number | undefined;
+                }
+              | undefined;
+            staged_convoys_default: boolean;
+            github_cli_pat?: string | undefined;
+            git_author_name?: string | undefined;
+            git_author_email?: string | undefined;
+            disable_ai_coauthor: boolean;
+          };
+          meta: object;
+        }>;
+        refreshContainerToken: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            rigId: string;
+            townId?: string | undefined;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        getMergeQueueData: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            rigId?: string | undefined;
+            limit?: number | undefined;
+            since?: string | undefined;
+          };
+          output: {
+            needsAttention: {
+              openPRs: {
+                mrBead: {
+                  bead_id: string;
+                  status: string;
+                  title: string;
+                  body: string | null;
+                  rig_id: string | null;
+                  created_at: string;
+                  updated_at: string;
+                  metadata: Record<string, unknown>;
                 };
-                agent: {
-                    id: string;
-                    rig_id: string | null;
-                    role: string;
-                    name: string;
-                    identity: string;
-                    status: string;
-                    current_hook_bead_id: string | null;
-                    dispatch_attempts: number;
-                    last_activity_at: string | null;
-                    checkpoint?: unknown;
-                    created_at: string;
-                    agent_status_message: string | null;
-                    agent_status_updated_at: string | null;
+                reviewMetadata: {
+                  branch: string;
+                  target_branch: string;
+                  merge_commit: string | null;
+                  pr_url: string | null;
+                  retry_count: number;
                 };
-            };
-            meta: object;
-        }>;
-        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                message: string;
-                model?: string | undefined;
-                rigId?: string | undefined;
-                uiContext?: string | undefined;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                configured: boolean;
-                townId: string | null;
-                session: {
-                    agentId: string;
-                    sessionId: string;
-                    status: "active" | "idle" | "starting";
-                    lastActivityAt: string;
+                sourceBead: {
+                  bead_id: string;
+                  title: string;
+                  status: string;
+                  body: string | null;
                 } | null;
-            };
-            meta: object;
-        }>;
-        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
+                convoy: {
+                  convoy_id: string;
+                  title: string;
+                  total_beads: number;
+                  closed_beads: number;
+                  feature_branch: string | null;
+                  merge_mode: string | null;
+                } | null;
+                agent: {
+                  agent_id: string;
+                  name: string;
+                  role: string;
+                } | null;
+                rigName: string | null;
+                staleSince: string | null;
+                failureReason: string | null;
+              }[];
+              failedReviews: {
+                mrBead: {
+                  bead_id: string;
+                  status: string;
+                  title: string;
+                  body: string | null;
+                  rig_id: string | null;
+                  created_at: string;
+                  updated_at: string;
+                  metadata: Record<string, unknown>;
                 };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
+                reviewMetadata: {
+                  branch: string;
+                  target_branch: string;
+                  merge_commit: string | null;
+                  pr_url: string | null;
+                  retry_count: number;
                 };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    inReview: number;
-                    failed: number;
-                    triageRequests: number;
+                sourceBead: {
+                  bead_id: string;
+                  title: string;
+                  status: string;
+                  body: string | null;
+                } | null;
+                convoy: {
+                  convoy_id: string;
+                  title: string;
+                  total_beads: number;
+                  closed_beads: number;
+                  feature_branch: string | null;
+                  merge_mode: string | null;
+                } | null;
+                agent: {
+                  agent_id: string;
+                  name: string;
+                  role: string;
+                } | null;
+                rigName: string | null;
+                staleSince: string | null;
+                failureReason: string | null;
+              }[];
+              stalePRs: {
+                mrBead: {
+                  bead_id: string;
+                  status: string;
+                  title: string;
+                  body: string | null;
+                  rig_id: string | null;
+                  created_at: string;
+                  updated_at: string;
+                  metadata: Record<string, unknown>;
                 };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
+                reviewMetadata: {
+                  branch: string;
+                  target_branch: string;
+                  merge_commit: string | null;
+                  pr_url: string | null;
+                  retry_count: number;
                 };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
+                sourceBead: {
+                  bead_id: string;
+                  title: string;
+                  status: string;
+                  body: string | null;
+                } | null;
+                convoy: {
+                  convoy_id: string;
+                  title: string;
+                  total_beads: number;
+                  closed_beads: number;
+                  feature_branch: string | null;
+                  merge_mode: string | null;
+                } | null;
+                agent: {
+                  agent_id: string;
+                  name: string;
+                  role: string;
+                } | null;
+                rigName: string | null;
+                staleSince: string | null;
+                failureReason: string | null;
+              }[];
             };
-            meta: object;
-        }>;
-        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                agentId: string;
-                sessionStatus: "active" | "idle" | "starting";
-            };
-            meta: object;
-        }>;
-        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                agentId: string;
-                townId: string;
-            };
-            output: {
-                url: string;
-                ticket: string;
-            };
-            meta: object;
-        }>;
-        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: {
-                pty: {
-                    [x: string]: unknown;
-                    id: string;
-                };
-                wsUrl: string;
-            };
-            meta: object;
-        }>;
-        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-                ptyId: string;
-                cols: number;
-                rows: number;
-            };
-            output: void;
-            meta: object;
-        }>;
-        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                owner_type: "org" | "user";
-                owner_id?: string | undefined;
-                created_by_user_id?: string | undefined;
-                organization_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-                staged_convoys_default: boolean;
-                github_cli_pat?: string | undefined;
-                git_author_name?: string | undefined;
-                git_author_email?: string | undefined;
-                disable_ai_coauthor: boolean;
-            };
-            meta: object;
-        }>;
-        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                config: {
-                    env_vars?: Record<string, string> | undefined;
-                    git_auth?: {
-                        github_token?: string | undefined;
-                        gitlab_token?: string | undefined;
-                        gitlab_instance_url?: string | undefined;
-                        platform_integration_id?: string | undefined;
-                    } | undefined;
-                    owner_user_id?: string | undefined;
-                    owner_type?: "org" | "user" | undefined;
-                    owner_id?: string | undefined;
-                    created_by_user_id?: string | undefined;
-                    organization_id?: string | undefined;
-                    kilocode_token?: string | undefined;
-                    default_model?: string | undefined;
-                    small_model?: string | undefined;
-                    max_polecats_per_rig?: number | undefined;
-                    merge_strategy?: "direct" | "pr" | undefined;
-                    refinery?: {
-                        gates?: string[] | undefined;
-                        auto_merge?: boolean | undefined;
-                        require_clean_merge?: boolean | undefined;
-                    } | undefined;
-                    alarm_interval_active?: number | undefined;
-                    alarm_interval_idle?: number | undefined;
-                    container?: {
-                        sleep_after_minutes?: number | undefined;
-                    } | undefined;
-                    staged_convoys_default?: boolean | undefined;
-                    github_cli_pat?: string | undefined;
-                    git_author_name?: string | undefined;
-                    git_author_email?: string | undefined;
-                    disable_ai_coauthor?: boolean | undefined;
-                };
-            };
-            output: {
-                env_vars: Record<string, string>;
-                git_auth: {
-                    github_token?: string | undefined;
-                    gitlab_token?: string | undefined;
-                    gitlab_instance_url?: string | undefined;
-                    platform_integration_id?: string | undefined;
-                };
-                owner_user_id?: string | undefined;
-                owner_type: "org" | "user";
-                owner_id?: string | undefined;
-                created_by_user_id?: string | undefined;
-                organization_id?: string | undefined;
-                kilocode_token?: string | undefined;
-                default_model?: string | undefined;
-                small_model?: string | undefined;
-                max_polecats_per_rig?: number | undefined;
-                merge_strategy: "direct" | "pr";
-                refinery?: {
-                    gates: string[];
-                    auto_merge: boolean;
-                    require_clean_merge: boolean;
-                } | undefined;
-                alarm_interval_active?: number | undefined;
-                alarm_interval_idle?: number | undefined;
-                container?: {
-                    sleep_after_minutes?: number | undefined;
-                } | undefined;
-                staged_convoys_default: boolean;
-                github_cli_pat?: string | undefined;
-                git_author_name?: string | undefined;
-                git_author_email?: string | undefined;
-                disable_ai_coauthor: boolean;
-            };
-            meta: object;
-        }>;
-        refreshContainerToken: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                rigId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
+            activityLog: {
+              event: {
                 bead_event_id: string;
                 bead_id: string;
                 agent_id: string | null;
@@ -1701,610 +2012,480 @@ export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRoute
                 new_value: string | null;
                 metadata: Record<string, unknown>;
                 created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
-            }[];
-            meta: object;
-        }>;
-        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
+              };
+              mrBead: {
                 bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
-            }[];
-            meta: object;
-        }>;
-        getMergeQueueData: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                rigId?: string | undefined;
-                limit?: number | undefined;
-                since?: string | undefined;
-            };
-            output: {
-                needsAttention: {
-                    openPRs: {
-                        mrBead: {
-                            bead_id: string;
-                            status: string;
-                            title: string;
-                            body: string | null;
-                            rig_id: string | null;
-                            created_at: string;
-                            updated_at: string;
-                            metadata: Record<string, unknown>;
-                        };
-                        reviewMetadata: {
-                            branch: string;
-                            target_branch: string;
-                            merge_commit: string | null;
-                            pr_url: string | null;
-                            retry_count: number;
-                        };
-                        sourceBead: {
-                            bead_id: string;
-                            title: string;
-                            status: string;
-                            body: string | null;
-                        } | null;
-                        convoy: {
-                            convoy_id: string;
-                            title: string;
-                            total_beads: number;
-                            closed_beads: number;
-                            feature_branch: string | null;
-                            merge_mode: string | null;
-                        } | null;
-                        agent: {
-                            agent_id: string;
-                            name: string;
-                            role: string;
-                        } | null;
-                        rigName: string | null;
-                        staleSince: string | null;
-                        failureReason: string | null;
-                    }[];
-                    failedReviews: {
-                        mrBead: {
-                            bead_id: string;
-                            status: string;
-                            title: string;
-                            body: string | null;
-                            rig_id: string | null;
-                            created_at: string;
-                            updated_at: string;
-                            metadata: Record<string, unknown>;
-                        };
-                        reviewMetadata: {
-                            branch: string;
-                            target_branch: string;
-                            merge_commit: string | null;
-                            pr_url: string | null;
-                            retry_count: number;
-                        };
-                        sourceBead: {
-                            bead_id: string;
-                            title: string;
-                            status: string;
-                            body: string | null;
-                        } | null;
-                        convoy: {
-                            convoy_id: string;
-                            title: string;
-                            total_beads: number;
-                            closed_beads: number;
-                            feature_branch: string | null;
-                            merge_mode: string | null;
-                        } | null;
-                        agent: {
-                            agent_id: string;
-                            name: string;
-                            role: string;
-                        } | null;
-                        rigName: string | null;
-                        staleSince: string | null;
-                        failureReason: string | null;
-                    }[];
-                    stalePRs: {
-                        mrBead: {
-                            bead_id: string;
-                            status: string;
-                            title: string;
-                            body: string | null;
-                            rig_id: string | null;
-                            created_at: string;
-                            updated_at: string;
-                            metadata: Record<string, unknown>;
-                        };
-                        reviewMetadata: {
-                            branch: string;
-                            target_branch: string;
-                            merge_commit: string | null;
-                            pr_url: string | null;
-                            retry_count: number;
-                        };
-                        sourceBead: {
-                            bead_id: string;
-                            title: string;
-                            status: string;
-                            body: string | null;
-                        } | null;
-                        convoy: {
-                            convoy_id: string;
-                            title: string;
-                            total_beads: number;
-                            closed_beads: number;
-                            feature_branch: string | null;
-                            merge_mode: string | null;
-                        } | null;
-                        agent: {
-                            agent_id: string;
-                            name: string;
-                            role: string;
-                        } | null;
-                        rigName: string | null;
-                        staleSince: string | null;
-                        failureReason: string | null;
-                    }[];
-                };
-                activityLog: {
-                    event: {
-                        bead_event_id: string;
-                        bead_id: string;
-                        agent_id: string | null;
-                        event_type: string;
-                        old_value: string | null;
-                        new_value: string | null;
-                        metadata: Record<string, unknown>;
-                        created_at: string;
-                    };
-                    mrBead: {
-                        bead_id: string;
-                        title: string;
-                        type: string;
-                        status: string;
-                        rig_id: string | null;
-                        metadata: Record<string, unknown>;
-                    } | null;
-                    sourceBead: {
-                        bead_id: string;
-                        title: string;
-                        status: string;
-                    } | null;
-                    convoy: {
-                        convoy_id: string;
-                        title: string;
-                        total_beads: number;
-                        closed_beads: number;
-                        feature_branch: string | null;
-                        merge_mode: string | null;
-                    } | null;
-                    agent: {
-                        agent_id: string;
-                        name: string;
-                        role: string;
-                    } | null;
-                    rigName: string | null;
-                    reviewMetadata: {
-                        pr_url: string | null;
-                        branch: string | null;
-                        target_branch: string | null;
-                        merge_commit: string | null;
-                    } | null;
-                }[];
-            };
-            meta: object;
-        }>;
-        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
                 title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            }[];
-            meta: object;
-        }>;
-        getConvoy: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            } | null;
-            meta: object;
-        }>;
-        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            } | null;
-            meta: object;
-        }>;
-        startConvoy: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                convoyId: string;
-            };
-            output: {
-                id: string;
-                title: string;
-                status: "active" | "landed";
-                staged: boolean;
-                total_beads: number;
-                closed_beads: number;
-                created_by: string | null;
-                created_at: string;
-                landed_at: string | null;
-                feature_branch: string | null;
-                merge_mode: string | null;
-                beads: {
-                    bead_id: string;
-                    title: string;
-                    status: string;
-                    rig_id: string | null;
-                    assignee_agent_name: string | null;
-                }[];
-                dependency_edges: {
-                    bead_id: string;
-                    depends_on_bead_id: string;
-                }[];
-            } | null;
-            meta: object;
-        }>;
-        listOrgTowns: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                organizationId: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_org_id: string;
-                created_by_user_id: string;
-                created_at: string;
-                updated_at: string;
-            }[];
-            meta: object;
-        }>;
-        createOrgTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                organizationId: string;
-                name: string;
-            };
-            output: {
-                id: string;
-                name: string;
-                owner_org_id: string;
-                created_by_user_id: string;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        deleteOrgTown: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                organizationId: string;
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        listOrgRigs: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                organizationId: string;
-                townId: string;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-            }[];
-            meta: object;
-        }>;
-        createOrgRig: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                organizationId: string;
-                townId: string;
-                name: string;
-                gitUrl: string;
-                defaultBranch?: string | undefined;
-                platformIntegrationId?: string | undefined;
-            };
-            output: {
-                id: string;
-                town_id: string;
-                name: string;
-                git_url: string;
-                default_branch: string;
-                platform_integration_id: string | null;
-                created_at: string;
-                updated_at: string;
-            };
-            meta: object;
-        }>;
-        adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
-                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            }[];
-            meta: object;
-        }>;
-        adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                id: string;
-                rig_id: string | null;
-                role: string;
-                name: string;
-                identity: string;
+                type: string;
                 status: string;
-                current_hook_bead_id: string | null;
-                dispatch_attempts: number;
-                last_activity_at: string | null;
-                checkpoint?: unknown;
-                created_at: string;
-                agent_status_message: string | null;
-                agent_status_updated_at: string | null;
+                rig_id: string | null;
+                metadata: Record<string, unknown>;
+              } | null;
+              sourceBead: {
+                bead_id: string;
+                title: string;
+                status: string;
+              } | null;
+              convoy: {
+                convoy_id: string;
+                title: string;
+                total_beads: number;
+                closed_beads: number;
+                feature_branch: string | null;
+                merge_mode: string | null;
+              } | null;
+              agent: {
+                agent_id: string;
+                name: string;
+                role: string;
+              } | null;
+              rigName: string | null;
+              reviewMetadata: {
+                pr_url: string | null;
+                branch: string | null;
+                target_branch: string | null;
+                merge_commit: string | null;
+              } | null;
             }[];
-            meta: object;
+          };
+          meta: object;
         }>;
-        adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                agentId: string;
-            };
-            output: void;
-            meta: object;
-        }>;
-        adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
-        }>;
-        adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
-            };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            };
-            meta: object;
-        }>;
-        adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-            };
-            output: {
-                alarm: {
-                    nextFireAt: string | null;
-                    intervalMs: number;
-                    intervalLabel: string;
-                };
-                agents: {
-                    working: number;
-                    idle: number;
-                    stalled: number;
-                    dead: number;
-                    total: number;
-                };
-                beads: {
-                    open: number;
-                    inProgress: number;
-                    inReview: number;
-                    failed: number;
-                    triageRequests: number;
-                };
-                patrol: {
-                    guppWarnings: number;
-                    guppEscalations: number;
-                    stalledAgents: number;
-                    orphanedHooks: number;
-                };
-                recentEvents: {
-                    time: string;
-                    type: string;
-                    message: string;
-                }[];
-            };
-            meta: object;
-        }>;
-        adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                beadId?: string | undefined;
-                since?: string | undefined;
-                limit?: number | undefined;
-            };
-            output: {
-                bead_event_id: string;
-                bead_id: string;
-                agent_id: string | null;
-                event_type: string;
-                old_value: string | null;
-                new_value: string | null;
-                metadata: Record<string, unknown>;
-                created_at: string;
-                rig_id?: string | undefined;
-                rig_name?: string | undefined;
+        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
             }[];
-            meta: object;
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          }[];
+          meta: object;
         }>;
-        adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
-                beadId: string;
+        getConvoy: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          } | null;
+          meta: object;
+        }>;
+        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          } | null;
+          meta: object;
+        }>;
+        startConvoy: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            convoyId: string;
+          };
+          output: {
+            id: string;
+            title: string;
+            status: 'active' | 'landed';
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+              bead_id: string;
+              title: string;
+              status: string;
+              rig_id: string | null;
+              assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+              bead_id: string;
+              depends_on_bead_id: string;
+            }[];
+          } | null;
+          meta: object;
+        }>;
+        listOrgTowns: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            organizationId: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_org_id: string;
+            created_by_user_id: string;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        createOrgTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            organizationId: string;
+            name: string;
+          };
+          output: {
+            id: string;
+            name: string;
+            owner_org_id: string;
+            created_by_user_id: string;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        deleteOrgTown: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            organizationId: string;
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        listOrgRigs: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            organizationId: string;
+            townId: string;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          }[];
+          meta: object;
+        }>;
+        createOrgRig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            organizationId: string;
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+          };
+          output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+          };
+          meta: object;
+        }>;
+        adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
+            type?:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule'
+              | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+          }[];
+          meta: object;
+        }>;
+        adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            agentId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            alarm: {
+              nextFireAt: string | null;
+              intervalMs: number;
+              intervalLabel: string;
             };
-            output: {
-                bead_id: string;
-                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
-                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
-                title: string;
-                body: string | null;
-                rig_id: string | null;
-                parent_bead_id: string | null;
-                assignee_agent_bead_id: string | null;
-                priority: "critical" | "high" | "low" | "medium";
-                labels: string[];
-                metadata: Record<string, unknown>;
-                created_by: string | null;
-                created_at: string;
-                updated_at: string;
-                closed_at: string | null;
-            } | null;
-            meta: object;
-        }>;
-        debugAgentMetadata: import("@trpc/server").TRPCQueryProcedure<{
-            input: {
-                townId: string;
+            agents: {
+              working: number;
+              idle: number;
+              stalled: number;
+              dead: number;
+              total: number;
             };
-            output: never;
-            meta: object;
+            beads: {
+              open: number;
+              inProgress: number;
+              inReview: number;
+              failed: number;
+              triageRequests: number;
+            };
+            patrol: {
+              guppWarnings: number;
+              guppEscalations: number;
+              stalledAgents: number;
+              orphanedHooks: number;
+            };
+            recentEvents: {
+              time: string;
+              type: string;
+              message: string;
+            }[];
+          };
+          meta: object;
         }>;
-    }>>;
-}>>;
+        adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+          };
+          output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+          }[];
+          meta: object;
+        }>;
+        adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            beadId: string;
+          };
+          output: {
+            bead_id: string;
+            type:
+              | 'agent'
+              | 'convoy'
+              | 'escalation'
+              | 'issue'
+              | 'merge_request'
+              | 'message'
+              | 'molecule';
+            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: 'critical' | 'high' | 'low' | 'medium';
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+          } | null;
+          meta: object;
+        }>;
+        debugAgentMetadata: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output: never;
+          meta: object;
+        }>;
+      }>
+    >;
+  }>
+>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -1,1271 +1,77 @@
 import type { TRPCContext } from './init';
-export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
+export declare const gastownRouter: import("@trpc/server").TRPCBuiltRouter<{
     ctx: TRPCContext;
     meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
     transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    createTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        name: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listTowns: import('@trpc/server').TRPCQueryProcedure<{
-      input: void;
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getTown: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    createRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        name: string;
-        gitUrl: string;
-        defaultBranch?: string | undefined;
-        platformIntegrationId?: string | undefined;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    listRigs: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    getRig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-        agents: {
-          id: string;
-          rig_id: string | null;
-          role: string;
-          name: string;
-          identity: string;
-          status: string;
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-          agent_status_message: string | null;
-          agent_status_updated_at: string | null;
-        }[];
-        beads: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
-        }[];
-      };
-      meta: object;
-    }>;
-    deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listBeads: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        beadId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    updateBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        beadId: string;
-        title?: string | undefined;
-        body?: string | null | undefined;
-        status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-        priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
-        labels?: string[] | undefined;
-        metadata?: Record<string, unknown> | undefined;
-        rig_id?: string | null | undefined;
-        parent_bead_id?: string | null | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      };
-      meta: object;
-    }>;
-    listAgents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-      };
-      output: {
-        id: string;
-        rig_id: string | null;
-        role: string;
-        name: string;
-        identity: string;
-        status: string;
-        current_hook_bead_id: string | null;
-        dispatch_attempts: number;
-        last_activity_at: string | null;
-        checkpoint?: unknown;
-        created_at: string;
-        agent_status_message: string | null;
-        agent_status_updated_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        agentId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    sling: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        rigId: string;
-        title: string;
-        body?: string | undefined;
-        model?: string | undefined;
-      };
-      output: {
-        bead: {
-          bead_id: string;
-          type:
-            | 'agent'
-            | 'convoy'
-            | 'escalation'
-            | 'issue'
-            | 'merge_request'
-            | 'message'
-            | 'molecule';
-          status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-          title: string;
-          body: string | null;
-          rig_id: string | null;
-          parent_bead_id: string | null;
-          assignee_agent_bead_id: string | null;
-          priority: 'critical' | 'high' | 'low' | 'medium';
-          labels: string[];
-          metadata: Record<string, unknown>;
-          created_by: string | null;
-          created_at: string;
-          updated_at: string;
-          closed_at: string | null;
-        };
-        agent: {
-          id: string;
-          rig_id: string | null;
-          role: string;
-          name: string;
-          identity: string;
-          status: string;
-          current_hook_bead_id: string | null;
-          dispatch_attempts: number;
-          last_activity_at: string | null;
-          checkpoint?: unknown;
-          created_at: string;
-          agent_status_message: string | null;
-          agent_status_updated_at: string | null;
-        };
-      };
-      meta: object;
-    }>;
-    sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        message: string;
-        model?: string | undefined;
-        rigId?: string | undefined;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        configured: boolean;
-        townId: string | null;
-        session: {
-          agentId: string;
-          sessionId: string;
-          status: 'active' | 'idle' | 'starting';
-          lastActivityAt: string;
-        } | null;
-      };
-      meta: object;
-    }>;
-    getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        alarm: {
-          nextFireAt: string | null;
-          intervalMs: number;
-          intervalLabel: string;
-        };
-        agents: {
-          working: number;
-          idle: number;
-          stalled: number;
-          dead: number;
-          total: number;
-        };
-        beads: {
-          open: number;
-          inProgress: number;
-          inReview: number;
-          failed: number;
-          triageRequests: number;
-        };
-        patrol: {
-          guppWarnings: number;
-          guppEscalations: number;
-          stalledAgents: number;
-          orphanedHooks: number;
-        };
-        recentEvents: {
-          time: string;
-          type: string;
-          message: string;
-        }[];
-      };
-      meta: object;
-    }>;
-    ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        agentId: string;
-        sessionStatus: 'active' | 'idle' | 'starting';
-      };
-      meta: object;
-    }>;
-    getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        agentId: string;
-        townId: string;
-      };
-      output: {
-        url: string;
-        ticket: string;
-      };
-      meta: object;
-    }>;
-    createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-      };
-      output: {
-        pty: {
-          [x: string]: unknown;
-          id: string;
-        };
-        wsUrl: string;
-      };
-      meta: object;
-    }>;
-    resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-        ptyId: string;
-        cols: number;
-        rows: number;
-      };
-      output: void;
-      meta: object;
-    }>;
-    getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
-        };
-        owner_user_id?: string | undefined;
-        created_by_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-        staged_convoys_default: boolean;
-        github_cli_pat?: string | undefined;
-        git_author_name?: string | undefined;
-        git_author_email?: string | undefined;
-        disable_ai_coauthor: boolean;
-      };
-      meta: object;
-    }>;
-    updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        config: {
-          env_vars?: Record<string, string> | undefined;
-          git_auth?:
-            | {
-                github_token?: string | undefined;
-                gitlab_token?: string | undefined;
-                gitlab_instance_url?: string | undefined;
-                platform_integration_id?: string | undefined;
-              }
-            | undefined;
-          owner_user_id?: string | undefined;
-          kilocode_token?: string | undefined;
-          default_model?: string | undefined;
-          small_model?: string | undefined;
-          max_polecats_per_rig?: number | undefined;
-          merge_strategy?: 'direct' | 'pr' | undefined;
-          refinery?:
-            | {
-                gates?: string[] | undefined;
-                auto_merge?: boolean | undefined;
-                require_clean_merge?: boolean | undefined;
-              }
-            | undefined;
-          alarm_interval_active?: number | undefined;
-          alarm_interval_idle?: number | undefined;
-          container?:
-            | {
-                sleep_after_minutes?: number | undefined;
-              }
-            | undefined;
-          staged_convoys_default?: boolean | undefined;
-          github_cli_pat?: string | undefined;
-          git_author_name?: string | undefined;
-          git_author_email?: string | undefined;
-          disable_ai_coauthor?: boolean | undefined;
-        };
-      };
-      output: {
-        env_vars: Record<string, string>;
-        git_auth: {
-          github_token?: string | undefined;
-          gitlab_token?: string | undefined;
-          gitlab_instance_url?: string | undefined;
-          platform_integration_id?: string | undefined;
-        };
-        owner_user_id?: string | undefined;
-        kilocode_token?: string | undefined;
-        default_model?: string | undefined;
-        small_model?: string | undefined;
-        max_polecats_per_rig?: number | undefined;
-        merge_strategy: 'direct' | 'pr';
-        refinery?:
-          | {
-              gates: string[];
-              auto_merge: boolean;
-              require_clean_merge: boolean;
-            }
-          | undefined;
-        alarm_interval_active?: number | undefined;
-        alarm_interval_idle?: number | undefined;
-        container?:
-          | {
-              sleep_after_minutes?: number | undefined;
-            }
-          | undefined;
-        staged_convoys_default: boolean;
-      };
-      meta: object;
-    }>;
-    refreshContainerToken: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        rigId: string;
-        beadId?: string | undefined;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    getMergeQueueData: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        rigId?: string | undefined;
-        limit?: number | undefined;
-        since?: string | undefined;
-      };
-      output: {
-        needsAttention: {
-          openPRs: {
-            mrBead: {
-              bead_id: string;
-              status: string;
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              created_at: string;
-              updated_at: string;
-              metadata: Record<string, unknown>;
-            };
-            reviewMetadata: {
-              branch: string;
-              target_branch: string;
-              merge_commit: string | null;
-              pr_url: string | null;
-              retry_count: number;
-            };
-            sourceBead: {
-              bead_id: string;
-              title: string;
-              status: string;
-              body: string | null;
-            } | null;
-            convoy: {
-              convoy_id: string;
-              title: string;
-              total_beads: number;
-              closed_beads: number;
-              feature_branch: string | null;
-              merge_mode: string | null;
-            } | null;
-            agent: {
-              agent_id: string;
-              name: string;
-              role: string;
-            } | null;
-            rigName: string | null;
-            staleSince: string | null;
-            failureReason: string | null;
-          }[];
-          failedReviews: {
-            mrBead: {
-              bead_id: string;
-              status: string;
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              created_at: string;
-              updated_at: string;
-              metadata: Record<string, unknown>;
-            };
-            reviewMetadata: {
-              branch: string;
-              target_branch: string;
-              merge_commit: string | null;
-              pr_url: string | null;
-              retry_count: number;
-            };
-            sourceBead: {
-              bead_id: string;
-              title: string;
-              status: string;
-              body: string | null;
-            } | null;
-            convoy: {
-              convoy_id: string;
-              title: string;
-              total_beads: number;
-              closed_beads: number;
-              feature_branch: string | null;
-              merge_mode: string | null;
-            } | null;
-            agent: {
-              agent_id: string;
-              name: string;
-              role: string;
-            } | null;
-            rigName: string | null;
-            staleSince: string | null;
-            failureReason: string | null;
-          }[];
-          stalePRs: {
-            mrBead: {
-              bead_id: string;
-              status: string;
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              created_at: string;
-              updated_at: string;
-              metadata: Record<string, unknown>;
-            };
-            reviewMetadata: {
-              branch: string;
-              target_branch: string;
-              merge_commit: string | null;
-              pr_url: string | null;
-              retry_count: number;
-            };
-            sourceBead: {
-              bead_id: string;
-              title: string;
-              status: string;
-              body: string | null;
-            } | null;
-            convoy: {
-              convoy_id: string;
-              title: string;
-              total_beads: number;
-              closed_beads: number;
-              feature_branch: string | null;
-              merge_mode: string | null;
-            } | null;
-            agent: {
-              agent_id: string;
-              name: string;
-              role: string;
-            } | null;
-            rigName: string | null;
-            staleSince: string | null;
-            failureReason: string | null;
-          }[];
-        };
-        activityLog: {
-          event: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-          };
-          mrBead: {
-            bead_id: string;
-            title: string;
-            type: string;
-            status: string;
-            rig_id: string | null;
-            metadata: Record<string, unknown>;
-          } | null;
-          sourceBead: {
-            bead_id: string;
-            title: string;
-            status: string;
-          } | null;
-          convoy: {
-            convoy_id: string;
-            title: string;
-            total_beads: number;
-            closed_beads: number;
-            feature_branch: string | null;
-            merge_mode: string | null;
-          } | null;
-          agent: {
-            agent_id: string;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    createTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             name: string;
-            role: string;
-          } | null;
-          rigName: string | null;
-          reviewMetadata: {
-            pr_url: string | null;
-            branch: string | null;
-            target_branch: string | null;
-            merge_commit: string | null;
-          } | null;
-        }[];
-      };
-      meta: object;
-    }>;
-    listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        staged: boolean;
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      }[];
-      meta: object;
-    }>;
-    getConvoy: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        convoyId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        staged: boolean;
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      } | null;
-      meta: object;
-    }>;
-    closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        convoyId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        staged: boolean;
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      } | null;
-      meta: object;
-    }>;
-    startConvoy: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        convoyId: string;
-      };
-      output: {
-        id: string;
-        title: string;
-        status: 'active' | 'landed';
-        staged: boolean;
-        total_beads: number;
-        closed_beads: number;
-        created_by: string | null;
-        created_at: string;
-        landed_at: string | null;
-        feature_branch: string | null;
-        merge_mode: string | null;
-        beads: {
-          bead_id: string;
-          title: string;
-          status: string;
-          rig_id: string | null;
-          assignee_agent_name: string | null;
-        }[];
-        dependency_edges: {
-          bead_id: string;
-          depends_on_bead_id: string;
-        }[];
-      } | null;
-      meta: object;
-    }>;
-    adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
-        type?:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule'
-          | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        id: string;
-        rig_id: string | null;
-        role: string;
-        name: string;
-        identity: string;
-        status: string;
-        current_hook_bead_id: string | null;
-        dispatch_attempts: number;
-        last_activity_at: string | null;
-        checkpoint?: unknown;
-        created_at: string;
-        agent_status_message: string | null;
-        agent_status_updated_at: string | null;
-      }[];
-      meta: object;
-    }>;
-    adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        agentId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        beadId: string;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      };
-      meta: object;
-    }>;
-    adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        townId: string;
-        beadId: string;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      };
-      meta: object;
-    }>;
-    adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-      };
-      output: {
-        alarm: {
-          nextFireAt: string | null;
-          intervalMs: number;
-          intervalLabel: string;
         };
-        agents: {
-          working: number;
-          idle: number;
-          stalled: number;
-          dead: number;
-          total: number;
+        output: {
+            id: string;
+            name: string;
+            owner_user_id: string;
+            created_at: string;
+            updated_at: string;
         };
-        beads: {
-          open: number;
-          inProgress: number;
-          inReview: number;
-          failed: number;
-          triageRequests: number;
-        };
-        patrol: {
-          guppWarnings: number;
-          guppEscalations: number;
-          stalledAgents: number;
-          orphanedHooks: number;
-        };
-        recentEvents: {
-          time: string;
-          type: string;
-          message: string;
-        }[];
-      };
-      meta: object;
-    }>;
-    adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        beadId?: string | undefined;
-        since?: string | undefined;
-        limit?: number | undefined;
-      };
-      output: {
-        bead_event_id: string;
-        bead_id: string;
-        agent_id: string | null;
-        event_type: string;
-        old_value: string | null;
-        new_value: string | null;
-        metadata: Record<string, unknown>;
-        created_at: string;
-        rig_id?: string | undefined;
-        rig_name?: string | undefined;
-      }[];
-      meta: object;
-    }>;
-    adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        townId: string;
-        beadId: string;
-      };
-      output: {
-        bead_id: string;
-        type:
-          | 'agent'
-          | 'convoy'
-          | 'escalation'
-          | 'issue'
-          | 'merge_request'
-          | 'message'
-          | 'molecule';
-        status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-        title: string;
-        body: string | null;
-        rig_id: string | null;
-        parent_bead_id: string | null;
-        assignee_agent_bead_id: string | null;
-        priority: 'critical' | 'high' | 'low' | 'medium';
-        labels: string[];
-        metadata: Record<string, unknown>;
-        created_by: string | null;
-        created_at: string;
-        updated_at: string;
-        closed_at: string | null;
-      } | null;
-      meta: object;
-    }>;
-    listOrgTowns: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        organizationId: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_org_id: string;
-        created_by_user_id: string;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    createOrgTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        organizationId: string;
-        name: string;
-      };
-      output: {
-        id: string;
-        name: string;
-        owner_org_id: string;
-        created_by_user_id: string;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-    deleteOrgTown: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        organizationId: string;
-        townId: string;
-      };
-      output: void;
-      meta: object;
-    }>;
-    listOrgRigs: import('@trpc/server').TRPCQueryProcedure<{
-      input: {
-        organizationId: string;
-        townId: string;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      }[];
-      meta: object;
-    }>;
-    createOrgRig: import('@trpc/server').TRPCMutationProcedure<{
-      input: {
-        organizationId: string;
-        townId: string;
-        name: string;
-        gitUrl: string;
-        defaultBranch?: string | undefined;
-        platformIntegrationId?: string | undefined;
-      };
-      output: {
-        id: string;
-        town_id: string;
-        name: string;
-        git_url: string;
-        default_branch: string;
-        platform_integration_id: string | null;
-        created_at: string;
-        updated_at: string;
-      };
-      meta: object;
-    }>;
-  }>
->;
-export type GastownRouter = typeof gastownRouter;
-/**
- * Wrapped router that nests gastownRouter under a `gastown` key.
- * This preserves the `trpc.gastown.X` call pattern on the frontend,
- * matching the existing RootRouter shape so components don't need
- * to change their procedure paths.
- */
-export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRouter<
-  {
-    ctx: TRPCContext;
-    meta: object;
-    errorShape: import('@trpc/server').TRPCDefaultErrorShape;
-    transformer: false;
-  },
-  import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-    gastown: import('@trpc/server').TRPCBuiltRouter<
-      {
-        ctx: TRPCContext;
         meta: object;
-        errorShape: import('@trpc/server').TRPCDefaultErrorShape;
-        transformer: false;
-      },
-      import('@trpc/server').TRPCDecorateCreateRouterOptions<{
-        createTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            name: string;
-          };
-          output: {
+    }>;
+    listTowns: import("@trpc/server").TRPCQueryProcedure<{
+        input: void;
+        output: {
             id: string;
             name: string;
             owner_user_id: string;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        listTowns: import('@trpc/server').TRPCQueryProcedure<{
-          input: void;
-          output: {
-            id: string;
-            name: string;
-            owner_user_id: string;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getTown: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getTown: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             name: string;
             owner_user_id: string;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        deleteTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    /**
+     * Check whether the current user is an admin viewing a town they don't own.
+     * Used by the frontend to show an admin banner.
+     */
+    checkAdminAccess: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        createRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: {
+            isAdminViewing: boolean;
+            ownerUserId: string | null;
+        };
+        meta: object;
+    }>;
+    deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    createRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             name: string;
             gitUrl: string;
             defaultBranch?: string | undefined;
             platformIntegrationId?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -1274,14 +80,14 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-          };
-          meta: object;
-        }>;
-        listRigs: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    listRigs: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -1290,14 +96,14 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        getRig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getRig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             town_id: string;
             name: string;
@@ -1307,137 +113,116 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             updated_at: string;
             agents: {
-              id: string;
-              rig_id: string | null;
-              role: string;
-              name: string;
-              identity: string;
-              status: string;
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
-              agent_status_message: string | null;
-              agent_status_updated_at: string | null;
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
             }[];
             beads: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             }[];
-          };
-          meta: object;
-        }>;
-        deleteRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listBeads: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    listBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-          };
-          output: {
+            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+        };
+        output: {
             bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
             title: string;
             body: string | null;
             rig_id: string | null;
             parent_bead_id: string | null;
             assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
+            priority: "critical" | "high" | "low" | "medium";
             labels: string[];
             metadata: Record<string, unknown>;
             created_by: string | null;
             created_at: string;
             updated_at: string;
             closed_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             beadId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        updateBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    updateBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             beadId: string;
             title?: string | undefined;
             body?: string | null | undefined;
-            status?: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open' | undefined;
-            priority?: 'critical' | 'high' | 'low' | 'medium' | undefined;
+            status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+            priority?: "critical" | "high" | "low" | "medium" | undefined;
             labels?: string[] | undefined;
             metadata?: Record<string, unknown> | undefined;
             rig_id?: string | null | undefined;
             parent_bead_id?: string | null | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
             title: string;
             body: string | null;
             rig_id: string | null;
             parent_bead_id: string | null;
             assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
+            priority: "critical" | "high" | "low" | "medium";
             labels: string[];
             metadata: Record<string, unknown>;
             created_by: string | null;
             created_at: string;
             updated_at: string;
             closed_at: string | null;
-          };
-          meta: object;
-        }>;
-        listAgents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    listAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
-          };
-          output: {
+        };
+        output: {
             id: string;
             rig_id: string | null;
             role: string;
@@ -1451,308 +236,303 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             agent_status_message: string | null;
             agent_status_updated_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             agentId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        sling: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    sling: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             rigId: string;
             title: string;
             body?: string | undefined;
             model?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             bead: {
-              bead_id: string;
-              type:
-                | 'agent'
-                | 'convoy'
-                | 'escalation'
-                | 'issue'
-                | 'merge_request'
-                | 'message'
-                | 'molecule';
-              status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-              title: string;
-              body: string | null;
-              rig_id: string | null;
-              parent_bead_id: string | null;
-              assignee_agent_bead_id: string | null;
-              priority: 'critical' | 'high' | 'low' | 'medium';
-              labels: string[];
-              metadata: Record<string, unknown>;
-              created_by: string | null;
-              created_at: string;
-              updated_at: string;
-              closed_at: string | null;
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             };
             agent: {
-              id: string;
-              rig_id: string | null;
-              role: string;
-              name: string;
-              identity: string;
-              status: string;
-              current_hook_bead_id: string | null;
-              dispatch_attempts: number;
-              last_activity_at: string | null;
-              checkpoint?: unknown;
-              created_at: string;
-              agent_status_message: string | null;
-              agent_status_updated_at: string | null;
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
             };
-          };
-          meta: object;
-        }>;
-        sendMessage: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             message: string;
             model?: string | undefined;
             rigId?: string | undefined;
-          };
-          output: {
+            uiContext?: string | undefined;
+        };
+        output: {
             agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getMayorStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             configured: boolean;
             townId: string | null;
             session: {
-              agentId: string;
-              sessionId: string;
-              status: 'active' | 'idle' | 'starting';
-              lastActivityAt: string;
+                agentId: string;
+                sessionId: string;
+                status: "active" | "idle" | "starting";
+                lastActivityAt: string;
             } | null;
-          };
-          meta: object;
-        }>;
-        getAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             alarm: {
-              nextFireAt: string | null;
-              intervalMs: number;
-              intervalLabel: string;
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
             };
             agents: {
-              working: number;
-              idle: number;
-              stalled: number;
-              dead: number;
-              total: number;
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
             };
             beads: {
-              open: number;
-              inProgress: number;
-              inReview: number;
-              failed: number;
-              triageRequests: number;
+                open: number;
+                inProgress: number;
+                inReview: number;
+                failed: number;
+                triageRequests: number;
             };
             patrol: {
-              guppWarnings: number;
-              guppEscalations: number;
-              stalledAgents: number;
-              orphanedHooks: number;
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
             };
             recentEvents: {
-              time: string;
-              type: string;
-              message: string;
+                time: string;
+                type: string;
+                message: string;
             }[];
-          };
-          meta: object;
-        }>;
-        ensureMayor: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             agentId: string;
-            sessionStatus: 'active' | 'idle' | 'starting';
-          };
-          meta: object;
-        }>;
-        getAgentStreamUrl: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+            sessionStatus: "active" | "idle" | "starting";
+        };
+        meta: object;
+    }>;
+    getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             agentId: string;
             townId: string;
-          };
-          output: {
+        };
+        output: {
             url: string;
             ticket: string;
-          };
-          meta: object;
-        }>;
-        createPtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             agentId: string;
-          };
-          output: {
+        };
+        output: {
             pty: {
-              [x: string]: unknown;
-              id: string;
+                [x: string]: unknown;
+                id: string;
             };
             wsUrl: string;
-          };
-          meta: object;
-        }>;
-        resizePtySession: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             agentId: string;
             ptyId: string;
             cols: number;
             rows: number;
-          };
-          output: void;
-          meta: object;
-        }>;
-        getTownConfig: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
-          };
-          output: {
+        };
+        output: {
             env_vars: Record<string, string>;
             git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
             };
             owner_user_id?: string | undefined;
+            owner_type: "org" | "user";
+            owner_id?: string | undefined;
             created_by_user_id?: string | undefined;
+            organization_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
             alarm_interval_active?: number | undefined;
             alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
             staged_convoys_default: boolean;
             github_cli_pat?: string | undefined;
             git_author_name?: string | undefined;
             git_author_email?: string | undefined;
             disable_ai_coauthor: boolean;
-          };
-          meta: object;
-        }>;
-        updateTownConfig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+        };
+        meta: object;
+    }>;
+    updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
             config: {
-              env_vars?: Record<string, string> | undefined;
-              git_auth?:
-                | {
+                env_vars?: Record<string, string> | undefined;
+                git_auth?: {
                     github_token?: string | undefined;
                     gitlab_token?: string | undefined;
                     gitlab_instance_url?: string | undefined;
                     platform_integration_id?: string | undefined;
-                  }
-                | undefined;
-              owner_user_id?: string | undefined;
-              kilocode_token?: string | undefined;
-              default_model?: string | undefined;
-              small_model?: string | undefined;
-              max_polecats_per_rig?: number | undefined;
-              merge_strategy?: 'direct' | 'pr' | undefined;
-              refinery?:
-                | {
+                } | undefined;
+                owner_user_id?: string | undefined;
+                owner_type?: "org" | "user" | undefined;
+                owner_id?: string | undefined;
+                created_by_user_id?: string | undefined;
+                organization_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy?: "direct" | "pr" | undefined;
+                refinery?: {
                     gates?: string[] | undefined;
                     auto_merge?: boolean | undefined;
                     require_clean_merge?: boolean | undefined;
-                  }
-                | undefined;
-              alarm_interval_active?: number | undefined;
-              alarm_interval_idle?: number | undefined;
-              container?:
-                | {
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
                     sleep_after_minutes?: number | undefined;
-                  }
-                | undefined;
-              staged_convoys_default?: boolean | undefined;
-              github_cli_pat?: string | undefined;
-              git_author_name?: string | undefined;
-              git_author_email?: string | undefined;
-              disable_ai_coauthor?: boolean | undefined;
+                } | undefined;
+                staged_convoys_default?: boolean | undefined;
+                github_cli_pat?: string | undefined;
+                git_author_name?: string | undefined;
+                git_author_email?: string | undefined;
+                disable_ai_coauthor?: boolean | undefined;
             };
-          };
-          output: {
+        };
+        output: {
             env_vars: Record<string, string>;
             git_auth: {
-              github_token?: string | undefined;
-              gitlab_token?: string | undefined;
-              gitlab_instance_url?: string | undefined;
-              platform_integration_id?: string | undefined;
+                github_token?: string | undefined;
+                gitlab_token?: string | undefined;
+                gitlab_instance_url?: string | undefined;
+                platform_integration_id?: string | undefined;
             };
             owner_user_id?: string | undefined;
+            owner_type: "org" | "user";
+            owner_id?: string | undefined;
+            created_by_user_id?: string | undefined;
+            organization_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
-            merge_strategy: 'direct' | 'pr';
-            refinery?:
-              | {
-                  gates: string[];
-                  auto_merge: boolean;
-                  require_clean_merge: boolean;
-                }
-              | undefined;
+            merge_strategy: "direct" | "pr";
+            refinery?: {
+                gates: string[];
+                auto_merge: boolean;
+                require_clean_merge: boolean;
+            } | undefined;
             alarm_interval_active?: number | undefined;
             alarm_interval_idle?: number | undefined;
-            container?:
-              | {
-                  sleep_after_minutes?: number | undefined;
-                }
-              | undefined;
+            container?: {
+                sleep_after_minutes?: number | undefined;
+            } | undefined;
             staged_convoys_default: boolean;
-          };
-          meta: object;
-        }>;
-        refreshContainerToken: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
+            github_cli_pat?: string | undefined;
+            git_author_name?: string | undefined;
+            git_author_email?: string | undefined;
+            disable_ai_coauthor: boolean;
+        };
+        meta: object;
+    }>;
+    refreshContainerToken: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
             townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        };
+        output: void;
+        meta: object;
+    }>;
+    getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             rigId: string;
             beadId?: string | undefined;
             since?: string | undefined;
             limit?: number | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -1763,16 +543,16 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             rig_id?: string | undefined;
             rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        getTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
             since?: string | undefined;
             limit?: number | undefined;
-          };
-          output: {
+        };
+        output: {
             bead_event_id: string;
             bead_id: string;
             agent_id: string | null;
@@ -1783,144 +563,1136 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             rig_id?: string | undefined;
             rig_name?: string | undefined;
-          }[];
-          meta: object;
-        }>;
-        getMergeQueueData: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
+        }[];
+        meta: object;
+    }>;
+    getMergeQueueData: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
             townId: string;
             rigId?: string | undefined;
             limit?: number | undefined;
             since?: string | undefined;
-          };
-          output: {
+        };
+        output: {
             needsAttention: {
-              openPRs: {
-                mrBead: {
-                  bead_id: string;
-                  status: string;
-                  title: string;
-                  body: string | null;
-                  rig_id: string | null;
-                  created_at: string;
-                  updated_at: string;
-                  metadata: Record<string, unknown>;
-                };
-                reviewMetadata: {
-                  branch: string;
-                  target_branch: string;
-                  merge_commit: string | null;
-                  pr_url: string | null;
-                  retry_count: number;
-                };
-                sourceBead: {
-                  bead_id: string;
-                  title: string;
-                  status: string;
-                  body: string | null;
-                } | null;
-                convoy: {
-                  convoy_id: string;
-                  title: string;
-                  total_beads: number;
-                  closed_beads: number;
-                  feature_branch: string | null;
-                  merge_mode: string | null;
-                } | null;
-                agent: {
-                  agent_id: string;
-                  name: string;
-                  role: string;
-                } | null;
-                rigName: string | null;
-                staleSince: string | null;
-                failureReason: string | null;
-              }[];
-              failedReviews: {
-                mrBead: {
-                  bead_id: string;
-                  status: string;
-                  title: string;
-                  body: string | null;
-                  rig_id: string | null;
-                  created_at: string;
-                  updated_at: string;
-                  metadata: Record<string, unknown>;
-                };
-                reviewMetadata: {
-                  branch: string;
-                  target_branch: string;
-                  merge_commit: string | null;
-                  pr_url: string | null;
-                  retry_count: number;
-                };
-                sourceBead: {
-                  bead_id: string;
-                  title: string;
-                  status: string;
-                  body: string | null;
-                } | null;
-                convoy: {
-                  convoy_id: string;
-                  title: string;
-                  total_beads: number;
-                  closed_beads: number;
-                  feature_branch: string | null;
-                  merge_mode: string | null;
-                } | null;
-                agent: {
-                  agent_id: string;
-                  name: string;
-                  role: string;
-                } | null;
-                rigName: string | null;
-                staleSince: string | null;
-                failureReason: string | null;
-              }[];
-              stalePRs: {
-                mrBead: {
-                  bead_id: string;
-                  status: string;
-                  title: string;
-                  body: string | null;
-                  rig_id: string | null;
-                  created_at: string;
-                  updated_at: string;
-                  metadata: Record<string, unknown>;
-                };
-                reviewMetadata: {
-                  branch: string;
-                  target_branch: string;
-                  merge_commit: string | null;
-                  pr_url: string | null;
-                  retry_count: number;
-                };
-                sourceBead: {
-                  bead_id: string;
-                  title: string;
-                  status: string;
-                  body: string | null;
-                } | null;
-                convoy: {
-                  convoy_id: string;
-                  title: string;
-                  total_beads: number;
-                  closed_beads: number;
-                  feature_branch: string | null;
-                  merge_mode: string | null;
-                } | null;
-                agent: {
-                  agent_id: string;
-                  name: string;
-                  role: string;
-                } | null;
-                rigName: string | null;
-                staleSince: string | null;
-                failureReason: string | null;
-              }[];
+                openPRs: {
+                    mrBead: {
+                        bead_id: string;
+                        status: string;
+                        title: string;
+                        body: string | null;
+                        rig_id: string | null;
+                        created_at: string;
+                        updated_at: string;
+                        metadata: Record<string, unknown>;
+                    };
+                    reviewMetadata: {
+                        branch: string;
+                        target_branch: string;
+                        merge_commit: string | null;
+                        pr_url: string | null;
+                        retry_count: number;
+                    };
+                    sourceBead: {
+                        bead_id: string;
+                        title: string;
+                        status: string;
+                        body: string | null;
+                    } | null;
+                    convoy: {
+                        convoy_id: string;
+                        title: string;
+                        total_beads: number;
+                        closed_beads: number;
+                        feature_branch: string | null;
+                        merge_mode: string | null;
+                    } | null;
+                    agent: {
+                        agent_id: string;
+                        name: string;
+                        role: string;
+                    } | null;
+                    rigName: string | null;
+                    staleSince: string | null;
+                    failureReason: string | null;
+                }[];
+                failedReviews: {
+                    mrBead: {
+                        bead_id: string;
+                        status: string;
+                        title: string;
+                        body: string | null;
+                        rig_id: string | null;
+                        created_at: string;
+                        updated_at: string;
+                        metadata: Record<string, unknown>;
+                    };
+                    reviewMetadata: {
+                        branch: string;
+                        target_branch: string;
+                        merge_commit: string | null;
+                        pr_url: string | null;
+                        retry_count: number;
+                    };
+                    sourceBead: {
+                        bead_id: string;
+                        title: string;
+                        status: string;
+                        body: string | null;
+                    } | null;
+                    convoy: {
+                        convoy_id: string;
+                        title: string;
+                        total_beads: number;
+                        closed_beads: number;
+                        feature_branch: string | null;
+                        merge_mode: string | null;
+                    } | null;
+                    agent: {
+                        agent_id: string;
+                        name: string;
+                        role: string;
+                    } | null;
+                    rigName: string | null;
+                    staleSince: string | null;
+                    failureReason: string | null;
+                }[];
+                stalePRs: {
+                    mrBead: {
+                        bead_id: string;
+                        status: string;
+                        title: string;
+                        body: string | null;
+                        rig_id: string | null;
+                        created_at: string;
+                        updated_at: string;
+                        metadata: Record<string, unknown>;
+                    };
+                    reviewMetadata: {
+                        branch: string;
+                        target_branch: string;
+                        merge_commit: string | null;
+                        pr_url: string | null;
+                        retry_count: number;
+                    };
+                    sourceBead: {
+                        bead_id: string;
+                        title: string;
+                        status: string;
+                        body: string | null;
+                    } | null;
+                    convoy: {
+                        convoy_id: string;
+                        title: string;
+                        total_beads: number;
+                        closed_beads: number;
+                        feature_branch: string | null;
+                        merge_mode: string | null;
+                    } | null;
+                    agent: {
+                        agent_id: string;
+                        name: string;
+                        role: string;
+                    } | null;
+                    rigName: string | null;
+                    staleSince: string | null;
+                    failureReason: string | null;
+                }[];
             };
             activityLog: {
-              event: {
+                event: {
+                    bead_event_id: string;
+                    bead_id: string;
+                    agent_id: string | null;
+                    event_type: string;
+                    old_value: string | null;
+                    new_value: string | null;
+                    metadata: Record<string, unknown>;
+                    created_at: string;
+                };
+                mrBead: {
+                    bead_id: string;
+                    title: string;
+                    type: string;
+                    status: string;
+                    rig_id: string | null;
+                    metadata: Record<string, unknown>;
+                } | null;
+                sourceBead: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                } | null;
+                convoy: {
+                    convoy_id: string;
+                    title: string;
+                    total_beads: number;
+                    closed_beads: number;
+                    feature_branch: string | null;
+                    merge_mode: string | null;
+                } | null;
+                agent: {
+                    agent_id: string;
+                    name: string;
+                    role: string;
+                } | null;
+                rigName: string | null;
+                reviewMetadata: {
+                    pr_url: string | null;
+                    branch: string | null;
+                    target_branch: string | null;
+                    merge_commit: string | null;
+                } | null;
+            }[];
+        };
+        meta: object;
+    }>;
+    listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        }[];
+        meta: object;
+    }>;
+    getConvoy: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            convoyId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        } | null;
+        meta: object;
+    }>;
+    closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            convoyId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        } | null;
+        meta: object;
+    }>;
+    startConvoy: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            convoyId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            status: "active" | "landed";
+            staged: boolean;
+            total_beads: number;
+            closed_beads: number;
+            created_by: string | null;
+            created_at: string;
+            landed_at: string | null;
+            feature_branch: string | null;
+            merge_mode: string | null;
+            beads: {
+                bead_id: string;
+                title: string;
+                status: string;
+                rig_id: string | null;
+                assignee_agent_name: string | null;
+            }[];
+            dependency_edges: {
+                bead_id: string;
+                depends_on_bead_id: string;
+            }[];
+        } | null;
+        meta: object;
+    }>;
+    listOrgTowns: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            organizationId: string;
+        };
+        output: {
+            id: string;
+            name: string;
+            owner_org_id: string;
+            created_by_user_id: string;
+            created_at: string;
+            updated_at: string;
+        }[];
+        meta: object;
+    }>;
+    createOrgTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            organizationId: string;
+            name: string;
+        };
+        output: {
+            id: string;
+            name: string;
+            owner_org_id: string;
+            created_by_user_id: string;
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    deleteOrgTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            organizationId: string;
+            townId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    listOrgRigs: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            organizationId: string;
+            townId: string;
+        };
+        output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+        }[];
+        meta: object;
+    }>;
+    createOrgRig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            organizationId: string;
+            townId: string;
+            name: string;
+            gitUrl: string;
+            defaultBranch?: string | undefined;
+            platformIntegrationId?: string | undefined;
+        };
+        output: {
+            id: string;
+            town_id: string;
+            name: string;
+            git_url: string;
+            default_branch: string;
+            platform_integration_id: string | null;
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+            type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            id: string;
+            rig_id: string | null;
+            role: string;
+            name: string;
+            identity: string;
+            status: string;
+            current_hook_bead_id: string | null;
+            dispatch_attempts: number;
+            last_activity_at: string | null;
+            checkpoint?: unknown;
+            created_at: string;
+            agent_status_message: string | null;
+            agent_status_updated_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            agentId: string;
+        };
+        output: void;
+        meta: object;
+    }>;
+    adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        };
+        meta: object;
+    }>;
+    adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: {
+            alarm: {
+                nextFireAt: string | null;
+                intervalMs: number;
+                intervalLabel: string;
+            };
+            agents: {
+                working: number;
+                idle: number;
+                stalled: number;
+                dead: number;
+                total: number;
+            };
+            beads: {
+                open: number;
+                inProgress: number;
+                inReview: number;
+                failed: number;
+                triageRequests: number;
+            };
+            patrol: {
+                guppWarnings: number;
+                guppEscalations: number;
+                stalledAgents: number;
+                orphanedHooks: number;
+            };
+            recentEvents: {
+                time: string;
+                type: string;
+                message: string;
+            }[];
+        };
+        meta: object;
+    }>;
+    adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            beadId?: string | undefined;
+            since?: string | undefined;
+            limit?: number | undefined;
+        };
+        output: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+            rig_id?: string | undefined;
+            rig_name?: string | undefined;
+        }[];
+        meta: object;
+    }>;
+    adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+            beadId: string;
+        };
+        output: {
+            bead_id: string;
+            type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+            status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+            title: string;
+            body: string | null;
+            rig_id: string | null;
+            parent_bead_id: string | null;
+            assignee_agent_bead_id: string | null;
+            priority: "critical" | "high" | "low" | "medium";
+            labels: string[];
+            metadata: Record<string, unknown>;
+            created_by: string | null;
+            created_at: string;
+            updated_at: string;
+            closed_at: string | null;
+        } | null;
+        meta: object;
+    }>;
+    debugAgentMetadata: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            townId: string;
+        };
+        output: never;
+        meta: object;
+    }>;
+}>>;
+export type GastownRouter = typeof gastownRouter;
+/**
+ * Wrapped router that nests gastownRouter under a `gastown` key.
+ * This preserves the `trpc.gastown.X` call pattern on the frontend,
+ * matching the existing RootRouter shape so components don't need
+ * to change their procedure paths.
+ */
+export declare const wrappedGastownRouter: import("@trpc/server").TRPCBuiltRouter<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    gastown: import("@trpc/server").TRPCBuiltRouter<{
+        ctx: TRPCContext;
+        meta: object;
+        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        transformer: false;
+    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+        createTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                name: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        listTowns: import("@trpc/server").TRPCQueryProcedure<{
+            input: void;
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getTown: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        /**
+         * Check whether the current user is an admin viewing a town they don't own.
+         * Used by the frontend to show an admin banner.
+         */
+        checkAdminAccess: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                isAdminViewing: boolean;
+                ownerUserId: string | null;
+            };
+            meta: object;
+        }>;
+        deleteTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        createRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                name: string;
+                gitUrl: string;
+                defaultBranch?: string | undefined;
+                platformIntegrationId?: string | undefined;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        listRigs: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getRig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+                agents: {
+                    id: string;
+                    rig_id: string | null;
+                    role: string;
+                    name: string;
+                    identity: string;
+                    status: string;
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                    agent_status_message: string | null;
+                    agent_status_updated_at: string | null;
+                }[];
+                beads: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                }[];
+            };
+            meta: object;
+        }>;
+        deleteRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        listBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        deleteBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        updateBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                beadId: string;
+                title?: string | undefined;
+                body?: string | null | undefined;
+                status?: "closed" | "failed" | "in_progress" | "in_review" | "open" | undefined;
+                priority?: "critical" | "high" | "low" | "medium" | undefined;
+                labels?: string[] | undefined;
+                metadata?: Record<string, unknown> | undefined;
+                rig_id?: string | null | undefined;
+                parent_bead_id?: string | null | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        listAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
+                role: string;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        deleteAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                agentId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        sling: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                rigId: string;
+                title: string;
+                body?: string | undefined;
+                model?: string | undefined;
+            };
+            output: {
+                bead: {
+                    bead_id: string;
+                    type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                    status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                    title: string;
+                    body: string | null;
+                    rig_id: string | null;
+                    parent_bead_id: string | null;
+                    assignee_agent_bead_id: string | null;
+                    priority: "critical" | "high" | "low" | "medium";
+                    labels: string[];
+                    metadata: Record<string, unknown>;
+                    created_by: string | null;
+                    created_at: string;
+                    updated_at: string;
+                    closed_at: string | null;
+                };
+                agent: {
+                    id: string;
+                    rig_id: string | null;
+                    role: string;
+                    name: string;
+                    identity: string;
+                    status: string;
+                    current_hook_bead_id: string | null;
+                    dispatch_attempts: number;
+                    last_activity_at: string | null;
+                    checkpoint?: unknown;
+                    created_at: string;
+                    agent_status_message: string | null;
+                    agent_status_updated_at: string | null;
+                };
+            };
+            meta: object;
+        }>;
+        sendMessage: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                message: string;
+                model?: string | undefined;
+                rigId?: string | undefined;
+                uiContext?: string | undefined;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getMayorStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                configured: boolean;
+                townId: string | null;
+                session: {
+                    agentId: string;
+                    sessionId: string;
+                    status: "active" | "idle" | "starting";
+                    lastActivityAt: string;
+                } | null;
+            };
+            meta: object;
+        }>;
+        getAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    inReview: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        ensureMayor: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                agentId: string;
+                sessionStatus: "active" | "idle" | "starting";
+            };
+            meta: object;
+        }>;
+        getAgentStreamUrl: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                agentId: string;
+                townId: string;
+            };
+            output: {
+                url: string;
+                ticket: string;
+            };
+            meta: object;
+        }>;
+        createPtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+            };
+            output: {
+                pty: {
+                    [x: string]: unknown;
+                    id: string;
+                };
+                wsUrl: string;
+            };
+            meta: object;
+        }>;
+        resizePtySession: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
+                ptyId: string;
+                cols: number;
+                rows: number;
+            };
+            output: void;
+            meta: object;
+        }>;
+        getTownConfig: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                owner_type: "org" | "user";
+                owner_id?: string | undefined;
+                created_by_user_id?: string | undefined;
+                organization_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+                staged_convoys_default: boolean;
+                github_cli_pat?: string | undefined;
+                git_author_name?: string | undefined;
+                git_author_email?: string | undefined;
+                disable_ai_coauthor: boolean;
+            };
+            meta: object;
+        }>;
+        updateTownConfig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                config: {
+                    env_vars?: Record<string, string> | undefined;
+                    git_auth?: {
+                        github_token?: string | undefined;
+                        gitlab_token?: string | undefined;
+                        gitlab_instance_url?: string | undefined;
+                        platform_integration_id?: string | undefined;
+                    } | undefined;
+                    owner_user_id?: string | undefined;
+                    owner_type?: "org" | "user" | undefined;
+                    owner_id?: string | undefined;
+                    created_by_user_id?: string | undefined;
+                    organization_id?: string | undefined;
+                    kilocode_token?: string | undefined;
+                    default_model?: string | undefined;
+                    small_model?: string | undefined;
+                    max_polecats_per_rig?: number | undefined;
+                    merge_strategy?: "direct" | "pr" | undefined;
+                    refinery?: {
+                        gates?: string[] | undefined;
+                        auto_merge?: boolean | undefined;
+                        require_clean_merge?: boolean | undefined;
+                    } | undefined;
+                    alarm_interval_active?: number | undefined;
+                    alarm_interval_idle?: number | undefined;
+                    container?: {
+                        sleep_after_minutes?: number | undefined;
+                    } | undefined;
+                    staged_convoys_default?: boolean | undefined;
+                    github_cli_pat?: string | undefined;
+                    git_author_name?: string | undefined;
+                    git_author_email?: string | undefined;
+                    disable_ai_coauthor?: boolean | undefined;
+                };
+            };
+            output: {
+                env_vars: Record<string, string>;
+                git_auth: {
+                    github_token?: string | undefined;
+                    gitlab_token?: string | undefined;
+                    gitlab_instance_url?: string | undefined;
+                    platform_integration_id?: string | undefined;
+                };
+                owner_user_id?: string | undefined;
+                owner_type: "org" | "user";
+                owner_id?: string | undefined;
+                created_by_user_id?: string | undefined;
+                organization_id?: string | undefined;
+                kilocode_token?: string | undefined;
+                default_model?: string | undefined;
+                small_model?: string | undefined;
+                max_polecats_per_rig?: number | undefined;
+                merge_strategy: "direct" | "pr";
+                refinery?: {
+                    gates: string[];
+                    auto_merge: boolean;
+                    require_clean_merge: boolean;
+                } | undefined;
+                alarm_interval_active?: number | undefined;
+                alarm_interval_idle?: number | undefined;
+                container?: {
+                    sleep_after_minutes?: number | undefined;
+                } | undefined;
+                staged_convoys_default: boolean;
+                github_cli_pat?: string | undefined;
+                git_author_name?: string | undefined;
+                git_author_email?: string | undefined;
+                disable_ai_coauthor: boolean;
+            };
+            meta: object;
+        }>;
+        refreshContainerToken: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        getBeadEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                rigId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
                 bead_event_id: string;
                 bead_id: string;
                 agent_id: string | null;
@@ -1929,473 +1701,610 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                 new_value: string | null;
                 metadata: Record<string, unknown>;
                 created_at: string;
-              };
-              mrBead: {
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        getTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
                 bead_id: string;
-                title: string;
-                type: string;
-                status: string;
-                rig_id: string | null;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
                 metadata: Record<string, unknown>;
-              } | null;
-              sourceBead: {
-                bead_id: string;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
+            }[];
+            meta: object;
+        }>;
+        getMergeQueueData: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                rigId?: string | undefined;
+                limit?: number | undefined;
+                since?: string | undefined;
+            };
+            output: {
+                needsAttention: {
+                    openPRs: {
+                        mrBead: {
+                            bead_id: string;
+                            status: string;
+                            title: string;
+                            body: string | null;
+                            rig_id: string | null;
+                            created_at: string;
+                            updated_at: string;
+                            metadata: Record<string, unknown>;
+                        };
+                        reviewMetadata: {
+                            branch: string;
+                            target_branch: string;
+                            merge_commit: string | null;
+                            pr_url: string | null;
+                            retry_count: number;
+                        };
+                        sourceBead: {
+                            bead_id: string;
+                            title: string;
+                            status: string;
+                            body: string | null;
+                        } | null;
+                        convoy: {
+                            convoy_id: string;
+                            title: string;
+                            total_beads: number;
+                            closed_beads: number;
+                            feature_branch: string | null;
+                            merge_mode: string | null;
+                        } | null;
+                        agent: {
+                            agent_id: string;
+                            name: string;
+                            role: string;
+                        } | null;
+                        rigName: string | null;
+                        staleSince: string | null;
+                        failureReason: string | null;
+                    }[];
+                    failedReviews: {
+                        mrBead: {
+                            bead_id: string;
+                            status: string;
+                            title: string;
+                            body: string | null;
+                            rig_id: string | null;
+                            created_at: string;
+                            updated_at: string;
+                            metadata: Record<string, unknown>;
+                        };
+                        reviewMetadata: {
+                            branch: string;
+                            target_branch: string;
+                            merge_commit: string | null;
+                            pr_url: string | null;
+                            retry_count: number;
+                        };
+                        sourceBead: {
+                            bead_id: string;
+                            title: string;
+                            status: string;
+                            body: string | null;
+                        } | null;
+                        convoy: {
+                            convoy_id: string;
+                            title: string;
+                            total_beads: number;
+                            closed_beads: number;
+                            feature_branch: string | null;
+                            merge_mode: string | null;
+                        } | null;
+                        agent: {
+                            agent_id: string;
+                            name: string;
+                            role: string;
+                        } | null;
+                        rigName: string | null;
+                        staleSince: string | null;
+                        failureReason: string | null;
+                    }[];
+                    stalePRs: {
+                        mrBead: {
+                            bead_id: string;
+                            status: string;
+                            title: string;
+                            body: string | null;
+                            rig_id: string | null;
+                            created_at: string;
+                            updated_at: string;
+                            metadata: Record<string, unknown>;
+                        };
+                        reviewMetadata: {
+                            branch: string;
+                            target_branch: string;
+                            merge_commit: string | null;
+                            pr_url: string | null;
+                            retry_count: number;
+                        };
+                        sourceBead: {
+                            bead_id: string;
+                            title: string;
+                            status: string;
+                            body: string | null;
+                        } | null;
+                        convoy: {
+                            convoy_id: string;
+                            title: string;
+                            total_beads: number;
+                            closed_beads: number;
+                            feature_branch: string | null;
+                            merge_mode: string | null;
+                        } | null;
+                        agent: {
+                            agent_id: string;
+                            name: string;
+                            role: string;
+                        } | null;
+                        rigName: string | null;
+                        staleSince: string | null;
+                        failureReason: string | null;
+                    }[];
+                };
+                activityLog: {
+                    event: {
+                        bead_event_id: string;
+                        bead_id: string;
+                        agent_id: string | null;
+                        event_type: string;
+                        old_value: string | null;
+                        new_value: string | null;
+                        metadata: Record<string, unknown>;
+                        created_at: string;
+                    };
+                    mrBead: {
+                        bead_id: string;
+                        title: string;
+                        type: string;
+                        status: string;
+                        rig_id: string | null;
+                        metadata: Record<string, unknown>;
+                    } | null;
+                    sourceBead: {
+                        bead_id: string;
+                        title: string;
+                        status: string;
+                    } | null;
+                    convoy: {
+                        convoy_id: string;
+                        title: string;
+                        total_beads: number;
+                        closed_beads: number;
+                        feature_branch: string | null;
+                        merge_mode: string | null;
+                    } | null;
+                    agent: {
+                        agent_id: string;
+                        name: string;
+                        role: string;
+                    } | null;
+                    rigName: string | null;
+                    reviewMetadata: {
+                        pr_url: string | null;
+                        branch: string | null;
+                        target_branch: string | null;
+                        merge_commit: string | null;
+                    } | null;
+                }[];
+            };
+            meta: object;
+        }>;
+        listConvoys: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
                 title: string;
-                status: string;
-              } | null;
-              convoy: {
-                convoy_id: string;
-                title: string;
+                status: "active" | "landed";
+                staged: boolean;
                 total_beads: number;
                 closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
                 feature_branch: string | null;
                 merge_mode: string | null;
-              } | null;
-              agent: {
-                agent_id: string;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            }[];
+            meta: object;
+        }>;
+        getConvoy: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                staged: boolean;
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
+        }>;
+        closeConvoy: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                staged: boolean;
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
+        }>;
+        startConvoy: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                convoyId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                status: "active" | "landed";
+                staged: boolean;
+                total_beads: number;
+                closed_beads: number;
+                created_by: string | null;
+                created_at: string;
+                landed_at: string | null;
+                feature_branch: string | null;
+                merge_mode: string | null;
+                beads: {
+                    bead_id: string;
+                    title: string;
+                    status: string;
+                    rig_id: string | null;
+                    assignee_agent_name: string | null;
+                }[];
+                dependency_edges: {
+                    bead_id: string;
+                    depends_on_bead_id: string;
+                }[];
+            } | null;
+            meta: object;
+        }>;
+        listOrgTowns: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                organizationId: string;
+            };
+            output: {
+                id: string;
                 name: string;
+                owner_org_id: string;
+                created_by_user_id: string;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        createOrgTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                organizationId: string;
+                name: string;
+            };
+            output: {
+                id: string;
+                name: string;
+                owner_org_id: string;
+                created_by_user_id: string;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        deleteOrgTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                organizationId: string;
+                townId: string;
+            };
+            output: void;
+            meta: object;
+        }>;
+        listOrgRigs: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                organizationId: string;
+                townId: string;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        createOrgRig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                organizationId: string;
+                townId: string;
+                name: string;
+                gitUrl: string;
+                defaultBranch?: string | undefined;
+                platformIntegrationId?: string | undefined;
+            };
+            output: {
+                id: string;
+                town_id: string;
+                name: string;
+                git_url: string;
+                default_branch: string;
+                platform_integration_id: string | null;
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        adminListBeads: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                status?: "closed" | "failed" | "in_progress" | "open" | undefined;
+                type?: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule" | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        adminListAgents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                id: string;
+                rig_id: string | null;
                 role: string;
-              } | null;
-              rigName: string | null;
-              reviewMetadata: {
-                pr_url: string | null;
-                branch: string | null;
-                target_branch: string | null;
-                merge_commit: string | null;
-              } | null;
+                name: string;
+                identity: string;
+                status: string;
+                current_hook_bead_id: string | null;
+                dispatch_attempts: number;
+                last_activity_at: string | null;
+                checkpoint?: unknown;
+                created_at: string;
+                agent_status_message: string | null;
+                agent_status_updated_at: string | null;
             }[];
-          };
-          meta: object;
+            meta: object;
         }>;
-        listConvoys: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            id: string;
-            title: string;
-            status: 'active' | 'landed';
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
-            }[];
-          }[];
-          meta: object;
-        }>;
-        getConvoy: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            convoyId: string;
-          };
-          output: {
-            id: string;
-            title: string;
-            status: 'active' | 'landed';
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
-            }[];
-          } | null;
-          meta: object;
-        }>;
-        closeConvoy: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            convoyId: string;
-          };
-          output: {
-            id: string;
-            title: string;
-            status: 'active' | 'landed';
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
-            }[];
-          } | null;
-          meta: object;
-        }>;
-        startConvoy: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            convoyId: string;
-          };
-          output: {
-            id: string;
-            title: string;
-            status: 'active' | 'landed';
-            staged: boolean;
-            total_beads: number;
-            closed_beads: number;
-            created_by: string | null;
-            created_at: string;
-            landed_at: string | null;
-            feature_branch: string | null;
-            merge_mode: string | null;
-            beads: {
-              bead_id: string;
-              title: string;
-              status: string;
-              rig_id: string | null;
-              assignee_agent_name: string | null;
-            }[];
-            dependency_edges: {
-              bead_id: string;
-              depends_on_bead_id: string;
-            }[];
-          } | null;
-          meta: object;
-        }>;
-        adminListBeads: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            status?: 'closed' | 'failed' | 'in_progress' | 'open' | undefined;
-            type?:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule'
-              | undefined;
-            limit?: number | undefined;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        adminListAgents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            id: string;
-            rig_id: string | null;
-            role: string;
-            name: string;
-            identity: string;
-            status: string;
-            current_hook_bead_id: string | null;
-            dispatch_attempts: number;
-            last_activity_at: string | null;
-            checkpoint?: unknown;
-            created_at: string;
-            agent_status_message: string | null;
-            agent_status_updated_at: string | null;
-          }[];
-          meta: object;
-        }>;
-        adminForceRestartContainer: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        adminForceResetAgent: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            agentId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        adminForceCloseBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            beadId: string;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          };
-          meta: object;
-        }>;
-        adminForceFailBead: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            townId: string;
-            beadId: string;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          };
-          meta: object;
-        }>;
-        adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-          };
-          output: {
-            alarm: {
-              nextFireAt: string | null;
-              intervalMs: number;
-              intervalLabel: string;
+        adminForceRestartContainer: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
             };
-            agents: {
-              working: number;
-              idle: number;
-              stalled: number;
-              dead: number;
-              total: number;
+            output: void;
+            meta: object;
+        }>;
+        adminForceResetAgent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                agentId: string;
             };
-            beads: {
-              open: number;
-              inProgress: number;
-              inReview: number;
-              failed: number;
-              triageRequests: number;
+            output: void;
+            meta: object;
+        }>;
+        adminForceCloseBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
             };
-            patrol: {
-              guppWarnings: number;
-              guppEscalations: number;
-              stalledAgents: number;
-              orphanedHooks: number;
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
             };
-            recentEvents: {
-              time: string;
-              type: string;
-              message: string;
+            meta: object;
+        }>;
+        adminForceFailBead: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            };
+            meta: object;
+        }>;
+        adminGetAlarmStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: {
+                alarm: {
+                    nextFireAt: string | null;
+                    intervalMs: number;
+                    intervalLabel: string;
+                };
+                agents: {
+                    working: number;
+                    idle: number;
+                    stalled: number;
+                    dead: number;
+                    total: number;
+                };
+                beads: {
+                    open: number;
+                    inProgress: number;
+                    inReview: number;
+                    failed: number;
+                    triageRequests: number;
+                };
+                patrol: {
+                    guppWarnings: number;
+                    guppEscalations: number;
+                    stalledAgents: number;
+                    orphanedHooks: number;
+                };
+                recentEvents: {
+                    time: string;
+                    type: string;
+                    message: string;
+                }[];
+            };
+            meta: object;
+        }>;
+        adminGetTownEvents: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                beadId?: string | undefined;
+                since?: string | undefined;
+                limit?: number | undefined;
+            };
+            output: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+                rig_id?: string | undefined;
+                rig_name?: string | undefined;
             }[];
-          };
-          meta: object;
+            meta: object;
         }>;
-        adminGetTownEvents: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            beadId?: string | undefined;
-            since?: string | undefined;
-            limit?: number | undefined;
-          };
-          output: {
-            bead_event_id: string;
-            bead_id: string;
-            agent_id: string | null;
-            event_type: string;
-            old_value: string | null;
-            new_value: string | null;
-            metadata: Record<string, unknown>;
-            created_at: string;
-            rig_id?: string | undefined;
-            rig_name?: string | undefined;
-          }[];
-          meta: object;
+        adminGetBead: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+                beadId: string;
+            };
+            output: {
+                bead_id: string;
+                type: "agent" | "convoy" | "escalation" | "issue" | "merge_request" | "message" | "molecule";
+                status: "closed" | "failed" | "in_progress" | "in_review" | "open";
+                title: string;
+                body: string | null;
+                rig_id: string | null;
+                parent_bead_id: string | null;
+                assignee_agent_bead_id: string | null;
+                priority: "critical" | "high" | "low" | "medium";
+                labels: string[];
+                metadata: Record<string, unknown>;
+                created_by: string | null;
+                created_at: string;
+                updated_at: string;
+                closed_at: string | null;
+            } | null;
+            meta: object;
         }>;
-        adminGetBead: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            townId: string;
-            beadId: string;
-          };
-          output: {
-            bead_id: string;
-            type:
-              | 'agent'
-              | 'convoy'
-              | 'escalation'
-              | 'issue'
-              | 'merge_request'
-              | 'message'
-              | 'molecule';
-            status: 'closed' | 'failed' | 'in_progress' | 'in_review' | 'open';
-            title: string;
-            body: string | null;
-            rig_id: string | null;
-            parent_bead_id: string | null;
-            assignee_agent_bead_id: string | null;
-            priority: 'critical' | 'high' | 'low' | 'medium';
-            labels: string[];
-            metadata: Record<string, unknown>;
-            created_by: string | null;
-            created_at: string;
-            updated_at: string;
-            closed_at: string | null;
-          } | null;
-          meta: object;
+        debugAgentMetadata: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                townId: string;
+            };
+            output: never;
+            meta: object;
         }>;
-        listOrgTowns: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            organizationId: string;
-          };
-          output: {
-            id: string;
-            name: string;
-            owner_org_id: string;
-            created_by_user_id: string;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        createOrgTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            organizationId: string;
-            name: string;
-          };
-          output: {
-            id: string;
-            name: string;
-            owner_org_id: string;
-            created_by_user_id: string;
-            created_at: string;
-            updated_at: string;
-          };
-          meta: object;
-        }>;
-        deleteOrgTown: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            organizationId: string;
-            townId: string;
-          };
-          output: void;
-          meta: object;
-        }>;
-        listOrgRigs: import('@trpc/server').TRPCQueryProcedure<{
-          input: {
-            organizationId: string;
-            townId: string;
-          };
-          output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-          }[];
-          meta: object;
-        }>;
-        createOrgRig: import('@trpc/server').TRPCMutationProcedure<{
-          input: {
-            organizationId: string;
-            townId: string;
-            name: string;
-            gitUrl: string;
-            defaultBranch?: string | undefined;
-            platformIntegrationId?: string | undefined;
-          };
-          output: {
-            id: string;
-            town_id: string;
-            name: string;
-            git_url: string;
-            default_branch: string;
-            platform_integration_id: string | null;
-            created_at: string;
-            updated_at: string;
-          };
-          meta: object;
-        }>;
-      }>
-    >;
-  }>
->;
+    }>>;
+}>>;
 export type WrappedGastownRouter = typeof wrappedGastownRouter;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,16 +1,12 @@
 import type { z } from 'zod';
-export declare const TownOutput: z.ZodObject<
-  {
+export declare const TownOutput: z.ZodObject<{
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const RigOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const RigOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -19,27 +15,24 @@ export declare const RigOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const BeadOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadOutput: z.ZodObject<{
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-      agent: 'agent';
-      convoy: 'convoy';
-      escalation: 'escalation';
-      issue: 'issue';
-      merge_request: 'merge_request';
-      message: 'message';
-      molecule: 'molecule';
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
     }>;
     status: z.ZodEnum<{
-      closed: 'closed';
-      failed: 'failed';
-      in_progress: 'in_progress';
-      in_review: 'in_review';
-      open: 'open';
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        in_review: "in_review";
+        open: "open";
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -47,10 +40,10 @@ export declare const BeadOutput: z.ZodObject<
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-      critical: 'critical';
-      high: 'high';
-      low: 'low';
-      medium: 'medium';
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -58,36 +51,23 @@ export declare const BeadOutput: z.ZodObject<
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const AgentOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const AgentOutput: z.ZodObject<{
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<
-      [
-        z.ZodEnum<{
-          mayor: 'mayor';
-          polecat: 'polecat';
-          refinery: 'refinery';
-        }>,
-        z.ZodString,
-      ]
-    >;
+    role: z.ZodUnion<[z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>, z.ZodString]>;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodUnion<
-      [
-        z.ZodEnum<{
-          dead: 'dead';
-          idle: 'idle';
-          stalled: 'stalled';
-          working: 'working';
-        }>,
-        z.ZodString,
-      ]
-    >;
+    status: z.ZodUnion<[z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>, z.ZodString]>;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
@@ -95,11 +75,8 @@ export declare const AgentOutput: z.ZodObject<
     created_at: z.ZodString;
     agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-  },
-  z.core.$strip
->;
-export declare const BeadEventOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const BeadEventOutput: z.ZodObject<{
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -110,68 +87,45 @@ export declare const BeadEventOutput: z.ZodObject<
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const MayorSendResultOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorSendResultOutput: z.ZodObject<{
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-      active: 'active';
-      idle: 'idle';
-      starting: 'starting';
+        active: "active";
+        idle: "idle";
+        starting: "starting";
     }>;
-  },
-  z.core.$strip
->;
-export declare const MayorStatusOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const MayorStatusOutput: z.ZodObject<{
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<
-      z.ZodObject<
-        {
-          agentId: z.ZodString;
-          sessionId: z.ZodString;
-          status: z.ZodEnum<{
-            active: 'active';
-            idle: 'idle';
-            starting: 'starting';
-          }>;
-          lastActivityAt: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const StreamTicketOutput: z.ZodObject<
-  {
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const StreamTicketOutput: z.ZodObject<{
     url: z.ZodString;
     ticket: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const PtySessionOutput: z.ZodObject<
-  {
-    pty: z.ZodObject<
-      {
+}, z.core.$strip>;
+export declare const PtySessionOutput: z.ZodObject<{
+    pty: z.ZodObject<{
         id: z.ZodString;
-      },
-      z.core.$loose
-    >;
+    }, z.core.$loose>;
     wsUrl: z.ZodString;
-  },
-  z.core.$strip
->;
-export declare const ConvoyOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
     staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
@@ -181,16 +135,13 @@ export declare const ConvoyOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-  },
-  z.core.$strip
->;
-export declare const ConvoyDetailOutput: z.ZodObject<
-  {
+}, z.core.$strip>;
+export declare const ConvoyDetailOutput: z.ZodObject<{
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-      active: 'active';
-      landed: 'landed';
+        active: "active";
+        landed: "landed";
     }>;
     staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
@@ -200,50 +151,36 @@ export declare const ConvoyDetailOutput: z.ZodObject<
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          title: z.ZodString;
-          status: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_name: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-    dependency_edges: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          depends_on_bead_id: z.ZodString;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const SlingResultOutput: z.ZodObject<
-  {
-    bead: z.ZodObject<
-      {
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const SlingResultOutput: z.ZodObject<{
+    bead: z.ZodObject<{
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-          agent: 'agent';
-          convoy: 'convoy';
-          escalation: 'escalation';
-          issue: 'issue';
-          merge_request: 'merge_request';
-          message: 'message';
-          molecule: 'molecule';
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
         }>;
         status: z.ZodEnum<{
-          closed: 'closed';
-          failed: 'failed';
-          in_progress: 'in_progress';
-          in_review: 'in_review';
-          open: 'open';
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -251,10 +188,10 @@ export declare const SlingResultOutput: z.ZodObject<
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-          critical: 'critical';
-          high: 'high';
-          low: 'low';
-          medium: 'medium';
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -262,36 +199,23 @@ export declare const SlingResultOutput: z.ZodObject<
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-      },
-      z.core.$strip
-    >;
-    agent: z.ZodObject<
-      {
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<
-          [
-            z.ZodEnum<{
-              mayor: 'mayor';
-              polecat: 'polecat';
-              refinery: 'refinery';
-            }>,
-            z.ZodString,
-          ]
-        >;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodUnion<
-          [
-            z.ZodEnum<{
-              dead: 'dead';
-              idle: 'idle';
-              stalled: 'stalled';
-              working: 'working';
-            }>,
-            z.ZodString,
-          ]
-        >;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
@@ -299,14 +223,9 @@ export declare const SlingResultOutput: z.ZodObject<
         created_at: z.ZodString;
         agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
         agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      },
-      z.core.$strip
-    >;
-  },
-  z.core.$strip
->;
-export declare const RigDetailOutput: z.ZodObject<
-  {
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const RigDetailOutput: z.ZodObject<{
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -315,579 +234,752 @@ export declare const RigDetailOutput: z.ZodObject<
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<
-      z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                mayor: 'mayor';
-                polecat: 'polecat';
-                refinery: 'refinery';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                dead: 'dead';
-                idle: 'idle';
-                stalled: 'stalled';
-                working: 'working';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        },
-        z.core.$strip
-      >
-    >;
-    beads: z.ZodArray<
-      z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            in_review: 'in_review';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >
-    >;
-  },
-  z.core.$strip
->;
-export declare const RpcTownOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      name: z.ZodString;
-      owner_user_id: z.ZodString;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_id: z.ZodString;
-      type: z.ZodEnum<{
-        agent: 'agent';
-        convoy: 'convoy';
-        escalation: 'escalation';
-        issue: 'issue';
-        merge_request: 'merge_request';
-        message: 'message';
-        molecule: 'molecule';
-      }>;
-      status: z.ZodEnum<{
-        closed: 'closed';
-        failed: 'failed';
-        in_progress: 'in_progress';
-        in_review: 'in_review';
-        open: 'open';
-      }>;
-      title: z.ZodString;
-      body: z.ZodNullable<z.ZodString>;
-      rig_id: z.ZodNullable<z.ZodString>;
-      parent_bead_id: z.ZodNullable<z.ZodString>;
-      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-      priority: z.ZodEnum<{
-        critical: 'critical';
-        high: 'high';
-        low: 'low';
-        medium: 'medium';
-      }>;
-      labels: z.ZodArray<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      closed_at: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAgentOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      rig_id: z.ZodNullable<z.ZodString>;
-      role: z.ZodUnion<
-        [
-          z.ZodEnum<{
-            mayor: 'mayor';
-            polecat: 'polecat';
-            refinery: 'refinery';
-          }>,
-          z.ZodString,
-        ]
-      >;
-      name: z.ZodString;
-      identity: z.ZodString;
-      status: z.ZodUnion<
-        [
-          z.ZodEnum<{
-            dead: 'dead';
-            idle: 'idle';
-            stalled: 'stalled';
-            working: 'working';
-          }>,
-          z.ZodString,
-        ]
-      >;
-      current_hook_bead_id: z.ZodNullable<z.ZodString>;
-      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-      last_activity_at: z.ZodNullable<z.ZodString>;
-      checkpoint: z.ZodOptional<z.ZodUnknown>;
-      created_at: z.ZodString;
-      agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcBeadEventOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead_event_id: z.ZodString;
-      bead_id: z.ZodString;
-      agent_id: z.ZodNullable<z.ZodString>;
-      event_type: z.ZodString;
-      old_value: z.ZodNullable<z.ZodString>;
-      new_value: z.ZodNullable<z.ZodString>;
-      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-      created_at: z.ZodString;
-      rig_id: z.ZodOptional<z.ZodString>;
-      rig_name: z.ZodOptional<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      agentId: z.ZodString;
-      sessionStatus: z.ZodEnum<{
-        active: 'active';
-        idle: 'idle';
-        starting: 'starting';
-      }>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcMayorStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      configured: z.ZodBoolean;
-      townId: z.ZodNullable<z.ZodString>;
-      session: z.ZodNullable<
-        z.ZodObject<
-          {
-            agentId: z.ZodString;
-            sessionId: z.ZodString;
-            status: z.ZodEnum<{
-              active: 'active';
-              idle: 'idle';
-              starting: 'starting';
-            }>;
-            lastActivityAt: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcStreamTicketOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      url: z.ZodString;
-      ticket: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcPtySessionOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      pty: z.ZodObject<
-        {
-          id: z.ZodString;
-        },
-        z.core.$loose
-      >;
-      wsUrl: z.ZodString;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      staged: z.ZodBoolean;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      title: z.ZodString;
-      status: z.ZodEnum<{
-        active: 'active';
-        landed: 'landed';
-      }>;
-      staged: z.ZodBoolean;
-      total_beads: z.ZodNumber;
-      closed_beads: z.ZodNumber;
-      created_by: z.ZodNullable<z.ZodString>;
-      created_at: z.ZodString;
-      landed_at: z.ZodNullable<z.ZodString>;
-      feature_branch: z.ZodNullable<z.ZodString>;
-      merge_mode: z.ZodNullable<z.ZodString>;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodString;
+    owner_user_id: z.ZodString;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_id: z.ZodString;
+    type: z.ZodEnum<{
+        agent: "agent";
+        convoy: "convoy";
+        escalation: "escalation";
+        issue: "issue";
+        merge_request: "merge_request";
+        message: "message";
+        molecule: "molecule";
+    }>;
+    status: z.ZodEnum<{
+        closed: "closed";
+        failed: "failed";
+        in_progress: "in_progress";
+        in_review: "in_review";
+        open: "open";
+    }>;
+    title: z.ZodString;
+    body: z.ZodNullable<z.ZodString>;
+    rig_id: z.ZodNullable<z.ZodString>;
+    parent_bead_id: z.ZodNullable<z.ZodString>;
+    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    labels: z.ZodArray<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    closed_at: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    rig_id: z.ZodNullable<z.ZodString>;
+    role: z.ZodUnion<[z.ZodEnum<{
+        mayor: "mayor";
+        polecat: "polecat";
+        refinery: "refinery";
+    }>, z.ZodString]>;
+    name: z.ZodString;
+    identity: z.ZodString;
+    status: z.ZodUnion<[z.ZodEnum<{
+        dead: "dead";
+        idle: "idle";
+        stalled: "stalled";
+        working: "working";
+    }>, z.ZodString]>;
+    current_hook_bead_id: z.ZodNullable<z.ZodString>;
+    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+    last_activity_at: z.ZodNullable<z.ZodString>;
+    checkpoint: z.ZodOptional<z.ZodUnknown>;
+    created_at: z.ZodString;
+    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+}, z.core.$strip>>;
+export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead_event_id: z.ZodString;
+    bead_id: z.ZodString;
+    agent_id: z.ZodNullable<z.ZodString>;
+    event_type: z.ZodString;
+    old_value: z.ZodNullable<z.ZodString>;
+    new_value: z.ZodNullable<z.ZodString>;
+    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+    created_at: z.ZodString;
+    rig_id: z.ZodOptional<z.ZodString>;
+    rig_name: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    agentId: z.ZodString;
+    sessionStatus: z.ZodEnum<{
+        active: "active";
+        idle: "idle";
+        starting: "starting";
+    }>;
+}, z.core.$strip>>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    configured: z.ZodBoolean;
+    townId: z.ZodNullable<z.ZodString>;
+    session: z.ZodNullable<z.ZodObject<{
+        agentId: z.ZodString;
+        sessionId: z.ZodString;
+        status: z.ZodEnum<{
+            active: "active";
+            idle: "idle";
+            starting: "starting";
+        }>;
+        lastActivityAt: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    url: z.ZodString;
+    ticket: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    pty: z.ZodObject<{
+        id: z.ZodString;
+    }, z.core.$loose>;
+    wsUrl: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    staged: z.ZodBoolean;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    status: z.ZodEnum<{
+        active: "active";
+        landed: "landed";
+    }>;
+    staged: z.ZodBoolean;
+    total_beads: z.ZodNumber;
+    closed_beads: z.ZodNumber;
+    created_by: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    landed_at: z.ZodNullable<z.ZodString>;
+    feature_branch: z.ZodNullable<z.ZodString>;
+    merge_mode: z.ZodNullable<z.ZodString>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        title: z.ZodString;
+        status: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_name: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    dependency_edges: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        depends_on_bead_id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    bead: z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>;
+    agent: z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>;
+}, z.core.$strip>>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    alarm: z.ZodObject<{
+        nextFireAt: z.ZodNullable<z.ZodString>;
+        intervalMs: z.ZodNumber;
+        intervalLabel: z.ZodString;
+    }, z.core.$strip>;
+    agents: z.ZodObject<{
+        working: z.ZodNumber;
+        idle: z.ZodNumber;
+        stalled: z.ZodNumber;
+        dead: z.ZodNumber;
+        total: z.ZodNumber;
+    }, z.core.$strip>;
+    beads: z.ZodObject<{
+        open: z.ZodNumber;
+        inProgress: z.ZodNumber;
+        inReview: z.ZodNumber;
+        failed: z.ZodNumber;
+        triageRequests: z.ZodNumber;
+    }, z.core.$strip>;
+    patrol: z.ZodObject<{
+        guppWarnings: z.ZodNumber;
+        guppEscalations: z.ZodNumber;
+        stalledAgents: z.ZodNumber;
+        orphanedHooks: z.ZodNumber;
+    }, z.core.$strip>;
+    recentEvents: z.ZodArray<z.ZodObject<{
+        time: z.ZodString;
+        type: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    town_id: z.ZodString;
+    name: z.ZodString;
+    git_url: z.ZodString;
+    default_branch: z.ZodString;
+    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+    agents: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        rig_id: z.ZodNullable<z.ZodString>;
+        role: z.ZodUnion<[z.ZodEnum<{
+            mayor: "mayor";
+            polecat: "polecat";
+            refinery: "refinery";
+        }>, z.ZodString]>;
+        name: z.ZodString;
+        identity: z.ZodString;
+        status: z.ZodUnion<[z.ZodEnum<{
+            dead: "dead";
+            idle: "idle";
+            stalled: "stalled";
+            working: "working";
+        }>, z.ZodString]>;
+        current_hook_bead_id: z.ZodNullable<z.ZodString>;
+        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+        last_activity_at: z.ZodNullable<z.ZodString>;
+        checkpoint: z.ZodOptional<z.ZodUnknown>;
+        created_at: z.ZodString;
+        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    }, z.core.$strip>>;
+    beads: z.ZodArray<z.ZodObject<{
+        bead_id: z.ZodString;
+        type: z.ZodEnum<{
+            agent: "agent";
+            convoy: "convoy";
+            escalation: "escalation";
+            issue: "issue";
+            merge_request: "merge_request";
+            message: "message";
+            molecule: "molecule";
+        }>;
+        status: z.ZodEnum<{
+            closed: "closed";
+            failed: "failed";
+            in_progress: "in_progress";
+            in_review: "in_review";
+            open: "open";
+        }>;
+        title: z.ZodString;
+        body: z.ZodNullable<z.ZodString>;
+        rig_id: z.ZodNullable<z.ZodString>;
+        parent_bead_id: z.ZodNullable<z.ZodString>;
+        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+        priority: z.ZodEnum<{
+            critical: "critical";
+            high: "high";
+            low: "low";
+            medium: "medium";
+        }>;
+        labels: z.ZodArray<z.ZodString>;
+        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        created_by: z.ZodNullable<z.ZodString>;
+        created_at: z.ZodString;
+        updated_at: z.ZodString;
+        closed_at: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const MergeQueueDataOutput: z.ZodObject<{
+    needsAttention: z.ZodObject<{
+        openPRs: z.ZodArray<z.ZodObject<{
+            mrBead: z.ZodObject<{
+                bead_id: z.ZodString;
+                status: z.ZodString;
+                title: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+                rig_id: z.ZodNullable<z.ZodString>;
+                created_at: z.ZodString;
+                updated_at: z.ZodString;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            }, z.core.$strip>;
+            reviewMetadata: z.ZodObject<{
+                branch: z.ZodString;
+                target_branch: z.ZodString;
+                merge_commit: z.ZodNullable<z.ZodString>;
+                pr_url: z.ZodNullable<z.ZodString>;
+                retry_count: z.ZodNumber;
+            }, z.core.$strip>;
+            sourceBead: z.ZodNullable<z.ZodObject<{
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            convoy: z.ZodNullable<z.ZodObject<{
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            agent: z.ZodNullable<z.ZodObject<{
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+            }, z.core.$strip>>;
+            rigName: z.ZodNullable<z.ZodString>;
+            staleSince: z.ZodNullable<z.ZodString>;
+            failureReason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        failedReviews: z.ZodArray<z.ZodObject<{
+            mrBead: z.ZodObject<{
+                bead_id: z.ZodString;
+                status: z.ZodString;
+                title: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+                rig_id: z.ZodNullable<z.ZodString>;
+                created_at: z.ZodString;
+                updated_at: z.ZodString;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            }, z.core.$strip>;
+            reviewMetadata: z.ZodObject<{
+                branch: z.ZodString;
+                target_branch: z.ZodString;
+                merge_commit: z.ZodNullable<z.ZodString>;
+                pr_url: z.ZodNullable<z.ZodString>;
+                retry_count: z.ZodNumber;
+            }, z.core.$strip>;
+            sourceBead: z.ZodNullable<z.ZodObject<{
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            convoy: z.ZodNullable<z.ZodObject<{
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            agent: z.ZodNullable<z.ZodObject<{
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+            }, z.core.$strip>>;
+            rigName: z.ZodNullable<z.ZodString>;
+            staleSince: z.ZodNullable<z.ZodString>;
+            failureReason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        stalePRs: z.ZodArray<z.ZodObject<{
+            mrBead: z.ZodObject<{
+                bead_id: z.ZodString;
+                status: z.ZodString;
+                title: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+                rig_id: z.ZodNullable<z.ZodString>;
+                created_at: z.ZodString;
+                updated_at: z.ZodString;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            }, z.core.$strip>;
+            reviewMetadata: z.ZodObject<{
+                branch: z.ZodString;
+                target_branch: z.ZodString;
+                merge_commit: z.ZodNullable<z.ZodString>;
+                pr_url: z.ZodNullable<z.ZodString>;
+                retry_count: z.ZodNumber;
+            }, z.core.$strip>;
+            sourceBead: z.ZodNullable<z.ZodObject<{
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            convoy: z.ZodNullable<z.ZodObject<{
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            agent: z.ZodNullable<z.ZodObject<{
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+            }, z.core.$strip>>;
+            rigName: z.ZodNullable<z.ZodString>;
+            staleSince: z.ZodNullable<z.ZodString>;
+            failureReason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+    }, z.core.$strip>;
+    activityLog: z.ZodArray<z.ZodObject<{
+        event: z.ZodObject<{
+            bead_event_id: z.ZodString;
+            bead_id: z.ZodString;
+            agent_id: z.ZodNullable<z.ZodString>;
+            event_type: z.ZodString;
+            old_value: z.ZodNullable<z.ZodString>;
+            new_value: z.ZodNullable<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            created_at: z.ZodString;
+        }, z.core.$strip>;
+        mrBead: z.ZodNullable<z.ZodObject<{
+            bead_id: z.ZodString;
+            title: z.ZodString;
+            type: z.ZodString;
+            status: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        }, z.core.$strip>>;
+        sourceBead: z.ZodNullable<z.ZodObject<{
             bead_id: z.ZodString;
             title: z.ZodString;
             status: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_name: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-      dependency_edges: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            depends_on_bead_id: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcSlingResultOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      bead: z.ZodObject<
-        {
-          bead_id: z.ZodString;
-          type: z.ZodEnum<{
-            agent: 'agent';
-            convoy: 'convoy';
-            escalation: 'escalation';
-            issue: 'issue';
-            merge_request: 'merge_request';
-            message: 'message';
-            molecule: 'molecule';
-          }>;
-          status: z.ZodEnum<{
-            closed: 'closed';
-            failed: 'failed';
-            in_progress: 'in_progress';
-            in_review: 'in_review';
-            open: 'open';
-          }>;
-          title: z.ZodString;
-          body: z.ZodNullable<z.ZodString>;
-          rig_id: z.ZodNullable<z.ZodString>;
-          parent_bead_id: z.ZodNullable<z.ZodString>;
-          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-          priority: z.ZodEnum<{
-            critical: 'critical';
-            high: 'high';
-            low: 'low';
-            medium: 'medium';
-          }>;
-          labels: z.ZodArray<z.ZodString>;
-          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-          created_by: z.ZodNullable<z.ZodString>;
-          created_at: z.ZodString;
-          updated_at: z.ZodString;
-          closed_at: z.ZodNullable<z.ZodString>;
-        },
-        z.core.$strip
-      >;
-      agent: z.ZodObject<
-        {
-          id: z.ZodString;
-          rig_id: z.ZodNullable<z.ZodString>;
-          role: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                mayor: 'mayor';
-                polecat: 'polecat';
-                refinery: 'refinery';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          name: z.ZodString;
-          identity: z.ZodString;
-          status: z.ZodUnion<
-            [
-              z.ZodEnum<{
-                dead: 'dead';
-                idle: 'idle';
-                stalled: 'stalled';
-                working: 'working';
-              }>,
-              z.ZodString,
-            ]
-          >;
-          current_hook_bead_id: z.ZodNullable<z.ZodString>;
-          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-          last_activity_at: z.ZodNullable<z.ZodString>;
-          checkpoint: z.ZodOptional<z.ZodUnknown>;
-          created_at: z.ZodString;
-          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        },
-        z.core.$strip
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      alarm: z.ZodObject<
-        {
-          nextFireAt: z.ZodNullable<z.ZodString>;
-          intervalMs: z.ZodNumber;
-          intervalLabel: z.ZodString;
-        },
-        z.core.$strip
-      >;
-      agents: z.ZodObject<
-        {
-          working: z.ZodNumber;
-          idle: z.ZodNumber;
-          stalled: z.ZodNumber;
-          dead: z.ZodNumber;
-          total: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      beads: z.ZodObject<
-        {
-          open: z.ZodNumber;
-          inProgress: z.ZodNumber;
-          inReview: z.ZodNumber;
-          failed: z.ZodNumber;
-          triageRequests: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      patrol: z.ZodObject<
-        {
-          guppWarnings: z.ZodNumber;
-          guppEscalations: z.ZodNumber;
-          stalledAgents: z.ZodNumber;
-          orphanedHooks: z.ZodNumber;
-        },
-        z.core.$strip
-      >;
-      recentEvents: z.ZodArray<
-        z.ZodObject<
-          {
-            time: z.ZodString;
-            type: z.ZodString;
-            message: z.ZodString;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
-export declare const RpcRigDetailOutput: z.ZodPipe<
-  z.ZodAny,
-  z.ZodObject<
-    {
-      id: z.ZodString;
-      town_id: z.ZodString;
-      name: z.ZodString;
-      git_url: z.ZodString;
-      default_branch: z.ZodString;
-      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-      created_at: z.ZodString;
-      updated_at: z.ZodString;
-      agents: z.ZodArray<
-        z.ZodObject<
-          {
-            id: z.ZodString;
-            rig_id: z.ZodNullable<z.ZodString>;
-            role: z.ZodUnion<
-              [
-                z.ZodEnum<{
-                  mayor: 'mayor';
-                  polecat: 'polecat';
-                  refinery: 'refinery';
-                }>,
-                z.ZodString,
-              ]
-            >;
-            name: z.ZodString;
-            identity: z.ZodString;
-            status: z.ZodUnion<
-              [
-                z.ZodEnum<{
-                  dead: 'dead';
-                  idle: 'idle';
-                  stalled: 'stalled';
-                  working: 'working';
-                }>,
-                z.ZodString,
-              ]
-            >;
-            current_hook_bead_id: z.ZodNullable<z.ZodString>;
-            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-            last_activity_at: z.ZodNullable<z.ZodString>;
-            checkpoint: z.ZodOptional<z.ZodUnknown>;
-            created_at: z.ZodString;
-            agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-            agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-          },
-          z.core.$strip
-        >
-      >;
-      beads: z.ZodArray<
-        z.ZodObject<
-          {
-            bead_id: z.ZodString;
-            type: z.ZodEnum<{
-              agent: 'agent';
-              convoy: 'convoy';
-              escalation: 'escalation';
-              issue: 'issue';
-              merge_request: 'merge_request';
-              message: 'message';
-              molecule: 'molecule';
-            }>;
-            status: z.ZodEnum<{
-              closed: 'closed';
-              failed: 'failed';
-              in_progress: 'in_progress';
-              in_review: 'in_review';
-              open: 'open';
-            }>;
+        }, z.core.$strip>>;
+        convoy: z.ZodNullable<z.ZodObject<{
+            convoy_id: z.ZodString;
             title: z.ZodString;
-            body: z.ZodNullable<z.ZodString>;
-            rig_id: z.ZodNullable<z.ZodString>;
-            parent_bead_id: z.ZodNullable<z.ZodString>;
-            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-            priority: z.ZodEnum<{
-              critical: 'critical';
-              high: 'high';
-              low: 'low';
-              medium: 'medium';
-            }>;
-            labels: z.ZodArray<z.ZodString>;
+            total_beads: z.ZodNumber;
+            closed_beads: z.ZodNumber;
+            feature_branch: z.ZodNullable<z.ZodString>;
+            merge_mode: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        agent: z.ZodNullable<z.ZodObject<{
+            agent_id: z.ZodString;
+            name: z.ZodString;
+            role: z.ZodString;
+        }, z.core.$strip>>;
+        rigName: z.ZodNullable<z.ZodString>;
+        reviewMetadata: z.ZodNullable<z.ZodObject<{
+            pr_url: z.ZodNullable<z.ZodString>;
+            branch: z.ZodNullable<z.ZodString>;
+            target_branch: z.ZodNullable<z.ZodString>;
+            merge_commit: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+export declare const RpcMergeQueueDataOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    needsAttention: z.ZodObject<{
+        openPRs: z.ZodArray<z.ZodObject<{
+            mrBead: z.ZodObject<{
+                bead_id: z.ZodString;
+                status: z.ZodString;
+                title: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+                rig_id: z.ZodNullable<z.ZodString>;
+                created_at: z.ZodString;
+                updated_at: z.ZodString;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            }, z.core.$strip>;
+            reviewMetadata: z.ZodObject<{
+                branch: z.ZodString;
+                target_branch: z.ZodString;
+                merge_commit: z.ZodNullable<z.ZodString>;
+                pr_url: z.ZodNullable<z.ZodString>;
+                retry_count: z.ZodNumber;
+            }, z.core.$strip>;
+            sourceBead: z.ZodNullable<z.ZodObject<{
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            convoy: z.ZodNullable<z.ZodObject<{
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            agent: z.ZodNullable<z.ZodObject<{
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+            }, z.core.$strip>>;
+            rigName: z.ZodNullable<z.ZodString>;
+            staleSince: z.ZodNullable<z.ZodString>;
+            failureReason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        failedReviews: z.ZodArray<z.ZodObject<{
+            mrBead: z.ZodObject<{
+                bead_id: z.ZodString;
+                status: z.ZodString;
+                title: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+                rig_id: z.ZodNullable<z.ZodString>;
+                created_at: z.ZodString;
+                updated_at: z.ZodString;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            }, z.core.$strip>;
+            reviewMetadata: z.ZodObject<{
+                branch: z.ZodString;
+                target_branch: z.ZodString;
+                merge_commit: z.ZodNullable<z.ZodString>;
+                pr_url: z.ZodNullable<z.ZodString>;
+                retry_count: z.ZodNumber;
+            }, z.core.$strip>;
+            sourceBead: z.ZodNullable<z.ZodObject<{
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            convoy: z.ZodNullable<z.ZodObject<{
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            agent: z.ZodNullable<z.ZodObject<{
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+            }, z.core.$strip>>;
+            rigName: z.ZodNullable<z.ZodString>;
+            staleSince: z.ZodNullable<z.ZodString>;
+            failureReason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        stalePRs: z.ZodArray<z.ZodObject<{
+            mrBead: z.ZodObject<{
+                bead_id: z.ZodString;
+                status: z.ZodString;
+                title: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+                rig_id: z.ZodNullable<z.ZodString>;
+                created_at: z.ZodString;
+                updated_at: z.ZodString;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            }, z.core.$strip>;
+            reviewMetadata: z.ZodObject<{
+                branch: z.ZodString;
+                target_branch: z.ZodString;
+                merge_commit: z.ZodNullable<z.ZodString>;
+                pr_url: z.ZodNullable<z.ZodString>;
+                retry_count: z.ZodNumber;
+            }, z.core.$strip>;
+            sourceBead: z.ZodNullable<z.ZodObject<{
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+                body: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            convoy: z.ZodNullable<z.ZodObject<{
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            agent: z.ZodNullable<z.ZodObject<{
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+            }, z.core.$strip>>;
+            rigName: z.ZodNullable<z.ZodString>;
+            staleSince: z.ZodNullable<z.ZodString>;
+            failureReason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+    }, z.core.$strip>;
+    activityLog: z.ZodArray<z.ZodObject<{
+        event: z.ZodObject<{
+            bead_event_id: z.ZodString;
+            bead_id: z.ZodString;
+            agent_id: z.ZodNullable<z.ZodString>;
+            event_type: z.ZodString;
+            old_value: z.ZodNullable<z.ZodString>;
+            new_value: z.ZodNullable<z.ZodString>;
             metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            created_by: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
-            updated_at: z.ZodString;
-            closed_at: z.ZodNullable<z.ZodString>;
-          },
-          z.core.$strip
-        >
-      >;
-    },
-    z.core.$strip
-  >
->;
+        }, z.core.$strip>;
+        mrBead: z.ZodNullable<z.ZodObject<{
+            bead_id: z.ZodString;
+            title: z.ZodString;
+            type: z.ZodString;
+            status: z.ZodString;
+            rig_id: z.ZodNullable<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+        }, z.core.$strip>>;
+        sourceBead: z.ZodNullable<z.ZodObject<{
+            bead_id: z.ZodString;
+            title: z.ZodString;
+            status: z.ZodString;
+        }, z.core.$strip>>;
+        convoy: z.ZodNullable<z.ZodObject<{
+            convoy_id: z.ZodString;
+            title: z.ZodString;
+            total_beads: z.ZodNumber;
+            closed_beads: z.ZodNumber;
+            feature_branch: z.ZodNullable<z.ZodString>;
+            merge_mode: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        agent: z.ZodNullable<z.ZodObject<{
+            agent_id: z.ZodString;
+            name: z.ZodString;
+            role: z.ZodString;
+        }, z.core.$strip>>;
+        rigName: z.ZodNullable<z.ZodString>;
+        reviewMetadata: z.ZodNullable<z.ZodObject<{
+            pr_url: z.ZodNullable<z.ZodString>;
+            branch: z.ZodNullable<z.ZodString>;
+            target_branch: z.ZodNullable<z.ZodString>;
+            merge_commit: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+    }, z.core.$strip>>;
+}, z.core.$strip>>;
+export declare const OrgTownOutput: z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodString;
+    owner_org_id: z.ZodString;
+    created_by_user_id: z.ZodString;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>;
+export declare const RpcOrgTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    name: z.ZodString;
+    owner_org_id: z.ZodString;
+    created_by_user_id: z.ZodString;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;

--- a/src/lib/gastown/types/schemas.d.ts
+++ b/src/lib/gastown/types/schemas.d.ts
@@ -1,12 +1,16 @@
 import type { z } from 'zod';
-export declare const TownOutput: z.ZodObject<{
+export declare const TownOutput: z.ZodObject<
+  {
     id: z.ZodString;
     name: z.ZodString;
     owner_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const RigOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const RigOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -15,24 +19,27 @@ export declare const RigOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const BeadOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadOutput: z.ZodObject<
+  {
     bead_id: z.ZodString;
     type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
+      agent: 'agent';
+      convoy: 'convoy';
+      escalation: 'escalation';
+      issue: 'issue';
+      merge_request: 'merge_request';
+      message: 'message';
+      molecule: 'molecule';
     }>;
     status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        in_review: "in_review";
-        open: "open";
+      closed: 'closed';
+      failed: 'failed';
+      in_progress: 'in_progress';
+      in_review: 'in_review';
+      open: 'open';
     }>;
     title: z.ZodString;
     body: z.ZodNullable<z.ZodString>;
@@ -40,10 +47,10 @@ export declare const BeadOutput: z.ZodObject<{
     parent_bead_id: z.ZodNullable<z.ZodString>;
     assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
     priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
+      critical: 'critical';
+      high: 'high';
+      low: 'low';
+      medium: 'medium';
     }>;
     labels: z.ZodArray<z.ZodString>;
     metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -51,23 +58,36 @@ export declare const BeadOutput: z.ZodObject<{
     created_at: z.ZodString;
     updated_at: z.ZodString;
     closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const AgentOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const AgentOutput: z.ZodObject<
+  {
     id: z.ZodString;
     rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<[z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>, z.ZodString]>;
+    role: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          mayor: 'mayor';
+          polecat: 'polecat';
+          refinery: 'refinery';
+        }>,
+        z.ZodString,
+      ]
+    >;
     name: z.ZodString;
     identity: z.ZodString;
-    status: z.ZodUnion<[z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>, z.ZodString]>;
+    status: z.ZodUnion<
+      [
+        z.ZodEnum<{
+          dead: 'dead';
+          idle: 'idle';
+          stalled: 'stalled';
+          working: 'working';
+        }>,
+        z.ZodString,
+      ]
+    >;
     current_hook_bead_id: z.ZodNullable<z.ZodString>;
     dispatch_attempts: z.ZodDefault<z.ZodNumber>;
     last_activity_at: z.ZodNullable<z.ZodString>;
@@ -75,8 +95,11 @@ export declare const AgentOutput: z.ZodObject<{
     created_at: z.ZodString;
     agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-}, z.core.$strip>;
-export declare const BeadEventOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const BeadEventOutput: z.ZodObject<
+  {
     bead_event_id: z.ZodString;
     bead_id: z.ZodString;
     agent_id: z.ZodNullable<z.ZodString>;
@@ -87,45 +110,68 @@ export declare const BeadEventOutput: z.ZodObject<{
     created_at: z.ZodString;
     rig_id: z.ZodOptional<z.ZodString>;
     rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>;
-export declare const MayorSendResultOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorSendResultOutput: z.ZodObject<
+  {
     agentId: z.ZodString;
     sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
+      active: 'active';
+      idle: 'idle';
+      starting: 'starting';
     }>;
-}, z.core.$strip>;
-export declare const MayorStatusOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const MayorStatusOutput: z.ZodObject<
+  {
     configured: z.ZodBoolean;
     townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const StreamTicketOutput: z.ZodObject<{
+    session: z.ZodNullable<
+      z.ZodObject<
+        {
+          agentId: z.ZodString;
+          sessionId: z.ZodString;
+          status: z.ZodEnum<{
+            active: 'active';
+            idle: 'idle';
+            starting: 'starting';
+          }>;
+          lastActivityAt: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const StreamTicketOutput: z.ZodObject<
+  {
     url: z.ZodString;
     ticket: z.ZodString;
-}, z.core.$strip>;
-export declare const PtySessionOutput: z.ZodObject<{
-    pty: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const PtySessionOutput: z.ZodObject<
+  {
+    pty: z.ZodObject<
+      {
         id: z.ZodString;
-    }, z.core.$loose>;
+      },
+      z.core.$loose
+    >;
     wsUrl: z.ZodString;
-}, z.core.$strip>;
-export declare const ConvoyOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
@@ -135,13 +181,16 @@ export declare const ConvoyOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>;
-export declare const ConvoyDetailOutput: z.ZodObject<{
+  },
+  z.core.$strip
+>;
+export declare const ConvoyDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     title: z.ZodString;
     status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
+      active: 'active';
+      landed: 'landed';
     }>;
     staged: z.ZodBoolean;
     total_beads: z.ZodNumber;
@@ -151,36 +200,50 @@ export declare const ConvoyDetailOutput: z.ZodObject<{
     landed_at: z.ZodNullable<z.ZodString>;
     feature_branch: z.ZodNullable<z.ZodString>;
     merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const SlingResultOutput: z.ZodObject<{
-    bead: z.ZodObject<{
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          title: z.ZodString;
+          status: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_name: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+    dependency_edges: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          depends_on_bead_id: z.ZodString;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const SlingResultOutput: z.ZodObject<
+  {
+    bead: z.ZodObject<
+      {
         bead_id: z.ZodString;
         type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
+          agent: 'agent';
+          convoy: 'convoy';
+          escalation: 'escalation';
+          issue: 'issue';
+          merge_request: 'merge_request';
+          message: 'message';
+          molecule: 'molecule';
         }>;
         status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
+          closed: 'closed';
+          failed: 'failed';
+          in_progress: 'in_progress';
+          in_review: 'in_review';
+          open: 'open';
         }>;
         title: z.ZodString;
         body: z.ZodNullable<z.ZodString>;
@@ -188,10 +251,10 @@ export declare const SlingResultOutput: z.ZodObject<{
         parent_bead_id: z.ZodNullable<z.ZodString>;
         assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
         priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
+          critical: 'critical';
+          high: 'high';
+          low: 'low';
+          medium: 'medium';
         }>;
         labels: z.ZodArray<z.ZodString>;
         metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
@@ -199,23 +262,36 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         updated_at: z.ZodString;
         closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+    agent: z.ZodObject<
+      {
         id: z.ZodString;
         rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
+        role: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              mayor: 'mayor';
+              polecat: 'polecat';
+              refinery: 'refinery';
+            }>,
+            z.ZodString,
+          ]
+        >;
         name: z.ZodString;
         identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
+        status: z.ZodUnion<
+          [
+            z.ZodEnum<{
+              dead: 'dead';
+              idle: 'idle';
+              stalled: 'stalled';
+              working: 'working';
+            }>,
+            z.ZodString,
+          ]
+        >;
         current_hook_bead_id: z.ZodNullable<z.ZodString>;
         dispatch_attempts: z.ZodDefault<z.ZodNumber>;
         last_activity_at: z.ZodNullable<z.ZodString>;
@@ -223,9 +299,14 @@ export declare const SlingResultOutput: z.ZodObject<{
         created_at: z.ZodString;
         agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
         agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>;
-}, z.core.$strip>;
-export declare const RigDetailOutput: z.ZodObject<{
+      },
+      z.core.$strip
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RigDetailOutput: z.ZodObject<
+  {
     id: z.ZodString;
     town_id: z.ZodString;
     name: z.ZodString;
@@ -234,752 +315,1185 @@ export declare const RigDetailOutput: z.ZodObject<{
     platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const RpcTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    name: z.ZodString;
-    owner_user_id: z.ZodString;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcBeadOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_id: z.ZodString;
-    type: z.ZodEnum<{
-        agent: "agent";
-        convoy: "convoy";
-        escalation: "escalation";
-        issue: "issue";
-        merge_request: "merge_request";
-        message: "message";
-        molecule: "molecule";
-    }>;
-    status: z.ZodEnum<{
-        closed: "closed";
-        failed: "failed";
-        in_progress: "in_progress";
-        in_review: "in_review";
-        open: "open";
-    }>;
-    title: z.ZodString;
-    body: z.ZodNullable<z.ZodString>;
-    rig_id: z.ZodNullable<z.ZodString>;
-    parent_bead_id: z.ZodNullable<z.ZodString>;
-    assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-    priority: z.ZodEnum<{
-        critical: "critical";
-        high: "high";
-        low: "low";
-        medium: "medium";
-    }>;
-    labels: z.ZodArray<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    closed_at: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcAgentOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    rig_id: z.ZodNullable<z.ZodString>;
-    role: z.ZodUnion<[z.ZodEnum<{
-        mayor: "mayor";
-        polecat: "polecat";
-        refinery: "refinery";
-    }>, z.ZodString]>;
-    name: z.ZodString;
-    identity: z.ZodString;
-    status: z.ZodUnion<[z.ZodEnum<{
-        dead: "dead";
-        idle: "idle";
-        stalled: "stalled";
-        working: "working";
-    }>, z.ZodString]>;
-    current_hook_bead_id: z.ZodNullable<z.ZodString>;
-    dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-    last_activity_at: z.ZodNullable<z.ZodString>;
-    checkpoint: z.ZodOptional<z.ZodUnknown>;
-    created_at: z.ZodString;
-    agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-}, z.core.$strip>>;
-export declare const RpcBeadEventOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead_event_id: z.ZodString;
-    bead_id: z.ZodString;
-    agent_id: z.ZodNullable<z.ZodString>;
-    event_type: z.ZodString;
-    old_value: z.ZodNullable<z.ZodString>;
-    new_value: z.ZodNullable<z.ZodString>;
-    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    created_at: z.ZodString;
-    rig_id: z.ZodOptional<z.ZodString>;
-    rig_name: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcMayorSendResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    agentId: z.ZodString;
-    sessionStatus: z.ZodEnum<{
-        active: "active";
-        idle: "idle";
-        starting: "starting";
-    }>;
-}, z.core.$strip>>;
-export declare const RpcMayorStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    configured: z.ZodBoolean;
-    townId: z.ZodNullable<z.ZodString>;
-    session: z.ZodNullable<z.ZodObject<{
-        agentId: z.ZodString;
-        sessionId: z.ZodString;
-        status: z.ZodEnum<{
-            active: "active";
-            idle: "idle";
-            starting: "starting";
-        }>;
-        lastActivityAt: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcStreamTicketOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    url: z.ZodString;
-    ticket: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcPtySessionOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    pty: z.ZodObject<{
-        id: z.ZodString;
-    }, z.core.$loose>;
-    wsUrl: z.ZodString;
-}, z.core.$strip>>;
-export declare const RpcConvoyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    staged: z.ZodBoolean;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-}, z.core.$strip>>;
-export declare const RpcConvoyDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    title: z.ZodString;
-    status: z.ZodEnum<{
-        active: "active";
-        landed: "landed";
-    }>;
-    staged: z.ZodBoolean;
-    total_beads: z.ZodNumber;
-    closed_beads: z.ZodNumber;
-    created_by: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    landed_at: z.ZodNullable<z.ZodString>;
-    feature_branch: z.ZodNullable<z.ZodString>;
-    merge_mode: z.ZodNullable<z.ZodString>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        title: z.ZodString;
-        status: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_name: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-    dependency_edges: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        depends_on_bead_id: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcSlingResultOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    bead: z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>;
-    agent: z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>;
-}, z.core.$strip>>;
-export declare const RpcAlarmStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    alarm: z.ZodObject<{
-        nextFireAt: z.ZodNullable<z.ZodString>;
-        intervalMs: z.ZodNumber;
-        intervalLabel: z.ZodString;
-    }, z.core.$strip>;
-    agents: z.ZodObject<{
-        working: z.ZodNumber;
-        idle: z.ZodNumber;
-        stalled: z.ZodNumber;
-        dead: z.ZodNumber;
-        total: z.ZodNumber;
-    }, z.core.$strip>;
-    beads: z.ZodObject<{
-        open: z.ZodNumber;
-        inProgress: z.ZodNumber;
-        inReview: z.ZodNumber;
-        failed: z.ZodNumber;
-        triageRequests: z.ZodNumber;
-    }, z.core.$strip>;
-    patrol: z.ZodObject<{
-        guppWarnings: z.ZodNumber;
-        guppEscalations: z.ZodNumber;
-        stalledAgents: z.ZodNumber;
-        orphanedHooks: z.ZodNumber;
-    }, z.core.$strip>;
-    recentEvents: z.ZodArray<z.ZodObject<{
-        time: z.ZodString;
-        type: z.ZodString;
-        message: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const RpcRigDetailOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    town_id: z.ZodString;
-    name: z.ZodString;
-    git_url: z.ZodString;
-    default_branch: z.ZodString;
-    platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-    agents: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        rig_id: z.ZodNullable<z.ZodString>;
-        role: z.ZodUnion<[z.ZodEnum<{
-            mayor: "mayor";
-            polecat: "polecat";
-            refinery: "refinery";
-        }>, z.ZodString]>;
-        name: z.ZodString;
-        identity: z.ZodString;
-        status: z.ZodUnion<[z.ZodEnum<{
-            dead: "dead";
-            idle: "idle";
-            stalled: "stalled";
-            working: "working";
-        }>, z.ZodString]>;
-        current_hook_bead_id: z.ZodNullable<z.ZodString>;
-        dispatch_attempts: z.ZodDefault<z.ZodNumber>;
-        last_activity_at: z.ZodNullable<z.ZodString>;
-        checkpoint: z.ZodOptional<z.ZodUnknown>;
-        created_at: z.ZodString;
-        agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-        agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
-    }, z.core.$strip>>;
-    beads: z.ZodArray<z.ZodObject<{
-        bead_id: z.ZodString;
-        type: z.ZodEnum<{
-            agent: "agent";
-            convoy: "convoy";
-            escalation: "escalation";
-            issue: "issue";
-            merge_request: "merge_request";
-            message: "message";
-            molecule: "molecule";
-        }>;
-        status: z.ZodEnum<{
-            closed: "closed";
-            failed: "failed";
-            in_progress: "in_progress";
-            in_review: "in_review";
-            open: "open";
-        }>;
-        title: z.ZodString;
-        body: z.ZodNullable<z.ZodString>;
-        rig_id: z.ZodNullable<z.ZodString>;
-        parent_bead_id: z.ZodNullable<z.ZodString>;
-        assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
-        priority: z.ZodEnum<{
-            critical: "critical";
-            high: "high";
-            low: "low";
-            medium: "medium";
-        }>;
-        labels: z.ZodArray<z.ZodString>;
-        metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        created_by: z.ZodNullable<z.ZodString>;
-        created_at: z.ZodString;
-        updated_at: z.ZodString;
-        closed_at: z.ZodNullable<z.ZodString>;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const MergeQueueDataOutput: z.ZodObject<{
-    needsAttention: z.ZodObject<{
-        openPRs: z.ZodArray<z.ZodObject<{
-            mrBead: z.ZodObject<{
-                bead_id: z.ZodString;
-                status: z.ZodString;
-                title: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-                rig_id: z.ZodNullable<z.ZodString>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            }, z.core.$strip>;
-            reviewMetadata: z.ZodObject<{
-                branch: z.ZodString;
-                target_branch: z.ZodString;
-                merge_commit: z.ZodNullable<z.ZodString>;
-                pr_url: z.ZodNullable<z.ZodString>;
-                retry_count: z.ZodNumber;
-            }, z.core.$strip>;
-            sourceBead: z.ZodNullable<z.ZodObject<{
-                bead_id: z.ZodString;
-                title: z.ZodString;
-                status: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            convoy: z.ZodNullable<z.ZodObject<{
-                convoy_id: z.ZodString;
-                title: z.ZodString;
-                total_beads: z.ZodNumber;
-                closed_beads: z.ZodNumber;
-                feature_branch: z.ZodNullable<z.ZodString>;
-                merge_mode: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            agent: z.ZodNullable<z.ZodObject<{
-                agent_id: z.ZodString;
-                name: z.ZodString;
-                role: z.ZodString;
-            }, z.core.$strip>>;
-            rigName: z.ZodNullable<z.ZodString>;
-            staleSince: z.ZodNullable<z.ZodString>;
-            failureReason: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-        failedReviews: z.ZodArray<z.ZodObject<{
-            mrBead: z.ZodObject<{
-                bead_id: z.ZodString;
-                status: z.ZodString;
-                title: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-                rig_id: z.ZodNullable<z.ZodString>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            }, z.core.$strip>;
-            reviewMetadata: z.ZodObject<{
-                branch: z.ZodString;
-                target_branch: z.ZodString;
-                merge_commit: z.ZodNullable<z.ZodString>;
-                pr_url: z.ZodNullable<z.ZodString>;
-                retry_count: z.ZodNumber;
-            }, z.core.$strip>;
-            sourceBead: z.ZodNullable<z.ZodObject<{
-                bead_id: z.ZodString;
-                title: z.ZodString;
-                status: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            convoy: z.ZodNullable<z.ZodObject<{
-                convoy_id: z.ZodString;
-                title: z.ZodString;
-                total_beads: z.ZodNumber;
-                closed_beads: z.ZodNumber;
-                feature_branch: z.ZodNullable<z.ZodString>;
-                merge_mode: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            agent: z.ZodNullable<z.ZodObject<{
-                agent_id: z.ZodString;
-                name: z.ZodString;
-                role: z.ZodString;
-            }, z.core.$strip>>;
-            rigName: z.ZodNullable<z.ZodString>;
-            staleSince: z.ZodNullable<z.ZodString>;
-            failureReason: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-        stalePRs: z.ZodArray<z.ZodObject<{
-            mrBead: z.ZodObject<{
-                bead_id: z.ZodString;
-                status: z.ZodString;
-                title: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-                rig_id: z.ZodNullable<z.ZodString>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            }, z.core.$strip>;
-            reviewMetadata: z.ZodObject<{
-                branch: z.ZodString;
-                target_branch: z.ZodString;
-                merge_commit: z.ZodNullable<z.ZodString>;
-                pr_url: z.ZodNullable<z.ZodString>;
-                retry_count: z.ZodNumber;
-            }, z.core.$strip>;
-            sourceBead: z.ZodNullable<z.ZodObject<{
-                bead_id: z.ZodString;
-                title: z.ZodString;
-                status: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            convoy: z.ZodNullable<z.ZodObject<{
-                convoy_id: z.ZodString;
-                title: z.ZodString;
-                total_beads: z.ZodNumber;
-                closed_beads: z.ZodNumber;
-                feature_branch: z.ZodNullable<z.ZodString>;
-                merge_mode: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            agent: z.ZodNullable<z.ZodObject<{
-                agent_id: z.ZodString;
-                name: z.ZodString;
-                role: z.ZodString;
-            }, z.core.$strip>>;
-            rigName: z.ZodNullable<z.ZodString>;
-            staleSince: z.ZodNullable<z.ZodString>;
-            failureReason: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-    }, z.core.$strip>;
-    activityLog: z.ZodArray<z.ZodObject<{
-        event: z.ZodObject<{
-            bead_event_id: z.ZodString;
-            bead_id: z.ZodString;
-            agent_id: z.ZodNullable<z.ZodString>;
-            event_type: z.ZodString;
-            old_value: z.ZodNullable<z.ZodString>;
-            new_value: z.ZodNullable<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            created_at: z.ZodString;
-        }, z.core.$strip>;
-        mrBead: z.ZodNullable<z.ZodObject<{
+    agents: z.ZodArray<
+      z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        },
+        z.core.$strip
+      >
+    >;
+    beads: z.ZodArray<
+      z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            in_review: 'in_review';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RpcTownOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      name: z.ZodString;
+      owner_user_id: z.ZodString;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_id: z.ZodString;
+      type: z.ZodEnum<{
+        agent: 'agent';
+        convoy: 'convoy';
+        escalation: 'escalation';
+        issue: 'issue';
+        merge_request: 'merge_request';
+        message: 'message';
+        molecule: 'molecule';
+      }>;
+      status: z.ZodEnum<{
+        closed: 'closed';
+        failed: 'failed';
+        in_progress: 'in_progress';
+        in_review: 'in_review';
+        open: 'open';
+      }>;
+      title: z.ZodString;
+      body: z.ZodNullable<z.ZodString>;
+      rig_id: z.ZodNullable<z.ZodString>;
+      parent_bead_id: z.ZodNullable<z.ZodString>;
+      assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+      priority: z.ZodEnum<{
+        critical: 'critical';
+        high: 'high';
+        low: 'low';
+        medium: 'medium';
+      }>;
+      labels: z.ZodArray<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      closed_at: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAgentOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      rig_id: z.ZodNullable<z.ZodString>;
+      role: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            mayor: 'mayor';
+            polecat: 'polecat';
+            refinery: 'refinery';
+          }>,
+          z.ZodString,
+        ]
+      >;
+      name: z.ZodString;
+      identity: z.ZodString;
+      status: z.ZodUnion<
+        [
+          z.ZodEnum<{
+            dead: 'dead';
+            idle: 'idle';
+            stalled: 'stalled';
+            working: 'working';
+          }>,
+          z.ZodString,
+        ]
+      >;
+      current_hook_bead_id: z.ZodNullable<z.ZodString>;
+      dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+      last_activity_at: z.ZodNullable<z.ZodString>;
+      checkpoint: z.ZodOptional<z.ZodUnknown>;
+      created_at: z.ZodString;
+      agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcBeadEventOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead_event_id: z.ZodString;
+      bead_id: z.ZodString;
+      agent_id: z.ZodNullable<z.ZodString>;
+      event_type: z.ZodString;
+      old_value: z.ZodNullable<z.ZodString>;
+      new_value: z.ZodNullable<z.ZodString>;
+      metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+      created_at: z.ZodString;
+      rig_id: z.ZodOptional<z.ZodString>;
+      rig_name: z.ZodOptional<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorSendResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      agentId: z.ZodString;
+      sessionStatus: z.ZodEnum<{
+        active: 'active';
+        idle: 'idle';
+        starting: 'starting';
+      }>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcMayorStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      configured: z.ZodBoolean;
+      townId: z.ZodNullable<z.ZodString>;
+      session: z.ZodNullable<
+        z.ZodObject<
+          {
+            agentId: z.ZodString;
+            sessionId: z.ZodString;
+            status: z.ZodEnum<{
+              active: 'active';
+              idle: 'idle';
+              starting: 'starting';
+            }>;
+            lastActivityAt: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcStreamTicketOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      url: z.ZodString;
+      ticket: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcPtySessionOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      pty: z.ZodObject<
+        {
+          id: z.ZodString;
+        },
+        z.core.$loose
+      >;
+      wsUrl: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      staged: z.ZodBoolean;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcConvoyDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      title: z.ZodString;
+      status: z.ZodEnum<{
+        active: 'active';
+        landed: 'landed';
+      }>;
+      staged: z.ZodBoolean;
+      total_beads: z.ZodNumber;
+      closed_beads: z.ZodNumber;
+      created_by: z.ZodNullable<z.ZodString>;
+      created_at: z.ZodString;
+      landed_at: z.ZodNullable<z.ZodString>;
+      feature_branch: z.ZodNullable<z.ZodString>;
+      merge_mode: z.ZodNullable<z.ZodString>;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
             bead_id: z.ZodString;
             title: z.ZodString;
-            type: z.ZodString;
             status: z.ZodString;
             rig_id: z.ZodNullable<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        }, z.core.$strip>>;
-        sourceBead: z.ZodNullable<z.ZodObject<{
+            assignee_agent_name: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+      dependency_edges: z.ZodArray<
+        z.ZodObject<
+          {
             bead_id: z.ZodString;
-            title: z.ZodString;
-            status: z.ZodString;
-        }, z.core.$strip>>;
-        convoy: z.ZodNullable<z.ZodObject<{
-            convoy_id: z.ZodString;
-            title: z.ZodString;
-            total_beads: z.ZodNumber;
-            closed_beads: z.ZodNumber;
-            feature_branch: z.ZodNullable<z.ZodString>;
-            merge_mode: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-        agent: z.ZodNullable<z.ZodObject<{
-            agent_id: z.ZodString;
-            name: z.ZodString;
-            role: z.ZodString;
-        }, z.core.$strip>>;
-        rigName: z.ZodNullable<z.ZodString>;
-        reviewMetadata: z.ZodNullable<z.ZodObject<{
-            pr_url: z.ZodNullable<z.ZodString>;
-            branch: z.ZodNullable<z.ZodString>;
-            target_branch: z.ZodNullable<z.ZodString>;
-            merge_commit: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
-export declare const RpcMergeQueueDataOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    needsAttention: z.ZodObject<{
-        openPRs: z.ZodArray<z.ZodObject<{
-            mrBead: z.ZodObject<{
-                bead_id: z.ZodString;
-                status: z.ZodString;
-                title: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-                rig_id: z.ZodNullable<z.ZodString>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            }, z.core.$strip>;
-            reviewMetadata: z.ZodObject<{
-                branch: z.ZodString;
-                target_branch: z.ZodString;
-                merge_commit: z.ZodNullable<z.ZodString>;
-                pr_url: z.ZodNullable<z.ZodString>;
-                retry_count: z.ZodNumber;
-            }, z.core.$strip>;
-            sourceBead: z.ZodNullable<z.ZodObject<{
-                bead_id: z.ZodString;
-                title: z.ZodString;
-                status: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            convoy: z.ZodNullable<z.ZodObject<{
-                convoy_id: z.ZodString;
-                title: z.ZodString;
-                total_beads: z.ZodNumber;
-                closed_beads: z.ZodNumber;
-                feature_branch: z.ZodNullable<z.ZodString>;
-                merge_mode: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            agent: z.ZodNullable<z.ZodObject<{
-                agent_id: z.ZodString;
-                name: z.ZodString;
-                role: z.ZodString;
-            }, z.core.$strip>>;
-            rigName: z.ZodNullable<z.ZodString>;
-            staleSince: z.ZodNullable<z.ZodString>;
-            failureReason: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-        failedReviews: z.ZodArray<z.ZodObject<{
-            mrBead: z.ZodObject<{
-                bead_id: z.ZodString;
-                status: z.ZodString;
-                title: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-                rig_id: z.ZodNullable<z.ZodString>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            }, z.core.$strip>;
-            reviewMetadata: z.ZodObject<{
-                branch: z.ZodString;
-                target_branch: z.ZodString;
-                merge_commit: z.ZodNullable<z.ZodString>;
-                pr_url: z.ZodNullable<z.ZodString>;
-                retry_count: z.ZodNumber;
-            }, z.core.$strip>;
-            sourceBead: z.ZodNullable<z.ZodObject<{
-                bead_id: z.ZodString;
-                title: z.ZodString;
-                status: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            convoy: z.ZodNullable<z.ZodObject<{
-                convoy_id: z.ZodString;
-                title: z.ZodString;
-                total_beads: z.ZodNumber;
-                closed_beads: z.ZodNumber;
-                feature_branch: z.ZodNullable<z.ZodString>;
-                merge_mode: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            agent: z.ZodNullable<z.ZodObject<{
-                agent_id: z.ZodString;
-                name: z.ZodString;
-                role: z.ZodString;
-            }, z.core.$strip>>;
-            rigName: z.ZodNullable<z.ZodString>;
-            staleSince: z.ZodNullable<z.ZodString>;
-            failureReason: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-        stalePRs: z.ZodArray<z.ZodObject<{
-            mrBead: z.ZodObject<{
-                bead_id: z.ZodString;
-                status: z.ZodString;
-                title: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-                rig_id: z.ZodNullable<z.ZodString>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            }, z.core.$strip>;
-            reviewMetadata: z.ZodObject<{
-                branch: z.ZodString;
-                target_branch: z.ZodString;
-                merge_commit: z.ZodNullable<z.ZodString>;
-                pr_url: z.ZodNullable<z.ZodString>;
-                retry_count: z.ZodNumber;
-            }, z.core.$strip>;
-            sourceBead: z.ZodNullable<z.ZodObject<{
-                bead_id: z.ZodString;
-                title: z.ZodString;
-                status: z.ZodString;
-                body: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            convoy: z.ZodNullable<z.ZodObject<{
-                convoy_id: z.ZodString;
-                title: z.ZodString;
-                total_beads: z.ZodNumber;
-                closed_beads: z.ZodNumber;
-                feature_branch: z.ZodNullable<z.ZodString>;
-                merge_mode: z.ZodNullable<z.ZodString>;
-            }, z.core.$strip>>;
-            agent: z.ZodNullable<z.ZodObject<{
-                agent_id: z.ZodString;
-                name: z.ZodString;
-                role: z.ZodString;
-            }, z.core.$strip>>;
-            rigName: z.ZodNullable<z.ZodString>;
-            staleSince: z.ZodNullable<z.ZodString>;
-            failureReason: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-    }, z.core.$strip>;
-    activityLog: z.ZodArray<z.ZodObject<{
-        event: z.ZodObject<{
-            bead_event_id: z.ZodString;
-            bead_id: z.ZodString;
-            agent_id: z.ZodNullable<z.ZodString>;
-            event_type: z.ZodString;
-            old_value: z.ZodNullable<z.ZodString>;
-            new_value: z.ZodNullable<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-            created_at: z.ZodString;
-        }, z.core.$strip>;
-        mrBead: z.ZodNullable<z.ZodObject<{
-            bead_id: z.ZodString;
-            title: z.ZodString;
+            depends_on_bead_id: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcSlingResultOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      bead: z.ZodObject<
+        {
+          bead_id: z.ZodString;
+          type: z.ZodEnum<{
+            agent: 'agent';
+            convoy: 'convoy';
+            escalation: 'escalation';
+            issue: 'issue';
+            merge_request: 'merge_request';
+            message: 'message';
+            molecule: 'molecule';
+          }>;
+          status: z.ZodEnum<{
+            closed: 'closed';
+            failed: 'failed';
+            in_progress: 'in_progress';
+            in_review: 'in_review';
+            open: 'open';
+          }>;
+          title: z.ZodString;
+          body: z.ZodNullable<z.ZodString>;
+          rig_id: z.ZodNullable<z.ZodString>;
+          parent_bead_id: z.ZodNullable<z.ZodString>;
+          assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+          priority: z.ZodEnum<{
+            critical: 'critical';
+            high: 'high';
+            low: 'low';
+            medium: 'medium';
+          }>;
+          labels: z.ZodArray<z.ZodString>;
+          metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+          created_by: z.ZodNullable<z.ZodString>;
+          created_at: z.ZodString;
+          updated_at: z.ZodString;
+          closed_at: z.ZodNullable<z.ZodString>;
+        },
+        z.core.$strip
+      >;
+      agent: z.ZodObject<
+        {
+          id: z.ZodString;
+          rig_id: z.ZodNullable<z.ZodString>;
+          role: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                mayor: 'mayor';
+                polecat: 'polecat';
+                refinery: 'refinery';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          name: z.ZodString;
+          identity: z.ZodString;
+          status: z.ZodUnion<
+            [
+              z.ZodEnum<{
+                dead: 'dead';
+                idle: 'idle';
+                stalled: 'stalled';
+                working: 'working';
+              }>,
+              z.ZodString,
+            ]
+          >;
+          current_hook_bead_id: z.ZodNullable<z.ZodString>;
+          dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+          last_activity_at: z.ZodNullable<z.ZodString>;
+          checkpoint: z.ZodOptional<z.ZodUnknown>;
+          created_at: z.ZodString;
+          agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+        },
+        z.core.$strip
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcAlarmStatusOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      alarm: z.ZodObject<
+        {
+          nextFireAt: z.ZodNullable<z.ZodString>;
+          intervalMs: z.ZodNumber;
+          intervalLabel: z.ZodString;
+        },
+        z.core.$strip
+      >;
+      agents: z.ZodObject<
+        {
+          working: z.ZodNumber;
+          idle: z.ZodNumber;
+          stalled: z.ZodNumber;
+          dead: z.ZodNumber;
+          total: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      beads: z.ZodObject<
+        {
+          open: z.ZodNumber;
+          inProgress: z.ZodNumber;
+          inReview: z.ZodNumber;
+          failed: z.ZodNumber;
+          triageRequests: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      patrol: z.ZodObject<
+        {
+          guppWarnings: z.ZodNumber;
+          guppEscalations: z.ZodNumber;
+          stalledAgents: z.ZodNumber;
+          orphanedHooks: z.ZodNumber;
+        },
+        z.core.$strip
+      >;
+      recentEvents: z.ZodArray<
+        z.ZodObject<
+          {
+            time: z.ZodString;
             type: z.ZodString;
-            status: z.ZodString;
+            message: z.ZodString;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const RpcRigDetailOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      town_id: z.ZodString;
+      name: z.ZodString;
+      git_url: z.ZodString;
+      default_branch: z.ZodString;
+      platform_integration_id: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+      agents: z.ZodArray<
+        z.ZodObject<
+          {
+            id: z.ZodString;
             rig_id: z.ZodNullable<z.ZodString>;
-            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        }, z.core.$strip>>;
-        sourceBead: z.ZodNullable<z.ZodObject<{
-            bead_id: z.ZodString;
-            title: z.ZodString;
-            status: z.ZodString;
-        }, z.core.$strip>>;
-        convoy: z.ZodNullable<z.ZodObject<{
-            convoy_id: z.ZodString;
-            title: z.ZodString;
-            total_beads: z.ZodNumber;
-            closed_beads: z.ZodNumber;
-            feature_branch: z.ZodNullable<z.ZodString>;
-            merge_mode: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-        agent: z.ZodNullable<z.ZodObject<{
-            agent_id: z.ZodString;
+            role: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  mayor: 'mayor';
+                  polecat: 'polecat';
+                  refinery: 'refinery';
+                }>,
+                z.ZodString,
+              ]
+            >;
             name: z.ZodString;
-            role: z.ZodString;
-        }, z.core.$strip>>;
-        rigName: z.ZodNullable<z.ZodString>;
-        reviewMetadata: z.ZodNullable<z.ZodObject<{
-            pr_url: z.ZodNullable<z.ZodString>;
-            branch: z.ZodNullable<z.ZodString>;
-            target_branch: z.ZodNullable<z.ZodString>;
-            merge_commit: z.ZodNullable<z.ZodString>;
-        }, z.core.$strip>>;
-    }, z.core.$strip>>;
-}, z.core.$strip>>;
-export declare const OrgTownOutput: z.ZodObject<{
+            identity: z.ZodString;
+            status: z.ZodUnion<
+              [
+                z.ZodEnum<{
+                  dead: 'dead';
+                  idle: 'idle';
+                  stalled: 'stalled';
+                  working: 'working';
+                }>,
+                z.ZodString,
+              ]
+            >;
+            current_hook_bead_id: z.ZodNullable<z.ZodString>;
+            dispatch_attempts: z.ZodDefault<z.ZodNumber>;
+            last_activity_at: z.ZodNullable<z.ZodString>;
+            checkpoint: z.ZodOptional<z.ZodUnknown>;
+            created_at: z.ZodString;
+            agent_status_message: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+            agent_status_updated_at: z.ZodDefault<z.ZodOptional<z.ZodNullable<z.ZodString>>>;
+          },
+          z.core.$strip
+        >
+      >;
+      beads: z.ZodArray<
+        z.ZodObject<
+          {
+            bead_id: z.ZodString;
+            type: z.ZodEnum<{
+              agent: 'agent';
+              convoy: 'convoy';
+              escalation: 'escalation';
+              issue: 'issue';
+              merge_request: 'merge_request';
+              message: 'message';
+              molecule: 'molecule';
+            }>;
+            status: z.ZodEnum<{
+              closed: 'closed';
+              failed: 'failed';
+              in_progress: 'in_progress';
+              in_review: 'in_review';
+              open: 'open';
+            }>;
+            title: z.ZodString;
+            body: z.ZodNullable<z.ZodString>;
+            rig_id: z.ZodNullable<z.ZodString>;
+            parent_bead_id: z.ZodNullable<z.ZodString>;
+            assignee_agent_bead_id: z.ZodNullable<z.ZodString>;
+            priority: z.ZodEnum<{
+              critical: 'critical';
+              high: 'high';
+              low: 'low';
+              medium: 'medium';
+            }>;
+            labels: z.ZodArray<z.ZodString>;
+            metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+            created_by: z.ZodNullable<z.ZodString>;
+            created_at: z.ZodString;
+            updated_at: z.ZodString;
+            closed_at: z.ZodNullable<z.ZodString>;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const MergeQueueDataOutput: z.ZodObject<
+  {
+    needsAttention: z.ZodObject<
+      {
+        openPRs: z.ZodArray<
+          z.ZodObject<
+            {
+              mrBead: z.ZodObject<
+                {
+                  bead_id: z.ZodString;
+                  status: z.ZodString;
+                  title: z.ZodString;
+                  body: z.ZodNullable<z.ZodString>;
+                  rig_id: z.ZodNullable<z.ZodString>;
+                  created_at: z.ZodString;
+                  updated_at: z.ZodString;
+                  metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                },
+                z.core.$strip
+              >;
+              reviewMetadata: z.ZodObject<
+                {
+                  branch: z.ZodString;
+                  target_branch: z.ZodString;
+                  merge_commit: z.ZodNullable<z.ZodString>;
+                  pr_url: z.ZodNullable<z.ZodString>;
+                  retry_count: z.ZodNumber;
+                },
+                z.core.$strip
+              >;
+              sourceBead: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    bead_id: z.ZodString;
+                    title: z.ZodString;
+                    status: z.ZodString;
+                    body: z.ZodNullable<z.ZodString>;
+                  },
+                  z.core.$strip
+                >
+              >;
+              convoy: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    convoy_id: z.ZodString;
+                    title: z.ZodString;
+                    total_beads: z.ZodNumber;
+                    closed_beads: z.ZodNumber;
+                    feature_branch: z.ZodNullable<z.ZodString>;
+                    merge_mode: z.ZodNullable<z.ZodString>;
+                  },
+                  z.core.$strip
+                >
+              >;
+              agent: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    agent_id: z.ZodString;
+                    name: z.ZodString;
+                    role: z.ZodString;
+                  },
+                  z.core.$strip
+                >
+              >;
+              rigName: z.ZodNullable<z.ZodString>;
+              staleSince: z.ZodNullable<z.ZodString>;
+              failureReason: z.ZodNullable<z.ZodString>;
+            },
+            z.core.$strip
+          >
+        >;
+        failedReviews: z.ZodArray<
+          z.ZodObject<
+            {
+              mrBead: z.ZodObject<
+                {
+                  bead_id: z.ZodString;
+                  status: z.ZodString;
+                  title: z.ZodString;
+                  body: z.ZodNullable<z.ZodString>;
+                  rig_id: z.ZodNullable<z.ZodString>;
+                  created_at: z.ZodString;
+                  updated_at: z.ZodString;
+                  metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                },
+                z.core.$strip
+              >;
+              reviewMetadata: z.ZodObject<
+                {
+                  branch: z.ZodString;
+                  target_branch: z.ZodString;
+                  merge_commit: z.ZodNullable<z.ZodString>;
+                  pr_url: z.ZodNullable<z.ZodString>;
+                  retry_count: z.ZodNumber;
+                },
+                z.core.$strip
+              >;
+              sourceBead: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    bead_id: z.ZodString;
+                    title: z.ZodString;
+                    status: z.ZodString;
+                    body: z.ZodNullable<z.ZodString>;
+                  },
+                  z.core.$strip
+                >
+              >;
+              convoy: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    convoy_id: z.ZodString;
+                    title: z.ZodString;
+                    total_beads: z.ZodNumber;
+                    closed_beads: z.ZodNumber;
+                    feature_branch: z.ZodNullable<z.ZodString>;
+                    merge_mode: z.ZodNullable<z.ZodString>;
+                  },
+                  z.core.$strip
+                >
+              >;
+              agent: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    agent_id: z.ZodString;
+                    name: z.ZodString;
+                    role: z.ZodString;
+                  },
+                  z.core.$strip
+                >
+              >;
+              rigName: z.ZodNullable<z.ZodString>;
+              staleSince: z.ZodNullable<z.ZodString>;
+              failureReason: z.ZodNullable<z.ZodString>;
+            },
+            z.core.$strip
+          >
+        >;
+        stalePRs: z.ZodArray<
+          z.ZodObject<
+            {
+              mrBead: z.ZodObject<
+                {
+                  bead_id: z.ZodString;
+                  status: z.ZodString;
+                  title: z.ZodString;
+                  body: z.ZodNullable<z.ZodString>;
+                  rig_id: z.ZodNullable<z.ZodString>;
+                  created_at: z.ZodString;
+                  updated_at: z.ZodString;
+                  metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                },
+                z.core.$strip
+              >;
+              reviewMetadata: z.ZodObject<
+                {
+                  branch: z.ZodString;
+                  target_branch: z.ZodString;
+                  merge_commit: z.ZodNullable<z.ZodString>;
+                  pr_url: z.ZodNullable<z.ZodString>;
+                  retry_count: z.ZodNumber;
+                },
+                z.core.$strip
+              >;
+              sourceBead: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    bead_id: z.ZodString;
+                    title: z.ZodString;
+                    status: z.ZodString;
+                    body: z.ZodNullable<z.ZodString>;
+                  },
+                  z.core.$strip
+                >
+              >;
+              convoy: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    convoy_id: z.ZodString;
+                    title: z.ZodString;
+                    total_beads: z.ZodNumber;
+                    closed_beads: z.ZodNumber;
+                    feature_branch: z.ZodNullable<z.ZodString>;
+                    merge_mode: z.ZodNullable<z.ZodString>;
+                  },
+                  z.core.$strip
+                >
+              >;
+              agent: z.ZodNullable<
+                z.ZodObject<
+                  {
+                    agent_id: z.ZodString;
+                    name: z.ZodString;
+                    role: z.ZodString;
+                  },
+                  z.core.$strip
+                >
+              >;
+              rigName: z.ZodNullable<z.ZodString>;
+              staleSince: z.ZodNullable<z.ZodString>;
+              failureReason: z.ZodNullable<z.ZodString>;
+            },
+            z.core.$strip
+          >
+        >;
+      },
+      z.core.$strip
+    >;
+    activityLog: z.ZodArray<
+      z.ZodObject<
+        {
+          event: z.ZodObject<
+            {
+              bead_event_id: z.ZodString;
+              bead_id: z.ZodString;
+              agent_id: z.ZodNullable<z.ZodString>;
+              event_type: z.ZodString;
+              old_value: z.ZodNullable<z.ZodString>;
+              new_value: z.ZodNullable<z.ZodString>;
+              metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+              created_at: z.ZodString;
+            },
+            z.core.$strip
+          >;
+          mrBead: z.ZodNullable<
+            z.ZodObject<
+              {
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                type: z.ZodString;
+                status: z.ZodString;
+                rig_id: z.ZodNullable<z.ZodString>;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+              },
+              z.core.$strip
+            >
+          >;
+          sourceBead: z.ZodNullable<
+            z.ZodObject<
+              {
+                bead_id: z.ZodString;
+                title: z.ZodString;
+                status: z.ZodString;
+              },
+              z.core.$strip
+            >
+          >;
+          convoy: z.ZodNullable<
+            z.ZodObject<
+              {
+                convoy_id: z.ZodString;
+                title: z.ZodString;
+                total_beads: z.ZodNumber;
+                closed_beads: z.ZodNumber;
+                feature_branch: z.ZodNullable<z.ZodString>;
+                merge_mode: z.ZodNullable<z.ZodString>;
+              },
+              z.core.$strip
+            >
+          >;
+          agent: z.ZodNullable<
+            z.ZodObject<
+              {
+                agent_id: z.ZodString;
+                name: z.ZodString;
+                role: z.ZodString;
+              },
+              z.core.$strip
+            >
+          >;
+          rigName: z.ZodNullable<z.ZodString>;
+          reviewMetadata: z.ZodNullable<
+            z.ZodObject<
+              {
+                pr_url: z.ZodNullable<z.ZodString>;
+                branch: z.ZodNullable<z.ZodString>;
+                target_branch: z.ZodNullable<z.ZodString>;
+                merge_commit: z.ZodNullable<z.ZodString>;
+              },
+              z.core.$strip
+            >
+          >;
+        },
+        z.core.$strip
+      >
+    >;
+  },
+  z.core.$strip
+>;
+export declare const RpcMergeQueueDataOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      needsAttention: z.ZodObject<
+        {
+          openPRs: z.ZodArray<
+            z.ZodObject<
+              {
+                mrBead: z.ZodObject<
+                  {
+                    bead_id: z.ZodString;
+                    status: z.ZodString;
+                    title: z.ZodString;
+                    body: z.ZodNullable<z.ZodString>;
+                    rig_id: z.ZodNullable<z.ZodString>;
+                    created_at: z.ZodString;
+                    updated_at: z.ZodString;
+                    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                  },
+                  z.core.$strip
+                >;
+                reviewMetadata: z.ZodObject<
+                  {
+                    branch: z.ZodString;
+                    target_branch: z.ZodString;
+                    merge_commit: z.ZodNullable<z.ZodString>;
+                    pr_url: z.ZodNullable<z.ZodString>;
+                    retry_count: z.ZodNumber;
+                  },
+                  z.core.$strip
+                >;
+                sourceBead: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      bead_id: z.ZodString;
+                      title: z.ZodString;
+                      status: z.ZodString;
+                      body: z.ZodNullable<z.ZodString>;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                convoy: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      convoy_id: z.ZodString;
+                      title: z.ZodString;
+                      total_beads: z.ZodNumber;
+                      closed_beads: z.ZodNumber;
+                      feature_branch: z.ZodNullable<z.ZodString>;
+                      merge_mode: z.ZodNullable<z.ZodString>;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                agent: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      agent_id: z.ZodString;
+                      name: z.ZodString;
+                      role: z.ZodString;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                rigName: z.ZodNullable<z.ZodString>;
+                staleSince: z.ZodNullable<z.ZodString>;
+                failureReason: z.ZodNullable<z.ZodString>;
+              },
+              z.core.$strip
+            >
+          >;
+          failedReviews: z.ZodArray<
+            z.ZodObject<
+              {
+                mrBead: z.ZodObject<
+                  {
+                    bead_id: z.ZodString;
+                    status: z.ZodString;
+                    title: z.ZodString;
+                    body: z.ZodNullable<z.ZodString>;
+                    rig_id: z.ZodNullable<z.ZodString>;
+                    created_at: z.ZodString;
+                    updated_at: z.ZodString;
+                    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                  },
+                  z.core.$strip
+                >;
+                reviewMetadata: z.ZodObject<
+                  {
+                    branch: z.ZodString;
+                    target_branch: z.ZodString;
+                    merge_commit: z.ZodNullable<z.ZodString>;
+                    pr_url: z.ZodNullable<z.ZodString>;
+                    retry_count: z.ZodNumber;
+                  },
+                  z.core.$strip
+                >;
+                sourceBead: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      bead_id: z.ZodString;
+                      title: z.ZodString;
+                      status: z.ZodString;
+                      body: z.ZodNullable<z.ZodString>;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                convoy: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      convoy_id: z.ZodString;
+                      title: z.ZodString;
+                      total_beads: z.ZodNumber;
+                      closed_beads: z.ZodNumber;
+                      feature_branch: z.ZodNullable<z.ZodString>;
+                      merge_mode: z.ZodNullable<z.ZodString>;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                agent: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      agent_id: z.ZodString;
+                      name: z.ZodString;
+                      role: z.ZodString;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                rigName: z.ZodNullable<z.ZodString>;
+                staleSince: z.ZodNullable<z.ZodString>;
+                failureReason: z.ZodNullable<z.ZodString>;
+              },
+              z.core.$strip
+            >
+          >;
+          stalePRs: z.ZodArray<
+            z.ZodObject<
+              {
+                mrBead: z.ZodObject<
+                  {
+                    bead_id: z.ZodString;
+                    status: z.ZodString;
+                    title: z.ZodString;
+                    body: z.ZodNullable<z.ZodString>;
+                    rig_id: z.ZodNullable<z.ZodString>;
+                    created_at: z.ZodString;
+                    updated_at: z.ZodString;
+                    metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                  },
+                  z.core.$strip
+                >;
+                reviewMetadata: z.ZodObject<
+                  {
+                    branch: z.ZodString;
+                    target_branch: z.ZodString;
+                    merge_commit: z.ZodNullable<z.ZodString>;
+                    pr_url: z.ZodNullable<z.ZodString>;
+                    retry_count: z.ZodNumber;
+                  },
+                  z.core.$strip
+                >;
+                sourceBead: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      bead_id: z.ZodString;
+                      title: z.ZodString;
+                      status: z.ZodString;
+                      body: z.ZodNullable<z.ZodString>;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                convoy: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      convoy_id: z.ZodString;
+                      title: z.ZodString;
+                      total_beads: z.ZodNumber;
+                      closed_beads: z.ZodNumber;
+                      feature_branch: z.ZodNullable<z.ZodString>;
+                      merge_mode: z.ZodNullable<z.ZodString>;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                agent: z.ZodNullable<
+                  z.ZodObject<
+                    {
+                      agent_id: z.ZodString;
+                      name: z.ZodString;
+                      role: z.ZodString;
+                    },
+                    z.core.$strip
+                  >
+                >;
+                rigName: z.ZodNullable<z.ZodString>;
+                staleSince: z.ZodNullable<z.ZodString>;
+                failureReason: z.ZodNullable<z.ZodString>;
+              },
+              z.core.$strip
+            >
+          >;
+        },
+        z.core.$strip
+      >;
+      activityLog: z.ZodArray<
+        z.ZodObject<
+          {
+            event: z.ZodObject<
+              {
+                bead_event_id: z.ZodString;
+                bead_id: z.ZodString;
+                agent_id: z.ZodNullable<z.ZodString>;
+                event_type: z.ZodString;
+                old_value: z.ZodNullable<z.ZodString>;
+                new_value: z.ZodNullable<z.ZodString>;
+                metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                created_at: z.ZodString;
+              },
+              z.core.$strip
+            >;
+            mrBead: z.ZodNullable<
+              z.ZodObject<
+                {
+                  bead_id: z.ZodString;
+                  title: z.ZodString;
+                  type: z.ZodString;
+                  status: z.ZodString;
+                  rig_id: z.ZodNullable<z.ZodString>;
+                  metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+                },
+                z.core.$strip
+              >
+            >;
+            sourceBead: z.ZodNullable<
+              z.ZodObject<
+                {
+                  bead_id: z.ZodString;
+                  title: z.ZodString;
+                  status: z.ZodString;
+                },
+                z.core.$strip
+              >
+            >;
+            convoy: z.ZodNullable<
+              z.ZodObject<
+                {
+                  convoy_id: z.ZodString;
+                  title: z.ZodString;
+                  total_beads: z.ZodNumber;
+                  closed_beads: z.ZodNumber;
+                  feature_branch: z.ZodNullable<z.ZodString>;
+                  merge_mode: z.ZodNullable<z.ZodString>;
+                },
+                z.core.$strip
+              >
+            >;
+            agent: z.ZodNullable<
+              z.ZodObject<
+                {
+                  agent_id: z.ZodString;
+                  name: z.ZodString;
+                  role: z.ZodString;
+                },
+                z.core.$strip
+              >
+            >;
+            rigName: z.ZodNullable<z.ZodString>;
+            reviewMetadata: z.ZodNullable<
+              z.ZodObject<
+                {
+                  pr_url: z.ZodNullable<z.ZodString>;
+                  branch: z.ZodNullable<z.ZodString>;
+                  target_branch: z.ZodNullable<z.ZodString>;
+                  merge_commit: z.ZodNullable<z.ZodString>;
+                },
+                z.core.$strip
+              >
+            >;
+          },
+          z.core.$strip
+        >
+      >;
+    },
+    z.core.$strip
+  >
+>;
+export declare const OrgTownOutput: z.ZodObject<
+  {
     id: z.ZodString;
     name: z.ZodString;
     owner_org_id: z.ZodString;
     created_by_user_id: z.ZodString;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, z.core.$strip>;
-export declare const RpcOrgTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
-    id: z.ZodString;
-    name: z.ZodString;
-    owner_org_id: z.ZodString;
-    created_by_user_id: z.ZodString;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.core.$strip>>;
+  },
+  z.core.$strip
+>;
+export declare const RpcOrgTownOutput: z.ZodPipe<
+  z.ZodAny,
+  z.ZodObject<
+    {
+      id: z.ZodString;
+      name: z.ZodString;
+      owner_org_id: z.ZodString;
+      created_by_user_id: z.ZodString;
+      created_at: z.ZodString;
+      updated_at: z.ZodString;
+    },
+    z.core.$strip
+  >
+>;


### PR DESCRIPTION
## Summary

- Add admin bypass to the gastown tRPC ownership verification layer (`resolveTownOwnership`, `verifyTownOwnership`, `verifyRigOwnership`) so Kilo admins can access any town's routes — beads, agents, convoys, terminal, settings, mayor chat — without being the town owner
- Block admins from destructive actions (delete town/rig) and config modifications on towns they don't own; mask secrets in town config for admin viewers
- Add admin audit logging middleware (`adminAuditMiddleware`) that writes `admin.town_access` events to Cloudflare Analytics Engine with admin user ID, town ID, and route
- Add `checkAdminAccess` tRPC query and `AdminViewingBanner` component that shows "Viewing as admin — this town belongs to user@..." when an admin views another user's town
- Force settings page into read-only mode for admin viewers; allow admins to bypass the `gastown-access` PostHog feature flag
- Add "View Town UI" buttons to the admin panel's TownInspectorDashboard and UserAdminGastown components

## Verification

- [ ] TypeScript typecheck (`pnpm typecheck`)
- [ ] Gastown worker unit tests (`pnpm test` in `cloudflare-gastown/`)
- [ ] Lint (`pnpm lint`)
- [ ] Build (`pnpm build`)
- [ ] New unit tests for admin audit middleware and town-auth admin bypass pass

## Visual Changes

<img width="1666" height="1234" alt="image" src="https://github.com/user-attachments/assets/11ffa091-d060-47a7-88f3-d18e34e0b882" />

## Reviewer Notes

- The existing `townAuthMiddleware` and `townOwnershipMiddleware` already had admin bypass (`if (c.get('kiloIsAdmin')) return next()`). The gap was in the **tRPC layer** where `resolveTownOwnership`/`verifyTownOwnership`/`verifyRigOwnership` did not check `isAdmin`. This PR adds a new `'admin'` ownership type that propagates through the tRPC flow.
- Admin access to a town they don't own returns `{ type: 'admin' }` from `resolveTownOwnership`. Callers check for this type to block destructive mutations while allowing read access and mayor chat.
- The `checkAdminAccess` tRPC query is cheap — it only hits the TownDO config when the user is an admin, and returns immediately for non-admins.
- Audit events are written to the same Cloudflare Analytics Engine dataset as existing gastown events, using the existing `writeEvent` utility. No new tables or migrations required.