### PR TITLE
feat(kiloclaw): add structured console logging for instance DO events

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -120,6 +120,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       | 'flyRegion'
     > & { event: KiloClawEventName }
   ): void {
+    doLog(this.s, data.event, {
+      ...(data.status ? { status: data.status } : undefined),
+      ...(data.label ? { label: data.label } : undefined),
+      ...(data.error ? { error: data.error } : undefined),
+      ...(data.durationMs !== undefined ? { durationMs: data.durationMs } : undefined),
+      ...(data.value !== undefined ? { value: data.value } : undefined),
+    });
     writeEvent(this.env, {
       ...data,
       delivery: 'do',


### PR DESCRIPTION
## Summary

The 7 `instance.*` events emitted by the KiloClaw DO lifecycle (`instance.provisioned`, `instance.started`, `instance.provisioning_failed`, `instance.start_capacity_recovery`, `instance.stopped`, `instance.restarting`, `instance.destroy_started`) were only written to Cloudflare Analytics Engine via `writeEvent`. Unlike reconcile events — which get both a `console.log` and an AE write — instance events had no console output and therefore never appeared in Cloudflare logpush or Axiom.

This adds a `doLog()` call inside the DO's `emitEvent` method, reusing the existing structured logging format (`tag: 'kiloclaw_do'`). Event-specific fields (status, label, error, durationMs, value) are forwarded as details. No new log formats introduced.

## Verification

- [x] `pnpm typecheck` — passed (tsgo, no errors)
- [x] `pnpm test` — passed (966 tests, 44 test files)
- [x] `pnpm lint` — passed for kiloclaw (oxlint + eslint)
- [ ] Deploy and verify events appear in Axiom `cloudflare-logpush` dataset

## Visual Changes

N/A

## Reviewer Notes

One-line change to `emitEvent` — `doLog` was already imported and used elsewhere in the same file. The 4 HTTP-path instance events (`manual_start_*`, `crash_recovery_*`) are not covered by this change since they call `writeEvent` directly from route handlers without DO state; those can be addressed separately.