### PR TITLE
fix(cloud-agent): surface setup stderr during preparation

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -51,7 +51,12 @@ import {
   type IngestDOContext,
 } from '../websocket/ingest.js';
 import type { StoredEvent } from '../websocket/types.js';
-import type { WrapperCommand, PreparingStep, CloudStatusData } from '../shared/protocol.js';
+import type {
+  WrapperCommand,
+  PreparingEventData,
+  PreparingStep,
+  CloudStatusData,
+} from '../shared/protocol.js';
 import { STALE_THRESHOLD_MS, SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
 import { ExecutionOrchestrator, type OrchestratorDeps } from '../execution/orchestrator.js';
 import type {
@@ -70,7 +75,7 @@ import { GitHubTokenService } from '../services/github-token-service.js';
 import { validateStreamTicket } from '../auth.js';
 import { getSandbox } from '@cloudflare/sandbox';
 import { stopWrapper } from '../kilo/wrapper-manager.js';
-import { SessionService } from '../session-service.js';
+import { SessionService, SetupCommandFailedError } from '../session-service.js';
 import { executePreparationSteps } from './async-preparation.js';
 
 // ---------------------------------------------------------------------------
@@ -945,23 +950,25 @@ export class CloudAgentSession extends DurableObject {
     const prepExecutionId: EventSourceId = `prep_${input.sessionId}`;
     const env = this.env as unknown as WorkerEnv;
 
-    const emitProgress = (step: PreparingStep, message: string) => {
+    const emitProgress = (event: PreparingEventData) => {
       const now = Date.now();
-      // Backward-compatible preparing event
       this.broadcastVolatileEvent({
         executionId: prepExecutionId,
         sessionId: input.sessionId,
         streamEventType: 'preparing',
-        payload: JSON.stringify({ step, message }),
+        payload: JSON.stringify(event),
         timestamp: now,
       });
-      // cloud.status event derived from preparation step
       const cloudStatus =
-        step === 'ready'
+        event.step === 'ready'
           ? { type: 'ready' as const }
-          : step === 'failed'
-            ? { type: 'error' as const, message }
-            : { type: 'preparing' as const, step, message };
+          : event.step === 'failed'
+            ? {
+                type: 'error' as const,
+                message: event.message,
+                ...(event.stderr ? { stderr: event.stderr } : {}),
+              }
+            : { type: 'preparing' as const, step: event.step, message: event.message };
       this.broadcastVolatileEvent({
         executionId: prepExecutionId,
         sessionId: input.sessionId,
@@ -969,6 +976,10 @@ export class CloudAgentSession extends DurableObject {
         payload: JSON.stringify({ cloudStatus }),
         timestamp: now,
       });
+    };
+
+    const emitPreparingStep = (step: PreparingStep, message: string) => {
+      emitProgress({ step, message });
     };
 
     let createdKiloSessionId: string | undefined = input.kiloSessionId;
@@ -992,7 +1003,7 @@ export class CloudAgentSession extends DurableObject {
 
     try {
       // Steps 1–9: workspace orchestration (token, disk, clone, branch, setup, wrapper)
-      const result = await executePreparationSteps(input, env, emitProgress);
+      const result = await executePreparationSteps(input, env, emitPreparingStep);
       if (!result) {
         // executePreparationSteps already emitted 'failed' — clean up DO metadata
         await this.ctx.storage.delete('metadata');
@@ -1040,7 +1051,7 @@ export class CloudAgentSession extends DurableObject {
       });
 
       if (!prepareResult.success) {
-        emitProgress('failed', prepareResult.error ?? 'Failed to prepare session');
+        emitPreparingStep('failed', prepareResult.error ?? 'Failed to prepare session');
         await this.ctx.storage.delete('metadata');
         await cleanupCliSession();
         return;
@@ -1073,13 +1084,13 @@ export class CloudAgentSession extends DurableObject {
             await this.ctx.storage.put('metadata', { ...rest, version: Date.now() });
           }
 
-          emitProgress('failed', `Auto-initiate failed: ${initiateResult.error}`);
+          emitPreparingStep('failed', `Auto-initiate failed: ${initiateResult.error}`);
           return;
         }
       }
 
       // 12. Emit ready — session is prepared (and initiated, if autoInitiate)
-      emitProgress('ready', 'Session ready');
+      emitPreparingStep('ready', 'Session ready');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger
@@ -1092,7 +1103,11 @@ export class CloudAgentSession extends DurableObject {
 
       await cleanupCliSession();
 
-      emitProgress('failed', message);
+      emitProgress({
+        step: 'failed',
+        message,
+        ...(error instanceof SetupCommandFailedError ? { stderr: error.stderr } : {}),
+      });
       await this.ctx.storage.delete('metadata');
     }
   }

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -107,6 +107,7 @@ export type PreparingStep =
 export type PreparingEventData = {
   step: PreparingStep;
   message: string;
+  stderr?: string;
 };
 
 /** Cloud infrastructure status types. */
@@ -118,6 +119,7 @@ export type CloudStatusData = {
     type: CloudStatusType;
     step?: string;
     message?: string;
+    stderr?: string;
   };
 };
 

--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -242,7 +242,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
 
   const placeholder = isLoading
     ? 'Loading session…'
-    : cloudStatus?.type === 'preparing'
+    : cloudStatus?.type === 'preparing' && cloudStatus.step !== 'failed'
       ? 'Setting up environment…'
       : cloudStatus?.type === 'finalizing'
         ? 'Wrapping up…'

--- a/src/components/cloud-agent-next/SessionStatusIndicator.tsx
+++ b/src/components/cloud-agent-next/SessionStatusIndicator.tsx
@@ -1,11 +1,14 @@
-import { AlertCircle, Check } from 'lucide-react';
 import type { SessionStatusIndicator as SessionStatusIndicatorType } from '@/lib/cloud-agent-sdk';
 import { StatusSpinner } from './StatusSpinner';
+import { AlertCircle, Check, ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 export function SessionStatusIndicator({ indicator }: { indicator: SessionStatusIndicatorType }) {
   return (
     <div className="flex items-center gap-2 py-2 text-xs">
-      <IndicatorContent indicator={indicator} />
+      <div className="min-w-0 flex-1">
+        <IndicatorContent indicator={indicator} />
+      </div>
     </div>
   );
 }
@@ -13,6 +16,10 @@ export function SessionStatusIndicator({ indicator }: { indicator: SessionStatus
 function IndicatorContent({ indicator }: { indicator: SessionStatusIndicatorType }) {
   switch (indicator.type) {
     case 'error':
+      if (indicator.stderr) {
+        return <ErrorIndicatorWithDetails message={indicator.message} stderr={indicator.stderr} />;
+      }
+
       return (
         <span className="text-destructive flex items-center gap-2">
           <AlertCircle className="h-3 w-3 shrink-0" />
@@ -41,4 +48,26 @@ function IndicatorContent({ indicator }: { indicator: SessionStatusIndicatorType
         </span>
       );
   }
+}
+
+function ErrorIndicatorWithDetails({ message, stderr }: { message: string; stderr: string }) {
+  return (
+    <details className="bg-destructive/5 border-destructive/20 w-full min-w-0 rounded-md border">
+      <summary className="text-destructive flex cursor-pointer list-none items-center gap-2 px-3 py-2">
+        <AlertCircle className="h-3 w-3 shrink-0" />
+        <span className="min-w-0 flex-1">{message}</span>
+        <span className="text-muted-foreground text-[11px]">Details</span>
+        <ChevronDown
+          className={cn(
+            'text-muted-foreground h-3 w-3 shrink-0 transition-transform [[open]>&]:rotate-180'
+          )}
+        />
+      </summary>
+      <div className="border-destructive/15 border-t px-3 py-2">
+        <pre className="text-foreground max-h-52 overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-4">
+          {stderr}
+        </pre>
+      </div>
+    </details>
+  );
 }

--- a/src/components/cloud-agent-next/store/atoms.ts
+++ b/src/components/cloud-agent-next/store/atoms.ts
@@ -211,14 +211,6 @@ export const clearStandaloneQuestionAtom = atom(null, (get, set, resolvedRequest
   }
 });
 
-export type SessionStatusIndicator = {
-  type: 'error' | 'warning' | 'info' | 'progress';
-  message: string;
-  timestamp: number;
-};
-
-export const sessionStatusIndicatorAtom = atom<SessionStatusIndicator | null>(null);
-
 export const currentSessionIdAtom = atom<string | null>(null);
 export const sessionOrganizationIdAtom = atom<string | null>(null);
 export const sessionConfigAtom = atom<SessionConfig | null>(null);
@@ -240,7 +232,6 @@ export const clearMessagesAtom = atom(null, (get, set) => {
   set(errorAtom, null);
   set(isStreamingAtom, false);
   set(questionRequestIdsAtom, new Map());
-  set(sessionStatusIndicatorAtom, null);
   set(standaloneQuestionAtom, null);
   set(sessionParentsAtom, new Map());
 });

--- a/src/lib/cloud-agent-sdk/normalizer.test.ts
+++ b/src/lib/cloud-agent-sdk/normalizer.test.ts
@@ -823,6 +823,22 @@ describe('normalize', () => {
       });
     });
 
+    it('normalizes failed preparing event with stderr', () => {
+      const result = normalize(
+        createRaw('preparing', {
+          step: 'failed',
+          message: 'Setup command failed',
+          stderr: 'npm ERR! missing script: build',
+        })
+      );
+      expect(result).toEqual({
+        type: 'preparing',
+        step: 'failed',
+        message: 'Setup command failed',
+        stderr: 'npm ERR! missing script: build',
+      });
+    });
+
     it('returns null when step is missing', () => {
       expect(normalize(createRaw('preparing', { message: 'Cloning repository...' }))).toBeNull();
     });

--- a/src/lib/cloud-agent-sdk/normalizer.ts
+++ b/src/lib/cloud-agent-sdk/normalizer.ts
@@ -82,7 +82,7 @@ export type ServiceEvent =
       branch?: string;
     }
   | { type: 'warning' }
-  | { type: 'preparing'; step: string; message: string }
+  | { type: 'preparing'; step: string; message: string; stderr?: string }
   | { type: 'autocommit_started'; messageId: string; message?: string }
   | {
       type: 'autocommit_completed';
@@ -292,7 +292,12 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
     case 'preparing': {
       const r = preparingDataSchema.safeParse(data);
       if (!r.success) return null;
-      return { type: 'preparing', step: r.data.step, message: r.data.message };
+      return {
+        type: 'preparing',
+        step: r.data.step,
+        message: r.data.message,
+        stderr: r.data.stderr,
+      };
     }
 
     case 'autocommit_started': {

--- a/src/lib/cloud-agent-sdk/schemas.ts
+++ b/src/lib/cloud-agent-sdk/schemas.ts
@@ -56,7 +56,7 @@ export const cloudStatusSchema = z.discriminatedUnion('type', [
     step: z.string().optional(),
     message: z.string().optional(),
   }),
-  z.object({ type: z.literal('error'), message: z.string() }),
+  z.object({ type: z.literal('error'), message: z.string(), stderr: z.string().optional() }),
 ]);
 export type CloudStatus = z.infer<typeof cloudStatusSchema>;
 
@@ -259,6 +259,7 @@ export type WrapperDisconnectedData = z.infer<typeof wrapperDisconnectedDataSche
 export const preparingDataSchema = z.object({
   step: z.string(),
   message: z.string(),
+  stderr: z.string().optional(),
 });
 export type PreparingData = z.infer<typeof preparingDataSchema>;
 

--- a/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -460,16 +460,29 @@ describe('createServiceState', () => {
       expect(onPreparationReady).toHaveBeenCalledTimes(1);
     });
 
-    it('step failed fires onPreparationFailed and onError, sets cloudStatus to error', () => {
+    it('step failed preserves preparing cloudStatus and passes stderr to callback', () => {
       const onPreparationFailed = jest.fn();
       const onError = jest.fn();
       const state = createServiceState(makeConfig({ onPreparationFailed, onError }));
 
-      state.process({ type: 'preparing', step: 'failed', message: 'Clone failed' });
+      state.process({
+        type: 'preparing',
+        step: 'failed',
+        message: 'Clone failed',
+        stderr: 'fatal: repository not found',
+      });
 
-      expect(state.getCloudStatus()).toEqual({ type: 'error', message: 'Clone failed' });
+      expect(state.getCloudStatus()).toEqual({
+        type: 'preparing',
+        step: 'failed',
+        message: 'Clone failed',
+        stderr: 'fatal: repository not found',
+      });
       expect(onError).toHaveBeenCalledWith('Clone failed');
-      expect(onPreparationFailed).toHaveBeenCalledWith('Clone failed');
+      expect(onPreparationFailed).toHaveBeenCalledWith(
+        'Clone failed',
+        'fatal: repository not found'
+      );
     });
   });
 

--- a/src/lib/cloud-agent-sdk/service-state.ts
+++ b/src/lib/cloud-agent-sdk/service-state.ts
@@ -37,7 +37,7 @@ type ServiceStateConfig = {
   /** Fired when async preparation completes (preparing step === 'ready'). */
   onPreparationReady?: () => void;
   /** Fired when async preparation fails (preparing step === 'failed'). */
-  onPreparationFailed?: (message: string) => void;
+  onPreparationFailed?: (message: string, stderr?: string) => void;
 };
 
 type ServiceState = {
@@ -203,11 +203,20 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       cloudStatus = { type: 'ready' };
       config.onPreparationReady?.();
     } else if (event.step === 'failed') {
-      cloudStatus = { type: 'error', message: event.message };
+      cloudStatus = {
+        type: 'preparing',
+        step: event.step,
+        message: event.message,
+        stderr: event.stderr,
+      };
       config.onError?.(event.message);
-      config.onPreparationFailed?.(event.message);
+      config.onPreparationFailed?.(event.message, event.stderr);
     } else {
-      cloudStatus = { type: 'preparing', step: event.step, message: event.message };
+      cloudStatus = {
+        type: 'preparing',
+        step: event.step,
+        message: event.message,
+      };
     }
     notify();
   }

--- a/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -6,6 +6,7 @@ import {
   type FetchedSessionData,
 } from './session-manager';
 import { createCloudAgentSession } from './session';
+import type { CloudStatus } from './types';
 import { kiloId, cloudAgentId } from './test-helpers';
 
 // ---------------------------------------------------------------------------
@@ -24,10 +25,12 @@ const mockSession = {
   canSend: true,
   canInterrupt: true,
   state: {
-    subscribe: jest.fn(() => () => {}),
+    subscribe: jest.fn((_cb: () => void) => () => {}),
     getActivity: jest.fn(() => ({ type: 'idle' as const })),
     getStatus: jest.fn(() => ({ type: 'idle' as const })),
+    getCloudStatus: jest.fn((): CloudStatus | null => null),
     getQuestion: jest.fn(() => null),
+    getPermission: jest.fn(() => null),
     getSessionInfo: jest.fn(() => null),
   },
   storage: {},
@@ -129,7 +132,13 @@ describe('createSessionManager', () => {
     mockSession.respondToPermission.mockClear();
     mockSession.canSend = true;
     mockSession.canInterrupt = true;
-    mockSession.state.subscribe.mockImplementation(() => () => {});
+    mockSession.state.subscribe.mockImplementation((_cb: () => void) => () => {});
+    mockSession.state.getActivity.mockImplementation(() => ({ type: 'idle' as const }));
+    mockSession.state.getStatus.mockImplementation(() => ({ type: 'idle' as const }));
+    mockSession.state.getQuestion.mockImplementation(() => null);
+    mockSession.state.getSessionInfo.mockImplementation(() => null);
+    mockSession.state.getPermission = jest.fn(() => null);
+    mockSession.state.getCloudStatus = jest.fn(() => null);
     mockSessionCallbacks.onQuestionAsked = undefined;
     mockSessionCallbacks.onQuestionResolved = undefined;
     mockSessionCallbacks.onPermissionAsked = undefined;
@@ -805,6 +814,40 @@ describe('createSessionManager', () => {
       expect(
         atomValue<{ type: string; message: string } | null>(config.store, mgr.atoms.statusIndicator)
       ).toBeNull();
+    });
+  });
+
+  describe('status indicator stderr propagation', () => {
+    it('shows stderr details for failed preparing cloud status', async () => {
+      const listeners: Array<() => void> = [];
+      let cloudStatus: CloudStatus | null = null;
+
+      mockSession.state.subscribe.mockImplementation((cb: () => void) => {
+        listeners.push(cb);
+        return () => {};
+      });
+      mockSession.state.getCloudStatus = jest.fn(() => cloudStatus);
+
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      cloudStatus = {
+        type: 'preparing',
+        step: 'failed',
+        message: 'Setup command failed',
+        stderr: 'npm ERR! missing script: build',
+      };
+      listeners.at(-1)?.();
+
+      expect(atomValue(config.store, mgr.atoms.statusIndicator)).toEqual(
+        expect.objectContaining({
+          type: 'error',
+          message: 'Setup command failed',
+          stderr: 'npm ERR! missing script: build',
+        })
+      );
     });
   });
 

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -31,6 +31,7 @@ type StoredMessage = { info: MessageInfo; parts: Part[] };
 type SessionStatusIndicator = {
   type: 'error' | 'warning' | 'info' | 'progress';
   message: string;
+  stderr?: string;
   timestamp: number;
 };
 type SessionConfig = {
@@ -190,13 +191,21 @@ function isMessageStreaming(msg: StoredMessage): boolean {
 function indicatorForCloudStatus(cs: CloudStatus): SessionStatusIndicator | null {
   const now = Date.now();
   if (cs.type === 'preparing') {
+    if (cs.step === 'failed') {
+      return {
+        type: 'error',
+        message: cs.message ?? 'Setting up environment failed',
+        stderr: cs.stderr,
+        timestamp: now,
+      };
+    }
     return { type: 'progress', message: cs.message ?? 'Setting up environment…', timestamp: now };
   }
   if (cs.type === 'finalizing') {
     return { type: 'progress', message: cs.message ?? 'Wrapping up…', timestamp: now };
   }
   if (cs.type === 'error') {
-    return { type: 'error', message: cs.message, timestamp: now };
+    return { type: 'error', message: cs.message, stderr: cs.stderr, timestamp: now };
   }
   return null; // 'ready' — no indicator
 }

--- a/src/lib/cloud-agent-sdk/types.ts
+++ b/src/lib/cloud-agent-sdk/types.ts
@@ -76,10 +76,10 @@ export type AgentStatus =
 
 /** Cloud infrastructure status — independent from agent activity. */
 export type CloudStatus =
-  | { type: 'preparing'; step?: string; message?: string }
+  | { type: 'preparing'; step?: string; message?: string; stderr?: string }
   | { type: 'ready' }
   | { type: 'finalizing'; step?: string; message?: string }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string; stderr?: string };
 
 export type QuestionState = {
   requestId: string;


### PR DESCRIPTION
## Summary

- Surface setup-command stderr in preparation failure events: when `SetupCommandFailedError` is thrown during async preparation, the `stderr` field is included in the `preparing` event payload and in the `cloud.status` error event, giving users actionable error output instead of just a generic failure message.
- Add an expandable details panel in `SessionStatusIndicator` that renders the stderr content when present on error indicators.
- Fix `stderr` being dropped by the `cloud.status` event path: the backend emitted both a `preparing` event (with `stderr`) and a `cloud.status` event (without `stderr`), and the latter overwrote the former in `service-state`. Now `stderr` is propagated through both paths — the `CloudStatusData` protocol type, the Zod `cloudStatusSchema` error variant, the SDK `CloudStatus` type, and `session-manager`'s `indicatorForCloudStatus`.
- Fix the chat input placeholder to not show "Setting up environment…" when preparation has already failed.
- Clean up: consolidate duplicate imports in `CloudAgentSession`, remove `stderr` from the preparing cloud status (it belongs only on the error indicator).

## Verification

- [x] `pnpm typecheck` — passed (all workspaces, root + cloud-agent-next)
- [x] `pnpm format:check` — passed
- [x] `pnpm lint:oxlint` — passed
- [x] `pnpm lint:eslint:fallback` — passed

## Visual Changes

| Before | After |
| ------ | ----- |
| Setup failure shows generic error message only | Setup failure shows error message with expandable stderr details panel |

<img width="1120" height="854" alt="Screenshot 2026-03-25 at 21 59 29" src="https://github.com/user-attachments/assets/e2cb0326-c45b-406d-b67e-a05c98b63e09" />


## Reviewer Notes

- `stderr` emission is limited to the `SetupCommandFailedError` catch path in `CloudAgentSession.asyncPrepareSession`.
- The SDK-side changes propagate `stderr` through normalizer → session-manager → service-state → UI; all layers have corresponding test coverage.
- The root cause of `stderr` not appearing was a dual-event race: `emitProgress` broadcast both a `preparing` event (with `stderr`) and a `cloud.status` event (without), and `processCloudStatus` overwrote the cloudStatus that `processPreparing` had set. Fixed by adding `stderr` to the `cloud.status` error variant at every layer.