### PR TITLE
feat(kiloclaw): add debug logging to checkin and instance-ready flow

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1296,6 +1296,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    */
   async tryMarkInstanceReady(): Promise<{ shouldNotify: boolean; userId: string | null }> {
     await this.loadState();
+
+    console.info(`[tryMarkInstanceReady] instanceReadyEmailSent=${this.s.instanceReadyEmailSent}`);
+
     if (this.s.instanceReadyEmailSent) {
       return { shouldNotify: false, userId: this.s.userId };
     }

--- a/kiloclaw/src/routes/controller.ts
+++ b/kiloclaw/src/routes/controller.ts
@@ -178,11 +178,15 @@ controller.post('/checkin', async (c: Context<AppEnv>) => {
     waitUntil(telemetryPromise);
   }
 
+  console.info(`[controller] checkin ${data.sandboxId}, load: ${data.loadAvg5m}`);
+
   // Instance readiness detection: when load drops below threshold, send a
   // one-time "instance ready" email to the user via the Next.js internal API.
   if (data.loadAvg5m <= INSTANCE_READY_LOAD_THRESHOLD) {
     try {
       const { shouldNotify } = await stub.tryMarkInstanceReady();
+
+      console.info(`[controller] checkin ${data.sandboxId}, shouldNotify=${shouldNotify}`);
 
       if (shouldNotify && c.env.INTERNAL_API_SECRET) {
         const apiOrigin = nextApiOrigin(c.env.KILOCODE_API_BASE_URL);


### PR DESCRIPTION
## Summary

Add `console.info` logging to the KiloClaw checkin endpoint and `tryMarkInstanceReady` method. This logs the sandbox ID, load average, `instanceReadyEmailSent` state, and `shouldNotify` result to help diagnose instance-ready notification timing in production.

## Verification

- [x] `pnpm typecheck` — passed (0 errors, via pre-push hook)
- [x] `oxfmt --list-different .` — passed (no formatting issues, via pre-push hook)

## Visual Changes

N/A

## Reviewer Notes

Logging-only change — no behavioral impact. The logs target the checkin → instance-ready notification path to help debug cases where the ready email is or isn't sent.