### PR TITLE
feat(gastown): add onboarding wizard page shell with multi-step framework

### DIFF
--- a/src/app/(app)/gastown/onboarding/OnboardingContext.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingContext.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
+
+type OnboardingRepo = {
+  platform: 'github' | 'gitlab' | 'manual';
+  fullName: string;
+  gitUrl: string;
+  defaultBranch: string;
+  platformIntegrationId?: string;
+};
+
+type ModelPreset = 'frontier' | 'balanced' | 'cost-effective' | 'free' | 'custom';
+
+type CustomModels = {
+  mayor?: string;
+  refinery?: string;
+  polecat?: string;
+};
+
+type OnboardingState = {
+  townName: string;
+  repo: OnboardingRepo | null;
+  modelPreset: ModelPreset;
+  customModels: CustomModels;
+  firstTask: string;
+};
+
+type OnboardingContextValue = {
+  state: OnboardingState;
+  setTownName: (name: string) => void;
+  setRepo: (repo: OnboardingRepo | null) => void;
+  setModelPreset: (preset: ModelPreset) => void;
+  setCustomModels: (models: CustomModels) => void;
+  setFirstTask: (task: string) => void;
+};
+
+const OnboardingContext = createContext<OnboardingContextValue | null>(null);
+
+const defaultState: OnboardingState = {
+  townName: '',
+  repo: null,
+  modelPreset: 'balanced',
+  customModels: {},
+  firstTask: '',
+};
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<OnboardingState>(defaultState);
+
+  const setTownName = useCallback(
+    (townName: string) => setState(prev => ({ ...prev, townName })),
+    []
+  );
+  const setRepo = useCallback(
+    (repo: OnboardingRepo | null) => setState(prev => ({ ...prev, repo })),
+    []
+  );
+  const setModelPreset = useCallback(
+    (modelPreset: ModelPreset) => setState(prev => ({ ...prev, modelPreset })),
+    []
+  );
+  const setCustomModels = useCallback(
+    (customModels: CustomModels) => setState(prev => ({ ...prev, customModels })),
+    []
+  );
+  const setFirstTask = useCallback(
+    (firstTask: string) => setState(prev => ({ ...prev, firstTask })),
+    []
+  );
+
+  return (
+    <OnboardingContext
+      value={{ state, setTownName, setRepo, setModelPreset, setCustomModels, setFirstTask }}
+    >
+      {children}
+    </OnboardingContext>
+  );
+}
+
+export function useOnboarding() {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) {
+    throw new Error('useOnboarding must be used within an OnboardingProvider');
+  }
+  return ctx;
+}
+
+export type { OnboardingState, OnboardingRepo, ModelPreset, CustomModels };

--- a/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useOnboarding } from './OnboardingContext';
+
+export function OnboardingStepModel() {
+  const { state } = useOnboarding();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <h2 className="text-xl font-semibold text-white/90">Choose your models</h2>
+      <p className="mt-2 text-sm text-white/40">
+        Pick a model configuration that fits your needs and budget.
+      </p>
+      <div className="mt-6 rounded-lg border border-white/10 bg-white/[0.03] px-6 py-4 text-sm text-white/60">
+        Step 3: Model — current preset: {state.modelPreset}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/onboarding/OnboardingStepName.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepName.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useOnboarding } from './OnboardingContext';
+
+export function OnboardingStepName() {
+  const { state } = useOnboarding();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <h2 className="text-xl font-semibold text-white/90">Name your town</h2>
+      <p className="mt-2 text-sm text-white/40">
+        This is your workspace where agents will collaborate on your code.
+      </p>
+      <div className="mt-6 rounded-lg border border-white/10 bg-white/[0.03] px-6 py-4 text-sm text-white/60">
+        Step 1: Name — current value: {state.townName || '(empty)'}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useOnboarding } from './OnboardingContext';
+
+export function OnboardingStepRepo() {
+  const { state } = useOnboarding();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <h2 className="text-xl font-semibold text-white/90">Connect a repo</h2>
+      <p className="mt-2 text-sm text-white/40">Choose a repository for your agents to work on.</p>
+      <div className="mt-6 rounded-lg border border-white/10 bg-white/[0.03] px-6 py-4 text-sm text-white/60">
+        Step 2: Repo — current value: {state.repo?.fullName || '(none selected)'}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/onboarding/OnboardingStepTask.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepTask.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useOnboarding } from './OnboardingContext';
+
+export function OnboardingStepTask() {
+  const { state } = useOnboarding();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <h2 className="text-xl font-semibold text-white/90">Give your first task</h2>
+      <p className="mt-2 text-sm text-white/40">
+        Tell your Mayor what to work on. This will be your first conversation.
+      </p>
+      <div className="mt-6 rounded-lg border border-white/10 bg-white/[0.03] px-6 py-4 text-sm text-white/60">
+        Step 4: Task — current value: {state.firstTask || '(empty)'}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/gastown/onboarding/OnboardingWizardClient.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingWizardClient.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { CheckCircle, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { OnboardingProvider } from './OnboardingContext';
+import { OnboardingStepName } from './OnboardingStepName';
+import { OnboardingStepRepo } from './OnboardingStepRepo';
+import { OnboardingStepModel } from './OnboardingStepModel';
+import { OnboardingStepTask } from './OnboardingStepTask';
+
+const STEPS = [
+  { key: 'name', label: 'Name' },
+  { key: 'repo', label: 'Repo' },
+  { key: 'model', label: 'Models' },
+  { key: 'task', label: 'Task' },
+] as const;
+
+type StepKey = (typeof STEPS)[number]['key'];
+
+function StepIndicator({ currentIndex }: { currentIndex: number }) {
+  return (
+    <div className="flex items-center justify-center gap-0">
+      {STEPS.map((step, i) => {
+        const status = i < currentIndex ? 'completed' : i === currentIndex ? 'current' : 'pending';
+
+        return (
+          <div key={step.key} className="flex items-center">
+            {/* Step circle + label */}
+            <div className="flex flex-col items-center gap-1.5">
+              <div className="relative flex items-center justify-center">
+                {status === 'completed' ? (
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                  >
+                    <CheckCircle className="size-6 text-emerald-400" />
+                  </motion.div>
+                ) : status === 'current' ? (
+                  <div className="relative">
+                    <motion.div
+                      initial={{ scale: 0.8, opacity: 0 }}
+                      animate={{ scale: 1, opacity: 1 }}
+                      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                      className="flex size-6 items-center justify-center rounded-full border-2 border-[color:oklch(95%_0.15_108)] bg-[color:oklch(95%_0.15_108_/_0.15)]"
+                    >
+                      <span className="text-xs font-bold text-[color:oklch(95%_0.15_108)]">
+                        {i + 1}
+                      </span>
+                    </motion.div>
+                    <span className="absolute -inset-1 animate-ping rounded-full bg-[color:oklch(95%_0.15_108_/_0.12)]" />
+                  </div>
+                ) : (
+                  <div className="flex size-6 items-center justify-center rounded-full border border-white/15">
+                    <span className="text-xs text-white/25">{i + 1}</span>
+                  </div>
+                )}
+              </div>
+              <span
+                className={`text-[11px] font-medium ${
+                  status === 'completed'
+                    ? 'text-white/60'
+                    : status === 'current'
+                      ? 'text-white/90'
+                      : 'text-white/25'
+                }`}
+              >
+                {step.label}
+              </span>
+            </div>
+
+            {/* Connector line between steps */}
+            {i < STEPS.length - 1 && (
+              <div className="mx-4 mb-5 h-px w-16">
+                <div
+                  className={`h-full w-full transition-colors duration-300 ${
+                    i < currentIndex ? 'bg-emerald-500/40' : 'bg-white/[0.08]'
+                  }`}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function WizardContent() {
+  const [currentStepKey, setCurrentStepKey] = useState<StepKey>('name');
+
+  const currentIndex = STEPS.findIndex(s => s.key === currentStepKey);
+
+  const goNext = useCallback(() => {
+    const nextIndex = currentIndex + 1;
+    if (nextIndex < STEPS.length) {
+      setCurrentStepKey(STEPS[nextIndex].key);
+    }
+  }, [currentIndex]);
+
+  const goBack = useCallback(() => {
+    const prevIndex = currentIndex - 1;
+    if (prevIndex >= 0) {
+      setCurrentStepKey(STEPS[prevIndex].key);
+    }
+  }, [currentIndex]);
+
+  const isFirstStep = currentIndex === 0;
+  const isLastStep = currentIndex === STEPS.length - 1;
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col items-center px-4 py-8">
+      {/* Header */}
+      <div className="mb-2 text-center">
+        <h1 className="text-2xl font-bold text-white/95">Set up your town</h1>
+        <p className="mt-1 text-sm text-white/40">
+          Get from zero to an agent working on your code in under 2 minutes.
+        </p>
+      </div>
+
+      {/* Step indicator */}
+      <div className="mb-8 mt-6">
+        <StepIndicator currentIndex={currentIndex} />
+      </div>
+
+      {/* Step content */}
+      <div className="w-full max-w-xl flex-1">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={currentStepKey}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.2 }}
+          >
+            {currentStepKey === 'name' && <OnboardingStepName />}
+            {currentStepKey === 'repo' && <OnboardingStepRepo />}
+            {currentStepKey === 'model' && <OnboardingStepModel />}
+            {currentStepKey === 'task' && <OnboardingStepTask />}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Navigation buttons */}
+      <div className="mt-8 flex w-full max-w-xl items-center justify-between">
+        <Button
+          variant="ghost"
+          onClick={goBack}
+          disabled={isFirstStep}
+          className="gap-1.5 text-white/60 hover:text-white/90 disabled:opacity-0"
+        >
+          <ChevronLeft className="size-4" />
+          Back
+        </Button>
+
+        <Button
+          onClick={goNext}
+          disabled={isLastStep}
+          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)] disabled:opacity-50"
+        >
+          Next
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function OnboardingWizardClient() {
+  return (
+    <OnboardingProvider>
+      <WizardContent />
+    </OnboardingProvider>
+  );
+}

--- a/src/app/(app)/gastown/onboarding/page.tsx
+++ b/src/app/(app)/gastown/onboarding/page.tsx
@@ -1,0 +1,14 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
+import { OnboardingWizardClient } from './OnboardingWizardClient';
+
+export default async function GastownOnboardingPage() {
+  const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/gastown/onboarding');
+
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) {
+    return notFound();
+  }
+
+  return <OnboardingWizardClient />;
+}


### PR DESCRIPTION
## Summary

Add the onboarding wizard page shell at `/gastown/onboarding` as the first piece of the onboarding flow (Issue #229). This establishes the routing, auth gating, step navigation framework, shared context, and stub step components that subsequent beads will flesh out.

- **Server page** with `getUserFromAuthOrRedirect` + `isGastownEnabled` feature flag check, matching existing gastown page patterns
- **4-step wizard client** with horizontal step indicator (completed checkmark, current pulsing ring, pending dimmed), AnimatePresence slide transitions, and Back/Next navigation using the branded oklch accent
- **OnboardingContext** providing shared wizard state (`townName`, `repo`, `modelPreset`, `customModels`, `firstTask`) via React context with memoized setter callbacks
- **Four stub step components** (`Name`, `Repo`, `Model`, `Task`) showing placeholder UI that will be replaced by subsequent implementation beads

## Verification

- [x] Code review: all imports resolve, patterns match existing gastown pages, no type assertions or unsafe patterns
- [x] Dependencies verified: `motion/react` (v12+), `lucide-react`, `@/components/ui/button` all present in project
- [x] Style consistency: oklch accent colors match `OrgTownListPageClient.tsx`, auth/feature-flag pattern matches `[townId]/page.tsx`

## Visual Changes

N/A — this is a new route with stub content; visual design will be refined in subsequent step implementation beads.

## Reviewer Notes

- This is scaffolding for the multi-bead onboarding wizard feature. The stub components intentionally show debug state values to aid development of the next beads.
- The `OnboardingContext` uses React 19's `value` prop syntax for the context provider — verify this matches the project's React version.
- The wizard `STEPS` array uses `as const` for exhaustive type checking on step keys.