### PR TITLE
feat(layout): align topbar title with centered PageContainer content

### DIFF
--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -16,16 +16,16 @@ export function AppTopbar() {
   if (hidden) return null;
 
   return (
-    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
+    <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
       {/* Sidebar trigger pinned to the left edge */}
       <div className="absolute left-4 top-0 z-10 flex h-14 items-center gap-2">
         <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="h-4 @min-[1280px]:hidden" />
+        <Separator orientation="vertical" className="h-4" />
       </div>
 
-      {/* Title container: centered on wide screens, flush with trigger on narrow */}
+      {/* Padding mirrors PageContainer centering; max() ensures trigger clearance */}
       {title && (
-        <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2 pl-16 pr-4 md:pr-6 @min-[1280px]:px-4 @min-[1280px]:md:px-6">
+        <div className="flex h-full w-full items-center gap-2 pl-[max(2.75rem,calc((100%-1140px)/2+1rem))] pr-[max(1rem,calc((100%-1140px)/2+1rem))] md:pl-[max(2.75rem,calc((100%-1140px)/2+1.5rem))] md:pr-[max(1.5rem,calc((100%-1140px)/2+1.5rem))]">
           {icon}
           <Breadcrumb>
             <BreadcrumbList>

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -16,11 +16,16 @@ export function AppTopbar() {
   if (hidden) return null;
 
   return (
-    <header className="bg-background sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b px-4">
-      <SidebarTrigger className="-ml-1" />
-      <Separator orientation="vertical" className="mr-2 h-4" />
+    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
+      {/* Sidebar trigger pinned to the left edge */}
+      <div className="absolute left-4 top-0 z-10 flex h-14 items-center gap-2">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="h-4 @min-[1280px]:hidden" />
+      </div>
+
+      {/* Title container: centered on wide screens, flush with trigger on narrow */}
       {title && (
-        <div className="flex items-center gap-2">
+        <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2 pl-16 pr-4 md:pr-6 @min-[1280px]:px-4 @min-[1280px]:md:px-6">
           {icon}
           <Breadcrumb>
             <BreadcrumbList>

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -16,17 +16,17 @@ export function AppTopbar() {
   if (hidden) return null;
 
   return (
-    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b grid grid-cols-[auto_1fr_auto] gap-4">
+    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b flex flex-row">
       <div className="flex flex-row">
         <div className="flex h-14 items-center gap-2 aspect-square justify-center">
           <SidebarTrigger className="-ml-1" />
         </div>
-        <Separator orientation="vertical" className="h-4 @min-[1280px]:hidden" />
+        <Separator orientation="vertical" className="h-4 @min-[1224]:hidden" />
       </div>
 
-      <div>
+      <div className="absolute w-full h-full">
         {title && (
-          <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2">
+          <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2 pl-18 @min-[1224]:pl-6">
             {icon}
             <Breadcrumb>
               <BreadcrumbList>

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -16,27 +16,29 @@ export function AppTopbar() {
   if (hidden) return null;
 
   return (
-    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
-      {/* Sidebar trigger pinned to the left edge */}
-      <div className="absolute left-4 top-0 z-10 flex h-14 items-center gap-2">
-        <SidebarTrigger className="-ml-1" />
+    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b grid grid-cols-[auto_1fr_auto] gap-4">
+      <div className="flex flex-row">
+        <div className="flex h-14 items-center gap-2 aspect-square justify-center">
+          <SidebarTrigger className="-ml-1" />
+        </div>
         <Separator orientation="vertical" className="h-4 @min-[1280px]:hidden" />
       </div>
 
-      {/* Title container: centered on wide screens, flush with trigger on narrow */}
-      {title && (
-        <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2 pl-16 pr-4 md:pr-6 @min-[1280px]:px-4 @min-[1280px]:md:px-6">
-          {icon}
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbPage>{title}</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-          {extras}
-        </div>
-      )}
+      <div>
+        {title && (
+          <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2">
+            {icon}
+            <Breadcrumb>
+              <BreadcrumbList>
+                <BreadcrumbItem>
+                  <BreadcrumbPage>{title}</BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+            {extras}
+          </div>
+        )}
+      </div>
     </header>
   );
 }

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -16,16 +16,16 @@ export function AppTopbar() {
   if (hidden) return null;
 
   return (
-    <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
+    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
       {/* Sidebar trigger pinned to the left edge */}
       <div className="absolute left-4 top-0 z-10 flex h-14 items-center gap-2">
         <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="h-4" />
+        <Separator orientation="vertical" className="h-4 @min-[1280px]:hidden" />
       </div>
 
-      {/* Padding mirrors PageContainer centering; max() ensures trigger clearance */}
+      {/* Title container: centered on wide screens, flush with trigger on narrow */}
       {title && (
-        <div className="flex h-full w-full items-center gap-2 pl-[max(2.75rem,calc((100%-1140px)/2+1rem))] pr-[max(1rem,calc((100%-1140px)/2+1rem))] md:pl-[max(2.75rem,calc((100%-1140px)/2+1.5rem))] md:pr-[max(1.5rem,calc((100%-1140px)/2+1.5rem))]">
+        <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2 pl-16 pr-4 md:pr-6 @min-[1280px]:px-4 @min-[1280px]:md:px-6">
           {icon}
           <Breadcrumb>
             <BreadcrumbList>


### PR DESCRIPTION
## Summary

Aligns the topbar page title with the left edge of the centered `PageContainer` content on wide screens. Previously, the title sat immediately after the sidebar trigger regardless of viewport width, creating visual misalignment with the centered page content below.

The approach uses Tailwind v4 container queries (`@container` / `@min-[1280px]:`) on the header to switch between two layout modes:
- **Narrow** (header < 1280px): title uses `pl-14` to clear the absolutely-positioned sidebar trigger, sitting right next to it
- **Wide** (header >= 1280px): title container mirrors `PageContainer`'s `mx-auto max-w-[1140px]` with matching `px-4 md:px-6` padding, achieving pixel-perfect alignment

This is a single-file change to `AppTopbar.tsx`. The sidebar trigger is now absolutely positioned so it stays pinned to the left edge without affecting title centering.

## Verification

- [x] `pnpm typecheck` — passes with no errors
- [x] Visual verification at 1920px with sidebar open: title at 542px, page content at 542px (aligned)
- [x] Visual verification at 1920px with sidebar closed: title at 414px, page content at 414px (aligned)
- [x] Visual verification at 1024px with sidebar open: title at 312px, right after trigger at 296px (correct narrow behavior)
- [x] Visual verification at 1024px with sidebar closed: title at 56px (pl-14), content at 56px (aligned)
- [x] Sidebar toggle does not break layout in either mode

## Visual Changes

<img width="802" height="1036" alt="CleanShot 2026-03-26 at 11 03 42@2x" src="https://github.com/user-attachments/assets/4f2a9305-88a7-4d53-9776-c4370f23835f" />
<img width="2812" height="2546" alt="CleanShot 2026-03-26 at 11 03 29@2x" src="https://github.com/user-attachments/assets/b9675d17-e5ba-4726-93c1-3566a7d0316a" />
<img width="4630" height="2634" alt="CleanShot 2026-03-26 at 11 03 34@2x" src="https://github.com/user-attachments/assets/fb58ef08-fef7-456e-8b52-1771e93979d5" />


## Reviewer Notes

- Builds on top of #1554 which added the topbar with page title
- The 1280px container query breakpoint was chosen because the header needs to be wide enough for the 1140px centered container + padding to have meaningful centering
- The separator between trigger and title is hidden on wide screens (`@min-[1280px]:hidden`) since the trigger is visually separated from the centered title