### PR TITLE
feat(admin): add multi-repo support to community PRs dashboard

### DIFF
--- a/src/app/admin/community-prs/page.tsx
+++ b/src/app/admin/community-prs/page.tsx
@@ -18,6 +18,15 @@ import {
   type ClosedPrSortKey,
 } from '@/app/admin/community-prs/sorting';
 
+const ALL_REPOS = ['kilocode', 'cloud', 'kilo-marketplace'] as const;
+type RepoFilterId = (typeof ALL_REPOS)[number];
+
+const REPO_LABELS: Record<RepoFilterId, string> = {
+  kilocode: 'kilocode',
+  cloud: 'cloud',
+  'kilo-marketplace': 'marketplace',
+};
+
 const breadcrumbs = (
   <BreadcrumbItem>
     <BreadcrumbPage>Community PRs</BreadcrumbPage>
@@ -28,6 +37,33 @@ export default function GithubPrCountsAdminPage() {
   const trpcClient = useRawTRPCClient();
 
   const [includeDrafts, setIncludeDrafts] = useState(false);
+
+  const [selectedRepos, setSelectedRepos] = useState<ReadonlySet<RepoFilterId>>(new Set(ALL_REPOS));
+
+  const toggleRepo = useCallback((repo: RepoFilterId) => {
+    setSelectedRepos(prev => {
+      // If all are currently selected, clicking one repo selects only that repo
+      if (prev.size === ALL_REPOS.length) {
+        return new Set([repo]);
+      }
+      const next = new Set(prev);
+      if (next.has(repo)) {
+        next.delete(repo);
+      } else {
+        next.add(repo);
+      }
+      // If nothing selected, revert to all
+      if (next.size === 0) return new Set(ALL_REPOS);
+      return next;
+    });
+  }, []);
+
+  const selectAllRepos = useCallback(() => {
+    setSelectedRepos(new Set(ALL_REPOS));
+  }, []);
+
+  const allSelected = selectedRepos.size === ALL_REPOS.length;
+  const reposArray = useMemo(() => [...selectedRepos], [selectedRepos]);
 
   const [externalSort, setExternalSort] = useState<ExternalPrSort>({
     key: 'ageDays',
@@ -54,11 +90,19 @@ export default function GithubPrCountsAdminPage() {
   }, []);
 
   const { data, error, isFetching, isLoading, refetch } = useQuery({
-    queryKey: ['admin', 'github', 'kilocode', 'open-prs-summary', { includeDrafts }],
+    queryKey: [
+      'admin',
+      'github',
+      'community-prs',
+      'open-summary',
+      { includeDrafts, repos: reposArray },
+    ],
     queryFn: async () =>
-      trpcClient.admin.github.getKilocodeOpenPullRequestsSummary.query({ includeDrafts }),
+      trpcClient.admin.github.getKilocodeOpenPullRequestsSummary.query({
+        includeDrafts,
+        repos: reposArray,
+      }),
     staleTime: 60_000,
-    refetchInterval: 60_000,
   });
 
   const {
@@ -67,10 +111,12 @@ export default function GithubPrCountsAdminPage() {
     isLoading: closedIsLoading,
     refetch: closedRefetch,
   } = useQuery({
-    queryKey: ['admin', 'github', 'kilocode', 'closed-external-prs'],
-    queryFn: async () => trpcClient.admin.github.getKilocodeRecentlyClosedExternalPRs.query(),
+    queryKey: ['admin', 'github', 'community-prs', 'closed', { repos: reposArray }],
+    queryFn: async () =>
+      trpcClient.admin.github.getKilocodeRecentlyClosedExternalPRs.query({
+        repos: reposArray,
+      }),
     staleTime: 60_000,
-    refetchInterval: 60_000,
   });
 
   const handleRefresh = useCallback(() => {
@@ -112,10 +158,13 @@ export default function GithubPrCountsAdminPage() {
     };
   }, []);
 
-  const externalPrHref = useCallback((pr: { number: number; url?: string | null }) => {
-    if (pr.url) return pr.url;
-    return `https://github.com/Kilo-Org/kilocode/pull/${pr.number}`;
-  }, []);
+  const externalPrHref = useCallback(
+    (pr: { number: number; repo: string; url?: string | null }) => {
+      if (pr.url) return pr.url;
+      return `https://github.com/Kilo-Org/${pr.repo}/pull/${pr.number}`;
+    },
+    []
+  );
 
   const reviewStatusLabel = useCallback((reviewStatus: string) => {
     if (reviewStatus === 'changes_requested') return 'Changes requested';
@@ -136,10 +185,34 @@ export default function GithubPrCountsAdminPage() {
     >
       <div className="flex w-full flex-col gap-y-6">
         <div>
-          <h2 className="text-2xl font-bold">kilocode repo – open PRs</h2>
+          <h2 className="text-2xl font-bold">Community PRs</h2>
           <p className="text-muted-foreground mt-1">
-            Counts are split by whether the PR author is a member of the GitHub org “Kilo-Org”.
+            Counts are split by whether the PR author is a member of the GitHub org
+            &quot;Kilo-Org&quot;.
           </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground text-sm font-medium">Repos:</span>
+          <Button
+            type="button"
+            variant={allSelected ? 'default' : 'outline'}
+            size="sm"
+            onClick={selectAllRepos}
+          >
+            All
+          </Button>
+          {ALL_REPOS.map(repo => (
+            <Button
+              key={repo}
+              type="button"
+              variant={selectedRepos.has(repo) ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => toggleRepo(repo)}
+            >
+              {REPO_LABELS[repo]}
+            </Button>
+          ))}
         </div>
 
         {isLoading ? (
@@ -207,8 +280,8 @@ export default function GithubPrCountsAdminPage() {
                 <div className="flex flex-col gap-1">
                   <h3 className="text-lg font-semibold">Community open PRs</h3>
                   <p className="text-muted-foreground text-sm">
-                    Sorted by urgency by default (oldest first). “Team commented” checks both issue
-                    comments and review comments by Kilo team members.
+                    Sorted by urgency by default (oldest first). &quot;Team commented&quot; checks
+                    both issue comments and review comments by Kilo team members.
                   </p>
                 </div>
 
@@ -228,6 +301,14 @@ export default function GithubPrCountsAdminPage() {
                     onClick={() => toggleSort('ageDays')}
                   >
                     Age {externalSort.key === 'ageDays' ? `(${externalSort.direction})` : ''}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={externalSort.key === 'repo' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => toggleSort('repo')}
+                  >
+                    Repo {externalSort.key === 'repo' ? `(${externalSort.direction})` : ''}
                   </Button>
                   <Button
                     type="button"
@@ -257,6 +338,7 @@ export default function GithubPrCountsAdminPage() {
                       <thead>
                         <tr className="text-muted-foreground border-b">
                           <th className="px-2 py-2 text-left font-medium">PR</th>
+                          <th className="px-2 py-2 text-left font-medium">Repo</th>
                           <th className="px-2 py-2 text-left font-medium">Author</th>
                           <th className="px-2 py-2 text-left font-medium">Age</th>
                           <th className="px-2 py-2 text-left font-medium">Review status</th>
@@ -270,7 +352,7 @@ export default function GithubPrCountsAdminPage() {
                           const prHref = externalPrHref(pr);
                           return (
                             <tr
-                              key={pr.number}
+                              key={`${pr.repo}:${pr.number}`}
                               className={`border-b border-l-4 ${urgency.rowBorder} hover:bg-muted/30`}
                             >
                               <td className="px-2 py-3 align-top">
@@ -282,6 +364,11 @@ export default function GithubPrCountsAdminPage() {
                                 >
                                   #{pr.number} <span className="text-foreground">{pr.title}</span>
                                 </a>
+                              </td>
+                              <td className="px-2 py-3 align-top">
+                                <span className="text-muted-foreground text-xs">
+                                  {REPO_LABELS[pr.repo as RepoFilterId] ?? pr.repo}
+                                </span>
                               </td>
                               <td className="px-2 py-3 align-top">
                                 <span className="font-medium">{pr.authorLogin}</span>
@@ -348,6 +435,14 @@ export default function GithubPrCountsAdminPage() {
                   </Button>
                   <Button
                     type="button"
+                    variant={closedSort.key === 'repo' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => toggleClosedSort('repo')}
+                  >
+                    Repo {closedSort.key === 'repo' ? `(${closedSort.direction})` : ''}
+                  </Button>
+                  <Button
+                    type="button"
                     variant={closedSort.key === 'status' ? 'default' : 'outline'}
                     size="sm"
                     onClick={() => toggleClosedSort('status')}
@@ -374,6 +469,7 @@ export default function GithubPrCountsAdminPage() {
                       <thead>
                         <tr className="text-muted-foreground border-b">
                           <th className="px-2 py-2 text-left font-medium">PR</th>
+                          <th className="px-2 py-2 text-left font-medium">Repo</th>
                           <th className="px-2 py-2 text-left font-medium">Author</th>
                           <th className="px-2 py-2 text-left font-medium">Date</th>
                           <th className="px-2 py-2 text-left font-medium">Status</th>
@@ -388,7 +484,10 @@ export default function GithubPrCountsAdminPage() {
                               : 'border-red-600/40 bg-red-600/10 text-red-200';
 
                           return (
-                            <tr key={pr.number} className="hover:bg-muted/30 border-b">
+                            <tr
+                              key={`${pr.repo}:${pr.number}`}
+                              className="hover:bg-muted/30 border-b"
+                            >
                               <td className="px-2 py-3 align-top">
                                 <a
                                   href={pr.url}
@@ -398,6 +497,11 @@ export default function GithubPrCountsAdminPage() {
                                 >
                                   #{pr.number} <span className="text-foreground">{pr.title}</span>
                                 </a>
+                              </td>
+                              <td className="px-2 py-3 align-top">
+                                <span className="text-muted-foreground text-xs">
+                                  {REPO_LABELS[pr.repo as RepoFilterId] ?? pr.repo}
+                                </span>
                               </td>
                               <td className="px-2 py-3 align-top">
                                 <span className="font-medium">{pr.authorLogin}</span>

--- a/src/app/admin/community-prs/page.tsx
+++ b/src/app/admin/community-prs/page.tsx
@@ -18,13 +18,14 @@ import {
   type ClosedPrSortKey,
 } from '@/app/admin/community-prs/sorting';
 
-const ALL_REPOS = ['kilocode', 'cloud', 'kilo-marketplace'] as const;
+const ALL_REPOS = ['kilocode', 'cloud', 'kilo-marketplace', 'kilocode-legacy'] as const;
 type RepoFilterId = (typeof ALL_REPOS)[number];
 
 const REPO_LABELS: Record<RepoFilterId, string> = {
   kilocode: 'kilocode',
   cloud: 'cloud',
   'kilo-marketplace': 'marketplace',
+  'kilocode-legacy': 'legacy',
 };
 
 const breadcrumbs = (

--- a/src/app/admin/community-prs/page.tsx
+++ b/src/app/admin/community-prs/page.tsx
@@ -63,7 +63,7 @@ export default function GithubPrCountsAdminPage() {
   }, []);
 
   const allSelected = selectedRepos.size === ALL_REPOS.length;
-  const reposArray = useMemo(() => [...selectedRepos], [selectedRepos]);
+  const reposArray = useMemo(() => [...selectedRepos].sort(), [selectedRepos]);
 
   const [externalSort, setExternalSort] = useState<ExternalPrSort>({
     key: 'ageDays',

--- a/src/app/admin/community-prs/sorting.test.ts
+++ b/src/app/admin/community-prs/sorting.test.ts
@@ -12,6 +12,7 @@ function row(partial: Partial<ExternalOpenPullRequestRow>): ExternalOpenPullRequ
     number: partial.number ?? 1,
     title: partial.title ?? 't',
     url: partial.url ?? 'https://example.com',
+    repo: partial.repo ?? 'kilocode',
     authorLogin: partial.authorLogin ?? 'a',
     createdAt: partial.createdAt ?? new Date('2020-01-01T00:00:00.000Z').toISOString(),
     ageDays: partial.ageDays ?? 0,
@@ -41,6 +42,7 @@ function closedRow(partial: Partial<ExternalClosedPullRequestRow>): ExternalClos
     number: partial.number ?? 1,
     title: partial.title ?? 't',
     url: partial.url ?? 'https://example.com',
+    repo: partial.repo ?? 'kilocode',
     authorLogin: partial.authorLogin ?? 'a',
     closedAt,
     mergedAt,
@@ -90,6 +92,26 @@ describe('sortExternalPullRequests', () => {
     ];
     const sorted = sortExternalPullRequests(rows, { key: 'reviewStatus', direction: 'asc' });
     expect(sorted.map(r => r.number)).toEqual([3, 4, 2, 1]);
+  });
+
+  it('sorts by repo asc (alphabetical)', () => {
+    const rows = [
+      row({ number: 1, repo: 'kilo-marketplace' }),
+      row({ number: 2, repo: 'cloud' }),
+      row({ number: 3, repo: 'kilocode' }),
+    ];
+    const sorted = sortExternalPullRequests(rows, { key: 'repo', direction: 'asc' });
+    expect(sorted.map(r => r.number)).toEqual([2, 1, 3]);
+  });
+
+  it('sorts by repo desc (reverse alphabetical)', () => {
+    const rows = [
+      row({ number: 1, repo: 'kilo-marketplace' }),
+      row({ number: 2, repo: 'cloud' }),
+      row({ number: 3, repo: 'kilocode' }),
+    ];
+    const sorted = sortExternalPullRequests(rows, { key: 'repo', direction: 'desc' });
+    expect(sorted.map(r => r.number)).toEqual([3, 1, 2]);
   });
 });
 
@@ -164,5 +186,15 @@ describe('sortClosedPullRequests', () => {
     ];
     const sorted = sortClosedPullRequests(rows, { key: 'status', direction: 'desc' });
     expect(sorted.map(r => r.number)).toEqual([1, 3, 2]);
+  });
+
+  it('sorts by repo asc (alphabetical)', () => {
+    const rows = [
+      closedRow({ number: 1, repo: 'kilocode' }),
+      closedRow({ number: 2, repo: 'cloud' }),
+      closedRow({ number: 3, repo: 'kilo-marketplace' }),
+    ];
+    const sorted = sortClosedPullRequests(rows, { key: 'repo', direction: 'asc' });
+    expect(sorted.map(r => r.number)).toEqual([2, 3, 1]);
   });
 });

--- a/src/app/admin/community-prs/sorting.ts
+++ b/src/app/admin/community-prs/sorting.ts
@@ -2,6 +2,7 @@ export type ExternalOpenPullRequestRow = {
   number: number;
   title: string;
   url: string;
+  repo: string;
   authorLogin: string;
   createdAt: string;
   ageDays: number;
@@ -10,7 +11,7 @@ export type ExternalOpenPullRequestRow = {
   reviewStatus: string;
 };
 
-export type ExternalPrSortKey = 'ageDays' | 'teamCommented' | 'reviewStatus';
+export type ExternalPrSortKey = 'ageDays' | 'teamCommented' | 'reviewStatus' | 'repo';
 
 export type ExternalPrSortDirection = 'asc' | 'desc';
 
@@ -33,6 +34,7 @@ export type ExternalClosedPullRequestRow = {
   number: number;
   title: string;
   url: string;
+  repo: string;
   authorLogin: string;
   closedAt: string;
   mergedAt: string | null;
@@ -47,7 +49,7 @@ export type MergedPrSort = {
   direction: ExternalPrSortDirection;
 };
 
-export type ClosedPrSortKey = 'displayDate' | 'status';
+export type ClosedPrSortKey = 'displayDate' | 'status' | 'repo';
 
 export type ClosedPrSort = {
   key: ClosedPrSortKey;
@@ -77,6 +79,8 @@ function compareBySort(
 ): number {
   const sign = sort.direction === 'asc' ? 1 : -1;
   if (sort.key === 'ageDays') return sign * (a.ageDays - b.ageDays);
+
+  if (sort.key === 'repo') return sign * a.repo.localeCompare(b.repo);
 
   if (sort.key === 'teamCommented') {
     // teamCommented: booleans, default ordering is false < true.
@@ -135,6 +139,8 @@ function compareByClosedSort(
     const dateB = new Date(b.displayDate).getTime();
     return sign * (dateA - dateB);
   }
+
+  if (sort.key === 'repo') return sign * a.repo.localeCompare(b.repo);
 
   // status: default ordering is closed < merged (closed first, more actionable)
   const aVal = a.status === 'closed' ? 0 : 1;

--- a/src/lib/github/open-pull-request-counts.test.ts
+++ b/src/lib/github/open-pull-request-counts.test.ts
@@ -7,17 +7,32 @@ jest.mock('@/lib/fetchWithBackoff', () => ({
     fetch(input, init),
 }));
 
-import {
-  getKilocodeRepoOpenPullRequestsSummary,
-  getKilocodeRepoRecentlyClosedExternalPRs,
-  parseGithubListPullRequestsSummaryResponse,
-} from '@/lib/github/open-pull-request-counts';
+import { parseGithubListPullRequestsSummaryResponse } from '@/lib/github/open-pull-request-counts';
+
+beforeEach(() => {
+  // Reset the module registry so each test gets a fresh import with clean caches.
+  jest.resetModules();
+});
+
+async function importModule() {
+  return await import('@/lib/github/open-pull-request-counts');
+}
 
 function mockGithubJsonResponse(json: unknown): Response {
   return new Response(JSON.stringify(json), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+// Default org members response: empty org (all authors are external)
+function emptyOrgMembersResponse(): Response {
+  return mockGithubJsonResponse([]);
+}
+
+// Org members response with specified members
+function orgMembersResponse(logins: string[]): Response {
+  return mockGithubJsonResponse(logins.map(login => ({ login })));
 }
 
 describe('getKilocodeRepoOpenPullRequestsSummary bot author classification', () => {
@@ -63,9 +78,9 @@ describe('getKilocodeRepoOpenPullRequestsSummary bot author classification', () 
           return mockGithubJsonResponse(prListJson);
         }
 
-        // Org membership check for "some-user" should classify as external.
-        if (urlString.includes('/orgs/Kilo-Org/members/')) {
-          return new Response('', { status: 404 });
+        // Bulk org members endpoint
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
         }
 
         // Comment endpoints should be hit only for the external PR (number 2).
@@ -84,8 +99,10 @@ describe('getKilocodeRepoOpenPullRequestsSummary bot author classification', () 
         throw new Error(`Unexpected fetch: ${urlString}`);
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -97,6 +114,7 @@ describe('getKilocodeRepoOpenPullRequestsSummary bot author classification', () 
 
     expect(summary.externalOpenPullRequestsList).toHaveLength(1);
     expect(summary.externalOpenPullRequestsList[0]?.authorLogin).toBe('some-user');
+    expect(summary.externalOpenPullRequestsList[0]?.repo).toBe('kilocode');
     expect(summary.externalOpenPullRequestsList.some(pr => pr.authorLogin === 'renovate')).toBe(
       false
     );
@@ -128,20 +146,26 @@ describe('getKilocodeRepoOpenPullRequestsSummary bot author classification', () 
           return mockGithubJsonResponse(prListJson);
         }
 
+        // Bulk org members endpoint
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
+        }
+
         if (
-          urlString.includes('/orgs/Kilo-Org/members/') ||
           urlString.includes('/issues/1/comments') ||
           urlString.includes('/pulls/1/comments') ||
           urlString.includes('/pulls/1/reviews')
         ) {
-          throw new Error('No membership/comment checks expected for bot-only PR list');
+          throw new Error('No comment checks expected for bot-only PR list');
         }
 
         throw new Error(`Unexpected fetch: ${urlString}`);
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -205,28 +229,28 @@ describe('getKilocodeRepoRecentlyClosedExternalPRs', () => {
           return mockGithubJsonResponse(closedPrsJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
-        }
-
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user-2')) {
-          return new Response('', { status: 404 });
-        }
-
-        if (urlString.includes('/orgs/Kilo-Org/members/kilo-team-member')) {
-          return new Response(null, { status: 204 });
+        // Bulk org members endpoint — kilo-team-member is a member
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-team-member']);
         }
 
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
-    const result = await getKilocodeRepoRecentlyClosedExternalPRs({ ttlMs: 0, maxResults: 50 });
+    const { getKilocodeRepoRecentlyClosedExternalPRs } = await importModule();
+    const result = await getKilocodeRepoRecentlyClosedExternalPRs({
+      ttlMs: 0,
+      maxResults: 50,
+      repos: ['kilocode'],
+    });
 
     expect(result.prs.map(pr => pr.number)).toEqual([2, 1]);
     expect(result.prs[0]?.status).toBe('closed');
     expect(result.prs[0]?.displayDate).toBe('2024-01-03T00:00:00.000Z');
+    expect(result.prs[0]?.repo).toBe('kilocode');
     expect(result.prs[1]?.status).toBe('merged');
     expect(result.prs[1]?.displayDate).toBe('2024-01-01T00:00:00.000Z');
+    expect(result.prs[1]?.repo).toBe('kilocode');
 
     expect(typeof result.thisWeekMergedCount).toBe('number');
     expect(typeof result.thisWeekClosedCount).toBe('number');
@@ -276,13 +300,12 @@ describe('getKilocodeRepoOpenPullRequestsSummary draft filtering', () => {
       .mockImplementation(async (input: RequestInfo | URL) => {
         const urlString = typeof input === 'string' ? input : input.toString();
 
-        // List pulls endpoint includes query params (e.g. /pulls?state=open...)
         if (urlString.includes('/repos/Kilo-Org/kilocode/pulls?')) {
           return mockGithubJsonResponse(prListJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/')) {
-          return new Response('', { status: 404 });
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
         }
 
         if (urlString.includes('/issues/') || urlString.includes('/pulls/')) {
@@ -292,8 +315,10 @@ describe('getKilocodeRepoOpenPullRequestsSummary draft filtering', () => {
         throw new Error(`Unexpected fetch: ${urlString}`);
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -348,13 +373,12 @@ describe('getKilocodeRepoOpenPullRequestsSummary draft filtering', () => {
       .mockImplementation(async (input: RequestInfo | URL) => {
         const urlString = typeof input === 'string' ? input : input.toString();
 
-        // List pulls endpoint includes query params (e.g. /pulls?state=open...)
         if (urlString.includes('/repos/Kilo-Org/kilocode/pulls?')) {
           return mockGithubJsonResponse(prListJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/')) {
-          return new Response('', { status: 404 });
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
         }
 
         // Comment endpoints should be hit only for external PRs (1 and 2), not the bot PR.
@@ -378,9 +402,11 @@ describe('getKilocodeRepoOpenPullRequestsSummary draft filtering', () => {
         throw new Error(`Unexpected fetch: ${urlString}`);
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
       includeDrafts: true,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -423,33 +449,26 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           ]);
         }
 
-        // List pulls endpoint includes query params (e.g. /pulls?state=open...)
         if (urlString.includes('/repos/Kilo-Org/kilocode/pulls?')) {
           return mockGithubJsonResponse(prListJson);
         }
 
-        // PR author is external.
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
+        // Bulk org members — kilo-team-member is in the org
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-team-member']);
         }
 
-        // Comments are empty.
         if (urlString.includes('/issues/10/comments') || urlString.includes('/pulls/10/comments')) {
           return mockGithubJsonResponse([]);
         }
 
-        // Approver is in the org.
-        if (urlString.includes('/orgs/Kilo-Org/members/kilo-team-member')) {
-          return new Response(null, { status: 204 });
-        }
-
-        // Returning a non-retriable status here helps avoid tests hanging due to
-        // fetchWithBackoff retrying thrown errors.
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -492,8 +511,8 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse(prListJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-team-member']);
         }
 
         if (urlString.includes('/issues/11/comments')) {
@@ -507,15 +526,13 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           );
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/kilo-team-member')) {
-          return new Response(null, { status: 204 });
-        }
-
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -558,8 +575,8 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse(prListJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-team-member']);
         }
 
         if (urlString.includes('/issues/12/comments')) {
@@ -573,15 +590,13 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           );
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/kilo-team-member')) {
-          return new Response(null, { status: 204 });
-        }
-
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -622,8 +637,8 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse(prListJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-team-member']);
         }
 
         if (urlString.includes('/issues/13/comments')) {
@@ -634,15 +649,13 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse([{ user: { login: 'kilo-team-member' } }]);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/kilo-team-member')) {
-          return new Response(null, { status: 204 });
-        }
-
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -685,31 +698,26 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse(prListJson);
         }
 
-        // PR author is external.
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
+        // No org members
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
         }
 
-        // Issue comments are empty.
         if (urlString.includes('/issues/14/comments')) {
           return mockGithubJsonResponse([]);
         }
 
-        // Inline review comment from an external user.
         if (urlString.includes('/pulls/14/comments')) {
           return mockGithubJsonResponse([{ user: { login: 'external-reviewer' } }]);
-        }
-
-        // Reviewer is NOT in the org.
-        if (urlString.includes('/orgs/Kilo-Org/members/external-reviewer')) {
-          return new Response('', { status: 404 });
         }
 
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -756,13 +764,12 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse(prListJson);
         }
 
-        if (urlString.includes('/orgs/Kilo-Org/members/external-user')) {
-          return new Response('', { status: 404 });
+        // kilo-team-member is in the org
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-team-member']);
         }
 
         // PR #20: same reviewer submits multiple reviews; latest wins.
-        // Final state has CHANGES_REQUESTED by external-reviewer, so precedence should pick it.
-        // Also includes a team approval, which should not override changes requested.
         if (urlString.includes('/repos/Kilo-Org/kilocode/pulls/20/reviews')) {
           return mockGithubJsonResponse([
             { state: 'APPROVED', user: { login: 'external-reviewer' } },
@@ -786,19 +793,13 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
           return mockGithubJsonResponse([]);
         }
 
-        // Membership checks.
-        if (urlString.includes('/orgs/Kilo-Org/members/kilo-team-member')) {
-          return new Response(null, { status: 204 });
-        }
-        if (urlString.includes('/orgs/Kilo-Org/members/external-reviewer')) {
-          return new Response('', { status: 404 });
-        }
-
         return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
       });
 
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     const summary = await getKilocodeRepoOpenPullRequestsSummary({
       ttlMs: 0,
+      repos: ['kilocode'],
       commentConcurrency: 1,
       maxIssueCommentPages: 1,
       maxReviewCommentPages: 1,
@@ -810,6 +811,281 @@ describe('getKilocodeRepoOpenPullRequestsSummary team approval classification', 
 
     expect(pr20?.reviewStatus).toBe('changes_requested');
     expect(pr21?.reviewStatus).toBe('no_reviews');
+
+    fetchMock.mockRestore();
+  });
+});
+
+describe('multi-repo aggregation', () => {
+  it('aggregates open PR counts and lists across repos with correct repo field', async () => {
+    const kilocodePrs = parseGithubListPullRequestsSummaryResponse([
+      {
+        number: 1,
+        title: 'kilocode pr',
+        html_url: 'https://github.com/Kilo-Org/kilocode/pull/1',
+        created_at: '2020-01-01T00:00:00.000Z',
+        draft: false,
+        comments: 0,
+        review_comments: 0,
+        user: { login: 'external-a', type: 'User' },
+      },
+    ]);
+
+    const cloudPrs = parseGithubListPullRequestsSummaryResponse([
+      {
+        number: 10,
+        title: 'cloud pr',
+        html_url: 'https://github.com/Kilo-Org/cloud/pull/10',
+        created_at: '2020-01-01T00:00:00.000Z',
+        draft: false,
+        comments: 0,
+        review_comments: 0,
+        user: { login: 'external-b', type: 'User' },
+      },
+      {
+        number: 11,
+        title: 'cloud team pr',
+        html_url: 'https://github.com/Kilo-Org/cloud/pull/11',
+        created_at: '2020-01-01T00:00:00.000Z',
+        draft: false,
+        comments: 0,
+        review_comments: 0,
+        user: { login: 'kilo-member', type: 'User' },
+      },
+    ]);
+
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const urlString = typeof input === 'string' ? input : input.toString();
+
+        if (urlString.includes('/repos/Kilo-Org/kilocode/pulls?')) {
+          return mockGithubJsonResponse(kilocodePrs);
+        }
+        if (urlString.includes('/repos/Kilo-Org/cloud/pulls?')) {
+          return mockGithubJsonResponse(cloudPrs);
+        }
+
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return orgMembersResponse(['kilo-member']);
+        }
+
+        if (urlString.includes('/issues/') || urlString.includes('/pulls/')) {
+          return mockGithubJsonResponse([]);
+        }
+
+        throw new Error(`Unexpected fetch: ${urlString}`);
+      });
+
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
+    const summary = await getKilocodeRepoOpenPullRequestsSummary({
+      ttlMs: 0,
+      repos: ['kilocode', 'cloud'],
+      commentConcurrency: 1,
+      maxIssueCommentPages: 1,
+      maxReviewCommentPages: 1,
+    });
+
+    expect(summary.totalOpenPullRequests).toBe(3);
+    expect(summary.teamOpenPullRequests).toBe(1);
+    expect(summary.externalOpenPullRequests).toBe(2);
+    expect(summary.externalOpenPullRequestsList).toHaveLength(2);
+
+    const pr1 = summary.externalOpenPullRequestsList.find(pr => pr.number === 1);
+    const pr10 = summary.externalOpenPullRequestsList.find(pr => pr.number === 10);
+    expect(pr1?.repo).toBe('kilocode');
+    expect(pr10?.repo).toBe('cloud');
+
+    fetchMock.mockRestore();
+  });
+
+  it('merges closed PRs across repos sorted by displayDate and trims to maxResults', async () => {
+    const kilocodeClosedPrs = [
+      {
+        number: 1,
+        title: 'oldest merged',
+        html_url: 'https://github.com/Kilo-Org/kilocode/pull/1',
+        closed_at: '2024-01-01T00:00:00.000Z',
+        merged_at: '2024-01-01T00:00:00.000Z',
+        user: { login: 'external-a', type: 'User' },
+      },
+      {
+        number: 2,
+        title: 'newest closed',
+        html_url: 'https://github.com/Kilo-Org/kilocode/pull/2',
+        closed_at: '2024-01-10T00:00:00.000Z',
+        merged_at: null,
+        user: { login: 'external-b', type: 'User' },
+      },
+    ];
+
+    const cloudClosedPrs = [
+      {
+        number: 20,
+        title: 'middle merged',
+        html_url: 'https://github.com/Kilo-Org/cloud/pull/20',
+        closed_at: '2024-01-06T00:00:00.000Z',
+        merged_at: '2024-01-05T00:00:00.000Z',
+        user: { login: 'external-c', type: 'User' },
+      },
+    ];
+
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const urlString = typeof input === 'string' ? input : input.toString();
+
+        if (
+          urlString.includes('/repos/Kilo-Org/kilocode/pulls?') &&
+          urlString.includes('state=closed')
+        ) {
+          return mockGithubJsonResponse(kilocodeClosedPrs);
+        }
+        if (
+          urlString.includes('/repos/Kilo-Org/cloud/pulls?') &&
+          urlString.includes('state=closed')
+        ) {
+          return mockGithubJsonResponse(cloudClosedPrs);
+        }
+
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
+        }
+
+        return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
+      });
+
+    const { getKilocodeRepoRecentlyClosedExternalPRs } = await importModule();
+
+    // maxResults=2 should trim to 2 after cross-repo sort
+    const result = await getKilocodeRepoRecentlyClosedExternalPRs({
+      ttlMs: 0,
+      maxResults: 2,
+      repos: ['kilocode', 'cloud'],
+    });
+
+    expect(result.prs).toHaveLength(2);
+    // Sorted by displayDate desc: PR #2 (Jan 10), PR #20 (Jan 5 merged_at)
+    expect(result.prs[0]?.number).toBe(2);
+    expect(result.prs[0]?.repo).toBe('kilocode');
+    expect(result.prs[1]?.number).toBe(20);
+    expect(result.prs[1]?.repo).toBe('cloud');
+
+    fetchMock.mockRestore();
+  });
+
+  it('aggregates week stats across repos', async () => {
+    // Use a fixed "now" in the middle of a known week (Mon Jan 15 2024)
+    const now = new Date('2024-01-17T12:00:00.000Z');
+
+    const kilocodeClosedPrs = [
+      {
+        number: 1,
+        title: 'merged this week',
+        html_url: 'https://github.com/Kilo-Org/kilocode/pull/1',
+        closed_at: '2024-01-16T00:00:00.000Z',
+        merged_at: '2024-01-16T00:00:00.000Z',
+        user: { login: 'external-a', type: 'User' },
+      },
+    ];
+
+    const cloudClosedPrs = [
+      {
+        number: 20,
+        title: 'also merged this week',
+        html_url: 'https://github.com/Kilo-Org/cloud/pull/20',
+        closed_at: '2024-01-17T00:00:00.000Z',
+        merged_at: '2024-01-17T00:00:00.000Z',
+        user: { login: 'external-b', type: 'User' },
+      },
+      {
+        number: 21,
+        title: 'closed unmerged this week',
+        html_url: 'https://github.com/Kilo-Org/cloud/pull/21',
+        closed_at: '2024-01-15T00:00:00.000Z',
+        merged_at: null,
+        user: { login: 'external-c', type: 'User' },
+      },
+    ];
+
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const urlString = typeof input === 'string' ? input : input.toString();
+
+        if (
+          urlString.includes('/repos/Kilo-Org/kilocode/pulls?') &&
+          urlString.includes('state=closed')
+        ) {
+          return mockGithubJsonResponse(kilocodeClosedPrs);
+        }
+        if (
+          urlString.includes('/repos/Kilo-Org/cloud/pulls?') &&
+          urlString.includes('state=closed')
+        ) {
+          return mockGithubJsonResponse(cloudClosedPrs);
+        }
+
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
+        }
+
+        return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
+      });
+
+    const { getKilocodeRepoRecentlyClosedExternalPRs } = await importModule();
+    const result = await getKilocodeRepoRecentlyClosedExternalPRs({
+      ttlMs: 0,
+      maxResults: 50,
+      repos: ['kilocode', 'cloud'],
+      now,
+      timeZone: 'UTC',
+    });
+
+    // 1 merged from kilocode + 1 merged from cloud = 2
+    expect(result.thisWeekMergedCount).toBe(2);
+    // 1 closed-unmerged from cloud
+    expect(result.thisWeekClosedCount).toBe(1);
+    expect(result.prs).toHaveLength(3);
+
+    fetchMock.mockRestore();
+  });
+
+  it('defaults to all repos when repos param is omitted', async () => {
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const urlString = typeof input === 'string' ? input : input.toString();
+
+        if (urlString.includes('/pulls?')) {
+          return mockGithubJsonResponse([]);
+        }
+
+        if (urlString.includes('/orgs/Kilo-Org/members')) {
+          return emptyOrgMembersResponse();
+        }
+
+        return new Response('', { status: 404, statusText: `Unexpected fetch: ${urlString}` });
+      });
+
+    const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
+    await getKilocodeRepoOpenPullRequestsSummary({ ttlMs: 0 });
+
+    // Should have fetched pulls for all 3 repos
+    const pullsCalls = fetchMock.mock.calls.filter(([input]) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      return url.includes('/pulls?');
+    });
+
+    const repos = pullsCalls.map(([input]) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const match = url.match(/repos\/Kilo-Org\/([^/]+)\/pulls/);
+      return match?.[1];
+    });
+
+    expect(repos).toContain('kilocode');
+    expect(repos).toContain('cloud');
+    expect(repos).toContain('kilo-marketplace');
 
     fetchMock.mockRestore();
   });

--- a/src/lib/github/open-pull-request-counts.test.ts
+++ b/src/lib/github/open-pull-request-counts.test.ts
@@ -1071,7 +1071,6 @@ describe('multi-repo aggregation', () => {
     const { getKilocodeRepoOpenPullRequestsSummary } = await importModule();
     await getKilocodeRepoOpenPullRequestsSummary({ ttlMs: 0 });
 
-    // Should have fetched pulls for all 3 repos
     const pullsCalls = fetchMock.mock.calls.filter(([input]) => {
       const url = typeof input === 'string' ? input : input.toString();
       return url.includes('/pulls?');
@@ -1086,6 +1085,7 @@ describe('multi-repo aggregation', () => {
     expect(repos).toContain('kilocode');
     expect(repos).toContain('cloud');
     expect(repos).toContain('kilo-marketplace');
+    expect(repos).toContain('kilocode-legacy');
 
     fetchMock.mockRestore();
   });

--- a/src/lib/github/open-pull-request-counts.ts
+++ b/src/lib/github/open-pull-request-counts.ts
@@ -19,6 +19,7 @@ type ExternalOpenPullRequest = {
   number: number;
   title: string;
   url: string;
+  repo: string;
   authorLogin: string;
   createdAt: string;
   ageDays: number;
@@ -49,6 +50,7 @@ type ExternalClosedPullRequest = {
   number: number;
   title: string;
   url: string;
+  repo: string;
   authorLogin: string;
   closedAt: string;
   mergedAt: string | null;
@@ -311,23 +313,37 @@ const CLOSED_PULL_REQUEST_ITEM_SCHEMA = z.object({
 const CLOSED_PULL_REQUESTS_RESPONSE_SCHEMA = z.array(CLOSED_PULL_REQUEST_ITEM_SCHEMA);
 
 const ORG = 'Kilo-Org';
-const REPO_OWNER = 'Kilo-Org';
-const REPO_NAME = 'kilocode';
 
-const countsCacheByIncludeDrafts = new Map<boolean, CacheEntry<OpenPullRequestCounts>>();
-const countsInFlightByIncludeDrafts = new Map<boolean, Promise<OpenPullRequestCounts>>();
+export const SUPPORTED_REPOS = {
+  kilocode: { owner: 'Kilo-Org', name: 'kilocode' },
+  cloud: { owner: 'Kilo-Org', name: 'cloud' },
+  'kilo-marketplace': { owner: 'Kilo-Org', name: 'kilo-marketplace' },
+} as const;
 
-const summaryCacheByIncludeDrafts = new Map<boolean, CacheEntry<OpenPullRequestsSummary>>();
-const summaryInFlightByIncludeDrafts = new Map<boolean, Promise<OpenPullRequestsSummary>>();
+export type RepoId = keyof typeof SUPPORTED_REPOS;
 
-const orgMemberCache = new Map<string, CacheEntry<boolean>>();
+export const ALL_REPO_IDS: readonly RepoId[] = Object.keys(SUPPORTED_REPOS) as RepoId[];
+
+type RepoRef = { owner: string; name: string };
+
+const countsCacheByKey = new Map<string, CacheEntry<OpenPullRequestCounts>>();
+const countsInFlightByKey = new Map<string, Promise<OpenPullRequestCounts>>();
+
+const summaryCacheByKey = new Map<string, CacheEntry<OpenPullRequestsSummary>>();
+const summaryInFlightByKey = new Map<string, Promise<OpenPullRequestsSummary>>();
+
+const orgMembersCache = new Map<string, CacheEntry<Set<string>>>();
+const orgMembersInFlight = new Map<string, Promise<Set<string>>>();
 
 type PullRequestTeamInteraction = {
   teamCommented: boolean;
   reviewStatus: PullRequestReviewStatus;
 };
 
-const teamCommentedCache = new Map<number, CacheEntry<PullRequestTeamInteraction>>();
+const DEFAULT_TTL_MS = 2 * 60_000;
+const ORG_MEMBERS_TTL_MS = 30 * 60_000;
+const TEAM_COMMENTED_TTL_MS = 10 * 60_000;
+const teamCommentedCache = new Map<string, CacheEntry<PullRequestTeamInteraction>>();
 
 function isBotGithubUser(user: GithubUserLite): boolean {
   return user.type === 'Bot';
@@ -363,13 +379,16 @@ async function githubRequest(url: string, init?: RequestInit): Promise<Response>
 }
 
 async function listOpenPullRequestAuthors(options: {
+  repo: RepoRef;
   includeDrafts: boolean;
 }): Promise<GithubUserLite[]> {
   const perPage = 100;
   const authors: GithubUserLite[] = [];
 
   for (let page = 1; ; page += 1) {
-    const url = new URL(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls`);
+    const url = new URL(
+      `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/pulls`
+    );
     url.searchParams.set('state', 'open');
     url.searchParams.set('per_page', String(perPage));
     url.searchParams.set('page', String(page));
@@ -404,13 +423,16 @@ export function parseGithubListPullRequestsSummaryResponse(
 }
 
 async function listOpenPullRequests(options: {
+  repo: RepoRef;
   includeDrafts: boolean;
 }): Promise<OpenPullRequestApiSummary[]> {
   const perPage = 100;
   const prs: OpenPullRequestApiSummary[] = [];
 
   for (let page = 1; ; page += 1) {
-    const url = new URL(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls`);
+    const url = new URL(
+      `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/pulls`
+    );
     url.searchParams.set('state', 'open');
     url.searchParams.set('per_page', String(perPage));
     url.searchParams.set('page', String(page));
@@ -436,31 +458,65 @@ async function listOpenPullRequests(options: {
   }
 }
 
-async function isOrgMember(org: string, username: string): Promise<boolean> {
-  const key = username.toLowerCase();
+const ORG_MEMBERS_SCHEMA = z.array(
+  z.object({
+    login: z.string().min(1),
+  })
+);
+
+async function fetchOrgMembers(org: string): Promise<Set<string>> {
   const now = Date.now();
-  const cached = orgMemberCache.get(key);
+  const cached = orgMembersCache.get(org);
   if (cached && cached.expiresAtMs > now) {
     return cached.value;
   }
 
-  const url = `https://api.github.com/orgs/${org}/members/${encodeURIComponent(username)}`;
-  const response = await githubRequest(url, { method: 'GET' });
-
-  if (response.status === 204) {
-    orgMemberCache.set(key, { value: true, expiresAtMs: now + 30 * 60_000 });
-    return true;
+  const inFlight = orgMembersInFlight.get(org);
+  if (inFlight) {
+    return inFlight;
   }
 
-  if (response.status === 404) {
-    orgMemberCache.set(key, { value: false, expiresAtMs: now + 30 * 60_000 });
-    return false;
-  }
+  const promise = (async () => {
+    const perPage = 100;
+    const logins = new Set<string>();
 
-  const bodyText = await response.text().catch(() => '');
-  throw new Error(
-    `GitHub org membership check failed: ${response.status} ${response.statusText}${bodyText ? ` - ${bodyText}` : ''}`
-  );
+    for (let page = 1; ; page += 1) {
+      const url = new URL(`https://api.github.com/orgs/${encodeURIComponent(org)}/members`);
+      url.searchParams.set('per_page', String(perPage));
+      url.searchParams.set('page', String(page));
+
+      const response = await githubRequest(url.toString(), { method: 'GET' });
+      if (!response.ok) {
+        const bodyText = await response.text().catch(() => '');
+        throw new Error(
+          `GitHub list org members failed: ${response.status} ${response.statusText}${bodyText ? ` - ${bodyText}` : ''}`
+        );
+      }
+
+      const members = ORG_MEMBERS_SCHEMA.parse(await response.json());
+      for (const member of members) {
+        logins.add(member.login.toLowerCase());
+      }
+
+      if (members.length < perPage) break;
+    }
+
+    orgMembersCache.set(org, { value: logins, expiresAtMs: Date.now() + ORG_MEMBERS_TTL_MS });
+    return logins;
+  })();
+
+  orgMembersInFlight.set(org, promise);
+
+  try {
+    return await promise;
+  } finally {
+    orgMembersInFlight.delete(org);
+  }
+}
+
+async function isOrgMember(org: string, username: string): Promise<boolean> {
+  const members = await fetchOrgMembers(org);
+  return members.has(username.toLowerCase());
 }
 
 function msBetween(earlier: Date, later: Date): number {
@@ -501,12 +557,13 @@ async function anyOrgMemberInLogins(org: string, logins: readonly string[]): Pro
 }
 
 async function listIssueCommentAuthorLoginsForPullRequest(options: {
+  repo: RepoRef;
   prNumber: number;
   page: number;
   perPage: number;
 }): Promise<string[]> {
   const url = new URL(
-    `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues/${options.prNumber}/comments`
+    `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/issues/${options.prNumber}/comments`
   );
   url.searchParams.set('per_page', String(options.perPage));
   url.searchParams.set('page', String(options.page));
@@ -529,12 +586,13 @@ async function listIssueCommentAuthorLoginsForPullRequest(options: {
 }
 
 async function listReviewCommentAuthorLoginsForPullRequest(options: {
+  repo: RepoRef;
   prNumber: number;
   page: number;
   perPage: number;
 }): Promise<string[]> {
   const url = new URL(
-    `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${options.prNumber}/comments`
+    `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/pulls/${options.prNumber}/comments`
   );
   url.searchParams.set('per_page', String(options.perPage));
   url.searchParams.set('page', String(options.page));
@@ -557,12 +615,13 @@ async function listReviewCommentAuthorLoginsForPullRequest(options: {
 }
 
 async function listPullRequestReviewApproverLoginsForPullRequest(options: {
+  repo: RepoRef;
   prNumber: number;
   page: number;
   perPage: number;
 }): Promise<{ reviews: Array<{ state: string; userLogin: string }>; totalReviews: number }> {
   const url = new URL(
-    `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${options.prNumber}/reviews`
+    `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/pulls/${options.prNumber}/reviews`
   );
   url.searchParams.set('per_page', String(options.perPage));
   url.searchParams.set('page', String(options.page));
@@ -595,48 +654,19 @@ async function listPullRequestReviewApproverLoginsForPullRequest(options: {
   return { reviews, totalReviews: json.length };
 }
 
-async function hasOrgMemberReviewedPullRequest(options: {
+async function getPullRequestReviewStatusAndTeamReviewed(options: {
+  repo: RepoRef;
   org: string;
   prNumber: number;
   maxPullRequestReviewPages: number;
-}): Promise<boolean> {
-  // Best-effort: bounded review checks to avoid rate-limit issues.
-  // Stop early if we find a team approval.
-  const perPage = 100;
-
-  for (let page = 1; page <= options.maxPullRequestReviewPages; page += 1) {
-    const { reviews, totalReviews } = await listPullRequestReviewApproverLoginsForPullRequest({
-      prNumber: options.prNumber,
-      page,
-      perPage,
-    });
-
-    if (
-      await anyOrgMemberInLogins(
-        options.org,
-        reviews.map(r => r.userLogin)
-      )
-    ) {
-      return true;
-    }
-
-    if (totalReviews < perPage) break;
-  }
-
-  return false;
-}
-
-async function getPullRequestReviewStatus(options: {
-  org: string;
-  prNumber: number;
-  maxPullRequestReviewPages: number;
-}): Promise<PullRequestReviewStatus> {
+}): Promise<{ reviewStatus: PullRequestReviewStatus; teamReviewed: boolean }> {
   const perPage = 100;
 
   const latestStateByLowerLogin = new Map<string, string>();
 
   for (let page = 1; page <= options.maxPullRequestReviewPages; page += 1) {
     const { reviews, totalReviews } = await listPullRequestReviewApproverLoginsForPullRequest({
+      repo: options.repo,
       prNumber: options.prNumber,
       page,
       perPage,
@@ -650,13 +680,16 @@ async function getPullRequestReviewStatus(options: {
   }
 
   if (latestStateByLowerLogin.size === 0) {
-    return 'no_reviews';
+    return { reviewStatus: 'no_reviews', teamReviewed: false };
   }
 
   const latestStates = [...latestStateByLowerLogin.values()];
+  const allLogins = [...latestStateByLowerLogin.keys()];
+
+  const teamReviewed = await anyOrgMemberInLogins(options.org, allLogins);
 
   if (latestStates.includes('CHANGES_REQUESTED')) {
-    return 'changes_requested';
+    return { reviewStatus: 'changes_requested', teamReviewed };
   }
 
   const approvedLogins = [...latestStateByLowerLogin.entries()]
@@ -665,61 +698,58 @@ async function getPullRequestReviewStatus(options: {
 
   if (approvedLogins.length > 0) {
     if (await anyOrgMemberInLogins(options.org, approvedLogins)) {
-      return 'approved';
+      return { reviewStatus: 'approved', teamReviewed };
     }
   }
 
   if (latestStates.includes('COMMENTED')) {
-    return 'commented';
+    return { reviewStatus: 'commented', teamReviewed };
   }
 
-  return 'no_reviews';
+  return { reviewStatus: 'no_reviews', teamReviewed };
 }
 
 async function hasOrgMemberCommentedOnPullRequest(options: {
+  repo: RepoRef;
+  repoId: string;
   org: string;
   prNumber: number;
-  ttlMs: number;
   maxIssueCommentPages: number;
   maxReviewCommentPages: number;
   maxPullRequestReviewPages: number;
 }): Promise<PullRequestTeamInteraction> {
+  const cacheKey = `${options.repoId}:${options.prNumber}`;
   const now = Date.now();
-  const cached = teamCommentedCache.get(options.prNumber);
+  const cached = teamCommentedCache.get(cacheKey);
   if (cached && cached.expiresAtMs > now) {
     return cached.value;
   }
 
-  // Best-effort: bounded comment page checks to avoid rate-limit issues.
-  // We check issue comments first, then review comments.
   const perPage = 100;
 
   for (let page = 1; page <= options.maxIssueCommentPages; page += 1) {
     const logins = await listIssueCommentAuthorLoginsForPullRequest({
+      repo: options.repo,
       prNumber: options.prNumber,
       page,
       perPage,
     });
     if (await anyOrgMemberInLogins(options.org, logins)) {
-      const reviewStatus = await getPullRequestReviewStatus({
+      const { reviewStatus } = await getPullRequestReviewStatusAndTeamReviewed({
+        repo: options.repo,
         org: options.org,
         prNumber: options.prNumber,
         maxPullRequestReviewPages: options.maxPullRequestReviewPages,
       });
       const value: PullRequestTeamInteraction = { teamCommented: true, reviewStatus };
-      teamCommentedCache.set(options.prNumber, { value, expiresAtMs: now + options.ttlMs });
+      teamCommentedCache.set(cacheKey, { value, expiresAtMs: now + TEAM_COMMENTED_TTL_MS });
       return value;
     }
     if (logins.length < perPage) break;
   }
 
-  const reviewStatus = await getPullRequestReviewStatus({
-    org: options.org,
-    prNumber: options.prNumber,
-    maxPullRequestReviewPages: options.maxPullRequestReviewPages,
-  });
-
-  const teamReviewed = await hasOrgMemberReviewedPullRequest({
+  const { reviewStatus, teamReviewed } = await getPullRequestReviewStatusAndTeamReviewed({
+    repo: options.repo,
     org: options.org,
     prNumber: options.prNumber,
     maxPullRequestReviewPages: options.maxPullRequestReviewPages,
@@ -727,52 +757,57 @@ async function hasOrgMemberCommentedOnPullRequest(options: {
 
   if (teamReviewed) {
     const value: PullRequestTeamInteraction = { teamCommented: true, reviewStatus };
-    teamCommentedCache.set(options.prNumber, { value, expiresAtMs: now + options.ttlMs });
+    teamCommentedCache.set(cacheKey, { value, expiresAtMs: now + TEAM_COMMENTED_TTL_MS });
     return value;
   }
 
   for (let page = 1; page <= options.maxReviewCommentPages; page += 1) {
     const logins = await listReviewCommentAuthorLoginsForPullRequest({
+      repo: options.repo,
       prNumber: options.prNumber,
       page,
       perPage,
     });
     if (await anyOrgMemberInLogins(options.org, logins)) {
       const value: PullRequestTeamInteraction = { teamCommented: true, reviewStatus };
-      teamCommentedCache.set(options.prNumber, { value, expiresAtMs: now + options.ttlMs });
+      teamCommentedCache.set(cacheKey, { value, expiresAtMs: now + TEAM_COMMENTED_TTL_MS });
       return value;
     }
     if (logins.length < perPage) break;
   }
 
   const value: PullRequestTeamInteraction = { teamCommented: false, reviewStatus };
-  teamCommentedCache.set(options.prNumber, { value, expiresAtMs: now + options.ttlMs });
+  teamCommentedCache.set(cacheKey, { value, expiresAtMs: now + TEAM_COMMENTED_TTL_MS });
   return value;
 }
 
 export async function getKilocodeRepoOpenPullRequestCounts(options?: {
   ttlMs?: number;
   includeDrafts?: boolean;
+  repoId?: RepoId;
 }): Promise<OpenPullRequestCounts> {
-  const ttlMs = options?.ttlMs ?? 2 * 60_000;
+  const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
   const includeDrafts = options?.includeDrafts ?? false;
+  const repoId = options?.repoId ?? 'kilocode';
+  const repo = SUPPORTED_REPOS[repoId];
   const shouldUseCache = ttlMs > 0;
   const now = Date.now();
+  const cacheKey = `${repoId}:${includeDrafts}`;
 
   if (shouldUseCache) {
-    const cached = countsCacheByIncludeDrafts.get(includeDrafts);
+    const cached = countsCacheByKey.get(cacheKey);
     if (cached && cached.expiresAtMs > now) {
       return cached.value;
     }
   }
 
-  const inFlight = countsInFlightByIncludeDrafts.get(includeDrafts);
+  const inFlight = countsInFlightByKey.get(cacheKey);
   if (inFlight) {
     return inFlight;
   }
 
   const promise = (async () => {
-    const authorsByPr = await listOpenPullRequestAuthors({ includeDrafts });
+    const authorsByPr = await listOpenPullRequestAuthors({ repo, includeDrafts });
 
     const uniqueNonBotAuthorsByLowerLogin = new Map<string, string>();
     for (const author of authorsByPr) {
@@ -809,77 +844,59 @@ export async function getKilocodeRepoOpenPullRequestCounts(options?: {
     };
 
     if (shouldUseCache) {
-      countsCacheByIncludeDrafts.set(includeDrafts, { value, expiresAtMs: Date.now() + ttlMs });
+      countsCacheByKey.set(cacheKey, { value, expiresAtMs: Date.now() + ttlMs });
     }
     return value;
   })();
 
-  countsInFlightByIncludeDrafts.set(includeDrafts, promise);
+  countsInFlightByKey.set(cacheKey, promise);
 
   try {
     return await promise;
   } finally {
-    countsInFlightByIncludeDrafts.delete(includeDrafts);
+    countsInFlightByKey.delete(cacheKey);
   }
 }
 
-export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
-  ttlMs?: number;
-  includeDrafts?: boolean;
-  commentConcurrency?: number;
-  maxIssueCommentPages?: number;
-  maxReviewCommentPages?: number;
-  maxPullRequestReviewPages?: number;
-}): Promise<OpenPullRequestsSummary> {
-  const ttlMs = options?.ttlMs ?? 2 * 60_000;
-  const includeDrafts = options?.includeDrafts ?? false;
+async function getOpenPullRequestsSummaryForRepo(
+  repoId: RepoId,
+  options: {
+    ttlMs: number;
+    includeDrafts: boolean;
+    commentConcurrency: number;
+    maxIssueCommentPages: number;
+    maxReviewCommentPages: number;
+    maxPullRequestReviewPages: number;
+  }
+): Promise<OpenPullRequestsSummary> {
+  const { ttlMs, includeDrafts } = options;
+  const repo = SUPPORTED_REPOS[repoId];
   const shouldUseCache = ttlMs > 0;
   const now = Date.now();
+  const cacheKey = `${repoId}:${includeDrafts}`;
 
   if (shouldUseCache) {
-    const cached = summaryCacheByIncludeDrafts.get(includeDrafts);
+    const cached = summaryCacheByKey.get(cacheKey);
     if (cached && cached.expiresAtMs > now) {
       return cached.value;
     }
   }
 
-  const inFlight = summaryInFlightByIncludeDrafts.get(includeDrafts);
+  const inFlight = summaryInFlightByKey.get(cacheKey);
   if (inFlight) {
     return inFlight;
   }
 
   const promise = (async () => {
-    const prs = await listOpenPullRequests({ includeDrafts });
-    const prsWithoutDrafts = includeDrafts ? prs : prs.filter(pr => !pr.draft);
+    const prs = await listOpenPullRequests({ repo, includeDrafts });
 
-    const prsWithAuthors = prsWithoutDrafts.flatMap(pr => {
+    const prsWithAuthors = prs.flatMap(pr => {
       const user = pr.user;
       if (!user) return [];
       return [{ pr, author: toGithubUserLite(user) }];
     });
 
-    const uniqueAuthorsByLowerLogin = new Map<string, string>();
-    for (const { author } of prsWithAuthors) {
-      if (isBotGithubUser(author)) continue;
-      const lower = author.login.toLowerCase();
-      if (!uniqueAuthorsByLowerLogin.has(lower)) {
-        uniqueAuthorsByLowerLogin.set(lower, author.login);
-      }
-    }
-
-    const authorMembershipChecks = await mapWithConcurrencyLimit(
-      [...uniqueAuthorsByLowerLogin.entries()],
-      5,
-      async ([lowerLogin, originalLogin]) => {
-        const isMember = await isOrgMember(ORG, originalLogin);
-        return { lowerLogin, isMember };
-      }
-    );
-
-    const isMemberByLowerLogin = new Map<string, boolean>();
-    for (const { lowerLogin, isMember } of authorMembershipChecks) {
-      isMemberByLowerLogin.set(lowerLogin, isMember);
-    }
+    const orgMembers = await fetchOrgMembers(ORG);
 
     let teamOpenPullRequests = 0;
     let externalOpenPullRequests = 0;
@@ -890,19 +907,13 @@ export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
         teamOpenPullRequests += 1;
         continue;
       }
-      const isMember = isMemberByLowerLogin.get(author.login.toLowerCase()) ?? false;
-      if (isMember) {
+      if (orgMembers.has(author.login.toLowerCase())) {
         teamOpenPullRequests += 1;
       } else {
         externalOpenPullRequests += 1;
         external.push({ pr, authorLogin: author.login });
       }
     }
-
-    const commentConcurrency = options?.commentConcurrency ?? 4;
-    const maxIssueCommentPages = options?.maxIssueCommentPages ?? 2;
-    const maxReviewCommentPages = options?.maxReviewCommentPages ?? 1;
-    const maxPullRequestReviewPages = options?.maxPullRequestReviewPages ?? 1;
 
     const nowDate = new Date();
     const externalListBase: ExternalOpenPullRequest[] = external.map(({ pr, authorLogin }) => {
@@ -918,6 +929,7 @@ export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
         number: pr.number,
         title: pr.title,
         url: pr.html_url,
+        repo: repoId,
         authorLogin,
         createdAt,
         ageDays,
@@ -930,14 +942,15 @@ export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
     const teamInteractionResults = await mapWithConcurrencyLimit<
       ExternalOpenPullRequest,
       PullRequestTeamInteraction
-    >(externalListBase, commentConcurrency, async pr => {
+    >(externalListBase, options.commentConcurrency, async pr => {
       return hasOrgMemberCommentedOnPullRequest({
+        repo,
+        repoId,
         org: ORG,
         prNumber: pr.number,
-        ttlMs,
-        maxIssueCommentPages,
-        maxReviewCommentPages,
-        maxPullRequestReviewPages,
+        maxIssueCommentPages: options.maxIssueCommentPages,
+        maxReviewCommentPages: options.maxReviewCommentPages,
+        maxPullRequestReviewPages: options.maxPullRequestReviewPages,
       });
     });
 
@@ -945,20 +958,13 @@ export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
       (pr, idx) => {
         const interaction = teamInteractionResults[idx];
         if (!interaction) {
-          const fallback: ExternalOpenPullRequest = {
-            ...pr,
-            teamCommented: false,
-            reviewStatus: 'no_reviews',
-          };
-          return fallback;
+          return { ...pr, teamCommented: false, reviewStatus: 'no_reviews' as const };
         }
-
-        const merged: ExternalOpenPullRequest = {
+        return {
           ...pr,
           teamCommented: interaction.teamCommented,
           reviewStatus: interaction.reviewStatus,
         };
-        return merged;
       }
     );
 
@@ -971,27 +977,74 @@ export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
     };
 
     if (shouldUseCache) {
-      summaryCacheByIncludeDrafts.set(includeDrafts, { value, expiresAtMs: Date.now() + ttlMs });
+      summaryCacheByKey.set(cacheKey, { value, expiresAtMs: Date.now() + ttlMs });
     }
     return value;
   })();
 
-  summaryInFlightByIncludeDrafts.set(includeDrafts, promise);
+  summaryInFlightByKey.set(cacheKey, promise);
 
   try {
     return await promise;
   } finally {
-    summaryInFlightByIncludeDrafts.delete(includeDrafts);
+    summaryInFlightByKey.delete(cacheKey);
   }
 }
 
-const mergedPrsCache = new Map<number, CacheEntry<ExternalMergedPullRequest[]>>();
-const mergedPrsInFlight = new Map<number, Promise<ExternalMergedPullRequest[]>>();
+export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
+  ttlMs?: number;
+  includeDrafts?: boolean;
+  repos?: RepoId[];
+  commentConcurrency?: number;
+  maxIssueCommentPages?: number;
+  maxReviewCommentPages?: number;
+  maxPullRequestReviewPages?: number;
+}): Promise<OpenPullRequestsSummary> {
+  const repos = options?.repos ?? ALL_REPO_IDS;
+  const resolvedOptions = {
+    ttlMs: options?.ttlMs ?? DEFAULT_TTL_MS,
+    includeDrafts: options?.includeDrafts ?? false,
+    commentConcurrency: options?.commentConcurrency ?? 4,
+    maxIssueCommentPages: options?.maxIssueCommentPages ?? 2,
+    maxReviewCommentPages: options?.maxReviewCommentPages ?? 1,
+    maxPullRequestReviewPages: options?.maxPullRequestReviewPages ?? 1,
+  };
 
-const closedPrsCache = new Map<number, CacheEntry<ExternalClosedPullRequestsWithWeekStats>>();
-const closedPrsInFlight = new Map<number, Promise<ExternalClosedPullRequestsWithWeekStats>>();
+  // Fetch all repos in parallel
+  const perRepoSummaries = await Promise.all(
+    repos.map(repoId => getOpenPullRequestsSummaryForRepo(repoId, resolvedOptions))
+  );
+
+  // Merge results
+  let totalOpenPullRequests = 0;
+  let teamOpenPullRequests = 0;
+  let externalOpenPullRequests = 0;
+  const externalOpenPullRequestsList: ExternalOpenPullRequest[] = [];
+
+  for (const summary of perRepoSummaries) {
+    totalOpenPullRequests += summary.totalOpenPullRequests;
+    teamOpenPullRequests += summary.teamOpenPullRequests;
+    externalOpenPullRequests += summary.externalOpenPullRequests;
+    externalOpenPullRequestsList.push(...summary.externalOpenPullRequestsList);
+  }
+
+  return {
+    totalOpenPullRequests,
+    teamOpenPullRequests,
+    externalOpenPullRequests,
+    externalOpenPullRequestsList,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+const mergedPrsCache = new Map<string, CacheEntry<ExternalMergedPullRequest[]>>();
+const mergedPrsInFlight = new Map<string, Promise<ExternalMergedPullRequest[]>>();
+
+const closedPrsCache = new Map<string, CacheEntry<ExternalClosedPullRequestsWithWeekStats>>();
+const closedPrsInFlight = new Map<string, Promise<ExternalClosedPullRequestsWithWeekStats>>();
 
 async function listMergedPullRequests(options: {
+  repo: RepoRef;
   maxResults: number;
 }): Promise<z.infer<typeof CLOSED_PULL_REQUEST_ITEM_SCHEMA>[]> {
   const perPage = 100;
@@ -999,7 +1052,9 @@ async function listMergedPullRequests(options: {
   const maxPages = Math.ceil(options.maxResults / perPage);
 
   for (let page = 1; page <= maxPages; page += 1) {
-    const url = new URL(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls`);
+    const url = new URL(
+      `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/pulls`
+    );
     url.searchParams.set('state', 'closed');
     url.searchParams.set('sort', 'updated');
     url.searchParams.set('direction', 'desc');
@@ -1037,26 +1092,30 @@ async function listMergedPullRequests(options: {
 export async function getKilocodeRepoRecentlyMergedExternalPRs(options?: {
   ttlMs?: number;
   maxResults?: number;
+  repoId?: RepoId;
 }): Promise<ExternalMergedPullRequest[]> {
-  const ttlMs = options?.ttlMs ?? 2 * 60_000;
+  const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
   const maxResults = options?.maxResults ?? 50;
+  const repoId = options?.repoId ?? 'kilocode';
+  const repo = SUPPORTED_REPOS[repoId];
   const shouldUseCache = ttlMs > 0;
   const now = Date.now();
+  const cacheKey = `${repoId}:${maxResults}`;
 
   if (shouldUseCache) {
-    const cached = mergedPrsCache.get(maxResults);
+    const cached = mergedPrsCache.get(cacheKey);
     if (cached && cached.expiresAtMs > now) {
       return cached.value;
     }
   }
 
-  const inFlight = mergedPrsInFlight.get(maxResults);
+  const inFlight = mergedPrsInFlight.get(cacheKey);
   if (inFlight) {
     return inFlight;
   }
 
   const promise = (async () => {
-    const prs = await listMergedPullRequests({ maxResults });
+    const prs = await listMergedPullRequests({ repo, maxResults });
 
     const prsWithAuthors = prs.flatMap(pr => {
       const user = pr.user;
@@ -1064,35 +1123,13 @@ export async function getKilocodeRepoRecentlyMergedExternalPRs(options?: {
       return [{ pr, author: toGithubUserLite(user), mergedAt: pr.merged_at }];
     });
 
-    const uniqueAuthorsByLowerLogin = new Map<string, string>();
-    for (const { author } of prsWithAuthors) {
-      if (isBotGithubUser(author)) continue;
-      const lower = author.login.toLowerCase();
-      if (!uniqueAuthorsByLowerLogin.has(lower)) {
-        uniqueAuthorsByLowerLogin.set(lower, author.login);
-      }
-    }
-
-    const authorMembershipChecks = await mapWithConcurrencyLimit(
-      [...uniqueAuthorsByLowerLogin.entries()],
-      5,
-      async ([lowerLogin, originalLogin]) => {
-        const isMember = await isOrgMember(ORG, originalLogin);
-        return { lowerLogin, isMember };
-      }
-    );
-
-    const isMemberByLowerLogin = new Map<string, boolean>();
-    for (const { lowerLogin, isMember } of authorMembershipChecks) {
-      isMemberByLowerLogin.set(lowerLogin, isMember);
-    }
+    const orgMembers = await fetchOrgMembers(ORG);
 
     const external: ExternalMergedPullRequest[] = [];
     for (const { pr, author, mergedAt } of prsWithAuthors) {
       if (isBotGithubUser(author)) continue;
 
-      const isMember = isMemberByLowerLogin.get(author.login.toLowerCase()) ?? false;
-      if (!isMember) {
+      if (!orgMembers.has(author.login.toLowerCase())) {
         external.push({
           number: pr.number,
           title: pr.title,
@@ -1103,7 +1140,6 @@ export async function getKilocodeRepoRecentlyMergedExternalPRs(options?: {
       }
     }
 
-    // Sort by merged date descending (newest first)
     external.sort((a, b) => {
       const dateA = new Date(a.mergedAt).getTime();
       const dateB = new Date(b.mergedAt).getTime();
@@ -1111,21 +1147,22 @@ export async function getKilocodeRepoRecentlyMergedExternalPRs(options?: {
     });
 
     if (shouldUseCache) {
-      mergedPrsCache.set(maxResults, { value: external, expiresAtMs: Date.now() + ttlMs });
+      mergedPrsCache.set(cacheKey, { value: external, expiresAtMs: Date.now() + ttlMs });
     }
     return external;
   })();
 
-  mergedPrsInFlight.set(maxResults, promise);
+  mergedPrsInFlight.set(cacheKey, promise);
 
   try {
     return await promise;
   } finally {
-    mergedPrsInFlight.delete(maxResults);
+    mergedPrsInFlight.delete(cacheKey);
   }
 }
 
 async function listRecentlyClosedPullRequests(options: {
+  repo: RepoRef;
   maxResults: number;
 }): Promise<z.infer<typeof CLOSED_PULL_REQUEST_ITEM_SCHEMA>[]> {
   const perPage = 100;
@@ -1135,7 +1172,9 @@ async function listRecentlyClosedPullRequests(options: {
   const maxPages = Math.ceil((options.maxResults * 4) / perPage);
 
   for (let page = 1; page <= maxPages; page += 1) {
-    const url = new URL(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls`);
+    const url = new URL(
+      `https://api.github.com/repos/${options.repo.owner}/${options.repo.name}/pulls`
+    );
     url.searchParams.set('state', 'closed');
     url.searchParams.set('sort', 'updated');
     url.searchParams.set('direction', 'desc');
@@ -1159,34 +1198,34 @@ async function listRecentlyClosedPullRequests(options: {
   return prs;
 }
 
-export async function getKilocodeRepoRecentlyClosedExternalPRs(options?: {
-  ttlMs?: number;
-  maxResults?: number;
-  now?: Date;
-  timeZone?: string;
-}): Promise<ExternalClosedPullRequestsWithWeekStats> {
-  const ttlMs = options?.ttlMs ?? 2 * 60_000;
-  const maxResults = options?.maxResults ?? 50;
-  const nowDate = options?.now ?? new Date();
-  const timeZone = options?.timeZone ?? 'Europe/Amsterdam';
-  const weekBounds = getCurrentIsoWeekBoundsInTimeZone({ now: nowDate, timeZone });
+async function getRecentlyClosedExternalPRsForRepo(
+  repoId: RepoId,
+  options: {
+    ttlMs: number;
+    maxResults: number;
+    weekBounds: IsoWeekBounds;
+  }
+): Promise<ExternalClosedPullRequestsWithWeekStats> {
+  const { ttlMs, maxResults, weekBounds } = options;
+  const repo = SUPPORTED_REPOS[repoId];
   const shouldUseCache = ttlMs > 0;
   const now = Date.now();
+  const cacheKey = `${repoId}:${maxResults}`;
 
   if (shouldUseCache) {
-    const cached = closedPrsCache.get(maxResults);
+    const cached = closedPrsCache.get(cacheKey);
     if (cached && cached.expiresAtMs > now) {
       return cached.value;
     }
   }
 
-  const inFlight = closedPrsInFlight.get(maxResults);
+  const inFlight = closedPrsInFlight.get(cacheKey);
   if (inFlight) {
     return inFlight;
   }
 
   const promise = (async () => {
-    const prs = await listRecentlyClosedPullRequests({ maxResults });
+    const prs = await listRecentlyClosedPullRequests({ repo, maxResults });
 
     const prsWithAuthors = prs.flatMap(pr => {
       const user = pr.user;
@@ -1195,35 +1234,13 @@ export async function getKilocodeRepoRecentlyClosedExternalPRs(options?: {
       return [{ pr, author: toGithubUserLite(user), closedAt }];
     });
 
-    const uniqueAuthorsByLowerLogin = new Map<string, string>();
-    for (const { author } of prsWithAuthors) {
-      if (isBotGithubUser(author)) continue;
-      const lower = author.login.toLowerCase();
-      if (!uniqueAuthorsByLowerLogin.has(lower)) {
-        uniqueAuthorsByLowerLogin.set(lower, author.login);
-      }
-    }
-
-    const authorMembershipChecks = await mapWithConcurrencyLimit(
-      [...uniqueAuthorsByLowerLogin.entries()],
-      5,
-      async ([lowerLogin, originalLogin]) => {
-        const isMember = await isOrgMember(ORG, originalLogin);
-        return { lowerLogin, isMember };
-      }
-    );
-
-    const isMemberByLowerLogin = new Map<string, boolean>();
-    for (const { lowerLogin, isMember } of authorMembershipChecks) {
-      isMemberByLowerLogin.set(lowerLogin, isMember);
-    }
+    const orgMembers = await fetchOrgMembers(ORG);
 
     const external: ExternalClosedPullRequest[] = [];
     for (const { pr, author, closedAt } of prsWithAuthors) {
       if (isBotGithubUser(author)) continue;
 
-      const isMember = isMemberByLowerLogin.get(author.login.toLowerCase()) ?? false;
-      if (isMember) continue;
+      if (orgMembers.has(author.login.toLowerCase())) continue;
 
       const mergedAt = pr.merged_at;
       const status: ExternalClosedPullRequestStatus = mergedAt ? 'merged' : 'closed';
@@ -1233,6 +1250,7 @@ export async function getKilocodeRepoRecentlyClosedExternalPRs(options?: {
         number: pr.number,
         title: pr.title,
         url: pr.html_url,
+        repo: repoId,
         authorLogin: author.login,
         closedAt,
         mergedAt,
@@ -1270,17 +1288,67 @@ export async function getKilocodeRepoRecentlyClosedExternalPRs(options?: {
     };
 
     if (shouldUseCache) {
-      closedPrsCache.set(maxResults, { value, expiresAtMs: Date.now() + ttlMs });
+      closedPrsCache.set(cacheKey, { value, expiresAtMs: Date.now() + ttlMs });
     }
 
     return value;
   })();
 
-  closedPrsInFlight.set(maxResults, promise);
+  closedPrsInFlight.set(cacheKey, promise);
 
   try {
     return await promise;
   } finally {
-    closedPrsInFlight.delete(maxResults);
+    closedPrsInFlight.delete(cacheKey);
   }
+}
+
+export async function getKilocodeRepoRecentlyClosedExternalPRs(options?: {
+  ttlMs?: number;
+  maxResults?: number;
+  repos?: RepoId[];
+  now?: Date;
+  timeZone?: string;
+}): Promise<ExternalClosedPullRequestsWithWeekStats> {
+  const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+  const maxResults = options?.maxResults ?? 50;
+  const repos = options?.repos ?? ALL_REPO_IDS;
+  const nowDate = options?.now ?? new Date();
+  const timeZone = options?.timeZone ?? 'Europe/Amsterdam';
+  const weekBounds = getCurrentIsoWeekBoundsInTimeZone({ now: nowDate, timeZone });
+
+  // Fetch all repos in parallel
+  const perRepoResults = await Promise.all(
+    repos.map(repoId =>
+      getRecentlyClosedExternalPRsForRepo(repoId, { ttlMs, maxResults, weekBounds })
+    )
+  );
+
+  // Merge results
+  const allPrs: ExternalClosedPullRequest[] = [];
+  let thisWeekMergedCount = 0;
+  let thisWeekClosedCount = 0;
+
+  for (const result of perRepoResults) {
+    allPrs.push(...result.prs);
+    thisWeekMergedCount += result.thisWeekMergedCount;
+    thisWeekClosedCount += result.thisWeekClosedCount;
+  }
+
+  // Re-sort merged results by displayDate descending, then trim
+  allPrs.sort((a, b) => {
+    const dateA = new Date(a.displayDate).getTime();
+    const dateB = new Date(b.displayDate).getTime();
+    return dateB - dateA;
+  });
+
+  const trimmed = allPrs.slice(0, maxResults);
+
+  return {
+    prs: trimmed,
+    thisWeekMergedCount,
+    thisWeekClosedCount,
+    weekStart: weekBounds.weekStart.toISOString(),
+    weekEnd: weekBounds.weekEnd.toISOString(),
+  };
 }

--- a/src/lib/github/open-pull-request-counts.ts
+++ b/src/lib/github/open-pull-request-counts.ts
@@ -1000,7 +1000,7 @@ export async function getKilocodeRepoOpenPullRequestsSummary(options?: {
   maxReviewCommentPages?: number;
   maxPullRequestReviewPages?: number;
 }): Promise<OpenPullRequestsSummary> {
-  const repos = options?.repos ?? ALL_REPO_IDS;
+  const repos = [...new Set(options?.repos ?? ALL_REPO_IDS)];
   const resolvedOptions = {
     ttlMs: options?.ttlMs ?? DEFAULT_TTL_MS,
     includeDrafts: options?.includeDrafts ?? false,
@@ -1312,7 +1312,7 @@ export async function getKilocodeRepoRecentlyClosedExternalPRs(options?: {
 }): Promise<ExternalClosedPullRequestsWithWeekStats> {
   const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
   const maxResults = options?.maxResults ?? 50;
-  const repos = options?.repos ?? ALL_REPO_IDS;
+  const repos = [...new Set(options?.repos ?? ALL_REPO_IDS)];
   const nowDate = options?.now ?? new Date();
   const timeZone = options?.timeZone ?? 'Europe/Amsterdam';
   const weekBounds = getCurrentIsoWeekBoundsInTimeZone({ now: nowDate, timeZone });

--- a/src/lib/github/open-pull-request-counts.ts
+++ b/src/lib/github/open-pull-request-counts.ts
@@ -318,6 +318,7 @@ export const SUPPORTED_REPOS = {
   kilocode: { owner: 'Kilo-Org', name: 'kilocode' },
   cloud: { owner: 'Kilo-Org', name: 'cloud' },
   'kilo-marketplace': { owner: 'Kilo-Org', name: 'kilo-marketplace' },
+  'kilocode-legacy': { owner: 'Kilo-Org', name: 'kilocode-legacy' },
 } as const;
 
 export type RepoId = keyof typeof SUPPORTED_REPOS;

--- a/src/routers/admin-github-router.test.ts
+++ b/src/routers/admin-github-router.test.ts
@@ -13,7 +13,7 @@ jest.mock('@/lib/github/open-pull-request-counts', () => ({
   getKilocodeRepoOpenPullRequestsSummary: jest.fn(),
   getKilocodeRepoRecentlyClosedExternalPRs: jest.fn(),
   getKilocodeRepoRecentlyMergedExternalPRs: jest.fn(),
-  ALL_REPO_IDS: ['kilocode', 'cloud', 'kilo-marketplace'],
+  ALL_REPO_IDS: ['kilocode', 'cloud', 'kilo-marketplace', 'kilocode-legacy'],
 }));
 
 let regularUser: User;

--- a/src/routers/admin-github-router.test.ts
+++ b/src/routers/admin-github-router.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/github/open-pull-request-counts', () => ({
   getKilocodeRepoOpenPullRequestsSummary: jest.fn(),
   getKilocodeRepoRecentlyClosedExternalPRs: jest.fn(),
   getKilocodeRepoRecentlyMergedExternalPRs: jest.fn(),
+  ALL_REPO_IDS: ['kilocode', 'cloud', 'kilo-marketplace'],
 }));
 
 let regularUser: User;
@@ -77,6 +78,7 @@ describe('admin.github.getKilocodeOpenPullRequestsSummary', () => {
           number: 123,
           title: 'Fix thing',
           url: 'https://github.com/Kilo-Org/kilocode/pull/123',
+          repo: 'kilocode',
           authorLogin: 'external-user',
           createdAt: new Date('2020-01-01T00:00:00.000Z').toISOString(),
           ageDays: 12,
@@ -96,6 +98,31 @@ describe('admin.github.getKilocodeOpenPullRequestsSummary', () => {
     expect(result).toEqual(mockSummary);
   });
 
+  it('passes repos parameter through to the service', async () => {
+    const mockSummary = {
+      totalOpenPullRequests: 1,
+      teamOpenPullRequests: 0,
+      externalOpenPullRequests: 1,
+      externalOpenPullRequestsList: [],
+      updatedAt: new Date().toISOString(),
+    };
+
+    (getKilocodeRepoOpenPullRequestsSummary as jest.Mock).mockResolvedValue(mockSummary);
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.github.getKilocodeOpenPullRequestsSummary({
+      repos: ['kilocode', 'cloud'],
+      includeDrafts: true,
+    });
+
+    expect(getKilocodeRepoOpenPullRequestsSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repos: ['kilocode', 'cloud'],
+        includeDrafts: true,
+      })
+    );
+  });
+
   it('always returns numeric commentCount values for external PR rows', async () => {
     const mockSummary = {
       totalOpenPullRequests: 1,
@@ -106,6 +133,7 @@ describe('admin.github.getKilocodeOpenPullRequestsSummary', () => {
           number: 1,
           title: 'Example',
           url: 'https://github.com/Kilo-Org/kilocode/pull/1',
+          repo: 'kilocode',
           authorLogin: 'external-user',
           createdAt: new Date('2020-01-01T00:00:00.000Z').toISOString(),
           ageDays: 1,
@@ -191,6 +219,7 @@ describe('admin.github.getKilocodeRecentlyClosedExternalPRs', () => {
           number: 456,
           title: 'External feature',
           url: 'https://github.com/Kilo-Org/kilocode/pull/456',
+          repo: 'kilocode',
           authorLogin: 'external-contributor',
           closedAt: new Date('2024-01-15T10:00:00.000Z').toISOString(),
           mergedAt: new Date('2024-01-15T09:00:00.000Z').toISOString(),
@@ -201,6 +230,7 @@ describe('admin.github.getKilocodeRecentlyClosedExternalPRs', () => {
           number: 789,
           title: 'Declined change',
           url: 'https://github.com/Kilo-Org/kilocode/pull/789',
+          repo: 'kilocode',
           authorLogin: 'community-dev',
           closedAt: new Date('2024-01-14T08:00:00.000Z').toISOString(),
           mergedAt: null,
@@ -226,6 +256,28 @@ describe('admin.github.getKilocodeRecentlyClosedExternalPRs', () => {
     expect(typeof result.thisWeekMergedCount).toBe('number');
     expect(typeof result.thisWeekClosedCount).toBe('number');
     expect(typeof result.weekStart).toBe('string');
+  });
+
+  it('passes repos parameter through to the service', async () => {
+    const mockClosedPrs = {
+      prs: [],
+      thisWeekMergedCount: 0,
+      thisWeekClosedCount: 0,
+      weekStart: new Date('2024-01-15T00:00:00.000Z').toISOString(),
+    };
+
+    (getKilocodeRepoRecentlyClosedExternalPRs as jest.Mock).mockResolvedValue(mockClosedPrs);
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.github.getKilocodeRecentlyClosedExternalPRs({
+      repos: ['cloud'],
+    });
+
+    expect(getKilocodeRepoRecentlyClosedExternalPRs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repos: ['cloud'],
+      })
+    );
   });
 
   it('returns empty array when no closed PRs', async () => {

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -171,7 +171,9 @@ export const adminRouter = createTRPCRouter({
         z
           .object({
             includeDrafts: z.boolean().optional(),
-            repos: z.array(z.enum(['kilocode', 'cloud', 'kilo-marketplace'])).optional(),
+            repos: z
+              .array(z.enum(['kilocode', 'cloud', 'kilo-marketplace', 'kilocode-legacy']))
+              .optional(),
           })
           .optional()
       )
@@ -192,7 +194,9 @@ export const adminRouter = createTRPCRouter({
       .input(
         z
           .object({
-            repos: z.array(z.enum(['kilocode', 'cloud', 'kilo-marketplace'])).optional(),
+            repos: z
+              .array(z.enum(['kilocode', 'cloud', 'kilo-marketplace', 'kilocode-legacy']))
+              .optional(),
           })
           .optional()
       )

--- a/src/routers/admin-router.ts
+++ b/src/routers/admin-router.ts
@@ -58,6 +58,7 @@ import {
   getKilocodeRepoOpenPullRequestsSummary,
   getKilocodeRepoRecentlyClosedExternalPRs,
   getKilocodeRepoRecentlyMergedExternalPRs,
+  ALL_REPO_IDS,
 } from '@/lib/github/open-pull-request-counts';
 
 const SyncResponseSchema = z.object({
@@ -166,11 +167,20 @@ export const adminRouter = createTRPCRouter({
     }),
 
     getKilocodeOpenPullRequestsSummary: adminProcedure
-      .input(z.object({ includeDrafts: z.boolean().optional() }).optional())
+      .input(
+        z
+          .object({
+            includeDrafts: z.boolean().optional(),
+            repos: z.array(z.enum(['kilocode', 'cloud', 'kilo-marketplace'])).optional(),
+          })
+          .optional()
+      )
       .query(async ({ input }) => {
+        const repos = input?.repos ?? [...ALL_REPO_IDS];
         return getKilocodeRepoOpenPullRequestsSummary({
           ttlMs: 2 * 60_000,
           includeDrafts: input?.includeDrafts ?? false,
+          repos,
         });
       }),
 
@@ -178,9 +188,22 @@ export const adminRouter = createTRPCRouter({
       return getKilocodeRepoRecentlyMergedExternalPRs({ ttlMs: 2 * 60_000, maxResults: 50 });
     }),
 
-    getKilocodeRecentlyClosedExternalPRs: adminProcedure.query(async () => {
-      return getKilocodeRepoRecentlyClosedExternalPRs({ ttlMs: 2 * 60_000, maxResults: 50 });
-    }),
+    getKilocodeRecentlyClosedExternalPRs: adminProcedure
+      .input(
+        z
+          .object({
+            repos: z.array(z.enum(['kilocode', 'cloud', 'kilo-marketplace'])).optional(),
+          })
+          .optional()
+      )
+      .query(async ({ input }) => {
+        const repos = input?.repos ?? [...ALL_REPO_IDS];
+        return getKilocodeRepoRecentlyClosedExternalPRs({
+          ttlMs: 2 * 60_000,
+          maxResults: 50,
+          repos,
+        });
+      }),
   }),
 
   users: createTRPCRouter({


### PR DESCRIPTION
## Summary

 - Add `cloud` and `kilo-marketplace` repos alongside `kilocode`
 - Add repo filter UI with toggle buttons and repo column/sort to both tables
 - Remove auto-refresh (`refetchInterval`) to avoid GitHub API rate limiting, keep manual refresh + `staleTime`
 - Replace per-user org membership API calls with bulk `GET /orgs/{org}/members` fetch (30min cache + in-flight dedup)
 - Merge duplicate review fetches into single function, saving 1 API call per external PR
 - Fetch repos concurrently via `Promise.all`
 - Parameterize backend functions by repo with composite cache keys
 - Add `repos` input to tRPC endpoints
 - Extract TTL numbers into named constants

## Verification

 - [x] `pnpm test` — 38 tests pass (sorting, router, open-pull-request-counts)
 - [x] Verified locally — 28s avg for 3 repos vs 37s avg for 1 repo in prod
 - [x] Multi-repo aggregation, cross-repo sort, week stats, and default repos covered by new tests

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
| ------ | ----- |
|   <img width="1274" height="1231" alt="Screenshot 2026-03-25 at 13 24 08" src="https://github.com/user-attachments/assets/f39419af-2b1a-4ddb-87c2-e9fc8d7f516c" /> |  <img width="1274" height="1231" alt="Screenshot 2026-03-25 at 13 24 41" src="https://github.com/user-attachments/assets/f139af5f-c20a-40ab-99d4-43630e7dfb71" /> |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
