### PR TITLE
fix(promo): extend Emilie Valentine's promo code expiration to December 2026

### DIFF
--- a/src/lib/promoCreditCategories.ts
+++ b/src/lib/promoCreditCategories.ts
@@ -571,7 +571,7 @@ const encryptedSelfServicePromos: readonly EncryptedSelfServicePromoCreditCatego
     is_user_selfservicable: true,
     is_idempotent: true,
     amount_usd: 10,
-    promotion_ends_at: new Date('2026-12-31'),
+    promotion_ends_at: new Date('2027-01-01'),
     description: 'Emilie Valentine Experiment',
     total_redemptions_allowed: 5000,
   },

--- a/src/lib/promoCreditCategories.ts
+++ b/src/lib/promoCreditCategories.ts
@@ -571,7 +571,7 @@ const encryptedSelfServicePromos: readonly EncryptedSelfServicePromoCreditCatego
     is_user_selfservicable: true,
     is_idempotent: true,
     amount_usd: 10,
-    promotion_ends_at: new Date('2026-03-01'),
+    promotion_ends_at: new Date('2026-12-31'),
     description: 'Emilie Valentine Experiment',
     total_redemptions_allowed: 5000,
   },


### PR DESCRIPTION
## Summary

Extended the expiration date for the Valentine's promo code from March 1, 2026 to December 31, 2026. The promo code had expired and needed to be reactivated to allow new redemptions through the end of the year.

- Updated `promotion_ends_at` date in `promoCreditCategories.ts`
- Promo code provides $10 USD in credits
- Maintains existing 5000 total redemption limit

## Verification

- Confirmed the date change in the promo code configuration
- No functional code changes, only configuration update

## Visual Changes

N/A

