### PR TITLE
refactor(email): add explicit return types to email send functions (3 of 4)

### DIFF
--- a/src/lib/email-mailgun.ts
+++ b/src/lib/email-mailgun.ts
@@ -11,19 +11,24 @@ type SendViaMailgunParams = {
   html: string;
 };
 
-export async function sendViaMailgun({ to, subject, html }: SendViaMailgunParams) {
+export async function sendViaMailgun({
+  to,
+  subject,
+  html,
+}: SendViaMailgunParams): Promise<boolean> {
   if (!MAILGUN_API_KEY || !MAILGUN_DOMAIN) {
     const message = 'MAILGUN_API_KEY/MAILGUN_DOMAIN not set — cannot send email via Mailgun';
     console.warn(message);
     captureMessage(message, { level: 'warning', tags: { source: 'email_service' } });
-    return;
+    return false;
   }
   const client = mailgun.client({ username: 'api', key: MAILGUN_API_KEY });
-  return client.messages.create(MAILGUN_DOMAIN, {
+  await client.messages.create(MAILGUN_DOMAIN, {
     from: 'Kilo Code <hi@app.kilocode.ai>',
     'h:Reply-To': 'hi@kilocode.ai',
     to,
     subject,
     html,
   });
+  return true;
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -115,7 +115,7 @@ type Props = {
   organizationId: string;
 };
 
-export async function sendOrgSubscriptionEmail(to: string, props: Props) {
+export async function sendOrgSubscriptionEmail(to: string, props: Props): Promise<SendResult> {
   const seats = `${props.seatCount} seat${props.seatCount === 1 ? '' : 's'}`;
   const organization_url = `${NEXTAUTH_URL}/organizations/${props.organizationId}`;
   const invoices_url = `${NEXTAUTH_URL}/organizations/${props.organizationId}/payment-details`;
@@ -126,7 +126,7 @@ export async function sendOrgSubscriptionEmail(to: string, props: Props) {
   });
 }
 
-export async function sendOrgRenewedEmail(to: string, props: Props) {
+export async function sendOrgRenewedEmail(to: string, props: Props): Promise<SendResult> {
   const seats = `${props.seatCount} seat${props.seatCount === 1 ? '' : 's'}`;
   const invoices_url = `${NEXTAUTH_URL}/organizations/${props.organizationId}/payment-details`;
   return send({
@@ -136,7 +136,10 @@ export async function sendOrgRenewedEmail(to: string, props: Props) {
   });
 }
 
-export async function sendOrgCancelledEmail(to: string, props: Omit<Props, 'seatCount'>) {
+export async function sendOrgCancelledEmail(
+  to: string,
+  props: Omit<Props, 'seatCount'>
+): Promise<SendResult> {
   const invoices_url = `${NEXTAUTH_URL}/organizations/${props.organizationId}/payment-details`;
   return send({
     to,
@@ -148,7 +151,7 @@ export async function sendOrgCancelledEmail(to: string, props: Omit<Props, 'seat
 export async function sendOrgSSOUserJoinedEmail(
   to: string,
   props: Omit<Props, 'seatCount'> & { new_user_email: string }
-) {
+): Promise<SendResult> {
   const organization_url = `${NEXTAUTH_URL}/organizations/${props.organizationId}`;
   return send({
     to,
@@ -157,7 +160,9 @@ export async function sendOrgSSOUserJoinedEmail(
   });
 }
 
-export async function sendOrganizationInviteEmail(data: OrganizationInviteEmailData) {
+export async function sendOrganizationInviteEmail(
+  data: OrganizationInviteEmailData
+): Promise<SendResult> {
   return send({
     to: data.to,
     templateName: 'orgInvitation',
@@ -172,7 +177,7 @@ export async function sendOrganizationInviteEmail(data: OrganizationInviteEmailD
 export async function sendMagicLinkEmail(
   magicLink: MagicLinkTokenWithPlaintext,
   callbackUrl?: string
-) {
+): Promise<SendResult> {
   return send({
     to: magicLink.email,
     templateName: 'magicLink',
@@ -189,7 +194,7 @@ export async function sendMagicLinkEmail(
 export async function sendAutoTopUpFailedEmail(
   to: string,
   props: { reason: string; organizationId?: string }
-) {
+): Promise<SendResult> {
   const credits_url = props.organizationId
     ? `${NEXTAUTH_URL}/organizations/${props.organizationId}/payment-details`
     : `${NEXTAUTH_URL}/credits?show-auto-top-up`;
@@ -207,7 +212,9 @@ type SendDeploymentFailedEmailProps = {
   repository: string;
 };
 
-export async function sendDeploymentFailedEmail(props: SendDeploymentFailedEmailProps) {
+export async function sendDeploymentFailedEmail(
+  props: SendDeploymentFailedEmailProps
+): Promise<SendResult> {
   return send({
     to: props.to,
     templateName: 'deployFailed',
@@ -225,7 +232,7 @@ type SendBalanceAlertEmailProps = {
   to: string[];
 };
 
-export async function sendBalanceAlertEmail(props: SendBalanceAlertEmailProps) {
+export async function sendBalanceAlertEmail(props: SendBalanceAlertEmailProps): Promise<void> {
   const { organizationId, minimum_balance, to } = props;
 
   if (!to || to.length === 0) {
@@ -270,7 +277,7 @@ type OssInviteEmailData = {
   monthlyCreditsUsd: number;
 };
 
-export async function sendOssInviteNewUserEmail(data: OssInviteEmailData) {
+export async function sendOssInviteNewUserEmail(data: OssInviteEmailData): Promise<SendResult> {
   const integrations_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}/integrations`;
   const code_reviews_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}/code-reviews`;
   const tierConfig = ossTierConfig[data.tier];
@@ -292,7 +299,7 @@ export async function sendOssInviteNewUserEmail(data: OssInviteEmailData) {
 
 export async function sendOssInviteExistingUserEmail(
   data: Omit<OssInviteEmailData, 'acceptInviteUrl' | 'inviteCode'>
-) {
+): Promise<SendResult> {
   const organization_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}`;
   const integrations_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}/integrations`;
   const code_reviews_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}/code-reviews`;
@@ -321,7 +328,9 @@ type OssProvisionEmailData = {
   monthlyCreditsUsd: number;
 };
 
-export async function sendOssExistingOrgProvisionedEmail(data: OssProvisionEmailData) {
+export async function sendOssExistingOrgProvisionedEmail(
+  data: OssProvisionEmailData
+): Promise<void> {
   const organization_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}`;
   const integrations_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}/integrations`;
   const code_reviews_url = `${NEXTAUTH_URL}/organizations/${data.organizationId}/code-reviews`;


### PR DESCRIPTION
## Summary

**PR series: 3 of 4** — merge in order: #1559 oxlint → #1560 CI → **this PR** → #1562 trpc
(This PR is independent of #1559 and #1560 and can merge in parallel with them.)

Add explicit return type annotations to all email send functions for tsgo 7.0 compatibility:

- tsgo 7.0 enforces TS2883, which requires explicit return types when the inferred type references non-portable vendor types
- Wrapper functions (e.g. `sendOrgSubscriptionEmail`) now declare `Promise<SendResult>` instead of relying on inference from `send()`
- `sendViaMailgun` now returns `Promise<boolean>` (`true` = sent, `false` = not configured) instead of leaking the mailgun client response type

## Verification

- [x] `scripts/typecheck-all.sh --changes-only` — pass
- [x] `pnpm format:check` — pass

## Visual Changes

N/A

## Reviewer Notes

- This is a prerequisite for #1562 which switches the `packages/trpc` build from `tsc` to `tsgo`. Without explicit return types, tsgo fails to emit declarations for the email functions.
- The `SendResult` type (`{ sent: true } | { sent: false; reason: ... }`) was introduced by the NeverBounce PR. The wrapper functions previously had no explicit return type, so they inferred the mailgun/CIO vendor types which tsgo rejects.