### PR TITLE
feat(kiloclaw): add force revive for terminally stopped instances

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -769,8 +769,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         flyConfig,
         this.ctx,
         this.s,
-        createReconcileContext(this.s, this.env, 'start_recovery'),
-        true /* skipCooldown — start() must always attempt recovery */
+        createReconcileContext(this.s, this.env, 'start_recovery')
       );
       if (!recovered && !this.s.flyMachineId) {
         throw new Error(

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -698,10 +698,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     await this.loadState();
 
     if (this.s.status === 'destroying') {
-      throw new Error('Cannot retry recovery: instance is being destroyed');
+      throw Object.assign(new Error('Cannot retry recovery: instance is being destroyed'), {
+        status: 409,
+      });
     }
     if (!this.s.status) {
-      throw new Error('Cannot retry recovery: instance has no status');
+      throw Object.assign(new Error('Cannot retry recovery: instance has no status'), {
+        status: 404,
+      });
     }
 
     doWarn(this.s, 'forceRetryRecovery: admin-initiated cooldown reset', {

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -700,6 +700,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     if (this.s.status === 'destroying') {
       throw new Error('Cannot retry recovery: instance is being destroyed');
     }
+    if (!this.s.status) {
+      throw new Error('Cannot retry recovery: instance has no status');
+    }
+
+    doWarn(this.s, 'forceRetryRecovery: admin-initiated cooldown reset', {
+      previousLastRecoveryAt: this.s.lastMetadataRecoveryAt,
+      status: this.s.status,
+    });
 
     this.s.lastMetadataRecoveryAt = null;
     await this.persist({ lastMetadataRecoveryAt: null });
@@ -758,7 +766,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         this.ctx,
         this.s,
         createReconcileContext(this.s, this.env, 'start_recovery'),
-        true
+        true /* skipCooldown — start() must always attempt recovery */
       );
       if (!recovered && !this.s.flyMachineId) {
         throw new Error(

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -715,7 +715,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     this.s.lastMetadataRecoveryAt = null;
     await this.persist({ lastMetadataRecoveryAt: null });
-    await this.scheduleAlarm();
+    await this.ctx.storage.setAlarm(Date.now());
 
     return { ok: true };
   }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -720,7 +720,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return { ok: true };
   }
 
-  async start(userId?: string, options?: { skipCooldown?: boolean }): Promise<{ started: boolean }> {
+  async start(
+    userId?: string,
+    options?: { skipCooldown?: boolean }
+  ): Promise<{ started: boolean }> {
     // Guard against concurrent start() calls — two overlapping invocations
     // (e.g. startAsync via waitUntil + a direct RPC start) can both see
     // flyMachineId as null and each create a Fly machine, orphaning one.

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -694,6 +694,20 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
+  async forceRetryRecovery(): Promise<{ ok: true }> {
+    await this.loadState();
+
+    if (this.s.status === 'destroying') {
+      throw new Error('Cannot retry recovery: instance is being destroyed');
+    }
+
+    this.s.lastMetadataRecoveryAt = null;
+    await this.persist({ lastMetadataRecoveryAt: null });
+    await this.scheduleAlarm();
+
+    return { ok: true };
+  }
+
   async start(userId?: string): Promise<{ started: boolean }> {
     // Guard against concurrent start() calls — two overlapping invocations
     // (e.g. startAsync via waitUntil + a direct RPC start) can both see
@@ -743,7 +757,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         flyConfig,
         this.ctx,
         this.s,
-        createReconcileContext(this.s, this.env, 'start_recovery')
+        createReconcileContext(this.s, this.env, 'start_recovery'),
+        true
       );
       if (!recovered && !this.s.flyMachineId) {
         throw new Error(

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -720,7 +720,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return { ok: true };
   }
 
-  async start(userId?: string): Promise<{ started: boolean }> {
+  async start(userId?: string, options?: { skipCooldown?: boolean }): Promise<{ started: boolean }> {
     // Guard against concurrent start() calls — two overlapping invocations
     // (e.g. startAsync via waitUntil + a direct RPC start) can both see
     // flyMachineId as null and each create a Fly machine, orphaning one.
@@ -731,13 +731,16 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.startInProgress = true;
 
     try {
-      return await this._startInner(userId);
+      return await this._startInner(userId, options);
     } finally {
       this.startInProgress = false;
     }
   }
 
-  private async _startInner(userId?: string): Promise<{ started: boolean }> {
+  private async _startInner(
+    userId?: string,
+    options?: { skipCooldown?: boolean }
+  ): Promise<{ started: boolean }> {
     await this.loadState();
 
     if (this.s.status === 'destroying') {
@@ -769,7 +772,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         flyConfig,
         this.ctx,
         this.s,
-        createReconcileContext(this.s, this.env, 'start_recovery')
+        createReconcileContext(this.s, this.env, 'start_recovery'),
+        options?.skipCooldown
       );
       if (!recovered && !this.s.flyMachineId) {
         throw new Error(

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -641,11 +641,13 @@ export async function attemptMetadataRecovery(
   flyConfig: FlyClientConfig,
   ctx: DurableObjectState,
   state: InstanceMutableState,
-  rctx: ReconcileContext
+  rctx: ReconcileContext,
+  skipCooldown?: boolean
 ): Promise<boolean> {
   if (!state.userId) return false;
 
   if (
+    !skipCooldown &&
     state.lastMetadataRecoveryAt &&
     Date.now() - state.lastMetadataRecoveryAt < METADATA_RECOVERY_COOLDOWN_MS
   ) {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -912,15 +912,20 @@ platform.post('/doctor', async c => {
 });
 
 // POST /api/platform/start
+const StartRequestSchema = UserIdRequestSchema.extend({
+  skipCooldown: z.boolean().optional(),
+});
+
 platform.post('/start', async c => {
-  const result = await parseBody(c, UserIdRequestSchema);
+  const result = await parseBody(c, StartRequestSchema);
   if ('error' in result) return result.error;
   const startedAt = performance.now();
 
   try {
+    const options = result.data.skipCooldown ? { skipCooldown: true } : undefined;
     const { started } = await withDORetry(
       instanceStubFactory(c.env, result.data.userId),
-      stub => stub.start(result.data.userId),
+      stub => stub.start(result.data.userId, options),
       'start'
     );
     if (started) {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -946,6 +946,24 @@ platform.post('/start', async c => {
   }
 });
 
+// POST /api/platform/force-retry-recovery
+platform.post('/force-retry-recovery', async c => {
+  const result = await parseBody(c, UserIdRequestSchema);
+  if ('error' in result) return result.error;
+
+  try {
+    const { ok } = await withDORetry(
+      instanceStubFactory(c.env, result.data.userId),
+      stub => stub.forceRetryRecovery(),
+      'forceRetryRecovery'
+    );
+    return c.json({ ok });
+  } catch (err) {
+    const { message, status } = sanitizeError(err, 'forceRetryRecovery');
+    return jsonError(message, status);
+  }
+});
+
 // POST /api/platform/stop
 platform.post('/stop', async c => {
   const result = await parseBody(c, UserIdRequestSchema);

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -158,6 +158,7 @@ const SAFE_ERROR_PREFIXES = [
   'Cannot enable Gmail ', // no Google account connected
   'New volume ID is ', // reassociate: same volume
   'Volume ', // reassociate: volume not found / bad state
+  'Cannot retry recovery', // force-retry-recovery guard messages
 ];
 
 function sanitizeError(err: unknown, operation: string): { message: string; status: number } {
@@ -950,6 +951,7 @@ platform.post('/start', async c => {
 platform.post('/force-retry-recovery', async c => {
   const result = await parseBody(c, UserIdRequestSchema);
   if ('error' in result) return result.error;
+  const startedAt = performance.now();
 
   try {
     const { ok } = await withDORetry(
@@ -957,9 +959,24 @@ platform.post('/force-retry-recovery', async c => {
       stub => stub.forceRetryRecovery(),
       'forceRetryRecovery'
     );
+    writeEvent(c.env, {
+      event: 'instance.force_retry_recovery_succeeded',
+      delivery: 'http',
+      route: '/api/platform/force-retry-recovery',
+      userId: result.data.userId,
+      durationMs: performance.now() - startedAt,
+    });
     return c.json({ ok });
   } catch (err) {
     const { message, status } = sanitizeError(err, 'forceRetryRecovery');
+    writeEvent(c.env, {
+      event: 'instance.force_retry_recovery_failed',
+      delivery: 'http',
+      route: '/api/platform/force-retry-recovery',
+      userId: result.data.userId,
+      error: message,
+      durationMs: performance.now() - startedAt,
+    });
     return jsonError(message, status);
   }
 });

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1409,25 +1409,23 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             <div className="flex items-center justify-between gap-3">
               <div>
                 <CardTitle>Live Worker Status</CardTitle>
-                <CardDescription>
-                  Real-time status from the KiloClaw Durable Object
-                </CardDescription>
+                <CardDescription>Real-time status from the KiloClaw Durable Object</CardDescription>
               </div>
               {canRetryRecovery && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={machineActionPending}
-                    onClick={() => void forceRetryRecovery({ userId: data.user_id })}
-                  >
-                    {isRetryingRecovery ? (
-                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                    ) : (
-                      <RotateCw className="mr-1 h-4 w-4" />
-                    )}
-                    Retry Recovery
-                  </Button>
-                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={machineActionPending}
+                  onClick={() => void forceRetryRecovery({ userId: data.user_id })}
+                >
+                  {isRetryingRecovery ? (
+                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                  ) : (
+                    <RotateCw className="mr-1 h-4 w-4" />
+                  )}
+                  Retry Recovery
+                </Button>
+              )}
             </div>
           </CardHeader>
           <CardContent>

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1109,7 +1109,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
   };
 
-  const machineControlsEnabled = data?.destroyed_at === null && !!data?.workerStatus?.flyMachineId;
+  const machineControlsEnabled = data?.destroyed_at === null;
+  const hasMachine = !!data?.workerStatus?.flyMachineId;
 
   const invalidateMachineQueries = () => {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
@@ -1163,6 +1164,18 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
       },
       onError: err => {
         toast.error(`Failed to upgrade: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: forceRetryRecovery, isPending: isRetryingRecovery } = useMutation(
+    trpc.admin.kiloclawInstances.forceRetryRecovery.mutationOptions({
+      onSuccess: () => {
+        toast.success('Recovery retry requested');
+        invalidateMachineQueries();
+      },
+      onError: err => {
+        toast.error(`Failed to retry recovery: ${err.message}`);
       },
     })
   );
@@ -1385,8 +1398,30 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
 
         <Card>
           <CardHeader>
-            <CardTitle>Live Worker Status</CardTitle>
-            <CardDescription>Real-time status from the KiloClaw Durable Object</CardDescription>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <CardTitle>Live Worker Status</CardTitle>
+                <CardDescription>
+                  Real-time status from the KiloClaw Durable Object
+                </CardDescription>
+              </div>
+              {!data.workerStatus?.flyMachineId &&
+                data.workerStatus?.status === 'stopped' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={isRetryingRecovery}
+                    onClick={() => void forceRetryRecovery({ userId: data.user_id })}
+                  >
+                    {isRetryingRecovery ? (
+                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                    ) : (
+                      <RotateCw className="mr-1 h-4 w-4" />
+                    )}
+                    Retry Recovery
+                  </Button>
+                )}
+            </div>
           </CardHeader>
           <CardContent>
             {data.workerStatusError && (
@@ -1604,7 +1639,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={machineActionPending}
+                  disabled={machineActionPending || !hasMachine}
                   onClick={() => void machineStop({ userId: data.user_id })}
                 >
                   {isMachineStopping ? (
@@ -1617,7 +1652,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={machineActionPending || machineRestartBlocked}
+                  disabled={machineActionPending || machineRestartBlocked || !hasMachine}
                   onClick={() => void machineRedeploy({ instanceId: data.id, imageTag: undefined })}
                 >
                   {isMachineRedeploying ? (
@@ -1630,7 +1665,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={machineActionPending || machineRestartBlocked}
+                  disabled={machineActionPending || machineRestartBlocked || !hasMachine}
                   onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
                 >
                   {isMachineUpgrading ? (

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1112,7 +1112,9 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const machineControlsEnabled = data?.destroyed_at === null;
   const hasMachine = !!data?.workerStatus?.flyMachineId;
   const canRetryRecovery =
-    !data?.workerStatus?.flyMachineId && data?.workerStatus?.status === 'stopped';
+    data?.destroyed_at === null &&
+    !data?.workerStatus?.flyMachineId &&
+    data?.workerStatus?.status === 'stopped';
 
   const invalidateMachineQueries = () => {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1111,6 +1111,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
 
   const machineControlsEnabled = data?.destroyed_at === null;
   const hasMachine = !!data?.workerStatus?.flyMachineId;
+  const canRetryRecovery =
+    !data?.workerStatus?.flyMachineId && data?.workerStatus?.status === 'stopped';
 
   const invalidateMachineQueries = () => {
     void queryClient.invalidateQueries({ queryKey: trpc.admin.kiloclawInstances.get.queryKey() });
@@ -1287,7 +1289,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     machineStatus === 'starting' ||
     machineStatus === 'restarting';
   const machineActionPending =
-    isMachineStarting || isMachineStopping || isMachineRedeploying || isMachineUpgrading;
+    isMachineStarting ||
+    isMachineStopping ||
+    isMachineRedeploying ||
+    isMachineUpgrading ||
+    isRetryingRecovery;
   const gatewayActionPending =
     isGatewayStarting ||
     isGatewayStopping ||
@@ -1405,12 +1411,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   Real-time status from the KiloClaw Durable Object
                 </CardDescription>
               </div>
-              {!data.workerStatus?.flyMachineId &&
-                data.workerStatus?.status === 'stopped' && (
+              {canRetryRecovery && (
                   <Button
                     variant="outline"
                     size="sm"
-                    disabled={isRetryingRecovery}
+                    disabled={machineActionPending}
                     onClick={() => void forceRetryRecovery({ userId: data.user_id })}
                   >
                     {isRetryingRecovery ? (

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -451,6 +451,17 @@ export class KiloClawInternalClient {
     );
   }
 
+  async forceRetryRecovery(userId: string): Promise<{ ok: true }> {
+    return this.request(
+      '/api/platform/force-retry-recovery',
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      },
+      { userId }
+    );
+  }
+
   async listCandidateVolumes(userId: string): Promise<CandidateVolumesResponse> {
     return this.request(
       `/api/platform/candidate-volumes?userId=${encodeURIComponent(userId)}`,

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -127,12 +127,12 @@ export class KiloClawInternalClient {
     );
   }
 
-  async start(userId: string): Promise<{ ok: true }> {
+  async start(userId: string, options?: { skipCooldown?: boolean }): Promise<{ ok: true }> {
     return this.request(
       '/api/platform/start',
       {
         method: 'POST',
-        body: JSON.stringify({ userId }),
+        body: JSON.stringify({ userId, ...options }),
       },
       { userId }
     );

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -549,6 +549,17 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     }
   }),
 
+  forceRetryRecovery: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
+    const fallbackMessage = 'Failed to retry recovery';
+    try {
+      const client = new KiloClawInternalClient();
+      return await client.forceRetryRecovery(input.userId);
+    } catch (err) {
+      console.error('Failed to retry recovery for user:', input.userId, err);
+      throwKiloclawAdminError(err, fallbackMessage);
+    }
+  }),
+
   machineStop: adminProcedure.input(GatewayProcessSchema).mutation(async ({ input }) => {
     const fallbackMessage = 'Failed to stop machine';
     try {

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -542,7 +542,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     const fallbackMessage = 'Failed to start machine';
     try {
       const client = new KiloClawInternalClient();
-      return await client.start(input.userId);
+      return await client.start(input.userId, { skipCooldown: true });
     } catch (err) {
       console.error('Failed to start machine for user:', input.userId, err);
       throwKiloclawAdminError(err, fallbackMessage);


### PR DESCRIPTION
## Summary

When a KiloClaw instance reaches a terminally stopped state (machine gone due to capacity issues, DO lost `flyMachineId`), admins had no way to bring it back — the Machine Controls card was hidden and the reconcile loop's metadata recovery cooldown blocked manual starts.

- **Fix Machine Controls visibility** — Remove `flyMachineId` requirement from the guard so Start Machine is available when the machine is gone. Stop/Redeploy/Upgrade remain disabled when there's no machine.
- **Add Retry Recovery button** — New button in Live Worker Status card header (visible when `status=stopped` + no `flyMachineId` + not destroyed). Clears the 30-min metadata recovery cooldown and schedules an immediate alarm to trigger the reconcile loop.
- **Admin Start Machine bypasses cooldown** — Admin-initiated starts pass `skipCooldown: true` through the platform route to `attemptMetadataRecovery()`, so admins can recover instances with a single click. User-facing starts still respect the cooldown to prevent thrashing.
- **Full-stack plumbing** — DO method → platform route → internal client → tRPC admin endpoint → UI button.

### Additional hardening from adversarial review (3 rounds, 7 specialized reviewers):
- `doWarn` audit logging on admin-initiated cooldown reset
- Analytics events (`writeEvent`) on the force-retry-recovery platform route
- `SAFE_ERROR_PREFIXES` entry so guard errors reach the admin UI instead of being sanitized to "forceRetryRecovery failed"
- Proper HTTP status codes (409/404) on guard errors instead of defaulting to 500
- `destroyed_at` check on `canRetryRecovery` to prevent showing button on destroyed instances
- `isRetryingRecovery` included in `machineActionPending` to prevent conflicting concurrent actions

### Changes

| File | Change |
|------|--------|
| `kiloclaw/.../index.ts` | `forceRetryRecovery()` DO method + `skipCooldown` on `start()` |
| `kiloclaw/.../reconcile.ts` | `skipCooldown` param on `attemptMetadataRecovery()` |
| `kiloclaw/src/routes/platform.ts` | Platform route + analytics + error prefix safelist + `StartRequestSchema` |
| `src/.../KiloclawInstanceDetail.tsx` | Fixed visibility guard, Retry Recovery button, disabled states |
| `src/lib/kiloclaw/kiloclaw-internal-client.ts` | `forceRetryRecovery()` + `skipCooldown` on `start()` |
| `src/routers/admin-kiloclaw-instances-router.ts` | tRPC admin endpoint + `skipCooldown: true` on `machineStart` |

## Test plan

### Prerequisites
- Local dev: Next.js app running on `:3000`, kiloclaw wrangler on `:8795`
- Admin login via `http://localhost:3000/users/sign_in?fakeUser=you@admin.example.com`
- A provisioned KiloClaw instance (provision via platform API if needed)

### Simulating terminal stopped state

1. Provision an instance if one doesn't exist:
   ```bash
   curl -s -X POST "http://localhost:8795/api/platform/provision" \
     -H "x-internal-api-key: <secret>" \
     -H "Content-Type: application/json" \
     -d '{"userId":"<user-id>"}'
   ```
2. Stop the instance via API:
   ```bash
   curl -s -X POST "http://localhost:8795/api/platform/stop" \
     -H "x-internal-api-key: <secret>" \
     -H "Content-Type: application/json" \
     -d '{"userId":"<user-id>"}'
   ```
3. Find and modify the DO's SQLite database:
   ```bash
   # Find the DB
   find kiloclaw/.wrangler/state/v3/do/kiloclaw-KiloClawInstance/ -name "*.sqlite"
   # Identify correct DB
   sqlite3 <db-path> "SELECT key, value FROM _cf_KV WHERE key IN ('userId','status','flyMachineId');"
   # Clear flyMachineId to simulate lost machine
   sqlite3 <db-path> "DELETE FROM _cf_KV WHERE key = 'flyMachineId';"
   ```
4. Restart the kiloclaw wrangler dev server (so the DO reloads from SQLite)
5. Verify via debug-status API: `status=stopped`, `flyMachineId=null`, `flyVolumeId=<exists>`

### Test 1: Admin Start Machine recovers instance in one click

**Starting state:** `status=stopped`, `flyMachineId=null`, cooldown active

1. Navigate to `/admin/kiloclaw/<instance-id>`
2. Click **Start Machine**
3. The admin start bypasses the 30-min cooldown, runs metadata recovery, finds the machine on Fly, and recovers the `flyMachineId`
4. Refresh the page
5. **Verify**: DO Status is **Running**, Fly Machine ID is populated, all controls enabled

<!-- IMAGE:admin-start-before — Screenshot showing terminal stopped state with Start Machine visible -->

<!-- IMAGE:admin-start-after — Screenshot showing recovered Running state after single Start Machine click -->

### Test 2: Retry Recovery button clears cooldown and triggers reconcile

**Starting state:** `status=stopped`, `flyMachineId=null`

1. Navigate to `/admin/kiloclaw/<instance-id>`
2. **Verify**: "Retry Recovery" button appears in Live Worker Status card header
3. Click **Retry Recovery**
4. **Verify**: Toast shows "Recovery retry requested"
5. **Verify**: "Last Metadata Recovery Attempt" changes to "—" (cleared)
6. **Verify**: "Next Alarm" updates to an imminent time
7. Wait for alarm to fire → reconcile loop runs metadata recovery
8. Refresh the page
9. **Verify**: Instance recovered — DO Status **Running**, Fly Machine ID populated

<!-- IMAGE:retry-recovery-before — Screenshot showing Retry Recovery button on stopped instance -->

<!-- IMAGE:retry-recovery-after — Screenshot showing recovered state after Retry Recovery + alarm -->

### Test 3: Machine Controls visibility

1. Navigate to any instance with `flyMachineId=null`
2. **Verify**: Machine Controls card IS visible
3. **Verify**: Start Machine is **enabled**
4. **Verify**: Stop Machine, Redeploy, Upgrade to Latest are all **disabled**

<!-- IMAGE:machine-controls-visibility — Screenshot showing enabled Start, disabled Stop/Redeploy/Upgrade -->

### Test 4: Button visibility guards

1. On a destroyed instance: **Verify** Retry Recovery button is NOT shown
2. On an instance with status != "stopped": **Verify** Retry Recovery button is NOT shown
3. On an instance with flyMachineId present: **Verify** Retry Recovery button is NOT shown

### Test 5: Mutual exclusion of pending states

1. On a terminal-stopped instance, click Retry Recovery
2. **Verify**: While mutation is in flight, Start/Stop/Redeploy/Upgrade are all disabled
3. Conversely, clicking Start Machine disables Retry Recovery during that mutation