### PR TITLE
feat(gastown): add delete town functionality to town settings

### DIFF
--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -52,6 +52,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { Button as UiButton } from '@/components/ui/button';
 
 type Props = { townId: string; readOnly?: boolean; organizationId?: string };
 
@@ -132,7 +133,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         toast.success('Town deleted');
         router.push('/gastown');
       },
-      onError: (err) => toast.error(`Failed to delete town: ${err.message}`),
+      onError: err => toast.error(`Failed to delete town: ${err.message}`),
     })
   );
 
@@ -144,7 +145,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           router.push(`/organizations/${organizationId}/gastown`);
         }
       },
-      onError: (err) => toast.error(`Failed to delete town: ${err.message}`),
+      onError: err => toast.error(`Failed to delete town: ${err.message}`),
     })
   );
 
@@ -155,7 +156,6 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
       deleteTown.mutate({ townId });
     }
   };
-
 
   const {
     data: modelsData,
@@ -842,20 +842,23 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                     <div>
                       <p className="text-sm text-red-400">Delete Town</p>
                       <p className="text-[11px] text-red-400/70">
-                        Permanently delete this town, all its agents, and all data. This action cannot be undone.
+                        Permanently delete this town, all its agents, and all data. This action
+                        cannot be undone.
                       </p>
                     </div>
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
-                        <Button
-                          disabled={deleteTown.isPending || deleteOrgTown.isPending || effectiveReadOnly}
-                          variant="red"
+                        <UiButton
+                          disabled={
+                            deleteTown.isPending || deleteOrgTown.isPending || effectiveReadOnly
+                          }
+                          variant="destructive"
                           size="sm"
                           className="ml-4 shrink-0 gap-1.5"
                         >
                           <Trash2 className="size-3" />
                           Delete Town
-                        </Button>
+                        </UiButton>
                       </AlertDialogTrigger>
                       <AlertDialogContent className="border-red-500/20 bg-[oklch(0.15_0_0)] sm:max-w-md">
                         <AlertDialogHeader>
@@ -863,8 +866,8 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                             Delete this town?
                           </AlertDialogTitle>
                           <AlertDialogDescription className="text-white/70">
-                            This action cannot be undone. This will permanently delete the town
-                            and all of its associated data, including agents, rigs, and settings.
+                            This action cannot be undone. This will permanently delete the town and
+                            all of its associated data, including agents, rigs, and settings.
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
@@ -875,7 +878,9 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                             onClick={handleDeleteTown}
                             className="bg-red-500/80 text-white hover:bg-red-500"
                           >
-                            {deleteTown.isPending || deleteOrgTown.isPending ? 'Deleting...' : 'Yes, delete town'}
+                            {deleteTown.isPending || deleteOrgTown.isPending
+                              ? 'Deleting...'
+                              : 'Yes, delete town'}
                           </AlertDialogAction>
                         </AlertDialogFooter>
                       </AlertDialogContent>

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -40,6 +40,18 @@ import {
 import { Slider } from '@/components/ui/slider';
 import { motion } from 'motion/react';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
+import { useRouter } from 'next/navigation';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 type Props = { townId: string; readOnly?: boolean; organizationId?: string };
 
@@ -56,6 +68,7 @@ const SECTIONS = [
   { id: 'merge-strategy', label: 'Merge Strategy', icon: GitPullRequest },
   { id: 'refinery', label: 'Refinery', icon: Shield },
   { id: 'container', label: 'Container', icon: Container },
+  { id: 'danger-zone', label: 'Danger Zone', icon: Trash2 },
 ] as const;
 
 function useScrollSpy(sectionIds: readonly string[]) {
@@ -111,6 +124,38 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const trpc = useGastownTRPC();
   const queryClient = useQueryClient();
   const { data: currentUser } = useUser();
+  const router = useRouter();
+
+  const deleteTown = useMutation(
+    trpc.gastown.deleteTown.mutationOptions({
+      onSuccess: () => {
+        toast.success('Town deleted');
+        router.push('/gastown');
+      },
+      onError: (err) => toast.error(`Failed to delete town: ${err.message}`),
+    })
+  );
+
+  const deleteOrgTown = useMutation(
+    trpc.gastown.deleteOrgTown.mutationOptions({
+      onSuccess: () => {
+        toast.success('Town deleted');
+        if (organizationId) {
+          router.push(`/organizations/${organizationId}/gastown`);
+        }
+      },
+      onError: (err) => toast.error(`Failed to delete town: ${err.message}`),
+    })
+  );
+
+  const handleDeleteTown = () => {
+    if (organizationId) {
+      deleteOrgTown.mutate({ organizationId, townId });
+    } else {
+      deleteTown.mutate({ townId });
+    }
+  };
+
 
   const {
     data: modelsData,
@@ -780,6 +825,61 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                       />
                       {refreshToken.isPending ? 'Refreshing...' : 'Refresh Token'}
                     </Button>
+                  </div>
+                </div>
+              </SettingsSection>
+
+              {/* ── Danger Zone ──────────────────────────────────────── */}
+              <SettingsSection
+                id="danger-zone"
+                title="Danger Zone"
+                description="Irreversible actions for this town."
+                icon={Trash2}
+                index={9}
+              >
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">
+                    <div>
+                      <p className="text-sm text-red-400">Delete Town</p>
+                      <p className="text-[11px] text-red-400/70">
+                        Permanently delete this town, all its agents, and all data. This action cannot be undone.
+                      </p>
+                    </div>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          disabled={deleteTown.isPending || deleteOrgTown.isPending || effectiveReadOnly}
+                          variant="red"
+                          size="sm"
+                          className="ml-4 shrink-0 gap-1.5"
+                        >
+                          <Trash2 className="size-3" />
+                          Delete Town
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent className="border-red-500/20 bg-[oklch(0.15_0_0)] sm:max-w-md">
+                        <AlertDialogHeader>
+                          <AlertDialogTitle className="text-red-400">
+                            Delete this town?
+                          </AlertDialogTitle>
+                          <AlertDialogDescription className="text-white/70">
+                            This action cannot be undone. This will permanently delete the town
+                            and all of its associated data, including agents, rigs, and settings.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel className="border-white/10 text-white/70 hover:bg-white/5 hover:text-white">
+                            Cancel
+                          </AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={handleDeleteTown}
+                            className="bg-red-500/80 text-white hover:bg-red-500"
+                          >
+                            {deleteTown.isPending || deleteOrgTown.isPending ? 'Deleting...' : 'Yes, delete town'}
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                   </div>
                 </div>
               </SettingsSection>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogFooter,
   DialogTitle,
   DialogDescription,
+  DialogTrigger,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -37,6 +38,7 @@ const AlertDialogHeader = DialogHeader;
 const AlertDialogFooter = DialogFooter;
 const AlertDialogTitle = DialogTitle;
 const AlertDialogDescription = DialogDescription;
+const AlertDialogTrigger = DialogTrigger;
 
 type AlertDialogCancelProps = React.ComponentPropsWithoutRef<typeof Button>;
 
@@ -63,6 +65,7 @@ export {
   AlertDialogFooter,
   AlertDialogTitle,
   AlertDialogDescription,
+  AlertDialogTrigger,
   AlertDialogCancel,
   AlertDialogAction,
 };


### PR DESCRIPTION
## Summary
- Added a "Danger Zone" section to the Town Settings UI to allow town owners and org owners to permanently delete a town.
- Re-exported `DialogTrigger` as `AlertDialogTrigger` from the UI library to support the delete confirmation dialog.
- The backend implementation of `deleteTown` on both `GastownUserDO` and `GastownOrgDO` alongside `TownDO.destroy()` was pre-existing and comprehensive, including unit tests.

## Verification
- Checked that the `TownSettingsPageClient` renders properly and calls the appropriate API procedure based on ownership.
- Validated correct frontend TS types and linting using `pnpm typecheck` and `pnpm lint`.

## Visual Changes

<img width="1426" height="1095" alt="image" src="https://github.com/user-attachments/assets/037458d0-46de-4240-92a7-22ca6372776b" />

<img width="1426" height="1095" alt="image" src="https://github.com/user-attachments/assets/06a166ba-9114-4882-bbb7-0cf932464daa" />


## Reviewer Notes
N/A