### PR TITLE
fix(claw): add Upgrade option to all toasts when adding secrets

### DIFF
--- a/src/app/(app)/claw/components/SecretEntrySection.tsx
+++ b/src/app/(app)/claw/components/SecretEntrySection.tsx
@@ -30,6 +30,7 @@ export function SecretEntrySection({
   defaultOpen,
   onRedeploy,
   redeployLabel = 'Redeploy',
+  onUpgrade,
 }: {
   entry: SecretCatalogEntry;
   configured: boolean;
@@ -41,6 +42,7 @@ export function SecretEntrySection({
   onRedeploy?: () => void;
   /** Label for the toast action button. Defaults to "Redeploy". */
   redeployLabel?: string;
+  onUpgrade?: () => void;
 }) {
   const [open, setOpen] = useState(defaultOpen ?? false);
   const [tokens, setTokens] = useState<Record<string, string>>({});
@@ -91,9 +93,13 @@ export function SecretEntrySection({
             `${entry.label} token${entry.fields.length > 1 ? 's' : ''} saved. ${redeployLabel} to apply.`,
             {
               duration: 8000,
-              ...(onRedeploy && {
-                action: { label: redeployLabel, onClick: onRedeploy },
-              }),
+              ...(onUpgrade
+                ? { action: { label: 'Upgrade', onClick: onUpgrade } }
+                : onRedeploy && { action: { label: redeployLabel, onClick: onRedeploy } }),
+              ...(onUpgrade &&
+                onRedeploy && {
+                  cancel: { label: redeployLabel, onClick: onRedeploy },
+                }),
             }
           );
           setTokens({});
@@ -118,9 +124,13 @@ export function SecretEntrySection({
             `${entry.label} token${entry.fields.length > 1 ? 's' : ''} removed. ${redeployLabel} to apply.`,
             {
               duration: 8000,
-              ...(onRedeploy && {
-                action: { label: redeployLabel, onClick: onRedeploy },
-              }),
+              ...(onUpgrade
+                ? { action: { label: 'Upgrade', onClick: onUpgrade } }
+                : onRedeploy && { action: { label: redeployLabel, onClick: onRedeploy } }),
+              ...(onUpgrade &&
+                onRedeploy && {
+                  cancel: { label: redeployLabel, onClick: onRedeploy },
+                }),
             }
           );
           setTokens({});

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -830,6 +830,7 @@ export function SettingsTab({
               onSecretsChanged={onSecretsChanged}
               isDirty={dirtySecrets.has(entry.id)}
               onRedeploy={onRedeploy}
+              onUpgrade={onUpgrade}
             />
           ))}
         </div>
@@ -850,6 +851,7 @@ export function SettingsTab({
                   mutations={mutations}
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
+                  onUpgrade={onUpgrade}
                 />
               ))}
           </div>
@@ -872,6 +874,7 @@ export function SettingsTab({
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
                   onRedeploy={onRedeploy}
+                  onUpgrade={onUpgrade}
                   actionRowExtra={
                     <span className="text-muted-foreground flex items-center gap-1 text-xs">
                       <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
@@ -917,8 +920,8 @@ export function SettingsTab({
                   mutations={mutations}
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
-                  onRedeploy={onUpgrade ?? onRedeploy}
-                  redeployLabel="Upgrade"
+                  onRedeploy={onRedeploy}
+                  onUpgrade={onUpgrade}
                   actionRowExtra={<AgentCardSetupGuide />}
                 />
               ))}
@@ -941,6 +944,7 @@ export function SettingsTab({
                   mutations={mutations}
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
+                  onUpgrade={onUpgrade}
                   actionRowExtra={<OnePasswordSetupGuide />}
                 />
               ))}


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

The logic that added the Upgrade option to the notification toast after a secret change was lost on merge. 

## Verification

<!-- List the checks you ran and what passed. Add command output notes when useful. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
| ------ | ----- |
|        |       |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
