### PR TITLE
feat(layout): migrate organization pages to topbar SetPageTitle

### DIFF
--- a/src/app/(app)/organizations/[id]/auto-fix/AutoFixPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/auto-fix/AutoFixPageClient.tsx
@@ -7,6 +7,7 @@ import { AutoFixTicketsCard } from '@/components/auto-fix/AutoFixTicketsCard';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Rocket, ExternalLink, Settings2, ListChecks } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -51,12 +52,11 @@ export function AutoFixPageClient({
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-8">
+      <SetPageTitle title="Auto Fix">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Auto Fix</h1>
-          <Badge variant="new">new</Badge>
-        </div>
         <p className="text-muted-foreground">
           Automatically create pull requests to fix issues labeled with kilo-auto-fix for{' '}
           {organizationName}

--- a/src/app/(app)/organizations/[id]/auto-triage/AutoTriagePageClient.tsx
+++ b/src/app/(app)/organizations/[id]/auto-triage/AutoTriagePageClient.tsx
@@ -7,6 +7,7 @@ import { AutoTriageTicketsCard } from '@/components/auto-triage/AutoTriageTicket
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Rocket, ExternalLink, Settings2, ListChecks } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -51,12 +52,11 @@ export function AutoTriagePageClient({
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-8">
+      <SetPageTitle title="Auto Triage">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Auto Triage</h1>
-          <Badge variant="new">new</Badge>
-        </div>
         <p className="text-muted-foreground">
           Automatically triage GitHub issues with AI-powered analysis for {organizationName}
         </p>

--- a/src/app/(app)/organizations/[id]/code-reviews/ReviewAgentPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/code-reviews/ReviewAgentPageClient.tsx
@@ -7,6 +7,7 @@ import { CodeReviewJobsCard } from '@/components/code-reviews/CodeReviewJobsCard
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Rocket, ExternalLink, Settings2, ListChecks } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -83,12 +84,11 @@ export function ReviewAgentPageClient({
 
   return (
     <>
+      <SetPageTitle title="Code Reviewer">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <h1 className="text-3xl font-bold">Code Reviewer</h1>
-          <Badge variant="new">new</Badge>
-        </div>
         <p className="text-muted-foreground">
           Automate code reviews with AI-powered analysis for {organizationName}
         </p>

--- a/src/app/(app)/organizations/[id]/deploy/DeployPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/deploy/DeployPageClient.tsx
@@ -7,6 +7,7 @@ import { NewDeploymentDialog } from '@/components/deployments/NewDeploymentDialo
 import { OrgDeploymentProvider } from '@/components/deployments/OrgDeploymentProvider';
 import { Button } from '@/components/Button';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ExternalLink, Plus } from 'lucide-react';
 import { useState } from 'react';
 
@@ -39,13 +40,12 @@ export function DeployPageClient({ organizationId, initialDeploymentId }: Deploy
 
   return (
     <OrgDeploymentProvider organizationId={organizationId}>
+      <SetPageTitle title="Deployments">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-3xl font-bold text-gray-100">Deployments</h1>
-              <Badge variant="new">new</Badge>
-            </div>
             <p className="text-gray-400">Deploy your web project</p>
             <a
               href="https://kilo.ai/docs/advanced-usage/deploy"

--- a/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
+++ b/src/app/(app)/organizations/[id]/gastown/OrgTownListPageClient.tsx
@@ -7,6 +7,7 @@ import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { Button } from '@/components/Button';
 import { Badge } from '@/components/ui/badge';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { GastownBackdrop } from '@/components/gastown/GastownBackdrop';
@@ -78,13 +79,12 @@ export function OrgTownListPageClient({ organizationId, role }: OrgTownListPageC
     <PageContainer>
       <GastownBackdrop contentClassName="p-5 md:p-7">
         <div className="flex flex-col gap-3">
+          <SetPageTitle title="Gas Town">
+            <Badge variant="beta">beta</Badge>
+          </SetPageTitle>
           <div className="flex items-start justify-between gap-3">
             <div>
-              <div className="flex items-center gap-3">
-                <h1 className="text-3xl font-semibold tracking-tight text-white/95">Gas Town</h1>
-                <Badge variant="beta">beta</Badge>
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/60">
+              <p className="max-w-2xl text-sm leading-relaxed text-white/60">
                 A chat-first orchestration console for towns, rigs, beads, and agents. Built for
                 radical transparency: every object is clickable; every outcome is attributable.
               </p>

--- a/src/app/(app)/organizations/[id]/integrations/discord/page.tsx
+++ b/src/app/(app)/organizations/[id]/integrations/discord/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { DiscordIntegrationDetails } from '@/components/integrations/DiscordIntegrationDetails';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
@@ -30,12 +31,10 @@ export default async function OrgDiscordIntegrationPage({
                 Back to Integrations
               </Button>
             </Link>
-            <div>
-              <h1 className="text-3xl font-bold">Discord Integration</h1>
-              <p className="text-muted-foreground mt-2">
-                Manage Discord integration for {organization.name}
-              </p>
-            </div>
+            <SetPageTitle title="Discord Integration" />
+            <p className="text-muted-foreground">
+              Manage Discord integration for {organization.name}
+            </p>
           </div>
 
           <Suspense

--- a/src/app/(app)/organizations/[id]/integrations/github/page.tsx
+++ b/src/app/(app)/organizations/[id]/integrations/github/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { GitHubIntegrationDetails } from '@/components/integrations/GitHubIntegrationDetails';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
@@ -32,12 +33,10 @@ export default async function GitHubIntegrationPage({
                 Back to Integrations
               </Button>
             </Link>
-            <div>
-              <h1 className="text-3xl font-bold">GitHub Integration</h1>
-              <p className="text-muted-foreground mt-2">
-                Manage GitHub App installation for {organization.name}
-              </p>
-            </div>
+            <SetPageTitle title="GitHub Integration" />
+            <p className="text-muted-foreground">
+              Manage GitHub App installation for {organization.name}
+            </p>
           </div>
 
           <Suspense

--- a/src/app/(app)/organizations/[id]/integrations/gitlab/page.tsx
+++ b/src/app/(app)/organizations/[id]/integrations/gitlab/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { GitLabIntegrationDetails } from '@/components/integrations/GitLabIntegrationDetails';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
@@ -30,12 +31,10 @@ export default async function GitLabIntegrationPage({
                 Back to Integrations
               </Button>
             </Link>
-            <div>
-              <h1 className="text-3xl font-bold">GitLab Integration</h1>
-              <p className="text-muted-foreground mt-2">
-                Manage GitLab OAuth integration for {organization.name}
-              </p>
-            </div>
+            <SetPageTitle title="GitLab Integration" />
+            <p className="text-muted-foreground">
+              Manage GitLab OAuth integration for {organization.name}
+            </p>
           </div>
 
           <Suspense

--- a/src/app/(app)/organizations/[id]/integrations/page.tsx
+++ b/src/app/(app)/organizations/[id]/integrations/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { IntegrationsPageClient } from './IntegrationsPageClient';
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { notFound } from 'next/navigation';
 import { ENABLE_DEPLOY_FEATURE } from '@/lib/constants';
@@ -17,12 +18,10 @@ export default async function IntegrationsPage({ params }: { params: Promise<{ i
       params={params}
       render={({ organization }) => (
         <>
-          <div>
-            <h1 className="text-3xl font-bold">Integrations</h1>
-            <p className="text-muted-foreground mt-2">
-              Connect and manage platform integrations for {organization.name}
-            </p>
-          </div>
+          <SetPageTitle title="Integrations" />
+          <p className="text-muted-foreground">
+            Connect and manage platform integrations for {organization.name}
+          </p>
 
           <Suspense fallback={<div>Loading...</div>}>
             <IntegrationsPageClient organizationId={organization.id} />

--- a/src/app/(app)/organizations/[id]/integrations/slack/page.tsx
+++ b/src/app/(app)/organizations/[id]/integrations/slack/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { SlackIntegrationDetails } from '@/components/integrations/SlackIntegrationDetails';
 import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
@@ -30,12 +31,10 @@ export default async function OrgSlackIntegrationPage({
                 Back to Integrations
               </Button>
             </Link>
-            <div>
-              <h1 className="text-3xl font-bold">Slack Integration</h1>
-              <p className="text-muted-foreground mt-2">
-                Manage Slack integration for {organization.name}
-              </p>
-            </div>
+            <SetPageTitle title="Slack Integration" />
+            <p className="text-muted-foreground">
+              Manage Slack integration for {organization.name}
+            </p>
           </div>
 
           <Suspense

--- a/src/components/organizations/OrganizationPageHeader.tsx
+++ b/src/components/organizations/OrganizationPageHeader.tsx
@@ -29,13 +29,13 @@ export function OrganizationPageHeader({
   const finalTitle = title.replace('<org name>', organizationName);
 
   return (
-    <>
+    <div className="flex w-full flex-col gap-y-4">
       <SetPageTitle title={finalTitle}>{badge}</SetPageTitle>
       {showBackButton && (
         <div>
           <BackButton href={finalBackHref}>{backButtonText}</BackButton>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/organizations/OrganizationPageHeader.tsx
+++ b/src/components/organizations/OrganizationPageHeader.tsx
@@ -2,11 +2,12 @@
 
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { BackButton } from '@/components/BackButton';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import type { ReactNode } from 'react';
 
 type OrganizationPageHeaderProps = {
   organizationId: string;
-  title: ReactNode;
+  title: string;
   showBackButton?: boolean;
   backButtonText?: string;
   backButtonHref?: string;
@@ -25,20 +26,16 @@ export function OrganizationPageHeader({
 
   const finalBackHref = backButtonHref || `/organizations/${organizationId}`;
   const organizationName = organization?.name || 'Organization';
-  const finalTitle =
-    typeof title === 'string' ? title.replace('<org name>', organizationName) : title;
+  const finalTitle = title.replace('<org name>', organizationName);
 
   return (
-    <div className="flex w-full flex-col gap-y-4">
+    <>
+      <SetPageTitle title={finalTitle}>{badge}</SetPageTitle>
       {showBackButton && (
         <div>
           <BackButton href={finalBackHref}>{backButtonText}</BackButton>
         </div>
       )}
-      <div className="flex items-center gap-3">
-        <h1 className="text-3xl font-bold">{finalTitle}</h1>
-        {badge}
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/components/organizations/OrganizationPaymentDetails.tsx
+++ b/src/components/organizations/OrganizationPaymentDetails.tsx
@@ -17,8 +17,7 @@ import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { AnimatedDollars } from './AnimatedDollars';
 import { formatDollars, formatIsoDateTime_IsoOrderNoSeconds, fromMicrodollars } from '@/lib/utils';
 import CreditPurchaseOptions from '@/components/payment/CreditPurchaseOptions';
-import { PiggyBank, Bell, ChevronRight, Clock } from 'lucide-react';
-import Link from 'next/link';
+import { PiggyBank, Bell, Clock } from 'lucide-react';
 import { useExpiringCredits } from './useExpiringCredits';
 
 type Props = {
@@ -65,19 +64,10 @@ export function OrganizationPaymentDetails({ organizationId, role, isAutoTopUpEn
       <div className="flex w-full flex-col gap-y-8">
         <OrganizationPageHeader
           organizationId={organizationId}
-          title={
-            <div className="flex items-center gap-2">
-              <Link
-                href={`/organizations/${organizationId}`}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Organization Details
-              </Link>
-              <ChevronRight className="text-muted-foreground h-5 w-5" />
-              <span>Payment Details</span>
-            </div>
-          }
-          showBackButton={false}
+          title="Payment Details"
+          showBackButton={true}
+          backButtonText="Organization Details"
+          backButtonHref={`/organizations/${organizationId}`}
         />
 
         {/* Buy Credits and Auto Top-Up Section */}

--- a/src/components/organizations/custom-modes/CustomModesLayout.tsx
+++ b/src/components/organizations/custom-modes/CustomModesLayout.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { LoadingCard } from '@/components/LoadingCard';
 import { ErrorCard } from '@/components/ErrorCard';
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { Plus, Edit, Trash2, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -267,10 +268,10 @@ export function CustomModesLayout({ organizationId }: CustomModesLayoutProps) {
   return (
     <LockableContainer>
       <div className="space-y-6">
+        <SetPageTitle title="Modes" />
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold">Modes</h1>
-            <p className="text-muted-foreground mt-2">
+            <p className="text-muted-foreground">
               Manage default and custom modes for your organization
             </p>
           </div>

--- a/src/components/organizations/welcome/OrganizationWelcomeCards.tsx
+++ b/src/components/organizations/welcome/OrganizationWelcomeCards.tsx
@@ -16,9 +16,9 @@ export function OrganizationWelcomeCards({
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <h1 className="text-foreground mb-2 text-3xl font-bold">
+        <h2 className="text-foreground mb-2 text-3xl font-bold">
           You've created an account for your organization
-        </h1>
+        </h2>
         <p className="text-muted-foreground">
           With Kilo Teams you get powerful collaboration features and insights on top of our open
           source coding agent.

--- a/src/components/profile/UserProfileCard.tsx
+++ b/src/components/profile/UserProfileCard.tsx
@@ -31,19 +31,19 @@ export function UserProfileCard({
 
   return (
     <>
-      <div className="flex items-start justify-between">
-        <div className="flex items-center space-x-4">
-          <Avatar className="h-14 w-14">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center space-x-4">
+          <Avatar className="h-14 w-14 shrink-0">
             {imageUrl ? <AvatarImage src={imageUrl} alt={name} /> : null}
             <AvatarFallback className="text-xl">
               {getInitialsFromName(name || email)}
             </AvatarFallback>
           </Avatar>
-          <div className="flex-1">
-            <h2 className="text-foreground text-xl font-semibold">{name}</h2>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-foreground truncate text-xl font-semibold">{name}</h2>
             <p className="text-muted-foreground flex items-center text-sm">
-              <Mail className="mr-1.5 h-3.5 w-3.5" />
-              {email}
+              <Mail className="mr-1.5 h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{email}</span>
             </p>
             <div className="mt-2 flex flex-col gap-1">
               <ProfileLink
@@ -61,7 +61,7 @@ export function UserProfileCard({
         </div>
         <button
           onClick={() => setEditDialogOpen(true)}
-          className="hover:bg-muted inline-flex cursor-pointer items-center gap-1 rounded p-1 transition-all duration-200 focus:outline-none"
+          className="hover:bg-muted inline-flex shrink-0 cursor-pointer items-center gap-1 rounded p-1 transition-all duration-200 focus:outline-none"
           title="Edit profile"
         >
           <Edit className="text-muted-foreground hover:text-foreground h-4 w-4" />


### PR DESCRIPTION
## Summary

- Continues the topbar title migration started in #1554, covering all remaining organization context pages
- Migrates `OrganizationPageHeader` (shared component) to use `SetPageTitle` instead of `<h1>`, which cascades the fix to 8 pages that use it (dashboard, audit logs, BYOK, code indexing, payment details, providers & models, subscription, usage)
- Migrates 5 integration pages (main, GitHub, GitLab, Discord, Slack), 5 feature client components (auto-fix, auto-triage, code-reviews, deploy, gastown), and `CustomModesLayout`
- Narrows `OrganizationPageHeader.title` from `ReactNode` to `string` since `SetPageTitle` requires a string; fixes `OrganizationPaymentDetails` which previously passed a JSX breadcrumb (now uses `showBackButton` instead)
- Downgrades `OrganizationWelcomeCards` heading from `<h1>` to `<h2>` since the page title is already set by `PageLayout`

## Verification

- [x] `pnpm typecheck` — passes with zero errors
- [x] `pnpm format:check` — passes (via pre-commit hook)
- [x] `eslint` — passes (via pre-commit hook)
- [x] Verified zero `<h1>` tags remain in `src/app/(app)/organizations/` and `src/components/organizations/` (except `CreateOrganizationPage.tsx` which is outside the `(app)` layout)

## Visual Changes

<img width="4388" height="2708" alt="CleanShot 2026-03-26 at 11 38 06@2x" src="https://github.com/user-attachments/assets/c91284c5-3e7f-4215-8adf-d622abaac296" />

## Reviewer Notes

- `OrganizationPageHeader.title` type changed from `ReactNode` to `string` — this is a narrowing change. All existing callers already pass string literals except `OrganizationPaymentDetails`, which was updated to use `showBackButton` + `backButtonHref` instead of a JSX breadcrumb title.
- The only `<h1>` intentionally left unmigrated is in `CreateOrganizationPage.tsx`, which renders outside the `(app)` route group (no sidebar/topbar).