### PR TITLE
fix(kiloclaw): disable openclaw update checks on start

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -99,10 +99,23 @@ describe('generateBaseConfig', () => {
     expect(config.tools.exec.security).toBe('allowlist');
     expect(config.tools.exec.ask).toBe('on-miss');
 
+    // Update checks disabled — KiloClaw manages updates via Docker images
+    expect(config.update.checkOnStart).toBe(false);
+
     // Browser
     expect(config.browser.enabled).toBe(true);
     expect(config.browser.headless).toBe(true);
     expect(config.browser.noSandbox).toBe(true);
+  });
+
+  it('disables update.checkOnStart even when existing config has it enabled', () => {
+    const existing = JSON.stringify({ update: { checkOnStart: true, channel: 'stable' } });
+    const { deps } = fakeDeps(existing);
+    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
+
+    expect(config.update.checkOnStart).toBe(false);
+    // Preserves other update keys
+    expect(config.update.channel).toBe('stable');
   });
 
   it('preserves user tool profile on non-fresh boot', () => {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -213,6 +213,11 @@ export function generateBaseConfig(
   config.tools.exec.security = env.KILOCLAW_EXEC_SECURITY || 'allowlist';
   config.tools.exec.ask = env.KILOCLAW_EXEC_ASK || 'on-miss';
 
+  // Disable update checks on start. KiloClaw manages updates via Docker
+  // image deployments, not openclaw's built-in updater.
+  config.update = config.update ?? {};
+  config.update.checkOnStart = false;
+
   // Browser: headless Chromium for the browser tool in Docker.
   // OpenClaw auto-detects /usr/bin/chromium and adds --disable-dev-shm-usage on Linux.
   // noSandbox is required in containers (Chromium's setuid sandbox needs kernel namespacing).


### PR DESCRIPTION
## Summary

Disable openclaw's built-in update check on machine startup by setting `update.checkOnStart: false` in the generated config.

KiloClaw manages openclaw updates via Docker image deployments — the built-in updater's startup check is unnecessary and adds network latency on every boot. The change is in `generateBaseConfig()` (`kiloclaw/controller/src/config-writer.ts`), which runs on every machine boot, so it applies to both new and existing deployments on their next restart. Other user-set `update.*` keys (e.g. `channel`) are preserved.

## Verification

- [x] `pnpm typecheck` — passed (kiloclaw + full workspace)
- [x] `pnpm test` (kiloclaw) — 967 tests passed
- [x] `pnpm lint` — passed (full workspace pre-push hook)
- [x] `pnpm format:check` — passed

## Visual Changes

N/A

## Reviewer Notes

The setting is unconditional (like `gateway.port`, `browser.headless`, etc.) — it's always forced to `false` regardless of what the existing config or `openclaw onboard` produces. This is intentional since KiloClaw should never self-update via openclaw's updater.