### PR TITLE
perf(usage): add date bound to org autocomplete query

### DIFF
--- a/src/app/api/organizations/hooks.ts
+++ b/src/app/api/organizations/hooks.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import type { Organization } from '@kilocode/db/schema';
-import type { OrgTrialStatus } from '@/lib/organizations/organization-types';
+import type { OrgTrialStatus, TimePeriod } from '@/lib/organizations/organization-types';
 import {
   getDaysRemainingInTrial,
   getOrgTrialStatusFromDays,
@@ -92,9 +92,17 @@ export function useOrganizationUsageStats(organizationId: string) {
   return useQuery(trpc.organizations.usageStats.queryOptions({ organizationId }));
 }
 
-export function useOrganizationAutocompleteMetrics(organizationId: string) {
+export function useOrganizationAutocompleteMetrics(
+  organizationId: string,
+  period: TimePeriod = 'month'
+) {
   const trpc = useTRPC();
-  return useQuery(trpc.organizations.usageDetails.getAutocomplete.queryOptions({ organizationId }));
+  return useQuery(
+    trpc.organizations.usageDetails.getAutocomplete.queryOptions({
+      organizationId,
+      period,
+    })
+  );
 }
 
 export function useOrganizationInvoices(organizationId: string, timePeriod: string = 'year') {

--- a/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
+++ b/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
@@ -106,7 +106,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
 
   // Fetch autocomplete metrics
   const { data: autocompleteMetrics, isLoading: isLoadingAutocompleteMetrics } =
-    useOrganizationAutocompleteMetrics(organizationId);
+    useOrganizationAutocompleteMetrics(organizationId, timePeriod);
 
   // Apply filters using custom hook
   const {

--- a/src/routers/organizations/organization-usage-details-router.test.ts
+++ b/src/routers/organizations/organization-usage-details-router.test.ts
@@ -387,6 +387,7 @@ describe('organizations usage details trpc router', () => {
 
       const result = await caller.organizations.usageDetails.getAutocomplete({
         organizationId: testOrganization.id,
+        period: 'month',
       });
 
       expect(result.cost).toBe(1500); // 1000 + 500
@@ -412,11 +413,61 @@ describe('organizations usage details trpc router', () => {
 
       const result = await caller.organizations.usageDetails.getAutocomplete({
         organizationId: testOrganization.id,
+        period: 'month',
       });
 
       expect(result.cost).toBe(0);
       expect(result.requests).toBe(0);
       expect(result.tokens).toBe(0);
+    });
+
+    it('should exclude autocomplete usage outside the selected period', async () => {
+      const now = await getDateFromDb();
+      const twoMonthsAgo = await getDateFromDb('60 days');
+
+      // Insert recent autocomplete usage (within the past week)
+      await insertUsageWithOverrides({
+        kilo_user_id: memberUser.id,
+        organization_id: testOrganization.id,
+        cost: 1000,
+        input_tokens: 300,
+        output_tokens: 200,
+        created_at: now,
+        model: 'codestral-2508',
+      });
+
+      // Insert old autocomplete usage (outside the past week)
+      await insertUsageWithOverrides({
+        kilo_user_id: memberUser.id,
+        organization_id: testOrganization.id,
+        cost: 5000,
+        input_tokens: 1000,
+        output_tokens: 800,
+        created_at: twoMonthsAgo,
+        model: 'codestral-2508',
+      });
+
+      const caller = await createCallerForUser(memberUser.id);
+
+      // Query with 'week' period — should only include recent usage
+      const weekResult = await caller.organizations.usageDetails.getAutocomplete({
+        organizationId: testOrganization.id,
+        period: 'week',
+      });
+
+      expect(weekResult.cost).toBe(1000);
+      expect(weekResult.requests).toBe(1);
+      expect(weekResult.tokens).toBe(500); // 300 + 200
+
+      // Query with 'all' period — should include everything
+      const allResult = await caller.organizations.usageDetails.getAutocomplete({
+        organizationId: testOrganization.id,
+        period: 'all',
+      });
+
+      expect(allResult.cost).toBe(6000); // 1000 + 5000
+      expect(allResult.requests).toBe(2);
+      expect(allResult.tokens).toBe(2300); // (300 + 200) + (1000 + 800)
     });
 
     it('should throw UNAUTHORIZED error for non-member users', async () => {

--- a/src/routers/organizations/organization-usage-details-router.ts
+++ b/src/routers/organizations/organization-usage-details-router.ts
@@ -358,10 +358,24 @@ export const organizationsUsageDetailsRouter = createTRPCRouter({
       };
     }),
   getAutocomplete: organizationMemberProcedure
-    .input(OrganizationIdInputSchema)
+    .input(
+      OrganizationIdInputSchema.extend({
+        period: TimePeriodSchema.default('month'),
+      })
+    )
     .output(AutocompleteMetricsOutputSchema)
     .query(async ({ input }) => {
-      const { organizationId } = input;
+      const { organizationId, period } = input;
+
+      const dateThreshold = getDateThreshold(period);
+
+      const whereConditions = [
+        eq(microdollar_usage.organization_id, organizationId),
+        eq(microdollar_usage.model, AUTOCOMPLETE_MODEL),
+      ];
+      if (dateThreshold) {
+        whereConditions.push(gte(microdollar_usage.created_at, dateThreshold));
+      }
 
       const result = await timedUsageQuery(
         {
@@ -369,7 +383,7 @@ export const organizationsUsageDetailsRouter = createTRPCRouter({
           route: 'organizations.usageDetails.getAutocomplete',
           queryLabel: 'org_autocomplete_aggregate',
           scope: 'org',
-          period: null,
+          period,
         },
         tx =>
           tx
@@ -379,12 +393,7 @@ export const organizationsUsageDetailsRouter = createTRPCRouter({
               total_tokens: sql<number>`COALESCE(SUM(${microdollar_usage.input_tokens}) + SUM(${microdollar_usage.output_tokens}), 0)::float`,
             })
             .from(microdollar_usage)
-            .where(
-              and(
-                eq(microdollar_usage.organization_id, organizationId),
-                eq(microdollar_usage.model, AUTOCOMPLETE_MODEL)
-              )
-            )
+            .where(and(...whereConditions))
       );
 
       const metrics = result[0] || { total_cost: 0, request_count: 0, total_tokens: 0 };


### PR DESCRIPTION
## Summary

The `getAutocomplete` query in the org usage details router was scanning all rows for an organization with no date filter, causing slow aggregation on the `microdollar_usage` table (10-22s for large orgs). This wires the existing period selector (already present in the UI) through to the autocomplete query, so it respects the same date bound as the rest of the org usage page.

- Added `period` parameter to `getAutocomplete` input schema (defaults to `'month'`)
- Applied `getDateThreshold(period)` filter to the query's WHERE clause, matching the pattern used by the `get` procedure
- Updated `useOrganizationAutocompleteMetrics` hook to accept and pass the period
- Updated `OrganizationUsageDetails` component to pass `timePeriod` to the autocomplete hook
- Added test for period-based date filtering

The `'all'` option preserves the previous unbounded behavior when explicitly selected.

## Verification

- [x] `pnpm typecheck` — passes (no new errors; all failures are pre-existing in unrelated modules)
- [x] Tests — jest has a pre-existing Haste module collision from `.kilo/worktrees/` that prevents running the test suite locally; the test file itself compiles and follows the same patterns as existing passing tests

## Visual Changes

N/A

## Reviewer Notes

- This is Phase 2c from `plans/db-perf-improvements.md` — the lowest-risk, highest-value change for this query
- The default period `'month'` matches the component's initial `timePeriod` state (`'week'` in the component, but the schema default is `'month'` to be conservative)
- Existing callers that don't pass `period` will get `'month'` via the schema default, which is a behavioral change from the previous all-time scan — but this is intentional and matches what the UI displays
