### PR TITLE
feat(api): add tRPC endpoints for kilo-app mobile dashboard

### DIFF
--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -8,6 +8,15 @@ import { SecretFieldKey } from '@kilocode/kiloclaw-secret-catalog';
 import * as _workos_inc_node from '@workos-inc/node';
 import * as stripe from 'stripe';
 
+type ChangelogCategory = 'feature' | 'bugfix';
+type ChangelogDeployHint = 'redeploy_suggested' | 'redeploy_required' | 'upgrade_required' | null;
+type ChangelogEntry = {
+    date: string;
+    description: string;
+    category: ChangelogCategory;
+    deployHint: ChangelogDeployHint;
+};
+
 declare enum KiloPassTier {
     Tier19 = "tier_19",
     Tier49 = "tier_49",
@@ -3291,6 +3300,8 @@ type PlatformStatusResponse = {
     trackedImageDigest: string | null;
     googleConnected: boolean;
     gmailNotificationsEnabled: boolean;
+    execSecurity: string | null;
+    execAsk: string | null;
 };
 /** Response from GET /api/platform/debug-status (internal/admin only). */
 type PlatformDebugStatusResponse = PlatformStatusResponse & {
@@ -7621,6 +7632,14 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                 totalBalance_mUsd: number;
                 isFirstPurchase: boolean;
                 autoTopUpEnabled: boolean;
+            };
+            meta: object;
+        }>;
+        getBalance: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: {
+                balance: number;
+                isDepleted: boolean;
             };
             meta: object;
         }>;
@@ -15403,6 +15422,11 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         };
         transformer: false;
     }, _trpc_server.TRPCDecorateCreateRouterOptions<{
+        getChangelog: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: ChangelogEntry[];
+            meta: object;
+        }>;
         serviceDegraded: _trpc_server.TRPCQueryProcedure<{
             input: void;
             output: boolean;
@@ -15438,6 +15462,8 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                 trackedImageDigest: string | null;
                 googleConnected: boolean;
                 gmailNotificationsEnabled: boolean;
+                execSecurity: string | null;
+                execAsk: string | null;
             };
             meta: object;
         }>;
@@ -15554,6 +15580,46 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         getConfig: _trpc_server.TRPCQueryProcedure<{
             input: void;
             output: UserConfigResponse;
+            meta: object;
+        }>;
+        getChannelCatalog: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: {
+                id: string;
+                label: string;
+                configured: boolean;
+                fields: {
+                    key: string;
+                    label: string;
+                    placeholder: string;
+                    placeholderConfigured: string;
+                    validationPattern: string | undefined;
+                    validationMessage: string | undefined;
+                }[];
+                helpText: string | undefined;
+                helpUrl: string | undefined;
+                allFieldsRequired: boolean;
+            }[];
+            meta: object;
+        }>;
+        getSecretCatalog: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: {
+                id: string;
+                label: string;
+                configured: boolean;
+                fields: {
+                    key: string;
+                    label: string;
+                    placeholder: string;
+                    placeholderConfigured: string;
+                    validationPattern: string | undefined;
+                    validationMessage: string | undefined;
+                }[];
+                helpText: string | undefined;
+                helpUrl: string | undefined;
+                allFieldsRequired: boolean;
+            }[];
             meta: object;
         }>;
         restartMachine: _trpc_server.TRPCMutationProcedure<{

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -12,6 +12,7 @@ import {
   FIELD_KEY_TO_ENTRY,
   MAX_SECRET_FIELD_LENGTH,
   validateFieldValue,
+  getEntriesByCategory,
   type SecretFieldKey,
 } from '@kilocode/kiloclaw-secret-catalog';
 import {
@@ -52,6 +53,7 @@ import {
   KILOCLAW_TRIAL_DURATION_DAYS,
 } from '@/lib/kiloclaw/constants';
 import type { ClawBillingStatus } from '@/app/(app)/claw/components/billing/billing-types';
+import { CHANGELOG_ENTRIES } from '@/app/(app)/claw/components/changelog-data';
 
 /**
  * Error codes whose messages may contain raw internal details (e.g. filesystem
@@ -408,6 +410,10 @@ async function ensureProvisionAccess(userId: string): Promise<void> {
 }
 
 export const kiloclawRouter = createTRPCRouter({
+  getChangelog: baseProcedure.query(() => {
+    return CHANGELOG_ENTRIES;
+  }),
+
   serviceDegraded: baseProcedure.query(async () => {
     return fetchKiloClawServiceDegraded();
   }),
@@ -607,6 +613,56 @@ export const kiloclawRouter = createTRPCRouter({
       generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
     );
     return client.getConfig({ userId: ctx.user.id });
+  }),
+
+  getChannelCatalog: baseProcedure.query(async ({ ctx }) => {
+    const client = new KiloClawUserClient(
+      generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+    );
+    const config = await client.getConfig({ userId: ctx.user.id });
+    const channels = getEntriesByCategory('channel');
+
+    return channels.map(entry => ({
+      id: entry.id,
+      label: entry.label,
+      configured: config.configuredSecrets[entry.id] ?? false,
+      fields: entry.fields.map(f => ({
+        key: f.key,
+        label: f.label,
+        placeholder: f.placeholder,
+        placeholderConfigured: f.placeholderConfigured,
+        validationPattern: f.validationPattern,
+        validationMessage: f.validationMessage,
+      })),
+      helpText: entry.helpText,
+      helpUrl: entry.helpUrl,
+      allFieldsRequired: entry.allFieldsRequired ?? false,
+    }));
+  }),
+
+  getSecretCatalog: baseProcedure.query(async ({ ctx }) => {
+    const client = new KiloClawUserClient(
+      generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+    );
+    const config = await client.getConfig({ userId: ctx.user.id });
+    const tools = getEntriesByCategory('tool');
+
+    return tools.map(entry => ({
+      id: entry.id,
+      label: entry.label,
+      configured: config.configuredSecrets[entry.id] ?? false,
+      fields: entry.fields.map(f => ({
+        key: f.key,
+        label: f.label,
+        placeholder: f.placeholder,
+        placeholderConfigured: f.placeholderConfigured,
+        validationPattern: f.validationPattern,
+        validationMessage: f.validationMessage,
+      })),
+      helpText: entry.helpText,
+      helpUrl: entry.helpUrl,
+      allFieldsRequired: entry.allFieldsRequired ?? false,
+    }));
   }),
 
   restartMachine: clawAccessProcedure

--- a/src/routers/user-router.ts
+++ b/src/routers/user-router.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_AUTO_TOP_UP_AMOUNT_CENTS,
 } from '@/lib/autoTopUpConstants';
 import { getCreditBlocks } from '@/lib/getCreditBlocks';
+import { getBalanceForUser } from '@/lib/user.balance';
 
 const ViewTypeSchema = z.union([z.literal('personal'), z.literal('all'), z.uuid()]);
 
@@ -150,6 +151,13 @@ export const userRouter = createTRPCRouter({
         ...getCreditBlocks(transactions, now, ctx.user, ctx.user.id),
         autoTopUpEnabled: ctx.user.auto_top_up_enabled,
       };
+    }),
+
+  getBalance: baseProcedure
+    .output(z.object({ balance: z.number(), isDepleted: z.boolean() }))
+    .query(async ({ ctx }) => {
+      const { balance } = await getBalanceForUser(ctx.user);
+      return { balance, isDepleted: balance <= 0 };
     }),
 
   getAutocompleteMetrics: baseProcedure


### PR DESCRIPTION
## Summary

Backend-only tRPC endpoints needed by the kilo-app mobile dashboard (PR #1500).

- `user.getBalance` — returns user's dollar balance and `isDepleted` flag, using existing `getBalanceForUser()` helper
- `kiloclaw.getChangelog` — serves `CHANGELOG_ENTRIES` from the server so mobile doesn't need a local copy
- `kiloclaw.getChannelCatalog` — returns channel-category secret catalog entries with per-channel `configured` status from `configuredSecrets`
- `kiloclaw.getSecretCatalog` — same pattern for tool-category entries (GitHub, 1Password, AgentCard, Brave Search)

All endpoints are read-only queries using `baseProcedure` (authenticated, no billing gate).

## Test plan

- [ ] Verify `user.getBalance` returns correct balance via tRPC playground or curl
- [ ] Verify `kiloclaw.getChangelog` returns the changelog array
- [ ] Verify `kiloclaw.getChannelCatalog` returns channel entries with correct `configured` flags
- [ ] Verify `kiloclaw.getSecretCatalog` returns tool entries with correct `configured` flags