### PR TITLE
fix(topbar): use float layout for title aligned with page content

### DIFF
--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -22,7 +22,7 @@ export function AppTopbar() {
 
       {title && (
         <div className="mx-auto h-full max-w-285 px-4 md:px-6">
-          <span className="inline-flex h-full items-center gap-2">
+          <div className="inline-flex h-full items-center gap-2">
             {icon}
             <Breadcrumb>
               <BreadcrumbList>
@@ -32,7 +32,7 @@ export function AppTopbar() {
               </BreadcrumbList>
             </Breadcrumb>
             {extras}
-          </span>
+          </div>
         </div>
       )}
     </header>

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -2,7 +2,6 @@
 
 import { usePageTitle } from '@/contexts/PageTitleContext';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import { Separator } from '@/components/ui/separator';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -16,17 +15,14 @@ export function AppTopbar() {
   if (hidden) return null;
 
   return (
-    <header className="@container bg-background sticky top-0 z-10 h-14 shrink-0 border-b flex flex-row">
-      <div className="flex flex-row">
-        <div className="flex h-14 items-center gap-2 aspect-square justify-center">
-          <SidebarTrigger className="-ml-1" />
-        </div>
-        <Separator orientation="vertical" className="h-4 @min-[1224]:hidden" />
+    <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
+      <div className="float-left flex h-14 aspect-square items-center justify-center">
+        <SidebarTrigger className="-ml-1" />
       </div>
 
-      <div className="absolute w-full h-full">
-        {title && (
-          <div className="mx-auto flex h-full w-full max-w-285 items-center gap-2 pl-18 @min-[1224]:pl-6">
+      {title && (
+        <div className="mx-auto h-full max-w-285 px-4 md:px-6">
+          <span className="inline-flex h-full items-center gap-2">
             {icon}
             <Breadcrumb>
               <BreadcrumbList>
@@ -36,9 +32,9 @@ export function AppTopbar() {
               </BreadcrumbList>
             </Breadcrumb>
             {extras}
-          </div>
-        )}
-      </div>
+          </span>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary

Replace the absolute-positioning + container-query approach in `AppTopbar` with a float-based layout. The sidebar trigger floats left while the title sits in a centered block that mirrors `PageContainer`'s `max-w-285` / `px-4 md:px-6`, so the title left-aligns with the main page content below instead of being centered in the topbar. This also removes the `@container` / `@min-[1224]` container queries and the `Separator` that were previously needed to prevent overlap.

## Verification

- [x] `pnpm typecheck` — passes
- [x] Formatting/lint hooks pass on push

## Visual Changes

N/A — screenshots were reviewed interactively during development.

## Reviewer Notes

The outer title `div` is intentionally a plain block (not flex) so it overlaps the float silently; only the inner `inline-flex` span is inline-level content that flows around the float when needed.