### PR TITLE
feat(onboarding): implement repo picker step with manual URL fallback

### DIFF
--- a/src/app/(app)/gastown/onboarding/OnboardingContext.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingContext.tsx
@@ -21,6 +21,7 @@ type CustomModels = {
 
 type OnboardingState = {
   townName: string;
+  townNameSetByUser: boolean;
   repo: OnboardingRepo | null;
   modelPreset: ModelPreset;
   customModels: CustomModels;
@@ -29,7 +30,7 @@ type OnboardingState = {
 
 type OnboardingContextValue = {
   state: OnboardingState;
-  setTownName: (name: string) => void;
+  setTownName: (name: string, setByUser?: boolean) => void;
   setRepo: (repo: OnboardingRepo | null) => void;
   setModelPreset: (preset: ModelPreset) => void;
   setCustomModels: (models: CustomModels) => void;
@@ -41,6 +42,7 @@ const OnboardingContext = createContext<OnboardingContextValue | null>(null);
 
 const defaultState: OnboardingState = {
   townName: '',
+  townNameSetByUser: false,
   repo: null,
   modelPreset: 'balanced',
   customModels: {},
@@ -59,7 +61,12 @@ export function OnboardingProvider({
   const [state, setState] = useState<OnboardingState>(defaultState);
 
   const setTownName = useCallback(
-    (townName: string) => setState(prev => ({ ...prev, townName })),
+    (townName: string, setByUser?: boolean) =>
+      setState(prev => ({
+        ...prev,
+        townName,
+        townNameSetByUser: setByUser ?? prev.townNameSetByUser,
+      })),
     []
   );
   const setRepo = useCallback(

--- a/src/app/(app)/gastown/onboarding/OnboardingStepName.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepName.tsx
@@ -64,7 +64,7 @@ export function OnboardingStepName() {
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value;
     if (value.length <= TOWN_NAME_MAX_LENGTH + 1 && TOWN_NAME_PATTERN.test(value)) {
-      setTownName(value);
+      setTownName(value, true);
     }
   }
 

--- a/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
@@ -29,7 +29,9 @@ export function OnboardingStepRepo() {
   const { data: user } = useUser();
   const mainTrpc = useTRPC();
 
-  const [mode, setMode] = useState<InputMode>('picker');
+  const [mode, setMode] = useState<InputMode>(
+    state.repo?.platform === 'manual' ? 'manual' : 'picker'
+  );
   const [selectedRepoFullName, setSelectedRepoFullName] = useState(
     state.repo?.platform !== 'manual' ? (state.repo?.fullName ?? '') : ''
   );
@@ -94,9 +96,9 @@ export function OnboardingStepRepo() {
         ?.instanceUrl;
       const gitUrl = resolveGitUrlFromRepo(platform, fullName, gitlabInstanceUrl);
 
-      // Auto-derive rig name from repo name and set as town name if still default
+      // Auto-derive town name from repo name, but only if the user hasn't explicitly edited it
       const repoName = fullName.split('/').pop() ?? fullName;
-      if (state.townName.endsWith('-town')) {
+      if (!state.townNameSetByUser) {
         setTownName(repoName);
       }
 

--- a/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
+++ b/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
@@ -1,16 +1,278 @@
 'use client';
 
+import { useState, useMemo, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { useUser } from '@/hooks/useUser';
+import { RepositoryCombobox, type RepositoryOption } from '@/components/shared/RepositoryCombobox';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { ExternalLink, GitBranch, Link2 } from 'lucide-react';
 import { useOnboarding } from './OnboardingContext';
 
+type InputMode = 'picker' | 'manual';
+
+function resolveGitUrlFromRepo(
+  platform: 'github' | 'gitlab',
+  fullName: string,
+  gitlabInstanceUrl?: string
+): string {
+  if (platform === 'gitlab') {
+    const baseUrl = (gitlabInstanceUrl ?? 'https://gitlab.com').replace(/\/+$/, '');
+    return `${baseUrl}/${fullName}.git`;
+  }
+  return `https://github.com/${fullName}.git`;
+}
+
 export function OnboardingStepRepo() {
-  const { state } = useOnboarding();
+  const { state, setRepo, setTownName, goNext } = useOnboarding();
+  const { data: user } = useUser();
+  const mainTrpc = useTRPC();
+
+  const [mode, setMode] = useState<InputMode>('picker');
+  const [selectedRepoFullName, setSelectedRepoFullName] = useState(
+    state.repo?.platform !== 'manual' ? (state.repo?.fullName ?? '') : ''
+  );
+  const [manualGitUrl, setManualGitUrl] = useState(
+    state.repo?.platform === 'manual' ? (state.repo?.gitUrl ?? '') : ''
+  );
+  const [manualBranch, setManualBranch] = useState(
+    state.repo?.platform === 'manual' ? (state.repo?.defaultBranch ?? 'main') : 'main'
+  );
+
+  // Fetch repos from integrations (personal-scope only for onboarding)
+  const githubReposQuery = useQuery({
+    ...mainTrpc.cloudAgent.listGitHubRepositories.queryOptions({ forceRefresh: false }),
+    enabled: mode === 'picker',
+  });
+
+  const gitlabReposQuery = useQuery({
+    ...mainTrpc.cloudAgent.listGitLabRepositories.queryOptions({ forceRefresh: false }),
+    enabled: mode === 'picker',
+  });
+
+  // Check GitHub installation status
+  const githubInstallQuery = useQuery(mainTrpc.githubApps.getInstallation.queryOptions(undefined));
+
+  const unifiedRepositories = useMemo<RepositoryOption[]>(() => {
+    const github = (githubReposQuery.data?.repositories ?? []).map(repo => ({
+      id: repo.id,
+      fullName: repo.fullName,
+      private: repo.private,
+      platform: 'github' as const,
+    }));
+    const gitlab = (gitlabReposQuery.data?.repositories ?? []).map(repo => ({
+      id: repo.id,
+      fullName: repo.fullName,
+      private: repo.private,
+      platform: 'gitlab' as const,
+    }));
+    return [...github, ...gitlab];
+  }, [githubReposQuery.data, gitlabReposQuery.data]);
+
+  const isLoadingRepos = githubReposQuery.isLoading || gitlabReposQuery.isLoading;
+  const hasGithubInstalled = githubInstallQuery.data?.installed === true;
+  const hasGitlabInstalled = (gitlabReposQuery.data?.repositories?.length ?? 0) > 0;
+  const hasAnyIntegration = hasGithubInstalled || hasGitlabInstalled;
+
+  const githubAppName = process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'KiloConnect';
+
+  const handleInstallGithub = useCallback(() => {
+    const installState = `user_${user?.id}`;
+    const installUrl = `https://github.com/apps/${githubAppName}/installations/new?state=${installState}`;
+    window.location.href = installUrl;
+  }, [user?.id, githubAppName]);
+
+  const handleRepoSelect = useCallback(
+    (fullName: string) => {
+      setSelectedRepoFullName(fullName);
+      const repo = unifiedRepositories.find(r => r.fullName === fullName);
+      if (!repo) return;
+
+      const platform = repo.platform ?? 'github';
+      const gitlabInstanceUrl = (gitlabReposQuery.data as { instanceUrl?: string } | undefined)
+        ?.instanceUrl;
+      const gitUrl = resolveGitUrlFromRepo(platform, fullName, gitlabInstanceUrl);
+
+      // Auto-derive rig name from repo name and set as town name if still default
+      const repoName = fullName.split('/').pop() ?? fullName;
+      if (state.townName.endsWith('-town')) {
+        setTownName(repoName);
+      }
+
+      setRepo({
+        platform,
+        fullName,
+        gitUrl,
+        defaultBranch: 'main',
+        platformIntegrationId: undefined,
+      });
+    },
+    [unifiedRepositories, gitlabReposQuery.data, state.townName, setTownName, setRepo]
+  );
+
+  const handleManualConfirm = useCallback(() => {
+    const trimmedUrl = manualGitUrl.trim();
+    if (!trimmedUrl) return;
+
+    // Derive a name from the URL for rig naming
+    const urlName = trimmedUrl
+      .replace(/\.git$/, '')
+      .split('/')
+      .pop();
+
+    setRepo({
+      platform: 'manual',
+      fullName: urlName ?? 'repo',
+      gitUrl: trimmedUrl,
+      defaultBranch: manualBranch.trim() || 'main',
+    });
+
+    goNext();
+  }, [manualGitUrl, manualBranch, setRepo, goNext]);
+
+  const handlePickerContinue = useCallback(() => {
+    if (state.repo && state.repo.platform !== 'manual') {
+      goNext();
+    }
+  }, [state.repo, goNext]);
+
+  const isPickerReady = state.repo !== null && state.repo.platform !== 'manual';
+  const isManualReady = manualGitUrl.trim().length > 0;
 
   return (
     <div className="flex flex-col items-center justify-center py-12">
       <h2 className="text-xl font-semibold text-white/90">Connect a repo</h2>
       <p className="mt-2 text-sm text-white/40">Choose a repository for your agents to work on.</p>
-      <div className="mt-6 rounded-lg border border-white/10 bg-white/[0.03] px-6 py-4 text-sm text-white/60">
-        Step 2: Repo — current value: {state.repo?.fullName || '(none selected)'}
+
+      <div className="mt-8 w-full max-w-md">
+        {mode === 'picker' ? (
+          <div className="space-y-4">
+            {/* Repo picker */}
+            {isLoadingRepos ? (
+              <div className="space-y-2">
+                <div className="h-9 w-full animate-pulse rounded-md bg-white/[0.06]" />
+                <p className="text-xs text-white/30">Loading repositories...</p>
+              </div>
+            ) : hasAnyIntegration ? (
+              <RepositoryCombobox
+                repositories={unifiedRepositories}
+                value={selectedRepoFullName}
+                onValueChange={handleRepoSelect}
+                isLoading={isLoadingRepos}
+                placeholder="Select a repository..."
+                searchPlaceholder="Search repositories..."
+                groupByPlatform
+                hideLabel
+              />
+            ) : (
+              <div className="space-y-3">
+                <div className="rounded-lg border border-white/10 bg-white/[0.03] p-4 text-sm text-white/50">
+                  No integrations connected yet. Install the GitHub App to see your repos.
+                </div>
+              </div>
+            )}
+
+            {/* Install GitHub App button when not installed */}
+            {!isLoadingRepos && !hasGithubInstalled && !githubInstallQuery.isLoading && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleInstallGithub}
+                className="w-full gap-2 border-white/10 text-white/70 hover:text-white/90"
+              >
+                <ExternalLink className="size-4" />
+                Install GitHub App
+              </Button>
+            )}
+
+            {/* Selected repo indicator */}
+            {state.repo && state.repo.platform !== 'manual' && (
+              <div className="flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-sm text-emerald-400/80">
+                <GitBranch className="size-4" />
+                <span className="truncate">{state.repo.fullName}</span>
+                <span className="ml-auto text-xs text-white/30">main</span>
+              </div>
+            )}
+
+            {/* Continue button for picker mode */}
+            {isPickerReady && (
+              <Button
+                type="button"
+                onClick={handlePickerContinue}
+                className="w-full bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+              >
+                Continue
+              </Button>
+            )}
+
+            {/* Manual URL escape hatch */}
+            <button
+              type="button"
+              onClick={() => setMode('manual')}
+              className="flex w-full items-center justify-center gap-1.5 text-xs text-white/30 transition-colors hover:text-white/50"
+            >
+              <Link2 className="size-3" />
+              Or enter a git URL manually
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* Manual URL input */}
+            <div>
+              <label className="mb-2 block text-sm font-medium text-white/70">Git URL</label>
+              <Input
+                value={manualGitUrl}
+                onChange={e => setManualGitUrl(e.target.value)}
+                placeholder="https://github.com/org/repo.git"
+                className="border-white/10 bg-black/25"
+                autoFocus
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && isManualReady) {
+                    handleManualConfirm();
+                  }
+                }}
+              />
+              <p className="mt-1 text-xs text-white/30">
+                For private repos, you can add credentials in Town Settings later.
+              </p>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-white/70">Default Branch</label>
+              <Input
+                value={manualBranch}
+                onChange={e => setManualBranch(e.target.value)}
+                placeholder="main"
+                className="border-white/10 bg-black/25"
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && isManualReady) {
+                    handleManualConfirm();
+                  }
+                }}
+              />
+            </div>
+
+            {/* Continue button */}
+            <Button
+              type="button"
+              onClick={handleManualConfirm}
+              disabled={!isManualReady}
+              className="w-full bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)] disabled:opacity-50"
+            >
+              Continue
+            </Button>
+
+            {/* Back to picker */}
+            <button
+              type="button"
+              onClick={() => setMode('picker')}
+              className="flex w-full items-center justify-center gap-1.5 text-xs text-white/30 transition-colors hover:text-white/50"
+            >
+              Back to repo picker
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Implement `OnboardingStepRepo.tsx` — the "Connect a repo" step of the onboarding wizard. The component provides two input modes:

- **Repo picker**: Uses `RepositoryCombobox` with GitHub/GitLab repos fetched via `cloudAgent.listGitHubRepositories` and `listGitLabRepositories`, grouped by platform. Shows an "Install GitHub App" button when no GitHub integration exists.
- **Manual URL fallback**: Togglable text inputs for git URL + branch name, for users without connected integrations.

When a repo is selected, the repo name is auto-derived and used to update the town name if it still has the default suffix. The selected repo is stored in `OnboardingState` via `setRepo()`.

## Verification

- [x] `pnpm typecheck` — passes cleanly
- [x] Pre-push hooks (typecheck, format check, oxlint) — all passed
- [x] Code review: types match `OnboardingContext` and `RepositoryCombobox` interfaces
- [x] GitHub install URL pattern matches existing `GitHubIntegrationDetails.tsx`

## Visual Changes

N/A

## Reviewer Notes

- The `as` cast on line 93 for `gitlabReposQuery.data` to access `instanceUrl` follows the same pattern used in `CreateRigDialog.tsx:123-124`. The tRPC inferred type doesn't expose `instanceUrl` directly.
- `defaultBranch` is hardcoded to `'main'` for picker-selected repos because the list endpoints don't return default branch info. Users can update this in Town Settings later.