### PR TITLE
(ui): Create a shared banner component & implement on the profile page KiloClaw CTA

### DIFF
--- a/src/components/profile/ProfileKiloClawBanner.tsx
+++ b/src/components/profile/ProfileKiloClawBanner.tsx
@@ -27,40 +27,57 @@ export function ProfileKiloClawBanner() {
 
   if (hasInstance && billing.hasAccess) {
     return (
-      <Banner
-        icon={KiloCrabIcon}
-        color="emerald"
-        title="Your KiloClaw instance is active"
-        description="Manage your instance, configure integrations, and monitor your Claw."
-        buttonLabel="Go to KiloClaw"
-        buttonHref="/claw"
-        buttonIcon={ArrowRight}
-      />
+      <Banner color="emerald">
+        <Banner.Icon>
+          <KiloCrabIcon />
+        </Banner.Icon>
+        <Banner.Content>
+          <Banner.Title>Your KiloClaw instance is active</Banner.Title>
+          <Banner.Description>
+            Manage your instance, configure integrations, and monitor your Claw.
+          </Banner.Description>
+        </Banner.Content>
+        <Banner.Button href="/claw">
+          Go to KiloClaw
+          <ArrowRight />
+        </Banner.Button>
+      </Banner>
     );
   }
 
   if (hasInstance && !billing.hasAccess) {
     return (
-      <Banner
-        icon={AlertTriangle}
-        color="amber"
-        title="Your KiloClaw instance needs attention"
-        description="Your access has lapsed. Visit the dashboard to resolve billing and restore your instance."
-        buttonLabel="Resolve"
-        buttonHref="/claw"
-        buttonIcon={ArrowRight}
-      />
+      <Banner color="amber">
+        <Banner.Icon>
+          <AlertTriangle />
+        </Banner.Icon>
+        <Banner.Content>
+          <Banner.Title>Your KiloClaw instance needs attention</Banner.Title>
+          <Banner.Description>
+            Your access has lapsed. Visit the dashboard to resolve billing and restore your
+            instance.
+          </Banner.Description>
+        </Banner.Content>
+        <Banner.Button href="/claw">
+          Resolve
+          <ArrowRight />
+        </Banner.Button>
+      </Banner>
     );
   }
 
   return (
-    <Banner
-      icon={KiloCrabIcon}
-      color="blue"
-      title="Get started with KiloClaw"
-      description="Fully-managed OpenClaw, always online. Set up in minutes."
-      buttonLabel="Get Started"
-      buttonHref="/claw"
-    />
+    <Banner color="blue">
+      <Banner.Icon>
+        <KiloCrabIcon />
+      </Banner.Icon>
+      <Banner.Content>
+        <Banner.Title>Get started with KiloClaw</Banner.Title>
+        <Banner.Description>
+          Fully-managed OpenClaw, always online. Set up in minutes.
+        </Banner.Description>
+      </Banner.Content>
+      <Banner.Button href="/claw">Get Started</Banner.Button>
+    </Banner>
   );
 }

--- a/src/components/profile/ProfileKiloClawBanner.tsx
+++ b/src/components/profile/ProfileKiloClawBanner.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
+import { Banner } from '@/components/shared/Banner';
 
 export function ProfileKiloClawBanner() {
   const trpc = useTRPC();
@@ -13,7 +14,7 @@ export function ProfileKiloClawBanner() {
 
   if (billingQuery.isLoading) {
     return (
-      <div className="flex w-full items-center justify-center rounded-lg border border-blue-500/20 bg-blue-500/5 p-6">
+      <div className="flex w-full items-center justify-center rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
         <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
       </div>
     );
@@ -28,80 +29,77 @@ export function ProfileKiloClawBanner() {
 
   if (hasInstance && billing.hasAccess) {
     return (
-      <div className="flex w-full items-center gap-4 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-5">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/20">
-          <KiloCrabIcon className="h-5 w-5 text-emerald-400" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-semibold text-emerald-100">Your KiloClaw instance is active</p>
-          <p className="text-sm text-emerald-300/80">
-            Manage your instance, configure integrations, and monitor your Claw.
-          </p>
-        </div>
-        <Button
-          asChild
-          variant="outline"
-          className="shrink-0 border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/20 hover:text-emerald-100"
-        >
-          <Link href="/claw">
-            Go to KiloClaw
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        </Button>
-      </div>
+      <Banner
+        icon={<KiloCrabIcon className="h-5 w-5 sm:h-6 sm:w-6 text-emerald-400" />}
+        title="Your KiloClaw instance is active"
+        description="Manage your instance, configure integrations, and monitor your Claw."
+        colors={{
+          border: 'border-emerald-500/30',
+          bg: 'bg-emerald-500/10',
+          text: 'text-emerald-400',
+        }}
+        action={
+          <Button
+            asChild
+            className="w-full shrink-0 bg-emerald-500 text-primary-foreground hover:bg-emerald-500/90 sm:w-auto"
+          >
+            <Link href="/claw">
+              Go to KiloClaw
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        }
+      />
     );
   }
 
   if (hasInstance && !billing.hasAccess) {
     return (
-      <div className="flex w-full items-center gap-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-5">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-500/20">
-          <AlertTriangle className="h-5 w-5 text-amber-400" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-semibold text-amber-100">
-            Your KiloClaw instance needs attention
-          </p>
-          <p className="text-sm text-amber-300/80">
-            Your access has lapsed. Visit the dashboard to resolve billing and restore your
-            instance.
-          </p>
-        </div>
-        <Button
-          asChild
-          variant="outline"
-          className="shrink-0 border-amber-500/40 text-amber-200 hover:bg-amber-500/20 hover:text-amber-100"
-        >
-          <Link href="/claw">
-            Resolve
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        </Button>
-      </div>
+      <Banner
+        icon={<AlertTriangle className="h-5 w-5 sm:h-6 sm:w-6 text-amber-400" />}
+        title="Your KiloClaw instance needs attention"
+        description="Your access has lapsed. Visit the dashboard to resolve billing and restore your instance."
+        colors={{
+          border: 'border-amber-500/30',
+          bg: 'bg-amber-500/10',
+          text: 'text-amber-400',
+        }}
+        action={
+          <Button
+            asChild
+            className="w-full shrink-0 bg-amber-500 text-primary-foreground hover:bg-amber-500/90 sm:w-auto"
+          >
+            <Link href="/claw">
+              Resolve
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        }
+      />
     );
   }
 
   return (
-    <div className="flex w-full items-center gap-4 rounded-lg border border-blue-500/30 bg-blue-500/10 p-5">
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/20">
-        <KiloCrabIcon className="h-5 w-5 text-blue-400" />
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-semibold text-blue-100">Get started with KiloClaw</p>
-        <p className="text-sm text-blue-300/80">
-          Fully-managed OpenClaw, always online. Set up in minutes.
-        </p>
-      </div>
-      <Button
-        asChild
-        variant="outline"
-        className="shrink-0 border-blue-500/40 text-blue-200 hover:bg-blue-500/20 hover:text-blue-100"
-      >
-        <Link href="/claw">
-          Get Started
-          <ArrowRight className="h-4 w-4" />
-        </Link>
-      </Button>
-    </div>
+    <Banner
+      icon={<KiloCrabIcon className="h-5 w-5 sm:h-6 sm:w-6 text-blue-400" />}
+      title="Get started with KiloClaw"
+      description="Fully-managed OpenClaw, always online. Set up in minutes."
+      colors={{
+        border: 'border-blue-500/30',
+        bg: 'bg-blue-500/10',
+        text: 'text-blue-400',
+      }}
+      action={
+        <Button
+          asChild
+          className="w-full shrink-0 bg-blue-500 text-primary-foreground hover:bg-blue-500/90 sm:w-auto"
+        >
+          <Link href="/claw">
+            Get Started
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </Button>
+      }
+    />
   );
 }

--- a/src/components/profile/ProfileKiloClawBanner.tsx
+++ b/src/components/profile/ProfileKiloClawBanner.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { ArrowRight, Loader2, AlertTriangle } from 'lucide-react';
-import Link from 'next/link';
+import { Loader2, AlertTriangle } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
-import { Button } from '@/components/ui/button';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 import { Banner } from '@/components/shared/Banner';
 
@@ -30,25 +28,12 @@ export function ProfileKiloClawBanner() {
   if (hasInstance && billing.hasAccess) {
     return (
       <Banner
-        icon={<KiloCrabIcon className="h-5 w-5 sm:h-6 sm:w-6 text-emerald-400" />}
+        icon={KiloCrabIcon}
+        color="emerald"
         title="Your KiloClaw instance is active"
         description="Manage your instance, configure integrations, and monitor your Claw."
-        colors={{
-          border: 'border-emerald-500/30',
-          bg: 'bg-emerald-500/10',
-          text: 'text-emerald-400',
-        }}
-        action={
-          <Button
-            asChild
-            className="w-full shrink-0 bg-emerald-500 text-primary-foreground hover:bg-emerald-500/90 sm:w-auto"
-          >
-            <Link href="/claw">
-              Go to KiloClaw
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </Button>
-        }
+        buttonLabel="Go to KiloClaw"
+        buttonHref="/claw"
       />
     );
   }
@@ -56,50 +41,24 @@ export function ProfileKiloClawBanner() {
   if (hasInstance && !billing.hasAccess) {
     return (
       <Banner
-        icon={<AlertTriangle className="h-5 w-5 sm:h-6 sm:w-6 text-amber-400" />}
+        icon={AlertTriangle}
+        color="amber"
         title="Your KiloClaw instance needs attention"
         description="Your access has lapsed. Visit the dashboard to resolve billing and restore your instance."
-        colors={{
-          border: 'border-amber-500/30',
-          bg: 'bg-amber-500/10',
-          text: 'text-amber-400',
-        }}
-        action={
-          <Button
-            asChild
-            className="w-full shrink-0 bg-amber-500 text-primary-foreground hover:bg-amber-500/90 sm:w-auto"
-          >
-            <Link href="/claw">
-              Resolve
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </Button>
-        }
+        buttonLabel="Resolve"
+        buttonHref="/claw"
       />
     );
   }
 
   return (
     <Banner
-      icon={<KiloCrabIcon className="h-5 w-5 sm:h-6 sm:w-6 text-blue-400" />}
+      icon={KiloCrabIcon}
+      color="blue"
       title="Get started with KiloClaw"
       description="Fully-managed OpenClaw, always online. Set up in minutes."
-      colors={{
-        border: 'border-blue-500/30',
-        bg: 'bg-blue-500/10',
-        text: 'text-blue-400',
-      }}
-      action={
-        <Button
-          asChild
-          className="w-full shrink-0 bg-blue-500 text-primary-foreground hover:bg-blue-500/90 sm:w-auto"
-        >
-          <Link href="/claw">
-            Get Started
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        </Button>
-      }
+      buttonLabel="Get Started"
+      buttonHref="/claw"
     />
   );
 }

--- a/src/components/profile/ProfileKiloClawBanner.tsx
+++ b/src/components/profile/ProfileKiloClawBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, AlertTriangle } from 'lucide-react';
+import { ArrowRight, Loader2, AlertTriangle } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 import { Banner } from '@/components/shared/Banner';
@@ -34,6 +34,7 @@ export function ProfileKiloClawBanner() {
         description="Manage your instance, configure integrations, and monitor your Claw."
         buttonLabel="Go to KiloClaw"
         buttonHref="/claw"
+        buttonIcon={ArrowRight}
       />
     );
   }
@@ -47,6 +48,7 @@ export function ProfileKiloClawBanner() {
         description="Your access has lapsed. Visit the dashboard to resolve billing and restore your instance."
         buttonLabel="Resolve"
         buttonHref="/claw"
+        buttonIcon={ArrowRight}
       />
     );
   }

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -118,11 +118,7 @@ function BannerButton({
   return (
     <Button
       asChild
-      className={cn(
-        'w-full shrink-0 sm:w-auto [&>*]:h-4 [&>*]:w-4',
-        colors?.button,
-        className
-      )}
+      className={cn('w-full shrink-0 sm:w-auto [&>*]:h-4 [&>*]:w-4', colors?.button, className)}
     >
       <Link href={href}>{children}</Link>
     </Button>

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -41,7 +41,11 @@ type BannerBaseProps = {
   /** Override default icon classes (only when icon is a component type). */
   iconClassName?: string;
   title: string;
+  /** Override default title classes. */
+  titleClassName?: string;
   description: React.ReactNode;
+  /** Override default description classes. */
+  descriptionClassName?: string;
   color: BannerColor;
   /** Override default container classes. */
   className?: string;
@@ -74,7 +78,9 @@ export function Banner({
   icon,
   iconClassName,
   title,
+  titleClassName,
   description,
+  descriptionClassName,
   action,
   buttonLabel,
   buttonHref,
@@ -115,8 +121,10 @@ export function Banner({
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
         <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">{iconNode}</div>
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-semibold sm:font-bold">{title}</p>
-          <p className="text-muted-foreground mt-0.5 text-sm sm:mt-0">{description}</p>
+          <p className={cn('text-sm font-semibold sm:font-bold', titleClassName)}>{title}</p>
+          <p className={cn('text-muted-foreground mt-0.5 text-sm sm:mt-0', descriptionClassName)}>
+            {description}
+          </p>
         </div>
       </div>
       {action ??

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -35,7 +35,7 @@ const colorMap: Record<BannerColor, { border: string; bg: string; text: string; 
   };
 
 type BannerBaseProps = {
-  icon: React.ComponentType<{ className?: string }>;
+  icon?: React.ComponentType<{ className?: string }>;
   /** Override default icon classes. */
   iconClassName?: string;
   title: string;
@@ -44,7 +44,7 @@ type BannerBaseProps = {
   description: React.ReactNode;
   /** Override default description classes. */
   descriptionClassName?: string;
-  color: BannerColor;
+  color?: BannerColor;
   /** Override default container classes. */
   className?: string;
   /** Optional ARIA role for the outer container. */
@@ -89,23 +89,25 @@ export function Banner({
   className,
   role,
 }: BannerProps) {
-  const colors = colorMap[color];
+  const colors = color ? colorMap[color] : undefined;
 
   return (
     <div
       role={role}
       className={cn(
         'flex w-full flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:gap-4',
-        colors.border,
-        colors.bg,
-        colors.text,
+        colors?.border,
+        colors?.bg,
+        colors?.text,
         className
       )}
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
-        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">
-          <Icon className={cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName)} />
-        </div>
+        {Icon && (
+          <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">
+            <Icon className={cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName)} />
+          </div>
+        )}
         <div className="min-w-0 flex-1">
           <p className={cn('text-sm font-semibold sm:font-bold', titleClassName)}>{title}</p>
           <p className={cn('text-muted-foreground mt-0.5 text-sm sm:mt-0', descriptionClassName)}>
@@ -117,7 +119,7 @@ export function Banner({
         (buttonLabel && buttonHref && (
           <Button
             asChild
-            className={cn('w-full shrink-0 sm:w-auto', colors.button, buttonClassName)}
+            className={cn('w-full shrink-0 sm:w-auto', colors?.button, buttonClassName)}
           >
             <Link href={buttonHref}>
               {buttonLabel}

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -8,42 +8,36 @@ import { Button } from '@/components/ui/button';
 
 type BannerColor = 'emerald' | 'amber' | 'blue' | 'red';
 
-const colorMap: Record<
-  BannerColor,
-  { border: string; bg: string; text: string; button: string }
-> = {
-  emerald: {
-    border: 'border-emerald-500/30',
-    bg: 'bg-emerald-500/10',
-    text: 'text-emerald-400',
-    button: 'bg-emerald-500 text-primary-foreground hover:bg-emerald-500/90',
-  },
-  amber: {
-    border: 'border-amber-500/30',
-    bg: 'bg-amber-500/10',
-    text: 'text-amber-400',
-    button: 'bg-amber-500 text-primary-foreground hover:bg-amber-500/90',
-  },
-  blue: {
-    border: 'border-blue-500/30',
-    bg: 'bg-blue-500/10',
-    text: 'text-blue-400',
-    button: 'bg-blue-500 text-primary-foreground hover:bg-blue-500/90',
-  },
-  red: {
-    border: 'border-red-500/30',
-    bg: 'bg-red-500/10',
-    text: 'text-red-400',
-    button: 'bg-red-500 text-primary-foreground hover:bg-red-500/90',
-  },
-};
+const colorMap: Record<BannerColor, { border: string; bg: string; text: string; button: string }> =
+  {
+    emerald: {
+      border: 'border-emerald-500/30',
+      bg: 'bg-emerald-500/10',
+      text: 'text-emerald-400',
+      button: 'bg-emerald-500 text-primary-foreground hover:bg-emerald-500/90',
+    },
+    amber: {
+      border: 'border-amber-500/30',
+      bg: 'bg-amber-500/10',
+      text: 'text-amber-400',
+      button: 'bg-amber-500 text-primary-foreground hover:bg-amber-500/90',
+    },
+    blue: {
+      border: 'border-blue-500/30',
+      bg: 'bg-blue-500/10',
+      text: 'text-blue-400',
+      button: 'bg-blue-500 text-primary-foreground hover:bg-blue-500/90',
+    },
+    red: {
+      border: 'border-red-500/30',
+      bg: 'bg-red-500/10',
+      text: 'text-red-400',
+      button: 'bg-red-500 text-primary-foreground hover:bg-red-500/90',
+    },
+  };
 
 type BannerBaseProps = {
-  /**
-   * Component type (auto-sized with default className) or ReactNode (full control).
-   * Accepts any component type — plain functions, React.memo(), React.forwardRef(),
-   * React.lazy(), etc. — as well as already-rendered ReactNode elements.
-   */
+  /** Function component (auto-sized) or ReactNode (full control). */
   icon: React.ComponentType<{ className?: string }> | React.ReactNode;
   /** Override default icon classes (only when icon is a component type). */
   iconClassName?: string;
@@ -56,7 +50,11 @@ type BannerBaseProps = {
 
 type BannerProps = BannerBaseProps &
   (
-    | { /** Custom action element. */ action: React.ReactNode; buttonLabel?: never; buttonHref?: never }
+    | {
+        /** Custom action element. */ action: React.ReactNode;
+        buttonLabel?: never;
+        buttonHref?: never;
+      }
     | { action?: never; buttonLabel: string; buttonHref: string }
     | { action?: never; buttonLabel?: never; buttonHref?: never }
   );
@@ -73,12 +71,12 @@ export function Banner({
   role,
 }: BannerProps) {
   const colors = colorMap[color];
-  const iconNode = React.isValidElement(icon)
-    ? icon
-    : React.createElement(
-        icon as React.ComponentType<{ className?: string }>,
-        { className: cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName) },
-      );
+  const iconNode =
+    typeof icon === 'function'
+      ? React.createElement(icon as React.ComponentType<{ className?: string }>, {
+          className: cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName),
+        })
+      : (icon as React.ReactNode);
 
   return (
     <div
@@ -91,9 +89,7 @@ export function Banner({
       )}
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
-        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">
-          {iconNode}
-        </div>
+        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">{iconNode}</div>
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold sm:font-bold">{title}</p>
           <p className="text-muted-foreground mt-0.5 text-sm sm:mt-0">{description}</p>

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -1,5 +1,10 @@
+'use client';
+
+import React from 'react';
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
 type BannerColor = 'emerald' | 'amber' | 'blue' | 'red';
 
@@ -33,19 +38,28 @@ const colorMap: Record<
   },
 };
 
-type BannerProps = {
-  /** Component type (auto-sized) or ReactNode (full control). */
+type BannerBaseProps = {
+  /**
+   * Component type (auto-sized with default className) or ReactNode (full control).
+   * Accepts any component type — plain functions, React.memo(), React.forwardRef(),
+   * React.lazy(), etc. — as well as already-rendered ReactNode elements.
+   */
   icon: React.ComponentType<{ className?: string }> | React.ReactNode;
   /** Override default icon classes (only when icon is a component type). */
   iconClassName?: string;
   title: string;
   description: React.ReactNode;
-  /** Custom action element, overrides buttonLabel/buttonHref. */
-  action?: React.ReactNode;
-  buttonLabel?: string;
-  buttonHref?: string;
   color: BannerColor;
+  /** Optional ARIA role for the outer container. */
+  role?: string;
 };
+
+type BannerProps = BannerBaseProps &
+  (
+    | { /** Custom action element. */ action: React.ReactNode; buttonLabel?: never; buttonHref?: never }
+    | { action?: never; buttonLabel: string; buttonHref: string }
+    | { action?: never; buttonLabel?: never; buttonHref?: never }
+  );
 
 export function Banner({
   icon,
@@ -56,15 +70,19 @@ export function Banner({
   buttonLabel,
   buttonHref,
   color,
+  role,
 }: BannerProps) {
   const colors = colorMap[color];
-  const IconComponent = typeof icon === 'function' ? icon : null;
-  const iconNode = IconComponent
-    ? <IconComponent className={cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName)} />
-    : icon;
+  const iconNode = React.isValidElement(icon)
+    ? icon
+    : React.createElement(
+        icon as React.ComponentType<{ className?: string }>,
+        { className: cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName) },
+      );
 
   return (
     <div
+      role={role}
       className={cn(
         'flex w-full flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:gap-4',
         colors.border,
@@ -83,15 +101,12 @@ export function Banner({
       </div>
       {action ??
         (buttonLabel && buttonHref && (
-          <Link
-            href={buttonHref}
-            className={cn(
-              'inline-flex w-full shrink-0 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors sm:w-auto',
-              colors.button
-            )}
-          >
-            {buttonLabel}
-          </Link>
+          <Button asChild className={cn('w-full shrink-0 sm:w-auto', colors.button)}>
+            <Link href={buttonHref}>
+              {buttonLabel}
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
         ))}
     </div>
   );

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -36,9 +35,8 @@ const colorMap: Record<BannerColor, { border: string; bg: string; text: string; 
   };
 
 type BannerBaseProps = {
-  /** Function component (auto-sized) or ReactNode (full control). */
-  icon: React.ComponentType<{ className?: string }> | React.ReactNode;
-  /** Override default icon classes (only when icon is a component type). */
+  icon: React.ComponentType<{ className?: string }>;
+  /** Override default icon classes. */
   iconClassName?: string;
   title: string;
   /** Override default title classes. */
@@ -51,9 +49,9 @@ type BannerBaseProps = {
   className?: string;
   /** Optional ARIA role for the outer container. */
   role?: string;
-  /** Icon after button label. Component type (auto-sized h-4 w-4) or ReactNode. */
-  buttonIcon?: React.ComponentType<{ className?: string }> | React.ReactNode;
-  /** Override default button icon classes (only when buttonIcon is a component type). */
+  /** Icon after button label. */
+  buttonIcon?: React.ComponentType<{ className?: string }>;
+  /** Override default button icon classes. */
   buttonIconClassName?: string;
   /** Override default button classes. */
   buttonClassName?: string;
@@ -75,7 +73,7 @@ type BannerProps = BannerBaseProps &
   );
 
 export function Banner({
-  icon,
+  icon: Icon,
   iconClassName,
   title,
   titleClassName,
@@ -84,7 +82,7 @@ export function Banner({
   action,
   buttonLabel,
   buttonHref,
-  buttonIcon,
+  buttonIcon: ButtonIcon,
   buttonIconClassName,
   buttonClassName,
   color,
@@ -92,20 +90,6 @@ export function Banner({
   role,
 }: BannerProps) {
   const colors = colorMap[color];
-  const iconNode =
-    typeof icon === 'function'
-      ? React.createElement(icon as React.ComponentType<{ className?: string }>, {
-          className: cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName),
-        })
-      : (icon as React.ReactNode);
-
-  const buttonIconNode = buttonIcon
-    ? typeof buttonIcon === 'function'
-      ? React.createElement(buttonIcon as React.ComponentType<{ className?: string }>, {
-          className: cn('h-4 w-4', buttonIconClassName),
-        })
-      : buttonIcon
-    : null;
 
   return (
     <div
@@ -119,7 +103,9 @@ export function Banner({
       )}
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
-        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">{iconNode}</div>
+        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">
+          <Icon className={cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName)} />
+        </div>
         <div className="min-w-0 flex-1">
           <p className={cn('text-sm font-semibold sm:font-bold', titleClassName)}>{title}</p>
           <p className={cn('text-muted-foreground mt-0.5 text-sm sm:mt-0', descriptionClassName)}>
@@ -135,7 +121,7 @@ export function Banner({
           >
             <Link href={buttonHref}>
               {buttonLabel}
-              {buttonIconNode}
+              {ButtonIcon && <ButtonIcon className={cn('h-4 w-4', buttonIconClassName)} />}
             </Link>
           </Button>
         ))}

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+
+type BannerProps = {
+  icon: React.ReactNode;
+  title: string;
+  description: React.ReactNode;
+  action?: React.ReactNode;
+  colors: {
+    border: string;
+    bg: string;
+    text: string;
+  };
+};
+
+export function Banner({ icon, title, description, action, colors }: BannerProps) {
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:gap-4',
+        colors.border,
+        colors.bg,
+        colors.text
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
+        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">{icon}</div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold sm:font-bold">{title}</p>
+          <p className="text-muted-foreground mt-0.5 text-sm sm:mt-0">{description}</p>
+        </div>
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createContext, useContext } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -34,99 +35,105 @@ const colorMap: Record<BannerColor, { border: string; bg: string; text: string; 
     },
   };
 
-type BannerBaseProps = {
-  icon?: React.ComponentType<{ className?: string }>;
-  /** Override default icon classes. */
-  iconClassName?: string;
-  title: string;
-  /** Override default title classes. */
-  titleClassName?: string;
-  description: React.ReactNode;
-  /** Override default description classes. */
-  descriptionClassName?: string;
-  color?: BannerColor;
-  /** Override default container classes. */
-  className?: string;
-  /** Optional ARIA role for the outer container. */
-  role?: string;
-  /** Icon after button label. */
-  buttonIcon?: React.ComponentType<{ className?: string }>;
-  /** Override default button icon classes. */
-  buttonIconClassName?: string;
-  /** Override default button classes. */
-  buttonClassName?: string;
-};
+const BannerContext = createContext<{ colors?: (typeof colorMap)[BannerColor] }>({});
 
-type BannerProps = BannerBaseProps &
-  (
-    | {
-        /** Custom action element. */ action: React.ReactNode;
-        buttonLabel?: never;
-        buttonHref?: never;
-      }
-    | {
-        action?: never;
-        buttonLabel: string;
-        buttonHref: string;
-      }
-    | { action?: never; buttonLabel?: never; buttonHref?: never }
-  );
-
-export function Banner({
-  icon: Icon,
-  iconClassName,
-  title,
-  titleClassName,
-  description,
-  descriptionClassName,
-  action,
-  buttonLabel,
-  buttonHref,
-  buttonIcon: ButtonIcon,
-  buttonIconClassName,
-  buttonClassName,
+function BannerRoot({
   color,
   className,
   role,
-}: BannerProps) {
+  children,
+}: {
+  color?: BannerColor;
+  className?: string;
+  role?: string;
+  children: React.ReactNode;
+}) {
   const colors = color ? colorMap[color] : undefined;
 
   return (
+    <BannerContext.Provider value={{ colors }}>
+      <div
+        role={role}
+        className={cn(
+          'flex w-full flex-wrap items-start gap-3 rounded-xl border p-4 sm:items-center sm:gap-4',
+          colors?.border,
+          colors?.bg,
+          colors?.text,
+          className
+        )}
+      >
+        {children}
+      </div>
+    </BannerContext.Provider>
+  );
+}
+
+function BannerIcon({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
     <div
-      role={role}
       className={cn(
-        'flex w-full flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:gap-4',
-        colors?.border,
-        colors?.bg,
-        colors?.text,
+        'mt-0.5 flex shrink-0 items-center sm:mt-0 [&>*]:h-5 [&>*]:w-5 sm:[&>*]:h-6 sm:[&>*]:w-6',
         className
       )}
     >
-      <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
-        {Icon && (
-          <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">
-            <Icon className={cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName)} />
-          </div>
-        )}
-        <div className="min-w-0 flex-1">
-          <p className={cn('text-sm font-semibold sm:font-bold', titleClassName)}>{title}</p>
-          <p className={cn('text-muted-foreground mt-0.5 text-sm sm:mt-0', descriptionClassName)}>
-            {description}
-          </p>
-        </div>
-      </div>
-      {action ??
-        (buttonLabel && buttonHref && (
-          <Button
-            asChild
-            className={cn('w-full shrink-0 sm:w-auto', colors?.button, buttonClassName)}
-          >
-            <Link href={buttonHref}>
-              {buttonLabel}
-              {ButtonIcon && <ButtonIcon className={cn('h-4 w-4', buttonIconClassName)} />}
-            </Link>
-          </Button>
-        ))}
+      {children}
     </div>
   );
 }
+
+function BannerContent({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('min-w-0 flex-1', className)}>{children}</div>;
+}
+
+function BannerTitle({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <p className={cn('text-sm font-semibold sm:font-bold', className)}>{children}</p>;
+}
+
+function BannerDescription({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={cn('text-muted-foreground mt-0.5 text-sm sm:mt-0', className)}>{children}</p>
+  );
+}
+
+function BannerAction({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('w-full shrink-0 sm:w-auto', className)}>{children}</div>;
+}
+
+function BannerButton({
+  href,
+  children,
+  className,
+}: {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { colors } = useContext(BannerContext);
+  return (
+    <Button
+      asChild
+      className={cn(
+        'w-full shrink-0 sm:w-auto [&>*]:h-4 [&>*]:w-4',
+        colors?.button,
+        className
+      )}
+    >
+      <Link href={href}>{children}</Link>
+    </Button>
+  );
+}
+
+export const Banner = Object.assign(BannerRoot, {
+  Icon: BannerIcon,
+  Content: BannerContent,
+  Title: BannerTitle,
+  Description: BannerDescription,
+  Action: BannerAction,
+  Button: BannerButton,
+});

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
@@ -44,8 +43,16 @@ type BannerBaseProps = {
   title: string;
   description: React.ReactNode;
   color: BannerColor;
+  /** Override default container classes. */
+  className?: string;
   /** Optional ARIA role for the outer container. */
   role?: string;
+  /** Icon after button label. Component type (auto-sized h-4 w-4) or ReactNode. */
+  buttonIcon?: React.ComponentType<{ className?: string }> | React.ReactNode;
+  /** Override default button icon classes (only when buttonIcon is a component type). */
+  buttonIconClassName?: string;
+  /** Override default button classes. */
+  buttonClassName?: string;
 };
 
 type BannerProps = BannerBaseProps &
@@ -55,7 +62,11 @@ type BannerProps = BannerBaseProps &
         buttonLabel?: never;
         buttonHref?: never;
       }
-    | { action?: never; buttonLabel: string; buttonHref: string }
+    | {
+        action?: never;
+        buttonLabel: string;
+        buttonHref: string;
+      }
     | { action?: never; buttonLabel?: never; buttonHref?: never }
   );
 
@@ -67,7 +78,11 @@ export function Banner({
   action,
   buttonLabel,
   buttonHref,
+  buttonIcon,
+  buttonIconClassName,
+  buttonClassName,
   color,
+  className,
   role,
 }: BannerProps) {
   const colors = colorMap[color];
@@ -78,6 +93,14 @@ export function Banner({
         })
       : (icon as React.ReactNode);
 
+  const buttonIconNode = buttonIcon
+    ? typeof buttonIcon === 'function'
+      ? React.createElement(buttonIcon as React.ComponentType<{ className?: string }>, {
+          className: cn('h-4 w-4', buttonIconClassName),
+        })
+      : buttonIcon
+    : null;
+
   return (
     <div
       role={role}
@@ -85,7 +108,8 @@ export function Banner({
         'flex w-full flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:gap-4',
         colors.border,
         colors.bg,
-        colors.text
+        colors.text,
+        className
       )}
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
@@ -97,10 +121,13 @@ export function Banner({
       </div>
       {action ??
         (buttonLabel && buttonHref && (
-          <Button asChild className={cn('w-full shrink-0 sm:w-auto', colors.button)}>
+          <Button
+            asChild
+            className={cn('w-full shrink-0 sm:w-auto', colors.button, buttonClassName)}
+          >
             <Link href={buttonHref}>
               {buttonLabel}
-              <ArrowRight className="h-4 w-4" />
+              {buttonIconNode}
             </Link>
           </Button>
         ))}

--- a/src/components/shared/Banner.tsx
+++ b/src/components/shared/Banner.tsx
@@ -1,18 +1,68 @@
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
-type BannerProps = {
-  icon: React.ReactNode;
-  title: string;
-  description: React.ReactNode;
-  action?: React.ReactNode;
-  colors: {
-    border: string;
-    bg: string;
-    text: string;
-  };
+type BannerColor = 'emerald' | 'amber' | 'blue' | 'red';
+
+const colorMap: Record<
+  BannerColor,
+  { border: string; bg: string; text: string; button: string }
+> = {
+  emerald: {
+    border: 'border-emerald-500/30',
+    bg: 'bg-emerald-500/10',
+    text: 'text-emerald-400',
+    button: 'bg-emerald-500 text-primary-foreground hover:bg-emerald-500/90',
+  },
+  amber: {
+    border: 'border-amber-500/30',
+    bg: 'bg-amber-500/10',
+    text: 'text-amber-400',
+    button: 'bg-amber-500 text-primary-foreground hover:bg-amber-500/90',
+  },
+  blue: {
+    border: 'border-blue-500/30',
+    bg: 'bg-blue-500/10',
+    text: 'text-blue-400',
+    button: 'bg-blue-500 text-primary-foreground hover:bg-blue-500/90',
+  },
+  red: {
+    border: 'border-red-500/30',
+    bg: 'bg-red-500/10',
+    text: 'text-red-400',
+    button: 'bg-red-500 text-primary-foreground hover:bg-red-500/90',
+  },
 };
 
-export function Banner({ icon, title, description, action, colors }: BannerProps) {
+type BannerProps = {
+  /** Component type (auto-sized) or ReactNode (full control). */
+  icon: React.ComponentType<{ className?: string }> | React.ReactNode;
+  /** Override default icon classes (only when icon is a component type). */
+  iconClassName?: string;
+  title: string;
+  description: React.ReactNode;
+  /** Custom action element, overrides buttonLabel/buttonHref. */
+  action?: React.ReactNode;
+  buttonLabel?: string;
+  buttonHref?: string;
+  color: BannerColor;
+};
+
+export function Banner({
+  icon,
+  iconClassName,
+  title,
+  description,
+  action,
+  buttonLabel,
+  buttonHref,
+  color,
+}: BannerProps) {
+  const colors = colorMap[color];
+  const IconComponent = typeof icon === 'function' ? icon : null;
+  const iconNode = IconComponent
+    ? <IconComponent className={cn('h-5 w-5 sm:h-6 sm:w-6', iconClassName)} />
+    : icon;
+
   return (
     <div
       className={cn(
@@ -23,13 +73,26 @@ export function Banner({ icon, title, description, action, colors }: BannerProps
       )}
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
-        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">{icon}</div>
+        <div className="mt-0.5 flex shrink-0 items-center sm:mt-0">
+          {iconNode}
+        </div>
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold sm:font-bold">{title}</p>
           <p className="text-muted-foreground mt-0.5 text-sm sm:mt-0">{description}</p>
         </div>
       </div>
-      {action}
+      {action ??
+        (buttonLabel && buttonHref && (
+          <Link
+            href={buttonHref}
+            className={cn(
+              'inline-flex w-full shrink-0 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors sm:w-auto',
+              colors.button
+            )}
+          >
+            {buttonLabel}
+          </Link>
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Fix mobile layout for KiloClaw CTA banner on /profile (was cramped single-row, now stacks vertically on mobile)
- Extract reusable `Banner` component to `src/components/shared/Banner.tsx`
- Standardize styling to match /claw dashboard banners (BillingBanner, config service nudge)

## Kilo Team — Loom
https://www.loom.com/share/f5d9c7ce6887427987d51d1a279df662

Not shown in the Loom, but the button and icon can also be omitted.
<img width="1689" height="153" alt="image" src="https://github.com/user-attachments/assets/860db099-3501-42ee-a2b5-87dc78d9d929" />


## Banner API

| Prop | Description |
|------|-------------|
| `icon` | Component type (auto-sized) or ReactNode |
| `color` | `'emerald' \| 'amber' \| 'blue' \| 'red'` — drives all color classes via static map |
| `buttonLabel` + `buttonHref` | Built-in button with color-matched styling |
| `buttonIcon` | Optional icon after button label (component type or ReactNode) |
| `action` | Custom action element (overrides built-in button) |
| `className`, `iconClassName`, `titleClassName`, `descriptionClassName`, `buttonClassName`, `buttonIconClassName` | Override any element's default classes |
| `role` | ARIA role for the container |

Type-safe discriminated union prevents mixing `action` with `buttonLabel`/`buttonHref`.

## Color system

Colors are managed via a static `Record<BannerColor, ...>` map rather than `tailwind-variants`. We evaluated `tailwind-variants` (tv) for its multi-slot support, but it adds a new dependency (~5KB + tailwind-merge) for a single-dimension variant on one component. The plain map is equivalent in code size, fully type-safe, and zero-dependency. `tailwind-variants` would pay off with multiple variant axes (color × size × outlined) — overkill here.

New colors are added by extending the `BannerColor` union and adding an entry to `colorMap` — TypeScript enforces completeness via `Record`. All color classes are static strings for Tailwind's purge.

Every element's classes can be overridden via `*ClassName` props (last position in `cn()`, so tailwind-merge gives caller priority).

## Test plan

Verified via Playwright across 7 configurations:

- [x] **Baseline** — desktop (1280×800) horizontal layout, mobile (375×812) stacked layout
- [x] **Custom `action` prop** — purple button renders correctly at both sizes
- [x] **ReactNode icon** — emoji icon passes through, `typeof` check works
- [x] **`iconClassName` override** — h-10 w-10 + pink color takes effect via tailwind-merge
- [x] **No action** — banner renders without button when neither prop given
- [x] **All 4 colors** — emerald, amber, blue, red visually distinct at both sizes
- [x] **ARIA `role="alert"`** — confirmed in Playwright accessibility tree snapshot