### PR TITLE
style(usage): reduce metric card value text size

### DIFF
--- a/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
+++ b/src/components/organizations/usage-details/OrganizationUsageDetails.tsx
@@ -139,7 +139,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
           <FormattedMicrodollars
             microdollars={metricsTotals.cost}
             decimalPlaces={2}
-            className="text-2xl font-bold"
+            className="text-xl font-bold"
           />
         ),
         chartType: 'line' as const,
@@ -152,7 +152,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
         key: 'requests',
         title: 'Total Requests',
         value: (
-          <span className="text-2xl font-bold">{formatLargeNumber(metricsTotals.requests)}</span>
+          <span className="text-xl font-bold">{formatLargeNumber(metricsTotals.requests)}</span>
         ),
         chartType: 'line' as const,
         data: convertTimeseriesData(metricsTimeseriesData.requests),
@@ -166,7 +166,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
         value: (
           <FormattedMicrodollars
             microdollars={metricsTotals.avg_cost_per_req}
-            className="text-2xl font-bold"
+            className="text-xl font-bold"
           />
         ),
         chartType: 'line' as const,
@@ -178,9 +178,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
       {
         key: 'tokens',
         title: 'Total Tokens',
-        value: (
-          <span className="text-2xl font-bold">{formatLargeNumber(metricsTotals.tokens)}</span>
-        ),
+        value: <span className="text-xl font-bold">{formatLargeNumber(metricsTotals.tokens)}</span>,
         chartType: 'line' as const,
         data: convertTimeseriesData(metricsTimeseriesData.tokens),
         icon: Hash,
@@ -191,9 +189,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
         key: 'inputTokens',
         title: 'Input Tokens',
         value: (
-          <span className="text-2xl font-bold">
-            {formatLargeNumber(metricsTotals.input_tokens)}
-          </span>
+          <span className="text-xl font-bold">{formatLargeNumber(metricsTotals.input_tokens)}</span>
         ),
         chartType: 'line' as const,
         data: convertTimeseriesData(metricsTimeseriesData.input_tokens),
@@ -205,7 +201,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
         key: 'outputTokens',
         title: 'Output Tokens',
         value: (
-          <span className="text-2xl font-bold">
+          <span className="text-xl font-bold">
             {formatLargeNumber(metricsTotals.output_tokens)}
           </span>
         ),
@@ -219,7 +215,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
         key: 'users',
         title: 'Active Users',
         value: (
-          <span className="text-2xl font-bold">
+          <span className="text-xl font-bold">
             {formatLargeNumber(Math.round(metricsTotals.active_users))}
           </span>
         ),
@@ -293,7 +289,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">
+                  <div className="text-xl font-bold">
                     {isLoadingAutocompleteMetrics ? (
                       <Skeleton className="h-8 w-16" />
                     ) : (
@@ -310,7 +306,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">
+                  <div className="text-xl font-bold">
                     {isLoadingAutocompleteMetrics ? (
                       <Skeleton className="h-8 w-20" />
                     ) : (
@@ -327,7 +323,7 @@ export function OrganizationUsageDetails({ organizationId }: { organizationId: s
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">
+                  <div className="text-xl font-bold">
                     {isLoadingAutocompleteMetrics ? (
                       <Skeleton className="h-8 w-16" />
                     ) : (


### PR DESCRIPTION
## Summary

- Reduce usage metric card value text from `text-2xl` (1.5rem) to `text-xl` (1.25rem) on the org usage page for a more compact appearance.
- Applies to all 7 primary metric cards (Total Cost, Total Requests, Avg Cost/Req, Total Tokens, Input Tokens, Output Tokens, Active Users) and the 3 autocomplete metric cards.

## Verification

- [x] `format:check` — passed (via pre-push hook)
- [x] `lint` — passed (via pre-push hook)
- [x] `typecheck` — passed (via pre-push hook)

## Visual Changes

| Before | After |
| ------ | ----- |
| Metric card values at `text-2xl` (1.5rem / 24px) | Metric card values at `text-xl` (1.25rem / 20px) |
|<img width="2296" height="292" alt="Helium 2026-03-25 17 20 19" src="https://github.com/user-attachments/assets/a2d81443-b96d-4768-af67-b826953f3d5a" />|<img width="2280" height="222" alt="Helium 2026-03-25 17 20 28" src="https://github.com/user-attachments/assets/08611439-fc3c-4ceb-8553-aaf797c6400f" />|

## Reviewer Notes

Pure cosmetic change — only Tailwind text size classes were modified in `OrganizationUsageDetails.tsx`. No logic, data, or layout changes.