### PR TITLE
feat(cloud-agent): continuation panel

### DIFF
--- a/packages/trpc/dist/index.d.ts
+++ b/packages/trpc/dist/index.d.ts
@@ -6201,6 +6201,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     prompt?: string | undefined;
                     mode?: "custom" | "plan" | "code" | "architect" | "ask" | "debug" | "orchestrator" | "build" | undefined;
                     model?: string | undefined;
+                    variant?: string | undefined;
                     autoCommit?: boolean | undefined;
                     upstreamBranch?: string | undefined;
                     envVarCount?: number | undefined;
@@ -12062,6 +12063,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                     prompt?: string | undefined;
                     mode?: "custom" | "plan" | "code" | "architect" | "ask" | "debug" | "orchestrator" | "build" | undefined;
                     model?: string | undefined;
+                    variant?: string | undefined;
                     autoCommit?: boolean | undefined;
                     upstreamBranch?: string | undefined;
                     envVarCount?: number | undefined;
@@ -13091,6 +13093,7 @@ declare const rootRouter: _trpc_server.TRPCBuiltRouter<{
                 prompt?: string | undefined;
                 mode?: "custom" | "plan" | "code" | "architect" | "ask" | "debug" | "orchestrator" | "build" | undefined;
                 model?: string | undefined;
+                variant?: string | undefined;
                 autoCommit?: boolean | undefined;
                 upstreamBranch?: string | undefined;
                 envVarCount?: number | undefined;

--- a/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -100,91 +100,97 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
 
       cliWebsocketUrl: SESSION_INGEST_WS_URL ? `${SESSION_INGEST_WS_URL}/api/user/web` : undefined,
 
-      send: async payload => {
-        const castSessionId = payload.sessionId as string;
-        const prompt = payload.prompt as string;
-        const mode = payload.mode as 'code' | 'plan' | 'debug' | 'orchestrator' | 'ask';
-        const model = payload.model as string;
-        const variant = payload.variant as string | undefined;
-        if (organizationId) {
-          return trpcClient.organizations.cloudAgentNext.sendMessage.mutate(
-            {
-              cloudAgentSessionId: castSessionId,
-              prompt,
-              mode,
-              model,
-              variant,
-              autoCommit: true,
-              organizationId,
-            },
+      api: {
+        send: async payload => {
+          const castSessionId = payload.sessionId as string;
+          const prompt = payload.prompt as string;
+          const mode = payload.mode as 'code' | 'plan' | 'debug' | 'orchestrator' | 'ask';
+          const model = payload.model as string;
+          const variant = payload.variant as string | undefined;
+          if (organizationId) {
+            return trpcClient.organizations.cloudAgentNext.sendMessage.mutate(
+              {
+                cloudAgentSessionId: castSessionId,
+                prompt,
+                mode,
+                model,
+                variant,
+                autoCommit: true,
+                organizationId,
+              },
+              { context: { skipBatch: true } }
+            );
+          }
+          return trpcClient.cloudAgentNext.sendMessage.mutate(
+            { cloudAgentSessionId: castSessionId, prompt, mode, model, variant, autoCommit: true },
             { context: { skipBatch: true } }
           );
-        }
-        return trpcClient.cloudAgentNext.sendMessage.mutate(
-          { cloudAgentSessionId: castSessionId, prompt, mode, model, variant, autoCommit: true },
-          { context: { skipBatch: true } }
-        );
-      },
+        },
 
-      interrupt: async payload => {
-        if (organizationId) {
-          return trpcClient.organizations.cloudAgentNext.interruptSession.mutate(
-            { organizationId, sessionId: payload.sessionId },
+        interrupt: async payload => {
+          if (organizationId) {
+            return trpcClient.organizations.cloudAgentNext.interruptSession.mutate(
+              { organizationId, sessionId: payload.sessionId },
+              { context: { skipBatch: true } }
+            );
+          }
+          return trpcClient.cloudAgentNext.interruptSession.mutate(
+            { sessionId: payload.sessionId },
             { context: { skipBatch: true } }
           );
-        }
-        return trpcClient.cloudAgentNext.interruptSession.mutate(
-          { sessionId: payload.sessionId },
-          { context: { skipBatch: true } }
-        );
-      },
+        },
 
-      answer: async payload => {
-        // Manager uses requestId; tRPC schema uses questionId
-        if (organizationId) {
-          return trpcClient.organizations.cloudAgentNext.answerQuestion.mutate(
+        answer: async payload => {
+          // Manager uses requestId; tRPC schema uses questionId
+          if (organizationId) {
+            return trpcClient.organizations.cloudAgentNext.answerQuestion.mutate(
+              {
+                organizationId,
+                sessionId: payload.sessionId,
+                questionId: payload.requestId,
+                answers: payload.answers,
+              },
+              { context: { skipBatch: true } }
+            );
+          }
+          return trpcClient.cloudAgentNext.answerQuestion.mutate(
             {
-              organizationId,
               sessionId: payload.sessionId,
               questionId: payload.requestId,
               answers: payload.answers,
             },
             { context: { skipBatch: true } }
           );
-        }
-        return trpcClient.cloudAgentNext.answerQuestion.mutate(
-          { sessionId: payload.sessionId, questionId: payload.requestId, answers: payload.answers },
-          { context: { skipBatch: true } }
-        );
-      },
+        },
 
-      reject: async payload => {
-        // Manager uses requestId; tRPC schema uses questionId
-        if (organizationId) {
-          return trpcClient.organizations.cloudAgentNext.rejectQuestion.mutate(
-            { organizationId, sessionId: payload.sessionId, questionId: payload.requestId },
+        reject: async payload => {
+          // Manager uses requestId; tRPC schema uses questionId
+          if (organizationId) {
+            return trpcClient.organizations.cloudAgentNext.rejectQuestion.mutate(
+              { organizationId, sessionId: payload.sessionId, questionId: payload.requestId },
+              { context: { skipBatch: true } }
+            );
+          }
+          return trpcClient.cloudAgentNext.rejectQuestion.mutate(
+            { sessionId: payload.sessionId, questionId: payload.requestId },
             { context: { skipBatch: true } }
           );
-        }
-        return trpcClient.cloudAgentNext.rejectQuestion.mutate(
-          { sessionId: payload.sessionId, questionId: payload.requestId },
-          { context: { skipBatch: true } }
-        );
-      },
+        },
 
-      respondToPermission: async payload => {
-        const trpc = organizationId
-          ? trpcClient.organizations.cloudAgentNext
-          : trpcClient.cloudAgentNext;
-        await trpc.answerPermission.mutate(
-          {
-            ...(organizationId ? { organizationId } : {}),
-            sessionId: payload.sessionId,
-            permissionId: payload.requestId,
-            response: payload.response,
-          },
-          { context: { skipBatch: true } }
-        );
+        respondToPermission: async payload => {
+          const trpc = organizationId
+            ? trpcClient.organizations.cloudAgentNext
+            : trpcClient.cloudAgentNext;
+          await trpc.answerPermission.mutate(
+            {
+              ...(organizationId ? { organizationId } : {}),
+              sessionId: payload.sessionId,
+              permissionId: payload.requestId,
+              response: payload.response,
+            },
+            { context: { skipBatch: true } }
+          );
+        },
       },
 
       prepare: async input => {

--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -18,6 +18,7 @@ import { WorkingIndicator } from './WorkingIndicator';
 import { QuestionToolCard } from './QuestionToolCard';
 import { QuestionContextProvider } from './QuestionContext';
 import { PermissionCard, PermissionContextProvider } from './PermissionCard';
+import { SessionContinuationPanel } from './SessionContinuationPanel';
 import { isMessageStreaming } from './types';
 import { useOrganizationModels } from './hooks/useOrganizationModels';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
@@ -115,6 +116,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const dynamicMessages = useAtomValue(manager.atoms.dynamicMessages);
   const totalCost = useAtomValue(manager.atoms.totalCost);
   const getChildMessages = useAtomValue(manager.atoms.childMessages);
+  const fetchedSessionData = useAtomValue(manager.atoms.fetchedSessionData);
 
   const setSessionConfig = useSetAtom(manager.atoms.sessionConfig);
 
@@ -244,9 +246,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
       ? 'Setting up environment…'
       : cloudStatus?.type === 'finalizing'
         ? 'Wrapping up…'
-        : !canSend
-          ? 'This session is read-only'
-          : 'Ask anything…';
+        : 'Ask anything…';
 
   // -- Render ---------------------------------------------------------------
   return (
@@ -305,54 +305,56 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                 )}
               </div>
 
-              {activeQuestion && (
-                <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
-                  <QuestionToolCard
-                    key={activeQuestion.requestId}
-                    questions={activeQuestion.questions}
-                    requestId={activeQuestion.requestId}
-                    status="running"
-                  />
-                </div>
-              )}
-              {activePermission && (
-                <div className="flex items-center border-t p-4">
-                  <PermissionCard
-                    key={activePermission.requestId}
-                    requestId={activePermission.requestId}
-                    permission={activePermission.permission}
-                    patterns={activePermission.patterns}
-                    metadata={activePermission.metadata}
-                    always={activePermission.always}
-                  />
-                </div>
-              )}
-              <div className={activeQuestion || activePermission ? 'hidden' : ''}>
-                <ChatInput
-                  onSend={handleSendMessage}
-                  onStop={handleStopExecution}
-                  disabled={isStreaming || !canSend}
-                  isStreaming={isStreaming}
-                  placeholder={placeholder}
-                  slashCommands={availableCommands}
-                  mode={sessionConfig?.mode as AgentMode | undefined}
-                  model={sessionConfig?.model}
-                  modelOptions={modelOptions}
-                  isLoadingModels={isLoadingModels}
-                  onModeChange={handleModeChange}
-                  onModelChange={handleModelChange}
-                  variant={sessionConfig?.variant ?? undefined}
-                  onVariantChange={handleVariantChange}
-                  availableVariants={availableVariants}
-                  showToolbar={Boolean(sessionIdFromParams)}
-                  initialValue={failedPrompt ?? undefined}
-                />
-              </div>
-
-              {isReadOnly && !isLoading && sessionIdFromParams && (
-                <div className="border-border bg-muted/50 text-muted-foreground border-t px-4 py-2 text-center text-xs">
-                  This is a completed session — read only
-                </div>
+              {isReadOnly ? (
+                !isLoading && sessionIdFromParams && fetchedSessionData ? (
+                  <SessionContinuationPanel sessionId={sessionIdFromParams} />
+                ) : null
+              ) : (
+                <>
+                  {activeQuestion && (
+                    <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
+                      <QuestionToolCard
+                        key={activeQuestion.requestId}
+                        questions={activeQuestion.questions}
+                        requestId={activeQuestion.requestId}
+                        status="running"
+                      />
+                    </div>
+                  )}
+                  {activePermission && (
+                    <div className="flex items-center border-t p-4">
+                      <PermissionCard
+                        key={activePermission.requestId}
+                        requestId={activePermission.requestId}
+                        permission={activePermission.permission}
+                        patterns={activePermission.patterns}
+                        metadata={activePermission.metadata}
+                        always={activePermission.always}
+                      />
+                    </div>
+                  )}
+                  <div className={activeQuestion || activePermission ? 'hidden' : ''}>
+                    <ChatInput
+                      onSend={handleSendMessage}
+                      onStop={handleStopExecution}
+                      disabled={isStreaming || !canSend}
+                      isStreaming={isStreaming}
+                      placeholder={placeholder}
+                      slashCommands={availableCommands}
+                      mode={sessionConfig?.mode as AgentMode | undefined}
+                      model={sessionConfig?.model}
+                      modelOptions={modelOptions}
+                      isLoadingModels={isLoadingModels}
+                      onModeChange={handleModeChange}
+                      onModelChange={handleModelChange}
+                      variant={sessionConfig?.variant ?? undefined}
+                      onVariantChange={handleVariantChange}
+                      availableVariants={availableVariants}
+                      showToolbar={Boolean(sessionIdFromParams)}
+                      initialValue={failedPrompt ?? undefined}
+                    />
+                  </div>
+                </>
               )}
             </>
           ) : (

--- a/src/components/cloud-agent-next/SessionContinuationPanel.tsx
+++ b/src/components/cloud-agent-next/SessionContinuationPanel.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Copy, Check, Terminal, ChevronUp } from 'lucide-react';
+import { OpenInEditorButton } from '@/app/share/[shareId]/open-in-editor-button';
+
+type SessionContinuationPanelProps = {
+  sessionId: string;
+};
+
+function SessionContinuationPanel({ sessionId }: SessionContinuationPanelProps) {
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const cliCommand = `kilo --session ${sessionId} --cloud-fork`;
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(cliCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [cliCommand]);
+
+  return (
+    <div className="border-border bg-muted/30 border-t">
+      <button
+        type="button"
+        onClick={() => setExpanded(prev => !prev)}
+        className="text-muted-foreground hover:text-foreground flex w-full items-center justify-between px-[max(1rem,calc(50%_-_27rem))] py-2 text-xs transition-colors"
+      >
+        <span>Continue this session</span>
+        <ChevronUp className={`h-3.5 w-3.5 transition-transform ${expanded ? '' : 'rotate-180'}`} />
+      </button>
+
+      {expanded && (
+        <div className="space-y-3 px-[max(1rem,calc(50%_-_27rem))] pb-4">
+          <OpenInEditorButton sessionId={sessionId} pathOverride={`/s/${sessionId}`} />
+
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <Terminal className="h-3.5 w-3.5" />
+              <span>Or use the CLI</span>
+            </div>
+            <div className="bg-background border-border flex items-center gap-2 rounded-md border px-3 py-2">
+              <code className="text-foreground flex-1 font-mono text-xs">{cliCommand}</code>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                title="Copy command"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-500" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <p className="text-muted-foreground text-xs italic">
+            Continue in Cloud Agent coming soon
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { SessionContinuationPanel };

--- a/src/lib/cloud-agent-sdk/cli-historical-transport.test.ts
+++ b/src/lib/cloud-agent-sdk/cli-historical-transport.test.ts
@@ -183,4 +183,17 @@ describe('CliHistoricalTransport', () => {
     expect(chatEvents).toHaveLength(0);
     expect(serviceEvents).toHaveLength(0);
   });
+
+  it('exposes no command methods (read-only transport)', async () => {
+    const snapshot = makeSnapshot({ id: SES_ID });
+    const { transport } = createTransportWithSinks(() => Promise.resolve(snapshot));
+
+    expect(transport.send).toBeUndefined();
+    expect(transport.interrupt).toBeUndefined();
+    expect(transport.answer).toBeUndefined();
+    expect(transport.reject).toBeUndefined();
+    expect(transport.respondToPermission).toBeUndefined();
+
+    transport.destroy();
+  });
 });

--- a/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
+++ b/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
@@ -576,28 +576,21 @@ describe('CliLiveTransport lifecycle', () => {
   });
 });
 
-function requireSendCommand(transport: ReturnType<typeof createTransportWithSinks>['transport']) {
-  const { sendCommand } = transport;
-  if (!sendCommand) throw new Error('sendCommand not available on transport');
-  return sendCommand.bind(transport);
-}
-
-describe('CliLiveTransport sendCommand', () => {
+describe('CliLiveTransport typed command methods', () => {
   beforeEach(() => {
     jest
       .spyOn(crypto, 'randomUUID')
       .mockReturnValue('mock-uuid-1234' as `${string}-${string}-${string}-${string}-${string}`);
   });
 
-  it('sends command message over WebSocket with correct format', () => {
+  it('send() formats and sends command message over WebSocket', () => {
     const { transport } = createTransportWithSinks();
-    const sendCommand = requireSendCommand(transport);
 
     transport.connect();
     openConnection();
     mockWs.send.mockClear();
 
-    const promise = sendCommand('send_message', { message: 'hello' });
+    const promise = transport.send!({ prompt: 'hello', mode: 'code', model: 'test-model' });
 
     expect(mockWs.send).toHaveBeenCalledWith(
       JSON.stringify({
@@ -605,7 +598,12 @@ describe('CliLiveTransport sendCommand', () => {
         id: 'mock-uuid-1234',
         command: 'send_message',
         sessionId: KILO_SESSION_ID,
-        data: { message: 'hello' },
+        data: {
+          sessionID: KILO_SESSION_ID,
+          parts: [{ type: 'text', text: 'hello' }],
+          agent: 'code',
+          model: 'test-model',
+        },
       })
     );
 
@@ -614,18 +612,113 @@ describe('CliLiveTransport sendCommand', () => {
     return promise;
   });
 
+  it('send() omits agent and model when not provided', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.send!({ prompt: 'hi' });
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as { data: Record<string, unknown> };
+    expect(sent.data).toEqual({
+      sessionID: KILO_SESSION_ID,
+      parts: [{ type: 'text', text: 'hi' }],
+    });
+    // agent and model should not be in the payload
+    expect(sent.data).not.toHaveProperty('agent');
+    expect(sent.data).not.toHaveProperty('model');
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
+  it('interrupt() sends interrupt command', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.interrupt!();
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as { command: string };
+    expect(sent.command).toBe('interrupt');
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
+  it('answer() sends question_reply command', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.answer!({ requestId: 'req-1', answers: [['yes']] });
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as {
+      command: string;
+      data: Record<string, unknown>;
+    };
+    expect(sent.command).toBe('question_reply');
+    expect(sent.data).toEqual({ requestID: 'req-1', answers: [['yes']] });
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
+  it('reject() sends question_reject command', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.reject!({ requestId: 'req-2' });
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as {
+      command: string;
+      data: Record<string, unknown>;
+    };
+    expect(sent.command).toBe('question_reject');
+    expect(sent.data).toEqual({ requestID: 'req-2' });
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
+  it('respondToPermission() sends permission_respond command', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.respondToPermission!({ requestId: 'req-3', response: 'always' });
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as {
+      command: string;
+      data: Record<string, unknown>;
+    };
+    expect(sent.command).toBe('permission_respond');
+    expect(sent.data).toEqual({ requestID: 'req-3', reply: 'always' });
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
   it('resolves when response arrives', async () => {
     const { transport } = createTransportWithSinks();
-    const sendCommand = requireSendCommand(transport);
 
     transport.connect();
     openConnection();
 
-    const promise = sendCommand('send_message', { message: 'hello' });
+    const promise = transport.send!({ prompt: 'hello' });
 
-    const sentPayload = JSON.parse(mockWs.send.mock.calls.at(-1)[0]) as {
-      id: string;
-    };
+    const sentPayload = JSON.parse(mockWs.send.mock.calls.at(-1)[0]) as { id: string };
     sendInbound({ type: 'response', id: sentPayload.id, result: { ok: true } });
 
     await expect(promise).resolves.toEqual({ ok: true });
@@ -635,16 +728,13 @@ describe('CliLiveTransport sendCommand', () => {
 
   it('rejects when error response arrives', async () => {
     const { transport } = createTransportWithSinks();
-    const sendCommand = requireSendCommand(transport);
 
     transport.connect();
     openConnection();
 
-    const promise = sendCommand('send_message', { message: 'fail' });
+    const promise = transport.send!({ prompt: 'fail' });
 
-    const sentPayload = JSON.parse(mockWs.send.mock.calls.at(-1)[0]) as {
-      id: string;
-    };
+    const sentPayload = JSON.parse(mockWs.send.mock.calls.at(-1)[0]) as { id: string };
     sendInbound({ type: 'response', id: sentPayload.id, error: 'bad request' });
 
     await expect(promise).rejects.toThrow('bad request');
@@ -654,21 +744,19 @@ describe('CliLiveTransport sendCommand', () => {
 
   it('rejects with "WebSocket is not connected" when not connected', async () => {
     const { transport } = createTransportWithSinks();
-    const sendCommand = requireSendCommand(transport);
 
-    await expect(sendCommand('send_message', { message: 'hello' })).rejects.toThrow(
+    await expect(transport.send!({ prompt: 'hello' })).rejects.toThrow(
       'WebSocket is not connected'
     );
   });
 
   it('rejects pending commands on disconnect', async () => {
     const { transport } = createTransportWithSinks();
-    const sendCommand = requireSendCommand(transport);
 
     transport.connect();
     openConnection();
 
-    const promise = sendCommand('send_message', { message: 'hello' });
+    const promise = transport.send!({ prompt: 'hello' });
 
     transport.disconnect();
 
@@ -677,12 +765,11 @@ describe('CliLiveTransport sendCommand', () => {
 
   it('rejects pending commands on destroy', async () => {
     const { transport } = createTransportWithSinks();
-    const sendCommand = requireSendCommand(transport);
 
     transport.connect();
     openConnection();
 
-    const promise = sendCommand('send_message', { message: 'hello' });
+    const promise = transport.send!({ prompt: 'hello' });
 
     transport.destroy();
 
@@ -705,12 +792,11 @@ describe('CliLiveTransport sendCommand', () => {
     jest.useFakeTimers();
     try {
       const { transport } = createTransportWithSinks();
-      const sendCommand = requireSendCommand(transport);
 
       transport.connect();
       openConnection();
 
-      const promise = sendCommand('send_message', { message: 'hello' });
+      const promise = transport.send!({ prompt: 'hello' });
 
       jest.advanceTimersByTime(30_000);
 
@@ -726,16 +812,13 @@ describe('CliLiveTransport sendCommand', () => {
     jest.useFakeTimers();
     try {
       const { transport } = createTransportWithSinks();
-      const sendCommand = requireSendCommand(transport);
 
       transport.connect();
       openConnection();
 
-      const promise = sendCommand('send_message', { message: 'hello' });
+      const promise = transport.send!({ prompt: 'hello' });
 
-      const sentPayload = JSON.parse(mockWs.send.mock.calls.at(-1)[0]) as {
-        id: string;
-      };
+      const sentPayload = JSON.parse(mockWs.send.mock.calls.at(-1)[0]) as { id: string };
       sendInbound({
         type: 'response',
         id: sentPayload.id,

--- a/src/lib/cloud-agent-sdk/cli-live-transport.ts
+++ b/src/lib/cloud-agent-sdk/cli-live-transport.ts
@@ -211,6 +211,30 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
       );
     }
 
+    function rawSendCommand(command: string, data: unknown): Promise<unknown> {
+      if (!currentWs || currentWs.readyState !== WebSocket.OPEN) {
+        return Promise.reject(new Error('WebSocket is not connected'));
+      }
+      const id = crypto.randomUUID();
+      const ws = currentWs;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingCommands.delete(id);
+          reject(new Error('Command timed out'));
+        }, COMMAND_TIMEOUT_MS);
+        pendingCommands.set(id, { resolve, reject, timer });
+        ws.send(
+          JSON.stringify({
+            type: 'command',
+            id,
+            command,
+            sessionId: config.kiloSessionId,
+            data,
+          })
+        );
+      });
+    }
+
     return {
       connect() {
         console.log(
@@ -256,29 +280,29 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         );
       },
 
-      sendCommand(command: string, data: unknown): Promise<unknown> {
-        if (!currentWs || currentWs.readyState !== WebSocket.OPEN) {
-          return Promise.reject(new Error('WebSocket is not connected'));
-        }
-        const id = crypto.randomUUID();
-        const ws = currentWs;
-        return new Promise((resolve, reject) => {
-          const timer = setTimeout(() => {
-            pendingCommands.delete(id);
-            reject(new Error('Command timed out'));
-          }, COMMAND_TIMEOUT_MS);
-          pendingCommands.set(id, { resolve, reject, timer });
-          ws.send(
-            JSON.stringify({
-              type: 'command',
-              id,
-              command,
-              sessionId: config.kiloSessionId,
-              data,
-            })
-          );
-        });
-      },
+      send: (payload: { prompt: string; mode?: string; model?: string; variant?: string }) =>
+        rawSendCommand('send_message', {
+          sessionID: config.kiloSessionId,
+          parts: [{ type: 'text', text: payload.prompt }],
+          ...(payload.mode ? { agent: payload.mode } : {}),
+          ...(payload.model ? { model: payload.model } : {}),
+          ...(payload.variant ? { variant: payload.variant } : {}),
+        }),
+      interrupt: () => rawSendCommand('interrupt', {}),
+      answer: (payload: { requestId: string; answers: unknown }) =>
+        rawSendCommand('question_reply', {
+          requestID: payload.requestId,
+          answers: payload.answers,
+        }),
+      reject: (payload: { requestId: string }) =>
+        rawSendCommand('question_reject', {
+          requestID: payload.requestId,
+        }),
+      respondToPermission: (payload: { requestId: string; response: unknown }) =>
+        rawSendCommand('permission_respond', {
+          requestID: payload.requestId,
+          reply: payload.response,
+        }),
 
       disconnect() {
         generation += 1;

--- a/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
+++ b/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
@@ -60,9 +60,20 @@ function sendRaw(event: CloudAgentEvent): void {
   mockWs.onmessage?.({ data: JSON.stringify(event) } as MessageEvent);
 }
 
+function createMockApi() {
+  return {
+    send: jest.fn(() => Promise.resolve('sent')),
+    interrupt: jest.fn(() => Promise.resolve('interrupted')),
+    answer: jest.fn(() => Promise.resolve('answered')),
+    reject: jest.fn(() => Promise.resolve('rejected')),
+    respondToPermission: jest.fn(() => Promise.resolve('responded')),
+  };
+}
+
 function createTransportWithSinks(
   getTicket: (sessionId: string) => string | Promise<string> = () => 'test-ticket',
-  onError?: (message: string) => void
+  onError?: (message: string) => void,
+  api = createMockApi()
 ) {
   const chatEvents: ChatEvent[] = [];
   const serviceEvents: ServiceEvent[] = [];
@@ -70,6 +81,7 @@ function createTransportWithSinks(
   const factory = createCloudAgentTransport({
     sessionId: cloudAgentId('ses-1'),
     kiloSessionId: kiloId('ses-1'),
+    api,
     getTicket,
     fetchSnapshot: () => Promise.resolve(emptySnapshot),
     websocketBaseUrl: 'ws://localhost:9999',
@@ -81,7 +93,7 @@ function createTransportWithSinks(
     onServiceEvent: event => serviceEvents.push(event),
   });
 
-  return { transport, chatEvents, serviceEvents };
+  return { transport, chatEvents, serviceEvents, api };
 }
 
 const { createEvent, kilocode, resetCounter } = createEventHelpers();
@@ -299,5 +311,78 @@ describe('CloudAgentTransport lifecycle', () => {
     // The initial connect() didn't create a WS (ticket was async and unresolved),
     // so no WS should have been constructed at all.
     expect(constructorCallsAfterDisconnect).toBe(0);
+  });
+});
+
+describe('CloudAgentTransport command delegation', () => {
+  it('send() delegates to api.send with bound sessionId', () => {
+    const api = createMockApi();
+    const { transport } = createTransportWithSinks(undefined, undefined, api);
+
+    void transport.send!({ prompt: 'hello', mode: 'code', model: 'gpt-4' });
+
+    expect(api.send).toHaveBeenCalledWith({
+      sessionId: 'ses-1',
+      prompt: 'hello',
+      mode: 'code',
+      model: 'gpt-4',
+    });
+
+    transport.destroy();
+  });
+
+  it('interrupt() delegates to api.interrupt with bound sessionId', () => {
+    const api = createMockApi();
+    const { transport } = createTransportWithSinks(undefined, undefined, api);
+
+    void transport.interrupt!();
+
+    expect(api.interrupt).toHaveBeenCalledWith({ sessionId: 'ses-1' });
+
+    transport.destroy();
+  });
+
+  it('answer() delegates to api.answer with bound sessionId', () => {
+    const api = createMockApi();
+    const { transport } = createTransportWithSinks(undefined, undefined, api);
+
+    void transport.answer!({ requestId: 'req-1', answers: [['yes']] });
+
+    expect(api.answer).toHaveBeenCalledWith({
+      sessionId: 'ses-1',
+      requestId: 'req-1',
+      answers: [['yes']],
+    });
+
+    transport.destroy();
+  });
+
+  it('reject() delegates to api.reject with bound sessionId', () => {
+    const api = createMockApi();
+    const { transport } = createTransportWithSinks(undefined, undefined, api);
+
+    void transport.reject!({ requestId: 'req-2' });
+
+    expect(api.reject).toHaveBeenCalledWith({
+      sessionId: 'ses-1',
+      requestId: 'req-2',
+    });
+
+    transport.destroy();
+  });
+
+  it('respondToPermission() delegates to api.respondToPermission with bound sessionId', () => {
+    const api = createMockApi();
+    const { transport } = createTransportWithSinks(undefined, undefined, api);
+
+    void transport.respondToPermission!({ requestId: 'req-3', response: 'once' });
+
+    expect(api.respondToPermission).toHaveBeenCalledWith({
+      sessionId: 'ses-1',
+      requestId: 'req-3',
+      response: 'once',
+    });
+
+    transport.destroy();
   });
 });

--- a/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
+++ b/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
@@ -11,11 +11,12 @@ import { createConnection, type Connection } from './cloud-agent-connection';
 import { normalize, isChatEvent } from './normalizer';
 import type { ServiceEvent } from './normalizer';
 import type { CloudAgentSessionId, KiloSessionId, SessionSnapshot } from './types';
-import type { TransportFactory, TransportSink } from './transport';
+import type { CloudAgentApi, TransportFactory, TransportSink } from './transport';
 
 type CloudAgentTransportConfig = {
   sessionId: CloudAgentSessionId;
   kiloSessionId: KiloSessionId;
+  api: CloudAgentApi;
   getTicket: (sessionId: CloudAgentSessionId) => string | Promise<string>;
   fetchSnapshot: (kiloSessionId: KiloSessionId) => Promise<SessionSnapshot>;
   websocketBaseUrl?: string;
@@ -141,6 +142,13 @@ function createCloudAgentTransport(config: CloudAgentTransportConfig): Transport
         lifecycleGeneration += 1;
         closeConnection('destroy');
       },
+
+      send: payload => config.api.send({ sessionId: config.sessionId, ...payload }),
+      interrupt: () => config.api.interrupt({ sessionId: config.sessionId }),
+      answer: payload => config.api.answer({ sessionId: config.sessionId, ...payload }),
+      reject: payload => config.api.reject({ sessionId: config.sessionId, ...payload }),
+      respondToPermission: payload =>
+        config.api.respondToPermission({ sessionId: config.sessionId, ...payload }),
     };
   };
 }

--- a/src/lib/cloud-agent-sdk/index.ts
+++ b/src/lib/cloud-agent-sdk/index.ts
@@ -21,10 +21,6 @@ export type {
   CloudAgentSessionRespondToPermissionInput,
   CloudAgentSessionSendInput,
   CloudAgentSessionTransport,
-  CloudAgentSessionTransportAnswerInput,
-  CloudAgentSessionTransportInterruptInput,
-  CloudAgentSessionTransportRejectInput,
-  CloudAgentSessionTransportRespondToPermissionInput,
   PermissionResponse,
 } from './session';
 
@@ -51,7 +47,7 @@ export type { CliHistoricalTransportConfig } from './cli-historical-transport';
 export { createCliLiveTransport } from './cli-live-transport';
 export type { CliLiveTransportConfig } from './cli-live-transport';
 
-export type { TransportSink, Transport, TransportFactory } from './transport';
+export type { TransportSink, Transport, TransportFactory, CloudAgentApi } from './transport';
 
 export { createConnection } from './cloud-agent-connection';
 export type { Connection, ConnectionConfig } from './cloud-agent-connection';

--- a/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -17,8 +17,10 @@ const mockSession = {
   disconnect: jest.fn(),
   destroy: jest.fn(),
   send: jest.fn(),
+  interrupt: jest.fn(),
   answer: jest.fn(),
   reject: jest.fn(),
+  respondToPermission: jest.fn(),
   canSend: true,
   canInterrupt: true,
   state: {
@@ -92,11 +94,13 @@ function createMockConfig(overrides: Partial<SessionManagerConfig> = {}): Sessio
     getTicket: jest.fn().mockResolvedValue('ticket-123'),
     fetchSnapshot: jest.fn().mockResolvedValue({ info: {}, messages: [] }),
     getAuthToken: jest.fn().mockResolvedValue('token-123'),
-    send: jest.fn().mockResolvedValue({}),
-    interrupt: jest.fn().mockResolvedValue({}),
-    answer: jest.fn().mockResolvedValue({}),
-    reject: jest.fn().mockResolvedValue({}),
-    respondToPermission: jest.fn().mockResolvedValue({}),
+    api: {
+      send: jest.fn().mockResolvedValue({}),
+      interrupt: jest.fn().mockResolvedValue({}),
+      answer: jest.fn().mockResolvedValue({}),
+      reject: jest.fn().mockResolvedValue({}),
+      respondToPermission: jest.fn().mockResolvedValue({}),
+    },
     prepare: jest.fn().mockResolvedValue({ cloudAgentSessionId: cloudAgentId('agent-new') }),
     initiate: jest.fn().mockResolvedValue({}),
     fetchSession: jest.fn().mockResolvedValue(defaultFetchedSession),
@@ -121,6 +125,8 @@ describe('createSessionManager', () => {
     mockSession.disconnect.mockClear();
     mockSession.destroy.mockClear();
     mockSession.send.mockClear();
+    mockSession.interrupt.mockClear();
+    mockSession.respondToPermission.mockClear();
     mockSession.canSend = true;
     mockSession.canInterrupt = true;
     mockSession.state.subscribe.mockImplementation(() => () => {});
@@ -564,14 +570,14 @@ describe('createSessionManager', () => {
   // -------------------------------------------------------------------------
 
   describe('interrupt', () => {
-    it('calls config.interrupt and sets info indicator', async () => {
+    it('calls session.interrupt and sets info indicator', async () => {
       const config = createMockConfig();
       const mgr = createSessionManager(config);
 
       await mgr.switchSession(kiloId('ses-1'));
       await mgr.interrupt();
 
-      expect(config.interrupt).toHaveBeenCalledWith({ sessionId: 'agent-1' });
+      expect(mockSession.interrupt).toHaveBeenCalledTimes(1);
       const indicator = atomValue<{ type: string; message: string } | null>(
         config.store,
         mgr.atoms.statusIndicator
@@ -582,12 +588,11 @@ describe('createSessionManager', () => {
     });
 
     it('sets error on failure', async () => {
-      const config = createMockConfig({
-        interrupt: jest.fn().mockRejectedValue(new Error('interrupt failed')),
-      });
+      const config = createMockConfig();
       const mgr = createSessionManager(config);
 
       await mgr.switchSession(kiloId('ses-1'));
+      mockSession.interrupt.mockRejectedValueOnce(new Error('interrupt failed'));
       await mgr.interrupt();
 
       expect(atomValue<string | null>(config.store, mgr.atoms.error)).toBe(
@@ -602,7 +607,7 @@ describe('createSessionManager', () => {
       // No switchSession
       await mgr.interrupt();
 
-      expect(config.interrupt).not.toHaveBeenCalled();
+      expect(mockSession.interrupt).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -5,6 +5,7 @@ import { createCloudAgentSession } from './session';
 import type { CloudAgentSession } from './session';
 import { createJotaiStorage } from './storage/jotai';
 import type { JotaiSessionStorage, JotaiStore } from './storage/jotai';
+import type { CloudAgentApi } from './transport';
 import type {
   CloudAgentSessionId,
   KiloSessionId,
@@ -86,19 +87,7 @@ type SessionManagerConfig = {
   getAuthToken: () => string | Promise<string>;
   cliWebsocketUrl?: string;
   websocketBaseUrl?: string;
-  send: (payload: { sessionId: CloudAgentSessionId } & Record<string, unknown>) => Promise<unknown>;
-  interrupt: (payload: { sessionId: CloudAgentSessionId }) => Promise<unknown>;
-  answer: (payload: {
-    sessionId: CloudAgentSessionId;
-    requestId: string;
-    answers: string[][];
-  }) => Promise<unknown>;
-  reject: (payload: { sessionId: CloudAgentSessionId; requestId: string }) => Promise<unknown>;
-  respondToPermission: (payload: {
-    sessionId: CloudAgentSessionId;
-    requestId: string;
-    response: 'once' | 'always' | 'reject';
-  }) => Promise<unknown>;
+  api: CloudAgentApi;
   prepare: (input: PrepareInput) => Promise<{ cloudAgentSessionId: CloudAgentSessionId }>;
   initiate: (input: { cloudAgentSessionId: CloudAgentSessionId }) => Promise<unknown>;
   fetchSession: (kiloSessionId: KiloSessionId) => Promise<FetchedSessionData>;
@@ -114,7 +103,7 @@ type W<T> = WritableAtom<T, [T], void>;
 type SessionManagerAtoms = {
   isStreaming: W<boolean>;
   isLoading: W<boolean>;
-  /** Session structurally cannot accept input (no transport send/sendCommand). */
+  /** Session structurally cannot accept input (no transport send). */
   isReadOnly: W<boolean>;
   canSend: W<boolean>;
   canInterrupt: W<boolean>;
@@ -132,6 +121,7 @@ type SessionManagerAtoms = {
   chatUI: W<{ shouldAutoScroll: boolean }>;
   permission: W<PermissionState | null>;
   failedPrompt: W<string | null>;
+  fetchedSessionData: W<FetchedSessionData | null>;
   messagesList: Atom<StoredMessage[]>;
   staticMessages: Atom<StoredMessage[]>;
   dynamicMessages: Atom<StoredMessage[]>;
@@ -256,6 +246,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   const permissionAtom = atom<PermissionState | null>(null);
   const activePermissionAtom = atom<StandalonePermission | null>(null);
   const failedPromptAtom = atom<string | null>(null);
+  const fetchedSessionDataAtom = atom<FetchedSessionData | null>(null);
 
   // Derived atoms
   const messagesListAtom = atom<StoredMessage[]>(get => {
@@ -346,6 +337,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(permissionAtom, null);
     store.set(activePermissionAtom, null);
     store.set(failedPromptAtom, null);
+    store.set(fetchedSessionDataAtom, null);
   }
 
   function subscribeToServiceState(
@@ -446,6 +438,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       return;
     }
     if (kiloSessionId !== activeSessionId) return;
+    store.set(fetchedSessionDataAtom, data);
 
     // Populate session metadata and swap in the new storage eagerly.
     // The storage starts empty; snapshot replay (inside session.connect)
@@ -467,10 +460,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       resolveSession: config.resolveSession,
       transport: {
         getTicket: config.getTicket,
-        send: config.send,
-        answer: config.answer,
-        reject: config.reject,
-        respondToPermission: config.respondToPermission,
+        api: config.api,
         fetchSnapshot: config.fetchSnapshot,
         getAuthToken: config.getAuthToken,
         cliWebsocketUrl: config.cliWebsocketUrl,
@@ -586,11 +576,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
   async function interrupt(): Promise<void> {
     if (!currentSession) return;
-    const sid = store.get(sessionIdAtom);
     try {
-      if (sid) {
-        await config.interrupt({ sessionId: sid });
-      } else if (currentSession.canInterrupt) {
+      if (currentSession.canInterrupt) {
         await currentSession.interrupt();
       }
       currentSession.disconnect();
@@ -676,6 +663,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       permission: permissionAtom,
       activePermission: activePermissionAtom,
       failedPrompt: failedPromptAtom,
+      fetchedSessionData: fetchedSessionDataAtom,
       messagesList: messagesListAtom,
       staticMessages: staticMessagesAtom,
       dynamicMessages: dynamicMessagesAtom,

--- a/src/lib/cloud-agent-sdk/session-phase.test.ts
+++ b/src/lib/cloud-agent-sdk/session-phase.test.ts
@@ -91,6 +91,13 @@ function createSessionWithStateCapture(
     transport: {
       getTicket: getTicketMock,
       fetchSnapshot: () => Promise.resolve(emptySnapshot),
+      api: {
+        send: () => Promise.resolve(),
+        interrupt: () => Promise.resolve(),
+        answer: () => Promise.resolve(),
+        reject: () => Promise.resolve(),
+        respondToPermission: () => Promise.resolve(),
+      },
     },
     onError: (msg: string) => errors.push(msg),
     onBranchChanged: (branch: string) => branches.push(branch),
@@ -376,6 +383,13 @@ describe('session state transitions', () => {
       transport: {
         getTicket: getTicketMock,
         fetchSnapshot: () => Promise.resolve(emptySnapshot),
+        api: {
+          send: () => Promise.resolve(),
+          interrupt: () => Promise.resolve(),
+          answer: () => Promise.resolve(),
+          reject: () => Promise.resolve(),
+          respondToPermission: () => Promise.resolve(),
+        },
       },
       onSessionCreated: (info: SessionInfo) => sessions.push(info),
     });

--- a/src/lib/cloud-agent-sdk/session-routing.test.ts
+++ b/src/lib/cloud-agent-sdk/session-routing.test.ts
@@ -89,6 +89,13 @@ describe('session transport routing', () => {
         transport: {
           getTicket: () => 'test-ticket',
           fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses-1' })),
+          api: {
+            send: () => Promise.resolve(),
+            interrupt: () => Promise.resolve(),
+            answer: () => Promise.resolve(),
+            reject: () => Promise.resolve(),
+            respondToPermission: () => Promise.resolve(),
+          },
         },
       });
 
@@ -185,6 +192,10 @@ describe('session transport routing', () => {
       // Messages in storage
       const messageIds = session.storage.getMessageIds();
       expect(messageIds).toContain('msg-1');
+
+      // Historical session should not be interactive
+      expect(session.canSend).toBe(false);
+      expect(session.canInterrupt).toBe(false);
 
       session.destroy();
     });
@@ -304,6 +315,40 @@ describe('session transport routing', () => {
 
       expect(onError).toHaveBeenCalledWith(
         'CloudAgentSession transport.fetchSnapshot is required for Cloud Agent sessions'
+      );
+      expect(session.state.getActivity()).toEqual({ type: 'idle' });
+      expect(session.state.getStatus().type).toBe('error');
+
+      session.destroy();
+    });
+
+    it('sets error state when Cloud Agent session lacks api', async () => {
+      const onError = jest.fn();
+
+      const resolveSession = jest.fn(
+        (): Promise<ResolvedSession> =>
+          Promise.resolve({
+            kiloSessionId: kiloId('ses-1'),
+            cloudAgentSessionId: cloudAgentId('do-1'),
+            isLive: true,
+          })
+      );
+
+      const session = createCloudAgentSession({
+        kiloSessionId: kiloId('ses-1'),
+        resolveSession,
+        transport: {
+          getTicket: () => 'ticket',
+          fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses-1' })),
+        },
+        onError,
+      });
+
+      session.connect();
+      await Promise.resolve();
+
+      expect(onError).toHaveBeenCalledWith(
+        'CloudAgentSession transport.api is required for Cloud Agent sessions'
       );
       expect(session.state.getActivity()).toEqual({ type: 'idle' });
       expect(session.state.getStatus().type).toBe('error');

--- a/src/lib/cloud-agent-sdk/session-transport.test.ts
+++ b/src/lib/cloud-agent-sdk/session-transport.test.ts
@@ -1,9 +1,6 @@
-import {
-  createCloudAgentSession,
-  type CloudAgentSession,
-  type CloudAgentSessionTransport,
-} from './session';
-import { kiloId, cloudAgentId } from './test-helpers';
+import { createCloudAgentSession, type CloudAgentSession } from './session';
+import type { CloudAgentApi } from './transport';
+import { kiloId, cloudAgentId, makeSnapshot } from './test-helpers';
 
 // ---------------------------------------------------------------------------
 // WebSocket mock — needed because connect() → resolveSession → transport → WS
@@ -48,7 +45,23 @@ afterEach(() => {
 const kiloSessionId = kiloId('ses_transport-tests');
 const cloudAgentSessionId = cloudAgentId('agent_12345678-1234-1234-1234-123456789abc');
 
-function createResolvedSession(transport: CloudAgentSessionTransport): CloudAgentSession {
+function createMockApi(): CloudAgentApi & {
+  send: jest.Mock;
+  interrupt: jest.Mock;
+  answer: jest.Mock;
+  reject: jest.Mock;
+  respondToPermission: jest.Mock;
+} {
+  return {
+    send: jest.fn(() => Promise.resolve('sent')),
+    interrupt: jest.fn(() => Promise.resolve('interrupted')),
+    answer: jest.fn(() => Promise.resolve('answered')),
+    reject: jest.fn(() => Promise.resolve('rejected')),
+    respondToPermission: jest.fn(() => Promise.resolve('responded')),
+  };
+}
+
+function createCloudAgentResolvedSession(api: CloudAgentApi): CloudAgentSession {
   return createCloudAgentSession({
     kiloSessionId,
     resolveSession: async () => ({
@@ -56,7 +69,11 @@ function createResolvedSession(transport: CloudAgentSessionTransport): CloudAgen
       cloudAgentSessionId,
       isLive: true,
     }),
-    transport,
+    transport: {
+      getTicket: () => 'ticket',
+      api,
+      fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses_transport-tests' })),
+    },
     websocketBaseUrl: 'ws://localhost:9999',
   });
 }
@@ -75,55 +92,46 @@ async function connectSession(session: CloudAgentSession): Promise<void> {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('session transport delegation', () => {
-  it('session.send() delegates to transport.send with resolved cloudAgentSessionId', async () => {
-    const send = jest.fn((_payload: Record<string, unknown>) => Promise.resolve('ok'));
-    const session = createResolvedSession({ getTicket: () => 'ticket', send });
+describe('session transport delegation (cloud agent)', () => {
+  it('session.send() delegates to api.send with resolved cloudAgentSessionId', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
 
     await connectSession(session);
-    await Promise.resolve(session.send({ message: 'hello', mode: 'auto' }));
+    await session.send({ prompt: 'hello', mode: 'auto' });
 
-    expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith({
+    expect(api.send).toHaveBeenCalledTimes(1);
+    expect(api.send).toHaveBeenCalledWith({
       sessionId: cloudAgentSessionId,
-      message: 'hello',
+      prompt: 'hello',
       mode: 'auto',
     });
 
     session.destroy();
   });
 
-  it('session.interrupt() delegates to transport.interrupt with resolved cloudAgentSessionId', async () => {
-    const interrupt = jest.fn((_payload: { sessionId: string }) => Promise.resolve('ok'));
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      interrupt,
-    });
+  it('session.interrupt() delegates to api.interrupt with resolved cloudAgentSessionId', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
 
     await connectSession(session);
-    await Promise.resolve(session.interrupt());
+    await session.interrupt();
 
-    expect(interrupt).toHaveBeenCalledTimes(1);
-    expect(interrupt).toHaveBeenCalledWith({ sessionId: cloudAgentSessionId });
+    expect(api.interrupt).toHaveBeenCalledTimes(1);
+    expect(api.interrupt).toHaveBeenCalledWith({ sessionId: cloudAgentSessionId });
 
     session.destroy();
   });
 
-  it('session.answer() delegates to transport.answer with resolved cloudAgentSessionId', async () => {
-    const answer = jest.fn(
-      (_payload: { sessionId: string; requestId: string; answers: string[][] }) =>
-        Promise.resolve('ok')
-    );
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      answer,
-    });
+  it('session.answer() delegates to api.answer with resolved cloudAgentSessionId', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
 
     await connectSession(session);
-    await Promise.resolve(session.answer({ requestId: 'req-1', answers: [['yes']] }));
+    await session.answer({ requestId: 'req-1', answers: [['yes']] });
 
-    expect(answer).toHaveBeenCalledTimes(1);
-    expect(answer).toHaveBeenCalledWith({
+    expect(api.answer).toHaveBeenCalledTimes(1);
+    expect(api.answer).toHaveBeenCalledWith({
       sessionId: cloudAgentSessionId,
       requestId: 'req-1',
       answers: [['yes']],
@@ -132,20 +140,15 @@ describe('session transport delegation', () => {
     session.destroy();
   });
 
-  it('session.reject() delegates to transport.reject with resolved cloudAgentSessionId', async () => {
-    const reject = jest.fn((_payload: { sessionId: string; requestId: string }) =>
-      Promise.resolve('ok')
-    );
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      reject,
-    });
+  it('session.reject() delegates to api.reject with resolved cloudAgentSessionId', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
 
     await connectSession(session);
-    await Promise.resolve(session.reject({ requestId: 'req-2' }));
+    await session.reject({ requestId: 'req-2' });
 
-    expect(reject).toHaveBeenCalledTimes(1);
-    expect(reject).toHaveBeenCalledWith({
+    expect(api.reject).toHaveBeenCalledTimes(1);
+    expect(api.reject).toHaveBeenCalledWith({
       sessionId: cloudAgentSessionId,
       requestId: 'req-2',
     });
@@ -153,21 +156,15 @@ describe('session transport delegation', () => {
     session.destroy();
   });
 
-  it('session.respondToPermission() delegates with resolved cloudAgentSessionId', async () => {
-    const respondToPermission = jest.fn(
-      (_payload: { sessionId: string; requestId: string; response: string }) =>
-        Promise.resolve('ok')
-    );
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      respondToPermission,
-    });
+  it('session.respondToPermission() delegates to api.respondToPermission', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
 
     await connectSession(session);
-    await Promise.resolve(session.respondToPermission({ requestId: 'req-3', response: 'once' }));
+    await session.respondToPermission({ requestId: 'req-3', response: 'once' });
 
-    expect(respondToPermission).toHaveBeenCalledTimes(1);
-    expect(respondToPermission).toHaveBeenCalledWith({
+    expect(api.respondToPermission).toHaveBeenCalledTimes(1);
+    expect(api.respondToPermission).toHaveBeenCalledWith({
       sessionId: cloudAgentSessionId,
       requestId: 'req-3',
       response: 'once',
@@ -177,45 +174,65 @@ describe('session transport delegation', () => {
   });
 });
 
-describe('commands throw before session is resolved', () => {
+describe('commands throw before transport is connected', () => {
   it('session.send() throws if called before connect()', () => {
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      send: jest.fn(),
-    });
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
 
-    expect(() => session.send({ message: 'hello' })).toThrow('Session not resolved yet');
-
-    session.destroy();
-  });
-
-  it('session.interrupt() throws if called before connect()', () => {
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      interrupt: jest.fn(),
-    });
-
-    expect(() => session.interrupt()).toThrow('Session not resolved yet');
-
-    session.destroy();
-  });
-});
-
-describe('session transport missing command methods', () => {
-  it('session.send() throws when transport.send is missing', async () => {
-    const session = createResolvedSession({ getTicket: () => 'ticket' });
-    await connectSession(session);
-
-    expect(() => session.send({ message: 'hello' })).toThrow(
+    expect(() => session.send({ prompt: 'hello' })).toThrow(
       'CloudAgentSession transport.send is not configured'
     );
 
     session.destroy();
   });
 
-  it('session.interrupt() throws when transport.interrupt is missing', async () => {
-    const session = createResolvedSession({ getTicket: () => 'ticket' });
-    await connectSession(session);
+  it('session.interrupt() throws if called before connect()', () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
+
+    expect(() => session.interrupt()).toThrow(
+      'CloudAgentSession transport.interrupt is not configured'
+    );
+
+    session.destroy();
+  });
+});
+
+describe('session transport missing command methods (historical session)', () => {
+  function createHistoricalSession(): CloudAgentSession {
+    return createCloudAgentSession({
+      kiloSessionId: kiloId('ses_historical'),
+      resolveSession: async () => ({
+        kiloSessionId: kiloId('ses_historical'),
+        cloudAgentSessionId: null,
+        isLive: false,
+      }),
+      transport: {
+        fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses_historical' })),
+      },
+    });
+  }
+
+  async function connectHistorical(session: CloudAgentSession): Promise<void> {
+    session.connect();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+  }
+
+  it('session.send() throws for historical session', async () => {
+    const session = createHistoricalSession();
+    await connectHistorical(session);
+
+    expect(() => session.send({ prompt: 'hello' })).toThrow(
+      'CloudAgentSession transport.send is not configured'
+    );
+
+    session.destroy();
+  });
+
+  it('session.interrupt() throws for historical session', async () => {
+    const session = createHistoricalSession();
+    await connectHistorical(session);
 
     expect(() => session.interrupt()).toThrow(
       'CloudAgentSession transport.interrupt is not configured'
@@ -224,9 +241,9 @@ describe('session transport missing command methods', () => {
     session.destroy();
   });
 
-  it('session.answer() throws when transport.answer is missing', async () => {
-    const session = createResolvedSession({ getTicket: () => 'ticket' });
-    await connectSession(session);
+  it('session.answer() throws for historical session', async () => {
+    const session = createHistoricalSession();
+    await connectHistorical(session);
 
     expect(() => session.answer({ requestId: 'req-3', answers: [[]] })).toThrow(
       'CloudAgentSession transport.answer is not configured'
@@ -235,9 +252,9 @@ describe('session transport missing command methods', () => {
     session.destroy();
   });
 
-  it('session.reject() throws when transport.reject is missing', async () => {
-    const session = createResolvedSession({ getTicket: () => 'ticket' });
-    await connectSession(session);
+  it('session.reject() throws for historical session', async () => {
+    const session = createHistoricalSession();
+    await connectHistorical(session);
 
     expect(() => session.reject({ requestId: 'req-4' })).toThrow(
       'CloudAgentSession transport.reject is not configured'
@@ -247,13 +264,10 @@ describe('session transport missing command methods', () => {
   });
 });
 
-describe('CLI live session send via sendCommand', () => {
-  // Simulates the CLI live transport path where cloudAgentSessionId is null.
-  // The session should send commands using kiloSessionId, not cloudAgentSessionId.
+describe('CLI live session send via typed transport methods', () => {
   const cliKiloSessionId = kiloId('ses_cli-live-session');
 
-  it('session.send() uses kiloSessionId (not cloudAgentSessionId) for sendCommand path', async () => {
-    // Create a session that resolves as CLI live (cloudAgentSessionId = null)
+  it('session.send() uses kiloSessionId for CLI live sessions', async () => {
     const session = createCloudAgentSession({
       kiloSessionId: cliKiloSessionId,
       resolveSession: async () => ({
@@ -278,16 +292,14 @@ describe('CLI live session send via sendCommand', () => {
     // Open the WebSocket
     mockWs.onopen?.(new Event('open'));
 
-    // Now send a message. This should use transport.sendCommand with
-    // kiloSessionId as the sessionID, NOT throw "Session not resolved yet".
+    // Now send a message via the typed send method
     const sendPromise = session.send({
       prompt: 'Hello world',
       mode: 'code',
       model: 'test/model-1',
     });
 
-    // The sendCommand sends a JSON message over the WebSocket.
-    // Verify it was sent with the correct sessionID.
+    // The transport wraps this into a WebSocket command
     const lastCall = mockWs.send.mock.calls.at(-1);
     expect(lastCall).toBeDefined();
     const sentPayload = JSON.parse(lastCall![0]) as {
@@ -323,46 +335,105 @@ describe('CLI live session send via sendCommand', () => {
 });
 
 describe('session capabilities', () => {
-  it('canSend is true when transport.send is configured', () => {
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      send: jest.fn(),
-    });
+  it('canSend is true after connecting a cloud agent session', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
+    await connectSession(session);
     expect(session.canSend).toBe(true);
     session.destroy();
   });
 
-  it('canSend is false when transport.send is NOT configured', () => {
-    const session = createResolvedSession({ getTicket: () => 'ticket' });
+  it('canSend is false before connect()', () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
     expect(session.canSend).toBe(false);
     session.destroy();
   });
 
-  it('canInterrupt is true when transport.interrupt is configured and session is resolved', async () => {
-    const session = createResolvedSession({
-      getTicket: () => 'ticket',
-      interrupt: jest.fn(),
+  it('canSend is true after connecting a CLI live session', async () => {
+    const session = createCloudAgentSession({
+      kiloSessionId: kiloId('ses_cli-live'),
+      resolveSession: async () => ({
+        kiloSessionId: kiloId('ses_cli-live'),
+        cloudAgentSessionId: null,
+        isLive: true,
+      }),
+      transport: {
+        cliWebsocketUrl: 'wss://localhost:9999/api/user/web',
+        getAuthToken: () => 'test-token',
+      },
     });
+
+    session.connect();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(session.canSend).toBe(true);
+    session.destroy();
+  });
+
+  it('canSend is false after connecting a historical session', async () => {
+    const session = createCloudAgentSession({
+      kiloSessionId: kiloId('ses_historical'),
+      resolveSession: async () => ({
+        kiloSessionId: kiloId('ses_historical'),
+        cloudAgentSessionId: null,
+        isLive: false,
+      }),
+      transport: {
+        fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses_historical' })),
+      },
+    });
+
+    session.connect();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(session.canSend).toBe(false);
+    session.destroy();
+  });
+
+  it('canInterrupt is true after connecting a cloud agent session', async () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
     await connectSession(session);
     expect(session.canInterrupt).toBe(true);
     session.destroy();
   });
 
-  it('canInterrupt is false when transport.interrupt is NOT configured', () => {
-    const session = createResolvedSession({ getTicket: () => 'ticket' });
+  it('canInterrupt is false before connect()', () => {
+    const api = createMockApi();
+    const session = createCloudAgentResolvedSession(api);
     expect(session.canInterrupt).toBe(false);
     session.destroy();
   });
 
-  it('canSend is false when only getTicket is configured (no send, no sendCommand)', () => {
-    const session = createResolvedSession({});
-    expect(session.canSend).toBe(false);
+  it('canInterrupt is false for historical sessions', async () => {
+    const session = createCloudAgentSession({
+      kiloSessionId: kiloId('ses_historical'),
+      resolveSession: async () => ({
+        kiloSessionId: kiloId('ses_historical'),
+        cloudAgentSessionId: null,
+        isLive: false,
+      }),
+      transport: {
+        fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses_historical' })),
+      },
+    });
+
+    session.connect();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(session.canInterrupt).toBe(false);
     session.destroy();
   });
 });
 
 describe('disconnect during resolution', () => {
   it('disconnect() before resolveSession settles prevents transport from attaching', async () => {
+    const api = createMockApi();
     let resolveSession!: (value: {
       kiloSessionId: typeof kiloSessionId;
       cloudAgentSessionId: typeof cloudAgentSessionId;
@@ -379,7 +450,11 @@ describe('disconnect during resolution', () => {
     const session = createCloudAgentSession({
       kiloSessionId,
       resolveSession: () => resolvePromise,
-      transport: { getTicket: () => 'ticket' },
+      transport: {
+        getTicket: () => 'ticket',
+        api,
+        fetchSnapshot: () => Promise.resolve(makeSnapshot({ id: 'ses_transport-tests' })),
+      },
       websocketBaseUrl: 'ws://localhost:9999',
     });
 

--- a/src/lib/cloud-agent-sdk/session.ts
+++ b/src/lib/cloud-agent-sdk/session.ts
@@ -13,7 +13,7 @@ import type { ServiceState } from './service-state';
 import { createCloudAgentTransport } from './cloud-agent-transport';
 import { createCliLiveTransport } from './cli-live-transport';
 import { createCliHistoricalTransport } from './cli-historical-transport';
-import type { TransportFactory, TransportSink, Transport } from './transport';
+import type { CloudAgentApi, TransportFactory, TransportSink, Transport } from './transport';
 import { createMemoryStorage } from './storage/memory';
 import type { SessionStorage } from './storage/types';
 import type {
@@ -47,10 +47,11 @@ type CloudAgentSessionConfig = {
   onEvent?: (event: NormalizedEvent) => void;
 };
 
-type CloudAgentSessionSendInput = Record<string, unknown>;
-
-type CloudAgentSessionTransportInterruptInput = {
-  sessionId: CloudAgentSessionId;
+type CloudAgentSessionSendInput = {
+  prompt: string;
+  mode?: string;
+  model?: string;
+  variant?: string;
 };
 
 type CloudAgentSessionAnswerInput = {
@@ -58,16 +59,8 @@ type CloudAgentSessionAnswerInput = {
   answers: string[][];
 };
 
-type CloudAgentSessionTransportAnswerInput = CloudAgentSessionAnswerInput & {
-  sessionId: CloudAgentSessionId;
-};
-
 type CloudAgentSessionRejectInput = {
   requestId: string;
-};
-
-type CloudAgentSessionTransportRejectInput = CloudAgentSessionRejectInput & {
-  sessionId: CloudAgentSessionId;
 };
 
 type PermissionResponse = 'once' | 'always' | 'reject';
@@ -77,26 +70,15 @@ type CloudAgentSessionRespondToPermissionInput = {
   response: PermissionResponse;
 };
 
-type CloudAgentSessionTransportRespondToPermissionInput =
-  CloudAgentSessionRespondToPermissionInput & {
-    sessionId: CloudAgentSessionId;
-  };
-
 type CloudAgentSessionTransport = {
-  // For Cloud Agent sessions
+  // Cloud Agent transport construction
   getTicket?: (sessionId: CloudAgentSessionId) => string | Promise<string>;
-  send?: (
-    payload: CloudAgentSessionSendInput & { sessionId: CloudAgentSessionId }
-  ) => unknown | Promise<unknown>;
-  interrupt?: (payload: CloudAgentSessionTransportInterruptInput) => unknown | Promise<unknown>;
-  answer?: (payload: CloudAgentSessionTransportAnswerInput) => unknown | Promise<unknown>;
-  reject?: (payload: CloudAgentSessionTransportRejectInput) => unknown | Promise<unknown>;
-  respondToPermission?: (
-    payload: CloudAgentSessionTransportRespondToPermissionInput
-  ) => unknown | Promise<unknown>;
+  api?: CloudAgentApi;
 
-  // For CLI sessions
+  // Shared
   fetchSnapshot?: (kiloSessionId: KiloSessionId) => Promise<SessionSnapshot>;
+
+  // CLI live transport construction
   getAuthToken?: () => string | Promise<string>;
   cliWebsocketUrl?: string;
 };
@@ -142,7 +124,6 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
   });
 
   let transport: Transport | null = null;
-  let resolvedCloudAgentSessionId: CloudAgentSessionId | null = null;
   let connectGeneration = 0;
 
   const sink: TransportSink = {
@@ -171,6 +152,9 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
           'CloudAgentSession transport.fetchSnapshot is required for Cloud Agent sessions'
         );
       }
+      if (!config.transport.api) {
+        throw new Error('CloudAgentSession transport.api is required for Cloud Agent sessions');
+      }
       console.log(
         '[cli-debug] pickTransportFactory: → Cloud Agent transport (cloudAgentSessionId=%s)',
         resolved.cloudAgentSessionId
@@ -178,6 +162,7 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
       return createCloudAgentTransport({
         sessionId: resolved.cloudAgentSessionId,
         kiloSessionId: config.kiloSessionId,
+        api: config.transport.api,
         getTicket: config.transport.getTicket,
         fetchSnapshot: config.transport.fetchSnapshot,
         websocketBaseUrl: config.websocketBaseUrl,
@@ -239,8 +224,6 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
 
     if (expectedGeneration !== connectGeneration) return;
 
-    resolvedCloudAgentSessionId = resolved.cloudAgentSessionId;
-
     console.log('[cli-debug] resolveAndConnect: resolved=%o', resolved);
 
     let factory: TransportFactory;
@@ -260,98 +243,44 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
     transport.connect();
   }
 
-  function throwTransportNotConfigured(
-    method: 'send' | 'interrupt' | 'answer' | 'reject' | 'respondToPermission'
-  ): never {
-    throw new Error(`CloudAgentSession transport.${method} is not configured`);
-  }
-
-  function commandSessionId(): CloudAgentSessionId {
-    if (!resolvedCloudAgentSessionId) {
-      throw new Error('Session not resolved yet — call connect() and wait for resolution');
-    }
-    return resolvedCloudAgentSessionId;
-  }
-
   return {
     storage,
     state: serviceState,
     send: payload => {
-      if (transport?.sendCommand) {
-        const parts = [{ type: 'text' as const, text: payload.prompt }];
-        const agent = payload.mode || undefined;
-        const model = payload.model || undefined;
-        const variant = payload.variant || undefined;
-        return transport.sendCommand('send_message', {
-          sessionID: config.kiloSessionId,
-          parts,
-          ...(agent ? { agent } : {}),
-          ...(model ? { model } : {}),
-          ...(variant ? { variant } : {}),
-        });
+      if (!transport?.send) {
+        throw new Error('CloudAgentSession transport.send is not configured');
       }
-      const send = config.transport.send;
-      if (!send) {
-        throwTransportNotConfigured('send');
-      }
-      return send({ ...payload, sessionId: commandSessionId() });
+      return transport.send(payload);
     },
     interrupt: () => {
-      if (transport?.sendCommand) {
-        return transport.sendCommand('interrupt', {});
+      if (!transport?.interrupt) {
+        throw new Error('CloudAgentSession transport.interrupt is not configured');
       }
-      const interrupt = config.transport.interrupt;
-      if (!interrupt) {
-        throwTransportNotConfigured('interrupt');
-      }
-      return interrupt({ sessionId: commandSessionId() });
+      return transport.interrupt();
     },
     answer: payload => {
-      if (transport?.sendCommand) {
-        return transport.sendCommand('question_reply', {
-          requestID: payload.requestId,
-          answers: payload.answers,
-        });
+      if (!transport?.answer) {
+        throw new Error('CloudAgentSession transport.answer is not configured');
       }
-      const answer = config.transport.answer;
-      if (!answer) {
-        throwTransportNotConfigured('answer');
-      }
-      return answer({ ...payload, sessionId: commandSessionId() });
+      return transport.answer(payload);
     },
     reject: payload => {
-      if (transport?.sendCommand) {
-        return transport.sendCommand('question_reject', {
-          requestID: payload.requestId,
-        });
+      if (!transport?.reject) {
+        throw new Error('CloudAgentSession transport.reject is not configured');
       }
-      const reject = config.transport.reject;
-      if (!reject) {
-        throwTransportNotConfigured('reject');
-      }
-      return reject({ ...payload, sessionId: commandSessionId() });
+      return transport.reject(payload);
     },
     respondToPermission: payload => {
-      if (transport?.sendCommand) {
-        return transport.sendCommand('permission_respond', {
-          requestID: payload.requestId,
-          reply: payload.response,
-        });
+      if (!transport?.respondToPermission) {
+        throw new Error('CloudAgentSession transport.respondToPermission is not configured');
       }
-      const respondToPermission = config.transport.respondToPermission;
-      if (!respondToPermission) {
-        throwTransportNotConfigured('respondToPermission');
-      }
-      return respondToPermission({ ...payload, sessionId: commandSessionId() });
+      return transport.respondToPermission(payload);
     },
     get canSend() {
-      return transport?.sendCommand !== undefined || config.transport.send !== undefined;
+      return transport?.send !== undefined;
     },
     get canInterrupt() {
-      return (
-        transport?.sendCommand !== undefined ||
-        (config.transport.interrupt !== undefined && resolvedCloudAgentSessionId !== null)
-      );
+      return transport?.interrupt !== undefined;
     },
     connect() {
       console.log(
@@ -362,7 +291,6 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
         transport.destroy();
         transport = null;
       }
-      resolvedCloudAgentSessionId = null;
       connectGeneration += 1;
       serviceState.setActivity({ type: 'connecting' });
       void resolveAndConnect(connectGeneration);
@@ -395,9 +323,5 @@ export type {
   CloudAgentSessionRespondToPermissionInput,
   CloudAgentSessionSendInput,
   CloudAgentSessionTransport,
-  CloudAgentSessionTransportAnswerInput,
-  CloudAgentSessionTransportInterruptInput,
-  CloudAgentSessionTransportRejectInput,
-  CloudAgentSessionTransportRespondToPermissionInput,
   PermissionResponse,
 };

--- a/src/lib/cloud-agent-sdk/transport.ts
+++ b/src/lib/cloud-agent-sdk/transport.ts
@@ -1,10 +1,11 @@
 /**
  * Transport interface — abstracts the connection between event sources and processors.
  *
- * For the current WebSocket case: one transport normalizes and routes to both sinks.
- * For future separate-source case: each processor gets its own transport.
+ * Each transport is the single source of truth for what it can do.
+ * Command methods are optional — present only on interactive transports.
  */
 import type { ChatEvent, ServiceEvent } from './normalizer';
+import type { CloudAgentSessionId } from './types';
 
 /** Sink callbacks that a transport pushes typed events into. */
 type TransportSink = {
@@ -17,11 +18,51 @@ type Transport = {
   connect(): void;
   disconnect(): void;
   destroy(): void;
-  /** Optional — only CliLiveTransport implements this. */
-  sendCommand?: (command: string, data: unknown) => Promise<unknown>;
+
+  // Commands — present only on interactive transports
+  send?: (payload: {
+    prompt: string;
+    mode?: string;
+    model?: string;
+    variant?: string;
+  }) => Promise<unknown>;
+  interrupt?: () => Promise<unknown>;
+  answer?: (payload: { requestId: string; answers: string[][] }) => Promise<unknown>;
+  reject?: (payload: { requestId: string }) => Promise<unknown>;
+  respondToPermission?: (payload: {
+    requestId: string;
+    response: 'once' | 'always' | 'reject';
+  }) => Promise<unknown>;
 };
 
 /** Factory signature — creates a transport wired to the given sink. */
 type TransportFactory = (sink: TransportSink) => Transport;
 
-export type { TransportSink, Transport, TransportFactory };
+/**
+ * Bundle of tRPC-backed cloud agent operations.
+ * Session-independent — the transport binds it to a specific session
+ * by closing over the cloudAgentSessionId.
+ */
+type CloudAgentApi = {
+  send: (payload: {
+    sessionId: CloudAgentSessionId;
+    prompt: string;
+    mode?: string;
+    model?: string;
+    variant?: string;
+  }) => Promise<unknown>;
+  interrupt: (payload: { sessionId: CloudAgentSessionId }) => Promise<unknown>;
+  answer: (payload: {
+    sessionId: CloudAgentSessionId;
+    requestId: string;
+    answers: string[][];
+  }) => Promise<unknown>;
+  reject: (payload: { sessionId: CloudAgentSessionId; requestId: string }) => Promise<unknown>;
+  respondToPermission: (payload: {
+    sessionId: CloudAgentSessionId;
+    requestId: string;
+    response: 'once' | 'always' | 'reject';
+  }) => Promise<unknown>;
+};
+
+export type { TransportSink, Transport, TransportFactory, CloudAgentApi };


### PR DESCRIPTION
## Summary

Moves command methods (`send`, `interrupt`, `answer`, `reject`, `respondToPermission`) from flat session-manager config onto the `Transport` interface as optional typed methods, and introduces a `CloudAgentApi` type that bundles the tRPC calls.

**Transport changes:**
- `CloudAgentTransport` now accepts an `api: CloudAgentApi` config and delegates all five commands through it, binding `sessionId` automatically.
- `CliLiveTransport` replaces the generic `sendCommand(name, data)` method with five typed command methods that format protocol-specific payloads (`send_message`, `interrupt`, `question_reply`, `question_reject`, `permission_respond`).
- `CliHistoricalTransport` exposes no command methods — `canSend` / `canInterrupt` are structurally `false`.

**Session simplification:**
- `CloudAgentSession` is now a thin delegator — command methods forward directly to the transport. Removed `commandSessionId()` and four transport-specific input types.
- `canSend` = `transport?.send !== undefined`, fixing a bug where the chat input appeared for historical sessions.

**Session manager:**
- Config takes `api: CloudAgentApi` instead of five flat command callbacks. `interrupt()` now delegates to `session.interrupt()` instead of `config.interrupt()`.
- Exposes new `fetchedSessionData` atom so the UI can access resolved session metadata.

**UI:**
- Added `SessionContinuationPanel` — shown in place of `ChatInput` when `canSend === false`, with "Open in Editor" button and CLI fork command (`kilo --session <id> --cloud-fork`).
- `CloudChatPage` conditionally renders `ChatInput` vs `SessionContinuationPanel` based on `canSend`.

## Verification

- [x] `pnpm test` — 510 tests pass
- [x] `pnpm typecheck` — clean, no errors

## Visual Changes

| Before | After |
| ------ | ----- |
| Chat input shown for historical/non-interactive sessions (commands fail silently) | `SessionContinuationPanel` with "Open in Editor" and CLI fork command |
| Read-only banner at bottom of completed sessions | Replaced by collapsible continuation panel |

<img width="771" height="487" alt="Screenshot 2026-03-25 at 23 34 49" src="https://github.com/user-attachments/assets/2a2f6174-3df2-4f3a-a259-ec56ccbbd7b9" />
<img width="769" height="617" alt="Screenshot 2026-03-25 at 23 34 58" src="https://github.com/user-attachments/assets/a042eb3b-b63a-4485-a4a2-52a87cca7b69" />


## Reviewer Notes

- The `CloudAgentApi` type lives in `transport.ts` and is purely a type — no runtime code. It decouples transports from tRPC.
- `CliLiveTransport` typed methods map SDK-level field names to protocol-level names (e.g. `requestId` → `requestID`, `mode` → `agent`).
- "Continue in Cloud Agent" is intentionally stubbed as "coming soon" — requires `sourceKiloSessionId` threading through `prepareSession` → wrapper, not yet supported.
- The lint fixup commit (`6459dd23d`) adds `void` prefixes for `no-floating-promises` and formats 6 files with `oxfmt`.