### PR TITLE
style(usage): compact metric cards for 7-column layout

### DIFF
--- a/src/components/organizations/usage-details/MetricSelector.tsx
+++ b/src/components/organizations/usage-details/MetricSelector.tsx
@@ -22,7 +22,7 @@ type Props = {
 
 export function MetricSelector({ metrics, selectedMetric, onSelectedMetricChange }: Props) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
       {metrics.map(metric => {
         const isSelected = metric.key === selectedMetric;
         const IconComponent = metric.icon;
@@ -44,16 +44,16 @@ export function MetricSelector({ metrics, selectedMetric, onSelectedMetricChange
                 isSelected ? 'opacity-100' : 'opacity-80'
               )}
             />
-            <CardHeader className="relative z-[1] flex flex-row items-center space-y-0 px-4 pt-4 pb-2">
+            <CardHeader className="relative z-[1] flex flex-row items-center space-y-0 px-3 pt-3 pb-1">
               {IconComponent && <IconComponent className="mr-2 h-4 w-4" />}
               <CardTitle className="text-sm font-medium whitespace-nowrap">
                 {metric.title}
               </CardTitle>
             </CardHeader>
-            <CardContent className="relative z-[1] px-4">
+            <CardContent className="relative z-[1] px-3">
               <div
                 className={cn(
-                  'text-2xl font-bold transition-colors duration-200',
+                  'text-xl font-bold transition-colors duration-200',
                   isSelected ? 'text-blue-300' : ''
                 )}
               >

--- a/src/components/organizations/usage-details/MetricSelector.tsx
+++ b/src/components/organizations/usage-details/MetricSelector.tsx
@@ -44,13 +44,13 @@ export function MetricSelector({ metrics, selectedMetric, onSelectedMetricChange
                 isSelected ? 'opacity-100' : 'opacity-80'
               )}
             />
-            <CardHeader className="relative z-[1] flex flex-row items-center space-y-0 px-3 pt-3 pb-1">
+            <CardHeader className="relative z-[1] flex flex-row items-center space-y-0 px-3 pt-2 pb-0.5">
               {IconComponent && <IconComponent className="mr-2 h-4 w-4" />}
               <CardTitle className="text-sm font-medium whitespace-nowrap">
                 {metric.title}
               </CardTitle>
             </CardHeader>
-            <CardContent className="relative z-[1] px-3">
+            <CardContent className="relative z-[1] px-3 pb-2">
               <div
                 className={cn(
                   'text-xl font-bold transition-colors duration-200',

--- a/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
+++ b/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
@@ -162,7 +162,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
       },
       {
         key: 'avgCost',
-        title: 'Avg Cost per Request',
+        title: 'Avg Cost/Req',
         value: (
           <FormattedMicrodollars
             microdollars={metricsTotals.avg_cost_per_req}


### PR DESCRIPTION
## Summary

### Problem

The org usage page displays 7 metric cards in a single row at `xl` breakpoint. The cards had excessive spacing and padding, and the longest label ("Avg Cost per Request") was truncated by overflow clipping.

### Solution

- Reduced grid gap from `gap-4` to `gap-2` so cards sit closer together.
- Reduced card header padding (`px-4 pt-4 pb-2` → `px-3 pt-3 pb-1`) and content padding (`px-4` → `px-3`).
- Reduced value font size from `text-2xl` to `text-xl` for a more compact appearance.
- Shortened the "Avg Cost per Request" label to "Avg Cost/Req" to prevent truncation.

### Why this approach

Wrapping or ellipsis-with-tooltip were considered for the label, but abbreviation is simpler and keeps all cards visually consistent at a single line height. The CSS-only spacing changes avoid any structural or behavioral changes to the component.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` — passed (via pre-push hook)
- [x] `pnpm format:check` — passed (via pre-push hook)
- [x] Manual visual verification via agent-browser on `/organizations/[id]/usage-details`

## Visual Changes

| Before | After |
| ------ | ----- |
| ![before: usage-metric-cards](https://res.cloudinary.com/pr-review-screenshots/image/upload/v1774445101/pr-screenshots/kilo-org/cloud/1532/before-1-usage-metric-cards.png) | ![after: usage-metric-cards](https://res.cloudinary.com/pr-review-screenshots/image/upload/v1774445101/pr-screenshots/kilo-org/cloud/1532/after-1-usage-metric-cards.png) |

## Reviewer Notes

- The change is purely visual — no logic, data, or API changes.
- The abbreviated label "Avg Cost/Req" matches the existing abbreviated style used elsewhere in the dashboard.