### PR TITLE
feat(gastown): enrich agent re-dispatch with tool call summaries and transcript formatting

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -52,7 +52,10 @@ import { getAgentDOStub } from './Agent.do';
 import { getTownContainerStub } from './TownContainer.do';
 
 import { writeEvent, type GastownEventData } from '../util/analytics.util';
-import { reconstructConversation } from '../util/reconstruct-conversation.util';
+import {
+  reconstructConversation,
+  formatTranscriptForRedispatch,
+} from '../util/reconstruct-conversation.util';
 import { RigAgentEventRecord } from '../db/tables/rig-agent-events.table';
 import { BeadPriority } from '../types';
 import type {
@@ -1841,11 +1844,7 @@ export class TownDO extends DurableObject<Env> {
       const priorEvents = RigAgentEventRecord.array().safeParse(rawEvents);
       const priorTurns = priorEvents.success ? reconstructConversation(priorEvents.data) : [];
       const priorTranscript =
-        priorTurns.length > 0
-          ? priorTurns
-              .map(t => `[${t.role === 'user' ? 'User' : 'Assistant'}]: ${t.content}`)
-              .join('\n\n')
-          : '';
+        priorTurns.length > 0 ? formatTranscriptForRedispatch(priorTurns) : '';
 
       const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
         townId,
@@ -1857,7 +1856,9 @@ export class TownDO extends DurableObject<Env> {
         identity: mayor.identity,
         beadId: '',
         beadTitle: message,
-        beadBody: priorTranscript ? `Prior conversation:\n\n${priorTranscript}` : '',
+        beadBody: priorTranscript
+          ? `Prior session transcript (container restarted):\n\n${priorTranscript}`
+          : '',
         checkpoint: mayor.checkpoint,
         gitUrl: rigConfig?.gitUrl ?? '',
         defaultBranch: rigConfig?.defaultBranch ?? 'main',
@@ -3118,10 +3119,13 @@ export class TownDO extends DurableObject<Env> {
       const priorTurns = priorEvents.success ? reconstructConversation(priorEvents.data) : [];
       let beadBody = bead.body ?? '';
       if (priorTurns.length > 0) {
-        const priorTranscript = priorTurns
-          .map(t => `[${t.role === 'user' ? 'User' : 'Assistant'}]: ${t.content}`)
-          .join('\n\n');
-        beadBody = `Prior conversation:\n\n${priorTranscript}`;
+        const priorTranscript = formatTranscriptForRedispatch(priorTurns);
+        // Prepend the original bead body so the agent retains the task
+        // description alongside the prior session context.
+        const originalBody = bead.body ?? '';
+        beadBody = originalBody
+          ? `${originalBody}\n\n---\n\nPrior session transcript (container restarted):\n\n${priorTranscript}`
+          : `Prior session transcript (container restarted):\n\n${priorTranscript}`;
       }
 
       const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -3120,11 +3120,8 @@ export class TownDO extends DurableObject<Env> {
       let beadBody = bead.body ?? '';
       if (priorTurns.length > 0) {
         const priorTranscript = formatTranscriptForRedispatch(priorTurns);
-        // Prepend the original bead body so the agent retains the task
-        // description alongside the prior session context.
-        const originalBody = bead.body ?? '';
-        beadBody = originalBody
-          ? `${originalBody}\n\n---\n\nPrior session transcript (container restarted):\n\n${priorTranscript}`
+        beadBody = beadBody
+          ? `${beadBody}\n\n---\n\nPrior session transcript (container restarted):\n\n${priorTranscript}`
           : `Prior session transcript (container restarted):\n\n${priorTranscript}`;
       }
 

--- a/cloudflare-gastown/src/util/reconstruct-conversation.util.ts
+++ b/cloudflare-gastown/src/util/reconstruct-conversation.util.ts
@@ -340,7 +340,8 @@ export function formatTranscriptForRedispatch(
   let charCount = 0;
 
   for (let i = turns.length - 1; i >= 0; i--) {
-    const turn = turns[i]!;
+    const turn = turns[i];
+    if (!turn) continue;
     const formatted = formatTurn(turn);
     if (charCount + formatted.length > maxChars && lines.length > 0) break;
     lines.unshift(formatted);

--- a/cloudflare-gastown/src/util/reconstruct-conversation.util.ts
+++ b/cloudflare-gastown/src/util/reconstruct-conversation.util.ts
@@ -22,9 +22,18 @@ import { type RigAgentEventRecord } from '../db/tables/rig-agent-events.table';
 
 // ── Output type ────────────────────────────────────────────────────────────
 
+export type ToolCallSummary = {
+  tool: string;
+  status: string;
+  /** Truncated one-liner describing the call (e.g. "bash: git status → ok") */
+  summary: string;
+};
+
 export type ConversationTurn = {
   role: 'user' | 'assistant';
   content: string;
+  /** Tool calls made during this assistant turn (empty for user turns). */
+  toolCalls: ToolCallSummary[];
 };
 
 // ── Zod schemas for the event data payloads ────────────────────────────────
@@ -75,12 +84,33 @@ const TextPartData = z
   })
   .passthrough();
 
-// Minimal Part schema — we only care about TextPart; everything else is
-// parsed as an unknown part so we can skip it gracefully.
+// ToolPart from message_part.updated — captures the tool name and execution state
+// so we can summarize what the agent did (not just what it said).
+const ToolStateData = z
+  .object({
+    status: z.string().optional(),
+    input: z.unknown().optional(),
+    output: z.unknown().optional(),
+    title: z.string().optional(),
+  })
+  .passthrough();
+
+const ToolPartData = z
+  .object({
+    id: z.string(),
+    messageID: z.string(),
+    type: z.literal('tool'),
+    tool: z.string().optional(),
+    state: ToolStateData.optional(),
+  })
+  .passthrough();
+
+// Minimal Part schema — we care about TextPart and ToolPart; everything else
+// is parsed as an unknown part so we can skip it gracefully.
 const PartData = z.discriminatedUnion('type', [
   TextPartData,
+  ToolPartData,
   z.object({ type: z.literal('reasoning'), messageID: z.string() }).passthrough(),
-  z.object({ type: z.literal('tool'), messageID: z.string() }).passthrough(),
   z.object({ type: z.literal('file'), messageID: z.string() }).passthrough(),
   z.object({ type: z.literal('step-start'), messageID: z.string() }).passthrough(),
   z.object({ type: z.literal('step-finish'), messageID: z.string() }).passthrough(),
@@ -110,6 +140,8 @@ type MessageAccumulator = {
   info: UserInfo | AssistantInfo | null;
   // Text parts keyed by part id; stored in insertion order
   textParts: Map<string, string>;
+  // Tool call summaries keyed by part id; stored in insertion order
+  toolCalls: Map<string, ToolCallSummary>;
   // Whether this message had any non-text parts (tool calls, etc.)
   hasNonTextParts: boolean;
 };
@@ -148,6 +180,7 @@ export function reconstructConversation(
           role: info.role,
           info,
           textParts: new Map(),
+          toolCalls: new Map(),
           hasNonTextParts: false,
         };
         messages.set(info.id, acc);
@@ -172,6 +205,7 @@ export function reconstructConversation(
           role: 'assistant', // default; corrected when message info arrives
           info: null,
           textParts: new Map(),
+          toolCalls: new Map(),
           hasNonTextParts: false,
         };
         messages.set(messageId, acc);
@@ -181,6 +215,9 @@ export function reconstructConversation(
         // Skip synthetic / ignored parts (used for internal context injection)
         if (part.synthetic || part.ignored) continue;
         acc.textParts.set(part.id, part.text);
+      } else if (part.type === 'tool') {
+        acc.hasNonTextParts = true;
+        acc.toolCalls.set(part.id, summarizeToolCall(part));
       } else {
         acc.hasNonTextParts = true;
       }
@@ -193,8 +230,9 @@ export function reconstructConversation(
 
   for (const acc of messages.values()) {
     const content = buildContent(acc);
-    if (content === null) continue; // skip tool-only or empty turns
-    turns.push({ role: acc.role, content });
+    if (content === null) continue; // skip empty turns
+    const toolCalls = [...acc.toolCalls.values()];
+    turns.push({ role: acc.role, content, toolCalls });
   }
 
   // ── Truncate ─────────────────────────────────────────────────────────────
@@ -232,12 +270,14 @@ function buildAssistantContent(acc: MessageAccumulator): string | null {
   const fromParts = joinTextParts(acc.textParts);
   if (fromParts !== '') return fromParts;
 
-  // Assistant messages with only tool calls (no text) are tool-only turns.
-  // These are not meaningful for a human-readable transcript.
-  if (acc.hasNonTextParts) return null;
+  // Tool-only turns: include them if we captured tool call summaries,
+  // since they describe work the agent performed (file edits, commands).
+  if (acc.toolCalls.size > 0) {
+    return [...acc.toolCalls.values()].map(tc => tc.summary).join('; ');
+  }
 
   // No content at all (e.g. message was created but never had parts — perhaps
-  // due to a crash mid-stream). Skip.
+  // due to a crash mid-stream, or had only non-tool non-text parts). Skip.
   return null;
 }
 
@@ -251,4 +291,73 @@ function extractSummaryBody(info: UserInfo | AssistantInfo | null): string | nul
   const parsed = UserMessageSummary.safeParse(info.summary);
   if (!parsed.success) return null;
   return parsed.data.body ?? null;
+}
+
+type ToolPartFields = z.infer<typeof ToolPartData>;
+
+function summarizeToolCall(part: ToolPartFields): ToolCallSummary {
+  const toolName = part.tool ?? 'unknown';
+  const status = part.state?.status ?? 'unknown';
+  const title = part.state?.title;
+
+  // Build a one-liner: "bash: git status → ok" or "edit: src/foo.ts → completed"
+  const inputBrief = title ?? truncateValue(part.state?.input, 60);
+  const outputBrief = truncateValue(part.state?.output, 60);
+
+  let summary = toolName;
+  if (inputBrief) summary += `: ${inputBrief}`;
+  if (outputBrief) summary += ` → ${outputBrief}`;
+  else if (status !== 'unknown') summary += ` → ${status}`;
+
+  return { tool: toolName, status, summary };
+}
+
+/** Truncate a value to a brief string for summaries. */
+function truncateValue(value: unknown, maxLen: number): string {
+  if (value === undefined || value === null) return '';
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + '...';
+}
+
+// ── Formatting for re-dispatch ────────────────────────────────────────────
+
+/**
+ * Format a reconstructed conversation transcript into a condensed string
+ * suitable for injection into a re-dispatch prompt. Includes text content
+ * and tool call summaries so the re-dispatched agent knows what it did.
+ *
+ * @param turns  Output of `reconstructConversation()`.
+ * @param maxChars  Approximate character budget. Older turns are dropped
+ *                  to fit. Defaults to 30_000 (~7.5k tokens).
+ */
+export function formatTranscriptForRedispatch(
+  turns: ConversationTurn[],
+  maxChars = 30_000
+): string {
+  // Build formatted lines from most recent to oldest, stopping when the budget is hit.
+  const lines: string[] = [];
+  let charCount = 0;
+
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const turn = turns[i]!;
+    const formatted = formatTurn(turn);
+    if (charCount + formatted.length > maxChars && lines.length > 0) break;
+    lines.unshift(formatted);
+    charCount += formatted.length;
+  }
+
+  return lines.join('\n\n');
+}
+
+function formatTurn(turn: ConversationTurn): string {
+  const label = turn.role === 'user' ? 'User' : 'Assistant';
+  let result = `[${label}]: ${turn.content}`;
+
+  if (turn.toolCalls.length > 0) {
+    const toolLines = turn.toolCalls.map(tc => `  - ${tc.summary}`);
+    result += `\n[Tool calls]:\n${toolLines.join('\n')}`;
+  }
+
+  return result;
 }

--- a/cloudflare-gastown/test/unit/reconstruct-conversation.test.ts
+++ b/cloudflare-gastown/test/unit/reconstruct-conversation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   reconstructConversation,
+  formatTranscriptForRedispatch,
   type ConversationTurn,
 } from '../../src/util/reconstruct-conversation.util';
 import { type RigAgentEventRecord } from '../../src/db/tables/rig-agent-events.table';
@@ -53,7 +54,11 @@ function textPartUpdated(
   });
 }
 
-function toolPartUpdated(messageID: string, partId: string) {
+function toolPartUpdated(
+  messageID: string,
+  partId: string,
+  overrides: Record<string, unknown> = {}
+) {
   return makeEvent('message_part.updated', {
     sessionID: 'sess-1',
     part: {
@@ -70,6 +75,7 @@ function toolPartUpdated(messageID: string, partId: string) {
         metadata: {},
         time: { start: 1, end: 2 },
       },
+      ...overrides,
     },
   });
 }
@@ -78,7 +84,7 @@ function toolPartUpdated(messageID: string, partId: string) {
 
 describe('reconstructConversation', () => {
   describe('basic happy path', () => {
-    it('reconstructs a simple user → assistant exchange', () => {
+    it('reconstructs a simple user -> assistant exchange', () => {
       const events = [
         textPartUpdated('msg-u1', 'part-u1', 'Hello, world!'),
         messageUpdated('msg-u1', 'user'),
@@ -89,8 +95,8 @@ describe('reconstructConversation', () => {
       const turns = reconstructConversation(events);
 
       expect(turns).toEqual<ConversationTurn[]>([
-        { role: 'user', content: 'Hello, world!' },
-        { role: 'assistant', content: 'Hi there!' },
+        { role: 'user', content: 'Hello, world!', toolCalls: [] },
+        { role: 'assistant', content: 'Hi there!', toolCalls: [] },
       ]);
     });
 
@@ -105,7 +111,8 @@ describe('reconstructConversation', () => {
       const turns = reconstructConversation(events);
 
       expect(turns).toHaveLength(1);
-      expect(turns[0]).toEqual({ role: 'assistant', content: 'First second third' });
+      expect(turns[0]?.content).toBe('First second third');
+      expect(turns[0]?.toolCalls).toEqual([]);
     });
 
     it('uses the most recent text for a part when updated multiple times', () => {
@@ -156,7 +163,8 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events);
-      expect(turns).toEqual([{ role: 'assistant', content: 'Done.' }]);
+      expect(turns[0]?.content).toBe('Done.');
+      expect(turns[0]?.toolCalls).toEqual([]);
     });
 
     it('handles message.part.updated (dot variant) as well as message_part.updated', () => {
@@ -169,7 +177,7 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events);
-      expect(turns).toEqual([{ role: 'assistant', content: 'dot variant' }]);
+      expect(turns[0]?.content).toBe('dot variant');
     });
 
     it('accepts parts before the message info event arrives', () => {
@@ -180,22 +188,12 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events);
-      expect(turns).toEqual([{ role: 'assistant', content: 'early text' }]);
+      expect(turns[0]?.content).toBe('early text');
     });
   });
 
-  describe('edge cases', () => {
-    it('skips tool-only assistant turns (no text content)', () => {
-      const events = [
-        toolPartUpdated('msg-a1', 'tool-p1'),
-        messageCompleted('msg-a1', 'assistant'),
-      ];
-
-      const turns = reconstructConversation(events);
-      expect(turns).toHaveLength(0);
-    });
-
-    it('includes assistant turns that mix text and tool calls', () => {
+  describe('tool call tracking', () => {
+    it('captures tool call summaries in assistant turns with text', () => {
       const events = [
         textPartUpdated('msg-a1', 'p-text', 'Let me run that for you.'),
         toolPartUpdated('msg-a1', 'p-tool'),
@@ -204,9 +202,89 @@ describe('reconstructConversation', () => {
 
       const turns = reconstructConversation(events);
       expect(turns).toHaveLength(1);
-      expect(turns[0]).toEqual({ role: 'assistant', content: 'Let me run that for you.' });
+      expect(turns[0]?.content).toBe('Let me run that for you.');
+      expect(turns[0]?.toolCalls).toHaveLength(1);
+      expect(turns[0]?.toolCalls[0]?.tool).toBe('bash');
+      expect(turns[0]?.toolCalls[0]?.status).toBe('completed');
+      expect(turns[0]?.toolCalls[0]?.summary).toContain('bash');
     });
 
+    it('includes tool-only assistant turns with tool call summaries as content', () => {
+      const events = [
+        toolPartUpdated('msg-a1', 'tool-p1'),
+        messageCompleted('msg-a1', 'assistant'),
+      ];
+
+      const turns = reconstructConversation(events);
+      expect(turns).toHaveLength(1);
+      expect(turns[0]?.toolCalls).toHaveLength(1);
+      expect(turns[0]?.content).toContain('bash');
+    });
+
+    it('captures multiple tool calls per turn', () => {
+      const events = [
+        textPartUpdated('msg-a1', 'p-text', 'Running commands.'),
+        toolPartUpdated('msg-a1', 'tool-1', {
+          tool: 'bash',
+          state: { status: 'completed', title: 'git status', output: 'clean' },
+        }),
+        toolPartUpdated('msg-a1', 'tool-2', {
+          tool: 'edit',
+          state: { status: 'completed', title: 'src/foo.ts' },
+        }),
+        messageCompleted('msg-a1', 'assistant'),
+      ];
+
+      const turns = reconstructConversation(events);
+      expect(turns).toHaveLength(1);
+      expect(turns[0]?.toolCalls).toHaveLength(2);
+      expect(turns[0]?.toolCalls[0]?.tool).toBe('bash');
+      expect(turns[0]?.toolCalls[0]?.summary).toContain('git status');
+      expect(turns[0]?.toolCalls[1]?.tool).toBe('edit');
+      expect(turns[0]?.toolCalls[1]?.summary).toContain('src/foo.ts');
+    });
+
+    it('handles tool parts without state gracefully', () => {
+      const events = [
+        makeEvent('message_part.updated', {
+          sessionID: 'sess-1',
+          part: {
+            id: 'tool-p1',
+            messageID: 'msg-a1',
+            type: 'tool',
+            tool: 'read',
+          },
+        }),
+        messageCompleted('msg-a1', 'assistant'),
+      ];
+
+      const turns = reconstructConversation(events);
+      expect(turns).toHaveLength(1);
+      expect(turns[0]?.toolCalls[0]?.tool).toBe('read');
+      expect(turns[0]?.toolCalls[0]?.status).toBe('unknown');
+    });
+
+    it('handles tool parts without tool name gracefully', () => {
+      const events = [
+        makeEvent('message_part.updated', {
+          sessionID: 'sess-1',
+          part: {
+            id: 'tool-p1',
+            messageID: 'msg-a1',
+            type: 'tool',
+            state: { status: 'completed', output: 'done' },
+          },
+        }),
+        messageCompleted('msg-a1', 'assistant'),
+      ];
+
+      const turns = reconstructConversation(events);
+      expect(turns).toHaveLength(1);
+      expect(turns[0]?.toolCalls[0]?.tool).toBe('unknown');
+    });
+  });
+
+  describe('edge cases', () => {
     it('skips synthetic text parts', () => {
       const events = [
         textPartUpdated('msg-a1', 'p-synth', 'injected context', { synthetic: true }),
@@ -252,7 +330,8 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events);
-      expect(turns).toEqual([{ role: 'user', content: 'What is 2+2?' }]);
+      expect(turns[0]?.content).toBe('What is 2+2?');
+      expect(turns[0]?.toolCalls).toEqual([]);
     });
 
     it('handles malformed events gracefully (non-object data)', () => {
@@ -263,7 +342,7 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events);
-      expect(turns).toEqual([{ role: 'assistant', content: 'still works' }]);
+      expect(turns[0]?.content).toBe('still works');
     });
 
     it('handles unknown event types gracefully', () => {
@@ -275,7 +354,7 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events);
-      expect(turns).toEqual([{ role: 'assistant', content: 'the answer' }]);
+      expect(turns[0]?.content).toBe('the answer');
     });
 
     it('returns empty array for empty event list', () => {
@@ -324,7 +403,7 @@ describe('reconstructConversation', () => {
       ];
 
       const turns = reconstructConversation(events, 1);
-      expect(turns).toEqual([{ role: 'assistant', content: 'last' }]);
+      expect(turns[0]?.content).toBe('last');
     });
 
     it('uses default maxTurns of 50', () => {
@@ -338,5 +417,63 @@ describe('reconstructConversation', () => {
       expect(turns).toHaveLength(50);
       expect(turns[49]?.content).toBe('turn 59');
     });
+  });
+});
+
+describe('formatTranscriptForRedispatch', () => {
+  it('formats turns with role labels', () => {
+    const turns: ConversationTurn[] = [
+      { role: 'user', content: 'Fix the bug', toolCalls: [] },
+      { role: 'assistant', content: 'Looking into it.', toolCalls: [] },
+    ];
+
+    const result = formatTranscriptForRedispatch(turns);
+    expect(result).toContain('[User]: Fix the bug');
+    expect(result).toContain('[Assistant]: Looking into it.');
+  });
+
+  it('includes tool call summaries', () => {
+    const turns: ConversationTurn[] = [
+      {
+        role: 'assistant',
+        content: 'Let me check.',
+        toolCalls: [
+          { tool: 'bash', status: 'completed', summary: 'bash: git status -> clean' },
+          { tool: 'edit', status: 'completed', summary: 'edit: src/foo.ts -> completed' },
+        ],
+      },
+    ];
+
+    const result = formatTranscriptForRedispatch(turns);
+    expect(result).toContain('[Tool calls]:');
+    expect(result).toContain('  - bash: git status -> clean');
+    expect(result).toContain('  - edit: src/foo.ts -> completed');
+  });
+
+  it('truncates to fit maxChars budget from the most recent turns', () => {
+    const turns: ConversationTurn[] = [];
+    for (let i = 0; i < 100; i++) {
+      turns.push({ role: 'user', content: `question ${i} ${'x'.repeat(200)}`, toolCalls: [] });
+      turns.push({ role: 'assistant', content: `answer ${i} ${'y'.repeat(200)}`, toolCalls: [] });
+    }
+
+    const result = formatTranscriptForRedispatch(turns, 2000);
+    // Should contain later turns, not earlier ones
+    expect(result).toContain('question 99');
+    expect(result).not.toContain('question 0');
+    expect(result.length).toBeLessThanOrEqual(2500); // some headroom for the last included turn
+  });
+
+  it('returns empty string for empty turns', () => {
+    expect(formatTranscriptForRedispatch([])).toBe('');
+  });
+
+  it('always includes at least the most recent turn even if it exceeds budget', () => {
+    const turns: ConversationTurn[] = [
+      { role: 'assistant', content: 'x'.repeat(500), toolCalls: [] },
+    ];
+
+    const result = formatTranscriptForRedispatch(turns, 100);
+    expect(result).toContain('x'.repeat(500));
   });
 });


### PR DESCRIPTION
## Summary

Enriches the conversation transcript injected on agent re-dispatch (container restart) with tool call summaries, so re-dispatched agents know what files they edited and commands they ran — not just what they said. Also fixes polecat re-dispatch to preserve the original bead body alongside the transcript instead of replacing it entirely.

Key changes:
- Add `ToolCallSummary` type and capture tool name/status/input/output from tool part events during conversation reconstruction
- Include tool-only assistant turns (previously skipped) with summarized tool call content
- Add `formatTranscriptForRedispatch()` with character budget truncation (default 30k chars) and `[Tool calls]` sections per assistant turn
- Fix polecat `dispatchAgent()` to preserve original `bead.body` when prepending the prior session transcript
- Remove non-null assertion (`!`) in favor of guard clause per coding standards

## Verification

- Code review: no `as` casts, no `!` assertions, no secrets, no build artifacts
- Tests: comprehensive test coverage for tool call tracking (5 new tests), `formatTranscriptForRedispatch` (5 new tests), and updated existing tests to include `toolCalls` field
- Style: follows existing patterns with `.passthrough()` on Zod schemas, `type` over `interface`, closure-based helpers

## Visual Changes

N/A

## Reviewer Notes

- The `formatTranscriptForRedispatch` truncation works from most-recent to oldest, always including at least the last turn even if it exceeds the character budget — this prevents edge cases where the agent gets zero context
- Polecat re-dispatch now separates original bead body from transcript with `\n\n---\n\n` delimiter, while mayor re-dispatch only injects transcript (no original bead body since mayor messages are ephemeral)
- Tool call summaries use the `title` field when available (e.g. "git status") falling back to truncated `input`, with `output` or `status` as the result indicator