### PR TITLE
fix(claw): prevent onboarding wizard from skipping steps after destroy and re-provision

### DIFF
--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Check, Sparkles, TriangleAlert, X, Zap } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
@@ -73,6 +73,19 @@ export function ClawDashboard({
   const [channelTokens, setChannelTokens] = useState<Record<string, string> | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const hasPairingStep = selectedChannelId === 'telegram' || selectedChannelId === 'discord';
+
+  // Reset onboarding wizard to step 1 whenever we enter setup mode so that
+  // a destroy → re-provision cycle always starts fresh.
+  const prevIsNewSetup = useRef(isNewSetup);
+  useEffect(() => {
+    if (isNewSetup && !prevIsNewSetup.current) {
+      setOnboardingStep('permissions');
+      setSelectedPreset(null);
+      setChannelTokens(null);
+      setSelectedChannelId(null);
+    }
+    prevIsNewSetup.current = isNewSetup;
+  }, [isNewSetup]);
 
   const [dirtySecrets, setDirtySecrets] = useState<Set<string>>(new Set());
 
@@ -182,6 +195,7 @@ export function ClawDashboard({
           <CreateInstanceCard
             mutations={mutations}
             onProvisionStart={() => onNewSetupChange(true)}
+            onProvisionFailed={() => onNewSetupChange(false)}
           />
         ) : isNewSetup && onboardingStep === 'permissions' ? (
           <PermissionStep

--- a/src/app/(app)/claw/components/CreateInstanceCard.tsx
+++ b/src/app/(app)/claw/components/CreateInstanceCard.tsx
@@ -24,9 +24,11 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 export function CreateInstanceCard({
   mutations,
   onProvisionStart,
+  onProvisionFailed,
 }: {
   mutations: ClawMutations;
   onProvisionStart?: () => void;
+  onProvisionFailed?: () => void;
 }) {
   // Evaluate the landing-page experiment flag so PostHog attaches
   // $feature/button-vs-card to events fired in this component.
@@ -115,11 +117,17 @@ export function CreateInstanceCard({
       auto_provision_after_payment: true,
     });
 
+    // Enter the onboarding wizard before the mutation fires so the UI
+    // shows the wizard immediately instead of racing with status polling.
+    onProvisionStart?.();
+
     mutations.provision.mutate(
       { kilocodeDefaultModel: `kilocode/${selectedModel}` },
       {
-        onSuccess: () => onProvisionStart?.(),
-        onError: err => toast.error(`Failed to create: ${err.message}`),
+        onError: err => {
+          onProvisionFailed?.();
+          toast.error(`Failed to create: ${err.message}`);
+        },
       }
     );
   }, [
@@ -131,6 +139,7 @@ export function CreateInstanceCard({
     mutations.provision,
     posthog,
     onProvisionStart,
+    onProvisionFailed,
   ]);
 
   function handleCreate() {
@@ -157,13 +166,16 @@ export function CreateInstanceCard({
     // doesn't depend on the useUser query still being resolved.
     const email = user?.google_user_email;
 
+    // Enter the onboarding wizard before the mutation fires so the UI
+    // shows the wizard immediately instead of racing with status polling.
+    onProvisionStart?.();
+
     mutations.provision.mutate(
       {
         kilocodeDefaultModel: `kilocode/${selectedModel}`,
       },
       {
         onSuccess: () => {
-          onProvisionStart?.();
           // Record a Rewardful lead when an affiliate-referred user starts a trial.
           // No-op if the visitor is not a referral or rw.js didn't load.
           if (email && typeof window.rewardful === 'function') {
@@ -171,6 +183,7 @@ export function CreateInstanceCard({
           }
         },
         onError: err => {
+          onProvisionFailed?.();
           toast.error(`Failed to create: ${err.message}`);
         },
       }

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -110,27 +110,23 @@ export function useKiloClawMutations() {
 
   // Wipe all instance-scoped caches so no stale data (e.g. gatewayReady
   // from the old instance) bleeds into a subsequent re-provision flow.
-  const invalidateAllInstanceState = async () => {
+  // removeQueries drops the cached payload entirely; invalidateQueries
+  // only marks stale but leaves the old value readable synchronously.
+  const resetAllInstanceState = async () => {
     await invalidateStatus();
     await queryClient.invalidateQueries({
       queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
     });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.gatewayReady.queryKey(),
-    });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
-    });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getConfig.queryKey(),
-    });
+    queryClient.removeQueries({ queryKey: trpc.kiloclaw.gatewayReady.queryKey() });
+    queryClient.removeQueries({ queryKey: trpc.kiloclaw.gatewayStatus.queryKey() });
+    queryClient.removeQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
   };
 
   return {
     start: useMutation(trpc.kiloclaw.start.mutationOptions({ onSuccess: invalidateStatus })),
     stop: useMutation(trpc.kiloclaw.stop.mutationOptions({ onSuccess: invalidateStatus })),
     destroy: useMutation(
-      trpc.kiloclaw.destroy.mutationOptions({ onSuccess: invalidateAllInstanceState })
+      trpc.kiloclaw.destroy.mutationOptions({ onSuccess: resetAllInstanceState })
     ),
     provision: useMutation(
       trpc.kiloclaw.provision.mutationOptions({ onSuccess: invalidateStatusAndBilling })

--- a/src/hooks/useKiloClaw.ts
+++ b/src/hooks/useKiloClaw.ts
@@ -108,10 +108,30 @@ export function useKiloClawMutations() {
     });
   };
 
+  // Wipe all instance-scoped caches so no stale data (e.g. gatewayReady
+  // from the old instance) bleeds into a subsequent re-provision flow.
+  const invalidateAllInstanceState = async () => {
+    await invalidateStatus();
+    await queryClient.invalidateQueries({
+      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
+    });
+    await queryClient.invalidateQueries({
+      queryKey: trpc.kiloclaw.gatewayReady.queryKey(),
+    });
+    await queryClient.invalidateQueries({
+      queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
+    });
+    await queryClient.invalidateQueries({
+      queryKey: trpc.kiloclaw.getConfig.queryKey(),
+    });
+  };
+
   return {
     start: useMutation(trpc.kiloclaw.start.mutationOptions({ onSuccess: invalidateStatus })),
     stop: useMutation(trpc.kiloclaw.stop.mutationOptions({ onSuccess: invalidateStatus })),
-    destroy: useMutation(trpc.kiloclaw.destroy.mutationOptions({ onSuccess: invalidateStatus })),
+    destroy: useMutation(
+      trpc.kiloclaw.destroy.mutationOptions({ onSuccess: invalidateAllInstanceState })
+    ),
     provision: useMutation(
       trpc.kiloclaw.provision.mutationOptions({ onSuccess: invalidateStatusAndBilling })
     ),

--- a/src/lib/kiloclaw/instance-registry.ts
+++ b/src/lib/kiloclaw/instance-registry.ts
@@ -82,6 +82,19 @@ export async function markActiveInstanceDestroyed(
 }
 
 /**
+ * Soft-delete a specific instance row by its primary key.
+ * Unlike {@link markActiveInstanceDestroyed} (which targets the user's
+ * current active row), this targets exactly one row and is safe to use
+ * for rollback when the caller knows which row it created.
+ */
+export async function markInstanceDestroyedById(instanceId: string): Promise<void> {
+  await db
+    .update(kiloclaw_instances)
+    .set({ destroyed_at: new Date().toISOString() })
+    .where(and(eq(kiloclaw_instances.id, instanceId), isNull(kiloclaw_instances.destroyed_at)));
+}
+
+/**
  * Revert a prior soft-delete (used when downstream destroy fails).
  */
 export async function restoreDestroyedInstance(instanceId: string): Promise<void> {

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -222,7 +222,13 @@ async function provisionInstance(
   user: Parameters<typeof generateApiToken>[0],
   input: z.infer<typeof updateConfigSchema>
 ) {
-  await ensureActiveInstance(user.id);
+  // Check whether this user already had an active row before we create one.
+  // ensureActiveInstance is idempotent: it may return a pre-existing row.
+  // On provision failure we only clean up a *freshly-created* row to avoid
+  // soft-deleting a legitimate pre-existing instance.
+  const preExistingRow = await getActiveInstance(user.id);
+  const instanceRow = await ensureActiveInstance(user.id);
+  const rowIsNew = !preExistingRow || preExistingRow.id !== instanceRow.id;
 
   const encryptedSecrets = input.secrets
     ? Object.fromEntries(
@@ -256,15 +262,17 @@ async function provisionInstance(
       pinnedImageTag,
     });
   } catch (error) {
-    // Clean up the DB row that ensureActiveInstance created so that an
-    // orphaned active row (e.g. from "Cannot provision: instance is being
-    // destroyed") doesn't confuse subsequent getBillingStatus queries.
-    await markActiveInstanceDestroyed(user.id).catch(cleanupErr => {
-      console.error(
-        '[kiloclaw] Failed to clean up instance row after provision error:',
-        cleanupErr
-      );
-    });
+    // Only clean up the row if ensureActiveInstance created it for this
+    // attempt. Pre-existing rows belong to a prior successful provision
+    // and must not be destroyed.
+    if (rowIsNew) {
+      await markActiveInstanceDestroyed(user.id).catch(cleanupErr => {
+        console.error(
+          '[kiloclaw] Failed to clean up instance row after provision error:',
+          cleanupErr
+        );
+      });
+    }
     throw error;
   }
 }

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -245,15 +245,28 @@ async function provisionInstance(
   const pinnedImageTag = pin?.image_tag;
 
   const client = new KiloClawInternalClient();
-  return client.provision(user.id, {
-    envVars: input.envVars,
-    encryptedSecrets,
-    channels: buildWorkerChannels(input.channels),
-    kilocodeApiKey,
-    kilocodeApiKeyExpiresAt,
-    kilocodeDefaultModel: input.kilocodeDefaultModel ?? undefined,
-    pinnedImageTag,
-  });
+  try {
+    return await client.provision(user.id, {
+      envVars: input.envVars,
+      encryptedSecrets,
+      channels: buildWorkerChannels(input.channels),
+      kilocodeApiKey,
+      kilocodeApiKeyExpiresAt,
+      kilocodeDefaultModel: input.kilocodeDefaultModel ?? undefined,
+      pinnedImageTag,
+    });
+  } catch (error) {
+    // Clean up the DB row that ensureActiveInstance created so that an
+    // orphaned active row (e.g. from "Cannot provision: instance is being
+    // destroyed") doesn't confuse subsequent getBillingStatus queries.
+    await markActiveInstanceDestroyed(user.id).catch(cleanupErr => {
+      console.error(
+        '[kiloclaw] Failed to clean up instance row after provision error:',
+        cleanupErr
+      );
+    });
+    throw error;
+  }
 }
 
 async function patchConfig(

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -37,6 +37,7 @@ import {
   ensureActiveInstance,
   getActiveInstance,
   markActiveInstanceDestroyed,
+  markInstanceDestroyedById,
   renameInstance,
   restoreDestroyedInstance,
 } from '@/lib/kiloclaw/instance-registry';
@@ -222,10 +223,8 @@ async function provisionInstance(
   user: Parameters<typeof generateApiToken>[0],
   input: z.infer<typeof updateConfigSchema>
 ) {
-  // Check whether this user already had an active row before we create one.
-  // ensureActiveInstance is idempotent: it may return a pre-existing row.
-  // On provision failure we only clean up a *freshly-created* row to avoid
-  // soft-deleting a legitimate pre-existing instance.
+  // Remember which row existed before so we can detect whether
+  // ensureActiveInstance created a new one for this attempt.
   const preExistingRow = await getActiveInstance(user.id);
   const instanceRow = await ensureActiveInstance(user.id);
   const rowIsNew = !preExistingRow || preExistingRow.id !== instanceRow.id;
@@ -262,11 +261,10 @@ async function provisionInstance(
       pinnedImageTag,
     });
   } catch (error) {
-    // Only clean up the row if ensureActiveInstance created it for this
-    // attempt. Pre-existing rows belong to a prior successful provision
-    // and must not be destroyed.
+    // Only clean up the exact row this attempt created. Target by primary
+    // key so a concurrent request's row is never affected.
     if (rowIsNew) {
-      await markActiveInstanceDestroyed(user.id).catch(cleanupErr => {
+      await markInstanceDestroyedById(instanceRow.id).catch(cleanupErr => {
         console.error(
           '[kiloclaw] Failed to clean up instance row after provision error:',
           cleanupErr


### PR DESCRIPTION
## Summary

When a user destroys their KiloClaw instance and immediately clicks "Get Started" to re-provision, the onboarding wizard often jumps straight to the final "Your instance is ready!" step, skipping the permissions, channels, and provisioning wait screens entirely. This was caused by two independent frontend bugs:

1. **`isNewSetup` set too late**: The `isNewSetup` flag (which controls whether the onboarding wizard renders) was set in the provision mutation's component-level `onSuccess` callback. TanStack Query runs the global `onSuccess` (cache invalidation + refetch) before the component-level one, so by the time `isNewSetup` became `true`, the status refetch had already populated `instanceStatus` — causing React to render the regular dashboard instead of the wizard.

2. **Stale `gatewayReady` cache from old instance**: The destroy mutation only invalidated `getStatus` and `controllerVersion`, leaving `gatewayReady` data (`{ ready: true, settled: true }`) from the previous running instance in the TanStack Query cache. When the `ProvisioningStep` eventually rendered, the stale cache made `isGatewaySettled` immediately true, causing the step to auto-complete in a fraction of a second.

**Fixes applied:**
- Set `isNewSetup` optimistically *before* the provision mutation fires, with rollback via `onProvisionFailed` on error
- Invalidate all instance-scoped caches (`gatewayReady`, `gatewayStatus`, `getConfig`, `getBillingStatus`) on destroy — no stale data survives the destroy boundary
- Reset `onboardingStep` to `'permissions'` when `isNewSetup` transitions to `true`, ensuring destroy → re-provision always starts the wizard fresh
- Clean up orphaned DB rows if the worker rejects provision (e.g. "Cannot provision: instance is being destroyed") — prevents `getBillingStatus` from thinking an active instance exists

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 2790/2793 tests pass (3 failures are pre-existing `beforeEach` timeout issues in `stripe-handlers-invoice-paid.test.ts` and `kiloclaw-billing-router.test.ts`, unrelated to this change)
- [x] `pnpm lint` — passes
- [x] `pnpm format:check` — passes
- [x] Manual test: created an instance, destroyed it, clicked "Get Started" immediately — wizard correctly shows all steps (permissions → channels → provisioning wait → done) without skipping

## Visual Changes

N/A

## Reviewer Notes

- The DO-level guard that rejects provision during `status === 'destroying'` was already correctly implemented; the bugs were entirely on the frontend side (callback ordering and insufficient cache invalidation).
- The `provisionInstance` DB row cleanup (Change 3) is defense-in-depth for the case where `ensureActiveInstance` creates a row but `client.provision()` fails. This prevents an orphaned active instance row that would make `getBillingStatus` report a non-existent instance.
- The `onProvisionFailed` callback is intentionally separate from `onProvisionStart` rather than overloading it, to keep the API clear and avoid accidental misuse.