### PR TITLE
fix(app-builder): create new session on vision capability change

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2334,6 +2334,7 @@ export const AppBuilderSessionReason = {
   Initial: 'initial', // First session created with project
   GitHubMigration: 'github_migration', // New session after migrating to GitHub
   Upgrade: 'upgrade', // New session after worker version upgrade (v1→v2)
+  ModelVisionChange: 'model_vision_change', // New session after switching between vision and text-only models
 } satisfies Record<string, string>;
 
 export const app_builder_project_sessions = pgTable(

--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -84,7 +84,7 @@ declare const OrganizationPlanSchema: z.ZodEnum<{
     enterprise: "enterprise";
 }>;
 type OrganizationPlan = z.infer<typeof OrganizationPlanSchema>;
-type AuthProviderId = 'email' | 'google' | 'github' | 'gitlab' | 'linkedin' | 'fake-login' | 'workos';
+type AuthProviderId = 'email' | 'google' | 'github' | 'gitlab' | 'linkedin' | 'discord' | 'fake-login' | 'workos';
 type IntegrationPermissions = Record<string, string>;
 type PlatformRepository = {
     id: number;
@@ -612,6 +612,23 @@ declare const kilocode_users: drizzle_orm_pg_core.PgTableWithColumns<{
             isAutoincrement: false;
             hasRuntimeDefault: false;
             enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {}>;
+        discord_server_membership_verified_at: drizzle_orm_pg_core.PgColumn<{
+            name: "discord_server_membership_verified_at";
+            tableName: "kilocode_users";
+            dataType: "string";
+            columnType: "PgTimestampString";
+            data: string;
+            driverParam: string;
+            notNull: false;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: undefined;
             baseColumn: never;
             identity: undefined;
             generated: undefined;
@@ -4562,6 +4579,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             getAutocomplete: _trpc_server.TRPCQueryProcedure<{
                 input: {
                     organizationId: string;
+                    period?: "all" | "year" | "month" | "week" | undefined;
                 };
                 output: {
                     cost: number;
@@ -7552,7 +7570,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         }>;
         linkAuthProvider: _trpc_server.TRPCMutationProcedure<{
             input: {
-                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "fake-login" | "workos";
+                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "discord" | "fake-login" | "workos";
             };
             output: {
                 success: true;
@@ -7561,7 +7579,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         }>;
         unlinkAuthProvider: _trpc_server.TRPCMutationProcedure<{
             input: {
-                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "fake-login" | "workos";
+                provider: "email" | "google" | "github" | "gitlab" | "linkedin" | "discord" | "fake-login" | "workos";
             };
             output: {
                 success: true;
@@ -7595,6 +7613,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
         getAutocompleteMetrics: _trpc_server.TRPCQueryProcedure<{
             input: {
                 viewType?: string | undefined;
+                period?: "all" | "year" | "month" | "week" | undefined;
             };
             output: {
                 cost: number;
@@ -7691,6 +7710,23 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             output: {
                 success: true;
             };
+            meta: object;
+        }>;
+        getDiscordGuildStatus: _trpc_server.TRPCQueryProcedure<{
+            input: void;
+            output: SuccessResult<{
+                linked: boolean;
+                discord_avatar_url: string | null;
+                discord_display_name: string | null;
+                discord_server_membership_verified_at: string | null;
+            }>;
+            meta: object;
+        }>;
+        verifyDiscordGuildMembership: _trpc_server.TRPCMutationProcedure<{
+            input: void;
+            output: SuccessResult<{
+                is_member: boolean;
+            }>;
             meta: object;
         }>;
     }>>;
@@ -7893,6 +7929,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                         completed_welcome_form: boolean;
                         linkedin_url: string | null;
                         github_url: string | null;
+                        discord_server_membership_verified_at: string | null;
                         openrouter_upstream_safety_identifier: string | null;
                         customer_source: string | null;
                     };
@@ -14760,6 +14797,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     isBonusUnlocked: boolean;
                     refillAt: string | null;
                 } | null;
+                isEligibleForFirstMonthPromo: boolean;
             };
             meta: object;
         }>;
@@ -14778,13 +14816,6 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     startedAt: string | null;
                 } | null;
                 creditsAwarded: boolean;
-            };
-            meta: object;
-        }>;
-        getFirstMonthPromoEligibility: _trpc_server.TRPCQueryProcedure<{
-            input: void;
-            output: {
-                eligible: boolean;
             };
             meta: object;
         }>;

--- a/src/lib/app-builder/app-builder-service.ts
+++ b/src/lib/app-builder/app-builder-service.ts
@@ -33,6 +33,7 @@ import { generateImageMCPToken } from '@/lib/app-builder/image-mcp-token';
 import { buildImageContextFromAttachments } from '@/lib/app-builder/image-context';
 import { deleteProjectAssets } from '@/lib/r2/app-builder-assets';
 import { getEnvVariable } from '@/lib/dotenvx';
+import { modelSupportsImages } from '@/lib/providers/model-capabilities';
 
 import type {
   AppBuilderProject,
@@ -168,14 +169,20 @@ type AnyInterruptResult = InterruptResult | InterruptResultV2;
 
 type NewSessionDecision =
   | { createNew: false; workerVersion: WorkerVersion }
-  | { createNew: true; reason: 'upgrade' | 'github_migration'; targetWorkerVersion: WorkerVersion };
+  | {
+      createNew: true;
+      reason: 'upgrade' | 'github_migration' | 'model_vision_change';
+      targetWorkerVersion: WorkerVersion;
+    };
 
 async function shouldCreateNewSession(
   project: AppBuilderProject,
   currentSessionId: string,
   currentWorkerVersion: WorkerVersion,
   requiredWorkerVersion: WorkerVersion,
-  authToken: string
+  authToken: string,
+  currentModelId: string,
+  newModelId: string
 ): Promise<NewSessionDecision> {
   if (currentWorkerVersion !== requiredWorkerVersion) {
     return { createNew: true, reason: 'upgrade', targetWorkerVersion: requiredWorkerVersion };
@@ -191,6 +198,20 @@ async function shouldCreateNewSession(
       return {
         createNew: true,
         reason: 'github_migration',
+        targetWorkerVersion: currentWorkerVersion,
+      };
+    }
+  }
+
+  if (currentModelId !== newModelId) {
+    const [currentSupportsImages, newSupportsImages] = await Promise.all([
+      modelSupportsImages(currentModelId),
+      modelSupportsImages(newModelId),
+    ]);
+    if (currentSupportsImages !== newSupportsImages) {
+      return {
+        createNew: true,
+        reason: 'model_vision_change',
         targetWorkerVersion: currentWorkerVersion,
       };
     }
@@ -234,8 +255,16 @@ type CreateSessionParams = {
   authToken: string;
   gitRepoFullName: string | null;
   images?: Images;
-  reason: 'upgrade' | 'github_migration';
+  reason: 'upgrade' | 'github_migration' | 'model_vision_change';
 };
+
+function toSessionReason(reason: CreateSessionParams['reason']): string {
+  if (reason === 'upgrade') return AppBuilderSessionReason.Upgrade;
+  if (reason === 'github_migration') return AppBuilderSessionReason.GitHubMigration;
+  if (reason === 'model_vision_change') return AppBuilderSessionReason.ModelVisionChange;
+  reason satisfies never;
+  throw new Error(`Unhandled session reason: ${reason}`);
+}
 
 async function createV1Session(params: CreateSessionParams): Promise<InitiateSessionV2Output> {
   const {
@@ -291,11 +320,6 @@ async function createV1Session(params: CreateSessionParams): Promise<InitiateSes
     cloudAgentSessionId: newSessionId,
   });
 
-  const sessionReason =
-    reason === 'upgrade'
-      ? AppBuilderSessionReason.Upgrade
-      : AppBuilderSessionReason.GitHubMigration;
-
   await db.transaction(async tx => {
     await tx
       .update(app_builder_project_sessions)
@@ -310,7 +334,7 @@ async function createV1Session(params: CreateSessionParams): Promise<InitiateSes
     await tx.insert(app_builder_project_sessions).values({
       project_id: projectId,
       cloud_agent_session_id: newSessionId,
-      reason: sessionReason,
+      reason: toSessionReason(reason),
       worker_version: 'v1',
     });
   });
@@ -379,11 +403,6 @@ async function createV2Session(params: CreateSessionParams): Promise<InitiateSes
     cloudAgentSessionId: newSessionId,
   });
 
-  const sessionReason =
-    reason === 'upgrade'
-      ? AppBuilderSessionReason.Upgrade
-      : AppBuilderSessionReason.GitHubMigration;
-
   await db.transaction(async tx => {
     await tx
       .update(app_builder_project_sessions)
@@ -398,7 +417,7 @@ async function createV2Session(params: CreateSessionParams): Promise<InitiateSes
     await tx.insert(app_builder_project_sessions).values({
       project_id: projectId,
       cloud_agent_session_id: newSessionId,
-      reason: sessionReason,
+      reason: toSessionReason(reason),
       worker_version: 'v2',
     });
   });
@@ -1000,7 +1019,9 @@ export async function sendMessage(input: SendMessageInput): Promise<SendMessageR
     currentSessionId,
     currentWorkerVersion ?? 'v1',
     requiredWorkerVersion,
-    authToken
+    authToken,
+    project.model_id,
+    effectiveModel
   );
 
   if (decision.createNew) {

--- a/src/lib/providers/model-capabilities.ts
+++ b/src/lib/providers/model-capabilities.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+import { AUTO_MODELS } from '@/lib/kilo-auto-model';
+import { db } from '@/lib/drizzle';
+import { modelStats } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Returns whether a given model ID supports image input.
+ *
+ * Handles two cases:
+ * - kilo-auto/* virtual models: checked via the AUTO_MODELS config (supports_images field)
+ * - All other models: queried from the model_stats DB table (inputModalities column)
+ *
+ * Falls back to false (safe default) if the model is not found in either source.
+ */
+export async function modelSupportsImages(modelId: string): Promise<boolean> {
+  const autoModel = AUTO_MODELS.find(m => m.id === modelId);
+  if (autoModel !== undefined) {
+    return autoModel.supports_images;
+  }
+
+  const row = await db
+    .select({ inputModalities: modelStats.inputModalities })
+    .from(modelStats)
+    .where(eq(modelStats.openrouterId, modelId))
+    .limit(1)
+    .then(rows => rows[0]);
+
+  if (row === undefined) {
+    return false;
+  }
+
+  return row.inputModalities?.includes('image') ?? false;
+}

--- a/src/lib/providers/model-capabilities.ts
+++ b/src/lib/providers/model-capabilities.ts
@@ -30,5 +30,7 @@ export async function modelSupportsImages(modelId: string): Promise<boolean> {
     return false;
   }
 
-  return row.inputModalities?.includes('image') ?? false;
+  return (
+    row.inputModalities?.some(modality => modality === 'image' || modality === 'image_url') ?? false
+  );
 }


### PR DESCRIPTION
## Summary

Fixes a crash ("No endpoints found that support image input") that occurs when a user switches from a vision-capable model to a text-only model (or vice versa) mid-session in App Builder. The App Builder worker session is tied to the model's input modalities at creation time, so a capability mismatch causes the active session to fail.

**Changes:**
- Adds `ModelVisionChange: 'model_vision_change'` to `AppBuilderSessionReason` (plain text enum, no migration needed).
- Adds `modelSupportsImages(modelId)` utility in `src/lib/providers/model-capabilities.ts`. Handles two cases: `kilo-auto/*` virtual models (via `AUTO_MODELS` config) and all others (via the `model_stats` DB table). Falls back to `false` if the model is not found in either source.
- Extends `shouldCreateNewSession` to accept `currentModelId` / `newModelId` and trigger a new session when vision capability differs between the two models (using `Promise.all` for parallel DB lookups).
- Extracts `toSessionReason()` helper, replacing duplicated binary ternary expressions in `createV1Session` and `createV2Session`.

## Reviewer Notes

- `modelSupportsImages()` falls back to `false` (safe/conservative) when a model is absent from both `AUTO_MODELS` and `model_stats`.
- Session creation is only triggered when vision capability **changes** between models — switching between two text-only or two vision models does not create a new session.
- `packages/trpc/dist/index.d.ts` is a regenerated file; the diff reflects accumulated upstream changes merged from main, not changes introduced by this branch.