### PR TITLE
refactor(notifications): remove unnecessary getKiloPassState check

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -10,8 +10,6 @@ import * as z from 'zod';
 import { subDays } from 'date-fns';
 import { hasReceivedPromotion } from '@/lib/promotionalCredits';
 
-import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
-import { db } from '@/lib/drizzle';
 import { fromMicrodollars } from '@/lib/utils';
 
 /** Pre-fetched data shared across notification generators to avoid duplicate DB queries. */
@@ -346,12 +344,6 @@ async function generateKiloPassNotification(
   user: User,
   ctx: NotificationContext
 ): Promise<KiloNotification[]> {
-  // Exclude users who already have a Kilo Pass
-  const kiloPassState = await getKiloPassStateForUser(db, user.id);
-  if (kiloPassState) {
-    return [];
-  }
-
   // Check if user belongs to an organization with balance > $5
   const hasHighBalanceOrg = ctx.userOrganizations.some(org => fromMicrodollars(org.balance) > 5);
   if (hasHighBalanceOrg) {


### PR DESCRIPTION
## Summary

Remove the `getKiloPassStateForUser` check from `generateKiloPassNotification` in `src/lib/notifications.ts`. Previously, users with an active Kilo Pass were excluded from receiving the Kilo Pass notification. This was unnecessary — Kilo Pass users should still see the notification. This also removes a redundant DB query per notification generation call.

## Verification

- [x] `pnpm typecheck` — no new errors (all existing errors are in unrelated files)

## Visual Changes

N/A

## Reviewer Notes

The removed imports (`getKiloPassStateForUser` from `@/lib/kilo-pass/state` and `db` from `@/lib/drizzle`) were only used for this check, so they are safe to remove.