### PR TITLE
fix(cloud-agent): improve chat auto-scroll and fix hooks order

### DIFF
--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -140,21 +140,31 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
+  const chatUI = useAtomValue(manager.atoms.chatUI);
+  const setChatUI = useSetAtom(manager.atoms.chatUI);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
-  }, [dynamicMessages]);
+    if (!chatUI.shouldAutoScroll) return;
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+  }, [dynamicMessages, chatUI.shouldAutoScroll]);
 
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    setShowScrollButton(distanceFromBottom > 200);
-  }, []);
+    const isNearBottom = distanceFromBottom < 100;
+    setShowScrollButton(!isNearBottom);
+    setChatUI({ shouldAutoScroll: isNearBottom });
+  }, [setChatUI]);
 
   const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, []);
+    setChatUI({ shouldAutoScroll: true });
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }, [setChatUI]);
 
   // -- Handlers -------------------------------------------------------------
   const handleSendMessage = useCallback(

--- a/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -457,6 +457,31 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   const isIntegrationMissing = githubIntegrationMissing && gitlabIntegrationMissing;
 
   // ---------------------------------------------------------------------------
+  // Repo popover state (must be declared before early returns to satisfy Rules of Hooks)
+  // ---------------------------------------------------------------------------
+  const [repoPopoverOpen, setRepoPopoverOpen] = useState(false);
+
+  const recentFullNames = useMemo(() => new Set(recentRepos.map(r => r.fullName)), [recentRepos]);
+  const githubRepos = unifiedRepositories.filter(
+    r => r.platform === 'github' && !recentFullNames.has(r.fullName)
+  );
+  const gitlabRepos = unifiedRepositories.filter(
+    r => r.platform === 'gitlab' && !recentFullNames.has(r.fullName)
+  );
+  const otherRepos = unifiedRepositories.filter(
+    r => !r.platform && !recentFullNames.has(r.fullName)
+  );
+  const filteredUnifiedRepos = unifiedRepositories.filter(r => !recentFullNames.has(r.fullName));
+
+  const handleRepoPillSelect = useCallback(
+    (fullName: string) => {
+      handleRepoSelect(fullName);
+      setRepoPopoverOpen(false);
+    },
+    [handleRepoSelect]
+  );
+
+  // ---------------------------------------------------------------------------
   // Submit
   // ---------------------------------------------------------------------------
   const isFormValid =
@@ -611,32 +636,6 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
       </div>
     );
   }
-
-  // ---------------------------------------------------------------------------
-  // Repo pill data
-  // ---------------------------------------------------------------------------
-  const [repoPopoverOpen, setRepoPopoverOpen] = useState(false);
-
-  // Group repos by platform for the Command list, excluding recently used
-  const recentFullNames = useMemo(() => new Set(recentRepos.map(r => r.fullName)), [recentRepos]);
-  const githubRepos = unifiedRepositories.filter(
-    r => r.platform === 'github' && !recentFullNames.has(r.fullName)
-  );
-  const gitlabRepos = unifiedRepositories.filter(
-    r => r.platform === 'gitlab' && !recentFullNames.has(r.fullName)
-  );
-  const otherRepos = unifiedRepositories.filter(
-    r => !r.platform && !recentFullNames.has(r.fullName)
-  );
-  const filteredUnifiedRepos = unifiedRepositories.filter(r => !recentFullNames.has(r.fullName));
-
-  const handleRepoPillSelect = useCallback(
-    (fullName: string) => {
-      handleRepoSelect(fullName);
-      setRepoPopoverOpen(false);
-    },
-    [handleRepoSelect]
-  );
 
   // ---------------------------------------------------------------------------
   // Render


### PR DESCRIPTION
## Summary

- **Auto-scroll improvement** (`CloudChatPage.tsx`): Replace `scrollIntoView` with `scrollTo` on the scroll container for more reliable auto-scrolling. Introduce a `shouldAutoScroll` flag (from the existing `chatUI` atom) that disables auto-scroll when the user manually scrolls away from the bottom (>100 px threshold) and re-enables it when they click the scroll-to-bottom button. This prevents the chat from jumping to the bottom while a user is reading earlier messages.
- **Hooks ordering fix** (`NewSessionPanel.tsx`): Move repo popover state declarations (`useState`, `useMemo`, `useCallback`) above early returns so hooks are always called in the same order, satisfying the React Rules of Hooks.

## Verification

- [x] `oxfmt` format check — passed
- [x] Typecheck — passed (no workspace changes)
- [x] ESLint — passed (0 warnings, 0 errors)

## Visual Changes

N/A

## Reviewer Notes

- The `shouldAutoScroll` flag lives on the existing `chatUI` jotai atom (`session-manager.ts:244`), so no new state primitives are introduced.
- The scroll threshold changed from 200 px (show button) to 100 px (show button + disable auto-scroll) — intentional tightening so the button appears closer to content.
- The hooks reordering in `NewSessionPanel` is a pure move with no logic changes; diff is noisy but the before/after code is identical.