### PR TITLE
feat: add user.getContextBalance tRPC procedure

### DIFF
--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -7645,6 +7645,16 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
             };
             meta: object;
         }>;
+        getContextBalance: _trpc_server.TRPCQueryProcedure<{
+            input: {
+                organizationId?: string | undefined;
+            };
+            output: {
+                balance: number;
+                isDepleted: boolean;
+            };
+            meta: object;
+        }>;
         getAutocompleteMetrics: _trpc_server.TRPCQueryProcedure<{
             input: {
                 viewType?: string | undefined;

--- a/src/routers/user-router.ts
+++ b/src/routers/user-router.ts
@@ -29,6 +29,7 @@ import {
 } from '@/lib/autoTopUpConstants';
 import { getCreditBlocks } from '@/lib/getCreditBlocks';
 import { getBalanceForUser } from '@/lib/user.balance';
+import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
 
 const ViewTypeSchema = z.union([z.literal('personal'), z.literal('all'), z.uuid()]);
 
@@ -157,6 +158,17 @@ export const userRouter = createTRPCRouter({
     .output(z.object({ balance: z.number(), isDepleted: z.boolean() }))
     .query(async ({ ctx }) => {
       const { balance } = await getBalanceForUser(ctx.user);
+      return { balance, isDepleted: balance <= 0 };
+    }),
+
+  getContextBalance: baseProcedure
+    .input(z.object({ organizationId: z.string().uuid().optional() }))
+    .output(z.object({ balance: z.number(), isDepleted: z.boolean() }))
+    .query(async ({ ctx, input }) => {
+      if (input.organizationId) {
+        await ensureOrganizationAccess(ctx, input.organizationId);
+      }
+      const { balance } = await getBalanceAndOrgSettings(input.organizationId, ctx.user);
       return { balance, isDepleted: balance <= 0 };
     }),
 


### PR DESCRIPTION
## Summary
- Adds `user.getContextBalance` tRPC procedure that accepts an optional `organizationId`
- Returns org balance when `organizationId` is provided, personal balance otherwise
- Mirrors the existing `/api/profile/balance` REST endpoint behavior, using `getBalanceAndOrgSettings` under the hood

## Test plan
- [ ] Call `user.getContextBalance({})` — returns personal balance (same as `user.getBalance`)
- [ ] Call `user.getContextBalance({ organizationId: "<valid-org-id>" })` — returns org balance
- [ ] Call with an org the user doesn't belong to — returns UNAUTHORIZED error