### PR TITLE
fix: encode user IDs in admin user links for OAuth users

### DIFF
--- a/src/app/admin/bulk-credits/page.tsx
+++ b/src/app/admin/bulk-credits/page.tsx
@@ -435,7 +435,7 @@ export default function BulkCreditsPage() {
                           <TableCell>{user.userName || '—'}</TableCell>
                           <TableCell>
                             <Link
-                              href={`/admin/users/${user.userId}`}
+                              href={`/admin/users/${encodeURIComponent(user.userId)}`}
                               className="font-mono text-sm text-blue-400 hover:underline"
                             >
                               {user.userId.slice(0, 8)}...
@@ -563,7 +563,7 @@ export default function BulkCreditsPage() {
                         <TableCell>
                           {result.userId ? (
                             <Link
-                              href={`/admin/users/${result.userId}`}
+                              href={`/admin/users/${encodeURIComponent(result.userId)}`}
                               className="font-mono text-sm text-blue-400 hover:underline"
                             >
                               {result.userId.slice(0, 8)}...

--- a/src/app/admin/components/AppBuilder/AppBuilderProjectDetail.tsx
+++ b/src/app/admin/components/AppBuilder/AppBuilderProjectDetail.tsx
@@ -136,7 +136,7 @@ export function AppBuilderProjectDetail({ projectId }: { projectId: string }) {
                 <div className="text-muted-foreground text-xs">Owner</div>
                 {project.owned_by_user_id ? (
                   <Link
-                    href={`/admin/users/${project.owned_by_user_id}`}
+                    href={`/admin/users/${encodeURIComponent(project.owned_by_user_id)}`}
                     className="text-sm text-blue-600 hover:underline"
                   >
                     {project.owner_email ?? project.owned_by_user_id}
@@ -266,7 +266,7 @@ export function AppBuilderProjectDetail({ projectId }: { projectId: string }) {
               <div>
                 <div className="text-muted-foreground text-xs">Created By User ID</div>
                 <Link
-                  href={`/admin/users/${project.created_by_user_id}`}
+                  href={`/admin/users/${encodeURIComponent(project.created_by_user_id)}`}
                   className="text-sm text-blue-600 hover:underline"
                 >
                   {project.created_by_user_id}

--- a/src/app/admin/components/AppBuilder/AppBuilderProjectsTable.tsx
+++ b/src/app/admin/components/AppBuilder/AppBuilderProjectsTable.tsx
@@ -311,7 +311,7 @@ export function AppBuilderProjectsTable() {
                   <TableCell>
                     {project.owned_by_user_id ? (
                       <Link
-                        href={`/admin/users/${project.owned_by_user_id}`}
+                        href={`/admin/users/${encodeURIComponent(project.owned_by_user_id)}`}
                         className="text-blue-600 hover:underline"
                         onClick={e => e.stopPropagation()}
                       >

--- a/src/app/admin/components/Deployments/DeploymentsTable.tsx
+++ b/src/app/admin/components/Deployments/DeploymentsTable.tsx
@@ -271,7 +271,7 @@ export function DeploymentsTable() {
                   <TableCell>
                     {deployment.owned_by_user_id ? (
                       <Link
-                        href={`/admin/users/${deployment.owned_by_user_id}`}
+                        href={`/admin/users/${encodeURIComponent(deployment.owned_by_user_id)}`}
                         className="text-blue-600 hover:underline"
                         onClick={e => e.stopPropagation()}
                       >

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1338,7 +1338,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               <User className="text-muted-foreground h-4 w-4 shrink-0" />
               <DetailField label="User">
                 <Link
-                  href={`/admin/users/${data.user_id}`}
+                  href={`/admin/users/${encodeURIComponent(data.user_id)}`}
                   className="text-blue-600 hover:underline"
                 >
                   {data.user_email ?? data.user_id}

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -522,7 +522,7 @@ export function KiloclawInstancesPage() {
                 >
                   <TableCell>
                     <Link
-                      href={`/admin/users/${instance.user_id}`}
+                      href={`/admin/users/${encodeURIComponent(instance.user_id)}`}
                       className="text-blue-600 hover:underline"
                       onClick={e => e.stopPropagation()}
                     >

--- a/src/app/admin/oss/page.tsx
+++ b/src/app/admin/oss/page.tsx
@@ -1188,7 +1188,7 @@ function SponsorshipsTable() {
                       {sponsorship.email ? (
                         sponsorship.kiloUserId ? (
                           <Link
-                            href={`/admin/users/${sponsorship.kiloUserId}`}
+                            href={`/admin/users/${encodeURIComponent(sponsorship.kiloUserId)}`}
                             className="text-blue-400 hover:underline"
                           >
                             {sponsorship.email}

--- a/src/components/organizations/OrganizationMembersCard.tsx
+++ b/src/components/organizations/OrganizationMembersCard.tsx
@@ -440,7 +440,7 @@ export function OrganizationAdminMembers({
                             {member.status === 'active' && member.name ? (
                               showAdminLinks ? (
                                 <Link
-                                  href={`/admin/users/${member.id}`}
+                                  href={`/admin/users/${encodeURIComponent(member.id)}`}
                                   className="flex items-center gap-1 font-medium hover:underline"
                                 >
                                   {member.name}


### PR DESCRIPTION
## Summary
- OAuth user IDs contain `/` and `:` which break URL routing when used raw in link hrefs
- Added `encodeURIComponent()` to 10 admin user link locations that were missing it (KiloClaw instances, bulk credits, deployments, OSS, AppBuilder, org members)
- Several other admin pages already had correct encoding

## Test plan
- [ ] Navigate to a KiloClaw instance detail page for an OAuth/Google user and verify the user email link navigates to the correct admin user page
- [ ] Verify the instances table user links also work correctly for OAuth users