### PR TITLE
chore: bump model versions on sign-up screen

### DIFF
--- a/src/app/payments/topup/thank-you/page.tsx
+++ b/src/app/payments/topup/thank-you/page.tsx
@@ -27,8 +27,8 @@ export default function TopUpThankYouPage() {
                 </p>
                 <p>
                   <span className="mr-2">→</span>
-                  <strong>Access 500+ AI models</strong>, including Claude Sonnet 4.6,
-                  GPT-5.4, Gemini 3.1, and hundreds more
+                  <strong>Access 500+ AI models</strong>, including Claude Sonnet 4.6, GPT-5.4,
+                  Gemini 3.1, and hundreds more
                 </p>
               </div>
 

--- a/src/app/payments/topup/thank-you/page.tsx
+++ b/src/app/payments/topup/thank-you/page.tsx
@@ -27,8 +27,8 @@ export default function TopUpThankYouPage() {
                 </p>
                 <p>
                   <span className="mr-2">→</span>
-                  <strong>Access 500+ AI models</strong>, including Claude Sonnet 4.5, GPT-5.2,
-                  Gemini 3, and hundreds more
+                  <strong>Access 500+ AI models</strong>, including Claude Sonnet 4.6,
+                  GPT-5.4, Gemini 3.1, and hundreds more
                 </p>
               </div>
 

--- a/src/components/auth/AuthMarketingAside.tsx
+++ b/src/components/auth/AuthMarketingAside.tsx
@@ -19,8 +19,8 @@ export function AuthMarketingAside() {
           </li>
           <li className="flex items-center gap-4">
             <div className="flex-1">
-              Access <span className="font-bold">500+ AI models</span>, including Claude Sonnet 4.5,
-              GPT-5.2, Gemini 3, and hundreds more
+              Access <span className="font-bold">500+ AI models</span>, including Claude Sonnet 4.6,
+              GPT-5.4, Gemini 3.1, and hundreds more
             </div>
           </li>
           <li className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- Update model names in the sign-up marketing aside to latest versions: Claude Sonnet 4.6, GPT-5.4, Gemini 3.1

## Test plan
- [ ] Verify sign-up page renders correctly with updated model names