### PR TITLE
feat(cloud-agent): unify question/permission paths and remove kilo_snapshot event

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -51,13 +51,7 @@ import {
   type IngestDOContext,
 } from '../websocket/ingest.js';
 import type { StoredEvent } from '../websocket/types.js';
-import type {
-  WrapperCommand,
-  PreparingStep,
-  CloudStatusData,
-  ConnectedEventData,
-  KiloSnapshotData,
-} from '../shared/protocol.js';
+import type { WrapperCommand, PreparingStep, CloudStatusData } from '../shared/protocol.js';
 import { STALE_THRESHOLD_MS, SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
 import { ExecutionOrchestrator, type OrchestratorDeps } from '../execution/orchestrator.js';
 import type {
@@ -274,9 +268,6 @@ export class CloudAgentSession extends DurableObject {
         clearActiveExecution: () => this.clearActiveExecution(),
         getActiveExecutionId: () => this.executionQueries.getActiveExecutionId(),
         cancelDisconnectGrace: () => this.cancelDisconnectGrace(),
-        onKiloSnapshot: (data: KiloSnapshotData) => {
-          void this.broadcastConnectedEvent(data);
-        },
         getExecution: async (executionId: string) => {
           const execution = await this.executionQueries.get(executionId as ExecutionId);
           if (!execution) return null;
@@ -379,8 +370,8 @@ export class CloudAgentSession extends DurableObject {
       const response = await streamHandler.handleStreamRequest(request);
 
       // Request fresh kilo state from wrapper if connected.
-      // The wrapper will respond with a kilo_snapshot event, which triggers
-      // broadcastConnectedEvent() and sends a `connected` event with real data.
+      // The wrapper will respond with regular kilocode events (session.status,
+      // question.asked, permission.asked) that are broadcast via the normal pipeline.
       this.requestKiloSnapshot();
 
       return response;
@@ -560,41 +551,6 @@ export class CloudAgentSession extends DurableObject {
 
     // Running executions mean the agent has control — infrastructure is ready
     return { type: 'ready' };
-  }
-
-  /**
-   * Broadcast a `connected` event to all /stream clients with current state.
-   * Called when a kilo_snapshot arrives (wrapper just connected/reconnected)
-   * or when a snapshot is requested for a newly connected client.
-   */
-  private async broadcastConnectedEvent(snapshot: KiloSnapshotData): Promise<void> {
-    try {
-      const sessionId = await this.resolveSessionId();
-      if (!sessionId) return;
-
-      const connectedData: ConnectedEventData = {
-        sessionStatus: snapshot.sessionStatus,
-      };
-      const cloudStatus = await this.deriveCloudStatus();
-      if (cloudStatus) connectedData.cloudStatus = cloudStatus;
-      if (snapshot.question) connectedData.question = snapshot.question;
-      if (snapshot.permission) connectedData.permission = snapshot.permission;
-
-      const activeExecId = await this.executionQueries.getActiveExecutionId();
-
-      this.broadcastEvent({
-        id: 0 as EventId,
-        execution_id: (activeExecId ?? '') as ExecutionId,
-        session_id: sessionId,
-        stream_event_type: 'connected',
-        payload: JSON.stringify(connectedData),
-        timestamp: Date.now(),
-      });
-    } catch (err) {
-      logger
-        .withFields({ error: err instanceof Error ? err.message : String(err) })
-        .error('Failed to broadcast connected event');
-    }
   }
 
   /**
@@ -793,8 +749,9 @@ export class CloudAgentSession extends DurableObject {
   }
 
   /**
-   * Request a fresh kilo state snapshot from the wrapper.
-   * The wrapper will respond with a kilo_snapshot ingest event.
+   * Request fresh kilo state from the wrapper.
+   * The wrapper will respond with regular kilocode events (session.status,
+   * question.asked, permission.asked) that flow through the normal ingest pipeline.
    * Best-effort: silently does nothing if no wrapper is connected.
    */
   private requestKiloSnapshot(): void {

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -585,7 +585,7 @@ export class SessionService {
     if (env.KILO_OPENROUTER_BASE) {
       providerOptions.baseURL = env.KILO_OPENROUTER_BASE;
     }
-    const isInteractive = !createdOnPlatform;
+    const isInteractive = createdOnPlatform == 'cloud-agent-web';
     const commandGuardPolicy = getCommandGuardPolicy(createdOnPlatform);
 
     const permission: Record<string, unknown> = {

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -22,8 +22,6 @@ export type StreamEventType =
   | 'wrapper_resumed' // Wrapper reconnected after disconnect (may have lost events)
   | 'autocommit_started' // Auto-commit process began
   | 'autocommit_completed' // Auto-commit finished (success, skip, or failure)
-  // Wrapper -> DO (kilo server state snapshot on connect)
-  | 'kilo_snapshot' // Initial kilo server state sent by wrapper on ingest WS connect
   // DO -> /stream clients (connection status)
   | 'wrapper_disconnected' // Wrapper WebSocket closed unexpectedly
   | 'wrapper_reconnected' // Wrapper reconnected successfully
@@ -123,7 +121,7 @@ export type CloudStatusData = {
   };
 };
 
-/** Session status as reported by the Kilo server via kilo_snapshot. */
+/** Session status as reported by the Kilo server via session.status events. */
 export type SessionStatus =
   | { type: 'busy' }
   | { type: 'idle' }
@@ -133,22 +131,6 @@ export type SessionStatus =
 export type ConnectedEventData = {
   sessionStatus?: SessionStatus;
   cloudStatus?: { type: CloudStatusType; step?: string; message?: string };
-  question?: { requestId: string; callId?: string };
-  permission?: {
-    requestId: string;
-    callId?: string;
-    permission: string;
-    patterns: string[];
-    metadata: Record<string, unknown>;
-    always: string[];
-  };
-};
-
-/** Data included in 'kilo_snapshot' events (wrapper→DO only, not broadcast to /stream clients). */
-export type KiloSnapshotData = {
-  sessionStatus: SessionStatus;
-  question?: ConnectedEventData['question'];
-  permission?: ConnectedEventData['permission'];
 };
 
 /**

--- a/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/cloud-agent-next/src/websocket/ingest.test.ts
@@ -268,6 +268,35 @@ describe('createIngestHandler', () => {
         );
       }
     );
+
+    it('kilo_snapshot is broadcast-only (no special handling)', async () => {
+      const eventQueries = createFakeEventQueries();
+      const broadcastFn = vi.fn();
+      const doContext = createFakeDOContext();
+      const handler = createIngestHandler(
+        createFakeState(),
+        eventQueries,
+        SESSION_ID,
+        broadcastFn,
+        doContext
+      );
+      const ws = createFakeWebSocket(makeAttachment());
+
+      await handler.handleIngestMessage(
+        ws,
+        JSON.stringify({
+          streamEventType: 'kilo_snapshot',
+          data: { sessionStatus: { type: 'busy' } },
+          timestamp: new Date().toISOString(),
+        })
+      );
+
+      // Should NOT call onKiloSnapshot (removed)
+      // Should be broadcast as a regular event with eventId 0
+      expect(broadcastFn).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 0, stream_event_type: 'kilo_snapshot' })
+      );
+    });
   });
 
   describe('hasActiveConnection', () => {

--- a/cloud-agent-next/src/websocket/ingest.ts
+++ b/cloud-agent-next/src/websocket/ingest.ts
@@ -25,12 +25,7 @@ import {
   extractEntityId,
   type KiloSessionCaptureState,
 } from '../session/ingest-handlers/index.js';
-import type {
-  CompleteEventData,
-  KilocodeEventData,
-  CloudStatusData,
-  KiloSnapshotData,
-} from '../shared/protocol.js';
+import type { CompleteEventData, KilocodeEventData, CloudStatusData } from '../shared/protocol.js';
 
 // ---------------------------------------------------------------------------
 // Ingest Attachment
@@ -179,8 +174,6 @@ export type IngestDOContext = {
   ) => Promise<void>;
   /** Cancel the disconnect grace period when wrapper reconnects */
   cancelDisconnectGrace?: () => Promise<void>;
-  /** Called when wrapper sends a kilo_snapshot with session status and pending question */
-  onKiloSnapshot?: (data: KiloSnapshotData) => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -353,13 +346,6 @@ export function createIngestHandler(
 
         const payload = JSON.stringify(ingestEvent.data ?? {});
         const eventType = ingestEvent.streamEventType;
-
-        // Handle kilo_snapshot: update DO's cached kilo state without persisting or broadcasting.
-        // The DO will broadcast a fresh `connected` event to all /stream clients.
-        if (eventType === 'kilo_snapshot') {
-          doContext.onKiloSnapshot?.(ingestEvent.data as KiloSnapshotData);
-          return;
-        }
 
         let eventId: number;
 

--- a/cloud-agent-next/src/websocket/stream.ts
+++ b/cloud-agent-next/src/websocket/stream.ts
@@ -144,8 +144,8 @@ export function createStreamHandler(
       }
 
       // Send `connected` event with current service state.
-      // sessionStatus is omitted here — it arrives later via kilo_snapshot broadcast
-      // from the wrapper, which is the authoritative source.
+      // sessionStatus is omitted here — it arrives later via the wrapper's
+      // session.status kilocode event, which is the authoritative source.
       {
         const connectedData: ConnectedEventData = {};
         const cloudStatus = await options?.deriveCloudStatus?.();

--- a/cloud-agent-next/src/websocket/types.ts
+++ b/cloud-agent-next/src/websocket/types.ts
@@ -35,8 +35,7 @@ export type StreamEventType =
   | 'kilocode' // Kilocode CLI structured events
   | 'status' // execution status updates
   | 'heartbeat' // keep-alive during idle periods
-  | 'pong' // response to ping command from DO
-  | 'kilo_snapshot'; // kilo server state snapshot (wrapper→DO only, not broadcast)
+  | 'pong'; // response to ping command from DO
 
 // ---------------------------------------------------------------------------
 // Server -> Client Events (/stream endpoint)

--- a/cloud-agent-next/test/unit/wrapper/snapshot.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/snapshot.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Unit tests for sendKiloSnapshot behavior in createConnectionManager.
+ *
+ * Verifies that sendKiloSnapshot sends regular kilocode events (session.status,
+ * question.asked, permission.asked) instead of a kilo_snapshot event.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createConnectionManager,
+  type ConnectionCallbacks,
+} from '../../../wrapper/src/connection.js';
+import { WrapperState, type JobContext } from '../../../wrapper/src/state.js';
+import type { WrapperKiloClient } from '../../../wrapper/src/kilo-api.js';
+
+// ---------------------------------------------------------------------------
+// Polyfills for Node.js test environment
+// ---------------------------------------------------------------------------
+
+if (typeof CloseEvent === 'undefined') {
+  const g = globalThis as Record<string, unknown>;
+  g.CloseEvent = class extends Event {
+    code: number;
+    reason: string;
+    wasClean: boolean;
+    constructor(type: string, init?: { code?: number; reason?: string; wasClean?: boolean }) {
+      super(type);
+      this.code = init?.code ?? 0;
+      this.reason = init?.reason ?? '';
+      this.wasClean = init?.wasClean ?? false;
+    }
+  };
+}
+
+if (typeof MessageEvent === 'undefined') {
+  const g = globalThis as Record<string, unknown>;
+  g.MessageEvent = class extends Event {
+    data: unknown;
+    constructor(type: string, init?: { data?: unknown }) {
+      super(type);
+      this.data = init?.data;
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MockWebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  sent: string[] = [];
+  url: string;
+
+  constructor(url: string, _options?: unknown) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(_code?: number, _reason?: string): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  simulateClose(code = 1006, reason = ''): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close', { code, reason }));
+  }
+
+  simulateError(): void {
+    this.onerror?.(new Event('error'));
+  }
+
+  static reset(): void {
+    MockWebSocket.instances = [];
+  }
+
+  static get latest(): MockWebSocket | undefined {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const createJobContext = (): JobContext => ({
+  executionId: 'exec_test',
+  kiloSessionId: 'kilo_sess_456',
+  ingestUrl: 'wss://ingest.example.com/ingest',
+  ingestToken: 'token_secret',
+  workerAuthToken: 'kilo_token_789',
+});
+
+const createCallbacks = (): ConnectionCallbacks => ({
+  onMessageComplete: vi.fn(),
+  onTerminalError: vi.fn(),
+  onCommand: vi.fn(),
+  onDisconnect: vi.fn(),
+  onCompletionSignal: vi.fn(),
+  onReconnecting: vi.fn(),
+  onReconnected: vi.fn(),
+});
+
+function createMockKiloClient(overrides?: Partial<WrapperKiloClient>): WrapperKiloClient {
+  return {
+    createSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
+    getSession: vi.fn().mockResolvedValue({ id: 'kilo_sess' }),
+    sendPromptAsync: vi.fn().mockResolvedValue(undefined),
+    abortSession: vi.fn().mockResolvedValue(true),
+    sendCommand: vi.fn().mockResolvedValue(undefined),
+    answerPermission: vi.fn().mockResolvedValue(true),
+    answerQuestion: vi.fn().mockResolvedValue(true),
+    rejectQuestion: vi.fn().mockResolvedValue(true),
+    generateCommitMessage: vi.fn().mockResolvedValue({ message: 'test commit' }),
+    getSessionStatuses: vi.fn().mockResolvedValue({}),
+    getQuestions: vi.fn().mockResolvedValue([]),
+    getPermissions: vi.fn().mockResolvedValue([]),
+    sdkClient: {
+      event: {
+        subscribe: vi.fn().mockResolvedValue({
+          stream: (async function* () {
+            await new Promise(() => {});
+          })(),
+        }),
+      },
+    } as unknown as WrapperKiloClient['sdkClient'],
+    serverUrl: 'http://127.0.0.1:0',
+    ...overrides,
+  };
+}
+
+function stubFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(() => {
+      const stream = new ReadableStream({
+        start() {
+          // Never push data — keeps SSE consumer alive without events
+        },
+      });
+      return Promise.resolve(
+        new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      );
+    })
+  );
+}
+
+async function openConnection(
+  manager: ReturnType<typeof createConnectionManager>
+): Promise<MockWebSocket> {
+  const openPromise = manager.open();
+  const ws = MockWebSocket.latest!;
+  ws.simulateOpen();
+  await openPromise;
+  return ws;
+}
+
+type ParsedEvent = { streamEventType: string; data: Record<string, unknown>; timestamp: string };
+
+/** Parse all messages sent through the WS and return them typed. */
+function parseSentMessages(ws: MockWebSocket): ParsedEvent[] {
+  return ws.sent.map(msg => JSON.parse(msg) as ParsedEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sendKiloSnapshot → sendKiloState', () => {
+  let state: WrapperState;
+  let callbacks: ConnectionCallbacks;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.reset();
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    stubFetch();
+
+    state = new WrapperState();
+    callbacks = createCallbacks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. session.status sent as kilocode event (not kilo_snapshot)
+  // -----------------------------------------------------------------------
+
+  it('sends session.status as kilocode event (not kilo_snapshot)', async () => {
+    const kiloClient = createMockKiloClient({
+      getSessionStatuses: vi.fn().mockResolvedValue({
+        kilo_sess_456: { type: 'idle' },
+      }),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+
+    // Must NOT contain a kilo_snapshot event
+    const snapshotEvents = messages.filter(m => m.streamEventType === 'kilo_snapshot');
+    expect(snapshotEvents).toHaveLength(0);
+
+    // Must contain a kilocode event with event: 'session.status'
+    const statusEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'session.status'
+    );
+    expect(statusEvents).toHaveLength(1);
+    expect(statusEvents[0].data).toMatchObject({
+      event: 'session.status',
+      sessionID: 'kilo_sess_456',
+      status: { type: 'idle' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. session.status with busy status from kilo server
+  // -----------------------------------------------------------------------
+
+  it('sends session.status with busy status from kilo server', async () => {
+    const kiloClient = createMockKiloClient({
+      getSessionStatuses: vi.fn().mockResolvedValue({
+        kilo_sess_456: { type: 'busy' },
+      }),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+    const statusEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'session.status'
+    );
+
+    expect(statusEvents).toHaveLength(1);
+    expect(statusEvents[0].data).toMatchObject({
+      event: 'session.status',
+      sessionID: 'kilo_sess_456',
+      status: { type: 'busy' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. defaults session status to idle when not present
+  // -----------------------------------------------------------------------
+
+  it('defaults session status to idle when not present', async () => {
+    const kiloClient = createMockKiloClient({
+      getSessionStatuses: vi.fn().mockResolvedValue({}),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+    const statusEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'session.status'
+    );
+
+    expect(statusEvents).toHaveLength(1);
+    expect(statusEvents[0].data).toMatchObject({
+      event: 'session.status',
+      sessionID: 'kilo_sess_456',
+      status: { type: 'idle' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. replays pending question as kilocode event
+  // -----------------------------------------------------------------------
+
+  it('replays pending question as kilocode event', async () => {
+    const pendingQuestion = {
+      id: 'q_123',
+      sessionID: 'kilo_sess_456',
+      tool: { messageID: 'msg_1', callID: 'call_1' },
+      questions: [
+        { question: 'Pick a color', header: 'Color', options: [{ label: 'Red', description: '' }] },
+      ],
+    };
+
+    const kiloClient = createMockKiloClient({
+      getQuestions: vi.fn().mockResolvedValue([pendingQuestion]),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+    const questionEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'question.asked'
+    );
+
+    expect(questionEvents).toHaveLength(1);
+    expect(questionEvents[0].data).toMatchObject({
+      event: 'question.asked',
+      properties: pendingQuestion,
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. replays pending permission as kilocode event
+  // -----------------------------------------------------------------------
+
+  it('replays pending permission as kilocode event', async () => {
+    const pendingPermission = {
+      id: 'p_456',
+      sessionID: 'kilo_sess_456',
+      permission: 'file_write',
+      patterns: ['**/*.ts'],
+      metadata: {},
+      always: [],
+      tool: { messageID: 'msg_2', callID: 'call_2' },
+    };
+
+    const kiloClient = createMockKiloClient({
+      getPermissions: vi.fn().mockResolvedValue([pendingPermission]),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+    const permissionEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'permission.asked'
+    );
+
+    expect(permissionEvents).toHaveLength(1);
+    expect(permissionEvents[0].data).toMatchObject({
+      event: 'permission.asked',
+      properties: pendingPermission,
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. does not send question event when no question is pending
+  // -----------------------------------------------------------------------
+
+  it('does not send question event when no question is pending', async () => {
+    const kiloClient = createMockKiloClient({
+      getQuestions: vi.fn().mockResolvedValue([]),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+    const questionEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'question.asked'
+    );
+
+    expect(questionEvents).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. does not send permission event when no permission is pending
+  // -----------------------------------------------------------------------
+
+  it('does not send permission event when no permission is pending', async () => {
+    const kiloClient = createMockKiloClient({
+      getPermissions: vi.fn().mockResolvedValue([]),
+    });
+
+    state.startJob(createJobContext());
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+    const permissionEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'permission.asked'
+    );
+
+    expect(permissionEvents).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // 8. skips when no kiloSessionId is available
+  // -----------------------------------------------------------------------
+
+  it('skips when no kiloSessionId is available', async () => {
+    const kiloClient = createMockKiloClient();
+
+    // Don't start a job — no kiloSessionId will be available
+    state = new WrapperState();
+    // Start a job without kiloSessionId by providing an empty string
+    // Actually, we need ingestUrl/token for the WS to open, so start a job
+    // but with no kiloSessionId set. The simplest way: don't call startJob
+    // at all, but then openIngestWs will throw "no job context".
+    // Instead, set a job with empty kiloSessionId.
+    state.startJob({
+      executionId: 'exec_test',
+      kiloSessionId: '',
+      ingestUrl: 'wss://ingest.example.com/ingest',
+      ingestToken: 'token_secret',
+      workerAuthToken: 'kilo_token_789',
+    });
+
+    const manager = createConnectionManager(state, { kiloClient }, callbacks);
+    const ws = await openConnection(manager);
+
+    const messages = parseSentMessages(ws);
+
+    // No kilo_snapshot or kilocode session.status events should be sent
+    const snapshotEvents = messages.filter(m => m.streamEventType === 'kilo_snapshot');
+    const statusEvents = messages.filter(
+      m => m.streamEventType === 'kilocode' && m.data.event === 'session.status'
+    );
+
+    expect(snapshotEvents).toHaveLength(0);
+    expect(statusEvents).toHaveLength(0);
+
+    // API methods should not have been called
+    expect(kiloClient.getSessionStatuses).not.toHaveBeenCalled();
+    expect(kiloClient.getQuestions).not.toHaveBeenCalled();
+    expect(kiloClient.getPermissions).not.toHaveBeenCalled();
+  });
+});

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -10,7 +10,7 @@
  */
 
 import type { WrapperState } from './state.js';
-import type { IngestEvent, WrapperCommand, KiloSnapshotData } from '../../src/shared/protocol.js';
+import type { IngestEvent, WrapperCommand } from '../../src/shared/protocol.js';
 import { trimPayload } from '../../src/shared/trim-payload.js';
 import { logToFile } from './utils.js';
 import type { WrapperKiloClient } from './kilo-api.js';
@@ -86,7 +86,7 @@ export type ConnectionManager = {
   isReconnecting: () => boolean;
   /** Abort and restart the SDK event subscription (does not tear down ingest WS). */
   reconnectEventSubscription: () => void;
-  /** Fetch fresh kilo server state and send a kilo_snapshot event to the DO. Best-effort. */
+  /** Fetch fresh kilo server state and send it as regular kilocode events to the DO. Best-effort. */
   sendKiloSnapshot: () => Promise<void>;
 };
 
@@ -160,7 +160,7 @@ export function createConnectionManager(
   }
 
   /**
-   * Fetch current kilo server state and send a kilo_snapshot event to the DO.
+   * Fetch current kilo server state and send it as regular kilocode events to the DO.
    * Called after ingest WS opens (initial connect and reconnect).
    * Best-effort: failures are logged but don't block the connection.
    */
@@ -179,38 +179,54 @@ export function createConnectionManager(
       ]);
 
       const statusEntry = statuses[kiloSessionId];
-      const sessionStatus = (statusEntry ?? { type: 'idle' }) as KiloSnapshotData['sessionStatus'];
+      const sessionStatus = (statusEntry ?? { type: 'idle' }) as {
+        type: string;
+        [key: string]: unknown;
+      };
 
       const pendingQuestion = questions.find(q => q.sessionID === kiloSessionId);
-
       const pendingPermission = permissions.find(p => p.sessionID === kiloSessionId);
 
-      const snapshot: KiloSnapshotData = { sessionStatus };
-      if (pendingQuestion) {
-        snapshot.question = {
-          requestId: pendingQuestion.id,
-          callId: pendingQuestion.tool?.callID,
-        };
-      }
-      if (pendingPermission) {
-        snapshot.permission = {
-          requestId: pendingPermission.id,
-          callId: pendingPermission.tool?.callID,
-          permission: pendingPermission.permission,
-          patterns: pendingPermission.patterns,
-          metadata: pendingPermission.metadata,
-          always: pendingPermission.always,
-        };
-      }
-
+      // Send session status as a regular kilocode event
+      const statusProperties = { sessionID: kiloSessionId, status: sessionStatus };
       sendToIngest({
-        streamEventType: 'kilo_snapshot',
-        data: snapshot,
+        streamEventType: 'kilocode',
+        data: {
+          ...statusProperties,
+          event: 'session.status',
+          type: 'session.status',
+          properties: statusProperties,
+        },
         timestamp: new Date().toISOString(),
       });
 
+      // Replay pending questions/permissions as regular events
+      // (same format as real-time delivery — matches CLI behavior)
+      if (pendingQuestion) {
+        sendToIngest({
+          streamEventType: 'kilocode',
+          data: {
+            event: 'question.asked',
+            type: 'question.asked',
+            properties: pendingQuestion,
+          },
+          timestamp: new Date().toISOString(),
+        });
+      }
+      if (pendingPermission) {
+        sendToIngest({
+          streamEventType: 'kilocode',
+          data: {
+            event: 'permission.asked',
+            type: 'permission.asked',
+            properties: pendingPermission,
+          },
+          timestamp: new Date().toISOString(),
+        });
+      }
+
       logToFile(
-        `kilo snapshot sent: status=${sessionStatus.type}, question=${pendingQuestion?.id ?? 'none'}, permission=${pendingPermission?.id ?? 'none'}`
+        `kilo state sent: status=${sessionStatus.type}, question=${pendingQuestion?.id ?? 'none'}, permission=${pendingPermission?.id ?? 'none'}`
       );
     } catch (err) {
       logToFile(

--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -79,6 +79,8 @@ function DynamicMessages({
 // ---------------------------------------------------------------------------
 // CloudChatPage
 // ---------------------------------------------------------------------------
+const emptyQuestionRequestIds = new Map<string, string>();
+
 type CloudChatPageProps = { organizationId?: string };
 
 export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
@@ -105,9 +107,8 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const sessionId = useAtomValue(manager.atoms.sessionId);
   const activity = useAtomValue(manager.atoms.activity);
   const cloudStatus = useAtomValue(manager.atoms.cloudStatus);
-  const standaloneQuestion = useAtomValue(manager.atoms.standaloneQuestion);
-  const questionRequestIds = useAtomValue(manager.atoms.questionRequestIds);
-  const standalonePermission = useAtomValue(manager.atoms.standalonePermission);
+  const activeQuestion = useAtomValue(manager.atoms.activeQuestion);
+  const activePermission = useAtomValue(manager.atoms.activePermission);
   const failedPrompt = useAtomValue(manager.atoms.failedPrompt);
   const staticMessages = useAtomValue(manager.atoms.staticMessages);
   const dynamicMessages = useAtomValue(manager.atoms.dynamicMessages);
@@ -229,7 +230,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   // -- Render ---------------------------------------------------------------
   return (
     <QuestionContextProvider
-      questionRequestIds={questionRequestIds}
+      questionRequestIds={emptyQuestionRequestIds}
       cloudAgentSessionId={sessionId}
       organizationId={organizationId ?? null}
       answerQuestion={handleAnswerQuestion}
@@ -282,29 +283,29 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                 )}
               </div>
 
-              <div className="relative">
-                {standaloneQuestion && (
-                  <div className="bg-background absolute inset-0 z-10 overflow-y-auto border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
-                    <QuestionToolCard
-                      key={standaloneQuestion.requestId}
-                      questions={standaloneQuestion.questions}
-                      requestId={standaloneQuestion.requestId}
-                      status="running"
-                    />
-                  </div>
-                )}
-                {standalonePermission && (
-                  <div className="bg-background absolute inset-0 z-10 flex items-center justify-center border-t p-4">
-                    <PermissionCard
-                      key={standalonePermission.requestId}
-                      requestId={standalonePermission.requestId}
-                      permission={standalonePermission.permission}
-                      patterns={standalonePermission.patterns}
-                      metadata={standalonePermission.metadata}
-                      always={standalonePermission.always}
-                    />
-                  </div>
-                )}
+              {activeQuestion && (
+                <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
+                  <QuestionToolCard
+                    key={activeQuestion.requestId}
+                    questions={activeQuestion.questions}
+                    requestId={activeQuestion.requestId}
+                    status="running"
+                  />
+                </div>
+              )}
+              {activePermission && (
+                <div className="flex items-center border-t p-4">
+                  <PermissionCard
+                    key={activePermission.requestId}
+                    requestId={activePermission.requestId}
+                    permission={activePermission.permission}
+                    patterns={activePermission.patterns}
+                    metadata={activePermission.metadata}
+                    always={activePermission.always}
+                  />
+                </div>
+              )}
+              <div className={activeQuestion || activePermission ? 'hidden' : ''}>
                 <ChatInput
                   onSend={handleSendMessage}
                   onStop={handleStopExecution}

--- a/src/components/cloud-agent-next/PartRenderer.tsx
+++ b/src/components/cloud-agent-next/PartRenderer.tsx
@@ -15,7 +15,7 @@ import { ListToolCard } from './ListToolCard';
 import { GenericToolCard } from './GenericToolCard';
 import { TodoReadToolCard } from './TodoReadToolCard';
 import { TodoWriteToolCard } from './TodoWriteToolCard';
-import { QuestionToolCard } from './QuestionToolCard';
+import { QuestionToolStatus } from './QuestionToolStatus';
 import { ChildSessionSection, getTaskToolSessionId } from './ChildSessionSection';
 import type { RenderPartFn } from './ChildSessionSection';
 import { useState } from 'react';
@@ -236,9 +236,9 @@ function ToolPartRenderer({
     return <TodoWriteToolCard toolPart={part} />;
   }
 
-  // Special handling for question tool - compact display with tabs
+  // Question tool — read-only status in message stream (interactive UI is in the dock)
   if (part.tool === 'question') {
-    return <QuestionToolCard toolPart={part} />;
+    return <QuestionToolStatus toolPart={part} />;
   }
 
   return <GenericToolCard toolPart={part} />;

--- a/src/components/cloud-agent-next/QuestionToolStatus.tsx
+++ b/src/components/cloud-agent-next/QuestionToolStatus.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+import { MessageCircleQuestion, Clock } from 'lucide-react';
+import { useManager } from './CloudAgentProvider';
+import { ToolCardShell } from './ToolCardShell';
+import type { ToolPart } from './types';
+import type { QuestionInfo } from '@/types/opencode.gen';
+
+type QuestionInput = {
+  questions: QuestionInfo[];
+};
+
+type QuestionMetadata = {
+  answers?: string[][];
+};
+
+/**
+ * Read-only question status for the message stream.
+ *
+ * While a question is pending/running, shows a subtle waiting indicator.
+ * After completion, shows a summary of questions and their answers.
+ * On error/dismissal, shows a dismissed label.
+ *
+ * This component has NO interactive elements — the interactive question UI
+ * lives in the dock area (CloudChatPage).
+ */
+export function QuestionToolStatus({ toolPart }: { toolPart: ToolPart }) {
+  const { status } = toolPart.state;
+  const manager = useManager();
+  const activeQuestion = useAtomValue(manager.atoms.activeQuestion);
+  const isStreaming = useAtomValue(manager.atoms.isStreaming);
+  const questions: QuestionInfo[] =
+    (toolPart.state.input as QuestionInput | undefined)?.questions ?? [];
+
+  if (status === 'pending' || status === 'running') {
+    // Only treat as interrupted when the session is idle — during streaming the
+    // question.asked event may not have propagated to activeQuestionAtom yet.
+    if (!activeQuestion && !isStreaming) {
+      return (
+        <ToolCardShell
+          icon={MessageCircleQuestion}
+          title="Questions"
+          subtitle="Question interrupted"
+          status="error"
+        >
+          {questions.length > 0 && (
+            <div className="space-y-2">
+              {questions.map((q, idx) => (
+                <div key={idx} className="text-xs">
+                  <div className="text-muted-foreground font-medium">{q.question}</div>
+                </div>
+              ))}
+            </div>
+          )}
+        </ToolCardShell>
+      );
+    }
+    return (
+      <div className="border-muted bg-muted/30 flex items-center gap-2 rounded-md border px-3 py-2">
+        <Clock className="text-muted-foreground h-4 w-4 shrink-0 animate-pulse" />
+        <span className="text-muted-foreground text-sm">Waiting for answer…</span>
+      </div>
+    );
+  }
+
+  // Error / dismissed
+  if (status === 'error') {
+    return (
+      <ToolCardShell
+        icon={MessageCircleQuestion}
+        title="Questions"
+        subtitle="Questions dismissed"
+        status="error"
+      />
+    );
+  }
+
+  // Completed — summary of questions with answers
+  const answers: string[][] =
+    (toolPart.state.metadata as QuestionMetadata | undefined)?.answers ?? [];
+  const answeredCount = answers.filter(a => a && a.length > 0).length;
+
+  return (
+    <ToolCardShell
+      icon={MessageCircleQuestion}
+      title="Questions"
+      subtitle={`${answeredCount} answered`}
+      status="completed"
+    >
+      <div className="space-y-2">
+        {questions.map((q, idx) => {
+          const qAnswers = answers[idx] ?? [];
+          return (
+            <div key={idx} className="text-xs">
+              <div className="text-muted-foreground font-medium">{q.question}</div>
+              {qAnswers.length > 0 && (
+                <div className="text-foreground mt-0.5">{qAnswers.join(', ')}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </ToolCardShell>
+  );
+}

--- a/src/lib/cloud-agent-sdk/normalizer.test.ts
+++ b/src/lib/cloud-agent-sdk/normalizer.test.ts
@@ -581,7 +581,7 @@ describe('normalize', () => {
   });
 
   describe('question.asked', () => {
-    it('includes callId from tool.callID', () => {
+    it('extracts requestId and questions from tool.callID', () => {
       const data = {
         id: 'q-1',
         tool: { callID: 'call-1' },
@@ -591,18 +591,16 @@ describe('normalize', () => {
       expect(result).toEqual({
         type: 'question.asked',
         requestId: 'q-1',
-        callId: 'call-1',
         questions: [{ text: 'Continue?' }],
       });
     });
 
-    it('has callId undefined when tool is absent', () => {
+    it('works when tool is absent', () => {
       const data = { id: 'q-1', questions: [{ text: 'Yes?' }] };
       const result = normalize(createRaw('question.asked', data));
       expect(result).toEqual({
         type: 'question.asked',
         requestId: 'q-1',
-        callId: undefined,
         questions: [{ text: 'Yes?' }],
       });
     });
@@ -613,7 +611,6 @@ describe('normalize', () => {
       expect(result).toEqual({
         type: 'question.asked',
         requestId: 'q-1',
-        callId: undefined,
         questions: undefined,
       });
     });
@@ -671,7 +668,6 @@ describe('normalize', () => {
       expect(result).toEqual({
         type: 'permission.asked',
         requestId: 'perm-1',
-        callId: 'call-1',
         permission: 'bash',
         patterns: ['**/*'],
         metadata: { command: 'ls -la' },
@@ -685,7 +681,6 @@ describe('normalize', () => {
       expect(result).toEqual({
         type: 'permission.asked',
         requestId: 'perm-2',
-        callId: undefined,
         permission: 'write',
         patterns: [],
         metadata: {},
@@ -710,7 +705,6 @@ describe('normalize', () => {
       expect(result).toEqual({
         type: 'permission.asked',
         requestId: 'perm-3',
-        callId: undefined,
         permission: 'read',
         patterns: [],
         metadata: {},
@@ -1089,7 +1083,7 @@ describe('normalize', () => {
       });
     });
 
-    it('normalizes with sessionStatus, cloudStatus, and question', () => {
+    it('normalizes with sessionStatus and cloudStatus', () => {
       const result = normalize(
         createRaw('connected', {
           sessionStatus: { type: 'busy' },
@@ -1101,7 +1095,6 @@ describe('normalize', () => {
         type: 'connected',
         sessionStatus: { type: 'busy' },
         cloudStatus: { type: 'preparing', step: 'cloning' },
-        question: { requestId: 'req-1', callId: 'call-1' },
       });
     });
 
@@ -1130,7 +1123,7 @@ describe('normalize', () => {
       });
     });
 
-    it('ignores invalid question', () => {
+    it('strips unknown fields like question from connected event', () => {
       const result = normalize(
         createRaw('connected', {
           sessionStatus: { type: 'idle' },
@@ -1141,9 +1134,10 @@ describe('normalize', () => {
         type: 'connected',
         sessionStatus: { type: 'idle' },
       });
+      expect(result).not.toHaveProperty('question');
     });
 
-    it('normalizes connected event with permission', () => {
+    it('strips unknown fields like permission from connected event', () => {
       const result = normalize(
         createRaw('connected', {
           sessionStatus: { type: 'busy' },
@@ -1160,40 +1154,6 @@ describe('normalize', () => {
       expect(result).toEqual({
         type: 'connected',
         sessionStatus: { type: 'busy' },
-        permission: {
-          requestId: 'perm-1',
-          callId: 'call-1',
-          permission: 'bash',
-          patterns: ['**/*'],
-          metadata: { command: 'ls' },
-          always: [],
-        },
-      });
-    });
-
-    it('normalizes connected event without permission', () => {
-      const result = normalize(
-        createRaw('connected', {
-          sessionStatus: { type: 'idle' },
-        })
-      );
-      expect(result).toEqual({
-        type: 'connected',
-        sessionStatus: { type: 'idle' },
-      });
-      expect(result).not.toHaveProperty('permission');
-    });
-
-    it('normalizes connected event with invalid permission', () => {
-      const result = normalize(
-        createRaw('connected', {
-          sessionStatus: { type: 'idle' },
-          permission: { callId: 'call-1' }, // missing requestId
-        })
-      );
-      expect(result).toEqual({
-        type: 'connected',
-        sessionStatus: { type: 'idle' },
       });
       expect(result).not.toHaveProperty('permission');
     });
@@ -1328,7 +1288,6 @@ describe('normalizeCliEvent', () => {
       expect(normalizeCliEvent('question.asked', data)).toEqual({
         type: 'question.asked',
         requestId: 'q-1',
-        callId: 'call-1',
         questions: [{ text: 'Continue?' }],
       });
     });

--- a/src/lib/cloud-agent-sdk/normalizer.ts
+++ b/src/lib/cloud-agent-sdk/normalizer.ts
@@ -4,7 +4,7 @@
  * boundary `as` casts so downstream code receives properly typed NormalizedEvents.
  */
 import type { Part, SessionStatus, QuestionInfo, Message } from '@/types/opencode.gen';
-import type { SessionInfo, CloudStatus, QuestionState, PermissionState } from './types';
+import type { SessionInfo, CloudStatus } from './types';
 import {
   cloudAgentEventSchema,
   kilocodePayloadSchema,
@@ -63,7 +63,6 @@ export type ServiceEvent =
   | {
       type: 'question.asked';
       requestId: string;
-      callId?: string;
       questions?: QuestionInfo[];
     }
   | { type: 'question.replied'; requestId: string }
@@ -71,7 +70,6 @@ export type ServiceEvent =
   | {
       type: 'permission.asked';
       requestId: string;
-      callId?: string;
       permission: string;
       patterns: string[];
       metadata: Record<string, unknown>;
@@ -100,8 +98,6 @@ export type ServiceEvent =
       type: 'connected';
       sessionStatus?: SessionStatus;
       cloudStatus?: CloudStatus;
-      question?: QuestionState;
-      permission?: PermissionState;
     };
 
 export type NormalizedEvent = ChatEvent | ServiceEvent;
@@ -237,7 +233,6 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
       return {
         type: 'question.asked',
         requestId: r.data.id,
-        callId: r.data.tool?.callID,
         questions: r.data.questions as QuestionInfo[] | undefined,
       };
     }
@@ -260,7 +255,6 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
       return {
         type: 'permission.asked',
         requestId: r.data.id,
-        callId: r.data.tool?.callID,
         permission: r.data.permission,
         patterns: r.data.patterns,
         metadata: r.data.metadata as Record<string, unknown>,
@@ -334,10 +328,6 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
         type: 'connected',
         ...(r.data.sessionStatus !== undefined && { sessionStatus: r.data.sessionStatus }),
         ...(r.data.cloudStatus !== undefined && { cloudStatus: r.data.cloudStatus }),
-        ...(r.data.question !== undefined && { question: r.data.question as QuestionState }),
-        ...(r.data.permission !== undefined && {
-          permission: r.data.permission as PermissionState,
-        }),
       };
     }
 

--- a/src/lib/cloud-agent-sdk/schemas.ts
+++ b/src/lib/cloud-agent-sdk/schemas.ts
@@ -286,8 +286,6 @@ export type CloudStatusData = z.infer<typeof cloudStatusDataSchema>;
 export const connectedDataSchema = z.object({
   sessionStatus: sessionStatusSchema.optional().catch(undefined),
   cloudStatus: cloudStatusSchema.optional().catch(undefined),
-  question: questionPayloadSchema.optional().catch(undefined),
-  permission: permissionPayloadSchema.optional().catch(undefined),
 });
 export type ConnectedData = z.infer<typeof connectedDataSchema>;
 

--- a/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -615,6 +615,45 @@ describe('createServiceState', () => {
       expect(state.getPermission()).toBeNull();
     });
 
+    it('fires onQuestionResolved when clearing stale question on reconnect', () => {
+      const onQuestionResolved = jest.fn();
+      const state = createServiceState(makeConfig({ onQuestionResolved }));
+      // Set a question
+      state.process({ type: 'question.asked', requestId: 'req-stale' });
+      onQuestionResolved.mockClear();
+      // Reconnect — question was answered while disconnected
+      state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
+      expect(onQuestionResolved).toHaveBeenCalledWith('req-stale');
+    });
+
+    it('fires onPermissionResolved when clearing stale permission on reconnect', () => {
+      const onPermissionResolved = jest.fn();
+      const state = createServiceState(makeConfig({ onPermissionResolved }));
+      // Set a permission
+      state.process({
+        type: 'permission.asked',
+        requestId: 'perm-stale',
+        permission: 'file-edit',
+        patterns: ['**/*'],
+        metadata: {},
+        always: [],
+      });
+      onPermissionResolved.mockClear();
+      // Reconnect — permission was resolved while disconnected
+      state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
+      expect(onPermissionResolved).toHaveBeenCalledWith('perm-stale');
+    });
+
+    it('does not fire resolve callbacks when no question/permission was pending', () => {
+      const onQuestionResolved = jest.fn();
+      const onPermissionResolved = jest.fn();
+      const state = createServiceState(makeConfig({ onQuestionResolved, onPermissionResolved }));
+      // Connect with no prior question/permission
+      state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
+      expect(onQuestionResolved).not.toHaveBeenCalled();
+      expect(onPermissionResolved).not.toHaveBeenCalled();
+    });
+
     it('clears terminated flag', () => {
       const onError = jest.fn();
       const state = createServiceState(makeConfig({ onError }));

--- a/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -218,6 +218,45 @@ describe('createServiceState', () => {
       expect(state.getStatus()).toEqual({ type: 'disconnected' });
       expect(onError).toHaveBeenCalledWith('Connection to agent lost');
     });
+
+    it('stopped resets cloudStatus to null when it was preparing', () => {
+      const state = createServiceState(makeConfig());
+      state.process({
+        type: 'cloud.status',
+        cloudStatus: { type: 'preparing', step: 'cloning', message: 'Cloning...' },
+      });
+      expect(state.getCloudStatus()).not.toBeNull();
+
+      state.process({ type: 'stopped', reason: 'error' });
+
+      expect(state.getCloudStatus()).toBeNull();
+    });
+
+    it('stopped resets cloudStatus to null when it was finalizing', () => {
+      const state = createServiceState(makeConfig());
+      state.process({
+        type: 'cloud.status',
+        cloudStatus: { type: 'finalizing', step: 'committing', message: 'Committing...' },
+      });
+      expect(state.getCloudStatus()).not.toBeNull();
+
+      state.process({ type: 'stopped', reason: 'complete' });
+
+      expect(state.getCloudStatus()).toBeNull();
+    });
+
+    it('stopped resets cloudStatus to null on disconnected', () => {
+      const state = createServiceState(makeConfig());
+      state.process({
+        type: 'cloud.status',
+        cloudStatus: { type: 'preparing', step: 'cloning', message: 'Cloning...' },
+      });
+      expect(state.getCloudStatus()).not.toBeNull();
+
+      state.process({ type: 'stopped', reason: 'disconnected' });
+
+      expect(state.getCloudStatus()).toBeNull();
+    });
   });
 
   describe('session.error', () => {
@@ -338,7 +377,7 @@ describe('createServiceState', () => {
   });
 
   describe('question.asked', () => {
-    it('sets question state with callId and fires callback', () => {
+    it('sets question state and fires callback', () => {
       const onQuestionAsked = jest.fn();
       const state = createServiceState(makeConfig({ onQuestionAsked }));
       const questions: QuestionInfo[] = [
@@ -348,19 +387,17 @@ describe('createServiceState', () => {
       state.process({
         type: 'question.asked',
         requestId: 'req-1',
-        callId: 'call-1',
         questions,
       });
 
       expect(state.getQuestion()).toEqual({
         requestId: 'req-1',
-        callId: 'call-1',
         questions,
       });
-      expect(onQuestionAsked).toHaveBeenCalledWith('req-1', 'call-1', questions);
+      expect(onQuestionAsked).toHaveBeenCalledWith('req-1', questions);
     });
 
-    it('sets question state without callId (standalone question)', () => {
+    it('sets question state without questions (standalone question)', () => {
       const onQuestionAsked = jest.fn();
       const state = createServiceState(makeConfig({ onQuestionAsked }));
 
@@ -368,10 +405,9 @@ describe('createServiceState', () => {
 
       expect(state.getQuestion()).toEqual({
         requestId: 'req-2',
-        callId: undefined,
         questions: undefined,
       });
-      expect(onQuestionAsked).toHaveBeenCalledWith('req-2', undefined, undefined);
+      expect(onQuestionAsked).toHaveBeenCalledWith('req-2', undefined);
     });
   });
 
@@ -380,7 +416,7 @@ describe('createServiceState', () => {
       const onQuestionResolved = jest.fn();
       const state = createServiceState(makeConfig({ onQuestionResolved }));
 
-      state.process({ type: 'question.asked', requestId: 'req-1', callId: 'call-1' });
+      state.process({ type: 'question.asked', requestId: 'req-1' });
       state.process({ type: 'question.replied', requestId: 'req-1' });
 
       expect(state.getQuestion()).toBeNull();
@@ -552,44 +588,31 @@ describe('createServiceState', () => {
       expect(state.getCloudStatus()).toBeNull();
     });
 
-    it('sets question when provided', () => {
-      const state = createServiceState(makeConfig());
-      state.process({
-        type: 'connected',
-        sessionStatus: { type: 'busy' },
-        question: { requestId: 'req-1', callId: 'call-1' },
-      });
-      expect(state.getQuestion()).toEqual({
-        requestId: 'req-1',
-        callId: 'call-1',
-        questions: undefined,
-      });
-    });
-
-    it('fires onQuestionAsked callback when question is provided', () => {
-      const onQuestionAsked = jest.fn();
-      const state = createServiceState(makeConfig({ onQuestionAsked }));
-      state.process({
-        type: 'connected',
-        sessionStatus: { type: 'busy' },
-        question: { requestId: 'req-1', callId: 'call-1', questions: [] },
-      });
-      expect(onQuestionAsked).toHaveBeenCalledWith('req-1', 'call-1', []);
-    });
-
     it('clears question when not provided on reconnect', () => {
       const state = createServiceState(makeConfig());
       // Set a question via question.asked
-      state.process({
-        type: 'question.asked',
-        requestId: 'req-stale',
-        callId: 'call-stale',
-        questions: [],
-      });
+      state.process({ type: 'question.asked', requestId: 'req-stale' });
       expect(state.getQuestion()).not.toBeNull();
       // Reconnect without question — it was answered while disconnected
       state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
       expect(state.getQuestion()).toBeNull();
+    });
+
+    it('clears permission when not provided on reconnect', () => {
+      const state = createServiceState(makeConfig());
+      // Set a permission via permission.asked
+      state.process({
+        type: 'permission.asked',
+        requestId: 'perm-stale',
+        permission: 'file-edit',
+        patterns: ['**/*'],
+        metadata: {},
+        always: [],
+      });
+      expect(state.getPermission()).not.toBeNull();
+      // Reconnect without permission — it was resolved while disconnected
+      state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
+      expect(state.getPermission()).toBeNull();
     });
 
     it('clears terminated flag', () => {
@@ -611,15 +634,9 @@ describe('createServiceState', () => {
         type: 'connected',
         sessionStatus: { type: 'busy' },
         cloudStatus: { type: 'ready' },
-        question: { requestId: 'req-1' },
       });
       expect(state.getActivity()).toEqual({ type: 'busy' });
       expect(state.getCloudStatus()).toEqual({ type: 'ready' });
-      expect(state.getQuestion()).toEqual({
-        requestId: 'req-1',
-        callId: undefined,
-        questions: undefined,
-      });
     });
 
     it('notifies subscribers once', () => {
@@ -928,7 +945,6 @@ describe('createServiceState', () => {
       state.process({
         type: 'permission.asked',
         requestId: 'perm-1',
-        callId: 'call-1',
         permission: 'file-edit',
         patterns: ['src/**/*.ts'],
         metadata: { reason: 'code generation' },
@@ -937,7 +953,6 @@ describe('createServiceState', () => {
 
       expect(state.getPermission()).toEqual({
         requestId: 'perm-1',
-        callId: 'call-1',
         permission: 'file-edit',
         patterns: ['src/**/*.ts'],
         metadata: { reason: 'code generation' },
@@ -952,7 +967,6 @@ describe('createServiceState', () => {
       state.process({
         type: 'permission.asked',
         requestId: 'perm-1',
-        callId: 'call-1',
         permission: 'file-edit',
         patterns: ['src/**/*.ts'],
         metadata: { reason: 'code generation' },
@@ -961,7 +975,6 @@ describe('createServiceState', () => {
 
       expect(onPermissionAsked).toHaveBeenCalledWith(
         'perm-1',
-        'call-1',
         'file-edit',
         ['src/**/*.ts'],
         { reason: 'code generation' },
@@ -983,7 +996,6 @@ describe('createServiceState', () => {
 
       expect(state.snapshot().permission).toEqual({
         requestId: 'perm-1',
-        callId: undefined,
         permission: 'file-edit',
         patterns: ['**/*'],
         metadata: {},
@@ -1026,96 +1038,6 @@ describe('createServiceState', () => {
       state.process({ type: 'permission.replied', requestId: 'perm-1' });
 
       expect(onPermissionResolved).toHaveBeenCalledWith('perm-1');
-    });
-  });
-
-  describe('connected permission sync', () => {
-    it('sets permission from connected event', () => {
-      const state = createServiceState(makeConfig());
-
-      state.process({
-        type: 'connected',
-        sessionStatus: { type: 'busy' },
-        permission: {
-          requestId: 'perm-1',
-          callId: 'call-1',
-          permission: 'file-edit',
-          patterns: ['src/**'],
-          metadata: {},
-          always: [],
-        },
-      });
-
-      expect(state.getPermission()).toEqual({
-        requestId: 'perm-1',
-        callId: 'call-1',
-        permission: 'file-edit',
-        patterns: ['src/**'],
-        metadata: {},
-        always: [],
-      });
-    });
-
-    it('clears permission when not provided on reconnect', () => {
-      const state = createServiceState(makeConfig());
-
-      // Set a permission via permission.asked
-      state.process({
-        type: 'permission.asked',
-        requestId: 'perm-stale',
-        permission: 'file-edit',
-        patterns: ['**/*'],
-        metadata: {},
-        always: [],
-      });
-      expect(state.getPermission()).not.toBeNull();
-
-      // Reconnect without permission — it was resolved while disconnected
-      state.process({ type: 'connected', sessionStatus: { type: 'idle' } });
-
-      expect(state.getPermission()).toBeNull();
-    });
-
-    it('preserves question when permission changes on reconnect', () => {
-      const state = createServiceState(makeConfig());
-
-      // Set both question and permission
-      state.process({ type: 'question.asked', requestId: 'q-1', callId: 'call-q' });
-      state.process({
-        type: 'permission.asked',
-        requestId: 'perm-1',
-        permission: 'file-edit',
-        patterns: ['**/*'],
-        metadata: {},
-        always: [],
-      });
-
-      expect(state.getQuestion()).not.toBeNull();
-      expect(state.getPermission()).not.toBeNull();
-
-      // Reconnect with permission but without question
-      state.process({
-        type: 'connected',
-        sessionStatus: { type: 'busy' },
-        permission: {
-          requestId: 'perm-2',
-          permission: 'shell',
-          patterns: ['*'],
-          metadata: {},
-          always: [],
-        },
-      });
-
-      // Question cleared (not in connected), permission updated
-      expect(state.getQuestion()).toBeNull();
-      expect(state.getPermission()).toEqual({
-        requestId: 'perm-2',
-        callId: undefined,
-        permission: 'shell',
-        patterns: ['*'],
-        metadata: {},
-        always: [],
-      });
     });
   });
 

--- a/src/lib/cloud-agent-sdk/service-state.ts
+++ b/src/lib/cloud-agent-sdk/service-state.ts
@@ -21,11 +21,10 @@ type ServiceStateConfig = {
   /** The root session ID we're tracking (to detect child sessions). */
   rootSessionId: string;
   onError?: (message: string) => void;
-  onQuestionAsked?: (requestId: string, callId?: string, questions?: QuestionInfo[]) => void;
+  onQuestionAsked?: (requestId: string, questions?: QuestionInfo[]) => void;
   onQuestionResolved?: (requestId: string) => void;
   onPermissionAsked?: (
     requestId: string,
-    callId?: string,
     permission?: string,
     patterns?: string[],
     metadata?: Record<string, unknown>,
@@ -114,6 +113,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
   function processStopped(event: Extract<ServiceEvent, { type: 'stopped' }>): void {
     activity = { type: 'idle' };
+    cloudStatus = null;
 
     switch (event.reason) {
       case 'complete':
@@ -168,10 +168,9 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   function processQuestionAsked(event: Extract<ServiceEvent, { type: 'question.asked' }>): void {
     question = {
       requestId: event.requestId,
-      callId: event.callId,
       questions: event.questions,
     };
-    config.onQuestionAsked?.(event.requestId, event.callId, event.questions);
+    config.onQuestionAsked?.(event.requestId, event.questions);
     notify();
   }
 
@@ -183,14 +182,13 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
   function processPermissionAsked(
     requestId: string,
-    callId: string | undefined,
     permissionType: string,
     patterns: string[],
     metadata: Record<string, unknown>,
     always: string[]
   ): void {
-    permission = { requestId, callId, permission: permissionType, patterns, metadata, always };
-    config.onPermissionAsked?.(requestId, callId, permissionType, patterns, metadata, always);
+    permission = { requestId, permission: permissionType, patterns, metadata, always };
+    config.onPermissionAsked?.(requestId, permissionType, patterns, metadata, always);
     notify();
   }
 
@@ -263,29 +261,11 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
     // Set cloudStatus (undefined means not provided — leave as null)
     cloudStatus = event.cloudStatus ?? null;
 
-    // Sync question state: set if present, clear if absent (question was answered while disconnected)
-    if (event.question) {
-      question = {
-        requestId: event.question.requestId,
-        callId: event.question.callId,
-        questions: event.question.questions,
-      };
-      // Notify via callback so questionRequestIdsAtom gets populated (needed for answering questions)
-      config.onQuestionAsked?.(
-        event.question.requestId,
-        event.question.callId,
-        event.question.questions
-      );
-    } else {
-      question = null;
-    }
-
-    // Sync permission state: set if present, clear if absent
-    if (event.permission) {
-      permission = event.permission;
-    } else {
-      permission = null;
-    }
+    // Clear question/permission — if still pending on the server the wrapper
+    // replays them as separate question.asked / permission.asked events
+    // immediately after the snapshot, so they'll be re-set.
+    question = null;
+    permission = null;
 
     // Clear terminated on connected
     terminated = false;
@@ -322,7 +302,6 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       case 'permission.asked':
         processPermissionAsked(
           event.requestId,
-          event.callId,
           event.permission,
           event.patterns,
           event.metadata,

--- a/src/lib/cloud-agent-sdk/service-state.ts
+++ b/src/lib/cloud-agent-sdk/service-state.ts
@@ -264,8 +264,21 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
     // Clear question/permission — if still pending on the server the wrapper
     // replays them as separate question.asked / permission.asked events
     // immediately after the snapshot, so they'll be re-set.
-    question = null;
-    permission = null;
+    // Fire resolve callbacks first so consumers (e.g. dock atoms) also clear.
+    if (question) {
+      const { requestId } = question;
+      question = null;
+      config.onQuestionResolved?.(requestId);
+    } else {
+      question = null;
+    }
+    if (permission) {
+      const { requestId } = permission;
+      permission = null;
+      config.onPermissionResolved?.(requestId);
+    } else {
+      permission = null;
+    }
 
     // Clear terminated on connected
     terminated = false;

--- a/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -30,16 +30,31 @@ const mockSession = {
   storage: {},
 };
 
+const mockSessionCallbacks: {
+  onQuestionAsked?: (...args: unknown[]) => void;
+  onQuestionResolved?: (...args: unknown[]) => void;
+  onPermissionAsked?: (...args: unknown[]) => void;
+  onPermissionResolved?: (...args: unknown[]) => void;
+} = {};
+
 jest.mock('./session', () => ({
   createCloudAgentSession: jest.fn(
     (sessionConfig: {
       onSessionCreated?: (info: { id: string; parentID: string | null }) => void;
+      onQuestionAsked?: (...args: unknown[]) => void;
+      onQuestionResolved?: (...args: unknown[]) => void;
+      onPermissionAsked?: (...args: unknown[]) => void;
+      onPermissionResolved?: (...args: unknown[]) => void;
     }) => {
       // Capture the onSessionCreated callback and fire it when connect() is called,
       // simulating what the real session does after connecting and replaying the snapshot.
       mockSession.connect.mockImplementation(() => {
         sessionConfig.onSessionCreated?.({ id: 'mock-session', parentID: null });
       });
+      mockSessionCallbacks.onQuestionAsked = sessionConfig.onQuestionAsked;
+      mockSessionCallbacks.onQuestionResolved = sessionConfig.onQuestionResolved;
+      mockSessionCallbacks.onPermissionAsked = sessionConfig.onPermissionAsked;
+      mockSessionCallbacks.onPermissionResolved = sessionConfig.onPermissionResolved;
       return mockSession;
     }
   ),
@@ -107,6 +122,10 @@ describe('createSessionManager', () => {
     mockSession.canSend = true;
     mockSession.canInterrupt = true;
     mockSession.state.subscribe.mockImplementation(() => () => {});
+    mockSessionCallbacks.onQuestionAsked = undefined;
+    mockSessionCallbacks.onQuestionResolved = undefined;
+    mockSessionCallbacks.onPermissionAsked = undefined;
+    mockSessionCallbacks.onPermissionResolved = undefined;
   });
 
   // -------------------------------------------------------------------------
@@ -482,6 +501,128 @@ describe('createSessionManager', () => {
         })
       );
       expect(config.initiate).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // activeQuestion / activePermission
+  // -------------------------------------------------------------------------
+
+  describe('activeQuestion / activePermission', () => {
+    it('onQuestionAsked sets activeQuestion', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const questions = [
+        {
+          question: 'Pick a color',
+          header: 'Color',
+          options: [
+            { label: 'Red', description: '' },
+            { label: 'Blue', description: '' },
+          ],
+        },
+      ];
+      mockSessionCallbacks.onQuestionAsked?.('req-1', questions);
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).toEqual({
+        requestId: 'req-1',
+        questions,
+      });
+
+      const questions2 = [{ question: 'Pick a shape', header: 'Shape', options: [] }];
+      mockSessionCallbacks.onQuestionAsked?.('req-2', questions2);
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).toEqual({
+        requestId: 'req-2',
+        questions: questions2,
+      });
+    });
+
+    it('onQuestionResolved clears activeQuestion', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const questions = [{ question: 'Pick one', header: 'Q', options: [] }];
+      mockSessionCallbacks.onQuestionAsked?.('req-1', questions);
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).not.toBeNull();
+
+      mockSessionCallbacks.onQuestionResolved?.('req-1');
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).toBeNull();
+    });
+
+    it('onPermissionAsked sets activePermission', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSessionCallbacks.onPermissionAsked?.('req-1', 'write', ['*.ts'], {}, []);
+      expect(atomValue(config.store, mgr.atoms.activePermission)).toEqual({
+        requestId: 'req-1',
+        permission: 'write',
+        patterns: ['*.ts'],
+        metadata: {},
+        always: [],
+      });
+
+      mockSessionCallbacks.onPermissionAsked?.('req-2', 'bash', ['**'], { command: 'rm' }, [
+        'write',
+      ]);
+      expect(atomValue(config.store, mgr.atoms.activePermission)).toEqual({
+        requestId: 'req-2',
+        permission: 'bash',
+        patterns: ['**'],
+        metadata: { command: 'rm' },
+        always: ['write'],
+      });
+    });
+
+    it('onPermissionResolved clears activePermission', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSessionCallbacks.onPermissionAsked?.('req-1', 'write', [], {}, []);
+      expect(atomValue(config.store, mgr.atoms.activePermission)).not.toBeNull();
+
+      mockSessionCallbacks.onPermissionResolved?.('req-1');
+      expect(atomValue(config.store, mgr.atoms.activePermission)).toBeNull();
+    });
+
+    it('destroy clears activeQuestion and activePermission', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSessionCallbacks.onQuestionAsked?.('req-q', [
+        { question: 'Q?', header: 'Q', options: [] },
+      ]);
+      mockSessionCallbacks.onPermissionAsked?.('req-p', 'write', [], {}, []);
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).not.toBeNull();
+      expect(atomValue(config.store, mgr.atoms.activePermission)).not.toBeNull();
+
+      mgr.destroy();
+
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).toBeNull();
+      expect(atomValue(config.store, mgr.atoms.activePermission)).toBeNull();
+    });
+
+    it('switchSession clears activeQuestion and activePermission', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSessionCallbacks.onQuestionAsked?.('req-q', [
+        { question: 'Q?', header: 'Q', options: [] },
+      ]);
+      mockSessionCallbacks.onPermissionAsked?.('req-p', 'write', [], {}, []);
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).not.toBeNull();
+      expect(atomValue(config.store, mgr.atoms.activePermission)).not.toBeNull();
+
+      await mgr.switchSession(kiloId('ses-2'));
+
+      expect(atomValue(config.store, mgr.atoms.activeQuestion)).toBeNull();
+      expect(atomValue(config.store, mgr.atoms.activePermission)).toBeNull();
     });
   });
 

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -118,7 +118,8 @@ type SessionManagerAtoms = {
   statusIndicator: W<SessionStatusIndicator | null>;
   error: W<string | null>;
   question: W<QuestionState | null>;
-  questionRequestIds: W<Map<string, string>>;
+  activeQuestion: W<StandaloneQuestion | null>;
+  activePermission: W<StandalonePermission | null>;
   sessionInfo: W<SessionInfo | null>;
   sessionId: W<CloudAgentSessionId | null>;
   activity: W<SessionActivity>;
@@ -126,10 +127,7 @@ type SessionManagerAtoms = {
   cloudStatus: W<CloudStatus | null>;
   sessionConfig: W<SessionConfig | null>;
   chatUI: W<{ shouldAutoScroll: boolean }>;
-  standaloneQuestion: W<StandaloneQuestion | null>;
   permission: W<PermissionState | null>;
-  permissionRequestIds: W<Map<string, string>>;
-  standalonePermission: W<StandalonePermission | null>;
   failedPrompt: W<string | null>;
   messagesList: Atom<StoredMessage[]>;
   staticMessages: Atom<StoredMessage[]>;
@@ -244,7 +242,6 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   const statusIndicatorAtom = atom<SessionStatusIndicator | null>(null);
   const errorAtom = atom<string | null>(null);
   const questionAtom = atom<QuestionState | null>(null);
-  const questionRequestIdsAtom = atom<Map<string, string>>(new Map());
   const sessionInfoAtom = atom<SessionInfo | null>(null);
   const sessionIdAtom = atom<CloudAgentSessionId | null>(null);
   const activityAtom = atom<SessionActivity>({ type: 'connecting' });
@@ -252,10 +249,9 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   const cloudStatusAtom = atom<CloudStatus | null>(null);
   const sessionConfigAtom = atom<SessionConfig | null>(null);
   const chatUIAtom = atom<{ shouldAutoScroll: boolean }>({ shouldAutoScroll: true });
-  const standaloneQuestionAtom = atom<StandaloneQuestion | null>(null);
+  const activeQuestionAtom = atom<StandaloneQuestion | null>(null);
   const permissionAtom = atom<PermissionState | null>(null);
-  const permissionRequestIdsAtom = atom<Map<string, string>>(new Map());
-  const standalonePermissionAtom = atom<StandalonePermission | null>(null);
+  const activePermissionAtom = atom<StandalonePermission | null>(null);
   const failedPromptAtom = atom<string | null>(null);
 
   // Derived atoms
@@ -338,17 +334,15 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(statusIndicatorAtom, null);
     store.set(errorAtom, null);
     store.set(questionAtom, null);
-    store.set(questionRequestIdsAtom, new Map());
     store.set(sessionInfoAtom, null);
     store.set(sessionIdAtom, null);
     store.set(activityAtom, { type: 'connecting' });
     store.set(agentStatusAtom, { type: 'idle' });
     store.set(cloudStatusAtom, null);
     store.set(sessionConfigAtom, null);
-    store.set(standaloneQuestionAtom, null);
+    store.set(activeQuestionAtom, null);
     store.set(permissionAtom, null);
-    store.set(permissionRequestIdsAtom, new Map());
-    store.set(standalonePermissionAtom, null);
+    store.set(activePermissionAtom, null);
     store.set(failedPromptAtom, null);
   }
 
@@ -499,26 +493,18 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
           }
         }
       },
-      onQuestionAsked: (requestId, callId, questions) => {
-        if (callId) {
-          const ids = new Map(store.get(questionRequestIdsAtom));
-          ids.set(callId, requestId);
-          store.set(questionRequestIdsAtom, ids);
-        } else if (questions) {
-          store.set(standaloneQuestionAtom, { requestId, questions });
+      onQuestionAsked: (requestId, questions) => {
+        if (questions) {
+          store.set(activeQuestionAtom, { requestId, questions });
         }
       },
       onQuestionResolved: requestId => {
-        const sq = store.get(standaloneQuestionAtom);
-        if (sq?.requestId === requestId) store.set(standaloneQuestionAtom, null);
+        const aq = store.get(activeQuestionAtom);
+        if (aq?.requestId === requestId) store.set(activeQuestionAtom, null);
       },
-      onPermissionAsked: (requestId, callId, permission, patterns, metadata, always) => {
-        if (callId) {
-          const ids = new Map(store.get(permissionRequestIdsAtom));
-          ids.set(callId, requestId);
-          store.set(permissionRequestIdsAtom, ids);
-        } else if (permission) {
-          store.set(standalonePermissionAtom, {
+      onPermissionAsked: (requestId, permission, patterns, metadata, always) => {
+        if (permission) {
+          store.set(activePermissionAtom, {
             requestId,
             permission,
             patterns: patterns ?? [],
@@ -528,8 +514,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
         }
       },
       onPermissionResolved: requestId => {
-        const sp = store.get(standalonePermissionAtom);
-        if (sp?.requestId === requestId) store.set(standalonePermissionAtom, null);
+        const ap = store.get(activePermissionAtom);
+        if (ap?.requestId === requestId) store.set(activePermissionAtom, null);
       },
       onBranchChanged: branch => config.onBranchChanged?.(branch),
       onError: message => store.set(errorAtom, message),
@@ -690,7 +676,6 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       statusIndicator: statusIndicatorAtom,
       error: errorAtom,
       question: questionAtom,
-      questionRequestIds: questionRequestIdsAtom,
       sessionInfo: sessionInfoAtom,
       sessionId: sessionIdAtom,
       activity: activityAtom,
@@ -698,10 +683,9 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       cloudStatus: cloudStatusAtom,
       sessionConfig: sessionConfigAtom,
       chatUI: chatUIAtom,
-      standaloneQuestion: standaloneQuestionAtom,
+      activeQuestion: activeQuestionAtom,
       permission: permissionAtom,
-      permissionRequestIds: permissionRequestIdsAtom,
-      standalonePermission: standalonePermissionAtom,
+      activePermission: activePermissionAtom,
       failedPrompt: failedPromptAtom,
       messagesList: messagesListAtom,
       staticMessages: staticMessagesAtom,

--- a/src/lib/cloud-agent-sdk/session.ts
+++ b/src/lib/cloud-agent-sdk/session.ts
@@ -31,11 +31,10 @@ type CloudAgentSessionConfig = {
   websocketBaseUrl?: string;
   storage?: SessionStorage;
   onError?: (message: string) => void;
-  onQuestionAsked?: (requestId: string, callId?: string, questions?: QuestionInfo[]) => void;
+  onQuestionAsked?: (requestId: string, questions?: QuestionInfo[]) => void;
   onQuestionResolved?: (requestId: string) => void;
   onPermissionAsked?: (
     requestId: string,
-    callId?: string,
     permission?: string,
     patterns?: string[],
     metadata?: Record<string, unknown>,

--- a/src/lib/cloud-agent-sdk/types.ts
+++ b/src/lib/cloud-agent-sdk/types.ts
@@ -83,13 +83,11 @@ export type CloudStatus =
 
 export type QuestionState = {
   requestId: string;
-  callId?: string;
   questions?: QuestionInfo[];
 };
 
 export type PermissionState = {
   requestId: string;
-  callId?: string;
   permission: string;
   patterns: string[];
   metadata: Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Replace the `kilo_snapshot` event type with individual kilocode events (`session.status`, `question.asked`, `permission.asked`) sent by the wrapper on connect/reconnect. This eliminates the async `broadcastConnectedEvent()` race condition in the DO where a replayed `question.asked` (zero awaits) could be broadcast before the `connected` event (three awaits), causing `processConnected()` to clear just-set question state.
- Unify four question/permission atoms (`standaloneQuestion`, `standalonePermission`, `questionRequestIds`, `permissionRequestIds`) into two (`activeQuestion`, `activePermission`), and remove `callId` from `ServiceEvent`, state management, and normalizer throughout the SDK.
- Add read-only `QuestionToolStatus` component for the message stream; interactive question/permission UI now renders in the dock area of `CloudChatPage`.
- Fix `cloudStatus` not resetting on `stopped` events (form staying disabled after 500 errors).
- Fix stale "Waiting for answer…" spinner for interrupted questions by checking `activeQuestionAtom`.
- Fix `isInteractive` check in session-service to require `cloud-agent-web` platform explicitly.

## Visual Changes

| Before | After |
| ------ | ----- |
| Question/permission overlays use absolute positioning with `z-10` over chat area | Question/permission dock below messages using standard flow layout |
| Question tool in message stream renders full interactive `QuestionToolCard` | Question tool in message stream renders read-only `QuestionToolStatus` (waiting indicator → answered summary) |
| Stale "Waiting for answer…" spinner persists on interrupted questions | Shows "Question interrupted" error state when session is idle with no active question |

<img width="1071" height="1094" alt="Screenshot 2026-03-25 at 21 01 20" src="https://github.com/user-attachments/assets/d162c720-c767-492e-8095-b7c3fbad2640" />


## Reviewer Notes

- The `kilo_snapshot` → individual events change is the core architectural shift. All three events now flow through the same synchronous broadcast path in the DO, removing the ordering race.
- `connected` events no longer carry `question`/`permission` fields — the wrapper replays them as separate events immediately after the snapshot, and `processConnected()` clears both to avoid stale state.
- AppBuilder paths are untouched (`QuestionToolCard`, `QuestionContext`, `session-store`, `event-processor`).
- `connectedDataSchema` in `schemas.ts` dropped `question` and `permission` fields — this is a breaking wire-format change for the `connected` event type.