### PR TITLE
Fix/kiloclaw kilo cli availability

### DIFF
--- a/kiloclaw/container/TOOLS.md
+++ b/kiloclaw/container/TOOLS.md
@@ -6,6 +6,8 @@
 - The openclaw process is managed by a supervisor process
 - Do not modify /root/.kilo
 
+<!-- BEGIN:kilo-cli -->
+
 ## Kilo CLI
 
 The Kilo CLI (`kilo`) is an agentic coding assistant for the terminal, pre-configured with your KiloCode account.
@@ -14,3 +16,4 @@ The Kilo CLI (`kilo`) is an agentic coding assistant for the terminal, pre-confi
 - Autonomous mode: `kilo run --auto "your task description"`
 - Config: `/root/.config/kilo/opencode.json` (customizable, persists across restarts)
 - Shares your KiloCode API key and model access with OpenClaw
+<!-- END:kilo-cli -->

--- a/kiloclaw/controller/src/bootstrap.test.ts
+++ b/kiloclaw/controller/src/bootstrap.test.ts
@@ -7,6 +7,7 @@ import {
   generateHooksToken,
   configureGitHub,
   runOnboardOrDoctor,
+  updateToolsMdKiloCliSection,
   updateToolsMd1PasswordSection,
   buildGatewayArgs,
   bootstrap,
@@ -565,6 +566,48 @@ describe('runOnboardOrDoctor', () => {
     expect(doctorCall?.args).toContain('--fix');
     expect(doctorCall?.args).toContain('--non-interactive');
     expect(env.KILOCLAW_FRESH_INSTALL).toBe('false');
+  });
+});
+
+// ---- updateToolsMdKiloCliSection ----
+
+describe('updateToolsMdKiloCliSection', () => {
+  it('adds Kilo CLI section unconditionally', () => {
+    const harness = fakeDeps();
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
+
+    const env: Record<string, string | undefined> = {};
+
+    updateToolsMdKiloCliSection(env, harness.deps);
+
+    expect(harness.writeCalls).toHaveLength(1);
+    expect(harness.writeCalls[0]!.data).toContain('<!-- BEGIN:kilo-cli -->');
+    expect(harness.writeCalls[0]!.data).toContain('kilo run --auto');
+    expect(harness.writeCalls[0]!.data).toContain('<!-- END:kilo-cli -->');
+  });
+
+  it('skips adding when section already present', () => {
+    const harness = fakeDeps();
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      '# TOOLS\n<!-- BEGIN:kilo-cli -->\nexisting\n<!-- END:kilo-cli -->'
+    );
+
+    const env: Record<string, string | undefined> = {};
+
+    updateToolsMdKiloCliSection(env, harness.deps);
+
+    expect(harness.writeCalls).toHaveLength(0);
+  });
+
+  it('no-ops when TOOLS.md does not exist', () => {
+    const harness = fakeDeps();
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const env: Record<string, string | undefined> = {};
+
+    updateToolsMdKiloCliSection(env, harness.deps);
+
+    expect(harness.writeCalls).toHaveLength(0);
   });
 });
 

--- a/kiloclaw/controller/src/bootstrap.ts
+++ b/kiloclaw/controller/src/bootstrap.ts
@@ -442,7 +442,44 @@ export function updateToolsMdGoogleSection(env: EnvLike, deps: BootstrapDeps): v
   }
 }
 
-// ---- Step 8: TOOLS.md 1Password section ----
+// ---- Step 8: TOOLS.md Kilo CLI section ----
+
+const KILO_CLI_MARKER_BEGIN = '<!-- BEGIN:kilo-cli -->';
+const KILO_CLI_MARKER_END = '<!-- END:kilo-cli -->';
+
+const KILO_CLI_TOOLS_SECTION = `
+${KILO_CLI_MARKER_BEGIN}
+## Kilo CLI
+
+The Kilo CLI (\`kilo\`) is an agentic coding assistant for the terminal, pre-configured with your KiloCode account.
+
+- Interactive mode: \`kilo\`
+- Autonomous mode: \`kilo run --auto "your task description"\`
+- Config: \`/root/.config/kilo/opencode.json\` (customizable, persists across restarts)
+- Shares your KiloCode API key and model access with OpenClaw
+${KILO_CLI_MARKER_END}`;
+
+/**
+ * Ensure the Kilo CLI section is present in TOOLS.md.
+ *
+ * The kilo binary is always in the image, so this runs unconditionally
+ * (not gated on a feature flag). Idempotent: skips if the marker is
+ * already present.
+ */
+export function updateToolsMdKiloCliSection(_env: EnvLike, deps: BootstrapDeps): void {
+  if (!deps.existsSync(TOOLS_MD_DEST)) return;
+
+  const content = deps.readFileSync(TOOLS_MD_DEST, 'utf8');
+
+  if (!content.includes(KILO_CLI_MARKER_BEGIN)) {
+    deps.writeFileSync(TOOLS_MD_DEST, content + KILO_CLI_TOOLS_SECTION);
+    console.log('TOOLS.md: added Kilo CLI section');
+  } else {
+    console.log('TOOLS.md: Kilo CLI section already present');
+  }
+}
+
+// ---- Step 9: TOOLS.md 1Password section ----
 
 const OP_MARKER_BEGIN = '<!-- BEGIN:1password -->';
 const OP_MARKER_END = '<!-- END:1password -->';
@@ -502,7 +539,7 @@ export function updateToolsMd1PasswordSection(env: EnvLike, deps: BootstrapDeps)
   }
 }
 
-// ---- Step 9: Gateway args ----
+// ---- Step 10: Gateway args ----
 
 /**
  * Build the gateway CLI arguments array.
@@ -556,6 +593,7 @@ export async function bootstrap(
   runOnboardOrDoctor(env, deps);
   await yieldToEventLoop();
 
+  updateToolsMdKiloCliSection(env, deps);
   updateToolsMdGoogleSection(env, deps);
   updateToolsMd1PasswordSection(env, deps);
 

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-03-24',
+    description:
+      'Fixed Kilo CLI discovery — OpenClaw now knows about the kilo CLI on all instances. Previously, instances provisioned before the CLI was added did not advertise it in TOOLS.md, so the agent could not find it.',
+    category: 'bugfix',
+    deployHint: 'upgrade_required',
+  },
+  {
     date: '2026-03-23',
     description:
       'Added Brave Search integration. Connect your Brave Search API key in Settings to enable the web_search tool. Brave Search removed their free tier, so an API key is now required.',


### PR DESCRIPTION
## Summary

- TOOLS.md was only seeded on fresh provision, so existing instances provisioned before the Kilo   CLI section was added never had it. OpenClaw didn't know about the kilo binary even though it's   always in the image.
- Added updateToolsMdKiloCliSection() in the controller bootstrap that unconditionally injects the   Kilo CLI section into TOOLS.md on every boot using the same marker pattern as Google Workspace and   1Password sections.
- Wrapped the existing static Kilo CLI section in container/TOOLS.md with <!-- BEGIN:kilo-cli --> /    <!-- END:kilo-cli --> markers for idempotency.
- Added changelog entry with upgrade_required hint.

## Verification

- All kiloclaw tests pass (969/969)
- pnpm run format:check clean
- pnpm --filter kiloclaw typecheck clean
- Deployed dev image dev-1774369332 to Fly, upgraded existing instance d890d42f77d448
- Confirmed TOOLS.md: added Kilo CLI section in machine logs on boot
- Verified idempotency: fresh instances with markers already present skip injection

## Visual Changes

- New changelog entry in "What's New" with upgrade_required badge:   ▎ "Fixed Kilo CLI discovery — OpenClaw now knows about the kilo CLI on all instances."

## Reviewer Notes

- The injection is not gated on the KILOCLAW_KILO_CLI feature flag — the binary is always in the   image, so TOOLS.md should always advertise it. The feature flag only controls config writing   (opencode.json) and KILO_API_KEY aliasing.
- Existing instances need an upgrade (not just restart/redeploy) to pick up the new controller code    that performs the injection.
- Cosmetic: the template string formatting matches the existing Google Workspace and 1Password   patterns exactly (no trailing \n after the end marker in any of the three sections).


