### PR TITLE
fix(gateway): prevent unhandled TypeError when abuse classification response lacks context

### DIFF
--- a/src/app/api/openrouter/[...path]/route.ts
+++ b/src/app/api/openrouter/[...path]/route.ts
@@ -530,10 +530,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       verdict: classifyResult.verdict,
       risk_score: classifyResult.risk_score,
       signals: classifyResult.signals,
-      identity_key: classifyResult.context.identity_key,
+      identity_key: classifyResult.context?.identity_key,
       kilo_user_id: user.id,
       requested_model: originalModelIdLowerCased,
-      rps: classifyResult.context.requests_per_second,
+      rps: classifyResult.context?.requests_per_second,
       request_id: classifyResult.request_id,
     });
     usageContext.abuse_request_id = classifyResult.request_id;


### PR DESCRIPTION
## Summary

- Adds optional chaining (`?.`) to two `classifyResult.context` property accesses that crash the gateway request handler when the abuse service returns a response without the `context` field

## Problem

The gateway proxy (`/api/openrouter/[...path]` and `/api/gateway/[...path]`) crashes with an unhandled `TypeError: Cannot read properties of undefined (reading 'identity_key')` whenever the abuse service returns a classification response that doesn't include the `context` property.

This is **[KILOCODE-WEB-G27](https://kilo-code.sentry.io/issues/7291596971/)** — 305K Sentry events since Feb 25, currently producing ~5,000 HTTP 500 errors every 15 minutes (~0.7% of all gateway requests).

### Root cause

Commit `4c55039` (Feb 4) refactored abuse classification from fire-and-forget (`.then()` callback where failures were silently swallowed) into the main `POST` handler's async flow. The unguarded `classifyResult.context.identity_key` access was always unsafe, but the refactor elevated it from a swallowed promise rejection to an unhandled exception that crashes the entire request handler — discarding the model response even when the upstream LLM call succeeded.

The TypeScript type `AbuseClassificationResponse` declares `context: ClassificationContext` as required, but the actual abuse service API response doesn't always include it. The `as T` type assertion in `fetchAbuseService` bypasses runtime validation, so the mismatch is invisible at compile time.

### Impact observed in production (2026-03-26 03:00–06:00 UTC)

**Axiom query data:**

| Time window (UTC) | Total gateway reqs/15m | HTTP 500s/15m | 500 error rate |
|---|---|---|---|
| 03:00 | 67,258 | 624 | 0.9% |
| 04:00 | 81,956 | 1,369 | 1.7% |
| 05:00 | 96,647 | 5,511 | 5.7% |
| 05:30 | 129,028 | 13,520 | 10.5% |

The 0.9% baseline 500 rate is this bug. The escalation to 10.5% includes a separate upstream provider degradation (OpenRouter mid-stream failures) that compounds on top of it.

**Sentry issues involved:**

| Issue | Events | Description |
|---|---|---|
| [KILOCODE-WEB-G27](https://kilo-code.sentry.io/issues/7291596971/) | 305K | `TypeError: Cannot read properties of undefined (reading 'identity_key')` — **this fix** |
| [KILOCODE-WEB-1HF7](https://kilo-code.sentry.io/issues/7362349743/) | 5.9K | `OpenRouter error: Provider returned error` / `Network connection lost` — upstream, separate |
| [KILOCODE-WEB-1HC4](https://kilo-code.sentry.io/issues/7361333401/) | 2.5K | `failed to pipe response` / `ECONNRESET` — upstream, separate |

**Key diagnostic signal:** Users reported the CLI throws 500s but direct OpenRouter access works fine. This is because the bug is in the gateway's post-response abuse-classification logging — the upstream call succeeds, but the handler crashes before returning the response to the client.

### Fix

Two characters changed: `.` → `?.` in two places (lines 533, 536). When `context` is missing, the log line will show `identity_key: undefined` and `rps: undefined` instead of crashing. No behavioral change for the success path. The `usageContext.abuse_request_id` assignment on line 539 is unaffected since it accesses `classifyResult.request_id` (not `.context`).

### Expected impact after deploy

Eliminates ~5,000 spurious 500 errors per 15 minutes. The remaining elevated error rate reflects genuine upstream provider issues, which are a separate concern.

### Follow-up (not in this PR)

The `AbuseClassificationResponse` type should be validated at runtime (e.g. Zod schema) in `fetchAbuseService` rather than relying on `as T` assertions. This would catch future API/type mismatches gracefully.