### PR TITLE
refactor(kilo-pass): inline promo eligibility into getState to reduce DB calls

### DIFF
--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -84,7 +84,7 @@ declare const OrganizationPlanSchema: z.ZodEnum<{
     enterprise: "enterprise";
 }>;
 type OrganizationPlan = z.infer<typeof OrganizationPlanSchema>;
-type AuthProviderId = 'email' | 'google' | 'github' | 'gitlab' | 'linkedin' | 'discord' | 'fake-login' | 'workos';
+type AuthProviderId = 'email' | 'google' | 'github' | 'gitlab' | 'linkedin' | 'fake-login' | 'workos';
 type IntegrationPermissions = Record<string, string>;
 type PlatformRepository = {
     id: number;
@@ -612,23 +612,6 @@ declare const kilocode_users: drizzle_orm_pg_core.PgTableWithColumns<{
             isAutoincrement: false;
             hasRuntimeDefault: false;
             enumValues: [string, ...string[]];
-            baseColumn: never;
-            identity: undefined;
-            generated: undefined;
-        }, {}, {}>;
-        discord_server_membership_verified_at: drizzle_orm_pg_core.PgColumn<{
-            name: "discord_server_membership_verified_at";
-            tableName: "kilocode_users";
-            dataType: "string";
-            columnType: "PgTimestampString";
-            data: string;
-            driverParam: string;
-            notNull: false;
-            hasDefault: false;
-            isPrimaryKey: false;
-            isAutoincrement: false;
-            hasRuntimeDefault: false;
-            enumValues: undefined;
             baseColumn: never;
             identity: undefined;
             generated: undefined;
@@ -7569,7 +7552,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         }>;
         linkAuthProvider: _trpc_server.TRPCMutationProcedure<{
             input: {
-                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "discord" | "fake-login" | "workos";
+                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "fake-login" | "workos";
             };
             output: {
                 success: true;
@@ -7578,7 +7561,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         }>;
         unlinkAuthProvider: _trpc_server.TRPCMutationProcedure<{
             input: {
-                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "discord" | "fake-login" | "workos";
+                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "fake-login" | "workos";
             };
             output: {
                 success: true;
@@ -7708,23 +7691,6 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             output: {
                 success: true;
             };
-            meta: object;
-        }>;
-        getDiscordGuildStatus: _trpc_server.TRPCQueryProcedure<{
-            input: void;
-            output: SuccessResult<{
-                linked: boolean;
-                discord_avatar_url: string | null;
-                discord_display_name: string | null;
-                discord_server_membership_verified_at: string | null;
-            }>;
-            meta: object;
-        }>;
-        verifyDiscordGuildMembership: _trpc_server.TRPCMutationProcedure<{
-            input: void;
-            output: SuccessResult<{
-                is_member: boolean;
-            }>;
             meta: object;
         }>;
     }>>;
@@ -7927,7 +7893,6 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                         completed_welcome_form: boolean;
                         linkedin_url: string | null;
                         github_url: string | null;
-                        discord_server_membership_verified_at: string | null;
                         openrouter_upstream_safety_identifier: string | null;
                         customer_source: string | null;
                     };
@@ -14795,7 +14760,6 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     isBonusUnlocked: boolean;
                     refillAt: string | null;
                 } | null;
-                isEligibleForFirstMonthPromo: boolean;
             };
             meta: object;
         }>;
@@ -14814,6 +14778,13 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     startedAt: string | null;
                 } | null;
                 creditsAwarded: boolean;
+            };
+            meta: object;
+        }>;
+        getFirstMonthPromoEligibility: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: {
+                eligible: boolean;
             };
             meta: object;
         }>;

--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -84,7 +84,7 @@ declare const OrganizationPlanSchema: z.ZodEnum<{
     enterprise: "enterprise";
 }>;
 type OrganizationPlan = z.infer<typeof OrganizationPlanSchema>;
-type AuthProviderId = 'email' | 'google' | 'github' | 'gitlab' | 'linkedin' | 'fake-login' | 'workos';
+type AuthProviderId = 'email' | 'google' | 'github' | 'gitlab' | 'linkedin' | 'discord' | 'fake-login' | 'workos';
 type IntegrationPermissions = Record<string, string>;
 type PlatformRepository = {
     id: number;
@@ -612,6 +612,23 @@ declare const kilocode_users: drizzle_orm_pg_core.PgTableWithColumns<{
             isAutoincrement: false;
             hasRuntimeDefault: false;
             enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {}>;
+        discord_server_membership_verified_at: drizzle_orm_pg_core.PgColumn<{
+            name: "discord_server_membership_verified_at";
+            tableName: "kilocode_users";
+            dataType: "string";
+            columnType: "PgTimestampString";
+            data: string;
+            driverParam: string;
+            notNull: false;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: undefined;
             baseColumn: never;
             identity: undefined;
             generated: undefined;
@@ -7552,7 +7569,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         }>;
         linkAuthProvider: _trpc_server.TRPCMutationProcedure<{
             input: {
-                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "fake-login" | "workos";
+                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "discord" | "fake-login" | "workos";
             };
             output: {
                 success: true;
@@ -7561,7 +7578,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         }>;
         unlinkAuthProvider: _trpc_server.TRPCMutationProcedure<{
             input: {
-                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "fake-login" | "workos";
+                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "discord" | "fake-login" | "workos";
             };
             output: {
                 success: true;
@@ -7691,6 +7708,23 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             output: {
                 success: true;
             };
+            meta: object;
+        }>;
+        getDiscordGuildStatus: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: SuccessResult<{
+                linked: boolean;
+                discord_avatar_url: string | null;
+                discord_display_name: string | null;
+                discord_server_membership_verified_at: string | null;
+            }>;
+            meta: object;
+        }>;
+        verifyDiscordGuildMembership: _trpc_server.TRPCMutationProcedure<{
+            input: void;
+            output: SuccessResult<{
+                is_member: boolean;
+            }>;
             meta: object;
         }>;
     }>>;
@@ -7893,6 +7927,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                         completed_welcome_form: boolean;
                         linkedin_url: string | null;
                         github_url: string | null;
+                        discord_server_membership_verified_at: string | null;
                         openrouter_upstream_safety_identifier: string | null;
                         customer_source: string | null;
                     };
@@ -14760,6 +14795,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     isBonusUnlocked: boolean;
                     refillAt: string | null;
                 } | null;
+                isEligibleForFirstMonthPromo: boolean;
             };
             meta: object;
         }>;
@@ -14778,13 +14814,6 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     startedAt: string | null;
                 } | null;
                 creditsAwarded: boolean;
-            };
-            meta: object;
-        }>;
-        getFirstMonthPromoEligibility: _trpc_server.TRPCQueryProcedure<{
-            input: void;
-            output: {
-                eligible: boolean;
             };
             meta: object;
         }>;

--- a/src/components/profile/ProfileKiloPassSection.tsx
+++ b/src/components/profile/ProfileKiloPassSection.tsx
@@ -22,11 +22,6 @@ export function ProfileKiloPassSection() {
   const hasActiveSubscription =
     subscriptionFromQuery != null && !isStripeSubscriptionEnded(subscriptionFromQuery.status);
 
-  const promoEligibilityQuery = useQuery({
-    ...trpc.kiloPass.getFirstMonthPromoEligibility.queryOptions(),
-    enabled: query.isSuccess && !hasActiveSubscription,
-  });
-
   const averageMonthlyUsageQuery = useQuery({
     ...trpc.kiloPass.getAverageMonthlyUsageLast3Months.queryOptions(),
     enabled: query.isSuccess && !hasActiveSubscription,
@@ -63,7 +58,7 @@ export function ProfileKiloPassSection() {
 
   if (!activeSubscription) {
     const pending = checkoutMutation.isPending;
-    const showFirstMonthPromo = promoEligibilityQuery.data?.eligible === true;
+    const showFirstMonthPromo = query.data.isEligibleForFirstMonthPromo;
     const showSecondMonthPromo =
       showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
     const averageMonthlyUsageUsd = averageMonthlyUsageQuery.data?.averageMonthlyUsageUsd;

--- a/src/routers/kilo-pass-router.test.ts
+++ b/src/routers/kilo-pass-router.test.ts
@@ -77,8 +77,8 @@ type KiloPassCaller = {
       isBonusUnlocked: boolean;
       refillAt: string | null;
     } | null;
+    isEligibleForFirstMonthPromo: boolean;
   }>;
-  getFirstMonthPromoEligibility: () => Promise<{ eligible: boolean }>;
   getAverageMonthlyUsageLast3Months: () => Promise<{ averageMonthlyUsageUsd: number }>;
   getCheckoutReturnState: () => Promise<{
     subscription: {
@@ -268,7 +268,7 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getState();
 
-      expect(result).toEqual({ subscription: null });
+      expect(result).toEqual({ subscription: null, isEligibleForFirstMonthPromo: true });
     });
 
     it('throws BAD_REQUEST when subscription exists but user has no stripe customer', async () => {
@@ -704,26 +704,34 @@ describe('kiloPassRouter', () => {
     });
   });
 
-  describe('getFirstMonthPromoEligibility', () => {
-    it('returns eligible=true when user has never had any kilo_pass_subscriptions row', async () => {
+  describe('isEligibleForFirstMonthPromo in getState', () => {
+    it('returns isEligibleForFirstMonthPromo=true when user has no subscriptions', async () => {
       const user = await insertTestUser({
-        google_user_email: 'kilo-pass-first-month-eligibility-true@example.com',
+        google_user_email: 'kilo-pass-promo-eligible-no-sub@example.com',
       });
 
       const caller = await createCallerForUser(user.id);
-      const result = await caller.kiloPass.getFirstMonthPromoEligibility();
+      const result = await caller.kiloPass.getState();
 
-      expect(result).toEqual({ eligible: true });
+      expect(result.isEligibleForFirstMonthPromo).toBe(true);
+      expect(result.subscription).toBeNull();
     });
 
-    it('returns eligible=false when user has any prior Kilo Pass subscription (monthly or yearly)', async () => {
+    it('returns isEligibleForFirstMonthPromo=false when user has a canceled subscription', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_test_prior_yearly_canceled',
+        status: 'canceled',
+        items: { data: [] },
+      });
+
       const user = await insertTestUser({
-        google_user_email: 'kilo-pass-first-month-eligibility-false@example.com',
+        google_user_email: 'kilo-pass-promo-ineligible-canceled@example.com',
       });
 
       await insertSubscription({
         kiloUserId: user.id,
-        stripeSubscriptionId: 'sub_test_prior_yearly',
+        stripeSubscriptionId: 'sub_test_prior_yearly_canceled',
         tier: KiloPassTier.Tier49,
         cadence: KiloPassCadence.Yearly,
         status: 'canceled',
@@ -731,9 +739,10 @@ describe('kiloPassRouter', () => {
       });
 
       const caller = await createCallerForUser(user.id);
-      const result = await caller.kiloPass.getFirstMonthPromoEligibility();
+      const result = await caller.kiloPass.getState();
 
-      expect(result).toEqual({ eligible: false });
+      expect(result.isEligibleForFirstMonthPromo).toBe(false);
+      expect(result.subscription).not.toBeNull();
     });
   });
 

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -85,6 +85,7 @@ const KiloPassSubscriptionStateSchema = KiloPassSubscriptionStateBaseSchema.exte
 
 const GetStateOutputSchema = z.object({
   subscription: KiloPassSubscriptionStateSchema.nullable(),
+  isEligibleForFirstMonthPromo: z.boolean(),
 });
 
 const GetAverageMonthlyUsageLast3MonthsOutputSchema = z.object({
@@ -233,10 +234,6 @@ const CreateCheckoutSessionOutputSchema = z.object({
   url: z.url().nullable(),
 });
 
-const FirstMonthPromoEligibilityOutputSchema = z.object({
-  eligible: z.boolean(),
-});
-
 const CancelSubscriptionOutputSchema = z.object({
   success: z.boolean(),
 });
@@ -311,7 +308,7 @@ export const kiloPassRouter = createTRPCRouter({
   getState: baseProcedure.output(GetStateOutputSchema).query(async ({ ctx }) => {
     const subscriptionBase = await getKiloPassStateForUser(db, ctx.user.id);
     if (!subscriptionBase) {
-      return { subscription: null };
+      return { subscription: null, isEligibleForFirstMonthPromo: true };
     }
 
     const stripeCustomerId = ctx.user.stripe_customer_id;
@@ -346,6 +343,7 @@ export const kiloPassRouter = createTRPCRouter({
           isBonusUnlocked: false,
           refillAt: null,
         },
+        isEligibleForFirstMonthPromo: false,
       };
     }
 
@@ -473,6 +471,7 @@ export const kiloPassRouter = createTRPCRouter({
         isBonusUnlocked,
         refillAt,
       },
+      isEligibleForFirstMonthPromo: false,
     };
   }),
 
@@ -507,14 +506,6 @@ export const kiloPassRouter = createTRPCRouter({
         subscription,
         creditsAwarded: issuedBaseCredits.length > 0,
       };
-    }),
-
-  getFirstMonthPromoEligibility: baseProcedure
-    .output(FirstMonthPromoEligibilityOutputSchema)
-    .query(async ({ ctx }) => {
-      const subscription = await getKiloPassStateForUser(db, ctx.user.id);
-
-      return { eligible: !subscription };
     }),
 
   getCustomerPortalUrl: baseProcedure


### PR DESCRIPTION
## Summary

- Inline promo eligibility into the `kiloPass.getState` response by adding `isEligibleForFirstMonthPromo` to `GetStateOutputSchema`, eliminating the need for a separate `getFirstMonthPromoEligibility` tRPC procedure and its redundant `getKiloPassStateForUser` DB query.
- Remove the `getFirstMonthPromoEligibility` procedure entirely and update `ProfileKiloPassSection` to read promo eligibility directly from `getState` data.
- This reduces the number of `getKiloPassStateForUser` DB calls on the profile page from 2 to 1 for users without an active subscription.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm jest -- src/routers/kilo-pass-router.test.ts` — 35/35 tests pass, including 2 new tests for `isEligibleForFirstMonthPromo` (eligible when no subscriptions, ineligible when canceled subscription exists)

## Visual Changes

N/A

## Reviewer Notes

- The `isEligibleForFirstMonthPromo` field is placed at the top level of the `getState` response (alongside `subscription`) so it's available even when `subscription` is `null`.
- The promo eligibility logic is: `true` when `getKiloPassStateForUser` returns `null` (no subscription rows at all), `false` otherwise (including canceled/ended subscriptions). This matches the prior `getFirstMonthPromoEligibility` behavior exactly.
