### PR TITLE
feat(gastown): terminal fullscreen toggle and product telemetry

### DIFF
--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -39,8 +39,6 @@ type TerminalBarProps = {
   townId: string;
   /** Override base path for org-scoped routes (e.g. /organizations/[id]/gastown/[townId]) */
   basePath?: string;
-  /** Whether the terminal is in fullscreen mode */
-  fullscreen?: boolean;
 };
 
 /**
@@ -48,7 +46,7 @@ type TerminalBarProps = {
  * Agent terminal tabs are opened/closed via TerminalBarContext.
  * Can be positioned at bottom/top/right/left with drag-to-resize.
  */
-export function TerminalBar({ townId, basePath: basePathOverride, fullscreen: propFullscreen }: TerminalBarProps) {
+export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarProps) {
   const townBasePath = basePathOverride ?? `/gastown/${townId}`;
   const { state: sidebarState, isMobile } = useSidebar();
   const {
@@ -149,9 +147,8 @@ export function TerminalBar({ townId, basePath: basePathOverride, fullscreen: pr
   const effectiveActiveId = activeTabId ?? 'mayor';
   const activeTab = allTabs.find(t => t.id === effectiveActiveId) ?? allTabs[0];
 
-  // ── Fullscreen state ────────────────────────────────────────────────
-  const [localFullscreen, setLocalFullscreen] = useState(false);
-  const isFullscreen = propFullscreen || localFullscreen;
+  // ── Fullscreen state (purely local — toggled via double-click / Escape) ──
+  const [isFullscreen, setLocalFullscreen] = useState(false);
   const previousSizeRef = useRef<number>(size);
 
   const enterFullscreen = useCallback(() => {
@@ -335,7 +332,11 @@ export function TerminalBar({ townId, basePath: basePathOverride, fullscreen: pr
         {position === 'bottom' && (
           <>
             {!collapsed && (
-              <div className={resizeHandleClass} onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick}>
+              <div
+                className={resizeHandleClass}
+                onPointerDown={onResizePointerDown}
+                onDoubleClick={onResizeDoubleClick}
+              >
                 <div className={resizeHandleIndicator} />
               </div>
             )}
@@ -386,7 +387,11 @@ export function TerminalBar({ townId, basePath: basePathOverride, fullscreen: pr
               closeTab={closeTab}
             />
             {!collapsed && (
-              <div className={resizeHandleClass} onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick}>
+              <div
+                className={resizeHandleClass}
+                onPointerDown={onResizePointerDown}
+                onDoubleClick={onResizeDoubleClick}
+              >
                 <div className={resizeHandleIndicator} />
               </div>
             )}
@@ -395,7 +400,11 @@ export function TerminalBar({ townId, basePath: basePathOverride, fullscreen: pr
         {position === 'right' && (
           <>
             {!collapsed && (
-              <div className={resizeHandleClass} onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick}>
+              <div
+                className={resizeHandleClass}
+                onPointerDown={onResizePointerDown}
+                onDoubleClick={onResizeDoubleClick}
+              >
                 <div className={resizeHandleIndicator} />
               </div>
             )}
@@ -446,7 +455,11 @@ export function TerminalBar({ townId, basePath: basePathOverride, fullscreen: pr
               fullscreen={isFullscreen}
             />
             {!collapsed && (
-              <div className={resizeHandleClass} onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick}>
+              <div
+                className={resizeHandleClass}
+                onPointerDown={onResizePointerDown}
+                onDoubleClick={onResizeDoubleClick}
+              >
                 <div className={resizeHandleIndicator} />
               </div>
             )}
@@ -840,7 +853,7 @@ function TerminalContent({
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.15 }}
-        style={fullscreen ? {} : (horizontal ? { height: size } : { width: size })}
+        style={fullscreen ? {} : horizontal ? { height: size } : { width: size }}
         className={`overflow-hidden ${horizontal ? '' : 'h-full'} ${fullscreen ? 'h-full' : ''}`}
       >
         {activeTab.kind === 'mayor' ? (


### PR DESCRIPTION
## Summary

Combines three related improvements shipped together:

- **Terminal fullscreen toggle**: Double-click on the resize bar toggles the TerminalBar into fullscreen (fixed overlay, z-index 100). Escape key exits. Size is saved before entering and restored on exit. A `fullscreen` prop is forwarded to `TerminalContent` so sizing constraints are disabled. A CSS module (`TerminalBar.module.css`) provides the fullscreen and transition styles.
- **Product telemetry via PostHog**: The controller checkin now optionally includes a `productTelemetry` payload (~every 24h with ±2h jitter). The worker picks this up and sends a `kc_instance_product_telemetry` event to PostHog using a fire-and-forget `waitUntil` pattern with a 5s timeout. Skipped in development and when PostHog key is unset. Falls back to `userId` as distinct ID when Hyperdrive is unavailable.
- **Dashboard tab styling**: Refactors the three `TabsTrigger` className strings into a shared `tabTriggerClass` variable (DRY) and updates the visual style to use bordered pill tabs instead of underline tabs.
- **`getContextBalance` tRPC procedure**: New query that returns balance and depletion status for either personal or org context, with org access check.

## Verification

- Tests added for `nextProductTelemetryDeadline` (jitter bounds, edge values)
- Tests added for `collectProductTelemetry` (full config, missing file, malformed JSON, partial config, sibling-section isolation)
- Tests added for PostHog capture path in controller: absent telemetry, missing key, dev mode suppression, successful capture, Hyperdrive fallback, error resilience

## Visual Changes

N/A (tab styling change is a visual tweak but no screenshot provided — minor enough to not warrant one)

## Reviewer Notes

- The double-click detection in `onResizePointerDown` returns early on the second pointer-down event (<300ms) to prevent a drag from starting during a double-click; the actual toggle fires from the separate `onDoubleClick` handler.
- The `as Record<string, unknown>` cast in `product-telemetry.ts` follows an explicit type guard and is unavoidable at the `object` boundary.
- The PostHog project token is public by design (same as `NEXT_PUBLIC_*` convention); safe to commit.