### PR TITLE
feat(gastown): add structured logging, CF log querying, and rig setup error visibility

### DIFF
--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -482,25 +482,44 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
       // Resolve credentials per-rig since each may use a different
       // GitHub App installation (platformIntegrationId).
       const baseEnvVars = request.envVars ?? {};
-      await Promise.allSettled(
+      const rigSetupResults = await Promise.allSettled(
         request.rigs.map(async rig => {
-          try {
-            const envVars = await resolveGitCredentials({
-              envVars: baseEnvVars,
-              platformIntegrationId: rig.platformIntegrationId,
-            });
-            await setupRigBrowseWorktree({
-              rigId: rig.rigId,
-              gitUrl: rig.gitUrl,
-              defaultBranch: rig.defaultBranch,
-              envVars,
-            });
-          } catch (err) {
-            const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
-            console.warn(`[runAgent] browse worktree setup failed for rig=${rig.rigId}: ${msg}`);
-          }
+          const envVars = await resolveGitCredentials({
+            envVars: baseEnvVars,
+            platformIntegrationId: rig.platformIntegrationId,
+          });
+          const hasGitToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
+          console.log(
+            `[runAgent] setting up browse worktree: rig=${rig.rigId} gitUrl=${rig.gitUrl} hasGitToken=${hasGitToken}`
+          );
+          await setupRigBrowseWorktree({
+            rigId: rig.rigId,
+            gitUrl: rig.gitUrl,
+            defaultBranch: rig.defaultBranch,
+            envVars,
+          });
+          return rig.rigId;
         })
       );
+
+      const failures = rigSetupResults
+        .map((r, i) => (r.status === 'rejected' ? { rigId: request.rigs![i].rigId, error: r.reason } : null))
+        .filter((f): f is { rigId: string; error: unknown } => f !== null);
+
+      if (failures.length > 0) {
+        for (const f of failures) {
+          const msg = f.error instanceof Error ? f.error.message : String(f.error);
+          const stack = f.error instanceof Error ? f.error.stack : undefined;
+          console.error(
+            `[runAgent] browse worktree setup FAILED for rig=${f.rigId}: ${msg}`,
+            stack ? `\n${stack}` : ''
+          );
+        }
+        console.error(
+          `[runAgent] mayor rig setup: ${failures.length}/${request.rigs.length} rigs failed. ` +
+          `Mayor will start but may not be able to browse these codebases.`
+        );
+      }
     }
 
     // Write the system prompt to AGENTS.md so the mayor AND its built-in

--- a/cloudflare-gastown/container/src/agent-runner.ts
+++ b/cloudflare-gastown/container/src/agent-runner.ts
@@ -502,9 +502,14 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
         })
       );
 
-      const failures = rigSetupResults
-        .map((r, i) => (r.status === 'rejected' ? { rigId: request.rigs![i].rigId, error: r.reason } : null))
-        .filter((f): f is { rigId: string; error: unknown } => f !== null);
+      const failures: Array<{ rigId: string; error: unknown }> = [];
+      for (let i = 0; i < rigSetupResults.length; i++) {
+        const r = rigSetupResults[i];
+        if (r.status === 'rejected') {
+          const reason: unknown = r.reason;
+          failures.push({ rigId: request.rigs[i].rigId, error: reason });
+        }
+      }
 
       if (failures.length > 0) {
         for (const f of failures) {
@@ -517,7 +522,7 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
         }
         console.error(
           `[runAgent] mayor rig setup: ${failures.length}/${request.rigs.length} rigs failed. ` +
-          `Mayor will start but may not be able to browse these codebases.`
+            `Mayor will start but may not be able to browse these codebases.`
         );
       }
     }

--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -315,6 +315,11 @@ app.post('/repos/setup', async c => {
         platformIntegrationId: req.platformIntegrationId,
       });
 
+      const hasGitToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
+      console.log(
+        `[control-server] /repos/setup: cloning rigId=${req.rigId} hasGitToken=${hasGitToken} hasPlatformIntegration=${!!req.platformIntegrationId}`
+      );
+
       const browseDir = await setupRigBrowseWorktree({
         rigId: req.rigId,
         gitUrl: req.gitUrl,
@@ -323,16 +328,17 @@ app.post('/repos/setup', async c => {
       });
       console.log(`[control-server] /repos/setup: done rigId=${req.rigId} browse=${browseDir}`);
     } catch (err) {
-      // Log as a warning, not an error — this is a best-effort background
-      // operation. The mayor and agents can still function without the
-      // browse worktree; it will be retried on the next agent dispatch.
       const message = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[control-server] /repos/setup: FAILED for rigId=${req.rigId}: ${message.split('\n')[0]}`
+      const stack = err instanceof Error ? err.stack : undefined;
+      console.error(
+        `[control-server] /repos/setup: FAILED rigId=${req.rigId} gitUrl=${req.gitUrl}: ${message}`,
+        stack ? `\n${stack}` : ''
       );
     }
   };
-  doSetup().catch(() => {});
+  doSetup().catch(err => {
+    console.error(`[control-server] /repos/setup: unhandled error rigId=${req.rigId}:`, err);
+  });
 
   return c.json({ status: 'accepted', message: 'Repo setup started' }, 202);
 });

--- a/cloudflare-gastown/docs/post-deploy-monitoring.md
+++ b/cloudflare-gastown/docs/post-deploy-monitoring.md
@@ -351,26 +351,26 @@ The `gastown_events` Analytics Engine dataset stores all lifecycle events (bead 
 
 The `gastown_events` dataset maps fields as follows:
 
-| Column  | Field              | Description                                      |
-| ------- | ------------------ | ------------------------------------------------ |
-| blob1   | event              | Event name (e.g. `bead.created`, `agent.spawned`) |
-| blob2   | userId             | User who triggered the event                     |
-| blob3   | delivery           | `http`, `trpc`, or `internal`                    |
-| blob4   | route              | HTTP route pattern (for HTTP events)             |
-| blob5   | error              | Error message (if any)                           |
-| blob6   | townId             | Town ID                                          |
-| blob7   | rigId              | Rig ID                                           |
-| blob8   | agentId            | Agent ID                                         |
-| blob9   | beadId             | Bead ID                                          |
-| blob10  | label              | Free-form label (e.g. actionsByType JSON)        |
-| blob11  | convoyId           | Convoy ID                                        |
-| blob12  | role               | Agent role (`polecat`, `refinery`, `mayor`)       |
-| blob13  | beadType           | Bead type                                        |
-| double1 | durationMs         | Duration in milliseconds                         |
-| double2 | value              | Generic numeric value                            |
-| double3 | actionsEmitted     | (reconciler_tick) actions count                  |
-| double7 | invariantViolations| (reconciler_tick) violation count                |
-| double8 | pendingEventCount  | (reconciler_tick) pending event count            |
+| Column  | Field               | Description                                       |
+| ------- | ------------------- | ------------------------------------------------- |
+| blob1   | event               | Event name (e.g. `bead.created`, `agent.spawned`) |
+| blob2   | userId              | User who triggered the event                      |
+| blob3   | delivery            | `http`, `trpc`, or `internal`                     |
+| blob4   | route               | HTTP route pattern (for HTTP events)              |
+| blob5   | error               | Error message (if any)                            |
+| blob6   | townId              | Town ID                                           |
+| blob7   | rigId               | Rig ID                                            |
+| blob8   | agentId             | Agent ID                                          |
+| blob9   | beadId              | Bead ID                                           |
+| blob10  | label               | Free-form label (e.g. actionsByType JSON)         |
+| blob11  | convoyId            | Convoy ID                                         |
+| blob12  | role                | Agent role (`polecat`, `refinery`, `mayor`)       |
+| blob13  | beadType            | Bead type                                         |
+| double1 | durationMs          | Duration in milliseconds                          |
+| double2 | value               | Generic numeric value                             |
+| double3 | actionsEmitted      | (reconciler_tick) actions count                   |
+| double7 | invariantViolations | (reconciler_tick) violation count                 |
+| double8 | pendingEventCount   | (reconciler_tick) pending event count             |
 
 ### Example AE queries
 
@@ -426,14 +426,14 @@ curl -s "$AE_API" \
 
 Worker logs now emit JSON-structured entries. Key fields available for filtering in Workers Observability:
 
-| JSON field | Description                   | Example filter                          |
-| ---------- | ----------------------------- | --------------------------------------- |
-| `source`   | Module that emitted the log   | `"Town.do"`, `"gastown-worker"`         |
-| `townId`   | Town UUID                     | `message : "townId":"<uuid>"`           |
-| `rigId`    | Rig UUID                      | `message : "rigId":"<uuid>"`            |
-| `userId`   | User UUID                     | `message : "userId":"<uuid>"`           |
-| `orgId`    | Organization UUID             | `message : "orgId":"<uuid>"`            |
-| `agentId`  | Agent UUID                    | `message : "agentId":"<uuid>"`          |
-| `level`    | `info`, `warn`, or `error`    | `message : "level":"error"`             |
+| JSON field | Description                 | Example filter                  |
+| ---------- | --------------------------- | ------------------------------- |
+| `source`   | Module that emitted the log | `"Town.do"`, `"gastown-worker"` |
+| `townId`   | Town UUID                   | `message : "townId":"<uuid>"`   |
+| `rigId`    | Rig UUID                    | `message : "rigId":"<uuid>"`    |
+| `userId`   | User UUID                   | `message : "userId":"<uuid>"`   |
+| `orgId`    | Organization UUID           | `message : "orgId":"<uuid>"`    |
+| `agentId`  | Agent UUID                  | `message : "agentId":"<uuid>"`  |
+| `level`    | `info`, `warn`, or `error`  | `message : "level":"error"`     |
 
 These fields are embedded in the `message` text as JSON, so use the `contains` operator or `:` in the dashboard query language to filter by them.

--- a/cloudflare-gastown/docs/post-deploy-monitoring.md
+++ b/cloudflare-gastown/docs/post-deploy-monitoring.md
@@ -19,6 +19,15 @@ export CF_ACCESS_CLIENT_ID="<service-token-client-id>"
 export CF_ACCESS_CLIENT_SECRET="<service-token-client-secret>"
 ```
 
+For querying Cloudflare logs and Analytics Engine, you also need:
+
+```bash
+# Cloudflare API token with Workers Observability + Analytics Engine read permissions
+export GASTOWN_CF_ANALYTICS_API_KEY="<api-token>"
+# Cloudflare account ID (found at: Workers & Pages → Overview, right sidebar)
+export CF_ACCOUNT_ID="<account-id>"
+```
+
 All `curl` commands in this document use a helper function that includes these headers:
 
 ```bash
@@ -252,3 +261,179 @@ done
 | Alarm interval        | `active (5s)` with work                 | Stuck at same `nextFireAt`            |
 | Reconciler wall clock | <100ms                                  | >500ms consistently                   |
 | Pending event count   | 0 between ticks                         | Growing (events not draining)         |
+
+## 6. Querying Cloudflare Logs (Workers Observability)
+
+Workers Observability is enabled at 100% sampling (`wrangler.jsonc` → `observability`). All `console.log/warn/error` output is indexed and searchable via the Cloudflare API. Key log lines emit structured JSON with `townId`, `rigId`, `userId`, `orgId`, and `agentId` fields for filtering.
+
+### Log Query Script
+
+The `scripts/query-logs.sh` script wraps the Workers Observability and Analytics Engine APIs:
+
+```bash
+export GASTOWN_CF_ANALYTICS_API_KEY="<api-token>"
+export CF_ACCOUNT_ID="<account-id>"
+
+# Fetch recent logs mentioning a town (last 30 min by default)
+./scripts/query-logs.sh logs <townId> [minutes]
+
+# Fetch only errors/warnings for a town
+./scripts/query-logs.sh errors <townId> [minutes]
+
+# Query Analytics Engine events for a town
+./scripts/query-logs.sh ae-events <townId> [hours]
+
+# Query reconciler tick metrics from Analytics Engine
+./scripts/query-logs.sh ae-reconciler <townId> [hours]
+```
+
+### Manual Log Queries
+
+Query the Workers Observability API directly. The structured logs use JSON format with fields like `townId`, `rigId`, `userId`, `orgId`, `agentId`:
+
+```bash
+# Search for all logs mentioning a specific town in the last hour
+curl -s "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/observability/telemetry/query" \
+  -H "Authorization: Bearer $GASTOWN_CF_ANALYTICS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "queryId": "",
+    "timeframe": { "from": '$(($(date +%s) - 3600))'000, "to": '$(date +%s)'000 },
+    "limit": 50,
+    "view": "events",
+    "parameters": {
+      "datasets": ["gastown"],
+      "calculations": [{ "operator": "count" }],
+      "filters": [
+        { "key": "message", "operation": "contains", "value": "'$TOWN_ID'", "type": "string" }
+      ],
+      "orderBy": { "value": "timestamp", "order": "desc" }
+    }
+  }' | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for ds, evts in data.get('result',{}).get('events',{}).items():
+    for e in evts:
+        ts = e.get('timestamp','')
+        msg = e.get('message','')[:200]
+        level = e.get('level','info')
+        print(f'{ts}  [{level}]  {msg}')
+"
+```
+
+### Useful search patterns
+
+Since the structured logs are JSON, you can search for specific fields:
+
+- **All errors for a town**: filter `message contains "<townId>"` + `level in ["error","warn"]`
+- **Mayor session issues**: search for `"ensureMayor"` or `"sendMayorMessage"` in message
+- **Rig configuration**: search for `"configureRig"` in message
+- **Reconciler problems**: search for `"reconciler"` + `level = "error"`
+- **Container dispatch failures**: search for `"startAgentInContainer"` + `level = "error"`
+- **Git credential issues**: search for `"git credential"` or `"refreshGitCredentials"` in message
+- **Rig repo setup failures (container)**: search for `"/repos/setup: FAILED"` or `"browse worktree setup FAILED"` — these are container-side errors logged at `error` level when git clone or worktree creation fails. Visible in Workers Observability via `$containers` log enrichment.
+- **Mayor can't see rigs**: search for `"mayor rig setup:"` to see summary of rig setup failures during mayor startup
+
+### Dashboard
+
+The Cloudflare Workers Observability dashboard provides an interactive UI for the same data:
+
+1. Go to **Workers & Pages** → select **gastown** → **Observability** → **Overview**
+2. Use the search bar with the query language: `message : "<townId>"`
+3. Filter by level: `level = "error"` or `level = "warn"`
+4. Group by invocation to see all logs from a single request
+
+## 7. Querying Analytics Engine
+
+The `gastown_events` Analytics Engine dataset stores all lifecycle events (bead status changes, agent dispatches, reconciler ticks, reviews, etc.). Unlike logs, AE data is designed for aggregation and time-series queries.
+
+### Dataset schema
+
+The `gastown_events` dataset maps fields as follows:
+
+| Column  | Field              | Description                                      |
+| ------- | ------------------ | ------------------------------------------------ |
+| blob1   | event              | Event name (e.g. `bead.created`, `agent.spawned`) |
+| blob2   | userId             | User who triggered the event                     |
+| blob3   | delivery           | `http`, `trpc`, or `internal`                    |
+| blob4   | route              | HTTP route pattern (for HTTP events)             |
+| blob5   | error              | Error message (if any)                           |
+| blob6   | townId             | Town ID                                          |
+| blob7   | rigId              | Rig ID                                           |
+| blob8   | agentId            | Agent ID                                         |
+| blob9   | beadId             | Bead ID                                          |
+| blob10  | label              | Free-form label (e.g. actionsByType JSON)        |
+| blob11  | convoyId           | Convoy ID                                        |
+| blob12  | role               | Agent role (`polecat`, `refinery`, `mayor`)       |
+| blob13  | beadType           | Bead type                                        |
+| double1 | durationMs         | Duration in milliseconds                         |
+| double2 | value              | Generic numeric value                            |
+| double3 | actionsEmitted     | (reconciler_tick) actions count                  |
+| double7 | invariantViolations| (reconciler_tick) violation count                |
+| double8 | pendingEventCount  | (reconciler_tick) pending event count            |
+
+### Example AE queries
+
+```bash
+AE_API="https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/analytics_engine/sql"
+
+# Count events by type for a town in the last hour
+curl -s "$AE_API" \
+  -H "Authorization: Bearer $GASTOWN_CF_ANALYTICS_API_KEY" \
+  -d "SELECT blob1 AS event, SUM(_sample_interval) AS count
+      FROM gastown_events
+      WHERE blob6 = '$TOWN_ID'
+        AND timestamp > NOW() - INTERVAL '1' HOUR
+      GROUP BY event ORDER BY count DESC LIMIT 20
+      FORMAT JSONCompact"
+
+# Reconciler health over the last 6 hours (5-min buckets)
+curl -s "$AE_API" \
+  -H "Authorization: Bearer $GASTOWN_CF_ANALYTICS_API_KEY" \
+  -d "SELECT
+        intDiv(toUInt32(timestamp), 300) * 300 AS t,
+        SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_wall_ms,
+        SUM(_sample_interval * double3) AS total_actions,
+        SUM(_sample_interval * double7) AS total_violations
+      FROM gastown_events
+      WHERE blob1 = 'reconciler_tick' AND blob6 = '$TOWN_ID'
+        AND timestamp > NOW() - INTERVAL '6' HOUR
+      GROUP BY t ORDER BY t
+      FORMAT JSONCompact"
+
+# Agent dispatch failures in the last day
+curl -s "$AE_API" \
+  -H "Authorization: Bearer $GASTOWN_CF_ANALYTICS_API_KEY" \
+  -d "SELECT timestamp, blob8 AS agent_id, blob12 AS role, blob5 AS error
+      FROM gastown_events
+      WHERE blob1 = 'agent.dispatch_failed' AND blob6 = '$TOWN_ID'
+        AND timestamp > NOW() - INTERVAL '1' DAY
+      ORDER BY timestamp DESC LIMIT 20
+      FORMAT JSONCompact"
+
+# Bead lifecycle for a specific town (status changes)
+curl -s "$AE_API" \
+  -H "Authorization: Bearer $GASTOWN_CF_ANALYTICS_API_KEY" \
+  -d "SELECT timestamp, blob1 AS event, blob9 AS bead_id, blob10 AS label
+      FROM gastown_events
+      WHERE blob1 LIKE 'bead.%' AND blob6 = '$TOWN_ID'
+        AND timestamp > NOW() - INTERVAL '1' HOUR
+      ORDER BY timestamp DESC LIMIT 50
+      FORMAT JSONCompact"
+```
+
+### Structured log fields
+
+Worker logs now emit JSON-structured entries. Key fields available for filtering in Workers Observability:
+
+| JSON field | Description                   | Example filter                          |
+| ---------- | ----------------------------- | --------------------------------------- |
+| `source`   | Module that emitted the log   | `"Town.do"`, `"gastown-worker"`         |
+| `townId`   | Town UUID                     | `message : "townId":"<uuid>"`           |
+| `rigId`    | Rig UUID                      | `message : "rigId":"<uuid>"`            |
+| `userId`   | User UUID                     | `message : "userId":"<uuid>"`           |
+| `orgId`    | Organization UUID             | `message : "orgId":"<uuid>"`            |
+| `agentId`  | Agent UUID                    | `message : "agentId":"<uuid>"`          |
+| `level`    | `info`, `warn`, or `error`    | `message : "level":"error"`             |
+
+These fields are embedded in the `message` text as JSON, so use the `contains` operator or `:` in the dashboard query language to filter by them.

--- a/cloudflare-gastown/package.json
+++ b/cloudflare-gastown/package.json
@@ -35,6 +35,7 @@
     "jose": "catalog:",
     "jsonwebtoken": "catalog:",
     "pg": "^8.16.3",
+    "workers-tagged-logger": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/cloudflare-gastown/scripts/query-logs.sh
+++ b/cloudflare-gastown/scripts/query-logs.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+# Query Cloudflare Workers Observability logs and Analytics Engine for a gastown town.
+#
+# Usage:
+#   ./scripts/query-logs.sh <subcommand> [options]
+#
+# Subcommands:
+#   logs      <townId> [minutes]   — Fetch recent worker logs mentioning this town
+#   errors    <townId> [minutes]   — Fetch recent errors/warnings for this town
+#   ae-events <townId> [hours]     — Query Analytics Engine events for this town
+#   ae-reconciler <townId> [hours] — Query reconciler tick metrics from Analytics Engine
+#
+# Required environment variables:
+#   GASTOWN_CF_ANALYTICS_API_KEY  — Cloudflare API token with Workers Observability + AE read
+#   CF_ACCOUNT_ID                 — Cloudflare account ID (auto-detected from wrangler if absent)
+#
+# Optional:
+#   GASTOWN_SCRIPT_NAME           — Worker script name (default: "gastown")
+
+set -euo pipefail
+
+SCRIPT_NAME="${GASTOWN_SCRIPT_NAME:-gastown}"
+
+# ── Resolve account ID ──────────────────────────────────────────────────
+if [ -z "${CF_ACCOUNT_ID:-}" ]; then
+  # Try to extract from wrangler whoami or fall back to prompting
+  echo "Error: CF_ACCOUNT_ID must be set."
+  echo "Find it at: https://dash.cloudflare.com → Workers & Pages → Overview (right sidebar)"
+  exit 1
+fi
+
+if [ -z "${GASTOWN_CF_ANALYTICS_API_KEY:-}" ]; then
+  echo "Error: GASTOWN_CF_ANALYTICS_API_KEY must be set."
+  echo "Create a token at https://dash.cloudflare.com/profile/api-tokens with:"
+  echo "  - Account > Workers Observability > Read"
+  echo "  - Account > Analytics > Read"
+  exit 1
+fi
+
+API_KEY="$GASTOWN_CF_ANALYTICS_API_KEY"
+ACCOUNT="$CF_ACCOUNT_ID"
+
+# ── Workers Observability query helper ──────────────────────────────────
+# Uses the telemetry/query API to search structured logs.
+# Docs: https://developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/query/
+query_observability() {
+  local body="$1"
+  curl -s "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/workers/observability/telemetry/query" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "$body"
+}
+
+# ── Analytics Engine SQL helper ─────────────────────────────────────────
+# Docs: https://developers.cloudflare.com/analytics/analytics-engine/sql-api
+query_ae() {
+  local sql="$1"
+  curl -s "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/analytics_engine/sql" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -d "$sql"
+}
+
+# ── Subcommands ─────────────────────────────────────────────────────────
+
+cmd_logs() {
+  local town_id="$1"
+  local minutes="${2:-30}"
+  local now_ms=$(date +%s)000
+  local from_ms=$(( ($(date +%s) - minutes * 60) ))000
+
+  echo "Fetching logs for town=${town_id} (last ${minutes}m)..."
+  echo ""
+
+  query_observability "$(cat <<EOF
+{
+  "queryId": "",
+  "timeframe": { "from": ${from_ms}, "to": ${now_ms} },
+  "limit": 100,
+  "view": "events",
+  "parameters": {
+    "datasets": ["${SCRIPT_NAME}"],
+    "calculations": [{ "operator": "count" }],
+    "filters": [
+      {
+        "key": "message",
+        "operation": "contains",
+        "value": "${town_id}",
+        "type": "string"
+      }
+    ],
+    "orderBy": { "value": "timestamp", "order": "desc" }
+  }
+}
+EOF
+)" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except:
+    print('[ERROR] Failed to parse response')
+    sys.exit(1)
+
+if data.get('errors'):
+    for e in data['errors']:
+        print(f'[API ERROR] {e.get(\"message\", e)}')
+    sys.exit(1)
+
+events = data.get('result', {}).get('events', {})
+for dataset_name, event_list in events.items():
+    for event in event_list:
+        ts = event.get('timestamp', '')
+        msg = event.get('message', '')
+        level = event.get('level', 'info')
+        # Format timestamp
+        if isinstance(ts, (int, float)):
+            from datetime import datetime, timezone
+            ts = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime('%H:%M:%S')
+        marker = '!!' if level in ('error', 'warn') else '  '
+        print(f'{ts} {marker} {msg[:200]}')
+
+if not any(events.values()):
+    print('(no logs found)')
+" 2>/dev/null
+}
+
+cmd_errors() {
+  local town_id="$1"
+  local minutes="${2:-60}"
+  local now_ms=$(date +%s)000
+  local from_ms=$(( ($(date +%s) - minutes * 60) ))000
+
+  echo "Fetching errors/warnings for town=${town_id} (last ${minutes}m)..."
+  echo ""
+
+  query_observability "$(cat <<EOF
+{
+  "queryId": "",
+  "timeframe": { "from": ${from_ms}, "to": ${now_ms} },
+  "limit": 50,
+  "view": "events",
+  "parameters": {
+    "datasets": ["${SCRIPT_NAME}"],
+    "calculations": [{ "operator": "count" }],
+    "filters": [
+      {
+        "key": "message",
+        "operation": "contains",
+        "value": "${town_id}",
+        "type": "string"
+      },
+      {
+        "key": "level",
+        "operation": "in",
+        "value": ["error", "warn"],
+        "type": "string"
+      }
+    ],
+    "orderBy": { "value": "timestamp", "order": "desc" }
+  }
+}
+EOF
+)" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except:
+    print('[ERROR] Failed to parse response')
+    sys.exit(1)
+
+if data.get('errors'):
+    for e in data['errors']:
+        print(f'[API ERROR] {e.get(\"message\", e)}')
+    sys.exit(1)
+
+events = data.get('result', {}).get('events', {})
+for dataset_name, event_list in events.items():
+    for event in event_list:
+        ts = event.get('timestamp', '')
+        msg = event.get('message', '')
+        level = event.get('level', 'info')
+        if isinstance(ts, (int, float)):
+            from datetime import datetime, timezone
+            ts = datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime('%H:%M:%S')
+        print(f'{ts} [{level:5s}] {msg[:200]}')
+
+if not any(events.values()):
+    print('(no errors/warnings found)')
+" 2>/dev/null
+}
+
+cmd_ae_events() {
+  local town_id="$1"
+  local hours="${2:-1}"
+
+  echo "Analytics Engine: events for town=${town_id} (last ${hours}h)..."
+  echo ""
+  echo "  blob1=event  blob2=userId  blob6=townId  blob7=rigId"
+  echo "  blob8=agentId  blob10=label  blob12=role  double1=durationMs"
+  echo ""
+
+  # The gastown_events dataset uses:
+  #   blob1=event, blob2=userId, blob6=townId, blob7=rigId,
+  #   blob8=agentId, blob9=beadId, blob10=label, blob12=role
+  #   double1=durationMs, double2=value
+  query_ae "
+    SELECT
+      timestamp,
+      blob1 AS event,
+      blob2 AS user_id,
+      blob7 AS rig_id,
+      blob8 AS agent_id,
+      blob12 AS role,
+      double1 AS duration_ms,
+      blob10 AS label
+    FROM gastown_events
+    WHERE blob6 = '${town_id}'
+      AND timestamp > NOW() - INTERVAL '${hours}' HOUR
+    ORDER BY timestamp DESC
+    LIMIT 50
+    FORMAT JSONCompact
+  " | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except:
+    print('[ERROR] Failed to parse AE response. Raw:')
+    sys.exit(1)
+
+rows = data.get('data', [])
+cols = [c.get('name','') for c in data.get('meta', [])]
+if not rows:
+    print('(no events found)')
+    sys.exit(0)
+
+for row in rows:
+    d = dict(zip(cols, row))
+    ts = d.get('timestamp','')[:19]
+    evt = d.get('event','')
+    role = d.get('role','')
+    dur = d.get('duration_ms','')
+    label = d.get('label','')[:60]
+    agent = d.get('agent_id','')[:8]
+    parts = [ts, evt]
+    if role: parts.append(f'role={role}')
+    if agent: parts.append(f'agent={agent}')
+    if dur and float(dur) > 0: parts.append(f'{float(dur):.0f}ms')
+    if label: parts.append(label)
+    print('  '.join(parts))
+" 2>/dev/null
+}
+
+cmd_ae_reconciler() {
+  local town_id="$1"
+  local hours="${2:-1}"
+
+  echo "Analytics Engine: reconciler ticks for town=${town_id} (last ${hours}h)..."
+  echo ""
+
+  # reconciler_tick events use:
+  #   double1=wallClockMs, double2=eventsDrained (stored in 'value'),
+  #   double3=actionsEmitted, double7=invariantViolations,
+  #   double8=pendingEventCount, blob10=actionsByType JSON
+  query_ae "
+    SELECT
+      timestamp,
+      SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_wall_ms,
+      SUM(_sample_interval * double2) AS total_events_drained,
+      SUM(_sample_interval * double3) AS total_actions,
+      SUM(_sample_interval * double7) AS total_violations,
+      MAX(double8) AS max_pending
+    FROM gastown_events
+    WHERE blob1 = 'reconciler_tick'
+      AND blob6 = '${town_id}'
+      AND timestamp > NOW() - INTERVAL '${hours}' HOUR
+    GROUP BY intDiv(toUInt32(timestamp), 300) * 300
+    ORDER BY timestamp DESC
+    LIMIT 20
+    FORMAT JSONCompact
+  " | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except:
+    print('[ERROR] Failed to parse AE response')
+    sys.exit(1)
+
+rows = data.get('data', [])
+if not rows:
+    print('(no reconciler ticks found)')
+    sys.exit(0)
+
+print(f'{\"time\":>10s}  {\"avgMs\":>6s}  {\"events\":>7s}  {\"actions\":>8s}  {\"violat\":>7s}  {\"pending\":>8s}')
+print('-' * 60)
+cols = [c.get('name','') for c in data.get('meta', [])]
+for row in rows:
+    d = dict(zip(cols, row))
+    ts = d.get('timestamp','')
+    if isinstance(ts, str) and len(ts) > 19:
+        ts = ts[11:19]
+    print(f'{str(ts):>10s}  {float(d.get(\"avg_wall_ms\",0)):6.1f}  {float(d.get(\"total_events_drained\",0)):7.0f}  {float(d.get(\"total_actions\",0)):8.0f}  {float(d.get(\"total_violations\",0)):7.0f}  {float(d.get(\"max_pending\",0)):8.0f}')
+" 2>/dev/null
+}
+
+# ── Dispatch ────────────────────────────────────────────────────────────
+
+case "${1:-help}" in
+  logs)
+    [ -z "${2:-}" ] && echo "Usage: $0 logs <townId> [minutes]" && exit 1
+    cmd_logs "$2" "${3:-30}"
+    ;;
+  errors)
+    [ -z "${2:-}" ] && echo "Usage: $0 errors <townId> [minutes]" && exit 1
+    cmd_errors "$2" "${3:-60}"
+    ;;
+  ae-events)
+    [ -z "${2:-}" ] && echo "Usage: $0 ae-events <townId> [hours]" && exit 1
+    cmd_ae_events "$2" "${3:-1}"
+    ;;
+  ae-reconciler)
+    [ -z "${2:-}" ] && echo "Usage: $0 ae-reconciler <townId> [hours]" && exit 1
+    cmd_ae_reconciler "$2" "${3:-1}"
+    ;;
+  *)
+    echo "Usage: $0 <subcommand> [options]"
+    echo ""
+    echo "Subcommands:"
+    echo "  logs           <townId> [minutes]  — Recent worker logs (default: 30m)"
+    echo "  errors         <townId> [minutes]  — Recent errors/warnings (default: 60m)"
+    echo "  ae-events      <townId> [hours]    — Analytics Engine events (default: 1h)"
+    echo "  ae-reconciler  <townId> [hours]    — Reconciler tick metrics (default: 1h)"
+    echo ""
+    echo "Required env vars:"
+    echo "  GASTOWN_CF_ANALYTICS_API_KEY  — CF API token (Workers Observability + AE read)"
+    echo "  CF_ACCOUNT_ID                 — Cloudflare account ID"
+    ;;
+esac

--- a/cloudflare-gastown/scripts/query-logs.sh
+++ b/cloudflare-gastown/scripts/query-logs.sh
@@ -262,7 +262,7 @@ cmd_ae_reconciler() {
   #   double8=pendingEventCount, blob10=actionsByType JSON
   query_ae "
     SELECT
-      timestamp,
+      intDiv(toUInt32(timestamp), 300) * 300 AS bucket,
       SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_wall_ms,
       SUM(_sample_interval * double2) AS total_events_drained,
       SUM(_sample_interval * double3) AS total_actions,
@@ -272,8 +272,8 @@ cmd_ae_reconciler() {
     WHERE blob1 = 'reconciler_tick'
       AND blob6 = '${town_id}'
       AND timestamp > NOW() - INTERVAL '${hours}' HOUR
-    GROUP BY intDiv(toUInt32(timestamp), 300) * 300
-    ORDER BY timestamp DESC
+    GROUP BY bucket
+    ORDER BY bucket DESC
     LIMIT 20
     FORMAT JSONCompact
   " | python3 -c "
@@ -294,9 +294,13 @@ print('-' * 60)
 cols = [c.get('name','') for c in data.get('meta', [])]
 for row in rows:
     d = dict(zip(cols, row))
-    ts = d.get('timestamp','')
-    if isinstance(ts, str) and len(ts) > 19:
-        ts = ts[11:19]
+    bucket = d.get('bucket','')
+    # bucket is a unix timestamp (seconds); convert to HH:MM:SS
+    try:
+        from datetime import datetime, timezone
+        ts = datetime.fromtimestamp(int(bucket), tz=timezone.utc).strftime('%H:%M:%S')
+    except (ValueError, TypeError, OSError):
+        ts = str(bucket)
     print(f'{str(ts):>10s}  {float(d.get(\"avg_wall_ms\",0)):6.1f}  {float(d.get(\"total_events_drained\",0)):7.0f}  {float(d.get(\"total_actions\",0)):8.0f}  {float(d.get(\"total_violations\",0)):7.0f}  {float(d.get(\"max_pending\",0)):8.0f}')
 " 2>/dev/null
 }

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -676,6 +676,12 @@ export class TownDO extends DurableObject<Env> {
   // ── Rig Config (KV, per-rig — configuration needed for container dispatch) ──
 
   async configureRig(rigConfig: RigConfig): Promise<void> {
+    return withLogTags({ source: 'Town.do', tags: { townId: this.townId } }, () =>
+      this._configureRig(rigConfig)
+    );
+  }
+
+  private async _configureRig(rigConfig: RigConfig): Promise<void> {
     logger.setTags({ rigId: rigConfig.rigId, userId: rigConfig.userId });
     logger.info('configureRig: start', { hasKilocodeToken: !!rigConfig.kilocodeToken });
     await this.ctx.storage.put(`rig:${rigConfig.rigId}:config`, rigConfig);
@@ -1846,6 +1852,19 @@ export class TownDO extends DurableObject<Env> {
     agentId: string;
     sessionStatus: 'idle' | 'active' | 'starting';
   }> {
+    return withLogTags({ source: 'Town.do', tags: { townId: this.townId } }, () =>
+      this._sendMayorMessage(message, _model, uiContext)
+    );
+  }
+
+  private async _sendMayorMessage(
+    message: string,
+    _model?: string,
+    uiContext?: string
+  ): Promise<{
+    agentId: string;
+    sessionStatus: 'idle' | 'active' | 'starting';
+  }> {
     const townId = this.townId;
 
     let mayor = agents.listAgents(this.sql, { role: 'mayor' })[0] ?? null;
@@ -1938,6 +1957,15 @@ export class TownDO extends DurableObject<Env> {
    * without requiring the user to send a message first.
    */
   async ensureMayor(): Promise<{
+    agentId: string;
+    sessionStatus: 'idle' | 'active' | 'starting';
+  }> {
+    return withLogTags({ source: 'Town.do', tags: { townId: this.townId } }, () =>
+      this._ensureMayor()
+    );
+  }
+
+  private async _ensureMayor(): Promise<{
     agentId: string;
     sessionStatus: 'idle' | 'active' | 'starting';
   }> {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -58,6 +58,7 @@ import { getAgentDOStub } from './Agent.do';
 import { getTownContainerStub } from './TownContainer.do';
 
 import { writeEvent, type GastownEventData } from '../util/analytics.util';
+import { logger, withLogTags } from '../util/log.util';
 import { BeadPriority } from '../types';
 import type {
   TownConfig,
@@ -675,15 +676,14 @@ export class TownDO extends DurableObject<Env> {
   // ── Rig Config (KV, per-rig — configuration needed for container dispatch) ──
 
   async configureRig(rigConfig: RigConfig): Promise<void> {
-    console.log(
-      `${TOWN_LOG} configureRig: rigId=${rigConfig.rigId} hasKilocodeToken=${!!rigConfig.kilocodeToken}`
-    );
+    logger.setTags({ rigId: rigConfig.rigId, userId: rigConfig.userId });
+    logger.info('configureRig: start', { hasKilocodeToken: !!rigConfig.kilocodeToken });
     await this.ctx.storage.put(`rig:${rigConfig.rigId}:config`, rigConfig);
 
     if (rigConfig.kilocodeToken) {
       const townConfig = await this.getTownConfig();
       if (!townConfig.kilocode_token || townConfig.kilocode_token !== rigConfig.kilocodeToken) {
-        console.log(`${TOWN_LOG} configureRig: propagating kilocodeToken to town config`);
+        logger.info('configureRig: propagating kilocodeToken to town config');
         await this.updateTownConfig({
           kilocode_token: rigConfig.kilocodeToken,
         });
@@ -695,13 +695,15 @@ export class TownDO extends DurableObject<Env> {
       try {
         const container = getTownContainerStub(this.env, this.townId);
         await container.setEnvVar('KILOCODE_TOKEN', token);
-        console.log(`${TOWN_LOG} configureRig: stored KILOCODE_TOKEN on TownContainerDO`);
+        logger.info('configureRig: stored KILOCODE_TOKEN on TownContainerDO');
       } catch (err) {
-        console.warn(`${TOWN_LOG} configureRig: failed to store token on container DO:`, err);
+        logger.warn('configureRig: failed to store token on container DO', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
 
-    console.log(`${TOWN_LOG} configureRig: proactively starting container`);
+    logger.info('configureRig: proactively starting container');
     await this.armAlarmIfNeeded();
     try {
       const container = getTownContainerStub(this.env, this.townId);
@@ -714,7 +716,9 @@ export class TownDO extends DurableObject<Env> {
     // the mayor has immediate access to the codebase without waiting for
     // the first agent dispatch.
     this.setupRigRepoInContainer(rigConfig).catch(err =>
-      console.warn(`${TOWN_LOG} configureRig: background repo setup failed:`, err)
+      logger.warn('configureRig: background repo setup failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
     );
   }
 
@@ -723,6 +727,7 @@ export class TownDO extends DurableObject<Env> {
    * Fire-and-forget — failures are logged but don't block the caller.
    */
   private async setupRigRepoInContainer(rigConfig: RigConfig): Promise<void> {
+    logger.setTags({ rigId: rigConfig.rigId });
     const townConfig = await this.getTownConfig();
     const envVars: Record<string, string> = {};
     if (townConfig.git_auth?.github_token) {
@@ -760,11 +765,12 @@ export class TownDO extends DurableObject<Env> {
 
     if (!response.ok) {
       const text = await response.text().catch(() => '(unreadable)');
-      console.warn(
-        `${TOWN_LOG} setupRigRepoInContainer: failed for rig=${rigConfig.rigId}: ${response.status} ${text.slice(0, 200)}`
-      );
+      logger.warn('setupRigRepoInContainer: failed', {
+        status: response.status,
+        body: text.slice(0, 200),
+      });
     } else {
-      console.log(`${TOWN_LOG} setupRigRepoInContainer: accepted for rig=${rigConfig.rigId}`);
+      logger.info('setupRigRepoInContainer: accepted');
     }
   }
 
@@ -1855,9 +1861,11 @@ export class TownDO extends DurableObject<Env> {
     const containerStatus = await dispatch.checkAgentContainerStatus(this.env, townId, mayor.id);
     const isAlive = containerStatus.status === 'running' || containerStatus.status === 'starting';
 
-    console.log(
-      `${TOWN_LOG} sendMayorMessage: townId=${townId} mayorId=${mayor.id} containerStatus=${containerStatus.status} isAlive=${isAlive}`
-    );
+    logger.setTags({ agentId: mayor.id });
+    logger.info('sendMayorMessage', {
+      containerStatus: containerStatus.status,
+      isAlive,
+    });
 
     const effectiveContext = uiContext ?? this._dashboardContext;
     const combinedMessage = effectiveContext
@@ -1874,9 +1882,14 @@ export class TownDO extends DurableObject<Env> {
       const rigConfig = await this.getMayorRigConfig();
       const kilocodeToken = await this.resolveKilocodeToken();
 
-      console.log(
-        `${TOWN_LOG} sendMayorMessage: townId=${townId} hasRigConfig=${!!rigConfig} hasKilocodeToken=${!!kilocodeToken} townConfigToken=${!!townConfig.kilocode_token} rigConfigToken=${!!rigConfig?.kilocodeToken}`
-      );
+      logger.info('sendMayorMessage: starting container', {
+        hasRigConfig: !!rigConfig,
+        hasKilocodeToken: !!kilocodeToken,
+        townConfigToken: !!townConfig.kilocode_token,
+        rigConfigToken: !!rigConfig?.kilocodeToken,
+        userId: townConfig.owner_user_id ?? rigConfig?.userId,
+        orgId: townConfig.organization_id,
+      });
 
       if (kilocodeToken) {
         try {
@@ -1938,8 +1951,10 @@ export class TownDO extends DurableObject<Env> {
         name: 'mayor',
         identity,
       });
-      console.log(`${TOWN_LOG} ensureMayor: created mayor agent ${mayor.id}`);
+      logger.info('ensureMayor: created mayor agent', { agentId: mayor.id });
     }
+
+    logger.setTags({ agentId: mayor.id });
 
     // Check if the container is already running
     const containerStatus = await dispatch.checkAgentContainerStatus(this.env, townId, mayor.id);
@@ -1960,7 +1975,10 @@ export class TownDO extends DurableObject<Env> {
     // will retry via status polling once a rig is created and the token
     // becomes available.
     if (!kilocodeToken) {
-      console.warn(`${TOWN_LOG} ensureMayor: no kilocodeToken available, deferring start`);
+      logger.warn('ensureMayor: no kilocodeToken available, deferring start', {
+        userId: townConfig.owner_user_id,
+        orgId: townConfig.organization_id,
+      });
       return { agentId: mayor.id, sessionStatus: 'idle' };
     }
 
@@ -2917,26 +2935,35 @@ export class TownDO extends DurableObject<Env> {
   // ══════════════════════════════════════════════════════════════════
 
   async alarm(): Promise<void> {
+    return withLogTags({ source: 'Town.do' }, async () => {
+      await this._alarm();
+    });
+  }
+
+  private async _alarm(): Promise<void> {
     // Exit condition: if this DO was destroyed, don't re-arm.
     // After destroy(), deleteAll() wipes storage but may not clear
     // the alarm (compat date < 2026-02-24). A resurrected alarm
     // will find no town:id — stop the loop immediately.
     const storedId = await this.ctx.storage.get<string>('town:id');
     if (!storedId) {
-      console.log(`${TOWN_LOG} alarm: no town:id — town was destroyed, not re-arming`);
+      logger.info('alarm: no town:id — town was destroyed, not re-arming');
       await this.ctx.storage.deleteAlarm();
       return;
     }
 
     const townId = this.townId;
-    console.log(`${TOWN_LOG} alarm: fired for town=${townId}`);
+    logger.setTags({ townId });
+    logger.info('alarm: fired');
 
     const hasRigs = rigs.listRigs(this.sql).length > 0;
     if (hasRigs) {
       try {
         await this.ensureContainerReady();
       } catch (err) {
-        console.warn(`${TOWN_LOG} alarm: container health check failed`, err);
+        logger.warn('alarm: container health check failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
 
       // Refresh the container-scoped JWT before any work that might
@@ -2948,7 +2975,9 @@ export class TownDO extends DurableObject<Env> {
       try {
         await this.refreshContainerToken();
       } catch (err) {
-        console.warn(`${TOWN_LOG} alarm: refreshContainerToken failed`, err);
+        logger.warn('alarm: refreshContainerToken failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
 
@@ -2991,16 +3020,18 @@ export class TownDO extends DurableObject<Env> {
               });
             }
           } catch (err) {
-            console.warn(
-              `${TOWN_LOG} alarm: container status check failed for agent=${row.bead_id}`,
-              err
-            );
+            logger.warn('alarm: container status check failed', {
+              agentId: row.bead_id,
+              error: err instanceof Error ? err.message : String(err),
+            });
           }
         });
         await Promise.allSettled(statusChecks);
       }
     } catch (err) {
-      console.error(`${TOWN_LOG} alarm: container observation failed`, err);
+      logger.error('alarm: container observation failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
     // ── Reconciler loop (Phase 0-2) with metrics ─────────────────────
@@ -3022,17 +3053,18 @@ export class TownDO extends DurableObject<Env> {
       const pending = events.drainEvents(this.sql);
       metrics.eventsDrained = pending.length;
       if (pending.length > 0) {
-        console.log(`${TOWN_LOG} [reconciler] town=${townId} draining ${pending.length} event(s)`);
+        logger.info('reconciler: draining events', { count: pending.length });
       }
       for (const event of pending) {
         try {
           reconciler.applyEvent(this.sql, event);
           events.markProcessed(this.sql, event.event_id);
         } catch (err) {
-          console.error(
-            `${TOWN_LOG} [reconciler] town=${townId} applyEvent failed: event=${event.event_id} type=${event.event_type}`,
-            err
-          );
+          logger.error('reconciler: applyEvent failed', {
+            eventId: event.event_id,
+            eventType: event.event_type,
+            error: err instanceof Error ? err.message : String(err),
+          });
           // Event stays unprocessed — will be retried on the next alarm tick.
           // Mark it processed anyway after 3 consecutive failures to prevent
           // a poison event from blocking the entire queue forever.
@@ -3040,7 +3072,9 @@ export class TownDO extends DurableObject<Env> {
         }
       }
     } catch (err) {
-      console.error(`${TOWN_LOG} [reconciler] town=${townId} event drain failed`, err);
+      logger.error('reconciler: event drain failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
       Sentry.captureException(err);
     }
 
@@ -3053,9 +3087,10 @@ export class TownDO extends DurableObject<Env> {
         metrics.actionsByType[a.type] = (metrics.actionsByType[a.type] ?? 0) + 1;
       }
       if (actions.length > 0) {
-        console.log(
-          `${TOWN_LOG} [reconciler] town=${townId} actions=${actions.length} types=${[...new Set(actions.map(a => a.type))].join(',')}`
-        );
+        logger.info('reconciler: actions computed', {
+          count: actions.length,
+          types: [...new Set(actions.map(a => a.type))].join(','),
+        });
       }
       const ctx = this.applyActionCtx;
       for (const action of actions) {
@@ -3063,14 +3098,16 @@ export class TownDO extends DurableObject<Env> {
           const effect = applyAction(ctx, action);
           if (effect) sideEffects.push(effect);
         } catch (err) {
-          console.error(
-            `${TOWN_LOG} [reconciler] town=${townId} applyAction failed: type=${action.type}`,
-            err
-          );
+          logger.error('reconciler: applyAction failed', {
+            actionType: action.type,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       }
     } catch (err) {
-      console.error(`${TOWN_LOG} [reconciler] town=${townId} reconcile failed`, err);
+      logger.error('reconciler: reconcile failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
       Sentry.captureException(err);
     }
 
@@ -3122,7 +3159,9 @@ export class TownDO extends DurableObject<Env> {
         }
       }
     } catch (err) {
-      console.warn(`${TOWN_LOG} [reconciler:invariants] town=${townId} check failed`, err);
+      logger.warn('reconciler: invariant check failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
     metrics.wallClockMs = Date.now() - reconcilerStart;
@@ -3157,23 +3196,33 @@ export class TownDO extends DurableObject<Env> {
     // ── Phase 3: Housekeeping (independent, all parallelizable) ────
     await Promise.allSettled([
       this.deliverPendingMail().catch(err =>
-        console.warn(`${TOWN_LOG} alarm: deliverPendingMail failed`, err)
+        logger.warn('alarm: deliverPendingMail failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
       ),
       this.expireStaleNudges().catch(err =>
-        console.warn(`${TOWN_LOG} alarm: expireStaleNudges failed`, err)
+        logger.warn('alarm: expireStaleNudges failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
       ),
       this.reEscalateStaleEscalations().catch(err =>
-        console.warn(`${TOWN_LOG} alarm: reEscalation failed`, err)
+        logger.warn('alarm: reEscalation failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
       ),
       this.maybeDispatchTriageAgent().catch(err =>
-        console.warn(`${TOWN_LOG} alarm: maybeDispatchTriageAgent failed`, err)
+        logger.warn('alarm: maybeDispatchTriageAgent failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
       ),
       // Prune processed reconciler events older than 7 days
       Promise.resolve().then(() => {
         try {
           events.pruneOldEvents(this.sql, 7 * 24 * 60 * 60 * 1000);
         } catch (err) {
-          console.warn(`${TOWN_LOG} alarm: event pruning failed`, err);
+          logger.warn('alarm: event pruning failed', {
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       }),
     ]);
@@ -3187,7 +3236,9 @@ export class TownDO extends DurableObject<Env> {
       const snapshot = await this.getAlarmStatus();
       this.broadcastAlarmStatus(snapshot);
     } catch (err) {
-      console.warn(`${TOWN_LOG} alarm: status broadcast failed`, err);
+      logger.warn('alarm: status broadcast failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -120,6 +120,8 @@ import { townAuthMiddleware } from './middleware/town-auth.middleware';
 import { orgAuthMiddleware } from './middleware/org-auth.middleware';
 import { adminAuditMiddleware } from './middleware/admin-audit.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
+import { logger } from './util/log.util';
+import { useWorkersLogger } from 'workers-tagged-logger/hono';
 import { handleGetTownConfig, handleUpdateTownConfig } from './handlers/town-config.handler';
 import {
   handleGetMoleculeCurrentStep,
@@ -146,20 +148,30 @@ export type GastownEnv = {
 
 const app = new Hono<GastownEnv>();
 
-const WORKER_LOG = '[gastown-worker]';
-
 // ── Timing ──────────────────────────────────────────────────────────────
 // Capture high-resolution start timestamp before any other middleware.
 app.use('*', timingMiddleware);
+
+// ── Structured logging context ──────────────────────────────────────────
+// Establishes AsyncLocalStorage context so all downstream logs are tagged.
+app.use('*', useWorkersLogger('gastown-worker'));
 
 // ── Request logging ─────────────────────────────────────────────────────
 app.use('*', async (c, next) => {
   const method = c.req.method;
   const path = c.req.path;
-  console.log(`${WORKER_LOG} --> ${method} ${path}`);
+  logger.info(`--> ${method} ${path}`);
   await next();
   const elapsed = Math.round(performance.now() - (c.get('requestStartTime') ?? 0));
-  console.log(`${WORKER_LOG} <-- ${method} ${path} ${c.res.status} (${elapsed}ms)`);
+  // After auth middleware has run, context vars are available.
+  logger.setTags({
+    townId: c.req.param('townId') || undefined,
+    rigId: c.req.param('rigId') || undefined,
+    agentId: c.req.param('agentId') || undefined,
+    userId: c.get('kiloUserId') || c.get('agentJWT')?.userId || undefined,
+    orgId: c.get('orgId') || undefined,
+  });
+  logger.info(`<-- ${method} ${path} ${c.res.status}`, { durationMs: elapsed });
 });
 
 // ── CORS ────────────────────────────────────────────────────────────────

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -122,6 +122,7 @@ import { adminAuditMiddleware } from './middleware/admin-audit.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
 import { logger } from './util/log.util';
 import { useWorkersLogger } from 'workers-tagged-logger';
+import type { MiddlewareHandler } from 'hono';
 import { handleGetTownConfig, handleUpdateTownConfig } from './handlers/town-config.handler';
 import {
   handleGetMoleculeCurrentStep,
@@ -154,23 +155,29 @@ app.use('*', timingMiddleware);
 
 // ── Structured logging context ──────────────────────────────────────────
 // Establishes AsyncLocalStorage context so all downstream logs are tagged.
-app.use('*', useWorkersLogger('gastown-worker'));
+// Cast needed: workers-tagged-logger@1.0.0 was built against an older Hono.
+app.use('*', useWorkersLogger('gastown-worker') as unknown as MiddlewareHandler);
 
 // ── Request logging ─────────────────────────────────────────────────────
 app.use('*', async (c, next) => {
   const method = c.req.method;
   const path = c.req.path;
-  logger.info(`--> ${method} ${path}`);
-  await next();
-  const elapsed = Math.round(performance.now() - (c.get('requestStartTime') ?? 0));
-  // After auth middleware has run, context vars are available.
+  // Tag with route params immediately so all downstream logs (auth,
+  // handlers, DO calls) inherit them. Auth-derived tags (userId, orgId)
+  // are added after next() since auth middleware hasn't run yet.
   logger.setTags({
     townId: c.req.param('townId') || undefined,
     rigId: c.req.param('rigId') || undefined,
     agentId: c.req.param('agentId') || undefined,
+  });
+  logger.info(`--> ${method} ${path}`);
+  await next();
+  // Auth context is now available — tag for the response log line.
+  logger.setTags({
     userId: c.get('kiloUserId') || c.get('agentJWT')?.userId || undefined,
     orgId: c.get('orgId') || undefined,
   });
+  const elapsed = Math.round(performance.now() - (c.get('requestStartTime') ?? 0));
   logger.info(`<-- ${method} ${path} ${c.res.status}`, { durationMs: elapsed });
 });
 

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -162,8 +162,12 @@ app.use('*', useWorkersLogger('gastown-worker') as unknown as MiddlewareHandler)
 // Extract IDs from the URL path directly — c.req.param() only works
 // after Hono has matched a route, which hasn't happened yet in a
 // wildcard middleware.
-const PATH_IDS =
-  /\/towns\/(?<townId>[^/]+)(?:\/rigs\/(?<rigId>[^/]+)(?:\/agents\/(?<agentId>[^/]+))?)?/;
+// Matches /orgs/:orgId, /towns/:townId, /rigs/:rigId, /agents/:agentId
+// in any combination that appears in our route patterns.
+const RE_ORG = /\/orgs\/(?<orgId>[^/]+)/;
+const RE_TOWN = /\/towns\/(?<townId>[^/]+)/;
+const RE_RIG = /\/rigs\/(?<rigId>[^/]+)/;
+const RE_AGENT = /\/agents\/(?<agentId>[^/]+)/;
 
 app.use('*', async (c, next) => {
   const method = c.req.method;
@@ -171,14 +175,12 @@ app.use('*', async (c, next) => {
   // Tag with route params immediately so all downstream logs (auth,
   // handlers, DO calls) inherit them. Auth-derived tags (userId, orgId)
   // are set by kiloAuthMiddleware and orgAuthMiddleware when they run.
-  const ids = PATH_IDS.exec(path)?.groups;
-  if (ids) {
-    logger.setTags({
-      townId: ids.townId,
-      rigId: ids.rigId,
-      agentId: ids.agentId,
-    });
-  }
+  logger.setTags({
+    orgId: RE_ORG.exec(path)?.groups?.orgId,
+    townId: RE_TOWN.exec(path)?.groups?.townId,
+    rigId: RE_RIG.exec(path)?.groups?.rigId,
+    agentId: RE_AGENT.exec(path)?.groups?.agentId,
+  });
   logger.info(`--> ${method} ${path}`);
   await next();
   const elapsed = Math.round(performance.now() - (c.get('requestStartTime') ?? 0));

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -159,17 +159,26 @@ app.use('*', timingMiddleware);
 app.use('*', useWorkersLogger('gastown-worker') as unknown as MiddlewareHandler);
 
 // ── Request logging ─────────────────────────────────────────────────────
+// Extract IDs from the URL path directly — c.req.param() only works
+// after Hono has matched a route, which hasn't happened yet in a
+// wildcard middleware.
+const PATH_IDS =
+  /\/towns\/(?<townId>[^/]+)(?:\/rigs\/(?<rigId>[^/]+)(?:\/agents\/(?<agentId>[^/]+))?)?/;
+
 app.use('*', async (c, next) => {
   const method = c.req.method;
   const path = c.req.path;
   // Tag with route params immediately so all downstream logs (auth,
   // handlers, DO calls) inherit them. Auth-derived tags (userId, orgId)
   // are set by kiloAuthMiddleware and orgAuthMiddleware when they run.
-  logger.setTags({
-    townId: c.req.param('townId') || undefined,
-    rigId: c.req.param('rigId') || undefined,
-    agentId: c.req.param('agentId') || undefined,
-  });
+  const ids = PATH_IDS.exec(path)?.groups;
+  if (ids) {
+    logger.setTags({
+      townId: ids.townId,
+      rigId: ids.rigId,
+      agentId: ids.agentId,
+    });
+  }
   logger.info(`--> ${method} ${path}`);
   await next();
   const elapsed = Math.round(performance.now() - (c.get('requestStartTime') ?? 0));

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -164,7 +164,7 @@ app.use('*', async (c, next) => {
   const path = c.req.path;
   // Tag with route params immediately so all downstream logs (auth,
   // handlers, DO calls) inherit them. Auth-derived tags (userId, orgId)
-  // are added after next() since auth middleware hasn't run yet.
+  // are set by kiloAuthMiddleware and orgAuthMiddleware when they run.
   logger.setTags({
     townId: c.req.param('townId') || undefined,
     rigId: c.req.param('rigId') || undefined,
@@ -172,11 +172,6 @@ app.use('*', async (c, next) => {
   });
   logger.info(`--> ${method} ${path}`);
   await next();
-  // Auth context is now available — tag for the response log line.
-  logger.setTags({
-    userId: c.get('kiloUserId') || c.get('agentJWT')?.userId || undefined,
-    orgId: c.get('orgId') || undefined,
-  });
   const elapsed = Math.round(performance.now() - (c.get('requestStartTime') ?? 0));
   logger.info(`<-- ${method} ${path} ${c.res.status}`, { durationMs: elapsed });
 });

--- a/cloudflare-gastown/src/gastown.worker.ts
+++ b/cloudflare-gastown/src/gastown.worker.ts
@@ -121,7 +121,7 @@ import { orgAuthMiddleware } from './middleware/org-auth.middleware';
 import { adminAuditMiddleware } from './middleware/admin-audit.middleware';
 import { timingMiddleware, instrumented } from './middleware/analytics.middleware';
 import { logger } from './util/log.util';
-import { useWorkersLogger } from 'workers-tagged-logger/hono';
+import { useWorkersLogger } from 'workers-tagged-logger';
 import { handleGetTownConfig, handleUpdateTownConfig } from './handlers/town-config.handler';
 import {
   handleGetMoleculeCurrentStep,

--- a/cloudflare-gastown/src/middleware/kilo-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/kilo-auth.middleware.ts
@@ -3,6 +3,7 @@ import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
 import { resError } from '../util/res.util';
 import type { GastownEnv } from '../gastown.worker';
 import { resolveSecret } from '../util/secret.util';
+import { logger } from '../util/log.util';
 
 /**
  * Auth middleware that validates Kilo user JWTs (signed with NEXTAUTH_SECRET).
@@ -35,6 +36,7 @@ export const kiloAuthMiddleware = createMiddleware<GastownEnv>(async (c, next) =
     c.set('kiloApiTokenPepper', payload.apiTokenPepper ?? null);
     c.set('kiloGastownAccess', payload.gastownAccess === true);
     c.set('kiloOrgMemberships', payload.orgMemberships ?? []);
+    logger.setTags({ userId: payload.kiloUserId });
   } catch (err) {
     console.warn(
       '[kilo-auth] token verification failed:',

--- a/cloudflare-gastown/src/middleware/org-auth.middleware.ts
+++ b/cloudflare-gastown/src/middleware/org-auth.middleware.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from 'hono/factory';
 import type { GastownEnv } from '../gastown.worker';
 import { resError } from '../util/res.util';
+import { logger } from '../util/log.util';
 
 /**
  * Verifies the authenticated Kilo user is a member of the org identified
@@ -24,5 +25,6 @@ export const orgAuthMiddleware = createMiddleware<GastownEnv>(async (c, next) =>
 
   c.set('orgId', orgId);
   c.set('orgRole', membership.role);
+  logger.setTags({ orgId });
   await next();
 });

--- a/cloudflare-gastown/src/util/log.util.ts
+++ b/cloudflare-gastown/src/util/log.util.ts
@@ -1,0 +1,32 @@
+/**
+ * Structured logging powered by workers-tagged-logger.
+ *
+ * Uses AsyncLocalStorage so tags (townId, rigId, userId, etc.) propagate
+ * to all downstream functions without explicit parameter passing.
+ *
+ * Setup:
+ *   - In the Hono worker: use `useWorkersLogger` middleware to establish context.
+ *   - In DOs: wrap the entry point (alarm, RPC) with `withLogTags`.
+ *   - Anywhere: call `logger.setTags({ townId })` to tag all subsequent logs.
+ *
+ * Usage:
+ *   import { logger } from '../util/log.util';
+ *   logger.info('configureRig: stored token');
+ *   logger.warn('ensureMayor: no kilocodeToken', { userId });
+ */
+
+import { WorkersLogger, withLogTags } from 'workers-tagged-logger';
+
+export type LogTags = {
+  source?: string;
+  townId?: string;
+  rigId?: string;
+  userId?: string;
+  orgId?: string;
+  agentId?: string;
+  beadId?: string;
+  convoyId?: string;
+};
+
+export const logger = new WorkersLogger<LogTags>();
+export { withLogTags };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1124,6 +1124,9 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.20.0
+      workers-tagged-logger:
+        specifier: 'catalog:'
+        version: 1.0.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -21625,7 +21628,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary

- Integrate `workers-tagged-logger` for structured JSON logging with AsyncLocalStorage-based tag propagation. All logs from HTTP requests (via Hono middleware) and DO alarm ticks (via `withLogTags` wrapper) are automatically tagged with `townId`, `rigId`, `userId`, `orgId`, `agentId` — making them filterable in Cloudflare Workers Observability.
- Add `scripts/query-logs.sh` CLI tool for querying Workers Observability logs and Analytics Engine data by town ID. Supports `logs`, `errors`, `ae-events`, and `ae-reconciler` subcommands.
- Expand `docs/post-deploy-monitoring.md` with new sections covering CF log queries, Analytics Engine dataset schema, example SQL queries, and search patterns for common debugging scenarios.
- Fix silent error swallowing in container rig setup paths (`/repos/setup` handler and mayor `runAgent` browse worktree setup). Failures are now logged at `console.error` with full stack traces instead of being silently dropped via `console.warn` or `.catch(() => {})`. This addresses a bug where customers adding a rig via manual URL + manual git token see the mayor fail to connect to rigs with no visibility into why.

## Verification

- Reviewed all modified files for correctness
- Could not run `pnpm typecheck` or tests in this session (node/pnpm not in shell PATH) — please verify CI passes

## Visual Changes

N/A

## Reviewer Notes

- The `workers-tagged-logger` migration covers the critical paths (alarm loop, mayor session, rig configuration, request logging). Remaining `console.log` calls with `TOWN_LOG` prefix in non-critical paths still work but aren't JSON-structured — can be migrated incrementally.
- The `alarm()` method is split into `alarm()` (thin `withLogTags` wrapper) and `_alarm()` (actual logic) to establish the AsyncLocalStorage context for DO alarm ticks.
- Container-side changes (`agent-runner.ts`, `control-server.ts`) upgrade rig setup error logging from `console.warn` to `console.error` with full stack traces. The `doSetup().catch(() => {})` in `/repos/setup` is replaced with an error-logging catch handler.
- `scripts/query-logs.sh` requires `GASTOWN_CF_ANALYTICS_API_KEY` and `CF_ACCOUNT_ID` env vars — documented in the updated monitoring doc.