### PR TITLE
feat(layout): add topbar with page title, icon, and badge

### DIFF
--- a/src/app/(app)/auto-fix/AutoFixPageClient.tsx
+++ b/src/app/(app)/auto-fix/AutoFixPageClient.tsx
@@ -7,6 +7,7 @@ import { AutoFixTicketsCard } from '@/components/auto-fix/AutoFixTicketsCard';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Rocket, ExternalLink, Settings2, ListChecks } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -47,10 +48,10 @@ export function AutoFixPageClient({
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-8">
+      <SetPageTitle title="Auto Fix" />
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Auto Fix</h1>
           <Badge variant="new">new</Badge>
         </div>
         <p className="text-muted-foreground">

--- a/src/app/(app)/auto-fix/AutoFixPageClient.tsx
+++ b/src/app/(app)/auto-fix/AutoFixPageClient.tsx
@@ -48,12 +48,11 @@ export function AutoFixPageClient({
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-8">
-      <SetPageTitle title="Auto Fix" />
+      <SetPageTitle title="Auto Fix">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Badge variant="new">new</Badge>
-        </div>
         <p className="text-muted-foreground">
           Automatically create pull requests to fix issues labeled with kilo-auto-fix
         </p>

--- a/src/app/(app)/auto-triage/AutoTriagePageClient.tsx
+++ b/src/app/(app)/auto-triage/AutoTriagePageClient.tsx
@@ -7,6 +7,7 @@ import { AutoTriageTicketsCard } from '@/components/auto-triage/AutoTriageTicket
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Rocket, ExternalLink, Settings2, ListChecks } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -49,10 +50,10 @@ export function AutoTriagePageClient({
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-8">
+      <SetPageTitle title="Auto Triage" />
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Auto Triage</h1>
           <Badge variant="beta">beta</Badge>
         </div>
         <p className="text-muted-foreground">

--- a/src/app/(app)/auto-triage/AutoTriagePageClient.tsx
+++ b/src/app/(app)/auto-triage/AutoTriagePageClient.tsx
@@ -50,12 +50,11 @@ export function AutoTriagePageClient({
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-8">
-      <SetPageTitle title="Auto Triage" />
+      <SetPageTitle title="Auto Triage">
+        <Badge variant="beta">beta</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Badge variant="beta">beta</Badge>
-        </div>
         <p className="text-muted-foreground">
           Automatically triage GitHub issues with Al-powered analysis
         </p>

--- a/src/app/(app)/claw/components/ClawHeader.tsx
+++ b/src/app/(app)/claw/components/ClawHeader.tsx
@@ -24,35 +24,30 @@ export function ClawHeader({
   const statusInfo = status ? CLAW_STATUS_BADGE[status] : null;
   return (
     <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <SetPageTitle
+        title="KiloClaw"
+        icon={<KiloCrabIcon className="text-muted-foreground h-4 w-4" />}
+      >
+        <Badge variant="beta">Beta</Badge>
+        {statusInfo && (
+          <Badge variant="outline" className={statusInfo.className}>
+            {statusInfo.label}
+          </Badge>
+        )}
+      </SetPageTitle>
       <div className="flex items-center gap-3">
-        <div className="bg-secondary flex h-10 w-10 items-center justify-center rounded-lg">
-          <KiloCrabIcon className="text-muted-foreground h-5 w-5" />
-        </div>
-        <div>
-          <SetPageTitle title="KiloClaw">
-            <KiloCrabIcon className="text-muted-foreground h-4 w-4" />
-            <Badge variant="beta">Beta</Badge>
-            {statusInfo && (
-              <Badge variant="outline" className={statusInfo.className}>
-                {statusInfo.label}
-              </Badge>
-            )}
-          </SetPageTitle>
-          {!isSetupWizard && region && (
-            <p className="text-muted-foreground font-mono text-sm">
-              {region.toUpperCase()} {sandboxId ? `- ${sandboxId}` : ''}
-            </p>
-          )}
-        </div>
-      </div>
-      {!isSetupWizard && (
-        <div className="flex flex-wrap items-center gap-2">
+        {!isSetupWizard && region && (
+          <p className="text-muted-foreground font-mono text-sm">
+            {region.toUpperCase()} {sandboxId ? `- ${sandboxId}` : ''}
+          </p>
+        )}
+        {!isSetupWizard && (
           <OpenClawButton
             canShow={status === 'running' && !!gatewayReady}
             gatewayUrl={gatewayUrl}
           />
-        </div>
-      )}
+        )}
+      </div>
     </header>
   );
 }

--- a/src/app/(app)/claw/components/ClawHeader.tsx
+++ b/src/app/(app)/claw/components/ClawHeader.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { OpenClawButton } from './OpenClawButton';
 import { CLAW_STATUS_BADGE, type ClawState } from './claw.types';
 
@@ -28,8 +29,8 @@ export function ClawHeader({
           <KiloCrabIcon className="text-muted-foreground h-5 w-5" />
         </div>
         <div>
+          <SetPageTitle title="KiloClaw" />
           <div className="flex items-center gap-2.5">
-            <h1 className="text-foreground text-lg font-semibold tracking-tight">KiloClaw</h1>
             <Badge variant="beta">Beta</Badge>
             {statusInfo && (
               <Badge variant="outline" className={statusInfo.className}>

--- a/src/app/(app)/claw/components/ClawHeader.tsx
+++ b/src/app/(app)/claw/components/ClawHeader.tsx
@@ -29,15 +29,15 @@ export function ClawHeader({
           <KiloCrabIcon className="text-muted-foreground h-5 w-5" />
         </div>
         <div>
-          <SetPageTitle title="KiloClaw" />
-          <div className="flex items-center gap-2.5">
+          <SetPageTitle title="KiloClaw">
+            <KiloCrabIcon className="text-muted-foreground h-4 w-4" />
             <Badge variant="beta">Beta</Badge>
             {statusInfo && (
               <Badge variant="outline" className={statusInfo.className}>
                 {statusInfo.label}
               </Badge>
             )}
-          </div>
+          </SetPageTitle>
           {!isSetupWizard && region && (
             <p className="text-muted-foreground font-mono text-sm">
               {region.toUpperCase()} {sandboxId ? `- ${sandboxId}` : ''}

--- a/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
+++ b/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Search, Cloud, Terminal, Puzzle, Bot } from 'lucide-react';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import type { SessionsListItem } from '@/components/cloud-agent/SessionsList';
 import { SessionsList } from '@/components/cloud-agent/SessionsList';
 import { extractRepoFromGitUrl } from '@/components/cloud-agent/store/db-session-atoms';
@@ -146,9 +147,9 @@ export function SessionsPageContent() {
 
   const content = (
     <>
+      <SetPageTitle title="Sessions" />
       {/* Header */}
       <div className="mb-6">
-        <h1 className="mb-4 text-3xl font-bold">Sessions</h1>
         <div className="flex gap-3">
           <div className="relative flex-1">
             <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />

--- a/src/app/(app)/code-indexing/page.tsx
+++ b/src/app/(app)/code-indexing/page.tsx
@@ -2,6 +2,7 @@ import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { CodeIndexingView } from '@/components/code-indexing/CodeIndexingView';
 import { isEnabledForUser } from '@/lib/code-indexing/util';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ExternalLink } from 'lucide-react';
 import { PageContainer } from '@/components/layouts/PageContainer';
 
@@ -14,8 +15,8 @@ export default async function UserCodeIndexingPage() {
     <PageContainer>
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2">
+          <SetPageTitle title="Managed Indexing" />
           <div className="flex items-center gap-3">
-            <h1 className="text-foreground text-3xl font-bold">Managed Indexing</h1>
             <Badge variant="new">new</Badge>
           </div>
           <p className="text-muted-foreground">View and manage your indexed code</p>

--- a/src/app/(app)/code-indexing/page.tsx
+++ b/src/app/(app)/code-indexing/page.tsx
@@ -15,10 +15,9 @@ export default async function UserCodeIndexingPage() {
     <PageContainer>
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2">
-          <SetPageTitle title="Managed Indexing" />
-          <div className="flex items-center gap-3">
+          <SetPageTitle title="Managed Indexing">
             <Badge variant="new">new</Badge>
-          </div>
+          </SetPageTitle>
           <p className="text-muted-foreground">View and manage your indexed code</p>
           <a
             href="https://kilo.ai/docs/advanced-usage/managed-indexing"

--- a/src/app/(app)/code-reviews/ReviewAgentPageClient.tsx
+++ b/src/app/(app)/code-reviews/ReviewAgentPageClient.tsx
@@ -7,6 +7,7 @@ import { CodeReviewJobsCard } from '@/components/code-reviews/CodeReviewJobsCard
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Rocket, ExternalLink, Settings2, ListChecks } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -76,10 +77,10 @@ export function ReviewAgentPageClient({
 
   return (
     <PageContainer>
+      <SetPageTitle title="Code Reviewer" />
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Code Reviewer</h1>
           <Badge variant="new">new</Badge>
         </div>
         <p className="text-muted-foreground">

--- a/src/app/(app)/code-reviews/ReviewAgentPageClient.tsx
+++ b/src/app/(app)/code-reviews/ReviewAgentPageClient.tsx
@@ -77,12 +77,11 @@ export function ReviewAgentPageClient({
 
   return (
     <PageContainer>
-      <SetPageTitle title="Code Reviewer" />
+      <SetPageTitle title="Code Reviewer">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Badge variant="new">new</Badge>
-        </div>
         <p className="text-muted-foreground">
           Automate code reviews with AI-powered analysis for your personal repositories
         </p>

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/breadcrumb';
 
 export function AppTopbar() {
-  const { title, extras } = usePageTitle();
+  const { title, icon, extras } = usePageTitle();
 
   return (
     <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b px-4">
@@ -19,6 +19,7 @@ export function AppTopbar() {
       <Separator orientation="vertical" className="mr-2 h-4" />
       {title && (
         <div className="flex items-center gap-2">
+          {icon}
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem>

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { usePageTitle } from '@/contexts/PageTitleContext';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { Separator } from '@/components/ui/separator';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+} from '@/components/ui/breadcrumb';
+
+export function AppTopbar() {
+  const { title } = usePageTitle();
+
+  return (
+    <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b px-4">
+      <SidebarTrigger className="-ml-1" />
+      <Separator orientation="vertical" className="mr-2 h-4" />
+      {title && (
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbPage>{title}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      )}
+    </header>
+  );
+}

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -11,20 +11,23 @@ import {
 } from '@/components/ui/breadcrumb';
 
 export function AppTopbar() {
-  const { title } = usePageTitle();
+  const { title, extras } = usePageTitle();
 
   return (
     <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4" />
       {title && (
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbPage>{title}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <div className="flex items-center gap-2">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbPage>{title}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          {extras}
+        </div>
       )}
     </header>
   );

--- a/src/app/(app)/deploy/DeployPageClient.tsx
+++ b/src/app/(app)/deploy/DeployPageClient.tsx
@@ -7,6 +7,7 @@ import { NewDeploymentDialog } from '@/components/deployments/NewDeploymentDialo
 import { UserDeploymentProvider } from '@/components/deployments/UserDeploymentProvider';
 import { Button } from '@/components/Button';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ExternalLink, Plus } from 'lucide-react';
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { useState } from 'react';
@@ -43,8 +44,8 @@ export function DeployPageClient({ initialDeploymentId }: DeployPageClientProps)
         <div className="mb-8">
           <div className="flex items-center justify-between">
             <div>
+              <SetPageTitle title="Deployments" />
               <div className="flex items-center gap-3">
-                <h1 className="text-3xl font-bold text-gray-100">Deployments</h1>
                 <Badge variant="new">new</Badge>
               </div>
               <p className="text-gray-400">Deploy your web project</p>

--- a/src/app/(app)/deploy/DeployPageClient.tsx
+++ b/src/app/(app)/deploy/DeployPageClient.tsx
@@ -44,10 +44,9 @@ export function DeployPageClient({ initialDeploymentId }: DeployPageClientProps)
         <div className="mb-8">
           <div className="flex items-center justify-between">
             <div>
-              <SetPageTitle title="Deployments" />
-              <div className="flex items-center gap-3">
+              <SetPageTitle title="Deployments">
                 <Badge variant="new">new</Badge>
-              </div>
+              </SetPageTitle>
               <p className="text-gray-400">Deploy your web project</p>
               <a
                 href="https://kilo.ai/docs/advanced-usage/deploy"

--- a/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/src/app/(app)/gastown/TownListPageClient.tsx
@@ -7,6 +7,7 @@ import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateTownDialog } from '@/components/gastown/CreateTownDialog';
@@ -41,8 +42,8 @@ export function TownListPageClient() {
         <div className="flex flex-col gap-3">
           <div className="flex items-start justify-between gap-3">
             <div>
+              <SetPageTitle title="Gas Town" />
               <div className="flex items-center gap-3">
-                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gas Town</h1>
                 <Badge variant="beta">beta</Badge>
               </div>
               <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">

--- a/src/app/(app)/gastown/TownListPageClient.tsx
+++ b/src/app/(app)/gastown/TownListPageClient.tsx
@@ -42,10 +42,9 @@ export function TownListPageClient() {
         <div className="flex flex-col gap-3">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <SetPageTitle title="Gas Town" />
-              <div className="flex items-center gap-3">
+              <SetPageTitle title="Gas Town">
                 <Badge variant="beta">beta</Badge>
-              </div>
+              </SetPageTitle>
               <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
                 A chat-first orchestration console for towns, rigs, beads, and agents. Built for
                 radical transparency: every object is clickable; every outcome is attributable.

--- a/src/app/(app)/integrations/IntegrationsPageClient.tsx
+++ b/src/app/(app)/integrations/IntegrationsPageClient.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { IntegrationsHub } from '@/components/integrations/IntegrationsHub';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { PageContainer } from '@/components/layouts/PageContainer';
 
 export function IntegrationsPageClient() {
   return (
     <PageContainer>
+      <SetPageTitle title="Integrations" />
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-100">Integrations</h1>
         <p className="text-muted-foreground mt-2">
           Connect your development tools and workflows with Kilocode
         </p>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,29 +1,27 @@
-import { AnimatedLogo } from '@/components/AnimatedLogo';
 import AppSidebar from './components/AppSidebar';
-import { SidebarProvider, SidebarTrigger, SidebarInset } from '@/components/ui/sidebar';
+import { AppTopbar } from './components/AppTopbar';
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { RoleTestingProvider } from '@/contexts/RoleTestingContext';
+import { PageTitleProvider } from '@/contexts/PageTitleContext';
 import { AdminOmnibox } from '@/components/admin-omnibox';
 import { PrefetchedOrganizations } from './components/PrefetchedOrganizations';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <RoleTestingProvider>
-      <SidebarProvider>
-        <PrefetchedOrganizations>
-          <div className="flex min-h-screen w-full">
-            <AppSidebar />
-            <SidebarInset>
-              {/* Mobile header with sidebar trigger */}
-              <header className="bg-background sticky top-0 z-10 flex h-18 items-center justify-between gap-4 border-b p-4 md:hidden">
-                <AnimatedLogo />
-                <SidebarTrigger />
-              </header>
-              {/* Main content */}
-              <main className="bg-background w-full flex-1">{children}</main>
-            </SidebarInset>
-          </div>
-        </PrefetchedOrganizations>
-      </SidebarProvider>
+      <PageTitleProvider>
+        <SidebarProvider>
+          <PrefetchedOrganizations>
+            <div className="flex min-h-screen w-full">
+              <AppSidebar />
+              <SidebarInset>
+                <AppTopbar />
+                <main className="bg-background w-full flex-1">{children}</main>
+              </SidebarInset>
+            </div>
+          </PrefetchedOrganizations>
+        </SidebarProvider>
+      </PageTitleProvider>
       <AdminOmnibox />
     </RoleTestingProvider>
   );

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -10,25 +10,27 @@ type PageLayoutProps = {
 };
 
 export function PageLayout({ title, subtitle, children, headerActions }: PageLayoutProps) {
+  const hasSubtitleOrActions = subtitle || headerActions;
   return (
     <PageContainer>
-      {typeof title === 'string' && <SetPageTitle title={title} />}
-      <div className="flex items-start justify-between">
-        <div className="flex flex-col gap-2">
-          {typeof title === 'string' ? (
-            <h1 className="text-foreground text-3xl font-bold">{title}</h1>
-          ) : (
-            title
-          )}
-          {subtitle &&
-            (typeof subtitle === 'string' ? (
-              <p className="text-muted-foreground">{subtitle}</p>
-            ) : (
-              subtitle
-            ))}
+      {typeof title === 'string' ? (
+        <SetPageTitle title={title} />
+      ) : (
+        title
+      )}
+      {hasSubtitleOrActions && (
+        <div className="flex items-start justify-between">
+          <div className="flex flex-col gap-2">
+            {subtitle &&
+              (typeof subtitle === 'string' ? (
+                <p className="text-muted-foreground">{subtitle}</p>
+              ) : (
+                subtitle
+              ))}
+          </div>
+          {headerActions && <div className="shrink-0">{headerActions}</div>}
         </div>
-        {headerActions && <div className="shrink-0">{headerActions}</div>}
-      </div>
+      )}
       {children}
     </PageContainer>
   );

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -13,11 +13,7 @@ export function PageLayout({ title, subtitle, children, headerActions }: PageLay
   const hasSubtitleOrActions = subtitle || headerActions;
   return (
     <PageContainer>
-      {typeof title === 'string' ? (
-        <SetPageTitle title={title} />
-      ) : (
-        title
-      )}
+      {typeof title === 'string' ? <SetPageTitle title={title} /> : title}
       {hasSubtitleOrActions && (
         <div className="flex items-start justify-between">
           <div className="flex flex-col gap-2">

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { PageContainer } from './layouts/PageContainer';
+import { SetPageTitle } from './SetPageTitle';
 
 type PageLayoutProps = {
   title: ReactNode;
@@ -11,6 +12,7 @@ type PageLayoutProps = {
 export function PageLayout({ title, subtitle, children, headerActions }: PageLayoutProps) {
   return (
     <PageContainer>
+      {typeof title === 'string' && <SetPageTitle title={title} />}
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2">
           {typeof title === 'string' ? (

--- a/src/components/SetPageTitle.tsx
+++ b/src/components/SetPageTitle.tsx
@@ -3,13 +3,25 @@
 import { useEffect, type ReactNode } from 'react';
 import { usePageTitle } from '@/contexts/PageTitleContext';
 
-/** Renders nothing. Sets the topbar page title and optional extras via context. */
-export function SetPageTitle({ title, children }: { title: string; children?: ReactNode }) {
-  const { setTitle, setExtras } = usePageTitle();
+/** Renders nothing. Sets the topbar page title, icon, and optional extras via context. */
+export function SetPageTitle({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon?: ReactNode;
+  children?: ReactNode;
+}) {
+  const { setTitle, setIcon, setExtras } = usePageTitle();
   useEffect(() => {
     setTitle(title);
     return () => setTitle('');
   }, [title, setTitle]);
+  useEffect(() => {
+    setIcon(icon ?? null);
+    return () => setIcon(null);
+  }, [icon, setExtras]);
   useEffect(() => {
     setExtras(children ?? null);
     return () => setExtras(null);

--- a/src/components/SetPageTitle.tsx
+++ b/src/components/SetPageTitle.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePageTitle } from '@/contexts/PageTitleContext';
+
+/** Renders nothing. Sets the topbar page title via context. */
+export function SetPageTitle({ title }: { title: string }) {
+  const { setTitle } = usePageTitle();
+  useEffect(() => {
+    setTitle(title);
+    return () => setTitle('');
+  }, [title, setTitle]);
+  return null;
+}

--- a/src/components/SetPageTitle.tsx
+++ b/src/components/SetPageTitle.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { usePageTitle } from '@/contexts/PageTitleContext';
 
-/** Renders nothing. Sets the topbar page title via context. */
-export function SetPageTitle({ title }: { title: string }) {
-  const { setTitle } = usePageTitle();
+/** Renders nothing. Sets the topbar page title and optional extras via context. */
+export function SetPageTitle({ title, children }: { title: string; children?: ReactNode }) {
+  const { setTitle, setExtras } = usePageTitle();
   useEffect(() => {
     setTitle(title);
     return () => setTitle('');
   }, [title, setTitle]);
+  useEffect(() => {
+    setExtras(children ?? null);
+    return () => setExtras(null);
+  }, [children, setExtras]);
   return null;
 }

--- a/src/components/app-builder/AppBuilderLanding.tsx
+++ b/src/components/app-builder/AppBuilderLanding.tsx
@@ -13,16 +13,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import {
-  Sparkles,
-  Clock,
-  FolderOpen,
-  Search,
-  ChevronRight,
-  Trash2,
-  Users,
-  User,
-} from 'lucide-react';
+import { Clock, FolderOpen, Search, ChevronRight, Trash2, Users, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -774,7 +765,7 @@ export function AppBuilderLanding({ organizationId, onProjectCreated }: AppBuild
     <div className="flex h-dvh w-full flex-col items-center overflow-y-auto p-4 md:p-8">
       <div className="my-auto w-full max-w-3xl">
         {/* Header */}
-         <div className="mb-8 text-center">
+        <div className="mb-8 text-center">
           <SetPageTitle title="App Builder">
             <Badge variant="new">new</Badge>
           </SetPageTitle>

--- a/src/components/app-builder/AppBuilderLanding.tsx
+++ b/src/components/app-builder/AppBuilderLanding.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import {
   Sheet,
   SheetContent,
@@ -777,8 +778,8 @@ export function AppBuilderLanding({ organizationId, onProjectCreated }: AppBuild
           <div className="bg-primary/10 mx-auto mb-4 w-fit rounded-full p-4">
             <Sparkles className="text-primary h-8 w-8" />
           </div>
+          <SetPageTitle title="App Builder" />
           <div className="flex items-center justify-center gap-3">
-            <h1 className="text-2xl font-bold md:text-3xl">App Builder</h1>
             <Badge variant="new">new</Badge>
           </div>
           <p className="text-muted-foreground mt-2 text-sm md:text-base">

--- a/src/components/app-builder/AppBuilderLanding.tsx
+++ b/src/components/app-builder/AppBuilderLanding.tsx
@@ -774,14 +774,10 @@ export function AppBuilderLanding({ organizationId, onProjectCreated }: AppBuild
     <div className="flex h-dvh w-full flex-col items-center overflow-y-auto p-4 md:p-8">
       <div className="my-auto w-full max-w-3xl">
         {/* Header */}
-        <div className="mb-8 text-center">
-          <div className="bg-primary/10 mx-auto mb-4 w-fit rounded-full p-4">
-            <Sparkles className="text-primary h-8 w-8" />
-          </div>
-          <SetPageTitle title="App Builder" />
-          <div className="flex items-center justify-center gap-3">
+         <div className="mb-8 text-center">
+          <SetPageTitle title="App Builder">
             <Badge variant="new">new</Badge>
-          </div>
+          </SetPageTitle>
           <p className="text-muted-foreground mt-2 text-sm md:text-base">
             Describe the app you want to build, and we'll create it for you
           </p>

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -15,6 +15,7 @@ import { AlertCircle, ExternalLink, Loader2, RefreshCw, Sparkles } from 'lucide-
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import { PageLayout } from '@/components/PageLayout';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { useProfile, useProfiles, useCombinedProfiles } from '@/hooks/useCloudAgentProfiles';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import {
@@ -463,7 +464,7 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
 
   const titleContent = (
     <div className="flex items-center gap-3">
-      <h1 className="text-foreground text-3xl font-bold">Cloud Agent</h1>
+      <SetPageTitle title="Cloud Agent" />
       <Badge variant="new">new</Badge>
     </div>
   );

--- a/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
+++ b/src/components/cloud-agent-next/CloudNextSessionsPage.tsx
@@ -463,10 +463,9 @@ export function CloudNextSessionsPage({ organizationId }: CloudNextSessionsPageP
     !hasInsufficientBalance;
 
   const titleContent = (
-    <div className="flex items-center gap-3">
-      <SetPageTitle title="Cloud Agent" />
+    <SetPageTitle title="Cloud Agent">
       <Badge variant="new">new</Badge>
-    </div>
+    </SetPageTitle>
   );
 
   const subtitleContent = (

--- a/src/components/cloud-agent/CloudSessionsPage.tsx
+++ b/src/components/cloud-agent/CloudSessionsPage.tsx
@@ -22,6 +22,7 @@ import { AlertCircle, ExternalLink, Loader2, RefreshCw, Rocket, Sparkles } from 
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import { PageLayout } from '@/components/PageLayout';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { DemoSessionCTA } from './DemoSessionCTA';
 import { DemoSessionModal } from './DemoSessionModal';
 import {
@@ -596,7 +597,7 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
 
   const titleContent = (
     <div className="flex items-center gap-3">
-      <h1 className="text-foreground text-3xl font-bold">Cloud Agent</h1>
+      <SetPageTitle title="Cloud Agent" />
       <Badge variant="new">new</Badge>
     </div>
   );

--- a/src/components/cloud-agent/CloudSessionsPage.tsx
+++ b/src/components/cloud-agent/CloudSessionsPage.tsx
@@ -596,10 +596,9 @@ export function CloudSessionsPage({ organizationId }: CloudSessionsPageProps) {
     !hasInsufficientBalance;
 
   const titleContent = (
-    <div className="flex items-center gap-3">
-      <SetPageTitle title="Cloud Agent" />
+    <SetPageTitle title="Cloud Agent">
       <Badge variant="new">new</Badge>
-    </div>
+    </SetPageTitle>
   );
 
   const subtitleContent = (

--- a/src/components/security-agent/SecurityAgentLayout.tsx
+++ b/src/components/security-agent/SecurityAgentLayout.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Button } from '@/components/ui/button';
 import {
   AlertTriangle,
@@ -78,10 +79,10 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
 
   return (
     <div className="space-y-6">
+      <SetPageTitle title="Security Agent" />
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Security Agent</h1>
           <Badge variant="beta">Beta</Badge>
         </div>
         <p className="text-muted-foreground">

--- a/src/components/security-agent/SecurityAgentLayout.tsx
+++ b/src/components/security-agent/SecurityAgentLayout.tsx
@@ -79,12 +79,11 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
 
   return (
     <div className="space-y-6">
-      <SetPageTitle title="Security Agent" />
+      <SetPageTitle title="Security Agent">
+        <Badge variant="beta">Beta</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Badge variant="beta">Beta</Badge>
-        </div>
         <p className="text-muted-foreground">
           Monitor and manage Dependabot security alerts for your repositories
         </p>

--- a/src/components/webhook-triggers/WebhookTriggersHeader.tsx
+++ b/src/components/webhook-triggers/WebhookTriggersHeader.tsx
@@ -32,10 +32,10 @@ export const WebhookTriggersHeader = memo(function WebhookTriggersHeader({
 }: WebhookTriggersHeaderProps) {
   return (
     <div className="mb-6">
-      <div className="flex items-center justify-between">
-        <SetPageTitle title={title} icon={<Webhook className="h-4 w-4" />}>
-          {badgeLabel && <Badge variant="new">{badgeLabel}</Badge>}
-        </SetPageTitle>
+      <SetPageTitle title={title} icon={<Webhook className="h-4 w-4" />}>
+        {badgeLabel && <Badge variant="new">{badgeLabel}</Badge>}
+      </SetPageTitle>
+      <div className="flex items-center justify-end">
         {!hideCreate && (
           <Button asChild disabled={disabled}>
             <Link href={disabled ? '#' : createUrl}>

--- a/src/components/webhook-triggers/WebhookTriggersHeader.tsx
+++ b/src/components/webhook-triggers/WebhookTriggersHeader.tsx
@@ -33,8 +33,7 @@ export const WebhookTriggersHeader = memo(function WebhookTriggersHeader({
   return (
     <div className="mb-6">
       <div className="flex items-center justify-between">
-        <SetPageTitle title={title}>
-          <Webhook className="h-5 w-5" />
+        <SetPageTitle title={title} icon={<Webhook className="h-4 w-4" />}>
           {badgeLabel && <Badge variant="new">{badgeLabel}</Badge>}
         </SetPageTitle>
         {!hideCreate && (

--- a/src/components/webhook-triggers/WebhookTriggersHeader.tsx
+++ b/src/components/webhook-triggers/WebhookTriggersHeader.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Webhook, Plus } from 'lucide-react';
 
 type WebhookTriggersHeaderProps = {
@@ -32,9 +33,9 @@ export const WebhookTriggersHeader = memo(function WebhookTriggersHeader({
   return (
     <div className="mb-6">
       <div className="flex items-center justify-between">
+        <SetPageTitle title={title} />
         <div className="flex items-center gap-3">
           <Webhook className="h-8 w-8" />
-          <h1 className="text-3xl font-bold">{title}</h1>
           {badgeLabel && <Badge variant="new">{badgeLabel}</Badge>}
         </div>
         {!hideCreate && (

--- a/src/components/webhook-triggers/WebhookTriggersHeader.tsx
+++ b/src/components/webhook-triggers/WebhookTriggersHeader.tsx
@@ -33,11 +33,10 @@ export const WebhookTriggersHeader = memo(function WebhookTriggersHeader({
   return (
     <div className="mb-6">
       <div className="flex items-center justify-between">
-        <SetPageTitle title={title} />
-        <div className="flex items-center gap-3">
-          <Webhook className="h-8 w-8" />
+        <SetPageTitle title={title}>
+          <Webhook className="h-5 w-5" />
           {badgeLabel && <Badge variant="new">{badgeLabel}</Badge>}
-        </div>
+        </SetPageTitle>
         {!hideCreate && (
           <Button asChild disabled={disabled}>
             <Link href={disabled ? '#' : createUrl}>

--- a/src/contexts/PageTitleContext.tsx
+++ b/src/contexts/PageTitleContext.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+type PageTitleContextValue = {
+  title: string;
+  setTitle: (title: string) => void;
+};
+
+const PageTitleContext = createContext<PageTitleContextValue | undefined>(undefined);
+
+export function PageTitleProvider({ children }: { children: ReactNode }) {
+  const [title, setTitleState] = useState('');
+  const setTitle = useCallback((next: string) => setTitleState(next), []);
+  return (
+    <PageTitleContext.Provider value={{ title, setTitle }}>{children}</PageTitleContext.Provider>
+  );
+}
+
+export function usePageTitle() {
+  const ctx = useContext(PageTitleContext);
+  if (!ctx) {
+    throw new Error('usePageTitle must be used within a PageTitleProvider');
+  }
+  return ctx;
+}

--- a/src/contexts/PageTitleContext.tsx
+++ b/src/contexts/PageTitleContext.tsx
@@ -4,8 +4,10 @@ import { createContext, useContext, useState, useCallback, type ReactNode } from
 
 type PageTitleContextValue = {
   title: string;
+  icon: ReactNode;
   extras: ReactNode;
   setTitle: (title: string) => void;
+  setIcon: (icon: ReactNode) => void;
   setExtras: (extras: ReactNode) => void;
 };
 
@@ -13,11 +15,13 @@ const PageTitleContext = createContext<PageTitleContextValue | undefined>(undefi
 
 export function PageTitleProvider({ children }: { children: ReactNode }) {
   const [title, setTitleState] = useState('');
+  const [icon, setIconState] = useState<ReactNode>(null);
   const [extras, setExtrasState] = useState<ReactNode>(null);
   const setTitle = useCallback((next: string) => setTitleState(next), []);
+  const setIcon = useCallback((next: ReactNode) => setIconState(next), []);
   const setExtras = useCallback((next: ReactNode) => setExtrasState(next), []);
   return (
-    <PageTitleContext.Provider value={{ title, extras, setTitle, setExtras }}>
+    <PageTitleContext.Provider value={{ title, icon, extras, setTitle, setIcon, setExtras }}>
       {children}
     </PageTitleContext.Provider>
   );

--- a/src/contexts/PageTitleContext.tsx
+++ b/src/contexts/PageTitleContext.tsx
@@ -4,16 +4,22 @@ import { createContext, useContext, useState, useCallback, type ReactNode } from
 
 type PageTitleContextValue = {
   title: string;
+  extras: ReactNode;
   setTitle: (title: string) => void;
+  setExtras: (extras: ReactNode) => void;
 };
 
 const PageTitleContext = createContext<PageTitleContextValue | undefined>(undefined);
 
 export function PageTitleProvider({ children }: { children: ReactNode }) {
   const [title, setTitleState] = useState('');
+  const [extras, setExtrasState] = useState<ReactNode>(null);
   const setTitle = useCallback((next: string) => setTitleState(next), []);
+  const setExtras = useCallback((next: ReactNode) => setExtrasState(next), []);
   return (
-    <PageTitleContext.Provider value={{ title, setTitle }}>{children}</PageTitleContext.Provider>
+    <PageTitleContext.Provider value={{ title, extras, setTitle, setExtras }}>
+      {children}
+    </PageTitleContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a sticky topbar to the app layout with a sidebar trigger, separator, and breadcrumb-based page title
- Introduces a `PageTitleContext` + `SetPageTitle` component for pages to declaratively supply their title, icon, and badge/extras to the topbar
- Removes in-page `<h1>` titles from all pages that used `PageLayout` (string titles) and from 12+ pages with custom headers (KiloClaw, Cloud Agent, Code Reviewer, Security Agent, Auto Triage, Auto Fix, Deploy, Gas Town, etc.)
- Migrates badges (new/beta) and icons from in-page headers into the topbar, following a consistent `<icon> <title> <badge>` pattern
- Uses shadcn `Breadcrumb`, `Separator`, and `SidebarTrigger` components in the topbar

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm run format` — passes
- [x] Lint (oxlint) — passes
- [x] Manually verified in browser: Profile, Organizations, Usage, KiloClaw, Cloud Agent, Code Reviewer, Sessions, Webhooks, Auto Triage, Auto Fix, Deploy, Gas Town, Integrations, Connected Accounts, Install, Learn, Credits, Invoices, BYOK pages

## Visual Changes

| Before | After |
| ------ | ----- |
| <img width="4388" height="2708" alt="profile-old" src="https://github.com/user-attachments/assets/6a9ead68-b81f-42ba-8595-f692eb679ed9" /> | <img width="4388" height="2708" alt="profile-new" src="https://github.com/user-attachments/assets/268dc9c5-44ab-44ee-97f0-8e84f42cd33a" /> |
| <img width="4388" height="2708" alt="kiloclaw-old" src="https://github.com/user-attachments/assets/dbe39e04-1133-4af0-b430-084148a90bfa" /> | <img width="4388" height="2708" alt="kiloclaw-new" src="https://github.com/user-attachments/assets/63ddd627-3065-464f-ac9e-c98c7da6cabf" /> |

## Reviewer Notes

- Pages using `PageLayout` with a string `title` prop automatically set the topbar title via `SetPageTitle` — no changes needed by those pages
- Pages not using `PageLayout` use `<SetPageTitle title="..." icon={...}>badge</SetPageTitle>` directly
- The `SetPageTitle` API has three slots: `icon` prop (before title), `title` prop (breadcrumb text), `children` (after title, typically badges)
- Sub-pages under `/gastown/[townId]/*` and `/organizations/[id]/*` still have their own in-page headings — those use a different layout and can be addressed as a follow-up