### PR TITLE
Use api url as pepper in hash generation for new providers

### DIFF
--- a/src/lib/providerHash.ts
+++ b/src/lib/providerHash.ts
@@ -14,11 +14,11 @@ import type { GatewayRequest } from '@/lib/providers/openrouter/types';
 export function generateProviderSpecificHash(payload: string, provider: Provider): string {
   const salt = 'd20250815';
   const pepper =
-    provider.id === 'custom'
-      ? provider.apiUrl
+    provider.id === 'vercel'
+      ? 'vercel'
       : provider.id === 'openrouter'
         ? 'henk is a boss'
-        : provider.id;
+        : provider.apiUrl;
   return crypto
     .createHash('sha256')
     .update(salt + pepper + payload)


### PR DESCRIPTION
I think this makes it less likely we change it accidentally