### PR TITLE
fix(fim): return 402 directly instead of querying credit_transactions

### DIFF
--- a/src/app/api/fim/completions/route.ts
+++ b/src/app/api/fim/completions/route.ts
@@ -157,10 +157,7 @@ export async function POST(request: NextRequest) {
   const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
 
   if (balance <= 0 && !isFreeModel(fimModel_withOpenRouterStyleProviderPrefix) && !userByok) {
-    return NextResponse.json(
-      { error: { message: 'Insufficient credits' } },
-      { status: 402 }
-    );
+    return NextResponse.json({ error: { message: 'Insufficient credits' } }, { status: 402 });
   }
 
   // Use shared helper for organization model restrictions

--- a/src/app/api/fim/completions/route.ts
+++ b/src/app/api/fim/completions/route.ts
@@ -15,7 +15,6 @@ import {
   extractFraudAndProjectHeaders,
   invalidRequestResponse,
   temporarilyUnavailableResponse,
-  usageLimitExceededResponse,
   wrapInSafeNextResponse,
   captureProxyError,
   extractHeaderAndLimitLength,
@@ -158,7 +157,10 @@ export async function POST(request: NextRequest) {
   const { balance, settings, plan } = await getBalanceAndOrgSettings(organizationId, user, readDb);
 
   if (balance <= 0 && !isFreeModel(fimModel_withOpenRouterStyleProviderPrefix) && !userByok) {
-    return await usageLimitExceededResponse(user, balance);
+    return NextResponse.json(
+      { error: { message: 'Insufficient credits' } },
+      { status: 402 }
+    );
   }
 
   // Use shared helper for organization model restrictions


### PR DESCRIPTION
## Summary

When FIM completions fail due to insufficient credits, the handler called `usageLimitExceededResponse` which internally runs `summarizeUserPayments` — a DB query on `credit_transactions` just to determine whether to show "Paid Model - Credits Required" vs "Low Credit Warning!". The extension client only checks for HTTP 402 and doesn't use that message distinction, so the query is unnecessary overhead on the hot path.

Replaced with a simple inline `NextResponse.json({ error: { message: 'Insufficient credits' } }, { status: 402 })`.

## Verification

- [x] Reviewed that the extension checks for status 402 only, not the message text
- [x] Confirmed `usageLimitExceededResponse` is still used by the openrouter and embeddings routes (no dead code introduced)
- [x] Typecheck could not run due to missing node_modules in worktree, but the change is minimal and type-safe (removed one import, replaced one function call with a `NextResponse.json` call that was already imported)

## Visual Changes

N/A

## Reviewer Notes

The other two callers of `usageLimitExceededResponse` (openrouter chat completions and embeddings) are left unchanged — they may benefit from the same optimization but FIM is the highest-frequency caller and the one where latency matters most.
