### PR TITLE
feat(kilo-app): add destroy instance in danger zone

### DIFF
--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -164,7 +164,7 @@ export default function DashboardScreen() {
                       onPress: () => {
                         mutations.destroy.mutate(undefined, {
                           onSuccess: () => {
-                            router.dismissAll();
+                            router.replace('/(app)/(tabs)/(1_kiloclaw)' as Href);
                           },
                         });
                       },

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -165,7 +165,7 @@ export default function DashboardScreen() {
                         mutations.destroy.mutate(undefined, {
                           onSuccess: () => {
                             router.dismissAll();
-                            router.replace('/(app)/(tabs)/(1_kiloclaw)' as Href);
+                            router.replace('/(app)/(tabs)/(1_kiloclaw)');
                           },
                         });
                       },

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -174,7 +174,9 @@ export default function DashboardScreen() {
               }}
             >
               {mutations.destroy.isPending ? (
-                <ActivityIndicator size="small" color="#ffffff" />
+                <View className="h-4 w-4 items-center justify-center">
+                  <ActivityIndicator size="small" color="#ffffff" />
+                </View>
               ) : (
                 <Trash2 size={16} color="#ffffff" />
               )}

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -145,12 +145,12 @@ export default function DashboardScreen() {
             </Pressable>
           </View>
 
-          <View className="rounded-lg bg-red-100 dark:bg-red-950 overflow-hidden">
-            <Text className="px-4 pt-3 pb-1 text-xs font-semibold text-red-600 dark:text-red-400 uppercase tracking-wide">
+          <View className="rounded-lg bg-red-100 dark:bg-red-950 overflow-hidden p-4 gap-3">
+            <Text className="text-xs font-semibold text-red-600 dark:text-red-400 uppercase tracking-wide">
               Danger Zone
             </Text>
             <Pressable
-              className="flex-row items-center gap-3 px-4 py-3 active:opacity-70"
+              className="flex-row items-center justify-center gap-2 rounded-md bg-red-600 dark:bg-red-700 py-2.5 px-4 active:opacity-70"
               onPress={() => {
                 Alert.alert(
                   'Destroy Instance',
@@ -172,10 +172,8 @@ export default function DashboardScreen() {
                 );
               }}
             >
-              <Trash2 size={18} color="#dc2626" />
-              <Text className="flex-1 text-sm font-medium text-red-600 dark:text-red-400">
-                Destroy Instance
-              </Text>
+              <Trash2 size={16} color="#ffffff" />
+              <Text className="text-sm font-semibold text-white">Destroy Instance</Text>
             </Pressable>
           </View>
         </Animated.View>

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -164,7 +164,8 @@ export default function DashboardScreen() {
                       onPress: () => {
                         mutations.destroy.mutate(undefined, {
                           onSuccess: () => {
-                            router.replace('/(app)/(tabs)/(1_kiloclaw)' as Href);
+                            router.dismissAll();
+                            router.back();
                           },
                         });
                       },

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -165,7 +165,7 @@ export default function DashboardScreen() {
                         mutations.destroy.mutate(undefined, {
                           onSuccess: () => {
                             router.dismissAll();
-                            router.back();
+                            router.replace('/(app)/(tabs)/(1_kiloclaw)' as Href);
                           },
                         });
                       },

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -1,7 +1,7 @@
 import { type Href, useLocalSearchParams, useRouter } from 'expo-router';
 import { AlertTriangle, CreditCard, Newspaper, Trash2 } from 'lucide-react-native';
 import { useState } from 'react';
-import { Alert, Linking, Pressable, ScrollView, View } from 'react-native';
+import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { BillingBanner } from '@/components/kiloclaw/billing-banner';
@@ -150,7 +150,8 @@ export default function DashboardScreen() {
               Danger Zone
             </Text>
             <Pressable
-              className="flex-row items-center justify-center gap-2 rounded-md bg-red-600 dark:bg-red-700 py-2.5 px-4 active:opacity-70"
+              disabled={mutations.destroy.isPending}
+              className="flex-row items-center justify-center gap-2 rounded-md bg-red-600 dark:bg-red-700 py-2.5 px-4 active:opacity-70 disabled:opacity-50"
               onPress={() => {
                 Alert.alert(
                   'Destroy Instance',
@@ -172,8 +173,14 @@ export default function DashboardScreen() {
                 );
               }}
             >
-              <Trash2 size={16} color="#ffffff" />
-              <Text className="text-sm font-semibold text-white">Destroy Instance</Text>
+              {mutations.destroy.isPending ? (
+                <ActivityIndicator size="small" color="#ffffff" />
+              ) : (
+                <Trash2 size={16} color="#ffffff" />
+              )}
+              <Text className="text-sm font-semibold text-white">
+                {mutations.destroy.isPending ? 'Destroying…' : 'Destroy Instance'}
+              </Text>
             </Pressable>
           </View>
         </Animated.View>

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/dashboard.tsx
@@ -1,7 +1,7 @@
 import { type Href, useLocalSearchParams, useRouter } from 'expo-router';
-import { AlertTriangle, CreditCard, Newspaper } from 'lucide-react-native';
+import { AlertTriangle, CreditCard, Newspaper, Trash2 } from 'lucide-react-native';
 import { useState } from 'react';
-import { Linking, Pressable, ScrollView, View } from 'react-native';
+import { Alert, Linking, Pressable, ScrollView, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { BillingBanner } from '@/components/kiloclaw/billing-banner';
@@ -142,6 +142,40 @@ export default function DashboardScreen() {
             >
               <Newspaper size={18} color={colors.foreground} />
               <Text className="flex-1 text-sm font-medium">What's New</Text>
+            </Pressable>
+          </View>
+
+          <View className="rounded-lg bg-red-100 dark:bg-red-950 overflow-hidden">
+            <Text className="px-4 pt-3 pb-1 text-xs font-semibold text-red-600 dark:text-red-400 uppercase tracking-wide">
+              Danger Zone
+            </Text>
+            <Pressable
+              className="flex-row items-center gap-3 px-4 py-3 active:opacity-70"
+              onPress={() => {
+                Alert.alert(
+                  'Destroy Instance',
+                  'This will permanently destroy your KiloClaw instance and all its data. This action cannot be undone.',
+                  [
+                    { text: 'Cancel', style: 'cancel' },
+                    {
+                      text: 'Destroy',
+                      style: 'destructive',
+                      onPress: () => {
+                        mutations.destroy.mutate(undefined, {
+                          onSuccess: () => {
+                            router.dismissAll();
+                          },
+                        });
+                      },
+                    },
+                  ]
+                );
+              }}
+            >
+              <Trash2 size={18} color="#dc2626" />
+              <Text className="flex-1 text-sm font-medium text-red-600 dark:text-red-400">
+                Destroy Instance
+              </Text>
             </Pressable>
           </View>
         </Animated.View>

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -37,7 +37,12 @@ export default function KiloClawInstanceList() {
   const chatPath = `/(app)/(tabs)/(1_kiloclaw)/${instanceId}` as const;
   const dashboardPath = `/(app)/(tabs)/(1_kiloclaw)/${instanceId}/dashboard` as const;
 
+  const isDestroying = status?.status === 'destroying';
+
   const handlePress = () => {
+    if (isDestroying) {
+      return;
+    }
     if (lockReason) {
       router.push(billingPath);
     } else {
@@ -46,6 +51,9 @@ export default function KiloClawInstanceList() {
   };
 
   const handleSettingsPress = () => {
+    if (isDestroying) {
+      return;
+    }
     if (lockReason) {
       router.push(billingPath);
     } else {
@@ -108,6 +116,7 @@ export default function KiloClawInstanceList() {
           name={status.name}
           sandboxId={status.sandboxId}
           status={status.status}
+          disabled={isDestroying}
           onPress={handlePress}
           onSettingsPress={handleSettingsPress}
         />

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -91,7 +91,7 @@ export default function KiloClawInstanceList() {
               <Button
                 variant="outline"
                 onPress={() => {
-                  void WebBrowser.openBrowserAsync('https://kilo.ai/claw');
+                  void WebBrowser.openBrowserAsync('https://app.kilo.ai/claw');
                 }}
               >
                 <Plus size={16} color={colors.foreground} />

--- a/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/kilo-app/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
-import { Server } from 'lucide-react-native';
-import { Linking, View } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import { Plus, Server } from 'lucide-react-native';
+import { View } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { EmptyState } from '@/components/empty-state';
@@ -14,9 +15,11 @@ import { Text } from '@/components/ui/text';
 import { useAppContext } from '@/lib/context/context-context';
 import { useKiloClawBillingStatus, useKiloClawStatus } from '@/lib/hooks/use-kiloclaw';
 import { deriveLockReason } from '@/lib/hooks/use-kiloclaw-billing';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
 export default function KiloClawInstanceList() {
   const router = useRouter();
+  const colors = useThemeColors();
   const { context, clearContext } = useAppContext();
   const isPersonal = context?.type === 'personal' || context == null;
 
@@ -88,10 +91,11 @@ export default function KiloClawInstanceList() {
               <Button
                 variant="outline"
                 onPress={() => {
-                  void Linking.openURL('https://kilo.ai/claw');
+                  void WebBrowser.openBrowserAsync('https://kilo.ai/claw');
                 }}
               >
-                <Text>Create on Web</Text>
+                <Plus size={16} color={colors.foreground} />
+                <Text>Create</Text>
               </Button>
             }
           />

--- a/kilo-app/src/components/kiloclaw/instance-row.tsx
+++ b/kilo-app/src/components/kiloclaw/instance-row.tsx
@@ -10,6 +10,7 @@ type InstanceRowProps = {
   name: string | null | undefined;
   sandboxId: string | null | undefined;
   status: InstanceStatus | null | undefined;
+  disabled?: boolean;
   onPress: () => void;
   onSettingsPress: () => void;
 };
@@ -18,6 +19,7 @@ export function InstanceRow({
   name,
   sandboxId,
   status,
+  disabled,
   onPress,
   onSettingsPress,
 }: Readonly<InstanceRowProps>) {
@@ -25,7 +27,8 @@ export function InstanceRow({
 
   return (
     <Pressable
-      className="flex-row items-center gap-3 rounded-lg bg-secondary p-3 active:opacity-70"
+      disabled={disabled}
+      className="flex-row items-center gap-3 rounded-lg bg-secondary p-3 active:opacity-70 disabled:opacity-50"
       onPress={onPress}
       accessibilityLabel={`Instance ${sandboxId ?? 'unknown'}`}
     >
@@ -36,6 +39,7 @@ export function InstanceRow({
         <StatusBadge status={status} />
       </View>
       <Pressable
+        disabled={disabled}
         className="items-center justify-center rounded-md bg-muted p-2 active:opacity-70"
         onPress={onSettingsPress}
         accessibilityLabel="Instance settings"

--- a/kilo-app/src/lib/hooks/use-kiloclaw.ts
+++ b/kilo-app/src/lib/hooks/use-kiloclaw.ts
@@ -280,5 +280,11 @@ export function useKiloClawMutations() {
         onError: onMutationError,
       })
     ),
+    destroy: useMutation(
+      trpc.kiloclaw.destroy.mutationOptions({
+        onSuccess: invalidateStatus,
+        onError: onMutationError,
+      })
+    ),
   };
 }


### PR DESCRIPTION
## Summary
- Adds a "Danger Zone" section below "More" on the KiloClaw dashboard
- Wires up the existing `kiloclaw.destroy` tRPC procedure as a new mutation
- Confirmation via native `Alert.alert` before destroying; navigates back to the instance list on success

## Test plan
- [ ] Open KiloClaw dashboard, scroll to bottom, verify "Danger Zone" section appears with red styling
- [ ] Tap "Destroy Instance", verify confirmation alert appears with Cancel/Destroy buttons
- [ ] Tap Cancel, verify nothing happens
- [ ] Tap Destroy, verify instance is destroyed and user is navigated back to the list screen (empty state)