### PR TITLE
fix(kiloclaw): persist instanceReadyEmailSent on provision

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -349,6 +349,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           pendingDestroyMachineId: null,
           pendingDestroyVolumeId: null,
           pendingPostgresMarkOnFinalize: false,
+          instanceReadyEmailSent: false,
         })
       : storageUpdate({
           ...configFields,
@@ -1296,9 +1297,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    */
   async tryMarkInstanceReady(): Promise<{ shouldNotify: boolean; userId: string | null }> {
     await this.loadState();
-
-    console.info(`[tryMarkInstanceReady] instanceReadyEmailSent=${this.s.instanceReadyEmailSent}`);
-
     if (this.s.instanceReadyEmailSent) {
       return { shouldNotify: false, userId: this.s.userId };
     }

--- a/kiloclaw/src/routes/controller.ts
+++ b/kiloclaw/src/routes/controller.ts
@@ -178,15 +178,11 @@ controller.post('/checkin', async (c: Context<AppEnv>) => {
     waitUntil(telemetryPromise);
   }
 
-  console.info(`[controller] checkin ${data.sandboxId}, load: ${data.loadAvg5m}`);
-
   // Instance readiness detection: when load drops below threshold, send a
   // one-time "instance ready" email to the user via the Next.js internal API.
   if (data.loadAvg5m <= INSTANCE_READY_LOAD_THRESHOLD) {
     try {
       const { shouldNotify } = await stub.tryMarkInstanceReady();
-
-      console.info(`[controller] checkin ${data.sandboxId}, shouldNotify=${shouldNotify}`);
 
       if (shouldNotify && c.env.INTERNAL_API_SECRET) {
         const apiOrigin = nextApiOrigin(c.env.KILOCODE_API_BASE_URL);


### PR DESCRIPTION
## Summary

- PR #1525 introduced the instance-ready email feature but missed persisting `instanceReadyEmailSent: false` to DO storage during `provision()`. The field was set in memory (line 379) but omitted from the `storageUpdate()` call (lines 336–352). When `tryMarkInstanceReady()` later ran (potentially on a recycled DO isolate), `loadState()` read from storage, didn't find the field, and the migration guard in `state.ts:77` treated its absence as `true` — permanently suppressing the email for all newly provisioned instances.
- Also removes debug `console.info` statements that were added to diagnose this issue.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — all 1020 KiloClaw tests pass
- [x] Existing `tryMarkInstanceReady` tests cover the fix path (the `seedProvisioned(storage, { instanceReadyEmailSent: false })` test helper writes the field to storage, matching the now-fixed provision behavior)

## Visual Changes

N/A

## Reviewer Notes

- The root cause: `provision()` has two persistence paths — in-memory state assignment (line 379: `this.s.instanceReadyEmailSent = false`) and the `storageUpdate()` call (lines 336–352). The field was in the former but not the latter. The migration guard in `loadState()` treats missing fields as `true` (already sent) to avoid spurious emails to pre-existing instances, which meant newly provisioned instances also got suppressed.
- After deploying, existing instances that were provisioned after PR #1525 but before this fix will still have the field missing from storage. They will need to be destroyed and re-provisioned to receive the email.