### PR TITLE
(kiloclaw-admin): Add Destroy Machine functionality to the KiloClaw admin dash

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5109,6 +5109,40 @@ describe("syncStatusWithFly: backfill lastStartedAt on 'starting' → 'running'"
   });
 });
 
+describe("syncStatusWithFly: 'destroyed' Fly state clears flyMachineId", () => {
+  it("clears flyMachineId and sets status to 'stopped' when Fly reports destroyed", async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'destroyed',
+      config: { mounts: [] },
+    });
+
+    await instance.alarm();
+
+    expect(storage._store.get('flyMachineId')).toBeNull();
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('lastStoppedAt')).toBeGreaterThan(0);
+    expect(storage._store.get('healthCheckFailCount')).toBe(0);
+  });
+
+  it("clears flyMachineId from 'stopped' status when Fly reports destroyed", async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { status: 'stopped', lastStoppedAt: Date.now() - 60_000 });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'destroyed',
+      config: { mounts: [] },
+    });
+
+    await instance.alarm();
+
+    expect(storage._store.get('flyMachineId')).toBeNull();
+    expect(storage._store.get('status')).toBe('stopped');
+  });
+});
+
 describe('reconcileStarting: transient Fly API errors respect starting timeout', () => {
   it("stays 'starting' on transient error when NOT timed out", async () => {
     const { instance, storage } = createInstance();

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -777,6 +777,30 @@ export async function syncStatusWithFly(
     return;
   }
 
+  // destroyed means the Fly machine is gone — clear the stale ID immediately
+  // so the DO doesn't keep referencing a dead machine.
+  if (flyState === 'destroyed') {
+    rctx.log('sync_status_destroyed', {
+      old_state: state.status,
+      new_state: 'stopped',
+      fly_state: flyState,
+      machine_id: state.flyMachineId,
+    });
+    state.flyMachineId = null;
+    state.status = 'stopped';
+    state.lastStoppedAt = Date.now();
+    state.healthCheckFailCount = 0;
+    await ctx.storage.put(
+      storageUpdate({
+        flyMachineId: null,
+        status: 'stopped',
+        lastStoppedAt: state.lastStoppedAt,
+        healthCheckFailCount: 0,
+      })
+    );
+    return;
+  }
+
   // failed is definitively terminal — transition immediately without waiting for
   // SELF_HEAL_THRESHOLD consecutive checks like we do for stopped/created.
   if (flyState === 'failed' && state.status !== 'stopped') {

--- a/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
+++ b/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { platform } from './platform';
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {},
+  waitUntil: (p: Promise<unknown>) => p,
+}));
+
+const testUserId = 'user-1';
+const testAppName = 'acct-abc123';
+const testMachineId = 'd890abc123';
+
+function makeEnv(overrides: Record<string, unknown> = {}) {
+  const forceRetryRecovery = vi.fn().mockResolvedValue(undefined);
+  return {
+    env: {
+      FLY_API_TOKEN: 'fly-test-token',
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ forceRetryRecovery }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+      ...overrides,
+    } as never,
+    forceRetryRecovery,
+  };
+}
+
+function postJson(path: string, body: Record<string, unknown>) {
+  return {
+    path,
+    init: {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  };
+}
+
+describe('POST /destroy-fly-machine', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 200 and calls Fly API DELETE with force=true', async () => {
+    const { env } = makeEnv();
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(200);
+    const json = await resp.json();
+    expect(json).toEqual({ ok: true });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://api.machines.dev/v1/apps/${testAppName}/machines/${testMachineId}?force=true`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer fly-test-token' },
+      }
+    );
+  });
+
+  it('triggers forceRetryRecovery after successful destroy', async () => {
+    const { env, forceRetryRecovery } = makeEnv();
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+    await platform.request(path, init, env);
+
+    expect(forceRetryRecovery).toHaveBeenCalled();
+  });
+
+  it('returns 503 when FLY_API_TOKEN is not configured', async () => {
+    const { env } = makeEnv({ FLY_API_TOKEN: undefined });
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(503);
+    const json = await resp.json();
+    expect(json.error).toContain('FLY_API_TOKEN');
+  });
+
+  it('forwards Fly API error status and body', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('machine not found', { status: 404 }));
+    const { env } = makeEnv();
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(404);
+    const json = await resp.json();
+    expect(json.error).toContain('machine not found');
+  });
+
+  it('returns 400 for invalid appName format', async () => {
+    const { env } = makeEnv();
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: 'INVALID',
+      machineId: testMachineId,
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid machineId format', async () => {
+    const { env } = makeEnv();
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: testAppName,
+      machineId: 'BAD-ID!',
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for missing userId', async () => {
+    const { env } = makeEnv();
+    const { path, init } = postJson('/destroy-fly-machine', {
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still returns ok when forceRetryRecovery fails', async () => {
+    const forceRetryRecovery = vi.fn().mockRejectedValue(new Error('DO unavailable'));
+    const { env } = makeEnv({
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ forceRetryRecovery }),
+      },
+    });
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+    const resp = await platform.request(path, init, env);
+
+    expect(resp.status).toBe(200);
+    const json = await resp.json();
+    expect(json).toEqual({ ok: true });
+    expect(forceRetryRecovery).toHaveBeenCalled();
+  });
+});

--- a/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
+++ b/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
@@ -33,6 +33,10 @@ function makeEnv(overrides: Record<string, unknown> = {}) {
   };
 }
 
+async function jsonBody(res: Response): Promise<Record<string, unknown>> {
+  return res.json();
+}
+
 function postJson(path: string, body: Record<string, unknown>) {
   return {
     path,
@@ -45,10 +49,14 @@ function postJson(path: string, body: Record<string, unknown>) {
 }
 
 describe('POST /destroy-fly-machine', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.fn<() => Promise<Response>>>;
 
   beforeEach(() => {
-    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 })) as ReturnType<
+      typeof vi.fn<() => Promise<Response>>
+    >;
   });
 
   afterEach(() => {
@@ -65,7 +73,7 @@ describe('POST /destroy-fly-machine', () => {
     const resp = await platform.request(path, init, env);
 
     expect(resp.status).toBe(200);
-    const json = await resp.json();
+    const json = await jsonBody(resp);
     expect(json).toEqual({ ok: true });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -132,7 +140,7 @@ describe('POST /destroy-fly-machine', () => {
     const resp = await platform.request(path, init, env);
 
     expect(resp.status).toBe(503);
-    const json = await resp.json();
+    const json = await jsonBody(resp);
     expect(json.error).toContain('FLY_API_TOKEN');
   });
 
@@ -147,7 +155,7 @@ describe('POST /destroy-fly-machine', () => {
     const resp = await platform.request(path, init, env);
 
     expect(resp.status).toBe(404);
-    const json = await resp.json();
+    const json = await jsonBody(resp);
     // Implementation wraps the Fly response body: "Fly API error (${status}): ${body}"
     expect(json.error).toBe('Fly API error (404): machine not found');
   });
@@ -206,7 +214,7 @@ describe('POST /destroy-fly-machine', () => {
     const resp = await platform.request(path, init, env);
 
     expect(resp.status).toBe(200);
-    const json = await resp.json();
+    const json = await jsonBody(resp);
     expect(json).toEqual({ ok: true });
     expect(forceRetryRecovery).toHaveBeenCalled();
   });

--- a/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
+++ b/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
@@ -77,22 +77,37 @@ describe('POST /destroy-fly-machine', () => {
     );
   });
 
-  it('builds Fly API URL with literal appName and machineId (no URI encoding needed)', async () => {
+  it('returns 400 for appName containing URI-special characters, proving the schema is the guard against URL injection', async () => {
+    // encodeURIComponent is not needed on the URL construction because the Zod schema
+    // never admits any character that would be percent-encoded. This test proves that
+    // boundary: a value containing a URI-special character (space, %, +) is rejected
+    // at the schema layer and never reaches the Fly API call.
     const { env } = makeEnv();
-    const appNameWithHyphen = 'acct-abc-123';
-    const { path, init } = postJson('/destroy-fly-machine', {
-      userId: testUserId,
-      appName: appNameWithHyphen,
-      machineId: testMachineId,
-    });
-    await platform.request(path, init, env);
+    for (const badAppName of ['acct abc', 'acct%20abc', 'acct+abc', 'ACCT-ABC']) {
+      const { path, init } = postJson('/destroy-fly-machine', {
+        userId: testUserId,
+        appName: badAppName,
+        machineId: testMachineId,
+      });
+      const resp = await platform.request(path, init, env);
+      expect(resp.status).toBe(400);
+    }
+    // None of the bad inputs reached the Fly API
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 
-    // Zod schema restricts appName to /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/ and machineId to
-    // /^[a-z0-9]+$/ — characters that never need URL-encoding, so no encodeURIComponent is needed.
-    expect(fetchSpy).toHaveBeenCalledWith(
-      `https://api.machines.dev/v1/apps/${appNameWithHyphen}/machines/${testMachineId}?force=true`,
-      expect.objectContaining({ method: 'DELETE' })
-    );
+  it('returns 400 for machineId containing URI-special characters, proving the schema is the guard against URL injection', async () => {
+    const { env } = makeEnv();
+    for (const badMachineId of ['d890 abc', 'd890%abc', 'd890+abc', 'D890ABC']) {
+      const { path, init } = postJson('/destroy-fly-machine', {
+        userId: testUserId,
+        appName: testAppName,
+        machineId: badMachineId,
+      });
+      const resp = await platform.request(path, init, env);
+      expect(resp.status).toBe(400);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('triggers forceRetryRecovery after successful destroy', async () => {

--- a/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
+++ b/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
@@ -103,7 +103,7 @@ describe('POST /destroy-fly-machine', () => {
     expect(json.error).toContain('FLY_API_TOKEN');
   });
 
-  it('forwards Fly API error status and body', async () => {
+  it('wraps Fly API error status and body in error message', async () => {
     fetchSpy.mockResolvedValueOnce(new Response('machine not found', { status: 404 }));
     const { env } = makeEnv();
     const { path, init } = postJson('/destroy-fly-machine', {
@@ -115,7 +115,8 @@ describe('POST /destroy-fly-machine', () => {
 
     expect(resp.status).toBe(404);
     const json = await resp.json();
-    expect(json.error).toContain('machine not found');
+    // Implementation wraps the Fly response body: "Fly API error (${status}): ${body}"
+    expect(json.error).toBe('Fly API error (404): machine not found');
   });
 
   it('returns 400 for invalid appName format', async () => {

--- a/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
+++ b/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
@@ -77,6 +77,24 @@ describe('POST /destroy-fly-machine', () => {
     );
   });
 
+  it('builds Fly API URL with literal appName and machineId (no URI encoding needed)', async () => {
+    const { env } = makeEnv();
+    const appNameWithHyphen = 'acct-abc-123';
+    const { path, init } = postJson('/destroy-fly-machine', {
+      userId: testUserId,
+      appName: appNameWithHyphen,
+      machineId: testMachineId,
+    });
+    await platform.request(path, init, env);
+
+    // Zod schema restricts appName to /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/ and machineId to
+    // /^[a-z0-9]+$/ — characters that never need URL-encoding, so no encodeURIComponent is needed.
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://api.machines.dev/v1/apps/${appNameWithHyphen}/machines/${testMachineId}?force=true`,
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
   it('triggers forceRetryRecovery after successful destroy', async () => {
     const { env, forceRetryRecovery } = makeEnv();
     const { path, init } = postJson('/destroy-fly-machine', {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1363,8 +1363,15 @@ platform.put('/regions', async c => {
 // This bypasses the DO's normal destroy flow — use for admin cleanup.
 const DestroyFlyMachineSchema = z.object({
   userId: z.string().min(1),
-  appName: z.string().min(1).max(63).regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Invalid Fly app name'),
-  machineId: z.string().min(1).regex(/^[a-z0-9]+$/, 'Invalid Fly machine ID'),
+  appName: z
+    .string()
+    .min(1)
+    .max(63)
+    .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Invalid Fly app name'),
+  machineId: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+$/, 'Invalid Fly machine ID'),
 });
 
 platform.post('/destroy-fly-machine', async c => {
@@ -1390,10 +1397,7 @@ platform.post('/destroy-fly-machine', async c => {
         `[platform] destroy-fly-machine failed (${resp.status}) app=${appName} machine=${machineId}:`,
         body
       );
-      return jsonError(
-        `Fly API error (${resp.status}): ${body}`,
-        resp.status
-      );
+      return jsonError(`Fly API error (${resp.status}): ${body}`, resp.status);
     }
 
     console.log(`[platform] destroy-fly-machine ok: app=${appName} machine=${machineId}`);

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1375,7 +1375,7 @@ platform.post('/destroy-fly-machine', async c => {
   const startedAt = performance.now();
   const apiToken = c.env.FLY_API_TOKEN;
   if (!apiToken) {
-    return jsonError('FLY_API_TOKEN is not configured', 500);
+    return c.json({ error: 'FLY_API_TOKEN is not configured' }, 503);
   }
 
   const url = `https://api.machines.dev/v1/apps/${appName}/machines/${machineId}?force=true`;
@@ -1399,7 +1399,7 @@ platform.post('/destroy-fly-machine', async c => {
         error: `Fly API error (${resp.status})`,
         durationMs: performance.now() - startedAt,
       });
-      return jsonError(`Fly API error (${resp.status}): ${body}`, resp.status);
+      return jsonError(`Fly API error (${resp.status}): ${body}`, resp.status >= 500 ? 502 : resp.status);
     }
 
     console.log(`[platform] destroy-fly-machine ok: app=${appName} machine=${machineId}`);
@@ -1427,8 +1427,7 @@ platform.post('/destroy-fly-machine', async c => {
     });
     return c.json({ ok: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`[platform] destroy-fly-machine error app=${appName} machine=${machineId}:`, err);
+    const { message, status } = sanitizeError(err, 'destroy-fly-machine');
     writeEvent(c.env, {
       event: 'instance.destroy_fly_machine_failed',
       delivery: 'http',
@@ -1437,7 +1436,7 @@ platform.post('/destroy-fly-machine', async c => {
       error: message,
       durationMs: performance.now() - startedAt,
     });
-    return jsonError(`Failed to destroy machine: ${message}`, 500);
+    return jsonError(message, status);
   }
 });
 

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1359,8 +1359,9 @@ platform.put('/regions', async c => {
 });
 
 // POST /api/platform/destroy-fly-machine
-// Directly destroys a Fly machine via the Machines API (force=true).
-// This bypasses the DO's normal destroy flow — use for admin cleanup.
+// This is for admin cleanup only.
+// It directly destroys a Fly machine via the Machines API (force=true).
+// It does not destroy the Fly app or volume.
 const DestroyFlyMachineSchema = z.object({
   userId: z.string().min(1),
   appName: z
@@ -1384,7 +1385,7 @@ platform.post('/destroy-fly-machine', async c => {
     return c.json({ error: 'FLY_API_TOKEN is not configured' }, 503);
   }
 
-  const url = `https://api.machines.dev/v1/apps/${encodeURIComponent(appName)}/machines/${encodeURIComponent(machineId)}?force=true`;
+  const url = `https://api.machines.dev/v1/apps/${appName}/machines/${machineId}?force=true`;
   try {
     const resp = await fetch(url, {
       method: 'DELETE',

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1363,8 +1363,8 @@ platform.put('/regions', async c => {
 // This bypasses the DO's normal destroy flow — use for admin cleanup.
 const DestroyFlyMachineSchema = z.object({
   userId: z.string().min(1),
-  appName: z.string().min(1),
-  machineId: z.string().min(1),
+  appName: z.string().min(1).max(63).regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Invalid Fly app name'),
+  machineId: z.string().min(1).regex(/^[a-z0-9]+$/, 'Invalid Fly machine ID'),
 });
 
 platform.post('/destroy-fly-machine', async c => {
@@ -1372,13 +1372,12 @@ platform.post('/destroy-fly-machine', async c => {
   if ('error' in result) return result.error;
 
   const { userId, appName, machineId } = result.data;
-  const startedAt = performance.now();
   const apiToken = c.env.FLY_API_TOKEN;
   if (!apiToken) {
     return c.json({ error: 'FLY_API_TOKEN is not configured' }, 503);
   }
 
-  const url = `https://api.machines.dev/v1/apps/${appName}/machines/${machineId}?force=true`;
+  const url = `https://api.machines.dev/v1/apps/${encodeURIComponent(appName)}/machines/${encodeURIComponent(machineId)}?force=true`;
   try {
     const resp = await fetch(url, {
       method: 'DELETE',
@@ -1391,17 +1390,9 @@ platform.post('/destroy-fly-machine', async c => {
         `[platform] destroy-fly-machine failed (${resp.status}) app=${appName} machine=${machineId}:`,
         body
       );
-      writeEvent(c.env, {
-        event: 'instance.destroy_fly_machine_failed',
-        delivery: 'http',
-        route: '/api/platform/destroy-fly-machine',
-        userId,
-        error: `Fly API error (${resp.status})`,
-        durationMs: performance.now() - startedAt,
-      });
       return jsonError(
         `Fly API error (${resp.status}): ${body}`,
-        resp.status >= 500 ? 502 : resp.status
+        resp.status
       );
     }
 
@@ -1421,24 +1412,9 @@ platform.post('/destroy-fly-machine', async c => {
       );
     }
 
-    writeEvent(c.env, {
-      event: 'instance.destroy_fly_machine_succeeded',
-      delivery: 'http',
-      route: '/api/platform/destroy-fly-machine',
-      userId,
-      durationMs: performance.now() - startedAt,
-    });
     return c.json({ ok: true });
   } catch (err) {
     const { message, status } = sanitizeError(err, 'destroy-fly-machine');
-    writeEvent(c.env, {
-      event: 'instance.destroy_fly_machine_failed',
-      delivery: 'http',
-      route: '/api/platform/destroy-fly-machine',
-      userId,
-      error: message,
-      durationMs: performance.now() - startedAt,
-    });
     return jsonError(message, status);
   }
 });

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1399,7 +1399,10 @@ platform.post('/destroy-fly-machine', async c => {
         error: `Fly API error (${resp.status})`,
         durationMs: performance.now() - startedAt,
       });
-      return jsonError(`Fly API error (${resp.status}): ${body}`, resp.status >= 500 ? 502 : resp.status);
+      return jsonError(
+        `Fly API error (${resp.status}): ${body}`,
+        resp.status >= 500 ? 502 : resp.status
+      );
     }
 
     console.log(`[platform] destroy-fly-machine ok: app=${appName} machine=${machineId}`);

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1412,7 +1412,10 @@ platform.post('/destroy-fly-machine', async c => {
         'forceRetryRecovery'
       );
     } catch (err) {
-      console.warn(`[platform] destroy-fly-machine: forceRetryRecovery failed for user=${userId}:`, err);
+      console.warn(
+        `[platform] destroy-fly-machine: forceRetryRecovery failed for user=${userId}:`,
+        err
+      );
     }
 
     writeEvent(c.env, {

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1372,6 +1372,7 @@ platform.post('/destroy-fly-machine', async c => {
   if ('error' in result) return result.error;
 
   const { userId, appName, machineId } = result.data;
+  const startedAt = performance.now();
   const apiToken = c.env.FLY_API_TOKEN;
   if (!apiToken) {
     return jsonError('FLY_API_TOKEN is not configured', 500);
@@ -1390,6 +1391,14 @@ platform.post('/destroy-fly-machine', async c => {
         `[platform] destroy-fly-machine failed (${resp.status}) app=${appName} machine=${machineId}:`,
         body
       );
+      writeEvent(c.env, {
+        event: 'instance.destroy_fly_machine_failed',
+        delivery: 'http',
+        route: '/api/platform/destroy-fly-machine',
+        userId,
+        error: `Fly API error (${resp.status})`,
+        durationMs: performance.now() - startedAt,
+      });
       return jsonError(`Fly API error (${resp.status}): ${body}`, resp.status);
     }
 
@@ -1406,10 +1415,25 @@ platform.post('/destroy-fly-machine', async c => {
       console.warn(`[platform] destroy-fly-machine: forceRetryRecovery failed for user=${userId}:`, err);
     }
 
+    writeEvent(c.env, {
+      event: 'instance.destroy_fly_machine_succeeded',
+      delivery: 'http',
+      route: '/api/platform/destroy-fly-machine',
+      userId,
+      durationMs: performance.now() - startedAt,
+    });
     return c.json({ ok: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error(`[platform] destroy-fly-machine error app=${appName} machine=${machineId}:`, err);
+    writeEvent(c.env, {
+      event: 'instance.destroy_fly_machine_failed',
+      delivery: 'http',
+      route: '/api/platform/destroy-fly-machine',
+      userId,
+      error: message,
+      durationMs: performance.now() - startedAt,
+    });
     return jsonError(`Failed to destroy machine: ${message}`, 500);
   }
 });

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -1358,4 +1358,60 @@ platform.put('/regions', async c => {
   return c.json({ ok: true, regions: result.data.regions, raw });
 });
 
+// POST /api/platform/destroy-fly-machine
+// Directly destroys a Fly machine via the Machines API (force=true).
+// This bypasses the DO's normal destroy flow — use for admin cleanup.
+const DestroyFlyMachineSchema = z.object({
+  userId: z.string().min(1),
+  appName: z.string().min(1),
+  machineId: z.string().min(1),
+});
+
+platform.post('/destroy-fly-machine', async c => {
+  const result = await parseBody(c, DestroyFlyMachineSchema);
+  if ('error' in result) return result.error;
+
+  const { userId, appName, machineId } = result.data;
+  const apiToken = c.env.FLY_API_TOKEN;
+  if (!apiToken) {
+    return jsonError('FLY_API_TOKEN is not configured', 500);
+  }
+
+  const url = `https://api.machines.dev/v1/apps/${appName}/machines/${machineId}?force=true`;
+  try {
+    const resp = await fetch(url, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${apiToken}` },
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      console.error(
+        `[platform] destroy-fly-machine failed (${resp.status}) app=${appName} machine=${machineId}:`,
+        body
+      );
+      return jsonError(`Fly API error (${resp.status}): ${body}`, resp.status);
+    }
+
+    console.log(`[platform] destroy-fly-machine ok: app=${appName} machine=${machineId}`);
+
+    // Trigger immediate reconcile so the DO discovers the machine is gone.
+    try {
+      await withDORetry(
+        instanceStubFactory(c.env, userId),
+        stub => stub.forceRetryRecovery(),
+        'forceRetryRecovery'
+      );
+    } catch (err) {
+      console.warn(`[platform] destroy-fly-machine: forceRetryRecovery failed for user=${userId}:`, err);
+    }
+
+    return c.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`[platform] destroy-fly-machine error app=${appName} machine=${machineId}:`, err);
+    return jsonError(`Failed to destroy machine: ${message}`, 500);
+  }
+});
+
 export { platform };

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -162,6 +162,7 @@ export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.gateway.restart',
   'kiloclaw.config.restore',
   'kiloclaw.doctor.run',
+  'kiloclaw.machine.destroy_fly',
 ]);
 
 export type KiloClawAdminAuditAction = z.infer<typeof KiloClawAdminAuditAction>;

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1838,6 +1838,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       appName: data.workerStatus.flyAppName,
                       machineId: data.workerStatus.flyMachineId,
                     });
+                  } else {
+                    toast.error('Missing machine ID or app name');
                   }
                 }}
               >

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1811,27 +1811,29 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
           open={destroyMachineDialogOpen}
           onOpenChange={isDestroyingFlyMachine ? () => {} : setDestroyMachineDialogOpen}
         >
-          <DialogContent>
+          <DialogContent className="sm:max-w-[425px]">
             <DialogHeader>
-              <DialogTitle>Destroy Fly Machine</DialogTitle>
-              <DialogDescription>
+              <DialogTitle className="text-destructive flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5" />
+                Destroy Fly Machine
+              </DialogTitle>
+              <DialogDescription className="pt-3">
                 This will force-destroy the Fly machine via the Machines API. Only the Fly machine
                 is deleted — the KiloClaw instance and Fly volume will remain intact.
+                <span className="text-foreground mt-2 block font-medium">
+                  User: {data?.user_email ?? data?.user_id}
+                </span>
+                <span className="mt-2 block">
+                  Machine ID: <code className="text-xs">{data?.workerStatus?.flyMachineId}</code>
+                </span>
+                <span className="block">
+                  App: <code className="text-xs">{data?.workerStatus?.flyAppName}</code>
+                </span>
               </DialogDescription>
             </DialogHeader>
-            <div className="space-y-2 text-sm">
-              <div>
-                <span className="text-muted-foreground">Machine ID:</span>{' '}
-                <code className="text-xs">{data?.workerStatus?.flyMachineId}</code>
-              </div>
-              <div>
-                <span className="text-muted-foreground">App:</span>{' '}
-                <code className="text-xs">{data?.workerStatus?.flyAppName}</code>
-              </div>
-            </div>
-            <DialogFooter>
+            <DialogFooter className="gap-2 sm:gap-0">
               <DialogClose asChild>
-                <Button variant="outline" disabled={isDestroyingFlyMachine}>
+                <Button variant="secondary" disabled={isDestroyingFlyMachine}>
                   Cancel
                 </Button>
               </DialogClose>

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1247,6 +1247,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     mutateAsync: destroyFlyMachine,
     isPending: isDestroyingFlyMachine,
     isSuccess: isFlyMachineDestroyed,
+    reset: resetDestroyFlyMachine,
   } = useMutation(
     trpc.admin.kiloclawInstances.destroyFlyMachine.mutationOptions({
       onSuccess: () => {
@@ -1259,6 +1260,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
       },
     })
   );
+
+  // Reset the destroyed success state when the machine ID changes (e.g. new machine created)
+  const flyMachineId = data?.workerStatus?.flyMachineId;
+  useEffect(() => {
+    resetDestroyFlyMachine();
+  }, [flyMachineId, resetDestroyFlyMachine]);
 
   const { mutateAsync: forceRetryRecovery, isPending: isRetryingRecovery } = useMutation(
     trpc.admin.kiloclawInstances.forceRetryRecovery.mutationOptions({

--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1014,6 +1014,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const [destroyDialogOpen, setDestroyDialogOpen] = useState(false);
   const [doctorDialogOpen, setDoctorDialogOpen] = useState(false);
   const [restoreConfigDialogOpen, setRestoreConfigDialogOpen] = useState(false);
+  const [destroyMachineDialogOpen, setDestroyMachineDialogOpen] = useState(false);
   const [awaitingRestartCompletion, setAwaitingRestartCompletion] = useState(false);
   const [restoreSnapshotDialogOpen, setRestoreSnapshotDialogOpen] = useState(false);
   const [restoreSnapshotId, setRestoreSnapshotId] = useState<string | null>(null);
@@ -1242,6 +1243,23 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     })
   );
 
+  const {
+    mutateAsync: destroyFlyMachine,
+    isPending: isDestroyingFlyMachine,
+    isSuccess: isFlyMachineDestroyed,
+  } = useMutation(
+    trpc.admin.kiloclawInstances.destroyFlyMachine.mutationOptions({
+      onSuccess: () => {
+        toast.success('Fly machine destroyed');
+        invalidateMachineQueries();
+        setDestroyMachineDialogOpen(false);
+      },
+      onError: err => {
+        toast.error(`Failed to destroy Fly machine: ${err.message}`);
+      },
+    })
+  );
+
   const { mutateAsync: forceRetryRecovery, isPending: isRetryingRecovery } = useMutation(
     trpc.admin.kiloclawInstances.forceRetryRecovery.mutationOptions({
       onSuccess: () => {
@@ -1365,7 +1383,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     isMachineStopping ||
     isMachineRedeploying ||
     isMachineUpgrading ||
-    isRetryingRecovery;
+    isRetryingRecovery ||
+    isDestroyingFlyMachine;
   const gatewayActionPending =
     isGatewayStarting ||
     isGatewayStopping ||
@@ -1755,10 +1774,79 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   )}
                   Upgrade to Latest
                 </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className={
+                    isFlyMachineDestroyed
+                      ? 'border-green-500 text-green-500'
+                      : 'border-orange-500 text-orange-500 hover:bg-orange-500/10'
+                  }
+                  disabled={machineActionPending || !hasMachine || isFlyMachineDestroyed}
+                  onClick={() => setDestroyMachineDialogOpen(true)}
+                >
+                  {isDestroyingFlyMachine ? (
+                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                  ) : isFlyMachineDestroyed ? (
+                    <CheckCircle2 className="mr-1 h-4 w-4" />
+                  ) : (
+                    <Trash2 className="mr-1 h-4 w-4" />
+                  )}
+                  {isFlyMachineDestroyed ? 'Machine Destroyed' : 'Destroy Machine'}
+                </Button>
               </div>
             </CardContent>
           </Card>
         )}
+
+        {/* Destroy Fly Machine Confirmation Dialog */}
+        <Dialog
+          open={destroyMachineDialogOpen}
+          onOpenChange={isDestroyingFlyMachine ? () => {} : setDestroyMachineDialogOpen}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Destroy Fly Machine</DialogTitle>
+              <DialogDescription>
+                This will force-destroy the Fly machine via the Machines API. Only the Fly machine
+                is deleted — the KiloClaw instance and Fly volume will remain intact.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2 text-sm">
+              <div>
+                <span className="text-muted-foreground">Machine ID:</span>{' '}
+                <code className="text-xs">{data?.workerStatus?.flyMachineId}</code>
+              </div>
+              <div>
+                <span className="text-muted-foreground">App:</span>{' '}
+                <code className="text-xs">{data?.workerStatus?.flyAppName}</code>
+              </div>
+            </div>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline" disabled={isDestroyingFlyMachine}>
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                variant="destructive"
+                disabled={isDestroyingFlyMachine}
+                onClick={() => {
+                  if (data?.workerStatus?.flyMachineId && data?.workerStatus?.flyAppName) {
+                    void destroyFlyMachine({
+                      userId: data.user_id,
+                      appName: data.workerStatus.flyAppName,
+                      machineId: data.workerStatus.flyMachineId,
+                    });
+                  }
+                }}
+              >
+                {isDestroyingFlyMachine && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+                Destroy Machine
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         {/* Gateway Process (controller) */}
         {isActive && (

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -519,7 +519,7 @@ export class KiloClawInternalClient {
     return this.request('/api/platform/destroy-fly-machine', {
       method: 'POST',
       body: JSON.stringify({ userId, appName, machineId }),
-    });
+    }, { userId });
   }
 
   async getRegions(): Promise<RegionsResponse> {

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -511,7 +511,11 @@ export class KiloClawInternalClient {
     );
   }
 
-  async destroyFlyMachine(userId: string, appName: string, machineId: string): Promise<{ ok: true }> {
+  async destroyFlyMachine(
+    userId: string,
+    appName: string,
+    machineId: string
+  ): Promise<{ ok: true }> {
     return this.request('/api/platform/destroy-fly-machine', {
       method: 'POST',
       body: JSON.stringify({ userId, appName, machineId }),

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -516,10 +516,14 @@ export class KiloClawInternalClient {
     appName: string,
     machineId: string
   ): Promise<{ ok: true }> {
-    return this.request('/api/platform/destroy-fly-machine', {
-      method: 'POST',
-      body: JSON.stringify({ userId, appName, machineId }),
-    }, { userId });
+    return this.request(
+      '/api/platform/destroy-fly-machine',
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId, appName, machineId }),
+      },
+      { userId }
+    );
   }
 
   async getRegions(): Promise<RegionsResponse> {

--- a/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -511,6 +511,13 @@ export class KiloClawInternalClient {
     );
   }
 
+  async destroyFlyMachine(userId: string, appName: string, machineId: string): Promise<{ ok: true }> {
+    return this.request('/api/platform/destroy-fly-machine', {
+      method: 'POST',
+      body: JSON.stringify({ userId, appName, machineId }),
+    });
+  }
+
   async getRegions(): Promise<RegionsResponse> {
     return this.request('/api/platform/regions');
   }

--- a/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -1,0 +1,215 @@
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import type { User } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { kiloclaw_admin_audit_logs } from '@kilocode/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
+const mockDestroyFlyMachine: jest.Mock<any, any> = jest.fn();
+
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
+  KiloClawInternalClient: jest.fn().mockImplementation(() => ({
+    getDebugStatus: mockGetDebugStatus,
+    destroyFlyMachine: mockDestroyFlyMachine,
+  })),
+  KiloClawApiError: class KiloClawApiError extends Error {
+    statusCode: number;
+    responseBody: string;
+    constructor(statusCode: number, responseBody: string) {
+      super(`KiloClawApiError: ${statusCode}`);
+      this.statusCode = statusCode;
+      this.responseBody = responseBody;
+    }
+  },
+}));
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let regularUser: User;
+let adminUser: User;
+
+const testAppName = 'acct-abc123def456';
+const testMachineId = 'd8901e123456';
+const testUserId = 'test-target-user-id';
+
+beforeAll(async () => {
+  regularUser = await insertTestUser({
+    google_user_email: 'regular-destroy-machine@example.com',
+    is_admin: false,
+  });
+  adminUser = await insertTestUser({
+    google_user_email: 'admin-destroy-machine@admin.example.com',
+    is_admin: true,
+  });
+});
+
+beforeEach(async () => {
+  mockGetDebugStatus.mockReset();
+  mockDestroyFlyMachine.mockReset();
+  // Clean audit logs between tests so counts are accurate
+  await db
+    .delete(kiloclaw_admin_audit_logs)
+    .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
+});
+
+/* eslint-disable drizzle/enforce-delete-with-where */
+afterAll(async () => {
+  try {
+    await db
+      .delete(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
+  } catch {
+    // Test DB may already be torn down
+  }
+});
+/* eslint-enable drizzle/enforce-delete-with-where */
+
+describe('admin.kiloclawInstances.destroyFlyMachine', () => {
+  it('throws FORBIDDEN for non-admin users', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: testAppName,
+        machineId: testMachineId,
+      })
+    ).rejects.toThrow('Admin access required');
+
+    expect(mockGetDebugStatus).not.toHaveBeenCalled();
+  });
+
+  it('destroys the Fly machine when appName/machineId match DO state', async () => {
+    mockGetDebugStatus.mockResolvedValue({
+      flyAppName: testAppName,
+      flyMachineId: testMachineId,
+      status: 'running',
+    });
+    mockDestroyFlyMachine.mockResolvedValue({ ok: true });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.destroyFlyMachine({
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockGetDebugStatus).toHaveBeenCalledWith(testUserId);
+    expect(mockDestroyFlyMachine).toHaveBeenCalledWith(testUserId, testAppName, testMachineId);
+  });
+
+  it('throws BAD_REQUEST when appName does not match DO state', async () => {
+    mockGetDebugStatus.mockResolvedValue({
+      flyAppName: 'acct-different',
+      flyMachineId: testMachineId,
+      status: 'running',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: testAppName,
+        machineId: testMachineId,
+      })
+    ).rejects.toThrow('Fly resource mismatch');
+
+    expect(mockDestroyFlyMachine).not.toHaveBeenCalled();
+  });
+
+  it('throws BAD_REQUEST when machineId does not match DO state', async () => {
+    mockGetDebugStatus.mockResolvedValue({
+      flyAppName: testAppName,
+      flyMachineId: 'differentmachineid',
+      status: 'running',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: testAppName,
+        machineId: testMachineId,
+      })
+    ).rejects.toThrow('Fly resource mismatch');
+
+    expect(mockDestroyFlyMachine).not.toHaveBeenCalled();
+  });
+
+  it('writes an audit log on success', async () => {
+    mockGetDebugStatus.mockResolvedValue({
+      flyAppName: testAppName,
+      flyMachineId: testMachineId,
+      status: 'running',
+    });
+    mockDestroyFlyMachine.mockResolvedValue({ ok: true });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.kiloclawInstances.destroyFlyMachine({
+      userId: testUserId,
+      appName: testAppName,
+      machineId: testMachineId,
+    });
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(
+        and(
+          eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id),
+          eq(kiloclaw_admin_audit_logs.action, 'kiloclaw.machine.destroy_fly')
+        )
+      );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].target_user_id).toBe(testUserId);
+    expect(logs[0].actor_email).toBe(adminUser.google_user_email);
+    expect(logs[0].message).toContain(testAppName);
+    expect(logs[0].message).toContain(testMachineId);
+  });
+
+  it('propagates errors from the internal client as INTERNAL_SERVER_ERROR', async () => {
+    mockGetDebugStatus.mockResolvedValue({
+      flyAppName: testAppName,
+      flyMachineId: testMachineId,
+      status: 'running',
+    });
+    mockDestroyFlyMachine.mockRejectedValue(new Error('Fly API timeout'));
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: testAppName,
+        machineId: testMachineId,
+      })
+    ).rejects.toThrow('Failed to destroy Fly machine');
+  });
+
+  it('rejects invalid appName format', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: 'INVALID_APP_NAME',
+        machineId: testMachineId,
+      })
+    ).rejects.toThrow();
+
+    expect(mockGetDebugStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid machineId format', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: testAppName,
+        machineId: 'INVALID-MACHINE-ID',
+      })
+    ).rejects.toThrow();
+
+    expect(mockGetDebugStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -167,9 +167,10 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
     expect(logs[0].actor_email).toBe(adminUser.google_user_email);
     expect(logs[0].message).toContain(testAppName);
     expect(logs[0].message).toContain(testMachineId);
+    expect(logs[0].metadata).toEqual({ appName: testAppName, machineId: testMachineId });
   });
 
-  it('propagates errors from the internal client as INTERNAL_SERVER_ERROR', async () => {
+  it('wraps generic errors as INTERNAL_SERVER_ERROR', async () => {
     mockGetDebugStatus.mockResolvedValue({
       flyAppName: testAppName,
       flyMachineId: testMachineId,
@@ -184,7 +185,32 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
         appName: testAppName,
         machineId: testMachineId,
       })
-    ).rejects.toThrow('Failed to destroy Fly machine');
+    ).rejects.toThrow('Failed to destroy Fly machine: Fly API timeout');
+  });
+
+  it('maps KiloClawApiError 404 to NOT_FOUND', async () => {
+    const { KiloClawApiError } = jest.requireMock<{
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+    }>('@/lib/kiloclaw/kiloclaw-internal-client');
+
+    mockGetDebugStatus.mockResolvedValue({
+      flyAppName: testAppName,
+      flyMachineId: testMachineId,
+      status: 'running',
+    });
+    mockDestroyFlyMachine.mockRejectedValue(
+      new KiloClawApiError(404, JSON.stringify({ error: 'machine not found' }))
+    );
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.destroyFlyMachine({
+        userId: testUserId,
+        appName: testAppName,
+        machineId: testMachineId,
+      })
+    ).rejects.toThrow('machine not found');
   });
 
   it('rejects invalid appName format', async () => {
@@ -195,7 +221,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
         appName: 'INVALID_APP_NAME',
         machineId: testMachineId,
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Invalid Fly app name');
 
     expect(mockGetDebugStatus).not.toHaveBeenCalled();
   });
@@ -208,7 +234,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
         appName: testAppName,
         machineId: 'INVALID-MACHINE-ID',
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Invalid Fly machine ID');
 
     expect(mockGetDebugStatus).not.toHaveBeenCalled();
   });

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -634,8 +634,15 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     .input(
       z.object({
         userId: z.string().min(1),
-        appName: z.string().min(1),
-        machineId: z.string().min(1),
+        appName: z
+          .string()
+          .min(1)
+          .max(63)
+          .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Invalid Fly app name'),
+        machineId: z
+          .string()
+          .min(1)
+          .regex(/^[a-z0-9]+$/, 'Invalid Fly machine ID'),
       })
     )
     .mutation(async ({ input, ctx }) => {

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -642,19 +642,19 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       console.log(
         `[admin-kiloclaw] destroyFlyMachine triggered by admin ${ctx.user.id} (${ctx.user.google_user_email}) app=${input.appName} machine=${input.machineId}`
       );
+      const client = new KiloClawInternalClient();
+
+      // Verify the appName/machineId match the DO's actual state
+      const status = await client.getDebugStatus(input.userId);
+      if (status.flyAppName !== input.appName || status.flyMachineId !== input.machineId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Fly resource mismatch: expected app=${status.flyAppName} machine=${status.flyMachineId}, got app=${input.appName} machine=${input.machineId}`,
+        });
+      }
+
       const fallbackMessage = 'Failed to destroy Fly machine';
       try {
-        const client = new KiloClawInternalClient();
-
-        // Verify the appName/machineId match the DO's actual state
-        const status = await client.getDebugStatus(input.userId);
-        if (status.flyAppName !== input.appName || status.flyMachineId !== input.machineId) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: `Fly resource mismatch: expected app=${status.flyAppName} machine=${status.flyMachineId}, got app=${input.appName} machine=${input.machineId}`,
-          });
-        }
-
         const result = await client.destroyFlyMachine(input.userId, input.appName, input.machineId);
 
         try {

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -645,6 +645,16 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const fallbackMessage = 'Failed to destroy Fly machine';
       try {
         const client = new KiloClawInternalClient();
+
+        // Verify the appName/machineId match the DO's actual state
+        const status = await client.getDebugStatus(input.userId);
+        if (status.flyAppName !== input.appName || status.flyMachineId !== input.machineId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Fly resource mismatch: expected app=${status.flyAppName} machine=${status.flyMachineId}, got app=${input.appName} machine=${input.machineId}`,
+          });
+        }
+
         const result = await client.destroyFlyMachine(input.userId, input.appName, input.machineId);
 
         try {

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -630,6 +630,50 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       }
     }),
 
+  destroyFlyMachine: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        appName: z.string().min(1),
+        machineId: z.string().min(1),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      console.log(
+        `[admin-kiloclaw] destroyFlyMachine triggered by admin ${ctx.user.id} (${ctx.user.google_user_email}) app=${input.appName} machine=${input.machineId}`
+      );
+      const fallbackMessage = 'Failed to destroy Fly machine';
+      try {
+        const client = new KiloClawInternalClient();
+        const result = await client.destroyFlyMachine(input.userId, input.appName, input.machineId);
+
+        try {
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.machine.destroy_fly',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `Fly machine force-destroyed: app=${input.appName} machine=${input.machineId}`,
+            metadata: {
+              appName: input.appName,
+              machineId: input.machineId,
+            },
+          });
+        } catch (auditErr) {
+          console.error('Failed to write audit log for destroyFlyMachine:', auditErr);
+        }
+
+        return result;
+      } catch (err) {
+        console.error(
+          `Failed to destroy Fly machine app=${input.appName} machine=${input.machineId}:`,
+          err
+        );
+        throwKiloclawAdminError(err, fallbackMessage);
+      }
+    }),
+
   destroy: adminProcedure.input(DestroyInstanceSchema).mutation(async ({ input, ctx }) => {
     const [instance] = await db
       .select({

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -652,7 +652,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       const client = new KiloClawInternalClient();
 
       // Verify the appName/machineId match the DO's actual state
-      const status = await client.getDebugStatus(input.userId);
+      let status: Awaited<ReturnType<KiloClawInternalClient['getDebugStatus']>>;
+      try {
+        status = await client.getDebugStatus(input.userId);
+      } catch (err) {
+        throwKiloclawAdminError(err, 'Failed to verify machine state before destroy');
+      }
       if (status.flyAppName !== input.appName || status.flyMachineId !== input.machineId) {
         throw new TRPCError({
           code: 'BAD_REQUEST',


### PR DESCRIPTION
## Summary

Adds a "Destroy Machine" button to the KiloClaw admin instance detail page that directly calls the Fly Machines API to force-destroy a machine — equivalent to `fly machine destroy <id> -a <app> --force`.

**Why this exists:** The normal instance destroy flow goes through the DO's teardown pipeline (machine → volume → cleanup). This button is an admin escape hatch for when you need to delete the Fly machine directly without triggering the full teardown.

**What it does NOT do:** This does not tear down the KiloClaw instance, delete the Fly volume, or mark the instance as destroyed in the database. Only the Fly machine is destroyed.

### Implementation

- **Platform route** (`POST /api/platform/destroy-fly-machine`): Calls `DELETE /v1/apps/{app}/machines/{id}?force=true` on the Fly Machines API using the worker's `FLY_API_TOKEN`. After a successful destroy, triggers `forceRetryRecovery` on the DO to schedule an immediate reconcile alarm — the DO will discover the machine is destroyed and clear its `flyMachineId` state.
- **tRPC mutation** (`destroyFlyMachine`): Admin-only mutation that proxies to the platform route and writes an audit log (`kiloclaw.machine.destroy_fly`).
- **UI**: Orange "Destroy Machine" button in Machine Controls with a confirmation dialog showing the machine ID and app name. After success, the button shows a green "Machine Destroyed" state and is disabled. An error toast is shown if `flyAppName` is missing from the DO state.
- **Observability**: `writeEvent` calls for success/failure (visible in the DO & Reconcile Events table on the admin page), plus `createKiloClawAdminAuditLog` for the audit trail.

### Reconciler fix: handle `"destroyed"` Fly state

`syncStatusWithFly` previously had no branch for the `"destroyed"` Fly machine state. When a machine is force-destroyed via the Fly API, Fly returns the machine with `state: "destroyed"` before it eventually starts returning 404. Without this fix, the reconciler would no-op on the `"destroyed"` state, leaving the stale `flyMachineId` in DO storage until a later alarm cycle when Fly finally returns 404 and `handleMachineGone` fires. The new `"destroyed"` branch mirrors `handleMachineGone` — clears `flyMachineId`, sets status to `"stopped"`, and persists immediately.

### New audit action

`kiloclaw.machine.destroy_fly` added to `KiloClawAdminAuditAction` enum.

## Verification

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Tested locally: destroy succeeds, Fly machine removed, DO reconciles after alarm fires
- [x] 4 rounds of adversarial code review (code reviewer, silent failure hunter, security auditor) with verification agents — converged to zero new actionable findings
- [x] E2E manual testing

## Loom — Kilo team only
https://www.loom.com/share/7e898ec288da4e9a83d2554780622dd9

## Reviewer Notes

- The `forceRetryRecovery` call after destroy is fire-and-forget (caught and warned). If it fails, the DO will still reconcile on its next regular alarm. The response returns `ok: true` regardless — this was a deliberate scoping decision to avoid threading a `reconcileTriggered` flag through three layers.
- Until the reconcile task following machine destruction finishes (should be fairly quick in the deployed env), the DO will log errors as it has lost connection with the controller. The noise should be relatively minimal and, as the reconcile alarm is set to _now_, it should be resolved quickly.
- `isFlyMachineDestroyed` comes from `useMutation`'s `isSuccess` which resets on component re-mount. A second click after re-mount would get a Fly 404 error toast — not harmful, just redundant.