### PR TITLE
feat(cloud-agent): add reasoning variant selector and short model names

### DIFF
--- a/cloud-agent-next/src/kilo/client.ts
+++ b/cloud-agent-next/src/kilo/client.ts
@@ -147,6 +147,7 @@ export class KiloClient {
             modelID: options.model.modelID,
           }
         : undefined,
+      variant: options?.variant,
       agent: options?.agent,
       noReply: options?.noReply,
       system: options?.system,

--- a/cloud-agent-next/src/kilo/types.ts
+++ b/cloud-agent-next/src/kilo/types.ts
@@ -49,6 +49,8 @@ export interface CreateSessionOptions {
 export interface PromptOptions {
   messageId?: string;
   model?: { providerID?: string; modelID: string };
+  /** Thinking/reasoning effort variant (e.g., "high", "max", "low") */
+  variant?: string;
   agent?: string;
   noReply?: boolean;
   /** Custom system prompt override */

--- a/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/cloud-agent-next/src/router/handlers/session-management.ts
@@ -407,6 +407,7 @@ export function createSessionManagementHandlers() {
             // mode is validated by zod (AgentModeSchema) at storage time
             mode: metadata.mode as AgentMode | undefined,
             model: metadata.model,
+            variant: metadata.variant,
             autoCommit: metadata.autoCommit,
             upstreamBranch: metadata.upstreamBranch,
 

--- a/cloud-agent-next/src/router/schemas.ts
+++ b/cloud-agent-next/src/router/schemas.ts
@@ -372,6 +372,7 @@ export const GetSessionOutput = z.object({
   prompt: z.string().optional().describe('Task prompt'),
   mode: AgentModeSchema.optional().describe('Execution mode'),
   model: z.string().optional().describe('AI model'),
+  variant: z.string().optional().describe('Thinking effort variant'),
   autoCommit: z.boolean().optional().describe('Auto-commit setting'),
   upstreamBranch: z.string().optional().describe('Upstream branch name'),
 

--- a/src/components/cloud-agent-next/ChatHeader.tsx
+++ b/src/components/cloud-agent-next/ChatHeader.tsx
@@ -16,6 +16,7 @@ import { SoundToggleButton } from '@/components/shared/SoundToggleButton';
 import { FeedbackDialog } from './FeedbackDialog';
 import { buildRepoBrowseUrl, detectGitPlatform } from './utils/git-utils';
 import { useSidebarToggle } from './CloudSidebarLayout';
+import { formatShortModelName } from '@/lib/format-model-name';
 
 type ChatHeaderProps = {
   cloudAgentSessionId: string;
@@ -25,6 +26,7 @@ type ChatHeaderProps = {
   branch?: string;
   gitUrl?: string | null;
   model?: string;
+  modelDisplayName?: string;
   totalCost?: number;
   soundEnabled?: boolean;
   onToggleSound?: () => void;
@@ -37,6 +39,7 @@ export function ChatHeader({
   branch,
   gitUrl,
   model = 'Unknown',
+  modelDisplayName,
   totalCost = 0,
   soundEnabled = true,
   onToggleSound,
@@ -62,6 +65,7 @@ export function ChatHeader({
         sessionId={cloudAgentSessionId}
         kiloSessionId={kiloSessionId}
         model={model}
+        modelDisplayName={modelDisplayName}
         cost={totalCost * 1_000_000}
       />
       <SessionActionsDialog
@@ -101,7 +105,9 @@ export function ChatHeader({
             {model && model !== 'Unknown' && (
               <>
                 <span className="text-muted-foreground">·</span>
-                <span className="text-muted-foreground hidden shrink-0 sm:inline">{model}</span>
+                <span className="text-muted-foreground hidden shrink-0 sm:inline">
+                  {modelDisplayName ?? formatShortModelName(model)}
+                </span>
               </>
             )}
             {totalCost > 0 && (

--- a/src/components/cloud-agent-next/ChatInput.tsx
+++ b/src/components/cloud-agent-next/ChatInput.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import { BrowseCommandsDialog } from './BrowseCommandsDialog';
 import { ModeCombobox, NEXT_MODE_OPTIONS } from '@/components/shared/ModeCombobox';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import { VariantCombobox } from '@/components/shared/VariantCombobox';
 import type { AgentMode } from './types';
 
 type ChatInputProps = {
@@ -32,6 +33,12 @@ type ChatInputProps = {
   onModeChange?: (mode: AgentMode) => void;
   /** Callback when model changes */
   onModelChange?: (model: string) => void;
+  /** Current variant for the toolbar */
+  variant?: string;
+  /** Callback when variant changes */
+  onVariantChange?: (variant: string) => void;
+  /** Available variant keys for the current model */
+  availableVariants?: string[];
   /** Whether to show the toolbar (hide when no active session) */
   showToolbar?: boolean;
   /** Pre-populate the textarea (e.g. to restore text after a failed send) */
@@ -51,6 +58,9 @@ export function ChatInput({
   isLoadingModels = false,
   onModeChange,
   onModelChange,
+  variant,
+  onVariantChange,
+  availableVariants = [],
   showToolbar = false,
   initialValue,
 }: ChatInputProps) {
@@ -288,6 +298,14 @@ export function ChatInput({
                 isLoading={isLoadingModels}
                 disabled={disabled || isStreaming}
               />
+              {availableVariants.length > 0 && onVariantChange && (
+                <VariantCombobox
+                  variants={availableVariants}
+                  value={variant}
+                  onValueChange={onVariantChange}
+                  disabled={disabled || isStreaming}
+                />
+              )}
             </>
           )}
           {slashCommands.length > 0 && <BrowseCommandsDialog />}

--- a/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -105,6 +105,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
         const prompt = payload.prompt as string;
         const mode = payload.mode as 'code' | 'plan' | 'debug' | 'orchestrator' | 'ask';
         const model = payload.model as string;
+        const variant = payload.variant as string | undefined;
         if (organizationId) {
           return trpcClient.organizations.cloudAgentNext.sendMessage.mutate(
             {
@@ -112,6 +113,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
               prompt,
               mode,
               model,
+              variant,
               autoCommit: true,
               organizationId,
             },
@@ -119,7 +121,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
           );
         }
         return trpcClient.cloudAgentNext.sendMessage.mutate(
-          { cloudAgentSessionId: castSessionId, prompt, mode, model, autoCommit: true },
+          { cloudAgentSessionId: castSessionId, prompt, mode, model, variant, autoCommit: true },
           { context: { skipBatch: true } }
         );
       },
@@ -236,6 +238,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
           gitBranch: rs?.upstreamBranch ?? sessionResult.git_branch,
           mode: rs?.mode ?? null,
           model: rs?.model ?? null,
+          variant: rs?.variant ?? null,
           repository: rs?.githubRepo ?? null,
           isInitiated: Boolean(rs?.initiatedAt),
           needsLegacyPrepare: Boolean(sessionResult.cloud_agent_session_id && !rs),

--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -159,6 +159,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
         prompt,
         mode: sessionConfig?.mode ?? 'code',
         model: sessionConfig?.model ?? '',
+        variant: sessionConfig?.variant ?? undefined,
       });
     },
     [manager, sessionConfig]
@@ -197,7 +198,21 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
 
   const handleModelChange = useCallback(
     (model: string) => {
-      if (sessionConfig) setSessionConfig({ ...sessionConfig, model });
+      if (!sessionConfig) return;
+      // Reset variant to first available (typically "none") when switching models if current is invalid
+      const newModelVariants = modelOptions.find(m => m.id === model)?.variants ?? [];
+      const validVariant =
+        sessionConfig.variant && newModelVariants.includes(sessionConfig.variant)
+          ? sessionConfig.variant
+          : newModelVariants[0];
+      setSessionConfig({ ...sessionConfig, model, variant: validVariant });
+    },
+    [sessionConfig, setSessionConfig, modelOptions]
+  );
+
+  const handleVariantChange = useCallback(
+    (variant: string) => {
+      if (sessionConfig) setSessionConfig({ ...sessionConfig, variant });
     },
     [sessionConfig, setSessionConfig]
   );
@@ -215,6 +230,9 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
 
   // -- Derived state --------------------------------------------------------
   const showChatInterface = Boolean(sessionConfig) || Boolean(sessionIdFromParams);
+  const currentModelOption = modelOptions.find(m => m.id === sessionConfig?.model);
+  const modelDisplayName = currentModelOption?.name;
+  const availableVariants = currentModelOption?.variants ?? [];
 
   const placeholder = isLoading
     ? 'Loading session…'
@@ -249,6 +267,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                 organizationId={organizationId}
                 repository={sessionConfig?.repository ?? ''}
                 model={sessionConfig?.model}
+                modelDisplayName={modelDisplayName}
                 totalCost={totalCost}
                 soundEnabled={soundEnabled}
                 onToggleSound={handleToggleSound}
@@ -318,6 +337,9 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                   isLoadingModels={isLoadingModels}
                   onModeChange={handleModeChange}
                   onModelChange={handleModelChange}
+                  variant={sessionConfig?.variant ?? undefined}
+                  onVariantChange={handleVariantChange}
+                  availableVariants={availableVariants}
                   showToolbar={Boolean(sessionIdFromParams)}
                   initialValue={failedPrompt ?? undefined}
                 />

--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -23,6 +23,7 @@ import { useOrganizationModels } from './hooks/useOrganizationModels';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
 import { useCelebrationSound } from '@/hooks/useCelebrationSound';
 
+import { formatShortModelDisplayName } from '@/lib/format-model-name';
 import type { AgentMode } from './types';
 import type { StoredMessage } from '@/lib/cloud-agent-sdk';
 
@@ -231,7 +232,9 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   // -- Derived state --------------------------------------------------------
   const showChatInterface = Boolean(sessionConfig) || Boolean(sessionIdFromParams);
   const currentModelOption = modelOptions.find(m => m.id === sessionConfig?.model);
-  const modelDisplayName = currentModelOption?.name;
+  const modelDisplayName = currentModelOption?.name
+    ? formatShortModelDisplayName(currentModelOption.name)
+    : undefined;
   const availableVariants = currentModelOption?.variants ?? [];
 
   const placeholder = isLoading

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -474,6 +474,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
     selectedProfile,
     trpc.unifiedSessions.list,
     trpcClient,
+    variant,
   ]);
 
   const isFormValid =

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/components/shared/RepositoryCombobox';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { ModeCombobox, NEXT_MODE_OPTIONS } from '@/components/shared/ModeCombobox';
+import { VariantCombobox } from '@/components/shared/VariantCombobox';
 import { InsufficientBalanceBanner } from '@/components/shared/InsufficientBalanceBanner';
 import { AdvancedConfig } from '@/components/shared/AdvancedConfig';
 import { cn } from '@/lib/utils';
@@ -85,7 +86,12 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
 
   // Format models for the combobox (ModelOption format: id, name)
   const modelOptions = useMemo<ModelOption[]>(
-    () => allModels.map(model => ({ id: model.id, name: model.name })),
+    () =>
+      allModels.map(model => ({
+        id: model.id,
+        name: model.name,
+        variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
+      })),
     [allModels]
   );
 
@@ -95,8 +101,11 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
   const [selectedPlatform, setSelectedPlatform] = useState<RepositoryPlatform>('github');
   const [mode, setMode] = useState<AgentMode>('code');
   const [model, setModel] = useState<string>('');
+  const [variant, setVariant] = useState<string | undefined>(undefined);
   const [isModelUserSelected, setIsModelUserSelected] = useState(false);
   const [isPreparing, setIsPreparing] = useState(false);
+
+  const availableVariants = modelOptions.find(m => m.id === model)?.variants ?? [];
 
   // Session form atoms (profile/env/commands)
   const [manualEnvVars, setManualEnvVars] = useAtom(manualEnvVarsAtom);
@@ -136,6 +145,9 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
       if (newModel && newModel !== model) {
         setModel(newModel);
         setIsModelUserSelected(false); // Auto-selected, not user-selected
+        // Default variant to first available variant (typically "none") for the new model
+        const newVariants = modelOptions.find(m => m.id === newModel)?.variants ?? [];
+        setVariant(newVariants[0]);
       }
     }
   }, [defaultsData?.defaultModel, modelOptions, model, isModelUserSelected]);
@@ -262,6 +274,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
   // Refresh repositories hook (refreshes both GitHub and GitLab)
   const { refresh: refreshGitHubRepositories, isRefreshing: isRefreshingGitHubRepos } =
     useRefreshRepositories({
+      silent: true,
       getRefreshQueryOptions: useCallback(
         () =>
           organizationId
@@ -290,6 +303,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
 
   const { refresh: refreshGitLabRepositories, isRefreshing: isRefreshingGitLabRepos } =
     useRefreshRepositories({
+      silent: true,
       getRefreshQueryOptions: useCallback(
         () =>
           organizationId
@@ -316,9 +330,16 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
       ),
     });
 
-  // Combined refresh function
+  // Combined refresh function — single toast for both platforms
   const refreshRepositories = useCallback(async () => {
-    await Promise.all([refreshGitHubRepositories(), refreshGitLabRepositories()]);
+    try {
+      await Promise.all([refreshGitHubRepositories(), refreshGitLabRepositories()]);
+      toast.success('Repositories refreshed');
+    } catch (error) {
+      toast.error('Failed to refresh repositories', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
   }, [refreshGitHubRepositories, refreshGitLabRepositories]);
 
   const isRefreshingRepos = isRefreshingGitHubRepos || isRefreshingGitLabRepos;
@@ -380,6 +401,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
         prompt: prompt.trim(),
         mode,
         model,
+        variant,
         envVars: Object.keys(manualEnvVars).length > 0 ? manualEnvVars : undefined,
         setupCommands: manualSetupCommands.length > 0 ? manualSetupCommands : undefined,
         profileName: selectedProfile?.name,
@@ -538,10 +560,24 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
             onModelChange={newModel => {
               setModel(newModel);
               setIsModelUserSelected(true);
+              // Reset variant to first available (typically "none") if current is invalid for new model
+              const newVariants = modelOptions.find(m => m.id === newModel)?.variants ?? [];
+              if (!variant || !newVariants.includes(variant)) {
+                setVariant(newVariants[0]);
+              }
             }}
             modelOptions={modelOptions}
             isLoadingModels={!modelsData}
           />
+
+          {/* Variant selector — only shown for models with variant support */}
+          {availableVariants.length > 0 && (
+            <VariantCombobox
+              variants={availableVariants}
+              value={variant}
+              onValueChange={setVariant}
+            />
+          )}
 
           {/* Advanced Configuration */}
           <AdvancedConfig

--- a/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -10,6 +10,7 @@ import {
   FolderGit2,
   Loader2,
   Lock,
+  RefreshCw,
   Send,
   Settings,
   Unlock,
@@ -18,6 +19,7 @@ import {
 import { useTRPC, useRawTRPCClient } from '@/lib/trpc/utils';
 
 import { useProfile, useProfiles, useCombinedProfiles } from '@/hooks/useCloudAgentProfiles';
+import { useRefreshRepositories } from '@/hooks/useRefreshRepositories';
 import { useOrganizationDefaults } from '@/app/api/organizations/hooks';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import {
@@ -36,6 +38,7 @@ import {
 } from '@/components/shared/RepositoryCombobox';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { ModeCombobox, NEXT_MODE_OPTIONS } from '@/components/shared/ModeCombobox';
+import { VariantCombobox } from '@/components/shared/VariantCombobox';
 import { InsufficientBalanceBanner } from '@/components/shared/InsufficientBalanceBanner';
 import { AdvancedConfig } from '@/components/shared/AdvancedConfig';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -101,7 +104,12 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   const allModels = modelsData?.data || [];
 
   const modelOptions = useMemo<ModelOption[]>(
-    () => allModels.map(model => ({ id: model.id, name: model.name })),
+    () =>
+      allModels.map(model => ({
+        id: model.id,
+        name: model.name,
+        variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
+      })),
     [allModels]
   );
 
@@ -113,6 +121,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   const [selectedPlatform, setSelectedPlatform] = useState<RepositoryPlatform>('github');
   const [mode, setMode] = useState<AgentMode>('code');
   const [model, setModel] = useState<string>('');
+  const [variant, setVariant] = useState<string | undefined>(undefined);
   const [isModelUserSelected, setIsModelUserSelected] = useState(false);
   const [isPreparing, setIsPreparing] = useState(false);
 
@@ -132,6 +141,8 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   useEffect(() => {
     resetSessionForm();
   }, [resetSessionForm]);
+
+  const availableVariants = modelOptions.find(m => m.id === model)?.variants ?? [];
 
   // ---------------------------------------------------------------------------
   // Model auto-selection
@@ -154,6 +165,9 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
       if (newModel && newModel !== model) {
         setModel(newModel);
         setIsModelUserSelected(false);
+        // Default variant to first available variant (typically "none") for the new model
+        const newVariants = modelOptions.find(m => m.id === newModel)?.variants ?? [];
+        setVariant(newVariants[0]);
       }
     }
   }, [defaultsData?.defaultModel, modelOptions, model, isModelUserSelected]);
@@ -334,6 +348,77 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
 
   const repoError = githubRepoError || gitlabRepoError;
 
+  const { refresh: refreshGitHubRepositories, isRefreshing: isRefreshingGitHubRepos } =
+    useRefreshRepositories({
+      silent: true,
+      getRefreshQueryOptions: useCallback(
+        () =>
+          organizationId
+            ? trpc.organizations.cloudAgentNext.listGitHubRepositories.queryOptions({
+                organizationId,
+                forceRefresh: true,
+              })
+            : trpc.cloudAgentNext.listGitHubRepositories.queryOptions({
+                forceRefresh: true,
+              }),
+        [organizationId, trpc]
+      ),
+      getCacheQueryKey: useCallback(
+        () =>
+          organizationId
+            ? trpc.organizations.cloudAgentNext.listGitHubRepositories.queryKey({
+                organizationId,
+                forceRefresh: false,
+              })
+            : trpc.cloudAgentNext.listGitHubRepositories.queryKey({
+                forceRefresh: false,
+              }),
+        [organizationId, trpc]
+      ),
+    });
+
+  const { refresh: refreshGitLabRepositories, isRefreshing: isRefreshingGitLabRepos } =
+    useRefreshRepositories({
+      silent: true,
+      getRefreshQueryOptions: useCallback(
+        () =>
+          organizationId
+            ? trpc.organizations.cloudAgentNext.listGitLabRepositories.queryOptions({
+                organizationId,
+                forceRefresh: true,
+              })
+            : trpc.cloudAgentNext.listGitLabRepositories.queryOptions({
+                forceRefresh: true,
+              }),
+        [organizationId, trpc]
+      ),
+      getCacheQueryKey: useCallback(
+        () =>
+          organizationId
+            ? trpc.organizations.cloudAgentNext.listGitLabRepositories.queryKey({
+                organizationId,
+                forceRefresh: false,
+              })
+            : trpc.cloudAgentNext.listGitLabRepositories.queryKey({
+                forceRefresh: false,
+              }),
+        [organizationId, trpc]
+      ),
+    });
+
+  const refreshRepositories = useCallback(async () => {
+    try {
+      await Promise.all([refreshGitHubRepositories(), refreshGitLabRepositories()]);
+      toast.success('Repositories refreshed');
+    } catch (error) {
+      toast.error('Failed to refresh repositories', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }, [refreshGitHubRepositories, refreshGitLabRepositories]);
+
+  const isRefreshingRepos = isRefreshingGitHubRepos || isRefreshingGitLabRepos;
+
   // ---------------------------------------------------------------------------
   // Integration missing check
   // ---------------------------------------------------------------------------
@@ -365,13 +450,13 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
         prompt: prompt.trim(),
         mode,
         model,
+        variant,
         envVars: Object.keys(manualEnvVars).length > 0 ? manualEnvVars : undefined,
         setupCommands: manualSetupCommands.length > 0 ? manualSetupCommands : undefined,
         profileName: selectedProfile?.name,
         autoCommit: true,
         autoInitiate: true,
       };
-
       let result: { kiloSessionId: string; cloudAgentSessionId: string };
 
       if (organizationId) {
@@ -433,6 +518,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
     selectedProfile,
     trpc.unifiedSessions.list,
     trpcClient,
+    variant,
   ]);
 
   // ---------------------------------------------------------------------------
@@ -558,123 +644,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
             disabled={isPreparing}
           />
           <div className="flex items-center gap-2 px-3 py-1.5">
-            {/* Repo pill */}
-            <Popover open={repoPopoverOpen} onOpenChange={setRepoPopoverOpen}>
-              <PopoverTrigger asChild>
-                <button
-                  type="button"
-                  className={cn(
-                    'hover:bg-accent inline-flex h-9 items-center gap-1.5 rounded-md border px-3 text-sm',
-                    !selectedRepo && 'text-muted-foreground'
-                  )}
-                  disabled={isPreparing}
-                >
-                  <FolderGit2 className="h-3.5 w-3.5" />
-                  <span className="max-w-[12rem] truncate">{selectedRepo || 'Repository...'}</span>
-                </button>
-              </PopoverTrigger>
-              <PopoverContent className="w-80 p-0" align="start">
-                {isLoadingRepos ? (
-                  <div className="text-muted-foreground p-4 text-center text-sm">
-                    Loading repositories...
-                  </div>
-                ) : repoError ? (
-                  <div className="p-4 text-center text-sm text-red-400">
-                    Failed to load repositories
-                  </div>
-                ) : unifiedRepositories.length === 0 ? (
-                  <div className="text-muted-foreground p-4 text-center text-sm">
-                    No repositories found
-                  </div>
-                ) : (
-                  <Command>
-                    <CommandInput placeholder="Search repositories..." />
-                    <CommandEmpty>No repositories match your search</CommandEmpty>
-                    <CommandList className="max-h-64 overflow-auto">
-                      {recentRepos.length > 0 && (
-                        <CommandGroup heading="Recently used">
-                          {recentRepos.map(repo => (
-                            <RepoCommandItem
-                              key={`recent-${repo.id}`}
-                              repo={repo}
-                              isSelected={repo.fullName === selectedRepo}
-                              onSelect={handleRepoPillSelect}
-                            />
-                          ))}
-                        </CommandGroup>
-                      )}
-                      {hasMultiplePlatforms ? (
-                        <>
-                          {githubRepos.length > 0 && (
-                            <CommandGroup heading="GitHub">
-                              {githubRepos.map(repo => (
-                                <RepoCommandItem
-                                  key={repo.id}
-                                  repo={repo}
-                                  isSelected={repo.fullName === selectedRepo}
-                                  onSelect={handleRepoPillSelect}
-                                />
-                              ))}
-                            </CommandGroup>
-                          )}
-                          {gitlabRepos.length > 0 && (
-                            <CommandGroup heading="GitLab">
-                              {gitlabRepos.map(repo => (
-                                <RepoCommandItem
-                                  key={repo.id}
-                                  repo={repo}
-                                  isSelected={repo.fullName === selectedRepo}
-                                  onSelect={handleRepoPillSelect}
-                                />
-                              ))}
-                            </CommandGroup>
-                          )}
-                          {otherRepos.length > 0 && (
-                            <CommandGroup heading="Other">
-                              {otherRepos.map(repo => (
-                                <RepoCommandItem
-                                  key={repo.id}
-                                  repo={repo}
-                                  isSelected={repo.fullName === selectedRepo}
-                                  onSelect={handleRepoPillSelect}
-                                />
-                              ))}
-                            </CommandGroup>
-                          )}
-                        </>
-                      ) : (
-                        <CommandGroup>
-                          {filteredUnifiedRepos.map(repo => (
-                            <RepoCommandItem
-                              key={repo.id}
-                              repo={repo}
-                              isSelected={repo.fullName === selectedRepo}
-                              onSelect={handleRepoPillSelect}
-                            />
-                          ))}
-                        </CommandGroup>
-                      )}
-                    </CommandList>
-                  </Command>
-                )}
-              </PopoverContent>
-            </Popover>
-
-            <div className="flex-1" />
-
-            {/* Model + Mode + submit */}
-            {isPreparing && <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />}
-            <ModelCombobox
-              models={modelOptions}
-              value={model}
-              onValueChange={newModel => {
-                setModel(newModel);
-                setIsModelUserSelected(true);
-              }}
-              isLoading={!modelsData}
-              variant="compact"
-              disabled={isPreparing}
-            />
+            {/* Mode → Model → Variant */}
             <ModeCombobox<AgentMode>
               value={mode}
               onValueChange={setMode}
@@ -682,6 +652,34 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
               variant="compact"
               disabled={isPreparing}
             />
+            <ModelCombobox
+              models={modelOptions}
+              value={model}
+              onValueChange={newModel => {
+                setModel(newModel);
+                setIsModelUserSelected(true);
+                // Reset variant to first available (typically "none") if current is invalid for new model
+                const newVariants = modelOptions.find(m => m.id === newModel)?.variants ?? [];
+                if (!variant || !newVariants.includes(variant)) {
+                  setVariant(newVariants[0]);
+                }
+              }}
+              isLoading={!modelsData}
+              variant="compact"
+              disabled={isPreparing}
+            />
+            {availableVariants.length > 0 && (
+              <VariantCombobox
+                variants={availableVariants}
+                value={variant}
+                onValueChange={setVariant}
+                disabled={isPreparing}
+              />
+            )}
+
+            <div className="flex-1" />
+
+            {isPreparing && <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />}
             <UIButton
               type="button"
               variant="primary"
@@ -695,8 +693,124 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
           </div>
         </div>
 
-        {/* Advanced settings (outside prompt, bottom-right) */}
-        <div className="flex justify-end">
+        {/* Repo + Settings row (outside prompt box) */}
+        <div className="flex items-center justify-between">
+          {/* Repo — bottom left */}
+          <Popover open={repoPopoverOpen} onOpenChange={setRepoPopoverOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  'text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm',
+                  selectedRepo && 'text-foreground'
+                )}
+                disabled={isPreparing}
+              >
+                <FolderGit2 className="h-3.5 w-3.5" />
+                <span className="max-w-[16rem] truncate">{selectedRepo || 'Repository'}</span>
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80 p-0" align="start">
+              {isLoadingRepos ? (
+                <div className="text-muted-foreground p-4 text-center text-sm">
+                  Loading repositories...
+                </div>
+              ) : repoError ? (
+                <div className="p-4 text-center text-sm text-red-400">
+                  Failed to load repositories
+                </div>
+              ) : unifiedRepositories.length === 0 ? (
+                <div className="text-muted-foreground p-4 text-center text-sm">
+                  No repositories found
+                </div>
+              ) : (
+                <Command>
+                  <div className="flex items-center border-b pr-2 [&_[cmdk-input-wrapper]]:flex-1 [&_[cmdk-input-wrapper]]:border-b-0">
+                    <CommandInput placeholder="Search repositories..." />
+                    <button
+                      type="button"
+                      onClick={() => void refreshRepositories()}
+                      disabled={isRefreshingRepos}
+                      className="text-muted-foreground hover:text-foreground shrink-0 rounded-sm p-1 disabled:opacity-50"
+                      title="Refresh repositories"
+                    >
+                      <RefreshCw
+                        className={cn('h-3.5 w-3.5', isRefreshingRepos && 'animate-spin')}
+                      />
+                    </button>
+                  </div>
+                  <CommandEmpty>No repositories match your search</CommandEmpty>
+                  <CommandList className="max-h-64 overflow-auto">
+                    {recentRepos.length > 0 && (
+                      <CommandGroup heading="Recently used">
+                        {recentRepos.map(repo => (
+                          <RepoCommandItem
+                            key={`recent-${repo.id}`}
+                            repo={repo}
+                            isSelected={repo.fullName === selectedRepo}
+                            onSelect={handleRepoPillSelect}
+                          />
+                        ))}
+                      </CommandGroup>
+                    )}
+                    {hasMultiplePlatforms ? (
+                      <>
+                        {githubRepos.length > 0 && (
+                          <CommandGroup heading="GitHub">
+                            {githubRepos.map(repo => (
+                              <RepoCommandItem
+                                key={repo.id}
+                                repo={repo}
+                                isSelected={repo.fullName === selectedRepo}
+                                onSelect={handleRepoPillSelect}
+                              />
+                            ))}
+                          </CommandGroup>
+                        )}
+                        {gitlabRepos.length > 0 && (
+                          <CommandGroup heading="GitLab">
+                            {gitlabRepos.map(repo => (
+                              <RepoCommandItem
+                                key={repo.id}
+                                repo={repo}
+                                isSelected={repo.fullName === selectedRepo}
+                                onSelect={handleRepoPillSelect}
+                              />
+                            ))}
+                          </CommandGroup>
+                        )}
+                        {otherRepos.length > 0 && (
+                          <CommandGroup heading="Other">
+                            {otherRepos.map(repo => (
+                              <RepoCommandItem
+                                key={repo.id}
+                                repo={repo}
+                                isSelected={repo.fullName === selectedRepo}
+                                onSelect={handleRepoPillSelect}
+                              />
+                            ))}
+                          </CommandGroup>
+                        )}
+                      </>
+                    ) : (
+                      <CommandGroup>
+                        {filteredUnifiedRepos.map(repo => (
+                          <RepoCommandItem
+                            key={repo.id}
+                            repo={repo}
+                            isSelected={repo.fullName === selectedRepo}
+                            onSelect={handleRepoPillSelect}
+                          />
+                        ))}
+                      </CommandGroup>
+                    )}
+                  </CommandList>
+                </Command>
+              )}
+            </PopoverContent>
+          </Popover>
+
+          {/* Settings — bottom right */}
           <Popover>
             <PopoverTrigger asChild>
               <button

--- a/src/components/cloud-agent-next/SessionInfoDialog.tsx
+++ b/src/components/cloud-agent-next/SessionInfoDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Share2 } from 'lucide-react';
 import { ShareSessionDialog } from './ShareSessionDialog';
+import { formatShortModelName } from '@/lib/format-model-name';
 
 type SessionInfoDialogProps = {
   open: boolean;
@@ -19,6 +20,7 @@ type SessionInfoDialogProps = {
   /** The Kilo session ID (UUID from cliSessions.session_id) */
   kiloSessionId?: string;
   model: string;
+  modelDisplayName?: string;
   cost: number; // in microdollars
 };
 
@@ -27,6 +29,7 @@ export function SessionInfoDialog({
   onOpenChange,
   sessionId,
   model,
+  modelDisplayName,
   cost,
   kiloSessionId,
 }: SessionInfoDialogProps) {
@@ -71,7 +74,9 @@ export function SessionInfoDialog({
 
             <div>
               <label className="text-muted-foreground mb-2 block text-sm font-medium">Model</label>
-              <div className="bg-muted rounded-md px-3 py-2 text-sm">{model}</div>
+              <div className="bg-muted rounded-md px-3 py-2 text-sm">
+                {modelDisplayName ?? formatShortModelName(model)}
+              </div>
             </div>
 
             <div>

--- a/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
+++ b/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
@@ -36,7 +36,13 @@ export function useOrganizationModels(organizationId?: string): UseOrganizationM
 
   // Format models for the combobox
   const modelOptions = useMemo<ModelOption[]>(() => {
-    return openRouterModels?.data.map(model => ({ id: model.id, name: model.name })) ?? [];
+    return (
+      openRouterModels?.data.map(model => ({
+        id: model.id,
+        name: model.name,
+        variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
+      })) ?? []
+    );
   }, [openRouterModels]);
 
   return {

--- a/src/components/cloud-agent/CloudSessionsPage.tsx
+++ b/src/components/cloud-agent/CloudSessionsPage.tsx
@@ -83,7 +83,12 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
 
   // Format models for the combobox (ModelOption format: id, name)
   const modelOptions = useMemo<ModelOption[]>(
-    () => allModels.map(model => ({ id: model.id, name: model.name })),
+    () =>
+      allModels.map(model => ({
+        id: model.id,
+        name: model.name,
+        variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
+      })),
     [allModels]
   );
 
@@ -278,6 +283,7 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
   // Refresh repositories hook (refreshes both GitHub and GitLab)
   const { refresh: refreshGitHubRepositories, isRefreshing: isRefreshingGitHubRepos } =
     useRefreshRepositories({
+      silent: true,
       getRefreshQueryOptions: useCallback(
         () =>
           organizationId
@@ -306,6 +312,7 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
 
   const { refresh: refreshGitLabRepositories, isRefreshing: isRefreshingGitLabRepos } =
     useRefreshRepositories({
+      silent: true,
       getRefreshQueryOptions: useCallback(
         () =>
           organizationId
@@ -332,9 +339,16 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
       ),
     });
 
-  // Combined refresh function
+  // Combined refresh function — single toast for both platforms
   const refreshRepositories = useCallback(async () => {
-    await Promise.all([refreshGitHubRepositories(), refreshGitLabRepositories()]);
+    try {
+      await Promise.all([refreshGitHubRepositories(), refreshGitLabRepositories()]);
+      toast.success('Repositories refreshed');
+    } catch (error) {
+      toast.error('Failed to refresh repositories', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
   }, [refreshGitHubRepositories, refreshGitLabRepositories]);
 
   const isRefreshingRepos = isRefreshingGitHubRepos || isRefreshingGitLabRepos;

--- a/src/components/shared/ModelCombobox.tsx
+++ b/src/components/shared/ModelCombobox.tsx
@@ -17,11 +17,14 @@ import { ChevronsUpDown, Check, Image } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { preferredModels } from '@/lib/models';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { formatShortModelDisplayName } from '@/lib/format-model-name';
 
 export type ModelOption = {
   id: string; // e.g., "anthropic/claude-sonnet-4.5"
   name: string; // e.g., "Claude Sonnet 4.5"
   supportsVision?: boolean;
+  /** Ordered list of variant key names (e.g., ["none","low","medium","high","max"]) */
+  variants?: string[];
 };
 
 export type ModelComboboxProps = {
@@ -189,7 +192,9 @@ export function ModelCombobox({
             className={cn('h-9 justify-between gap-1.5', className)}
             ref={triggerRef}
           >
-            <span className="truncate">{selectedModel ? selectedModel.name : placeholder}</span>
+            <span className="truncate">
+              {selectedModel ? formatShortModelDisplayName(selectedModel.name) : placeholder}
+            </span>
             <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>

--- a/src/components/shared/VariantCombobox.tsx
+++ b/src/components/shared/VariantCombobox.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+import { ChevronsUpDown, Check, Brain } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { thinkingEffortLabel } from '@/lib/code-reviews/core/model-variants';
+
+type VariantComboboxProps = {
+  /** Available variant keys for the current model (e.g., ["none","low","medium","high","max"]) */
+  variants: string[];
+  /** Currently selected variant key */
+  value?: string;
+  /** Called when the user selects a variant */
+  onValueChange: (value: string) => void;
+  /** Whether the combobox is disabled */
+  disabled?: boolean;
+  /** Visual variant — only compact is supported */
+  variant?: 'compact';
+  /** Optional className for the trigger button */
+  className?: string;
+};
+
+export function VariantCombobox({
+  variants,
+  value,
+  onValueChange,
+  disabled = false,
+  className,
+}: VariantComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  if (variants.length === 0) return null;
+
+  const selectedLabel = value ? thinkingEffortLabel(value) : 'Variant';
+
+  return (
+    <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn('h-9 justify-between gap-1.5', className)}
+        >
+          <Brain className="h-3.5 w-3.5 shrink-0 opacity-70" />
+          <span className="truncate">{selectedLabel}</span>
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-44 p-0" align="start">
+        <Command>
+          <CommandList className="max-h-64 overflow-auto">
+            <CommandGroup>
+              {variants.map(v => (
+                <CommandItem
+                  key={v}
+                  value={v}
+                  onSelect={() => {
+                    onValueChange(v);
+                    setOpen(false);
+                  }}
+                  className="flex items-center gap-2"
+                >
+                  <span className="truncate">{thinkingEffortLabel(v)}</span>
+                  <Check
+                    className={cn(
+                      'ml-auto h-4 w-4 shrink-0',
+                      v === value ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/hooks/useRefreshRepositories.ts
+++ b/src/hooks/useRefreshRepositories.ts
@@ -16,6 +16,8 @@ type UseRefreshRepositoriesOptions = {
    * This is used to update the cache after refresh
    */
   getCacheQueryKey: () => QueryKey;
+  /** Suppress toasts — useful when combining multiple refreshes into one. */
+  silent?: boolean;
 };
 
 /**
@@ -29,6 +31,7 @@ type UseRefreshRepositoriesOptions = {
 export function useRefreshRepositories({
   getRefreshQueryOptions,
   getCacheQueryKey,
+  silent = false,
 }: UseRefreshRepositoriesOptions) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const queryClient = useQueryClient();
@@ -38,15 +41,17 @@ export function useRefreshRepositories({
     try {
       const freshData = await queryClient.fetchQuery(getRefreshQueryOptions());
       queryClient.setQueryData(getCacheQueryKey(), freshData);
-      toast.success('Repositories refreshed');
+      if (!silent) toast.success('Repositories refreshed');
     } catch (error) {
-      toast.error('Failed to refresh repositories', {
-        description: error instanceof Error ? error.message : 'Unknown error',
-      });
+      if (!silent) {
+        toast.error('Failed to refresh repositories', {
+          description: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
     } finally {
       setIsRefreshing(false);
     }
-  }, [queryClient, getRefreshQueryOptions, getCacheQueryKey]);
+  }, [queryClient, getRefreshQueryOptions, getCacheQueryKey, silent]);
 
   return { refresh, isRefreshing };
 }

--- a/src/hooks/useRefreshRepositories.ts
+++ b/src/hooks/useRefreshRepositories.ts
@@ -48,7 +48,7 @@ export function useRefreshRepositories({
           description: error instanceof Error ? error.message : 'Unknown error',
         });
       }
-      throw error;
+      if (silent) throw error;
     } finally {
       setIsRefreshing(false);
     }

--- a/src/hooks/useRefreshRepositories.ts
+++ b/src/hooks/useRefreshRepositories.ts
@@ -48,6 +48,7 @@ export function useRefreshRepositories({
           description: error instanceof Error ? error.message : 'Unknown error',
         });
       }
+      throw error;
     } finally {
       setIsRefreshing(false);
     }

--- a/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -5,6 +5,7 @@ import {
   type SessionManagerConfig,
   type FetchedSessionData,
 } from './session-manager';
+import { createCloudAgentSession } from './session';
 import { kiloId, cloudAgentId } from './test-helpers';
 
 // ---------------------------------------------------------------------------
@@ -58,6 +59,7 @@ const defaultFetchedSession = {
   gitBranch: 'main',
   mode: 'code',
   model: 'claude-3-5-sonnet',
+  variant: null,
   repository: 'test/repo',
   isInitiated: true,
   needsLegacyPrepare: false,
@@ -144,12 +146,14 @@ describe('createSessionManager', () => {
         repository: string;
         mode: string;
         model: string;
+        variant?: string | null;
       }>(config.store, mgr.atoms.sessionConfig);
       expect(sessionConfig).toEqual({
         sessionId: 'agent-1',
         repository: 'test/repo',
         mode: 'code',
         model: 'claude-3-5-sonnet',
+        variant: null,
       });
     });
 
@@ -238,6 +242,43 @@ describe('createSessionManager', () => {
         mgr.atoms.sessionConfig
       );
       expect(sessionConfig?.sessionId).toBe('ses-cli');
+    });
+
+    it('includes variant from fetched data in sessionConfig', async () => {
+      const config = createMockConfig({
+        fetchSession: jest.fn().mockResolvedValue({
+          ...defaultFetchedSession,
+          variant: 'high',
+        }),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const sessionConfig = atomValue<{
+        sessionId: string;
+        repository: string;
+        mode: string;
+        model: string;
+        variant?: string | null;
+      }>(config.store, mgr.atoms.sessionConfig);
+      expect(sessionConfig?.variant).toBe('high');
+    });
+
+    it('defaults variant to null when fetched data has no variant', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const sessionConfig = atomValue<{
+        sessionId: string;
+        repository: string;
+        mode: string;
+        model: string;
+        variant?: string | null;
+      }>(config.store, mgr.atoms.sessionConfig);
+      expect(sessionConfig?.variant).toBe(null);
     });
   });
 
@@ -367,6 +408,45 @@ describe('createSessionManager', () => {
       expect(onSendFailed).toHaveBeenCalledWith('My prompt');
     });
 
+    it('passes variant through to session.send', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSession.send.mockResolvedValue(undefined);
+      await mgr.send({
+        prompt: 'Hello',
+        mode: 'code',
+        model: 'claude-3-5-sonnet',
+        variant: 'high',
+      });
+
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: 'Hello',
+        mode: 'code',
+        model: 'claude-3-5-sonnet',
+        variant: 'high',
+      });
+    });
+
+    it('omits variant when not provided (backward compat)', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSession.send.mockResolvedValue(undefined);
+      await mgr.send({ prompt: 'Hello', mode: 'code', model: 'claude-3-5-sonnet' });
+
+      expect(mockSession.send).toHaveBeenCalledWith({
+        prompt: 'Hello',
+        mode: 'code',
+        model: 'claude-3-5-sonnet',
+        variant: undefined,
+      });
+    });
+
     it('without active session sets error indicator', async () => {
       const config = createMockConfig();
       const mgr = createSessionManager(config);
@@ -384,6 +464,79 @@ describe('createSessionManager', () => {
           message: 'Connection failed. Please retry in a moment.',
         })
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // sessionConfig variant tracking
+  // -------------------------------------------------------------------------
+
+  describe('sessionConfig variant tracking', () => {
+    it('updates variant from assistant message events', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      const mockedCreate = jest.mocked(createCloudAgentSession);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      // The mock captures the session config — find the onEvent callback
+      const sessionConfig = mockedCreate.mock.calls[0][0];
+
+      // Simulate an assistant message with variant
+      sessionConfig.onEvent?.({
+        type: 'message.updated',
+        info: {
+          id: 'msg-1',
+          sessionID: 'ses-1',
+          role: 'assistant',
+          modelID: 'claude-3-5-sonnet',
+          providerID: 'test',
+          mode: 'code',
+          variant: 'high',
+          time: { created: 1 },
+          agent: 'test',
+          cost: 0,
+          parentID: '',
+          path: { cwd: '', root: '' },
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+      });
+
+      const sc = atomValue<{ variant?: string | null }>(config.store, mgr.atoms.sessionConfig);
+      expect(sc?.variant).toBe('high');
+    });
+
+    it('sets variant to null when assistant message has no variant', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      const mockedCreate = jest.mocked(createCloudAgentSession);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const sessionConfig = mockedCreate.mock.calls[0][0];
+
+      sessionConfig.onEvent?.({
+        type: 'message.updated',
+        info: {
+          id: 'msg-1',
+          sessionID: 'ses-1',
+          role: 'assistant',
+          modelID: 'claude-3-5-sonnet',
+          providerID: 'test',
+          mode: 'code',
+          time: { created: 1 },
+          agent: 'test',
+          cost: 0,
+          parentID: '',
+          path: { cwd: '', root: '' },
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+      });
+
+      const sc = atomValue<{ variant?: string | null }>(config.store, mgr.atoms.sessionConfig);
+      expect(sc?.variant).toBe(null);
     });
   });
 

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -37,6 +37,7 @@ type SessionConfig = {
   repository: string;
   mode: string;
   model: string;
+  variant?: string | null;
 };
 type StandaloneQuestion = { requestId: string; questions: QuestionInfo[] };
 type StandalonePermission = {
@@ -56,6 +57,7 @@ type FetchedSessionData = {
   gitBranch: string | null;
   mode: string | null;
   model: string | null;
+  variant: string | null;
   repository: string | null;
   isInitiated: boolean;
   needsLegacyPrepare: boolean;
@@ -66,6 +68,7 @@ type PrepareInput = {
   prompt: string;
   mode: string;
   model: string;
+  variant?: string;
   githubRepo?: string;
   gitlabProject?: string;
   envVars?: Record<string, string>;
@@ -140,7 +143,7 @@ type SessionManagerAtoms = {
 
 type SessionManager = {
   switchSession(kiloSessionId: KiloSessionId): Promise<void>;
-  send(payload: { prompt: string; mode: string; model: string }): Promise<void>;
+  send(payload: { prompt: string; mode: string; model: string; variant?: string }): Promise<void>;
   interrupt(): Promise<void>;
   answerQuestion(requestId: string, answers: string[][]): Promise<void>;
   rejectQuestion(requestId: string): Promise<void>;
@@ -489,6 +492,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
             repository: data.repository ?? '',
             mode: data.mode ?? '',
             model: data.model ?? '',
+            variant: data.variant ?? null,
           });
           store.set(sessionIdAtom, data.cloudAgentSessionId);
           store.set(sessionStorageAtom, jotaiStorage);
@@ -538,12 +542,15 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
           const currentConfig = store.get(sessionConfigAtom);
           if (
             currentConfig &&
-            (currentConfig.model !== event.info.modelID || currentConfig.mode !== event.info.mode)
+            (currentConfig.model !== event.info.modelID ||
+              currentConfig.mode !== event.info.mode ||
+              currentConfig.variant !== (event.info.variant ?? null))
           ) {
             store.set(sessionConfigAtom, {
               ...currentConfig,
               model: event.info.modelID,
               mode: event.info.mode,
+              variant: event.info.variant ?? null,
             });
           }
         }
@@ -577,7 +584,12 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     session.connect();
   }
 
-  async function send(payload: { prompt: string; mode: string; model: string }): Promise<void> {
+  async function send(payload: {
+    prompt: string;
+    mode: string;
+    model: string;
+    variant?: string;
+  }): Promise<void> {
     store.set(errorAtom, null);
     setIndicator(null);
     const id = `optimistic-${crypto.randomUUID()}`;
@@ -600,6 +612,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
         prompt: payload.prompt,
         mode: payload.mode,
         model: payload.model,
+        variant: payload.variant,
       });
     } catch (err) {
       store.set(optimisticMessageAtom, null);

--- a/src/lib/cloud-agent-sdk/session.ts
+++ b/src/lib/cloud-agent-sdk/session.ts
@@ -282,11 +282,13 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
         const parts = [{ type: 'text' as const, text: payload.prompt }];
         const agent = payload.mode || undefined;
         const model = payload.model || undefined;
+        const variant = payload.variant || undefined;
         return transport.sendCommand('send_message', {
           sessionID: config.kiloSessionId,
           parts,
           ...(agent ? { agent } : {}),
           ...(model ? { model } : {}),
+          ...(variant ? { variant } : {}),
         });
       }
       const send = config.transport.send;

--- a/src/lib/format-model-name.test.ts
+++ b/src/lib/format-model-name.test.ts
@@ -1,0 +1,45 @@
+import { formatShortModelName, formatShortModelDisplayName } from './format-model-name';
+
+describe('formatShortModelName', () => {
+  it('strips provider prefix', () => {
+    expect(formatShortModelName('anthropic/claude-sonnet-4')).toBe('claude-sonnet-4');
+  });
+
+  it('strips kilo/ and provider prefix', () => {
+    expect(formatShortModelName('kilo/anthropic/claude-sonnet-4')).toBe('claude-sonnet-4');
+  });
+
+  it('returns as-is when no slash present', () => {
+    expect(formatShortModelName('claude-sonnet-4')).toBe('claude-sonnet-4');
+  });
+
+  it('returns empty string as-is', () => {
+    expect(formatShortModelName('')).toBe('');
+  });
+
+  it('handles model with multiple path segments after provider', () => {
+    expect(formatShortModelName('google/gemini-2.5-pro')).toBe('gemini-2.5-pro');
+  });
+});
+
+describe('formatShortModelDisplayName', () => {
+  it('strips "Provider: " prefix', () => {
+    expect(formatShortModelDisplayName('Anthropic: Claude Opus 4.6')).toBe('Claude Opus 4.6');
+  });
+
+  it('strips Google prefix', () => {
+    expect(formatShortModelDisplayName('Google: Gemini 2.5 Pro')).toBe('Gemini 2.5 Pro');
+  });
+
+  it('returns as-is when no colon-space present', () => {
+    expect(formatShortModelDisplayName('GPT-4o')).toBe('GPT-4o');
+  });
+
+  it('returns empty string as-is', () => {
+    expect(formatShortModelDisplayName('')).toBe('');
+  });
+
+  it('handles colon without space (not a provider prefix)', () => {
+    expect(formatShortModelDisplayName('Model:v2')).toBe('Model:v2');
+  });
+});

--- a/src/lib/format-model-name.ts
+++ b/src/lib/format-model-name.ts
@@ -1,0 +1,30 @@
+/**
+ * Strips provider prefixes from a model slug to produce a short display name.
+ *
+ * - `kilo/anthropic/claude-sonnet-4` → `claude-sonnet-4`
+ * - `anthropic/claude-sonnet-4` → `claude-sonnet-4`
+ * - `claude-sonnet-4` (no slash) → `claude-sonnet-4`
+ * - Empty string → empty string
+ */
+export function formatShortModelName(slug: string): string {
+  if (!slug) return slug;
+  // Strip kilo/ prefix first
+  const withoutKilo = slug.startsWith('kilo/') ? slug.slice(5) : slug;
+  // Strip provider prefix (everything before and including the first /)
+  const slashIndex = withoutKilo.indexOf('/');
+  return slashIndex === -1 ? withoutKilo : withoutKilo.slice(slashIndex + 1);
+}
+
+/**
+ * Strips "Provider: " prefix from a human-readable model display name.
+ *
+ * - `"Anthropic: Claude Opus 4.6"` → `"Claude Opus 4.6"`
+ * - `"Google: Gemini 2.5 Pro"` → `"Gemini 2.5 Pro"`
+ * - `"GPT-4o"` (no colon) → `"GPT-4o"`
+ * - Empty string → empty string
+ */
+export function formatShortModelDisplayName(name: string): string {
+  if (!name) return name;
+  const colonIndex = name.indexOf(': ');
+  return colonIndex === -1 ? name : name.slice(colonIndex + 2);
+}

--- a/src/routers/cloud-agent-next-schemas.ts
+++ b/src/routers/cloud-agent-next-schemas.ts
@@ -173,6 +173,7 @@ export const baseGetSessionNextOutputSchema = z.object({
   prompt: z.string().optional(),
   mode: agentModeNextSchema.optional(),
   model: z.string().optional(),
+  variant: z.string().optional(),
   autoCommit: z.boolean().optional(),
   upstreamBranch: z.string().optional(),
 


### PR DESCRIPTION
## Summary

- Add end-to-end reasoning variant (thinking effort) support across the Cloud Agent SDK and UI. A new `VariantCombobox` component lets users select thinking effort levels (e.g., "low", "high", "max") for models that support variants. The `variant` field is plumbed through the SDK `send()` path, `SessionConfig` atom, backend schemas, and all session creation surfaces (`CloudChatPage`, `CloudNextSessionsPage`, `NewSessionPanel`). Variant auto-resets to the first available option when switching models.
- Display short model names in `ChatHeader`, `SessionInfoDialog`, and `ModelCombobox` by stripping provider prefixes. New `formatShortModelName()` (for slugs like `anthropic/claude-sonnet-4` → `claude-sonnet-4`) and `formatShortModelDisplayName()` (for display names like `"Anthropic: Claude Opus 4.6"` → `"Claude Opus 4.6"`) utilities with unit tests.
- Redesign `NewSessionPanel` layout: move repository selector below the prompt box, reorder toolbar to Mode → Model → Variant → Submit, and add an inline repo refresh button inside the repository popover.
- Add `silent` mode to `useRefreshRepositories` hook so combined GitHub + GitLab refreshes show a single consolidated toast instead of two separate ones.

## Verification

- [x] `oxfmt` formatting — pass
- [x] `oxlint` — pass (0 errors across all workspace projects)
- [x] `eslint` — pass
- [x] `typecheck` (`tsgo --noEmit`) — pass across all workspace projects
- [x] Manual verification of UI changes performed by author
- [x] Additional verification details (screenshots to be attached)

## Visual Changes

| Before | After |
| ------ | ----- |
| NewSessionPanel: repo selector inside prompt toolbar, no variant picker | NewSessionPanel: repo moved below prompt box, variant picker in toolbar, refresh button in repo popover |
| ChatHeader/SessionInfoDialog: raw model slugs (e.g., `anthropic/claude-sonnet-4`) | Short model names (e.g., `claude-sonnet-4`) or friendly display names |
| ModelCombobox: full provider-prefixed names (e.g., `"Anthropic: Claude Opus 4.6"`) | Short display names (e.g., `"Claude Opus 4.6"`) |


<img width="1422" height="1228" alt="Screenshot 2026-03-25 at 14 52 01" src="https://github.com/user-attachments/assets/77f92f89-3ecf-4be0-9b6d-004917bcb106" />


## Reviewer Notes

- The `variant` field is nullable in `SessionConfig` (`null` = no variant / model doesn't support variants). The wire format uses `undefined` to omit it for backward compatibility with older backends.
- Variant definitions come from `model.opencode.variants` (already in the API response) — the `ModelOption` type now carries `variants?: string[]` so parents can derive available variants without a second lookup.
- The `NewSessionPanel` layout change moves the repo selector from the prompt input toolbar to below the prompt box for better visual hierarchy. The repo popover now includes an inline refresh button.