### PR TITLE
feat(gastown): redesign Merge Queue with needs-attention, activity log, and dockable terminal

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -1722,6 +1722,14 @@ export class TownDO extends DurableObject<Env> {
     return reviewQueue.advanceMoleculeStep(this.sql, agentId, summary);
   }
 
+  async getMergeQueueData(params: {
+    rigId?: string;
+    limit?: number;
+    since?: string;
+  }): Promise<reviewQueue.MergeQueueData> {
+    return reviewQueue.getMergeQueueData(this.sql, params);
+  }
+
   // ══════════════════════════════════════════════════════════════════
   // Atomic Sling (create bead + agent + hook)
   // ══════════════════════════════════════════════════════════════════

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -12,6 +12,7 @@ import { review_metadata } from '../../db/tables/review-metadata.table';
 import { bead_dependencies } from '../../db/tables/bead-dependencies.table';
 import { agent_metadata } from '../../db/tables/agent-metadata.table';
 import { convoy_metadata } from '../../db/tables/convoy-metadata.table';
+import { bead_events } from '../../db/tables/bead-events.table';
 import { query } from '../../util/query.util';
 import {
   logBeadEvent,
@@ -742,6 +743,491 @@ export function agentCompleted(
   );
 
   return result;
+}
+
+// ── Merge Queue Data ────────────────────────────────────────────────
+
+/**
+ * 24 hours in milliseconds — MR beads in_review longer than this are "stale".
+ */
+const STALE_PR_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/** Zod schema for a single enriched MR bead row from the needsAttention query. */
+const MrBeadRow = z.object({
+  bead_id: z.string(),
+  status: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  rig_id: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  metadata: z.string().transform((v): Record<string, unknown> => {
+    try {
+      return JSON.parse(v) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }),
+  // review_metadata columns
+  branch: z.string(),
+  target_branch: z.string(),
+  merge_commit: z.string().nullable(),
+  pr_url: z.string().nullable(),
+  retry_count: z.number(),
+  // source bead (via bead_dependencies tracks)
+  source_bead_id: z.string().nullable(),
+  source_bead_title: z.string().nullable(),
+  source_bead_status: z.string().nullable(),
+  source_bead_body: z.string().nullable(),
+  // convoy info (via metadata.convoy_id → convoy_metadata)
+  convoy_id: z.string().nullable(),
+  convoy_title: z.string().nullable(),
+  convoy_total_beads: z.number().nullable(),
+  convoy_closed_beads: z.number().nullable(),
+  convoy_feature_branch: z.string().nullable(),
+  convoy_merge_mode: z.string().nullable(),
+  // agent info (via metadata.source_agent_id → agent_metadata)
+  agent_id: z.string().nullable(),
+  agent_name: z.string().nullable(),
+  agent_role: z.string().nullable(),
+  // rig name
+  rig_name: z.string().nullable(),
+});
+
+/** Zod schema for an enriched activity log event row. */
+const ActivityLogRow = z.object({
+  bead_event_id: z.string(),
+  bead_id: z.string(),
+  agent_id: z.string().nullable(),
+  event_type: z.string(),
+  old_value: z.string().nullable(),
+  new_value: z.string().nullable(),
+  event_metadata: z.string().transform((v): Record<string, unknown> => {
+    try {
+      return JSON.parse(v) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }),
+  event_created_at: z.string(),
+  // associated bead info
+  bead_title: z.string().nullable(),
+  bead_type: z.string().nullable(),
+  bead_status: z.string().nullable(),
+  bead_rig_id: z.string().nullable(),
+  bead_metadata: z
+    .string()
+    .nullable()
+    .transform((v): Record<string, unknown> => {
+      try {
+        return v ? (JSON.parse(v) as Record<string, unknown>) : {};
+      } catch {
+        return {};
+      }
+    }),
+  // agent info
+  agent_name: z.string().nullable(),
+  agent_role: z.string().nullable(),
+  // rig info
+  rig_name: z.string().nullable(),
+  // review metadata
+  rm_branch: z.string().nullable(),
+  rm_target_branch: z.string().nullable(),
+  rm_merge_commit: z.string().nullable(),
+  rm_pr_url: z.string().nullable(),
+  // convoy info
+  convoy_id: z.string().nullable(),
+  convoy_title: z.string().nullable(),
+  convoy_total_beads: z.number().nullable(),
+  convoy_closed_beads: z.number().nullable(),
+  convoy_feature_branch: z.string().nullable(),
+  convoy_merge_mode: z.string().nullable(),
+});
+
+export type MergeQueueParams = {
+  rigId?: string;
+  limit?: number;
+  since?: string;
+};
+
+export type MergeQueueData = {
+  needsAttention: {
+    openPRs: MergeQueueItem[];
+    failedReviews: MergeQueueItem[];
+    stalePRs: MergeQueueItem[];
+  };
+  activityLog: ActivityLogEntry[];
+};
+
+export type MergeQueueItem = {
+  mrBead: {
+    bead_id: string;
+    status: string;
+    title: string;
+    body: string | null;
+    rig_id: string | null;
+    created_at: string;
+    updated_at: string;
+    metadata: Record<string, unknown>;
+  };
+  reviewMetadata: {
+    branch: string;
+    target_branch: string;
+    merge_commit: string | null;
+    pr_url: string | null;
+    retry_count: number;
+  };
+  sourceBead: {
+    bead_id: string;
+    title: string;
+    status: string;
+    body: string | null;
+  } | null;
+  convoy: {
+    convoy_id: string;
+    title: string;
+    total_beads: number;
+    closed_beads: number;
+    feature_branch: string | null;
+    merge_mode: string | null;
+  } | null;
+  agent: {
+    agent_id: string;
+    name: string;
+    role: string;
+  } | null;
+  rigName: string | null;
+  staleSince: string | null;
+  failureReason: string | null;
+};
+
+export type ActivityLogEntry = {
+  event: {
+    bead_event_id: string;
+    bead_id: string;
+    agent_id: string | null;
+    event_type: string;
+    old_value: string | null;
+    new_value: string | null;
+    metadata: Record<string, unknown>;
+    created_at: string;
+  };
+  mrBead: {
+    bead_id: string;
+    title: string;
+    type: string;
+    status: string;
+    rig_id: string | null;
+    metadata: Record<string, unknown>;
+  } | null;
+  sourceBead: {
+    bead_id: string;
+    title: string;
+    status: string;
+  } | null;
+  convoy: {
+    convoy_id: string;
+    title: string;
+    total_beads: number;
+    closed_beads: number;
+    feature_branch: string | null;
+    merge_mode: string | null;
+  } | null;
+  agent: {
+    agent_id: string;
+    name: string;
+    role: string;
+  } | null;
+  rigName: string | null;
+  reviewMetadata: {
+    pr_url: string | null;
+    branch: string | null;
+    target_branch: string | null;
+    merge_commit: string | null;
+  } | null;
+};
+
+/**
+ * Query all data the Merge Queue page needs: MR beads needing attention
+ * (open PRs, failed reviews, stale PRs) and a recent activity log.
+ */
+export function getMergeQueueData(sql: SqlStorage, params: MergeQueueParams): MergeQueueData {
+  const rigId = params.rigId ?? null;
+
+  // ── 1. Query MR beads with full joins ───────────────────────────────
+  // Statuses: in_progress = "in review" (PR created, awaiting merge),
+  //           open = pending review, failed = review failed
+  // We fetch all non-closed MR beads for the needs-attention section.
+  const mrRows = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT
+          ${beads.bead_id},
+          ${beads.status},
+          ${beads.title},
+          ${beads.body},
+          ${beads.rig_id},
+          ${beads.created_at},
+          ${beads.updated_at},
+          ${beads.metadata},
+          ${review_metadata.branch},
+          ${review_metadata.target_branch},
+          ${review_metadata.merge_commit},
+          ${review_metadata.pr_url},
+          ${review_metadata.retry_count},
+          src.${beads.columns.bead_id} AS source_bead_id,
+          src.${beads.columns.title} AS source_bead_title,
+          src.${beads.columns.status} AS source_bead_status,
+          src.${beads.columns.body} AS source_bead_body,
+          cm.${convoy_metadata.columns.bead_id} AS convoy_id,
+          convoy_bead.${beads.columns.title} AS convoy_title,
+          cm.${convoy_metadata.columns.total_beads} AS convoy_total_beads,
+          cm.${convoy_metadata.columns.closed_beads} AS convoy_closed_beads,
+          cm.${convoy_metadata.columns.feature_branch} AS convoy_feature_branch,
+          cm.${convoy_metadata.columns.merge_mode} AS convoy_merge_mode,
+          am.${agent_metadata.columns.bead_id} AS agent_id,
+          agent_bead.${beads.columns.title} AS agent_name,
+          am.${agent_metadata.columns.role} AS agent_role,
+          rig.name AS rig_name
+        FROM ${beads}
+        INNER JOIN ${review_metadata}
+          ON ${beads.bead_id} = ${review_metadata.bead_id}
+        LEFT JOIN ${bead_dependencies} AS dep
+          ON dep.${bead_dependencies.columns.bead_id} = ${beads.bead_id}
+          AND dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+        LEFT JOIN ${beads} AS src
+          ON src.${beads.columns.bead_id} = dep.${bead_dependencies.columns.depends_on_bead_id}
+        LEFT JOIN ${convoy_metadata} AS cm
+          ON cm.${convoy_metadata.columns.bead_id} = json_extract(${beads.metadata}, '$.convoy_id')
+        LEFT JOIN ${beads} AS convoy_bead
+          ON convoy_bead.${beads.columns.bead_id} = cm.${convoy_metadata.columns.bead_id}
+        LEFT JOIN ${agent_metadata} AS am
+          ON am.${agent_metadata.columns.bead_id} = json_extract(${beads.metadata}, '$.source_agent_id')
+        LEFT JOIN ${beads} AS agent_bead
+          ON agent_bead.${beads.columns.bead_id} = am.${agent_metadata.columns.bead_id}
+        LEFT JOIN rigs AS rig
+          ON rig.id = ${beads.rig_id}
+        WHERE ${beads.type} = 'merge_request'
+          AND ${beads.status} IN ('open', 'in_progress', 'in_review', 'failed')
+          AND (? IS NULL OR ${beads.rig_id} = ?)
+        ORDER BY ${beads.created_at} DESC
+      `,
+      [rigId, rigId]
+    ),
+  ];
+
+  const parsedMrRows = MrBeadRow.array().parse(mrRows);
+  const staleThreshold = new Date(Date.now() - STALE_PR_THRESHOLD_MS).toISOString();
+
+  const openPRs: MergeQueueItem[] = [];
+  const failedReviews: MergeQueueItem[] = [];
+  const stalePRs: MergeQueueItem[] = [];
+
+  for (const row of parsedMrRows) {
+    const item = mrBeadRowToItem(row);
+
+    if (row.status === 'failed') {
+      failedReviews.push(item);
+    } else if (row.pr_url && row.status === 'in_progress') {
+      // in_progress with pr_url = PR created, awaiting human merge
+      if (row.updated_at < staleThreshold) {
+        item.staleSince = row.updated_at;
+        stalePRs.push(item);
+      } else {
+        openPRs.push(item);
+      }
+    }
+    // open/in_review without pr_url are pending queue items, not shown in needs-attention
+  }
+
+  // ── 2. Query activity log events ────────────────────────────────────
+  const limit = params.limit ?? 50;
+  const since = params.since ?? null;
+
+  const eventRows = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT
+          ${bead_events.bead_event_id},
+          ${bead_events.bead_id},
+          ${bead_events.agent_id},
+          ${bead_events.event_type},
+          ${bead_events.old_value},
+          ${bead_events.new_value},
+          ${bead_events.metadata} AS event_metadata,
+          ${bead_events.created_at} AS event_created_at,
+          b.${beads.columns.title} AS bead_title,
+          b.${beads.columns.type} AS bead_type,
+          b.${beads.columns.status} AS bead_status,
+          b.${beads.columns.rig_id} AS bead_rig_id,
+          b.${beads.columns.metadata} AS bead_metadata,
+          agent_bead.${beads.columns.title} AS agent_name,
+          am.${agent_metadata.columns.role} AS agent_role,
+          rig.name AS rig_name,
+          rm.${review_metadata.columns.branch} AS rm_branch,
+          rm.${review_metadata.columns.target_branch} AS rm_target_branch,
+          rm.${review_metadata.columns.merge_commit} AS rm_merge_commit,
+          rm.${review_metadata.columns.pr_url} AS rm_pr_url,
+          cm.${convoy_metadata.columns.bead_id} AS convoy_id,
+          convoy_bead.${beads.columns.title} AS convoy_title,
+          cm.${convoy_metadata.columns.total_beads} AS convoy_total_beads,
+          cm.${convoy_metadata.columns.closed_beads} AS convoy_closed_beads,
+          cm.${convoy_metadata.columns.feature_branch} AS convoy_feature_branch,
+          cm.${convoy_metadata.columns.merge_mode} AS convoy_merge_mode
+        FROM ${bead_events}
+        INNER JOIN ${beads} AS b
+          ON b.${beads.columns.bead_id} = ${bead_events.bead_id}
+        LEFT JOIN ${agent_metadata} AS am
+          ON am.${agent_metadata.columns.bead_id} = ${bead_events.agent_id}
+        LEFT JOIN ${beads} AS agent_bead
+          ON agent_bead.${beads.columns.bead_id} = ${bead_events.agent_id}
+        LEFT JOIN ${review_metadata} AS rm
+          ON rm.${review_metadata.columns.bead_id} = ${bead_events.bead_id}
+        LEFT JOIN ${convoy_metadata} AS cm
+          ON cm.${convoy_metadata.columns.bead_id} = json_extract(b.${beads.columns.metadata}, '$.convoy_id')
+        LEFT JOIN ${beads} AS convoy_bead
+          ON convoy_bead.${beads.columns.bead_id} = cm.${convoy_metadata.columns.bead_id}
+        LEFT JOIN rigs AS rig
+          ON rig.id = b.${beads.columns.rig_id}
+        WHERE ${bead_events.event_type} IN (
+          'review_submitted', 'review_completed', 'pr_created',
+          'pr_creation_failed', 'rework_requested', 'status_changed'
+        )
+          AND (? IS NULL OR b.${beads.columns.rig_id} = ?)
+          AND (? IS NULL OR ${bead_events.created_at} > ?)
+        ORDER BY ${bead_events.created_at} DESC
+        LIMIT ?
+      `,
+      [rigId, rigId, since, since, limit]
+    ),
+  ];
+
+  const parsedEventRows = ActivityLogRow.array().parse(eventRows);
+
+  const activityLog: ActivityLogEntry[] = parsedEventRows.map(eventRowToEntry);
+
+  return {
+    needsAttention: { openPRs, failedReviews, stalePRs },
+    activityLog,
+  };
+}
+
+function mrBeadRowToItem(row: z.output<typeof MrBeadRow>): MergeQueueItem {
+  return {
+    mrBead: {
+      bead_id: row.bead_id,
+      status: row.status,
+      title: row.title,
+      body: row.body,
+      rig_id: row.rig_id,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      metadata: row.metadata,
+    },
+    reviewMetadata: {
+      branch: row.branch,
+      target_branch: row.target_branch,
+      merge_commit: row.merge_commit,
+      pr_url: row.pr_url,
+      retry_count: row.retry_count,
+    },
+    sourceBead: row.source_bead_id
+      ? {
+          bead_id: row.source_bead_id,
+          title: row.source_bead_title ?? '',
+          status: row.source_bead_status ?? '',
+          body: row.source_bead_body ?? null,
+        }
+      : null,
+    convoy: row.convoy_id
+      ? {
+          convoy_id: row.convoy_id,
+          title: row.convoy_title ?? '',
+          total_beads: row.convoy_total_beads ?? 0,
+          closed_beads: row.convoy_closed_beads ?? 0,
+          feature_branch: row.convoy_feature_branch,
+          merge_mode: row.convoy_merge_mode,
+        }
+      : null,
+    agent: row.agent_id
+      ? {
+          agent_id: row.agent_id,
+          name: row.agent_name ?? '',
+          role: row.agent_role ?? '',
+        }
+      : null,
+    rigName: row.rig_name,
+    staleSince: null,
+    failureReason: null,
+  };
+}
+
+function eventRowToEntry(row: z.output<typeof ActivityLogRow>): ActivityLogEntry {
+  // Try to find the source bead from the event's bead metadata
+  const sourceBeadId =
+    typeof row.bead_metadata?.source_bead_id === 'string' ? row.bead_metadata.source_bead_id : null;
+
+  return {
+    event: {
+      bead_event_id: row.bead_event_id,
+      bead_id: row.bead_id,
+      agent_id: row.agent_id,
+      event_type: row.event_type,
+      old_value: row.old_value,
+      new_value: row.new_value,
+      metadata: row.event_metadata,
+      created_at: row.event_created_at,
+    },
+    mrBead: row.bead_title
+      ? {
+          bead_id: row.bead_id,
+          title: row.bead_title,
+          type: row.bead_type ?? 'merge_request',
+          status: row.bead_status ?? '',
+          rig_id: row.bead_rig_id,
+          metadata: row.bead_metadata,
+        }
+      : null,
+    sourceBead: sourceBeadId
+      ? {
+          bead_id: sourceBeadId,
+          title:
+            typeof row.bead_metadata?.source_bead_title === 'string'
+              ? row.bead_metadata.source_bead_title
+              : '',
+          status: '',
+        }
+      : null,
+    convoy: row.convoy_id
+      ? {
+          convoy_id: row.convoy_id,
+          title: row.convoy_title ?? '',
+          total_beads: row.convoy_total_beads ?? 0,
+          closed_beads: row.convoy_closed_beads ?? 0,
+          feature_branch: row.convoy_feature_branch,
+          merge_mode: row.convoy_merge_mode,
+        }
+      : null,
+    agent: row.agent_id
+      ? {
+          agent_id: row.agent_id,
+          name: row.agent_name ?? '',
+          role: row.agent_role ?? '',
+        }
+      : null,
+    rigName: row.rig_name,
+    reviewMetadata:
+      row.rm_branch !== null
+        ? {
+            pr_url: row.rm_pr_url,
+            branch: row.rm_branch,
+            target_branch: row.rm_target_branch,
+            merge_commit: row.rm_merge_commit,
+          }
+        : null,
+  };
 }
 
 // ── Molecules ───────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -792,6 +792,18 @@ const MrBeadRow = z.object({
   agent_role: z.string().nullable(),
   // rig name
   rig_name: z.string().nullable(),
+  // failure event metadata (correlated subquery for failed MR beads)
+  failure_event_metadata: z
+    .string()
+    .nullable()
+    .transform((v): Record<string, unknown> | null => {
+      if (!v) return null;
+      try {
+        return JSON.parse(v) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    }),
 });
 
 /** Zod schema for an enriched activity log event row. */
@@ -830,6 +842,10 @@ const ActivityLogRow = z.object({
   agent_role: z.string().nullable(),
   // rig info
   rig_name: z.string().nullable(),
+  // source bead (resolved via bead_dependencies tracks join)
+  source_bead_id: z.string().nullable(),
+  source_bead_title: z.string().nullable(),
+  source_bead_status: z.string().nullable(),
   // review metadata
   rm_branch: z.string().nullable(),
   rm_target_branch: z.string().nullable(),
@@ -989,7 +1005,13 @@ export function getMergeQueueData(sql: SqlStorage, params: MergeQueueParams): Me
           am.${agent_metadata.columns.bead_id} AS agent_id,
           agent_bead.${beads.columns.title} AS agent_name,
           am.${agent_metadata.columns.role} AS agent_role,
-          rig.name AS rig_name
+          rig.name AS rig_name,
+          (SELECT ${bead_events.metadata}
+           FROM ${bead_events}
+           WHERE ${bead_events.bead_id} = ${beads.bead_id}
+             AND ${bead_events.event_type} IN ('review_completed', 'pr_creation_failed')
+           ORDER BY ${bead_events.created_at} DESC
+           LIMIT 1) AS failure_event_metadata
         FROM ${beads}
         INNER JOIN ${review_metadata}
           ON ${beads.bead_id} = ${review_metadata.bead_id}
@@ -1066,6 +1088,9 @@ export function getMergeQueueData(sql: SqlStorage, params: MergeQueueParams): Me
           agent_bead.${beads.columns.title} AS agent_name,
           am.${agent_metadata.columns.role} AS agent_role,
           rig.name AS rig_name,
+          src.${beads.columns.bead_id} AS source_bead_id,
+          src.${beads.columns.title} AS source_bead_title,
+          src.${beads.columns.status} AS source_bead_status,
           rm.${review_metadata.columns.branch} AS rm_branch,
           rm.${review_metadata.columns.target_branch} AS rm_target_branch,
           rm.${review_metadata.columns.merge_commit} AS rm_merge_commit,
@@ -1083,6 +1108,11 @@ export function getMergeQueueData(sql: SqlStorage, params: MergeQueueParams): Me
           ON am.${agent_metadata.columns.bead_id} = ${bead_events.agent_id}
         LEFT JOIN ${beads} AS agent_bead
           ON agent_bead.${beads.columns.bead_id} = ${bead_events.agent_id}
+        LEFT JOIN ${bead_dependencies} AS dep
+          ON dep.${bead_dependencies.columns.bead_id} = b.${beads.columns.bead_id}
+          AND dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+        LEFT JOIN ${beads} AS src
+          ON src.${beads.columns.bead_id} = dep.${bead_dependencies.columns.depends_on_bead_id}
         LEFT JOIN ${review_metadata} AS rm
           ON rm.${review_metadata.columns.bead_id} = ${bead_events.bead_id}
         LEFT JOIN ${convoy_metadata} AS cm
@@ -1160,14 +1190,38 @@ function mrBeadRowToItem(row: z.output<typeof MrBeadRow>): MergeQueueItem {
       : null,
     rigName: row.rig_name,
     staleSince: null,
-    failureReason: null,
+    failureReason:
+      row.status === 'failed' && row.failure_event_metadata
+        ? typeof row.failure_event_metadata.message === 'string'
+          ? row.failure_event_metadata.message
+          : null
+        : null,
   };
 }
 
 function eventRowToEntry(row: z.output<typeof ActivityLogRow>): ActivityLogEntry {
-  // Try to find the source bead from the event's bead metadata
-  const sourceBeadId =
-    typeof row.bead_metadata?.source_bead_id === 'string' ? row.bead_metadata.source_bead_id : null;
+  // Source bead resolution:
+  // - Events on MR beads (pr_created, pr_creation_failed, rework_requested):
+  //   resolved via bead_dependencies LEFT JOIN (source_bead_id/title/status columns)
+  // - Events on source beads (review_submitted, review_completed):
+  //   the event's bead IS the source bead — use the bead columns directly
+  const isMrBeadEvent = row.bead_type === 'merge_request';
+
+  const resolvedSourceBead = isMrBeadEvent
+    ? row.source_bead_id
+      ? {
+          bead_id: row.source_bead_id,
+          title: row.source_bead_title ?? '',
+          status: row.source_bead_status ?? '',
+        }
+      : null
+    : row.bead_title
+      ? {
+          bead_id: row.bead_id,
+          title: row.bead_title,
+          status: row.bead_status ?? '',
+        }
+      : null;
 
   return {
     event: {
@@ -1190,16 +1244,7 @@ function eventRowToEntry(row: z.output<typeof ActivityLogRow>): ActivityLogEntry
           metadata: row.bead_metadata,
         }
       : null,
-    sourceBead: sourceBeadId
-      ? {
-          bead_id: sourceBeadId,
-          title:
-            typeof row.bead_metadata?.source_bead_title === 'string'
-              ? row.bead_metadata.source_bead_title
-              : '',
-          status: '',
-        }
-      : null,
+    sourceBead: resolvedSourceBead,
     convoy: row.convoy_id
       ? {
           convoy_id: row.convoy_id,

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -33,6 +33,7 @@ import {
   RpcConvoyDetailOutput,
   RpcAlarmStatusOutput,
   RpcOrgTownOutput,
+  RpcMergeQueueDataOutput,
 } from './schemas';
 import type { TRPCContext } from './init';
 
@@ -895,6 +896,26 @@ export const gastownRouter = router({
       return townStub.listBeadEvents({
         since: input.since,
         limit: input.limit,
+      });
+    }),
+
+  getMergeQueueData: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        rigId: z.string().uuid().optional(),
+        limit: z.number().int().positive().max(500).default(50),
+        since: z.string().optional(),
+      })
+    )
+    .output(RpcMergeQueueDataOutput)
+    .query(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.getMergeQueueData({
+        rigId: input.rigId,
+        limit: input.limit,
+        since: input.since,
       });
     }),
 

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -226,6 +226,114 @@ const AlarmStatusOutput = z.object({
 export const RpcAlarmStatusOutput = rpcSafe(AlarmStatusOutput);
 export const RpcRigDetailOutput = rpcSafe(RigDetailOutput);
 
+// ── Merge Queue ──────────────────────────────────────────────────────
+
+const MergeQueueBeadOutput = z.object({
+  bead_id: z.string(),
+  status: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  rig_id: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+const ReviewMetadataOutput = z.object({
+  branch: z.string(),
+  target_branch: z.string(),
+  merge_commit: z.string().nullable(),
+  pr_url: z.string().nullable(),
+  retry_count: z.number(),
+});
+
+const SourceBeadOutput = z.object({
+  bead_id: z.string(),
+  title: z.string(),
+  status: z.string(),
+  body: z.string().nullable(),
+});
+
+const ConvoyRefOutput = z.object({
+  convoy_id: z.string(),
+  title: z.string(),
+  total_beads: z.number(),
+  closed_beads: z.number(),
+  feature_branch: z.string().nullable(),
+  merge_mode: z.string().nullable(),
+});
+
+const AgentRefOutput = z.object({
+  agent_id: z.string(),
+  name: z.string(),
+  role: z.string(),
+});
+
+const MergeQueueItemOutput = z.object({
+  mrBead: MergeQueueBeadOutput,
+  reviewMetadata: ReviewMetadataOutput,
+  sourceBead: SourceBeadOutput.nullable(),
+  convoy: ConvoyRefOutput.nullable(),
+  agent: AgentRefOutput.nullable(),
+  rigName: z.string().nullable(),
+  staleSince: z.string().nullable(),
+  failureReason: z.string().nullable(),
+});
+
+const ActivityLogEventOutput = z.object({
+  bead_event_id: z.string(),
+  bead_id: z.string(),
+  agent_id: z.string().nullable(),
+  event_type: z.string(),
+  old_value: z.string().nullable(),
+  new_value: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+});
+
+const ActivityLogMrBeadOutput = z.object({
+  bead_id: z.string(),
+  title: z.string(),
+  type: z.string(),
+  status: z.string(),
+  rig_id: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+const ActivityLogReviewMetadataOutput = z.object({
+  pr_url: z.string().nullable(),
+  branch: z.string().nullable(),
+  target_branch: z.string().nullable(),
+  merge_commit: z.string().nullable(),
+});
+
+const ActivityLogSourceBeadOutput = z.object({
+  bead_id: z.string(),
+  title: z.string(),
+  status: z.string(),
+});
+
+const ActivityLogEntryOutput = z.object({
+  event: ActivityLogEventOutput,
+  mrBead: ActivityLogMrBeadOutput.nullable(),
+  sourceBead: ActivityLogSourceBeadOutput.nullable(),
+  convoy: ConvoyRefOutput.nullable(),
+  agent: AgentRefOutput.nullable(),
+  rigName: z.string().nullable(),
+  reviewMetadata: ActivityLogReviewMetadataOutput.nullable(),
+});
+
+export const MergeQueueDataOutput = z.object({
+  needsAttention: z.object({
+    openPRs: z.array(MergeQueueItemOutput),
+    failedReviews: z.array(MergeQueueItemOutput),
+    stalePRs: z.array(MergeQueueItemOutput),
+  }),
+  activityLog: z.array(ActivityLogEntryOutput),
+});
+
+export const RpcMergeQueueDataOutput = rpcSafe(MergeQueueDataOutput);
+
 // OrgTown (from GastownOrgDO)
 export const OrgTownOutput = z.object({
   id: z.string(),

--- a/src/app/(app)/gastown/[townId]/layout.tsx
+++ b/src/app/(app)/gastown/[townId]/layout.tsx
@@ -1,6 +1,7 @@
 import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
 import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
+import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
 import { MayorTerminalBar } from './MayorTerminalBar';
 
 export default function TownLayout({
@@ -13,11 +14,7 @@ export default function TownLayout({
   return (
     <TerminalBarProvider>
       <DrawerStackProvider renderContent={renderDrawerContent}>
-        {/* Fullscreen edge-to-edge layout for gastown town pages.
-            Bottom padding clears the fixed terminal bar. */}
-        <div className="flex min-h-screen flex-col pb-[340px]">
-          <div className="flex-1">{children}</div>
-        </div>
+        <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} />
       </DrawerStackProvider>
     </TerminalBarProvider>

--- a/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
@@ -2,72 +2,72 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
-import { GitMerge, CheckCircle } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { GitMerge, AlertCircle, Loader2 } from 'lucide-react';
+import { NeedsAttention } from './NeedsAttention';
 
 export function MergesPageClient({ townId }: { townId: string }) {
   const trpc = useGastownTRPC();
 
-  const eventsQuery = useQuery({
-    ...trpc.gastown.getTownEvents.queryOptions({ townId, limit: 200 }),
+  const mergeQueueQuery = useQuery({
+    ...trpc.gastown.getMergeQueueData.queryOptions({ townId }),
     refetchInterval: 5_000,
   });
 
-  const mergeEvents = (eventsQuery.data ?? []).filter(
-    e => e.event_type === 'review_submitted' || e.event_type === 'review_completed'
-  );
+  const needsAttention = mergeQueueQuery.data?.needsAttention;
+  const totalAttention = needsAttention
+    ? needsAttention.openPRs.length +
+      needsAttention.failedReviews.length +
+      needsAttention.stalePRs.length
+    : 0;
 
   return (
     <div className="flex h-full flex-col">
+      {/* Page header */}
       <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
         <div className="flex items-center gap-2">
           <GitMerge className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Merge Queue</h1>
-          <span className="ml-1 font-mono text-xs text-white/30">{mergeEvents.length}</span>
+          {totalAttention > 0 && (
+            <span className="ml-1 rounded-full bg-amber-500/15 px-2 py-0.5 font-mono text-[10px] font-medium text-amber-400">
+              {totalAttention}
+            </span>
+          )}
         </div>
       </div>
 
+      {/* Content */}
       <div className="flex-1 overflow-y-auto">
-        {mergeEvents.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <GitMerge className="mb-3 size-8 text-white/10" />
-            <p className="text-sm text-white/30">No merge activity yet.</p>
-            <p className="mt-1 text-xs text-white/20">
-              Review submissions and merge completions will appear here.
-            </p>
-          </div>
-        )}
+        <div className="mx-auto max-w-4xl space-y-6 p-6">
+          {/* Loading state */}
+          {mergeQueueQuery.isLoading && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <Loader2 className="mb-3 size-6 animate-spin text-white/20" />
+              <p className="text-sm text-white/30">Loading merge queue…</p>
+            </div>
+          )}
 
-        {mergeEvents
-          .slice()
-          .reverse()
-          .map(event => {
-            const isCompleted = event.event_type === 'review_completed';
-            return (
-              <div
-                key={event.bead_event_id}
-                className="flex items-start gap-3 border-b border-white/[0.04] px-6 py-3 transition-colors hover:bg-white/[0.02]"
-              >
-                {isCompleted ? (
-                  <CheckCircle className="mt-0.5 size-3.5 shrink-0 text-emerald-400/60" />
-                ) : (
-                  <GitMerge className="mt-0.5 size-3.5 shrink-0 text-indigo-400/60" />
-                )}
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm text-white/75">
-                    {isCompleted ? 'Review completed' : 'Submitted for review'}
-                    {event.new_value ? `: ${event.new_value}` : ''}
-                  </div>
-                  <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
-                    {event.rig_name && <span>{event.rig_name}</span>}
-                    <span>
-                      {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
-                    </span>
-                  </div>
-                </div>
+          {/* Error state */}
+          {mergeQueueQuery.isError && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <AlertCircle className="mb-3 size-6 text-red-400/40" />
+              <p className="text-sm text-red-400/60">Failed to load merge queue data.</p>
+              <p className="mt-1 text-xs text-white/20">{mergeQueueQuery.error.message}</p>
+            </div>
+          )}
+
+          {/* Needs Your Attention section */}
+          {needsAttention && (
+            <section>
+              <div className="mb-3 flex items-center gap-2">
+                <AlertCircle className="size-3.5 text-white/30" />
+                <span className="text-[11px] font-medium uppercase tracking-wide text-white/40">
+                  Needs Your Attention
+                </span>
               </div>
-            );
-          })}
+              <NeedsAttention data={needsAttention} townId={townId} />
+            </section>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
@@ -1,15 +1,36 @@
 'use client';
 
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
-import { GitMerge, AlertCircle, Loader2 } from 'lucide-react';
+import { GitMerge, AlertCircle, Loader2, Activity, Server } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { NeedsAttention } from './NeedsAttention';
+import { RefineryActivityLog } from './RefineryActivityLog';
+
+const ALL_RIGS = '__all__';
 
 export function MergesPageClient({ townId }: { townId: string }) {
   const trpc = useGastownTRPC();
+  const [selectedRigId, setSelectedRigId] = useState(ALL_RIGS);
+
+  const rigIdParam = selectedRigId === ALL_RIGS ? undefined : selectedRigId;
+
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+  const rigs = rigsQuery.data ?? [];
 
   const mergeQueueQuery = useQuery({
-    ...trpc.gastown.getMergeQueueData.queryOptions({ townId }),
+    ...trpc.gastown.getMergeQueueData.queryOptions({
+      townId,
+      rigId: rigIdParam,
+      limit: 200,
+    }),
     refetchInterval: 5_000,
   });
 
@@ -32,6 +53,27 @@ export function MergesPageClient({ townId }: { townId: string }) {
               {totalAttention}
             </span>
           )}
+        </div>
+
+        {/* Rig filter */}
+        <div className="flex items-center gap-2">
+          <Server className="size-3.5 text-white/25" />
+          <Select value={selectedRigId} onValueChange={setSelectedRigId}>
+            <SelectTrigger
+              size="sm"
+              className="h-7 min-w-[140px] border-white/10 bg-white/[0.04] text-xs text-white/60"
+            >
+              <SelectValue placeholder="All Rigs" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_RIGS}>All Rigs</SelectItem>
+              {rigs.map(rig => (
+                <SelectItem key={rig.id} value={rig.id}>
+                  {rig.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 
@@ -60,11 +102,33 @@ export function MergesPageClient({ townId }: { townId: string }) {
             <section>
               <div className="mb-3 flex items-center gap-2">
                 <AlertCircle className="size-3.5 text-white/30" />
-                <span className="text-[11px] font-medium uppercase tracking-wide text-white/40">
+                <h2 className="text-[11px] font-medium uppercase tracking-wide text-white/40">
                   Needs Your Attention
-                </span>
+                </h2>
+                {totalAttention > 0 && (
+                  <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 font-mono text-[10px] text-amber-400/70">
+                    {totalAttention}
+                  </span>
+                )}
               </div>
               <NeedsAttention data={needsAttention} townId={townId} />
+            </section>
+          )}
+
+          {/* Refinery Activity Log section */}
+          {mergeQueueQuery.data && (
+            <section>
+              <div className="mb-3 flex items-center gap-2">
+                <Activity className="size-3.5 text-white/30" />
+                <h2 className="text-[11px] font-medium uppercase tracking-wide text-white/40">
+                  Refinery Activity Log
+                </h2>
+              </div>
+              <RefineryActivityLog
+                activityLog={mergeQueueQuery.data.activityLog}
+                isLoading={false}
+                townId={townId}
+              />
             </section>
           )}
         </div>

--- a/src/app/(app)/gastown/[townId]/merges/NeedsAttention.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/NeedsAttention.tsx
@@ -1,0 +1,502 @@
+'use client';
+
+import { useState, useMemo, Fragment } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGastownTRPC } from '@/lib/gastown/trpc';
+import type { GastownOutputs } from '@/lib/gastown/trpc';
+import { useDrawerStack } from '@/components/gastown/DrawerStack';
+import { formatDistanceToNow } from 'date-fns';
+import { toast } from 'sonner';
+import { motion, AnimatePresence } from 'motion/react';
+import {
+  AlertTriangle,
+  ExternalLink,
+  Eye,
+  GitBranch,
+  GitMerge,
+  RefreshCw,
+  XCircle,
+  CheckCircle2,
+  Clock,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+type MergeQueueData = GastownOutputs['gastown']['getMergeQueueData'];
+type MergeQueueItem = MergeQueueData['needsAttention']['openPRs'][number];
+
+type ConvoyGroup = {
+  convoy: NonNullable<MergeQueueItem['convoy']>;
+  items: MergeQueueItem[];
+};
+
+type ConfirmAction = { beadId: string; title: string; action: 'fail' | 'retry' };
+
+// ── Status badges ────────────────────────────────────────────────────
+
+const CATEGORY_STYLES = {
+  openPR: {
+    border: 'border-violet-500/30',
+    bg: 'bg-violet-500/10',
+    text: 'text-violet-300',
+    label: 'PR Open',
+  },
+  failed: {
+    border: 'border-red-500/30',
+    bg: 'bg-red-500/10',
+    text: 'text-red-300',
+    label: 'Failed',
+  },
+  stale: {
+    border: 'border-amber-500/30',
+    bg: 'bg-amber-500/10',
+    text: 'text-amber-300',
+    label: 'Stale',
+  },
+} as const;
+
+type Category = keyof typeof CATEGORY_STYLES;
+
+// ── Convoy grouping ──────────────────────────────────────────────────
+
+function groupByConvoy(items: MergeQueueItem[]): {
+  convoyGroups: ConvoyGroup[];
+  standalone: MergeQueueItem[];
+} {
+  const convoyMap = new Map<string, ConvoyGroup>();
+  const standalone: MergeQueueItem[] = [];
+
+  for (const item of items) {
+    if (item.convoy) {
+      const existing = convoyMap.get(item.convoy.convoy_id);
+      if (existing) {
+        existing.items.push(item);
+      } else {
+        convoyMap.set(item.convoy.convoy_id, {
+          convoy: item.convoy,
+          items: [item],
+        });
+      }
+    } else {
+      standalone.push(item);
+    }
+  }
+
+  return {
+    convoyGroups: [...convoyMap.values()],
+    standalone,
+  };
+}
+
+// ── Main component ───────────────────────────────────────────────────
+
+export function NeedsAttention({
+  data,
+  townId,
+}: {
+  data: MergeQueueData['needsAttention'];
+  townId: string;
+}) {
+  const totalCount = data.openPRs.length + data.failedReviews.length + data.stalePRs.length;
+
+  // Tag each item with its category for rendering
+  const allItems = useMemo(() => {
+    const tagged: Array<{ item: MergeQueueItem; category: Category }> = [];
+    for (const item of data.openPRs) tagged.push({ item, category: 'openPR' });
+    for (const item of data.failedReviews) tagged.push({ item, category: 'failed' });
+    for (const item of data.stalePRs) tagged.push({ item, category: 'stale' });
+    return tagged;
+  }, [data]);
+
+  // Group by convoy
+  const { convoyGroups, standalone } = useMemo(() => {
+    const allItemsFlat = allItems.map(t => t.item);
+    return groupByConvoy(allItemsFlat);
+  }, [allItems]);
+
+  // Category lookup for rendering
+  const categoryByBeadId = useMemo(() => {
+    const map = new Map<string, Category>();
+    for (const { item, category } of allItems) {
+      map.set(item.mrBead.bead_id, category);
+    }
+    return map;
+  }, [allItems]);
+
+  if (totalCount === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-white/10 p-6 text-center">
+        <CheckCircle2 className="mx-auto mb-2 size-6 text-emerald-500/40" />
+        <p className="text-sm text-white/40">All clear — nothing needs your attention</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Convoy groups */}
+      <AnimatePresence initial={false}>
+        {convoyGroups.map(group => (
+          <motion.div
+            key={group.convoy.convoy_id}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.25 }}
+          >
+            <ConvoyGroupCard group={group} categoryByBeadId={categoryByBeadId} townId={townId} />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+
+      {/* Standalone items (no convoy) */}
+      <AnimatePresence initial={false}>
+        {standalone.map((item, i) => (
+          <motion.div
+            key={item.mrBead.bead_id}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ delay: i * 0.04, duration: 0.25 }}
+          >
+            <AttentionItemCard
+              item={item}
+              category={categoryByBeadId.get(item.mrBead.bead_id) ?? 'openPR'}
+              townId={townId}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Convoy group card ────────────────────────────────────────────────
+
+function ConvoyGroupCard({
+  group,
+  categoryByBeadId,
+  townId,
+}: {
+  group: ConvoyGroup;
+  categoryByBeadId: Map<string, Category>;
+  townId: string;
+}) {
+  const { open: openDrawer } = useDrawerStack();
+  const { convoy, items } = group;
+  const progress =
+    convoy.total_beads > 0 ? `${convoy.closed_beads}/${convoy.total_beads} beads reviewed` : '';
+
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02]">
+      {/* Convoy header */}
+      <button
+        onClick={() => openDrawer({ type: 'convoy', convoyId: convoy.convoy_id, townId })}
+        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-white/[0.03]"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium bg-violet-500/15 text-violet-400">
+            CONVOY
+          </span>
+          <span className="min-w-0 truncate text-xs font-medium text-white/70">{convoy.title}</span>
+          {convoy.feature_branch && (
+            <span className="flex min-w-0 shrink items-center gap-1 text-[9px] text-white/25">
+              <GitBranch className="size-2.5 shrink-0" />
+              <span className="min-w-0 truncate font-mono">{convoy.feature_branch}</span>
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {convoy.merge_mode && (
+            <span className="rounded border border-sky-500/20 bg-sky-500/10 px-1.5 py-0.5 text-[9px] font-medium text-sky-400">
+              {convoy.merge_mode}
+            </span>
+          )}
+          <span className="font-mono text-[10px] text-white/30">{progress}</span>
+        </div>
+      </button>
+
+      {/* Progress bar */}
+      {convoy.total_beads > 0 && (
+        <div className="mx-4 mb-2 h-1 overflow-hidden rounded-full bg-white/[0.06]">
+          <motion.div
+            className="h-full rounded-full bg-emerald-500/60"
+            initial={{ width: 0 }}
+            animate={{ width: `${(convoy.closed_beads / convoy.total_beads) * 100}%` }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+          />
+        </div>
+      )}
+
+      {/* Items within convoy */}
+      <div className="border-t border-white/[0.04]">
+        {items.map((item, i) => (
+          <Fragment key={item.mrBead.bead_id}>
+            {i > 0 && <div className="mx-4 border-t border-white/[0.04]" />}
+            <AttentionItemRow
+              item={item}
+              category={categoryByBeadId.get(item.mrBead.bead_id) ?? 'openPR'}
+              townId={townId}
+            />
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Standalone attention item card ───────────────────────────────────
+
+function AttentionItemCard({
+  item,
+  category,
+  townId,
+}: {
+  item: MergeQueueItem;
+  category: Category;
+  townId: string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02]">
+      <AttentionItemRow item={item} category={category} townId={townId} />
+    </div>
+  );
+}
+
+// ── Shared row component (used inside convoy group and standalone) ───
+
+function AttentionItemRow({
+  item,
+  category,
+  townId,
+}: {
+  item: MergeQueueItem;
+  category: Category;
+  townId: string;
+}) {
+  const { open: openDrawer } = useDrawerStack();
+  const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+
+  const style = CATEGORY_STYLES[category];
+  const sourceBeadTitle = item.sourceBead?.title ?? item.mrBead.title.replace(/^Review: /, '');
+  const rigId = item.mrBead.rig_id ?? '';
+
+  const invalidateMergeQueue = () => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.gastown.getMergeQueueData.queryKey({ townId }),
+    });
+  };
+
+  // Retry review: reset the MR bead status back to 'open' so the refinery re-queues it.
+  // updateBead requires a rigId — use the MR bead's rig_id.
+  const retryMutation = useMutation(
+    trpc.gastown.updateBead.mutationOptions({
+      onSuccess: () => {
+        setConfirmAction(null);
+        invalidateMergeQueue();
+        toast.success('Review retry requested');
+      },
+      onError: (err: { message: string }) => {
+        toast.error(`Failed to retry: ${err.message}`);
+      },
+    })
+  );
+
+  // Fail bead mutation: use adminForceFailBead
+  const failMutation = useMutation(
+    trpc.gastown.adminForceFailBead.mutationOptions({
+      onSuccess: () => {
+        setConfirmAction(null);
+        invalidateMergeQueue();
+        toast.success('Bead marked as failed');
+      },
+      onError: (err: { message: string }) => {
+        toast.error(`Failed to update bead: ${err.message}`);
+      },
+    })
+  );
+
+  const isPending = retryMutation.isPending || failMutation.isPending;
+
+  const handleConfirm = () => {
+    if (!confirmAction) return;
+    if (confirmAction.action === 'retry') {
+      retryMutation.mutate({
+        rigId,
+        beadId: confirmAction.beadId,
+        status: 'open',
+      });
+    } else {
+      failMutation.mutate({
+        townId,
+        beadId: confirmAction.beadId,
+      });
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-white/[0.02]">
+        {/* Category indicator */}
+        <div className="mt-1 shrink-0">
+          {category === 'openPR' && <GitMerge className="size-3.5 text-violet-400/60" />}
+          {category === 'failed' && <XCircle className="size-3.5 text-red-400/60" />}
+          {category === 'stale' && <Clock className="size-3.5 text-amber-400/60" />}
+        </div>
+
+        {/* Content */}
+        <div className="min-w-0 flex-1">
+          {/* Title row */}
+          <div className="flex items-center gap-2">
+            <span
+              className={`inline-flex shrink-0 items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium ${style.border} ${style.bg} ${style.text}`}
+            >
+              {style.label}
+            </span>
+            <button
+              onClick={() => {
+                if (item.sourceBead) {
+                  openDrawer({ type: 'bead', beadId: item.sourceBead.bead_id, rigId });
+                }
+              }}
+              className="min-w-0 truncate text-sm text-white/75 transition-colors hover:text-white/90"
+              title={sourceBeadTitle}
+            >
+              {sourceBeadTitle}
+            </button>
+          </div>
+
+          {/* Metadata row */}
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-white/30">
+            {item.rigName && <span>{item.rigName}</span>}
+            {item.agent && <span>{item.agent.name}</span>}
+            <span>
+              {formatDistanceToNow(new Date(item.mrBead.created_at), { addSuffix: true })}
+            </span>
+            {item.reviewMetadata.retry_count > 0 && (
+              <span className="text-amber-400/60">
+                {item.reviewMetadata.retry_count}{' '}
+                {item.reviewMetadata.retry_count === 1 ? 'retry' : 'retries'}
+              </span>
+            )}
+            {category === 'stale' && item.staleSince && (
+              <span className="text-amber-400/60">
+                stale since {formatDistanceToNow(new Date(item.staleSince), { addSuffix: true })}
+              </span>
+            )}
+            {category === 'failed' && item.failureReason && (
+              <span className="max-w-xs truncate text-red-400/60">{item.failureReason}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex shrink-0 items-center gap-1">
+          {item.reviewMetadata.pr_url && (
+            <a
+              href={item.reviewMetadata.pr_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+              title="Open PR"
+            >
+              <ExternalLink className="size-3.5" />
+            </a>
+          )}
+          {category === 'failed' && (
+            <button
+              onClick={() =>
+                setConfirmAction({
+                  beadId: item.mrBead.bead_id,
+                  title: sourceBeadTitle,
+                  action: 'retry',
+                })
+              }
+              className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+              title="Retry Review"
+            >
+              <RefreshCw className="size-3.5" />
+            </button>
+          )}
+          <button
+            onClick={() => {
+              if (item.sourceBead) {
+                openDrawer({ type: 'bead', beadId: item.sourceBead.bead_id, rigId });
+              }
+            }}
+            className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+            title="View Bead"
+          >
+            <Eye className="size-3.5" />
+          </button>
+          <button
+            onClick={() =>
+              setConfirmAction({
+                beadId: item.mrBead.bead_id,
+                title: sourceBeadTitle,
+                action: 'fail',
+              })
+            }
+            className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-red-500/10 hover:text-red-400"
+            title="Fail Bead"
+          >
+            <AlertTriangle className="size-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Confirmation dialog for retry or fail */}
+      <Dialog open={!!confirmAction} onOpenChange={() => setConfirmAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {confirmAction?.action === 'retry' ? 'Retry Review' : 'Fail Bead'}
+            </DialogTitle>
+            <DialogDescription>
+              {confirmAction?.action === 'retry' ? (
+                <>
+                  Re-queue <span className="font-semibold">{confirmAction.title}</span> for review?
+                  This resets the MR bead so the refinery picks it up again.
+                </>
+              ) : (
+                <>
+                  Mark <span className="font-semibold">{confirmAction?.title}</span> as failed? This
+                  stops the review process for this bead.
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant={confirmAction?.action === 'fail' ? 'destructive' : 'default'}
+              onClick={handleConfirm}
+              disabled={isPending}
+            >
+              {isPending
+                ? confirmAction?.action === 'retry'
+                  ? 'Retrying…'
+                  : 'Failing…'
+                : confirmAction?.action === 'retry'
+                  ? 'Retry Review'
+                  : 'Fail Bead'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/(app)/gastown/[townId]/merges/RefineryActivityLog.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/RefineryActivityLog.tsx
@@ -1,0 +1,531 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  GitMerge,
+  GitPullRequest,
+  GitBranch,
+  AlertTriangle,
+  RotateCcw,
+  Send,
+  XCircle,
+  Activity,
+} from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import { useDrawerStack } from '@/components/gastown/DrawerStack';
+import type { GastownOutputs } from '@/lib/gastown/trpc';
+
+type MergeQueueData = GastownOutputs['gastown']['getMergeQueueData'];
+type ActivityLogEntry = MergeQueueData['activityLog'][number];
+
+type ActionType =
+  | 'merged'
+  | 'failed'
+  | 'pr_created'
+  | 'pr_creation_failed'
+  | 'rework_requested'
+  | 'review_submitted'
+  | 'status_changed';
+
+const ACTION_CONFIG: Record<
+  ActionType,
+  {
+    icon: typeof GitMerge;
+    dotColor: string;
+    lineColor: string;
+  }
+> = {
+  merged: {
+    icon: GitMerge,
+    dotColor: 'bg-emerald-400',
+    lineColor: 'border-emerald-500/30',
+  },
+  failed: {
+    icon: XCircle,
+    dotColor: 'bg-red-400',
+    lineColor: 'border-red-500/30',
+  },
+  pr_created: {
+    icon: GitPullRequest,
+    dotColor: 'bg-sky-400',
+    lineColor: 'border-sky-500/30',
+  },
+  pr_creation_failed: {
+    icon: AlertTriangle,
+    dotColor: 'bg-red-400',
+    lineColor: 'border-red-500/30',
+  },
+  rework_requested: {
+    icon: RotateCcw,
+    dotColor: 'bg-amber-400',
+    lineColor: 'border-amber-500/30',
+  },
+  review_submitted: {
+    icon: Send,
+    dotColor: 'bg-indigo-400',
+    lineColor: 'border-indigo-500/30',
+  },
+  status_changed: {
+    icon: Activity,
+    dotColor: 'bg-white/40',
+    lineColor: 'border-white/10',
+  },
+};
+
+function isActionType(value: string): value is ActionType {
+  return value in ACTION_CONFIG;
+}
+
+function resolveActionType(entry: ActivityLogEntry): ActionType {
+  const eventType = entry.event.event_type;
+  if (eventType === 'review_completed') {
+    return entry.event.new_value === 'merged' ? 'merged' : 'failed';
+  }
+  if (isActionType(eventType)) {
+    return eventType;
+  }
+  return 'status_changed';
+}
+
+function extractPrNumber(prUrl: string | null): string | null {
+  if (!prUrl) return null;
+  const match = /\/pull\/(\d+)/.exec(prUrl);
+  return match ? match[1] : null;
+}
+
+function extractMessage(entry: ActivityLogEntry): string | null {
+  const meta = entry.event.metadata;
+  if (typeof meta.message === 'string') return meta.message;
+  if (typeof meta.feedback === 'string') return meta.feedback;
+  if (typeof meta.reason === 'string') return meta.reason;
+  return null;
+}
+
+function buildDescription(entry: ActivityLogEntry): {
+  prefix: string;
+  beadTitle: string;
+  suffix: string;
+} {
+  const action = resolveActionType(entry);
+  const agentName = entry.agent?.name ?? 'an agent';
+  const beadTitle = entry.sourceBead?.title ?? entry.mrBead?.title ?? 'untitled bead';
+  const targetBranch = entry.reviewMetadata?.target_branch;
+
+  const branchSuffix = targetBranch
+    ? targetBranch === 'main'
+      ? ' into main'
+      : ` into ${targetBranch}`
+    : '';
+
+  const convoySuffix = entry.convoy && branchSuffix ? ` (convoy: ${entry.convoy.title})` : '';
+
+  switch (action) {
+    case 'merged':
+      return {
+        prefix: `Refinery merged ${agentName}\u2019s `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: `${branchSuffix}${convoySuffix}`,
+      };
+    case 'failed':
+      return {
+        prefix: `Refinery review failed for ${agentName}\u2019s `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: '',
+      };
+    case 'pr_created': {
+      const prUrl = entry.reviewMetadata?.pr_url ?? null;
+      const prNum = extractPrNumber(prUrl);
+      const prLabel = prNum ? `PR #${prNum}` : 'a PR';
+      return {
+        prefix: `Refinery created ${prLabel} for ${agentName}\u2019s `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: '',
+      };
+    }
+    case 'pr_creation_failed':
+      return {
+        prefix: `Refinery failed to create PR for ${agentName}\u2019s `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: '',
+      };
+    case 'rework_requested':
+      return {
+        prefix: `Refinery requested changes from ${agentName} on `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: '',
+      };
+    case 'review_submitted':
+      return {
+        prefix: `${agentName} submitted `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: ' for review',
+      };
+    case 'status_changed':
+      return {
+        prefix: `Status changed on `,
+        beadTitle: `\u201c${beadTitle}\u201d`,
+        suffix: entry.event.new_value ? ` \u2192 ${entry.event.new_value}` : '',
+      };
+  }
+}
+
+// ── Convoy grouping ──────────────────────────────────────────────────
+
+type ConvoyInfo = NonNullable<ActivityLogEntry['convoy']>;
+
+type ConvoyActivityGroup = {
+  convoy: ConvoyInfo;
+  entries: ActivityLogEntry[];
+  latestTimestamp: string;
+};
+
+function groupActivityByConvoy(entries: ActivityLogEntry[]): {
+  convoyGroups: ConvoyActivityGroup[];
+  standalone: ActivityLogEntry[];
+} {
+  const convoyMap = new Map<string, ConvoyActivityGroup>();
+  const standalone: ActivityLogEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.convoy) {
+      const existing = convoyMap.get(entry.convoy.convoy_id);
+      if (existing) {
+        existing.entries.push(entry);
+        if (entry.event.created_at > existing.latestTimestamp) {
+          existing.latestTimestamp = entry.event.created_at;
+        }
+      } else {
+        convoyMap.set(entry.convoy.convoy_id, {
+          convoy: entry.convoy,
+          entries: [entry],
+          latestTimestamp: entry.event.created_at,
+        });
+      }
+    } else {
+      standalone.push(entry);
+    }
+  }
+
+  // Sort convoy groups by most recent activity
+  const convoyGroups = [...convoyMap.values()].sort((a, b) =>
+    b.latestTimestamp.localeCompare(a.latestTimestamp)
+  );
+
+  return { convoyGroups, standalone };
+}
+
+// ── Main component ───────────────────────────────────────────────────
+
+const PAGE_SIZE = 20;
+
+export function RefineryActivityLog({
+  activityLog,
+  isLoading,
+  townId,
+}: {
+  activityLog: ActivityLogEntry[] | undefined;
+  isLoading: boolean;
+  townId: string;
+}) {
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const entries = activityLog ?? [];
+
+  // Groups are sorted by most recent activity (latestTimestamp descending)
+  const { convoyGroups, standalone } = useMemo(() => groupActivityByConvoy(entries), [entries]);
+
+  // Paginate by convoy groups (keeps whole convoys together on a page).
+  // Each convoy group counts as its entry count toward the page budget;
+  // standalone entries fill the remaining budget after convoy groups.
+  const { visibleConvoyGroups, visibleStandalone, totalEntryCount, hasMore } = useMemo(() => {
+    const visibleConvoys: ConvoyActivityGroup[] = [];
+    let budget = visibleCount;
+
+    for (const group of convoyGroups) {
+      if (budget <= 0) break;
+      visibleConvoys.push(group);
+      budget -= group.entries.length;
+    }
+
+    // Fill remaining budget with standalone entries (already sorted by recency from the query)
+    const standaloneSlice = budget > 0 ? standalone.slice(0, budget) : [];
+
+    const total = convoyGroups.reduce((sum, g) => sum + g.entries.length, 0) + standalone.length;
+
+    return {
+      visibleConvoyGroups: visibleConvoys,
+      visibleStandalone: standaloneSlice,
+      totalEntryCount: total,
+      hasMore: visibleCount < total,
+    };
+  }, [convoyGroups, standalone, visibleCount]);
+
+  // All hooks are above — early returns below
+  if (isLoading) {
+    return (
+      <div className="space-y-4 py-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: i * 0.06 }}
+            className="flex gap-4"
+          >
+            <div className="flex flex-col items-center">
+              <div className="size-2.5 rounded-full bg-white/[0.08]" />
+              <div className="mt-1 h-12 w-px bg-white/[0.04]" />
+            </div>
+            <div className="flex-1 space-y-1.5">
+              <div className="h-3 w-32 rounded bg-white/[0.04]" />
+              <div className="h-4 w-64 rounded bg-white/[0.06]" />
+              <div className="h-3 w-48 rounded bg-white/[0.03]" />
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col items-center justify-center py-12 text-center"
+      >
+        <Activity className="mb-3 size-8 text-white/10" />
+        <p className="text-sm text-white/30">No refinery activity yet</p>
+        <p className="mt-1 text-xs text-white/20">
+          Merge reviews, PR creations, and rework requests will appear here.
+        </p>
+      </motion.div>
+    );
+  }
+
+  return (
+    <div className="py-4">
+      <div className="space-y-4">
+        {/* Convoy grouped entries — sorted by most recent activity */}
+        <AnimatePresence initial={false}>
+          {visibleConvoyGroups.map(group => (
+            <ConvoyActivityGroupCard
+              key={group.convoy.convoy_id}
+              convoy={group.convoy}
+              entries={group.entries}
+              townId={townId}
+            />
+          ))}
+        </AnimatePresence>
+
+        {/* Standalone entries */}
+        {visibleStandalone.length > 0 && (
+          <div>
+            <AnimatePresence initial={false}>
+              {visibleStandalone.map((entry, i, arr) => (
+                <TimelineEntry
+                  key={entry.event.bead_event_id}
+                  entry={entry}
+                  isLast={i === arr.length - 1 && !hasMore}
+                  delay={i * 0.03}
+                />
+              ))}
+            </AnimatePresence>
+          </div>
+        )}
+      </div>
+
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount(c => c + PAGE_SIZE)}
+          className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs text-white/35 transition-colors hover:bg-white/[0.04] hover:text-white/55"
+        >
+          Show more
+          <span className="font-mono text-[10px] text-white/20">
+            {totalEntryCount - visibleCount} remaining
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Convoy activity group card ───────────────────────────────────────
+
+function ConvoyActivityGroupCard({
+  convoy,
+  entries,
+  townId,
+}: {
+  convoy: ConvoyInfo;
+  entries: ActivityLogEntry[];
+  townId: string;
+}) {
+  const { open: openDrawer } = useDrawerStack();
+  const progress =
+    convoy.total_beads > 0 ? `${convoy.closed_beads}/${convoy.total_beads} beads reviewed` : '';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.25 }}
+      className="rounded-lg border border-white/[0.06] bg-white/[0.02]"
+    >
+      {/* Convoy header */}
+      <button
+        onClick={() => openDrawer({ type: 'convoy', convoyId: convoy.convoy_id, townId })}
+        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-white/[0.03]"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-medium text-violet-400">
+            CONVOY
+          </span>
+          <span className="min-w-0 truncate text-xs font-medium text-white/70">{convoy.title}</span>
+          {convoy.feature_branch && (
+            <span className="flex min-w-0 shrink items-center gap-1 text-[9px] text-white/25">
+              <GitBranch className="size-2.5 shrink-0" />
+              <span className="min-w-0 truncate font-mono">{convoy.feature_branch}</span>
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="font-mono text-[10px] text-white/30">{progress}</span>
+        </div>
+      </button>
+
+      {/* Progress bar */}
+      {convoy.total_beads > 0 && (
+        <div className="mx-4 mb-2 h-1 overflow-hidden rounded-full bg-white/[0.06]">
+          <motion.div
+            className="h-full rounded-full bg-emerald-500/60"
+            initial={{ width: 0 }}
+            animate={{ width: `${(convoy.closed_beads / convoy.total_beads) * 100}%` }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+          />
+        </div>
+      )}
+
+      {/* Timeline entries within convoy */}
+      <div className="border-t border-white/[0.04] px-4 pt-3 pb-1">
+        <AnimatePresence initial={false}>
+          {entries.map((entry, i) => (
+            <TimelineEntry
+              key={entry.event.bead_event_id}
+              entry={entry}
+              isLast={i === entries.length - 1}
+              delay={i * 0.03}
+            />
+          ))}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}
+
+// ── Timeline entry ───────────────────────────────────────────────────
+
+function TimelineEntry({
+  entry,
+  isLast,
+  delay,
+}: {
+  entry: ActivityLogEntry;
+  isLast: boolean;
+  delay: number;
+}) {
+  const { open } = useDrawerStack();
+  const action = resolveActionType(entry);
+  const config = ACTION_CONFIG[action];
+  const Icon = config.icon;
+  const description = buildDescription(entry);
+  const message = extractMessage(entry);
+  const commitSha = entry.reviewMetadata?.merge_commit ?? null;
+  const prUrl = entry.reviewMetadata?.pr_url ?? null;
+  const prNumber = extractPrNumber(prUrl);
+  const rigName = entry.rigName;
+  const rigId = entry.mrBead?.rig_id;
+
+  function handleBeadClick() {
+    const beadId = entry.sourceBead?.bead_id ?? entry.mrBead?.bead_id;
+    if (beadId && rigId) {
+      open({ type: 'bead', beadId, rigId });
+    }
+  }
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, height: 0 }}
+      transition={{ duration: 0.25, delay, ease: [0.25, 0.1, 0.25, 1] }}
+      className="flex gap-4"
+    >
+      {/* Timeline indicator */}
+      <div className="flex flex-col items-center pt-1">
+        <div className={`size-2.5 shrink-0 rounded-full ${config.dotColor}`} />
+        {!isLast && (
+          <div className={`mt-1 min-h-[2rem] w-px flex-1 border-l ${config.lineColor}`} />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1 pb-5">
+        {/* Rig name + timestamp header */}
+        <div className="flex items-center gap-2 text-[11px] text-white/30">
+          {rigName && <span>{rigName}</span>}
+          {rigName && <span className="text-white/15">&middot;</span>}
+          <span>{formatDistanceToNow(new Date(entry.event.created_at), { addSuffix: true })}</span>
+          <Icon className="ml-auto size-3 text-white/15" />
+        </div>
+
+        {/* Main description */}
+        <p className="mt-1 text-sm leading-relaxed text-white/75">
+          {description.prefix}
+          <button
+            onClick={handleBeadClick}
+            className="text-white/90 underline decoration-white/20 underline-offset-2 transition-colors hover:text-white hover:decoration-white/40"
+          >
+            {description.beadTitle}
+          </button>
+          {description.suffix}
+        </p>
+
+        {/* Reason/message line */}
+        {message && (
+          <p className="mt-1 text-xs leading-relaxed text-white/40">
+            {action === 'rework_requested' ? 'Reason: ' : ''}
+            {message}
+          </p>
+        )}
+
+        {/* Metadata line */}
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-white/25">
+          {commitSha && <span className="font-mono">Commit {commitSha.slice(0, 7)}</span>}
+          {prUrl && prNumber && (
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sky-400/60 transition-colors hover:text-sky-400/90"
+            >
+              PR #{prNumber}
+            </a>
+          )}
+          {prUrl && !prNumber && (
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sky-400/60 transition-colors hover:text-sky-400/90"
+            >
+              View PR
+            </a>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/app/(app)/gastown/[townId]/merges/RefineryActivityLog.tsx
+++ b/src/app/(app)/gastown/[townId]/merges/RefineryActivityLog.tsx
@@ -234,29 +234,55 @@ export function RefineryActivityLog({
   // Groups are sorted by most recent activity (latestTimestamp descending)
   const { convoyGroups, standalone } = useMemo(() => groupActivityByConvoy(entries), [entries]);
 
-  // Paginate by convoy groups (keeps whole convoys together on a page).
-  // Each convoy group counts as its entry count toward the page budget;
-  // standalone entries fill the remaining budget after convoy groups.
-  const { visibleConvoyGroups, visibleStandalone, totalEntryCount, hasMore } = useMemo(() => {
-    const visibleConvoys: ConvoyActivityGroup[] = [];
+  // Merge convoy groups and standalone entries into a single list sorted by
+  // most-recent timestamp, then paginate over that unified list. This ensures
+  // the most recently active items (whether convoy or standalone) appear first,
+  // rather than showing all convoy groups before any standalone entries.
+  type DisplayItem =
+    | { kind: 'convoy'; group: ConvoyActivityGroup; sortKey: string }
+    | { kind: 'standalone'; entry: ActivityLogEntry; sortKey: string };
+
+  const { visibleItems, totalEntryCount, visibleEntryCount, hasMore } = useMemo(() => {
+    const items: DisplayItem[] = [
+      ...convoyGroups.map(
+        (group): DisplayItem => ({
+          kind: 'convoy',
+          group,
+          sortKey: group.latestTimestamp,
+        })
+      ),
+      ...standalone.map(
+        (entry): DisplayItem => ({
+          kind: 'standalone',
+          entry,
+          sortKey: entry.event.created_at,
+        })
+      ),
+    ];
+
+    // Sort by most recent first
+    items.sort((a, b) => b.sortKey.localeCompare(a.sortKey));
+
+    // Paginate: each convoy group costs its entry count, each standalone costs 1
+    const visible: DisplayItem[] = [];
     let budget = visibleCount;
+    let visibleEntries = 0;
 
-    for (const group of convoyGroups) {
+    for (const item of items) {
       if (budget <= 0) break;
-      visibleConvoys.push(group);
-      budget -= group.entries.length;
+      const cost = item.kind === 'convoy' ? item.group.entries.length : 1;
+      visible.push(item);
+      budget -= cost;
+      visibleEntries += cost;
     }
-
-    // Fill remaining budget with standalone entries (already sorted by recency from the query)
-    const standaloneSlice = budget > 0 ? standalone.slice(0, budget) : [];
 
     const total = convoyGroups.reduce((sum, g) => sum + g.entries.length, 0) + standalone.length;
 
     return {
-      visibleConvoyGroups: visibleConvoys,
-      visibleStandalone: standaloneSlice,
+      visibleItems: visible,
       totalEntryCount: total,
-      hasMore: visibleCount < total,
+      visibleEntryCount: visibleEntries,
+      hasMore: visibleEntries < total,
     };
   }, [convoyGroups, standalone, visibleCount]);
 
@@ -306,33 +332,26 @@ export function RefineryActivityLog({
   return (
     <div className="py-4">
       <div className="space-y-4">
-        {/* Convoy grouped entries — sorted by most recent activity */}
+        {/* Convoy groups and standalone entries interleaved by recency */}
         <AnimatePresence initial={false}>
-          {visibleConvoyGroups.map(group => (
-            <ConvoyActivityGroupCard
-              key={group.convoy.convoy_id}
-              convoy={group.convoy}
-              entries={group.entries}
-              townId={townId}
-            />
-          ))}
+          {visibleItems.map((item, idx) =>
+            item.kind === 'convoy' ? (
+              <ConvoyActivityGroupCard
+                key={item.group.convoy.convoy_id}
+                convoy={item.group.convoy}
+                entries={item.group.entries}
+                townId={townId}
+              />
+            ) : (
+              <TimelineEntry
+                key={item.entry.event.bead_event_id}
+                entry={item.entry}
+                isLast={idx === visibleItems.length - 1 && !hasMore}
+                delay={idx * 0.03}
+              />
+            )
+          )}
         </AnimatePresence>
-
-        {/* Standalone entries */}
-        {visibleStandalone.length > 0 && (
-          <div>
-            <AnimatePresence initial={false}>
-              {visibleStandalone.map((entry, i, arr) => (
-                <TimelineEntry
-                  key={entry.event.bead_event_id}
-                  entry={entry}
-                  isLast={i === arr.length - 1 && !hasMore}
-                  delay={i * 0.03}
-                />
-              ))}
-            </AnimatePresence>
-          </div>
-        )}
       </div>
 
       {hasMore && (
@@ -342,7 +361,7 @@ export function RefineryActivityLog({
         >
           Show more
           <span className="font-mono text-[10px] text-white/20">
-            {totalEntryCount - visibleCount} remaining
+            {totalEntryCount - visibleEntryCount} remaining
           </span>
         </button>
       )}

--- a/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
+++ b/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
@@ -1,6 +1,7 @@
 import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
 import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
+import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
 import { MayorTerminalBar } from '@/app/(app)/gastown/[townId]/MayorTerminalBar';
 
 export default async function OrgTownLayout({
@@ -16,11 +17,7 @@ export default async function OrgTownLayout({
   return (
     <TerminalBarProvider>
       <DrawerStackProvider renderContent={renderDrawerContent}>
-        {/* Fullscreen edge-to-edge layout for gastown town pages.
-            Bottom padding clears the fixed terminal bar. */}
-        <div className="flex min-h-screen flex-col pb-[340px]">
-          <div className="flex-1">{children}</div>
-        </div>
+        <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} basePath={basePath} />
       </DrawerStackProvider>
     </TerminalBarProvider>

--- a/src/components/gastown/DrawerStack.tsx
+++ b/src/components/gastown/DrawerStack.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, useCallback, type ReactNode } from
 import { motion, AnimatePresence } from 'motion/react';
 import { X, ChevronLeft } from 'lucide-react';
 import type { TownEvent } from './ActivityFeed';
+import { useTerminalBar, COLLAPSED_SIZE } from './TerminalBarContext';
 
 // ── Resource types ───────────────────────────────────────────────────────
 
@@ -80,7 +81,7 @@ export function DrawerStackProvider({
   return (
     <DrawerStackContext.Provider value={{ stack, push, pop, closeAll, open }}>
       {children}
-      <DrawerStackRenderer
+      <DrawerStackRendererWithContext
         stack={stack}
         pop={pop}
         closeAll={closeAll}
@@ -99,12 +100,33 @@ const DEPTH_OFFSET = 40;
 /** Extra shift on hover */
 const HOVER_EXTRA = 24;
 
+/**
+ * Reads terminal bar context to compute right offset when the terminal
+ * is positioned on the right side of the viewport.
+ */
+function DrawerStackRendererWithContext(props: {
+  stack: DrawerStackEntry[];
+  pop: () => void;
+  closeAll: () => void;
+  push: (resource: ResourceRef) => void;
+  renderContent: (
+    resource: ResourceRef,
+    helpers: { push: (resource: ResourceRef) => void; close: () => void }
+  ) => ReactNode;
+}) {
+  const { position, size, collapsed } = useTerminalBar();
+  const rightOffset =
+    position === 'right' ? (collapsed ? COLLAPSED_SIZE : COLLAPSED_SIZE + size) : 0;
+  return <DrawerStackRenderer {...props} rightOffset={rightOffset} />;
+}
+
 function DrawerStackRenderer({
   stack,
   pop,
   closeAll,
   push,
   renderContent,
+  rightOffset = 0,
 }: {
   stack: DrawerStackEntry[];
   pop: () => void;
@@ -114,6 +136,7 @@ function DrawerStackRenderer({
     resource: ResourceRef,
     helpers: { push: (resource: ResourceRef) => void; close: () => void }
   ) => ReactNode;
+  rightOffset?: number;
 }) {
   const isOpen = stack.length > 0;
 
@@ -145,6 +168,7 @@ function DrawerStackRenderer({
                 isTop={isTop}
                 onClose={isTop ? pop : undefined}
                 onBack={index > 0 && isTop ? pop : undefined}
+                rightOffset={rightOffset}
               >
                 {renderContent(entry.resource, {
                   push,
@@ -167,6 +191,7 @@ function DrawerLayer({
   isTop,
   onClose,
   onBack,
+  rightOffset = 0,
   children,
 }: {
   depth: number;
@@ -174,13 +199,14 @@ function DrawerLayer({
   isTop: boolean;
   onClose?: () => void;
   onBack?: (() => void) | false;
+  rightOffset?: number;
   children: ReactNode;
 }) {
   const [hovered, setHovered] = useState(false);
 
   // Top layer: right: 0. Background layers: shift left by depth * offset.
   // On hover, background layers shift further left.
-  const rightOffset = isTop ? 0 : -(depth * DEPTH_OFFSET + (hovered ? HOVER_EXTRA : 0));
+  const layerShift = isTop ? 0 : -(depth * DEPTH_OFFSET + (hovered ? HOVER_EXTRA : 0));
   const scale = isTop ? 1 : 1 - depth * 0.015;
   const opacity = isTop ? 1 : 0.6 + (hovered ? 0.25 : 0);
 
@@ -188,7 +214,7 @@ function DrawerLayer({
     <motion.div
       initial={{ x: DRAWER_WIDTH + 20 }}
       animate={{
-        x: rightOffset,
+        x: layerShift,
         scale,
         opacity,
       }}
@@ -203,8 +229,9 @@ function DrawerLayer({
         if (!isTop) setHovered(true);
       }}
       onMouseLeave={() => setHovered(false)}
-      className="fixed top-0 right-0 bottom-0 z-[61] flex flex-col outline-none"
+      className="fixed top-0 bottom-0 z-[61] flex flex-col outline-none"
       style={{
+        right: rightOffset,
         width: DRAWER_WIDTH,
         maxWidth: '94vw',
         zIndex: 61 + (totalLayers - depth),

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -6,14 +6,30 @@ import { useRouter } from 'next/navigation';
 import { useGastownTRPC, gastownWsUrl } from '@/lib/gastown/trpc';
 
 import { useSidebar } from '@/components/ui/sidebar';
-import { useTerminalBar } from './TerminalBarContext';
+import {
+  useTerminalBar,
+  COLLAPSED_SIZE,
+  isHorizontal,
+  clampSize,
+  type TerminalPosition,
+} from './TerminalBarContext';
 import { useDrawerStack } from './DrawerStack';
 import { useXtermPty } from './useXtermPty';
-import { ChevronDown, ChevronUp, Crown, Activity, Terminal as TerminalIcon, X } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronUp,
+  ChevronLeft,
+  ChevronRight,
+  Crown,
+  Activity,
+  Terminal as TerminalIcon,
+  X,
+  PanelBottom,
+  PanelTop,
+  PanelLeft,
+  PanelRight,
+} from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-
-const COLLAPSED_HEIGHT = 38;
-const EXPANDED_HEIGHT = 300;
 
 type TerminalBarProps = {
   townId: string;
@@ -22,8 +38,9 @@ type TerminalBarProps = {
 };
 
 /**
- * Unified bottom terminal bar. Always shows a Mayor tab (non-closeable).
+ * Unified terminal bar. Always shows a Mayor tab (non-closeable).
  * Agent terminal tabs are opened/closed via TerminalBarContext.
+ * Can be positioned at bottom/top/right/left with drag-to-resize.
  */
 export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarProps) {
   const townBasePath = basePathOverride ?? `/gastown/${townId}`;
@@ -32,17 +49,19 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
     tabs: agentTabs,
     activeTabId,
     collapsed,
+    position,
+    size,
     closeTab,
     setActiveTabId,
     setCollapsed,
+    setPosition,
+    setSize,
   } = useTerminalBar();
   const queryClient = useQueryClient();
   const drawerStack = useDrawerStack();
   const router = useRouter();
 
   // ── Always-on WebSocket for alarm status + UI action dispatch ──────
-  // Lifted here so the connection persists regardless of which tab is active.
-
   const handleAgentStatus = useCallback(
     (_event: AgentStatusEvent) => {
       void queryClient.invalidateQueries({
@@ -92,7 +111,6 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
             };
             const path = pageMap[action.page];
             if (path) {
-              // Close any open drawers so they don't cover the new page
               drawerStack.closeAll();
               router.push(path);
             }
@@ -105,7 +123,7 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
           break;
       }
     },
-    [drawerStack, router, townId]
+    [drawerStack, router, townBasePath]
   );
 
   const alarmWs = useAlarmStatusWs(townId, {
@@ -114,6 +132,7 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
   });
 
   const sidebarLeft = isMobile ? '0px' : sidebarState === 'expanded' ? '16rem' : '3rem';
+  const horizontal = isHorizontal(position);
 
   const allTabs = [
     { id: 'status', label: 'Status', kind: 'status' as const, agentId: '' },
@@ -121,105 +140,539 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
     ...agentTabs,
   ];
 
-  // Default to mayor tab if nothing selected
   const effectiveActiveId = activeTabId ?? 'mayor';
   const activeTab = allTabs.find(t => t.id === effectiveActiveId) ?? allTabs[0];
 
+  // ── Resize drag logic ──────────────────────────────────────────────
+  const isDragging = useRef(false);
+  const startPos = useRef(0);
+  const startSize = useRef(0);
+
+  const onResizePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      isDragging.current = true;
+      startSize.current = size;
+      startPos.current = horizontal ? e.clientY : e.clientX;
+
+      const onPointerMove = (ev: PointerEvent) => {
+        if (!isDragging.current) return;
+        const currentPos = horizontal ? ev.clientY : ev.clientX;
+        // For bottom/right, dragging toward start of viewport increases size.
+        // For top/left, dragging away from start of viewport increases size.
+        const delta =
+          position === 'bottom' || position === 'right'
+            ? startPos.current - currentPos
+            : currentPos - startPos.current;
+        const newSize = clampSize(startSize.current + delta, position);
+        setSize(newSize);
+      };
+
+      const onPointerUp = () => {
+        isDragging.current = false;
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointerup', onPointerUp);
+        document.body.style.userSelect = '';
+        document.body.style.cursor = '';
+      };
+
+      document.body.style.userSelect = 'none';
+      document.body.style.cursor = horizontal ? 'ns-resize' : 'ew-resize';
+      document.addEventListener('pointermove', onPointerMove);
+      document.addEventListener('pointerup', onPointerUp);
+    },
+    [size, position, horizontal, setSize]
+  );
+
+  // ── Compute container styles ───────────────────────────────────────
+  const totalSize = collapsed ? COLLAPSED_SIZE : COLLAPSED_SIZE + size;
+
+  const containerStyle = (() => {
+    const base: React.CSSProperties = { zIndex: 50 };
+
+    if (position === 'bottom') {
+      return {
+        ...base,
+        left: sidebarLeft,
+        right: 0,
+        bottom: 0,
+        height: totalSize,
+      };
+    }
+    if (position === 'top') {
+      return {
+        ...base,
+        left: sidebarLeft,
+        right: 0,
+        top: 0,
+        height: totalSize,
+      };
+    }
+    if (position === 'right') {
+      return {
+        ...base,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        width: totalSize,
+      };
+    }
+    // left
+    return {
+      ...base,
+      left: sidebarLeft,
+      top: 0,
+      bottom: 0,
+      width: totalSize,
+    };
+  })();
+
+  // Border class depends on which edge faces content
+  const borderClass = {
+    bottom: 'border-t',
+    top: 'border-b',
+    right: 'border-l',
+    left: 'border-r',
+  }[position];
+
+  // Resize handle — rendered as a flex child so it naturally sits at the correct edge
+  // and doesn't compete with content stacking contexts for pointer events.
+  const isVerticalHandle = !horizontal;
+  const resizeHandleClass = [
+    'group/resize shrink-0 flex items-center justify-center',
+    isVerticalHandle ? 'h-full w-2 cursor-ew-resize' : 'w-full h-2 cursor-ns-resize',
+  ].join(' ');
+  const resizeHandleIndicator = isVerticalHandle
+    ? 'h-8 w-0.5 rounded-full bg-white/0 group-hover/resize:bg-white/25 transition-colors'
+    : 'w-8 h-0.5 rounded-full bg-white/0 group-hover/resize:bg-white/25 transition-colors';
+
+  // ── Collapse chevron direction ─────────────────────────────────────
+  const CollapseIcon = (() => {
+    if (collapsed) {
+      // Show icon pointing toward expansion
+      return { bottom: ChevronUp, top: ChevronDown, right: ChevronLeft, left: ChevronRight }[
+        position
+      ];
+    }
+    // Show icon pointing toward collapse
+    return { bottom: ChevronDown, top: ChevronUp, right: ChevronRight, left: ChevronLeft }[
+      position
+    ];
+  })();
+
+  // ── Layout direction ───────────────────────────────────────────────
+  // Horizontal: tab bar is a row at top (bottom position) or bottom (top position),
+  //             content fills remaining height.
+  // Vertical:   tab bar is a column at top, content fills remaining width.
+
   return (
     <div
-      className="fixed right-0 bottom-0 z-50 border-t border-white/[0.08] bg-[#0a0a0a] transition-[left] duration-200 ease-linear"
-      style={{
-        left: sidebarLeft,
-        height: collapsed ? COLLAPSED_HEIGHT : COLLAPSED_HEIGHT + EXPANDED_HEIGHT,
-      }}
+      className={`fixed ${borderClass} border-white/[0.08] bg-[#0a0a0a] transition-[left] duration-200 ease-linear`}
+      style={containerStyle}
     >
-      {/* Tab bar */}
-      <div
-        className="flex items-center border-b border-white/[0.06]"
-        style={{ height: COLLAPSED_HEIGHT }}
+      <div className={`flex h-full w-full ${horizontal ? 'flex-col' : 'flex-row'}`}>
+        {position === 'bottom' && (
+          <>
+            {!collapsed && (
+              <div className={resizeHandleClass} onPointerDown={onResizePointerDown}>
+                <div className={resizeHandleIndicator} />
+              </div>
+            )}
+            <TabBar
+              allTabs={allTabs}
+              effectiveActiveId={effectiveActiveId}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              position={position}
+              CollapseIcon={CollapseIcon}
+              setActiveTabId={setActiveTabId}
+              setCollapsed={setCollapsed}
+              setPosition={setPosition}
+              closeTab={closeTab}
+            />
+            <TerminalContent
+              activeTab={activeTab}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              size={size}
+              townId={townId}
+              alarmWs={alarmWs}
+            />
+          </>
+        )}
+        {position === 'top' && (
+          <>
+            <TerminalContent
+              activeTab={activeTab}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              size={size}
+              townId={townId}
+              alarmWs={alarmWs}
+            />
+            <TabBar
+              allTabs={allTabs}
+              effectiveActiveId={effectiveActiveId}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              position={position}
+              CollapseIcon={CollapseIcon}
+              setActiveTabId={setActiveTabId}
+              setCollapsed={setCollapsed}
+              setPosition={setPosition}
+              closeTab={closeTab}
+            />
+            {!collapsed && (
+              <div className={resizeHandleClass} onPointerDown={onResizePointerDown}>
+                <div className={resizeHandleIndicator} />
+              </div>
+            )}
+          </>
+        )}
+        {position === 'right' && (
+          <>
+            {!collapsed && (
+              <div className={resizeHandleClass} onPointerDown={onResizePointerDown}>
+                <div className={resizeHandleIndicator} />
+              </div>
+            )}
+            <TabBar
+              allTabs={allTabs}
+              effectiveActiveId={effectiveActiveId}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              position={position}
+              CollapseIcon={CollapseIcon}
+              setActiveTabId={setActiveTabId}
+              setCollapsed={setCollapsed}
+              setPosition={setPosition}
+              closeTab={closeTab}
+            />
+            <TerminalContent
+              activeTab={activeTab}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              size={size}
+              townId={townId}
+              alarmWs={alarmWs}
+            />
+          </>
+        )}
+        {position === 'left' && (
+          <>
+            <TabBar
+              allTabs={allTabs}
+              effectiveActiveId={effectiveActiveId}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              position={position}
+              CollapseIcon={CollapseIcon}
+              setActiveTabId={setActiveTabId}
+              setCollapsed={setCollapsed}
+              setPosition={setPosition}
+              closeTab={closeTab}
+            />
+            <TerminalContent
+              activeTab={activeTab}
+              collapsed={collapsed}
+              horizontal={horizontal}
+              size={size}
+              townId={townId}
+              alarmWs={alarmWs}
+            />
+            {!collapsed && (
+              <div className={resizeHandleClass} onPointerDown={onResizePointerDown}>
+                <div className={resizeHandleIndicator} />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Tab Bar ──────────────────────────────────────────────────────────────
+
+type TabDef = {
+  id: string;
+  label: string;
+  kind: 'mayor' | 'agent' | 'status';
+  agentId: string;
+};
+
+function TabBar({
+  allTabs,
+  effectiveActiveId,
+  collapsed,
+  horizontal,
+  position,
+  CollapseIcon,
+  setActiveTabId,
+  setCollapsed,
+  setPosition,
+  closeTab,
+}: {
+  allTabs: TabDef[];
+  effectiveActiveId: string;
+  collapsed: boolean;
+  horizontal: boolean;
+  position: TerminalPosition;
+  CollapseIcon: React.ComponentType<{ className?: string }>;
+  setActiveTabId: (id: string) => void;
+  setCollapsed: (collapsed: boolean) => void;
+  setPosition: (position: TerminalPosition) => void;
+  closeTab: (tabId: string) => void;
+}) {
+  const [showPositionPicker, setShowPositionPicker] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // Close picker on outside click
+  useEffect(() => {
+    if (!showPositionPicker) return;
+    const handler = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setShowPositionPicker(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showPositionPicker]);
+
+  const borderClass = horizontal ? 'border-b border-white/[0.06]' : 'border-r border-white/[0.06]';
+
+  return (
+    <div
+      className={`flex ${horizontal ? 'items-center' : 'flex-col items-stretch'} ${borderClass} shrink-0`}
+      style={horizontal ? { height: COLLAPSED_SIZE } : { width: COLLAPSED_SIZE }}
+    >
+      {/* Collapse toggle */}
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className={`flex items-center justify-center gap-1.5 text-white/40 transition-colors hover:text-white/60 ${
+          horizontal ? 'h-full px-3' : 'w-full py-3'
+        }`}
       >
-        {/* Collapse toggle */}
-        <button
-          onClick={() => setCollapsed(!collapsed)}
-          className="flex h-full items-center gap-1.5 px-3 text-white/40 transition-colors hover:text-white/60"
-        >
-          <TerminalIcon className="size-3" />
-          {collapsed ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
-        </button>
+        <TerminalIcon className="size-3" />
+        <CollapseIcon className="size-3" />
+      </button>
 
-        {/* Tabs */}
-        <div className="flex flex-1 items-center gap-0.5 overflow-x-auto px-1">
-          <AnimatePresence initial={false}>
-            {allTabs.map(tab => {
-              const isActive = tab.id === effectiveActiveId;
-              const isMayor = tab.kind === 'mayor';
+      {/* Tabs */}
+      <div
+        className={`flex ${horizontal ? 'flex-1 items-center gap-0.5 overflow-x-auto px-1' : 'flex-1 flex-col gap-0.5 overflow-y-auto py-1'}`}
+      >
+        <AnimatePresence initial={false}>
+          {allTabs.map(tab => {
+            const isActive = tab.id === effectiveActiveId;
+            const isMayor = tab.kind === 'mayor';
 
-              return (
-                <motion.div
-                  key={tab.id}
-                  layout
-                  initial={{ opacity: 0, scale: 0.85, width: 0 }}
-                  animate={{ opacity: 1, scale: 1, width: 'auto' }}
-                  exit={{ opacity: 0, scale: 0.85, width: 0 }}
-                  transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
-                  onClick={() => {
-                    setActiveTabId(tab.id);
-                    if (collapsed) setCollapsed(false);
-                  }}
-                  className={`group flex cursor-pointer items-center gap-1.5 overflow-hidden rounded-t-md px-3 py-1 text-[11px] whitespace-nowrap transition-colors ${
-                    isActive
-                      ? 'bg-white/[0.06] text-white/80'
-                      : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
-                  }`}
-                >
-                  {isMayor && (
-                    <Crown className="size-3 shrink-0 text-[color:oklch(95%_0.15_108_/_0.6)]" />
-                  )}
-                  {tab.kind === 'status' && (
-                    <Activity className="size-3 shrink-0 text-[color:oklch(85%_0.12_200_/_0.6)]" />
-                  )}
-                  <span className="max-w-[120px] truncate">{tab.label}</span>
-                  {!isMayor && tab.kind !== 'status' && (
-                    <button
-                      onClick={e => {
-                        e.stopPropagation();
-                        closeTab(tab.id);
-                      }}
-                      className="shrink-0 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-white/10"
-                    >
-                      <X className="size-2.5" />
-                    </button>
-                  )}
-                </motion.div>
-              );
-            })}
-          </AnimatePresence>
-        </div>
+            return (
+              <motion.div
+                key={tab.id}
+                layout
+                initial={{ opacity: 0, scale: 0.85 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.85 }}
+                transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+                onClick={() => {
+                  setActiveTabId(tab.id);
+                  if (collapsed) setCollapsed(false);
+                }}
+                className={`group flex cursor-pointer items-center whitespace-nowrap transition-colors ${
+                  horizontal
+                    ? `gap-1.5 overflow-hidden rounded-t-md px-3 py-1 text-[11px]`
+                    : `relative justify-center overflow-visible rounded-md px-1 py-2`
+                } ${
+                  isActive
+                    ? 'bg-white/[0.06] text-white/80'
+                    : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
+                }`}
+                title={horizontal ? undefined : tab.label}
+              >
+                {isMayor && (
+                  <Crown
+                    className={`shrink-0 text-[color:oklch(95%_0.15_108_/_0.6)] ${horizontal ? 'size-3' : 'size-3.5'}`}
+                  />
+                )}
+                {tab.kind === 'status' && (
+                  <Activity
+                    className={`shrink-0 text-[color:oklch(85%_0.12_200_/_0.6)] ${horizontal ? 'size-3' : 'size-3.5'}`}
+                  />
+                )}
+                {tab.kind === 'agent' && !horizontal && (
+                  <TerminalIcon className="size-3.5 shrink-0" />
+                )}
+                {horizontal && <span className="max-w-[120px] truncate">{tab.label}</span>}
+                {!isMayor && tab.kind !== 'status' && (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation();
+                      closeTab(tab.id);
+                    }}
+                    className={`shrink-0 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-white/10 ${
+                      horizontal ? '' : 'absolute -top-1 -right-1'
+                    }`}
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                )}
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
       </div>
 
-      {/* Terminal content area */}
-      <AnimatePresence mode="wait">
-        {!collapsed && activeTab && (
-          <motion.div
-            key={activeTab.id}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
-            style={{ height: EXPANDED_HEIGHT }}
-            className="overflow-hidden"
-          >
-            {activeTab.kind === 'mayor' ? (
-              <MayorTerminalPane townId={townId} collapsed={collapsed} />
-            ) : activeTab.kind === 'status' ? (
-              <AlarmStatusPane townId={townId} alarmWs={alarmWs} />
-            ) : (
-              <AgentTerminalPane townId={townId} agentId={activeTab.agentId} />
-            )}
-          </motion.div>
+      {/* Position picker */}
+      <div ref={pickerRef}>
+        <button
+          onClick={() => setShowPositionPicker(p => !p)}
+          className={`flex items-center justify-center text-white/30 transition-colors hover:text-white/50 ${
+            horizontal ? 'h-full px-2' : 'w-full py-2'
+          }`}
+          title="Change terminal position"
+        >
+          {position === 'bottom' && <PanelBottom className="size-3.5" />}
+          {position === 'top' && <PanelTop className="size-3.5" />}
+          {position === 'left' && <PanelLeft className="size-3.5" />}
+          {position === 'right' && <PanelRight className="size-3.5" />}
+        </button>
+        {showPositionPicker && (
+          <PositionPicker
+            current={position}
+            onSelect={p => {
+              setPosition(p);
+              setShowPositionPicker(false);
+            }}
+            position={position}
+            triggerRef={pickerRef}
+          />
         )}
-      </AnimatePresence>
+      </div>
     </div>
+  );
+}
+
+// ── Position Picker Popup ────────────────────────────────────────────────
+
+const POSITION_OPTIONS: { value: TerminalPosition; label: string; Icon: typeof PanelBottom }[] = [
+  { value: 'bottom', label: 'Bottom', Icon: PanelBottom },
+  { value: 'top', label: 'Top', Icon: PanelTop },
+  { value: 'left', label: 'Left', Icon: PanelLeft },
+  { value: 'right', label: 'Right', Icon: PanelRight },
+];
+
+function PositionPicker({
+  current,
+  onSelect,
+  position,
+  triggerRef,
+}: {
+  current: TerminalPosition;
+  onSelect: (p: TerminalPosition) => void;
+  position: TerminalPosition;
+  triggerRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<React.CSSProperties>({ opacity: 0 });
+
+  useEffect(() => {
+    const trigger = triggerRef.current;
+    const popover = popoverRef.current;
+    if (!trigger || !popover) return;
+    const tr = trigger.getBoundingClientRect();
+    const pr = popover.getBoundingClientRect();
+    const gap = 4;
+
+    let top: number;
+    let left: number;
+
+    if (position === 'bottom') {
+      top = tr.top - pr.height - gap;
+      left = tr.right - pr.width;
+    } else if (position === 'top') {
+      top = tr.bottom + gap;
+      left = tr.right - pr.width;
+    } else if (position === 'left') {
+      top = tr.top;
+      left = tr.right + gap;
+    } else {
+      // right
+      top = tr.top;
+      left = tr.left - pr.width - gap;
+    }
+
+    // Clamp to viewport
+    top = Math.max(4, Math.min(top, window.innerHeight - pr.height - 4));
+    left = Math.max(4, Math.min(left, window.innerWidth - pr.width - 4));
+
+    setStyle({ top, left, opacity: 1 });
+  }, [position, triggerRef]);
+
+  return (
+    <div
+      ref={popoverRef}
+      className="fixed z-[60] w-max rounded-lg border border-white/[0.15] bg-[#1e1e1e] p-1.5 shadow-2xl backdrop-blur-sm"
+      style={style}
+    >
+      <div className="grid grid-cols-2 gap-1">
+        {POSITION_OPTIONS.map(({ value, label, Icon }) => (
+          <button
+            key={value}
+            onClick={() => onSelect(value)}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-2 text-[11px] whitespace-nowrap transition-colors ${
+              current === value
+                ? 'bg-white/[0.12] text-white/90'
+                : 'text-white/50 hover:bg-white/[0.07] hover:text-white/70'
+            }`}
+          >
+            <Icon className="size-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Terminal Content Area ─────────────────────────────────────────────────
+
+function TerminalContent({
+  activeTab,
+  collapsed,
+  horizontal,
+  size,
+  townId,
+  alarmWs,
+}: {
+  activeTab: TabDef;
+  collapsed: boolean;
+  horizontal: boolean;
+  size: number;
+  townId: string;
+  alarmWs: AlarmWsResult;
+}) {
+  if (collapsed) return null;
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={activeTab.id}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.15 }}
+        style={horizontal ? { height: size } : { width: size }}
+        className={`overflow-hidden ${horizontal ? '' : 'h-full'}`}
+      >
+        {activeTab.kind === 'mayor' ? (
+          <MayorTerminalPane townId={townId} collapsed={collapsed} />
+        ) : activeTab.kind === 'status' ? (
+          <AlarmStatusPane townId={townId} alarmWs={alarmWs} horizontal={horizontal} />
+        ) : (
+          <AgentTerminalPane townId={townId} agentId={activeTab.agentId} />
+        )}
+      </motion.div>
+    </AnimatePresence>
   );
 }
 
@@ -315,16 +768,10 @@ function useAlarmStatusWs(
         const msg = parsed as Record<string, unknown>;
 
         if (msg.type === 'agent_status') {
-          // Lightweight agent_status event — dispatch to callback, don't
-          // overwrite the alarm status snapshot.
           onAgentStatusRef.current?.(parsed as AgentStatusEvent);
         } else if (msg.channel === 'ui_action') {
-          // UI action from the mayor — dispatch to callback for DrawerStack/router.
           onUiActionRef.current?.(parsed as UiActionEvent);
         } else if ('alarm' in msg) {
-          // Only alarm snapshots have an `alarm` field. Bead, convoy,
-          // and other channel frames are silently ignored here to avoid
-          // overwriting the status data with the wrong shape.
           setData(parsed as AlarmStatus);
         }
       } catch {
@@ -335,7 +782,6 @@ function useAlarmStatusWs(
     ws.onclose = () => {
       if (!mountedRef.current) return;
       setConnected(false);
-      // Reconnect after 3s
       reconnectTimerRef.current = setTimeout(connect, 3_000);
     };
 
@@ -365,14 +811,19 @@ type AlarmWsResult = {
   error: string | null;
 };
 
-function AlarmStatusPane({ townId, alarmWs }: { townId: string; alarmWs: AlarmWsResult }) {
+function AlarmStatusPane({
+  townId,
+  alarmWs,
+  horizontal,
+}: {
+  townId: string;
+  alarmWs: AlarmWsResult;
+  horizontal: boolean;
+}) {
   const trpc = useGastownTRPC();
 
   const { data: wsData, connected: wsConnected, error: wsError } = alarmWs;
 
-  // Fall back to polling when WebSocket is unavailable (blocked, errored,
-  // or never connected). The tRPC query is disabled while the WS is
-  // providing data to avoid redundant requests.
   const wsFailed = !!wsError && !wsData;
   const pollingQuery = useQuery({
     ...trpc.gastown.getAlarmStatus.queryOptions({ townId }),
@@ -404,143 +855,174 @@ function AlarmStatusPane({ townId, alarmWs }: { townId: string; alarmWs: AlarmWs
     data.patrol.stalledAgents > 0 ||
     data.patrol.orphanedHooks > 0;
 
+  // Vertical orientation: single-column stacked layout
+  if (!horizontal) {
+    return (
+      <div className="relative flex h-full flex-col gap-2 overflow-y-auto p-3 text-[11px] text-white/70">
+        <ConnectionIndicator connected={wsConnected} failed={wsFailed} />
+        <StatusCards data={data} hasIssues={hasIssues} />
+        <EventFeed events={data.recentEvents} />
+      </div>
+    );
+  }
+
+  // Horizontal: two-column layout
   return (
     <div className="relative flex h-full gap-3 overflow-hidden p-3 text-[11px] text-white/70">
-      {/* Connection indicator */}
-      <div className="absolute top-1.5 right-3 z-10 flex items-center gap-1.5">
-        <span
-          className={`size-1.5 rounded-full ${wsConnected ? 'bg-emerald-400' : wsFailed ? 'bg-blue-400' : 'animate-pulse bg-yellow-400'}`}
-        />
-        <span className="text-[10px] text-white/35">
-          {wsConnected ? 'Live' : wsFailed ? 'Polling' : 'Reconnecting...'}
-        </span>
-      </div>
+      <ConnectionIndicator connected={wsConnected} failed={wsFailed} />
 
       {/* Left column: status cards */}
       <div className="flex w-[340px] shrink-0 flex-col gap-2 overflow-y-auto">
-        {/* Alarm */}
-        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
-          <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
-            <Activity className="size-3" />
-            Alarm Loop
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-            <StatusRow label="Interval" value={data.alarm.intervalLabel} />
-            <StatusRow
-              label="Next fire"
-              value={data.alarm.nextFireAt ? formatRelativeTime(data.alarm.nextFireAt) : 'not set'}
-              warn={!data.alarm.nextFireAt}
-            />
-          </div>
-        </div>
-
-        {/* Agents */}
-        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
-          <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
-            Agents ({data.agents.total})
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-            <StatusRow
-              label="Working"
-              value={data.agents.working}
-              highlight={data.agents.working > 0}
-            />
-            <StatusRow label="Idle" value={data.agents.idle} />
-            <StatusRow label="Stalled" value={data.agents.stalled} warn={data.agents.stalled > 0} />
-            <StatusRow label="Dead" value={data.agents.dead} warn={data.agents.dead > 0} />
-          </div>
-        </div>
-
-        {/* Beads */}
-        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
-          <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
-            Beads
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-            <StatusRow label="Open" value={data.beads.open} />
-            <StatusRow
-              label="In Progress"
-              value={data.beads.inProgress}
-              highlight={data.beads.inProgress > 0}
-            />
-            <StatusRow
-              label="In Review"
-              value={data.beads.inReview}
-              highlight={data.beads.inReview > 0}
-            />
-            <StatusRow label="Failed" value={data.beads.failed} warn={data.beads.failed > 0} />
-            <StatusRow
-              label="Triage"
-              value={data.beads.triageRequests}
-              warn={data.beads.triageRequests > 0}
-            />
-          </div>
-        </div>
-
-        {/* Patrol */}
-        <div
-          className={`rounded-md border p-2 ${
-            hasIssues
-              ? 'border-yellow-500/20 bg-yellow-500/[0.03]'
-              : 'border-white/[0.06] bg-white/[0.02]'
-          }`}
-        >
-          <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
-            Patrol {hasIssues ? '(issues detected)' : ''}
-          </div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-            <StatusRow
-              label="GUPP Warns"
-              value={data.patrol.guppWarnings}
-              warn={data.patrol.guppWarnings > 0}
-            />
-            <StatusRow
-              label="GUPP Escalations"
-              value={data.patrol.guppEscalations}
-              warn={data.patrol.guppEscalations > 0}
-            />
-            <StatusRow
-              label="Stalled"
-              value={data.patrol.stalledAgents}
-              warn={data.patrol.stalledAgents > 0}
-            />
-            <StatusRow
-              label="Orphaned Hooks"
-              value={data.patrol.orphanedHooks}
-              warn={data.patrol.orphanedHooks > 0}
-            />
-          </div>
-        </div>
+        <StatusCards data={data} hasIssues={hasIssues} />
       </div>
 
       {/* Right column: event feed */}
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-md border border-white/[0.06] bg-white/[0.02]">
-        <div className="border-b border-white/[0.06] px-2.5 py-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
-          Recent Events
+      <EventFeed events={data.recentEvents} />
+    </div>
+  );
+}
+
+function ConnectionIndicator({ connected, failed }: { connected: boolean; failed: boolean }) {
+  return (
+    <div className="absolute top-1.5 right-3 z-10 flex items-center gap-1.5">
+      <span
+        className={`size-1.5 rounded-full ${connected ? 'bg-emerald-400' : failed ? 'bg-blue-400' : 'animate-pulse bg-yellow-400'}`}
+      />
+      <span className="text-[10px] text-white/35">
+        {connected ? 'Live' : failed ? 'Polling' : 'Reconnecting...'}
+      </span>
+    </div>
+  );
+}
+
+function StatusCards({ data, hasIssues }: { data: AlarmStatus; hasIssues: boolean }) {
+  return (
+    <>
+      {/* Alarm */}
+      <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
+        <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+          <Activity className="size-3" />
+          Alarm Loop
         </div>
-        <div className="flex-1 overflow-y-auto">
-          {data.recentEvents.length === 0 ? (
-            <div className="flex h-full items-center justify-center text-white/20">
-              No recent events
-            </div>
-          ) : (
-            <div className="divide-y divide-white/[0.04]">
-              {data.recentEvents.map((event, i) => (
-                <div key={i} className="flex items-baseline gap-2 px-2.5 py-1.5">
-                  <span className="shrink-0 text-[10px] text-white/25 tabular-nums">
-                    {formatTime(event.time)}
-                  </span>
-                  <span
-                    className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-medium ${eventTypeColor(event.type)}`}
-                  >
-                    {event.type}
-                  </span>
-                  <span className="min-w-0 truncate">{event.message}</span>
-                </div>
-              ))}
-            </div>
-          )}
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+          <StatusRow label="Interval" value={data.alarm.intervalLabel} />
+          <StatusRow
+            label="Next fire"
+            value={data.alarm.nextFireAt ? formatRelativeTime(data.alarm.nextFireAt) : 'not set'}
+            warn={!data.alarm.nextFireAt}
+          />
         </div>
+      </div>
+
+      {/* Agents */}
+      <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
+        <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+          Agents ({data.agents.total})
+        </div>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+          <StatusRow
+            label="Working"
+            value={data.agents.working}
+            highlight={data.agents.working > 0}
+          />
+          <StatusRow label="Idle" value={data.agents.idle} />
+          <StatusRow label="Stalled" value={data.agents.stalled} warn={data.agents.stalled > 0} />
+          <StatusRow label="Dead" value={data.agents.dead} warn={data.agents.dead > 0} />
+        </div>
+      </div>
+
+      {/* Beads */}
+      <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-2">
+        <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+          Beads
+        </div>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+          <StatusRow label="Open" value={data.beads.open} />
+          <StatusRow
+            label="In Progress"
+            value={data.beads.inProgress}
+            highlight={data.beads.inProgress > 0}
+          />
+          <StatusRow
+            label="In Review"
+            value={data.beads.inReview}
+            highlight={data.beads.inReview > 0}
+          />
+          <StatusRow label="Failed" value={data.beads.failed} warn={data.beads.failed > 0} />
+          <StatusRow
+            label="Triage"
+            value={data.beads.triageRequests}
+            warn={data.beads.triageRequests > 0}
+          />
+        </div>
+      </div>
+
+      {/* Patrol */}
+      <div
+        className={`rounded-md border p-2 ${
+          hasIssues
+            ? 'border-yellow-500/20 bg-yellow-500/[0.03]'
+            : 'border-white/[0.06] bg-white/[0.02]'
+        }`}
+      >
+        <div className="mb-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+          Patrol {hasIssues ? '(issues detected)' : ''}
+        </div>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+          <StatusRow
+            label="GUPP Warns"
+            value={data.patrol.guppWarnings}
+            warn={data.patrol.guppWarnings > 0}
+          />
+          <StatusRow
+            label="GUPP Escalations"
+            value={data.patrol.guppEscalations}
+            warn={data.patrol.guppEscalations > 0}
+          />
+          <StatusRow
+            label="Stalled"
+            value={data.patrol.stalledAgents}
+            warn={data.patrol.stalledAgents > 0}
+          />
+          <StatusRow
+            label="Orphaned Hooks"
+            value={data.patrol.orphanedHooks}
+            warn={data.patrol.orphanedHooks > 0}
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function EventFeed({ events }: { events: Array<{ time: string; type: string; message: string }> }) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-md border border-white/[0.06] bg-white/[0.02]">
+      <div className="border-b border-white/[0.06] px-2.5 py-1.5 text-[10px] font-medium tracking-wide text-white/40 uppercase">
+        Recent Events
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {events.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-white/20">
+            No recent events
+          </div>
+        ) : (
+          <div className="divide-y divide-white/[0.04]">
+            {events.map((event, i) => (
+              <div key={i} className="flex items-baseline gap-2 px-2.5 py-1.5">
+                <span className="shrink-0 text-[10px] text-white/25 tabular-nums">
+                  {formatTime(event.time)}
+                </span>
+                <span
+                  className={`shrink-0 rounded px-1 py-0.5 text-[9px] font-medium ${eventTypeColor(event.type)}`}
+                >
+                  {event.type}
+                </span>
+                <span className="min-w-0 truncate">{event.message}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -675,13 +1157,14 @@ function MayorTerminalPane({ townId, collapsed }: { townId: string; collapsed: b
   });
 
   const { state: sidebarState } = useSidebar();
+  const { position, size } = useTerminalBar();
 
-  // Re-fit terminal when expanding or sidebar changes
+  // Re-fit terminal when expanding, sidebar changes, or size/position changes
   useEffect(() => {
     if (collapsed || !fitAddonRef.current) return;
     const t = setTimeout(() => fitAddonRef.current?.fit(), 50);
     return () => clearTimeout(t);
-  }, [collapsed, sidebarState]);
+  }, [collapsed, sidebarState, position, size]);
 
   return (
     <div className="relative h-full">

--- a/src/components/gastown/TerminalBarContext.tsx
+++ b/src/components/gastown/TerminalBarContext.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
+
+export type TerminalPosition = 'bottom' | 'top' | 'right' | 'left';
 
 type TerminalTab = {
   id: string;
@@ -9,14 +11,65 @@ type TerminalTab = {
   agentId: string;
 };
 
+const COLLAPSED_SIZE = 38;
+const DEFAULT_EXPANDED_SIZE = 300;
+const MIN_SIZE_HORIZONTAL = 100;
+const MAX_SIZE_HORIZONTAL_RATIO = 0.7;
+const MIN_SIZE_VERTICAL = 200;
+const MAX_SIZE_VERTICAL_RATIO = 0.5;
+
+const LS_KEY_POSITION = 'gastown-terminal-position';
+const LS_KEY_SIZE = 'gastown-terminal-size';
+
+export { COLLAPSED_SIZE, DEFAULT_EXPANDED_SIZE };
+
+function isHorizontal(p: TerminalPosition) {
+  return p === 'bottom' || p === 'top';
+}
+
+export { isHorizontal };
+
+function readStoredPosition(): TerminalPosition {
+  if (typeof window === 'undefined') return 'bottom';
+  const stored = localStorage.getItem(LS_KEY_POSITION);
+  if (stored === 'bottom' || stored === 'top' || stored === 'right' || stored === 'left') {
+    return stored;
+  }
+  return 'bottom';
+}
+
+function readStoredSize(): number {
+  if (typeof window === 'undefined') return DEFAULT_EXPANDED_SIZE;
+  const stored = localStorage.getItem(LS_KEY_SIZE);
+  if (stored) {
+    const n = parseInt(stored, 10);
+    if (!isNaN(n) && n >= MIN_SIZE_HORIZONTAL) return n;
+  }
+  return DEFAULT_EXPANDED_SIZE;
+}
+
+export function clampSize(size: number, position: TerminalPosition): number {
+  if (isHorizontal(position)) {
+    const max =
+      typeof window !== 'undefined' ? window.innerHeight * MAX_SIZE_HORIZONTAL_RATIO : 600;
+    return Math.max(MIN_SIZE_HORIZONTAL, Math.min(size, max));
+  }
+  const max = typeof window !== 'undefined' ? window.innerWidth * MAX_SIZE_VERTICAL_RATIO : 800;
+  return Math.max(MIN_SIZE_VERTICAL, Math.min(size, max));
+}
+
 type TerminalBarContextValue = {
   tabs: TerminalTab[];
   activeTabId: string | null;
   collapsed: boolean;
+  position: TerminalPosition;
+  size: number;
   openAgentTab: (agentId: string, agentName: string) => void;
   closeTab: (tabId: string) => void;
   setActiveTabId: (id: string) => void;
   setCollapsed: (collapsed: boolean) => void;
+  setPosition: (position: TerminalPosition) => void;
+  setSize: (size: number) => void;
 };
 
 const TerminalBarContext = createContext<TerminalBarContextValue | null>(null);
@@ -31,6 +84,34 @@ export function TerminalBarProvider({ children }: { children: ReactNode }) {
   const [tabs, setTabs] = useState<TerminalTab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState(false);
+  const [position, setPositionState] = useState<TerminalPosition>('bottom');
+  const [size, setSizeState] = useState(DEFAULT_EXPANDED_SIZE);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    setPositionState(readStoredPosition());
+    setSizeState(readStoredSize());
+  }, []);
+
+  const setPosition = useCallback((p: TerminalPosition) => {
+    setPositionState(p);
+    localStorage.setItem(LS_KEY_POSITION, p);
+    // Re-clamp size for the new orientation's constraints
+    setSizeState(prev => {
+      const clamped = clampSize(prev, p);
+      localStorage.setItem(LS_KEY_SIZE, String(clamped));
+      return clamped;
+    });
+  }, []);
+
+  const setSize = useCallback(
+    (s: number, pos?: TerminalPosition) => {
+      const val = clampSize(s, pos ?? position);
+      setSizeState(val);
+      localStorage.setItem(LS_KEY_SIZE, String(val));
+    },
+    [position]
+  );
 
   const openAgentTab = useCallback((agentId: string, agentName: string) => {
     const tabId = `agent:${agentId}`;
@@ -56,7 +137,19 @@ export function TerminalBarProvider({ children }: { children: ReactNode }) {
 
   return (
     <TerminalBarContext.Provider
-      value={{ tabs, activeTabId, collapsed, openAgentTab, closeTab, setActiveTabId, setCollapsed }}
+      value={{
+        tabs,
+        activeTabId,
+        collapsed,
+        position,
+        size,
+        openAgentTab,
+        closeTab,
+        setActiveTabId,
+        setCollapsed,
+        setPosition,
+        setSize,
+      }}
     >
       {children}
     </TerminalBarContext.Provider>

--- a/src/components/gastown/TerminalBarPadding.tsx
+++ b/src/components/gastown/TerminalBarPadding.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useTerminalBar, COLLAPSED_SIZE, isHorizontal } from './TerminalBarContext';
+
+/**
+ * Client component that wraps page content and applies dynamic padding
+ * to clear the fixed terminal bar. Replaces the static `pb-[340px]`
+ * in layouts with position/size/collapse-aware padding.
+ */
+export function TerminalBarPadding({ children }: { children: ReactNode }) {
+  const { position, size, collapsed } = useTerminalBar();
+
+  const totalSize = collapsed ? COLLAPSED_SIZE : COLLAPSED_SIZE + size;
+
+  const style: React.CSSProperties = {};
+
+  if (isHorizontal(position)) {
+    if (position === 'bottom') {
+      style.paddingBottom = `${totalSize}px`;
+    } else {
+      style.paddingTop = `${totalSize}px`;
+    }
+  } else {
+    if (position === 'right') {
+      style.paddingRight = `${totalSize}px`;
+    } else {
+      style.paddingLeft = `${totalSize}px`;
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col" style={style}>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -580,6 +580,187 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
       }[];
       meta: object;
     }>;
+    getMergeQueueData: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+        rigId?: string | undefined;
+        limit?: number | undefined;
+        since?: string | undefined;
+      };
+      output: {
+        needsAttention: {
+          openPRs: {
+            mrBead: {
+              bead_id: string;
+              status: string;
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              created_at: string;
+              updated_at: string;
+              metadata: Record<string, unknown>;
+            };
+            reviewMetadata: {
+              branch: string;
+              target_branch: string;
+              merge_commit: string | null;
+              pr_url: string | null;
+              retry_count: number;
+            };
+            sourceBead: {
+              bead_id: string;
+              title: string;
+              status: string;
+              body: string | null;
+            } | null;
+            convoy: {
+              convoy_id: string;
+              title: string;
+              total_beads: number;
+              closed_beads: number;
+              feature_branch: string | null;
+              merge_mode: string | null;
+            } | null;
+            agent: {
+              agent_id: string;
+              name: string;
+              role: string;
+            } | null;
+            rigName: string | null;
+            staleSince: string | null;
+            failureReason: string | null;
+          }[];
+          failedReviews: {
+            mrBead: {
+              bead_id: string;
+              status: string;
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              created_at: string;
+              updated_at: string;
+              metadata: Record<string, unknown>;
+            };
+            reviewMetadata: {
+              branch: string;
+              target_branch: string;
+              merge_commit: string | null;
+              pr_url: string | null;
+              retry_count: number;
+            };
+            sourceBead: {
+              bead_id: string;
+              title: string;
+              status: string;
+              body: string | null;
+            } | null;
+            convoy: {
+              convoy_id: string;
+              title: string;
+              total_beads: number;
+              closed_beads: number;
+              feature_branch: string | null;
+              merge_mode: string | null;
+            } | null;
+            agent: {
+              agent_id: string;
+              name: string;
+              role: string;
+            } | null;
+            rigName: string | null;
+            staleSince: string | null;
+            failureReason: string | null;
+          }[];
+          stalePRs: {
+            mrBead: {
+              bead_id: string;
+              status: string;
+              title: string;
+              body: string | null;
+              rig_id: string | null;
+              created_at: string;
+              updated_at: string;
+              metadata: Record<string, unknown>;
+            };
+            reviewMetadata: {
+              branch: string;
+              target_branch: string;
+              merge_commit: string | null;
+              pr_url: string | null;
+              retry_count: number;
+            };
+            sourceBead: {
+              bead_id: string;
+              title: string;
+              status: string;
+              body: string | null;
+            } | null;
+            convoy: {
+              convoy_id: string;
+              title: string;
+              total_beads: number;
+              closed_beads: number;
+              feature_branch: string | null;
+              merge_mode: string | null;
+            } | null;
+            agent: {
+              agent_id: string;
+              name: string;
+              role: string;
+            } | null;
+            rigName: string | null;
+            staleSince: string | null;
+            failureReason: string | null;
+          }[];
+        };
+        activityLog: {
+          event: {
+            bead_event_id: string;
+            bead_id: string;
+            agent_id: string | null;
+            event_type: string;
+            old_value: string | null;
+            new_value: string | null;
+            metadata: Record<string, unknown>;
+            created_at: string;
+          };
+          mrBead: {
+            bead_id: string;
+            title: string;
+            type: string;
+            status: string;
+            rig_id: string | null;
+            metadata: Record<string, unknown>;
+          } | null;
+          sourceBead: {
+            bead_id: string;
+            title: string;
+            status: string;
+          } | null;
+          convoy: {
+            convoy_id: string;
+            title: string;
+            total_beads: number;
+            closed_beads: number;
+            feature_branch: string | null;
+            merge_mode: string | null;
+          } | null;
+          agent: {
+            agent_id: string;
+            name: string;
+            role: string;
+          } | null;
+          rigName: string | null;
+          reviewMetadata: {
+            pr_url: string | null;
+            branch: string | null;
+            target_branch: string | null;
+            merge_commit: string | null;
+          } | null;
+        }[];
+      };
+      meta: object;
+    }>;
     listConvoys: import('@trpc/server').TRPCQueryProcedure<{
       input: {
         townId: string;
@@ -1603,6 +1784,187 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             rig_id?: string | undefined;
             rig_name?: string | undefined;
           }[];
+          meta: object;
+        }>;
+        getMergeQueueData: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+            rigId?: string | undefined;
+            limit?: number | undefined;
+            since?: string | undefined;
+          };
+          output: {
+            needsAttention: {
+              openPRs: {
+                mrBead: {
+                  bead_id: string;
+                  status: string;
+                  title: string;
+                  body: string | null;
+                  rig_id: string | null;
+                  created_at: string;
+                  updated_at: string;
+                  metadata: Record<string, unknown>;
+                };
+                reviewMetadata: {
+                  branch: string;
+                  target_branch: string;
+                  merge_commit: string | null;
+                  pr_url: string | null;
+                  retry_count: number;
+                };
+                sourceBead: {
+                  bead_id: string;
+                  title: string;
+                  status: string;
+                  body: string | null;
+                } | null;
+                convoy: {
+                  convoy_id: string;
+                  title: string;
+                  total_beads: number;
+                  closed_beads: number;
+                  feature_branch: string | null;
+                  merge_mode: string | null;
+                } | null;
+                agent: {
+                  agent_id: string;
+                  name: string;
+                  role: string;
+                } | null;
+                rigName: string | null;
+                staleSince: string | null;
+                failureReason: string | null;
+              }[];
+              failedReviews: {
+                mrBead: {
+                  bead_id: string;
+                  status: string;
+                  title: string;
+                  body: string | null;
+                  rig_id: string | null;
+                  created_at: string;
+                  updated_at: string;
+                  metadata: Record<string, unknown>;
+                };
+                reviewMetadata: {
+                  branch: string;
+                  target_branch: string;
+                  merge_commit: string | null;
+                  pr_url: string | null;
+                  retry_count: number;
+                };
+                sourceBead: {
+                  bead_id: string;
+                  title: string;
+                  status: string;
+                  body: string | null;
+                } | null;
+                convoy: {
+                  convoy_id: string;
+                  title: string;
+                  total_beads: number;
+                  closed_beads: number;
+                  feature_branch: string | null;
+                  merge_mode: string | null;
+                } | null;
+                agent: {
+                  agent_id: string;
+                  name: string;
+                  role: string;
+                } | null;
+                rigName: string | null;
+                staleSince: string | null;
+                failureReason: string | null;
+              }[];
+              stalePRs: {
+                mrBead: {
+                  bead_id: string;
+                  status: string;
+                  title: string;
+                  body: string | null;
+                  rig_id: string | null;
+                  created_at: string;
+                  updated_at: string;
+                  metadata: Record<string, unknown>;
+                };
+                reviewMetadata: {
+                  branch: string;
+                  target_branch: string;
+                  merge_commit: string | null;
+                  pr_url: string | null;
+                  retry_count: number;
+                };
+                sourceBead: {
+                  bead_id: string;
+                  title: string;
+                  status: string;
+                  body: string | null;
+                } | null;
+                convoy: {
+                  convoy_id: string;
+                  title: string;
+                  total_beads: number;
+                  closed_beads: number;
+                  feature_branch: string | null;
+                  merge_mode: string | null;
+                } | null;
+                agent: {
+                  agent_id: string;
+                  name: string;
+                  role: string;
+                } | null;
+                rigName: string | null;
+                staleSince: string | null;
+                failureReason: string | null;
+              }[];
+            };
+            activityLog: {
+              event: {
+                bead_event_id: string;
+                bead_id: string;
+                agent_id: string | null;
+                event_type: string;
+                old_value: string | null;
+                new_value: string | null;
+                metadata: Record<string, unknown>;
+                created_at: string;
+              };
+              mrBead: {
+                bead_id: string;
+                title: string;
+                type: string;
+                status: string;
+                rig_id: string | null;
+                metadata: Record<string, unknown>;
+              } | null;
+              sourceBead: {
+                bead_id: string;
+                title: string;
+                status: string;
+              } | null;
+              convoy: {
+                convoy_id: string;
+                title: string;
+                total_beads: number;
+                closed_beads: number;
+                feature_branch: string | null;
+                merge_mode: string | null;
+              } | null;
+              agent: {
+                agent_id: string;
+                name: string;
+                role: string;
+              } | null;
+              rigName: string | null;
+              reviewMetadata: {
+                pr_url: string | null;
+                branch: string | null;
+                target_branch: string | null;
+                merge_commit: string | null;
+              } | null;
+            }[];
+          };
           meta: object;
         }>;
         listConvoys: import('@trpc/server').TRPCQueryProcedure<{


### PR DESCRIPTION
## Summary

Redesigns the Merge Queue page with three major additions:

- **`getMergeQueueData` tRPC procedure** — Server-side query that fetches MR beads needing attention (open PRs, failed reviews, stale PRs) and a rich activity log with convoy, agent, rig, and review metadata joins. Includes Zod schemas for both input validation and output serialization.
- **Needs Your Attention section** — Groups actionable MR beads by convoy with progress bars, retry/fail actions with confirmation dialogs, and direct links to PRs and bead drawers. Categorizes items as open PR, failed, or stale (>24h).
- **Refinery Activity Log** — Timeline-style event feed with convoy grouping. Pagination uses a budget system where convoy groups cost their entry count, and items are sorted by most-recent timestamp across convoy groups and standalone entries (fixes ordering bug where busy convoys pushed standalone events off page 1).
- **Dockable terminal bar** — Terminal bar can now be positioned at bottom/top/left/right with drag-to-resize. Position and size persist to localStorage. Dynamic padding via `TerminalBarPadding` replaces hardcoded `pb-[340px]`. Drawer stack adjusts right offset when terminal is on the right.
- **Per-rig filtering** — Dropdown to filter the merge queue by rig.

## Verification

- [x] `pnpm typecheck` — passes clean across all packages
- [x] `oxlint` — 0 warnings, 0 errors
- [x] `eslint` — passes across all packages
- [x] `oxfmt --list-different .` — no formatting issues
- [x] All pre-push hooks pass (format, lint, typecheck)

## Visual Changes

N/A (no screenshots available — UI-heavy changes to the Merge Queue page and terminal bar positioning)

## Reviewer Notes

- The pagination fix (top commit) merges convoy groups and standalone entries into a unified `DisplayItem` list sorted by most-recent timestamp, then paginates with a budget system. The "remaining" count uses actual visible entry count rather than the budget variable.
- `router.d.ts` is hand-maintained per project convention — the additions mirror the new tRPC procedure's input/output types.
- The `TerminalBarPadding` component replaces static padding in both the regular and org-scoped town layouts.
- SQL queries in `review-queue.ts` use parameterized inputs and town ownership is verified in the tRPC procedure.