### PR TITLE
feat(gastown): add per-role model configuration for agent roles

### DIFF
--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -211,6 +211,49 @@ app.patch('/agents/:agentId/model', async c => {
     return c.json({ error: 'Invalid request body', issues: parsed.error.issues }, 400);
   }
 
+  // Sync config-derived env vars from X-Town-Config into process.env so
+  // the SDK server restart picks up fresh tokens and git identity.
+  // The middleware already parsed the header into lastKnownTownConfig.
+  const cfg = getCurrentTownConfig();
+  if (cfg) {
+    const CONFIG_ENV_MAP: Array<[string, string]> = [
+      ['github_cli_pat', 'GITHUB_CLI_PAT'],
+      ['git_author_name', 'GASTOWN_GIT_AUTHOR_NAME'],
+      ['git_author_email', 'GASTOWN_GIT_AUTHOR_EMAIL'],
+    ];
+    for (const [cfgKey, envKey] of CONFIG_ENV_MAP) {
+      const val = cfg[cfgKey];
+      if (typeof val === 'string' && val) {
+        process.env[envKey] = val;
+      } else {
+        delete process.env[envKey];
+      }
+    }
+    // git_auth tokens
+    const gitAuth = cfg.git_auth;
+    if (typeof gitAuth === 'object' && gitAuth !== null) {
+      const auth = gitAuth as Record<string, unknown>;
+      for (const [authKey, envKey] of [
+        ['github_token', 'GIT_TOKEN'],
+        ['gitlab_token', 'GITLAB_TOKEN'],
+        ['gitlab_instance_url', 'GITLAB_INSTANCE_URL'],
+      ] as const) {
+        const val = auth[authKey];
+        if (typeof val === 'string' && val) {
+          process.env[envKey] = val;
+        } else {
+          delete process.env[envKey];
+        }
+      }
+    }
+    // disable_ai_coauthor
+    if (cfg.disable_ai_coauthor) {
+      process.env.GASTOWN_DISABLE_AI_COAUTHOR = '1';
+    } else {
+      delete process.env.GASTOWN_DISABLE_AI_COAUTHOR;
+    }
+  }
+
   await updateAgentModel(
     agentId,
     parsed.data.model,

--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -211,7 +211,12 @@ app.patch('/agents/:agentId/model', async c => {
     return c.json({ error: 'Invalid request body', issues: parsed.error.issues }, 400);
   }
 
-  await updateAgentModel(agentId, parsed.data.model, parsed.data.smallModel);
+  await updateAgentModel(
+    agentId,
+    parsed.data.model,
+    parsed.data.smallModel,
+    parsed.data.conversationHistory
+  );
   return c.json({ updated: true });
 });
 

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -825,9 +825,23 @@ export async function updateAgentModel(
   sdkInstances.delete(agent.workdir);
   agent.model = model;
 
+  // Build the env vars the gastown plugin needs to identify itself and
+  // connect back to the worker. During initial dispatch these come from
+  // buildAgentEnv; here we reconstruct them from the ManagedAgent record.
+  const pluginEnv: Record<string, string> = {
+    GASTOWN_AGENT_ID: agent.agentId,
+    GASTOWN_RIG_ID: agent.rigId,
+    GASTOWN_TOWN_ID: agent.townId,
+    GASTOWN_AGENT_ROLE: agent.role,
+    KILOCODE_FEATURE: 'gastown',
+  };
+  if (agent.gastownApiUrl) pluginEnv.GASTOWN_API_URL = agent.gastownApiUrl;
+  if (agent.gastownContainerToken) pluginEnv.GASTOWN_CONTAINER_TOKEN = agent.gastownContainerToken;
+  if (agent.gastownSessionToken) pluginEnv.GASTOWN_SESSION_TOKEN = agent.gastownSessionToken;
+
   try {
     // 4. Create a new SDK server (spawns a fresh kilo serve with updated env)
-    const { client, port } = await ensureSDKServer(agent.workdir, {});
+    const { client, port } = await ensureSDKServer(agent.workdir, pluginEnv);
     agent.serverPort = port;
 
     // 5. Create a new session and send the startup prompt.

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -831,17 +831,38 @@ export async function updateAgentModel(
   // gets the same git identity, auth tokens, and plugin vars. Exclude
   // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT — those were already
   // rebuilt above with the new model and set on process.env.
-  // For GASTOWN_CONTAINER_TOKEN, prefer the live process.env value since
-  // /refresh-token rotates it after initial dispatch.
+  //
+  // For env vars that syncConfigToContainer can update at runtime, prefer
+  // the live process.env value over the stale startupEnv snapshot.
+  const LIVE_ENV_KEYS = new Set([
+    'GASTOWN_CONTAINER_TOKEN',
+    'GIT_TOKEN',
+    'GITLAB_TOKEN',
+    'GITLAB_INSTANCE_URL',
+    'GITHUB_CLI_PAT',
+    'GASTOWN_GIT_AUTHOR_NAME',
+    'GASTOWN_GIT_AUTHOR_EMAIL',
+    'GASTOWN_DISABLE_AI_COAUTHOR',
+  ]);
   const hotSwapEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(agent.startupEnv)) {
     if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
-    if (key === 'GASTOWN_CONTAINER_TOKEN') {
-      const live = process.env.GASTOWN_CONTAINER_TOKEN;
+    if (LIVE_ENV_KEYS.has(key)) {
+      const live = process.env[key];
       if (live) hotSwapEnv[key] = live;
       continue;
     }
     hotSwapEnv[key] = value;
+  }
+
+  // Re-derive GH_TOKEN from live values using the same priority chain
+  // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
+  // syncConfigToContainer updates these on process.env, but buildAgentEnv
+  // only ran once at initial dispatch.
+  const liveGhCliPat = process.env.GITHUB_CLI_PAT;
+  const liveGhToken = liveGhCliPat ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (liveGhToken) {
+    hotSwapEnv.GH_TOKEN = liveGhToken;
   }
 
   try {

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -830,9 +830,16 @@ export async function updateAgentModel(
   // gets the same git identity, auth tokens, and plugin vars. Exclude
   // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT — those were already
   // rebuilt above with the new model and set on process.env.
+  // For GASTOWN_CONTAINER_TOKEN, prefer the live process.env value since
+  // /refresh-token rotates it after initial dispatch.
   const hotSwapEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(agent.startupEnv)) {
     if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
+    if (key === 'GASTOWN_CONTAINER_TOKEN') {
+      const live = process.env.GASTOWN_CONTAINER_TOKEN;
+      if (live) hotSwapEnv[key] = live;
+      continue;
+    }
     hotSwapEnv[key] = value;
   }
 

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -578,6 +578,7 @@ export async function startAgent(
     gastownSessionToken: request.envVars?.GASTOWN_SESSION_TOKEN ?? null,
     completionCallbackUrl: request.envVars?.GASTOWN_COMPLETION_CALLBACK_URL ?? null,
     model: request.model ?? null,
+    startupEnv: env,
   };
   agents.set(request.agentId, agent);
 
@@ -825,23 +826,19 @@ export async function updateAgentModel(
   sdkInstances.delete(agent.workdir);
   agent.model = model;
 
-  // Build the env vars the gastown plugin needs to identify itself and
-  // connect back to the worker. During initial dispatch these come from
-  // buildAgentEnv; here we reconstruct them from the ManagedAgent record.
-  const pluginEnv: Record<string, string> = {
-    GASTOWN_AGENT_ID: agent.agentId,
-    GASTOWN_RIG_ID: agent.rigId,
-    GASTOWN_TOWN_ID: agent.townId,
-    GASTOWN_AGENT_ROLE: agent.role,
-    KILOCODE_FEATURE: 'gastown',
-  };
-  if (agent.gastownApiUrl) pluginEnv.GASTOWN_API_URL = agent.gastownApiUrl;
-  if (agent.gastownContainerToken) pluginEnv.GASTOWN_CONTAINER_TOKEN = agent.gastownContainerToken;
-  if (agent.gastownSessionToken) pluginEnv.GASTOWN_SESSION_TOKEN = agent.gastownSessionToken;
+  // Replay the full env from the initial dispatch so the new SDK server
+  // gets the same git identity, auth tokens, and plugin vars. Exclude
+  // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT — those were already
+  // rebuilt above with the new model and set on process.env.
+  const hotSwapEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(agent.startupEnv)) {
+    if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
+    hotSwapEnv[key] = value;
+  }
 
   try {
     // 4. Create a new SDK server (spawns a fresh kilo serve with updated env)
-    const { client, port } = await ensureSDKServer(agent.workdir, pluginEnv);
+    const { client, port } = await ensureSDKServer(agent.workdir, hotSwapEnv);
     agent.serverPort = port;
 
     // 5. Create a new session and send the startup prompt.

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -782,7 +782,8 @@ const MAYOR_STARTUP_PROMPT = 'Mayor ready. Waiting for instructions.';
 export async function updateAgentModel(
   agentId: string,
   model: string,
-  smallModel?: string
+  smallModel?: string,
+  conversationHistory?: string
 ): Promise<void> {
   const agent = agents.get(agentId);
   if (!agent) throw new Error(`Agent ${agentId} not found`);
@@ -864,12 +865,17 @@ export async function updateAgentModel(
       newInstance.sessionCount++;
     }
 
-    // Send the startup prompt so the mayor is ready for instructions.
+    // Send the startup prompt, including conversation history if available
+    // so the mayor retains context across model changes (same mechanism
+    // used for container restarts — see PR #1494).
+    const prompt = conversationHistory
+      ? `${conversationHistory}\n\n${MAYOR_STARTUP_PROMPT}`
+      : MAYOR_STARTUP_PROMPT;
     const modelParam = { providerID: 'kilo', modelID: model };
     await client.session.prompt({
       path: { id: agent.sessionId },
       body: {
-        parts: [{ type: 'text', text: MAYOR_STARTUP_PROMPT }],
+        parts: [{ type: 'text', text: prompt }],
         model: modelParam,
       },
     });
@@ -886,7 +892,7 @@ export async function updateAgentModel(
       role: agent.role,
       name: agent.name,
       model,
-      prompt: MAYOR_STARTUP_PROMPT,
+      prompt,
       rigId: agent.rigId,
       townId: agent.townId,
       identity: '',

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -858,11 +858,14 @@ export async function updateAgentModel(
   // Re-derive GH_TOKEN from live values using the same priority chain
   // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
   // syncConfigToContainer updates these on process.env, but buildAgentEnv
-  // only ran once at initial dispatch.
+  // only ran once at initial dispatch. When all sources are cleared,
+  // remove GH_TOKEN so the SDK server doesn't retain stale credentials.
   const liveGhCliPat = process.env.GITHUB_CLI_PAT;
   const liveGhToken = liveGhCliPat ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
   if (liveGhToken) {
     hotSwapEnv.GH_TOKEN = liveGhToken;
+  } else {
+    delete hotSwapEnv.GH_TOKEN;
   }
 
   try {

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -78,6 +78,8 @@ export type SendMessageRequest = z.infer<typeof SendMessageRequest>;
 export const UpdateAgentModelRequest = z.object({
   model: z.string().min(1),
   smallModel: z.string().optional(),
+  /** Pre-formatted conversation history to inject into the new session prompt. */
+  conversationHistory: z.string().optional(),
 });
 export type UpdateAgentModelRequest = z.infer<typeof UpdateAgentModelRequest>;
 

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -129,6 +129,8 @@ export type ManagedAgent = {
   completionCallbackUrl: string | null;
   /** Model ID used for this agent's sessions (e.g. "anthropic/claude-sonnet-4.6") */
   model: string | null;
+  /** Full env dict from buildAgentEnv, stored so model hot-swap can replay it. */
+  startupEnv: Record<string, string>;
 };
 
 export type AgentStatusResponse = {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2016,12 +2016,17 @@ export class TownDO extends DurableObject<Env> {
     const isAlive = containerStatus.status === 'running' || containerStatus.status === 'starting';
 
     if (isAlive) {
+      // Reconstruct conversation history so the new session retains context
+      // (same mechanism used for container restarts — see PR #1494).
+      const conversationHistory = await this.reconstructConversation(mayor.id);
+
       const updated = await dispatch.updateAgentModelInContainer(
         this.env,
         townId,
         mayor.id,
         model,
-        smallModel
+        smallModel,
+        conversationHistory || undefined
       );
       if (updated) {
         console.log(

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2020,13 +2020,18 @@ export class TownDO extends DurableObject<Env> {
       // (same mechanism used for container restarts — see PR #1494).
       const conversationHistory = await this.reconstructConversation(mayor.id);
 
+      // Attach fresh town config so the container can update process.env
+      // before restarting the SDK server (tokens, git identity, etc.).
+      const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
+
       const updated = await dispatch.updateAgentModelInContainer(
         this.env,
         townId,
         mayor.id,
         model,
         smallModel,
-        conversationHistory || undefined
+        conversationHistory || undefined,
+        containerConfig
       );
       if (updated) {
         console.log(

--- a/cloudflare-gastown/src/dos/town/config.test.ts
+++ b/cloudflare-gastown/src/dos/town/config.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { TownConfigSchema } from '../../types';
+import { resolveModel } from './config';
+
+const HARDCODED_FALLBACK = 'anthropic/claude-sonnet-4.6';
+const DUMMY_RIG = 'rig-test';
+
+/** Parse a minimal TownConfig through the Zod schema (applies defaults). */
+function makeTownConfig(
+  overrides: { default_model?: string; role_models?: Record<string, string> } = {}
+) {
+  return TownConfigSchema.parse(overrides);
+}
+
+describe('resolveModel', () => {
+  it('returns hardcoded fallback when no default_model and no role_models', () => {
+    const config = makeTownConfig();
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+  });
+
+  it('returns default_model when set and no role_models', () => {
+    const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+  });
+
+  it('returns mayor-specific model when role_models.mayor is set', () => {
+    const config = makeTownConfig({
+      default_model: 'openai/gpt-4o',
+      role_models: { mayor: 'anthropic/claude-opus-4' },
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
+  });
+
+  it('falls back to default_model for roles not overridden in role_models', () => {
+    const config = makeTownConfig({
+      default_model: 'openai/gpt-4o',
+      role_models: { mayor: 'anthropic/claude-opus-4' },
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+  });
+
+  it('returns polecat model when set, falls back for other roles', () => {
+    const config = makeTownConfig({
+      role_models: { polecat: 'google/gemini-2.5-pro' },
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    // No default_model → hardcoded fallback for other roles
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+  });
+
+  it('returns role-specific model for all three roles when all overridden', () => {
+    const config = makeTownConfig({
+      default_model: 'openai/gpt-4o',
+      role_models: {
+        mayor: 'anthropic/claude-opus-4',
+        refinery: 'anthropic/claude-sonnet-4',
+        polecat: 'google/gemini-2.5-pro',
+      },
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('anthropic/claude-sonnet-4');
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+  });
+
+  it('treats empty role_models the same as no role_models', () => {
+    const config = makeTownConfig({
+      default_model: 'openai/gpt-4o',
+      role_models: {},
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+  });
+
+  it('treats undefined role_models the same as no role_models', () => {
+    const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
+    expect(config.role_models).toBeUndefined();
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+  });
+
+  it('falls back to default_model for unknown role strings', () => {
+    const config = makeTownConfig({
+      default_model: 'openai/gpt-4o',
+      role_models: { mayor: 'anthropic/claude-opus-4' },
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, '')).toBe('openai/gpt-4o');
+  });
+
+  it('falls back to hardcoded fallback for unknown role with no default_model', () => {
+    const config = makeTownConfig({
+      role_models: { mayor: 'anthropic/claude-opus-4' },
+    });
+    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe(HARDCODED_FALLBACK);
+  });
+});
+
+describe('resolveModel backward compatibility', () => {
+  it('works with a config that has no role_models field (legacy town)', () => {
+    // Simulate a legacy config stored before role_models existed
+    const legacyRaw = {
+      env_vars: {},
+      default_model: 'openai/gpt-4o',
+    };
+    const config = TownConfigSchema.parse(legacyRaw);
+    expect(config.role_models).toBeUndefined();
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+  });
+
+  it('works with a completely empty config (new town defaults)', () => {
+    const config = TownConfigSchema.parse({});
+    expect(config.role_models).toBeUndefined();
+    expect(config.default_model).toBeUndefined();
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
+  });
+
+  it('preserves resolution chain: role override > default_model > hardcoded', () => {
+    const config = makeTownConfig({
+      default_model: 'openai/gpt-4o',
+      role_models: { polecat: 'google/gemini-2.5-pro' },
+    });
+    // polecat: role override wins
+    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    // mayor: no role override → default_model
+    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+
+    // Remove default_model to test final fallback
+    const configNoDefault = makeTownConfig({
+      role_models: { polecat: 'google/gemini-2.5-pro' },
+    });
+    // refinery: no role override, no default → hardcoded
+    expect(resolveModel(configNoDefault, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+  });
+});

--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -90,8 +90,9 @@ export async function updateTownConfig(
  * Resolve the primary model from town config.
  * Priority: rig override → role-specific → town default → hardcoded default.
  */
-export function resolveModel(townConfig: TownConfig, _rigId: string, _role: string): string {
-  return townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
+export function resolveModel(townConfig: TownConfig, _rigId: string, role: string): string {
+  const roleModel = townConfig.role_models?.[role as keyof NonNullable<TownConfig['role_models']>];
+  return roleModel ?? townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
 }
 
 /**

--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -91,8 +91,8 @@ export async function updateTownConfig(
  * Priority: rig override → role-specific → town default → hardcoded default.
  */
 export function resolveModel(townConfig: TownConfig, _rigId: string, role: string): string {
-  const roleModel = townConfig.role_models?.[role as keyof NonNullable<TownConfig['role_models']>];
-  return roleModel ?? townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
+  const roleModels: Record<string, string | undefined> | undefined = townConfig.role_models;
+  return roleModels?.[role] ?? townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
 }
 
 /**

--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -55,11 +55,20 @@ export async function updateTownConfig(
     }
   }
 
+  // github_cli_pat: same mask-preservation as git_auth tokens
+  const resolvedGithubCliPat =
+    update.github_cli_pat !== undefined
+      ? MASKED_RE.test(update.github_cli_pat)
+        ? current.github_cli_pat
+        : update.github_cli_pat
+      : current.github_cli_pat;
+
   const merged: TownConfig = {
     ...current,
     ...update,
     env_vars: resolvedEnvVars,
     git_auth: resolvedGitAuth,
+    github_cli_pat: resolvedGithubCliPat,
     refinery:
       update.refinery !== undefined
         ? {

--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -63,12 +63,18 @@ export async function updateTownConfig(
         : update.github_cli_pat
       : current.github_cli_pat;
 
+  // Normalize empty-string model fields to undefined so resolveModel()'s
+  // nullish-coalescing fallback works correctly when the user clears them.
+  const resolvedDefaultModel =
+    update.default_model !== undefined ? update.default_model || undefined : current.default_model;
+
   const merged: TownConfig = {
     ...current,
     ...update,
     env_vars: resolvedEnvVars,
     git_auth: resolvedGitAuth,
     github_cli_pat: resolvedGithubCliPat,
+    default_model: resolvedDefaultModel,
     refinery:
       update.refinery !== undefined
         ? {

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -674,14 +674,19 @@ export async function updateAgentModelInContainer(
   townId: string,
   agentId: string,
   model: string,
-  smallModel?: string
+  smallModel?: string,
+  conversationHistory?: string
 ): Promise<boolean> {
   try {
     const container = getTownContainerStub(env, townId);
     const response = await container.fetch(`http://container/agents/${agentId}/model`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, ...(smallModel ? { smallModel } : {}) }),
+      body: JSON.stringify({
+        model,
+        ...(smallModel ? { smallModel } : {}),
+        ...(conversationHistory ? { conversationHistory } : {}),
+      }),
     });
     return response.ok;
   } catch {

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -675,13 +675,18 @@ export async function updateAgentModelInContainer(
   agentId: string,
   model: string,
   smallModel?: string,
-  conversationHistory?: string
+  conversationHistory?: string,
+  containerConfig?: Record<string, unknown>
 ): Promise<boolean> {
   try {
     const container = getTownContainerStub(env, townId);
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (containerConfig) {
+      headers['X-Town-Config'] = JSON.stringify(containerConfig);
+    }
     const response = await container.fetch(`http://container/agents/${agentId}/model`, {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({
         model,
         ...(smallModel ? { smallModel } : {}),

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -982,14 +982,19 @@ export const gastownRouter = router({
         console.warn('[gastown-trpc] updateTownConfig: syncConfigToContainer failed:', err);
       }
 
-      // If the mayor's effective model changed (via default_model, role_models.mayor,
-      // or small_model), hot-update the running mayor session so it picks up the
-      // new model without losing conversation context.
+      // Hot-update the running mayor session when the effective model or
+      // auth-relevant config changed. The SDK server is a child process
+      // that captures env at spawn time, so it must be restarted to pick
+      // up rotated tokens or cleared credentials.
       const oldMayorModel = resolveModel(existingConfig, '', 'mayor');
       const newMayorModel = resolveModel(result, '', 'mayor');
       const mayorModelChanged =
         newMayorModel !== oldMayorModel || result.small_model !== existingConfig.small_model;
-      if (mayorModelChanged) {
+      const authConfigChanged =
+        result.github_cli_pat !== existingConfig.github_cli_pat ||
+        result.git_auth?.github_token !== existingConfig.git_auth?.github_token ||
+        result.git_auth?.gitlab_token !== existingConfig.git_auth?.gitlab_token;
+      if (mayorModelChanged || authConfigChanged) {
         try {
           await townStub.updateMayorModel(newMayorModel, result.small_model ?? undefined);
         } catch (err) {

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -17,6 +17,7 @@ import type { JwtOrgMembership } from '../middleware/auth.middleware';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
 import { TownConfigSchema, TownConfigUpdateSchema } from '../types';
+import { resolveModel } from '../dos/town/config';
 import type { UserRigRecord } from '../db/tables/user-rigs.table';
 import {
   RpcTownOutput,
@@ -981,17 +982,16 @@ export const gastownRouter = router({
         console.warn('[gastown-trpc] updateTownConfig: syncConfigToContainer failed:', err);
       }
 
-      // If the model changed, hot-update the running mayor session so it
-      // picks up the new model without losing conversation context.
-      const modelChanged =
-        result.default_model !== existingConfig.default_model ||
-        result.small_model !== existingConfig.small_model;
-      if (modelChanged) {
+      // If the mayor's effective model changed (via default_model, role_models.mayor,
+      // or small_model), hot-update the running mayor session so it picks up the
+      // new model without losing conversation context.
+      const oldMayorModel = resolveModel(existingConfig, '', 'mayor');
+      const newMayorModel = resolveModel(result, '', 'mayor');
+      const mayorModelChanged =
+        newMayorModel !== oldMayorModel || result.small_model !== existingConfig.small_model;
+      if (mayorModelChanged) {
         try {
-          await townStub.updateMayorModel(
-            result.default_model ?? 'anthropic/claude-sonnet-4.6',
-            result.small_model ?? undefined
-          );
+          await townStub.updateMayorModel(newMayorModel, result.small_model ?? undefined);
         } catch (err) {
           console.warn('[gastown-trpc] updateTownConfig: updateMayorModel failed:', err);
         }

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -993,7 +993,8 @@ export const gastownRouter = router({
       const authConfigChanged =
         result.github_cli_pat !== existingConfig.github_cli_pat ||
         result.git_auth?.github_token !== existingConfig.git_auth?.github_token ||
-        result.git_auth?.gitlab_token !== existingConfig.git_auth?.gitlab_token;
+        result.git_auth?.gitlab_token !== existingConfig.git_auth?.gitlab_token ||
+        result.git_auth?.gitlab_instance_url !== existingConfig.git_auth?.gitlab_instance_url;
       if (mayorModelChanged || authConfigChanged) {
         try {
           await townStub.updateMayorModel(newMayorModel, result.small_model ?? undefined);

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -229,6 +229,16 @@ export const TownConfigSchema = z.object({
   /** Default LLM model for new agent sessions */
   default_model: z.string().optional(),
 
+  /** Per-role model overrides. When set, the specified role uses this model
+   *  instead of default_model. */
+  role_models: z
+    .object({
+      mayor: z.string().optional(),
+      refinery: z.string().optional(),
+      polecat: z.string().optional(),
+    })
+    .optional(),
+
   /** Lightweight model for title generation, explore subagent, etc. */
   small_model: z.string().optional(),
 
@@ -308,6 +318,13 @@ export const TownConfigUpdateSchema = z.object({
   organization_id: z.string().optional(),
   kilocode_token: z.string().optional(),
   default_model: z.string().optional(),
+  role_models: z
+    .object({
+      mayor: z.string().optional(),
+      refinery: z.string().optional(),
+      polecat: z.string().optional(),
+    })
+    .optional(),
   small_model: z.string().optional(),
   max_polecats_per_rig: z.number().int().min(1).max(20).optional(),
   merge_strategy: MergeStrategy.optional(),

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -243,7 +243,7 @@ export const TownConfigSchema = z.object({
   small_model: z.string().optional(),
 
   /** Maximum concurrent polecats per rig */
-  max_polecats_per_rig: z.number().int().min(1).max(20).optional(),
+  max_polecats_per_rig: z.number().int().min(1).max(50).optional(),
 
   /**
    * Town-level merge strategy. Rigs inherit this when they don't set their own.
@@ -326,7 +326,7 @@ export const TownConfigUpdateSchema = z.object({
     })
     .optional(),
   small_model: z.string().optional(),
-  max_polecats_per_rig: z.number().int().min(1).max(20).optional(),
+  max_polecats_per_rig: z.number().int().min(1).max(50).optional(),
   merge_strategy: MergeStrategy.optional(),
   refinery: z
     .object({

--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -10955,6 +10955,11 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     owner_user_id?: string | undefined;
                     kilocode_token?: string | undefined;
                     default_model?: string | null | undefined;
+                    role_models?: {
+                        mayor?: string | null | undefined;
+                        refinery?: string | null | undefined;
+                        polecat?: string | null | undefined;
+                    } | null | undefined;
                     small_model?: string | null | undefined;
                     max_polecats_per_rig?: number | undefined;
                     refinery?: {
@@ -11091,6 +11096,11 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                         owner_user_id?: string | undefined;
                         kilocode_token?: string | undefined;
                         default_model?: string | null | undefined;
+                        role_models?: {
+                            mayor?: string | null | undefined;
+                            refinery?: string | null | undefined;
+                            polecat?: string | null | undefined;
+                        } | null | undefined;
                         small_model?: string | null | undefined;
                         max_polecats_per_rig?: number | undefined;
                         merge_strategy?: "direct" | "pr" | undefined;
@@ -11119,6 +11129,11 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     owner_user_id?: string | undefined;
                     kilocode_token?: string | undefined;
                     default_model?: string | null | undefined;
+                    role_models?: {
+                        mayor?: string | null | undefined;
+                        refinery?: string | null | undefined;
+                        polecat?: string | null | undefined;
+                    } | null | undefined;
                     small_model?: string | null | undefined;
                     max_polecats_per_rig?: number | undefined;
                     refinery?: {

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -132,9 +132,12 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const effectiveReadOnly =
     isAdminViewing || (readOnly && currentUser?.id !== configQuery.data?.created_by_user_id);
 
-  // Track the server-side model so we can detect changes on save
+  // Track server-side values so we can detect changes that require a reload
   const savedModelRef = useRef<string>('');
   const savedMayorModelRef = useRef<string>('');
+  const savedGithubCliPatRef = useRef<string>('');
+  const savedGithubTokenRef = useRef<string>('');
+  const savedGitlabTokenRef = useRef<string>('');
 
   const updateConfig = useMutation(
     trpc.gastown.updateTownConfig.mutationOptions({
@@ -148,13 +151,28 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         const previousEffectiveMayor = savedMayorModelRef.current || savedModelRef.current;
         const mayorEffectiveChanged = effectiveMayor !== previousEffectiveMayor;
 
+        // Detect auth config changes that trigger an SDK server restart.
+        // Compare against the non-masked form: if the current value starts
+        // with "****" it wasn't changed by the user, so skip the comparison.
+        const ghCliPatChanged =
+          !githubCliPat.startsWith('****') && githubCliPat !== savedGithubCliPatRef.current;
+        const ghTokenChanged =
+          !githubToken.startsWith('****') && githubToken !== savedGithubTokenRef.current;
+        const glTokenChanged =
+          !gitlabToken.startsWith('****') && gitlabToken !== savedGitlabTokenRef.current;
+        const authChanged = ghCliPatChanged || ghTokenChanged || glTokenChanged;
+
         savedModelRef.current = defaultModel;
         savedMayorModelRef.current = mayorModel;
+        if (!githubCliPat.startsWith('****')) savedGithubCliPatRef.current = githubCliPat;
+        if (!githubToken.startsWith('****')) savedGithubTokenRef.current = githubToken;
+        if (!gitlabToken.startsWith('****')) savedGitlabTokenRef.current = gitlabToken;
 
-        if (defaultModelChanged || mayorEffectiveChanged) {
-          toast.success('Configuration saved — reloading for model change…');
-          // Reload after a brief delay so the server-side model update
-          // (SDK server restart + new session) has time to complete.
+        if (defaultModelChanged || mayorEffectiveChanged || authChanged) {
+          const reason = authChanged ? 'credential change' : 'model change';
+          toast.success(`Configuration saved — reloading for ${reason}…`);
+          // Reload after a brief delay so the server-side SDK server
+          // restart has time to complete.
           setTimeout(() => window.location.reload(), 2000);
         } else {
           toast.success('Configuration saved');
@@ -211,6 +229,9 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
     setMergeStrategy(cfg.merge_strategy === 'pr' ? 'pr' : 'direct');
     setStagedConvoysDefault(cfg.staged_convoys_default ?? false);
     setGithubCliPat(cfg.github_cli_pat ?? '');
+    savedGithubCliPatRef.current = cfg.github_cli_pat ?? '';
+    savedGithubTokenRef.current = cfg.git_auth?.github_token ?? '';
+    savedGitlabTokenRef.current = cfg.git_auth?.gitlab_token ?? '';
     setGitAuthorName(cfg.git_author_name ?? '');
     setGitAuthorEmail(cfg.git_author_email ?? '');
     setDisableAiCoauthor(cfg.disable_ai_coauthor ?? false);

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -29,7 +29,15 @@ import {
   Container,
   User,
   Key,
+  X,
 } from 'lucide-react';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion';
+import { Slider } from '@/components/ui/slider';
 import { motion } from 'motion/react';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
 
@@ -126,6 +134,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
 
   // Track the server-side model so we can detect changes on save
   const savedModelRef = useRef<string>('');
+  const savedMayorModelRef = useRef<string>('');
 
   const updateConfig = useMutation(
     trpc.gastown.updateTownConfig.mutationOptions({
@@ -134,10 +143,15 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           queryKey: trpc.gastown.getTownConfig.queryKey({ townId }),
         });
 
-        const modelChanged = defaultModel !== savedModelRef.current;
-        savedModelRef.current = defaultModel;
+        const defaultModelChanged = defaultModel !== savedModelRef.current;
+        const effectiveMayor = mayorModel || defaultModel;
+        const previousEffectiveMayor = savedMayorModelRef.current || savedModelRef.current;
+        const mayorEffectiveChanged = effectiveMayor !== previousEffectiveMayor;
 
-        if (modelChanged) {
+        savedModelRef.current = defaultModel;
+        savedMayorModelRef.current = mayorModel;
+
+        if (defaultModelChanged || mayorEffectiveChanged) {
           toast.success('Configuration saved — reloading for model change…');
           // Reload after a brief delay so the server-side model update
           // (SDK server restart + new session) has time to complete.
@@ -163,6 +177,9 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const [gitlabToken, setGitlabToken] = useState('');
   const [gitlabInstanceUrl, setGitlabInstanceUrl] = useState('');
   const [defaultModel, setDefaultModel] = useState('');
+  const [mayorModel, setMayorModel] = useState('');
+  const [refineryModel, setRefineryModel] = useState('');
+  const [polecatModel, setPolecatModel] = useState('');
   const [maxPolecats, setMaxPolecats] = useState<number | undefined>(undefined);
   const [refineryGates, setRefineryGates] = useState<string[]>([]);
   const [autoMerge, setAutoMerge] = useState(true);
@@ -184,6 +201,10 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
     setGitlabInstanceUrl(cfg.git_auth?.gitlab_instance_url ?? '');
     setDefaultModel(cfg.default_model ?? '');
     savedModelRef.current = cfg.default_model ?? '';
+    setMayorModel(cfg.role_models?.mayor ?? '');
+    setRefineryModel(cfg.role_models?.refinery ?? '');
+    setPolecatModel(cfg.role_models?.polecat ?? '');
+    savedMayorModelRef.current = cfg.role_models?.mayor ?? '';
     setMaxPolecats(cfg.max_polecats_per_rig);
     setRefineryGates(cfg.refinery?.gates ?? []);
     setAutoMerge(cfg.refinery?.auto_merge ?? true);
@@ -218,6 +239,11 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           ...(gitlabInstanceUrl ? { gitlab_instance_url: gitlabInstanceUrl } : {}),
         },
         ...(defaultModel ? { default_model: defaultModel } : {}),
+        role_models: {
+          mayor: mayorModel || undefined,
+          refinery: refineryModel || undefined,
+          polecat: polecatModel || undefined,
+        },
         ...(maxPolecats ? { max_polecats_per_rig: maxPolecats } : {}),
         ...(githubCliPat && !githubCliPat.startsWith('****')
           ? { github_cli_pat: githubCliPat }
@@ -523,21 +549,73 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                     )}
                   </FieldGroup>
 
+                  <Accordion type="single" collapsible className="border-none">
+                    <AccordionItem value="role-overrides" className="border-none">
+                      <AccordionTrigger className="py-0 text-xs text-white/40 hover:text-white/60 hover:no-underline">
+                        Override by role (optional)
+                      </AccordionTrigger>
+                      <AccordionContent className="space-y-4 pt-2">
+                        {(
+                          [
+                            ['Mayor', mayorModel, setMayorModel],
+                            ['Refinery', refineryModel, setRefineryModel],
+                            ['Polecat', polecatModel, setPolecatModel],
+                          ] as const
+                        ).map(([roleLabel, roleValue, setRoleValue]) => (
+                          <FieldGroup key={roleLabel} label={roleLabel}>
+                            <div className="flex items-center gap-2">
+                              <div className="flex-1">
+                                {modelsError ? (
+                                  <Input
+                                    value={roleValue}
+                                    onChange={e => setRoleValue(e.target.value)}
+                                    placeholder="Use default"
+                                    className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                                  />
+                                ) : (
+                                  <ModelCombobox
+                                    label=""
+                                    models={modelOptions}
+                                    value={roleValue}
+                                    onValueChange={setRoleValue}
+                                    isLoading={isLoadingModels}
+                                    placeholder="Use default"
+                                    className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                                  />
+                                )}
+                              </div>
+                              {roleValue && (
+                                <button
+                                  onClick={() => setRoleValue('')}
+                                  className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                                  title="Reset to default"
+                                >
+                                  <X className="size-3.5" />
+                                </button>
+                              )}
+                            </div>
+                          </FieldGroup>
+                        ))}
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+
                   <FieldGroup
                     label="Max Polecats per Rig"
                     hint="Upper bound on concurrent worker agents per rig."
                   >
-                    <Input
-                      type="number"
-                      min={1}
-                      max={20}
-                      value={maxPolecats ?? ''}
-                      onChange={e =>
-                        setMaxPolecats(e.target.value ? parseInt(e.target.value, 10) : undefined)
-                      }
-                      placeholder="5"
-                      className="w-28 border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
-                    />
+                    <div className="flex items-center gap-3">
+                      <Slider
+                        min={1}
+                        max={50}
+                        value={[maxPolecats ?? 5]}
+                        onValueChange={([v]) => setMaxPolecats(v)}
+                        className="w-full"
+                      />
+                      <span className="w-8 shrink-0 text-right font-mono text-sm text-white/70">
+                        {maxPolecats ?? 5}
+                      </span>
+                    </div>
                   </FieldGroup>
                 </div>
               </SettingsSection>

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -138,6 +138,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const savedGithubCliPatRef = useRef<string>('');
   const savedGithubTokenRef = useRef<string>('');
   const savedGitlabTokenRef = useRef<string>('');
+  const savedGitlabInstanceUrlRef = useRef<string>('');
 
   const updateConfig = useMutation(
     trpc.gastown.updateTownConfig.mutationOptions({
@@ -160,13 +161,16 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           !githubToken.startsWith('****') && githubToken !== savedGithubTokenRef.current;
         const glTokenChanged =
           !gitlabToken.startsWith('****') && gitlabToken !== savedGitlabTokenRef.current;
-        const authChanged = ghCliPatChanged || ghTokenChanged || glTokenChanged;
+        const glInstanceUrlChanged = gitlabInstanceUrl !== savedGitlabInstanceUrlRef.current;
+        const authChanged =
+          ghCliPatChanged || ghTokenChanged || glTokenChanged || glInstanceUrlChanged;
 
         savedModelRef.current = defaultModel;
         savedMayorModelRef.current = mayorModel;
         if (!githubCliPat.startsWith('****')) savedGithubCliPatRef.current = githubCliPat;
         if (!githubToken.startsWith('****')) savedGithubTokenRef.current = githubToken;
         if (!gitlabToken.startsWith('****')) savedGitlabTokenRef.current = gitlabToken;
+        savedGitlabInstanceUrlRef.current = gitlabInstanceUrl;
 
         if (defaultModelChanged || mayorEffectiveChanged || authChanged) {
           const reason = authChanged ? 'credential change' : 'model change';
@@ -232,6 +236,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
     savedGithubCliPatRef.current = cfg.github_cli_pat ?? '';
     savedGithubTokenRef.current = cfg.git_auth?.github_token ?? '';
     savedGitlabTokenRef.current = cfg.git_auth?.gitlab_token ?? '';
+    savedGitlabInstanceUrlRef.current = cfg.git_auth?.gitlab_instance_url ?? '';
     setGitAuthorName(cfg.git_author_name ?? '');
     setGitAuthorEmail(cfg.git_author_email ?? '');
     setDisableAiCoauthor(cfg.disable_ai_coauthor ?? false);
@@ -261,7 +266,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           ...(gitlabToken.startsWith('****') ? {} : { gitlab_token: gitlabToken }),
           gitlab_instance_url: gitlabInstanceUrl,
         },
-        default_model: defaultModel,
+        ...(defaultModel ? { default_model: defaultModel } : {}),
         role_models: {
           mayor: mayorModel || undefined,
           refinery: refineryModel || undefined,

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -266,7 +266,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           ...(gitlabToken.startsWith('****') ? {} : { gitlab_token: gitlabToken }),
           gitlab_instance_url: gitlabInstanceUrl,
         },
-        ...(defaultModel ? { default_model: defaultModel } : {}),
+        default_model: defaultModel,
         role_models: {
           mayor: mayorModel || undefined,
           refinery: refineryModel || undefined,

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -234,22 +234,23 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
       config: {
         env_vars: envVarObj,
         git_auth: {
-          ...(githubToken && !githubToken.startsWith('****') ? { github_token: githubToken } : {}),
-          ...(gitlabToken && !gitlabToken.startsWith('****') ? { gitlab_token: gitlabToken } : {}),
-          ...(gitlabInstanceUrl ? { gitlab_instance_url: gitlabInstanceUrl } : {}),
+          // Omit masked values to preserve the real secret server-side.
+          // Send empty string to clear, real value to update.
+          ...(githubToken.startsWith('****') ? {} : { github_token: githubToken }),
+          ...(gitlabToken.startsWith('****') ? {} : { gitlab_token: gitlabToken }),
+          gitlab_instance_url: gitlabInstanceUrl,
         },
-        ...(defaultModel ? { default_model: defaultModel } : {}),
+        default_model: defaultModel,
         role_models: {
           mayor: mayorModel || undefined,
           refinery: refineryModel || undefined,
           polecat: polecatModel || undefined,
         },
         ...(maxPolecats ? { max_polecats_per_rig: maxPolecats } : {}),
-        ...(githubCliPat && !githubCliPat.startsWith('****')
-          ? { github_cli_pat: githubCliPat }
-          : {}),
-        ...(gitAuthorName ? { git_author_name: gitAuthorName } : { git_author_name: '' }),
-        ...(gitAuthorEmail ? { git_author_email: gitAuthorEmail } : { git_author_email: '' }),
+        // Omit masked values to preserve the real secret; send empty string to clear.
+        ...(githubCliPat.startsWith('****') ? {} : { github_cli_pat: githubCliPat }),
+        git_author_name: gitAuthorName,
+        git_author_email: gitAuthorEmail,
         disable_ai_coauthor: disableAiCoauthor,
         merge_strategy: mergeStrategy,
         staged_convoys_default: stagedConvoysDefault,

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDownIcon } from 'lucide-react';
+import { ChevronRightIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -33,12 +33,12 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 cursor-pointer items-start gap-2 rounded-md pt-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 cursor-pointer items-start gap-2 rounded-md pt-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-90',
           className
         )}
         {...props}
       >
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        <ChevronRightIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
         {children}
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -460,6 +460,13 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         organization_id?: string | undefined;
         kilocode_token?: string | undefined;
         default_model?: string | undefined;
+        role_models?:
+          | {
+              mayor?: string | undefined;
+              refinery?: string | undefined;
+              polecat?: string | undefined;
+            }
+          | undefined;
         small_model?: string | undefined;
         max_polecats_per_rig?: number | undefined;
         merge_strategy: 'direct' | 'pr';
@@ -505,6 +512,13 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           organization_id?: string | undefined;
           kilocode_token?: string | undefined;
           default_model?: string | undefined;
+          role_models?:
+            | {
+                mayor?: string | undefined;
+                refinery?: string | undefined;
+                polecat?: string | undefined;
+              }
+            | undefined;
           small_model?: string | undefined;
           max_polecats_per_rig?: number | undefined;
           merge_strategy?: 'direct' | 'pr' | undefined;
@@ -544,6 +558,13 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         organization_id?: string | undefined;
         kilocode_token?: string | undefined;
         default_model?: string | undefined;
+        role_models?:
+          | {
+              mayor?: string | undefined;
+              refinery?: string | undefined;
+              polecat?: string | undefined;
+            }
+          | undefined;
         small_model?: string | undefined;
         max_polecats_per_rig?: number | undefined;
         merge_strategy: 'direct' | 'pr';
@@ -1711,6 +1732,13 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             organization_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
+            role_models?:
+              | {
+                  mayor?: string | undefined;
+                  refinery?: string | undefined;
+                  polecat?: string | undefined;
+                }
+              | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
             merge_strategy: 'direct' | 'pr';
@@ -1756,6 +1784,13 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               organization_id?: string | undefined;
               kilocode_token?: string | undefined;
               default_model?: string | undefined;
+              role_models?:
+                | {
+                    mayor?: string | undefined;
+                    refinery?: string | undefined;
+                    polecat?: string | undefined;
+                  }
+                | undefined;
               small_model?: string | undefined;
               max_polecats_per_rig?: number | undefined;
               merge_strategy?: 'direct' | 'pr' | undefined;
@@ -1795,6 +1830,13 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             organization_id?: string | undefined;
             kilocode_token?: string | undefined;
             default_model?: string | undefined;
+            role_models?:
+              | {
+                  mayor?: string | undefined;
+                  refinery?: string | undefined;
+                  polecat?: string | undefined;
+                }
+              | undefined;
             small_model?: string | undefined;
             max_polecats_per_rig?: number | undefined;
             merge_strategy: 'direct' | 'pr';

--- a/src/routers/admin/gastown-router.ts
+++ b/src/routers/admin/gastown-router.ts
@@ -122,6 +122,14 @@ const TownConfigRecord = z.object({
   owner_user_id: z.string().optional(),
   kilocode_token: z.string().optional(),
   default_model: z.string().nullable().optional(),
+  role_models: z
+    .object({
+      mayor: z.string().nullable().optional(),
+      refinery: z.string().nullable().optional(),
+      polecat: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   small_model: z.string().nullable().optional(),
   max_polecats_per_rig: z.number().optional(),
   merge_strategy: z.enum(['direct', 'pr']),


### PR DESCRIPTION
## Summary

- Add per-role model overrides (`role_models`) to TownConfig, allowing mayor, refinery, and polecat roles to each use a different LLM model instead of sharing a single `default_model`
- Implement `resolveModel()` priority chain: role-specific override > `default_model` > hardcoded fallback
- Add role-specific model selectors in the town settings UI behind an "Override by role" accordion
- Replace the max polecats numeric input with a slider (range 1–50, aligned with Zod schema)
- Persist mayor conversation history across container restarts by reconstructing transcript from agent events and injecting it into the prompt on re-dispatch
- Hot-swap mayor model uses `resolveModel()` for correct effective model detection

## Verification

- Pre-push hooks (lint, typecheck, format) passed on `git push`

## Visual Changes

<img width="3332" height="2468" alt="image" src="https://github.com/user-attachments/assets/7c3880ac-a082-41c2-b10e-fff5c2411c02" />

<img width="1762" height="1026" alt="image" src="https://github.com/user-attachments/assets/7a2ca313-5cf3-4c54-be58-84cde1c3acae" />


## Reviewer Notes

- The `resolveModel` function has thorough unit tests covering the full priority chain and backward compatibility with legacy configs
- Conversation persistence (`reconstructConversation`) delegates work to the AgentDO to avoid loading thousands of events in the TownDO
- The `trpc/dist/index.d.ts` changes are generated build artifacts from the gastown router type changes