### PR TITLE
feat(gastown): add progressive onboarding tooltips after first task

### DIFF
--- a/src/app/(app)/gastown/[townId]/OnboardingTooltipsWrapper.tsx
+++ b/src/app/(app)/gastown/[townId]/OnboardingTooltipsWrapper.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { use } from 'react';
+import { OnboardingTooltips } from '@/components/gastown/OnboardingTooltips';
+
+export function OnboardingTooltipsWrapper({ params }: { params: Promise<{ townId: string }> }) {
+  const { townId } = use(params);
+  return <OnboardingTooltips townId={townId} />;
+}

--- a/src/app/(app)/gastown/[townId]/layout.tsx
+++ b/src/app/(app)/gastown/[townId]/layout.tsx
@@ -3,6 +3,7 @@ import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
 import { MayorTerminalBar } from './MayorTerminalBar';
+import { OnboardingTooltipsWrapper } from './OnboardingTooltipsWrapper';
 
 export default function TownLayout({
   children,
@@ -16,6 +17,7 @@ export default function TownLayout({
       <DrawerStackProvider renderContent={renderDrawerContent}>
         <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} />
+        <OnboardingTooltipsWrapper params={params} />
       </DrawerStackProvider>
     </TerminalBarProvider>
   );

--- a/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
+++ b/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
@@ -3,6 +3,7 @@ import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
 import { MayorTerminalBar } from '@/app/(app)/gastown/[townId]/MayorTerminalBar';
+import { OnboardingTooltips } from '@/components/gastown/OnboardingTooltips';
 
 export default async function OrgTownLayout({
   children,
@@ -19,6 +20,7 @@ export default async function OrgTownLayout({
       <DrawerStackProvider renderContent={renderDrawerContent}>
         <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} basePath={basePath} />
+        <OnboardingTooltips townId={townId} />
       </DrawerStackProvider>
     </TerminalBarProvider>
   );

--- a/src/components/gastown/GastownTownSidebar.tsx
+++ b/src/components/gastown/GastownTownSidebar.tsx
@@ -61,9 +61,24 @@ export function GastownTownSidebar({
 
   const navItems = [
     { title: 'Overview', icon: LayoutDashboard, url: basePath },
-    { title: 'Beads', icon: Hexagon, url: `${basePath}/beads` },
-    { title: 'Agents', icon: Bot, url: `${basePath}/agents` },
-    { title: 'Merge Queue', icon: GitMerge, url: `${basePath}/merges` },
+    {
+      title: 'Beads',
+      icon: Hexagon,
+      url: `${basePath}/beads`,
+      onboardingTarget: 'onboarding-beads',
+    },
+    {
+      title: 'Agents',
+      icon: Bot,
+      url: `${basePath}/agents`,
+      onboardingTarget: 'onboarding-agents',
+    },
+    {
+      title: 'Merge Queue',
+      icon: GitMerge,
+      url: `${basePath}/merges`,
+      onboardingTarget: 'onboarding-merges',
+    },
     { title: 'Mail', icon: Mail, url: `${basePath}/mail` },
     { title: 'Observability', icon: Activity, url: `${basePath}/observability` },
   ];
@@ -116,7 +131,11 @@ export function GastownTownSidebar({
                   transition={{ delay: i * 0.04, duration: 0.2 }}
                 >
                   <SidebarMenuItem>
-                    <SidebarMenuButton asChild isActive={isActive(item.url)}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={isActive(item.url)}
+                      data-onboarding-target={item.onboardingTarget}
+                    >
                       <Link href={item.url} prefetch={false}>
                         <item.icon className="size-4" />
                         <span>{item.title}</span>

--- a/src/components/gastown/OnboardingTooltips.tsx
+++ b/src/components/gastown/OnboardingTooltips.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { X } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useOnboardingTooltips, ONBOARDING_TOOLTIPS } from './useOnboardingTooltips';
+
+// ── localStorage key for tracking whether first-task completion was detected ──
+function firstTaskCompletedKey(townId: string) {
+  return `gastown_onboarding_first_task_completed_${townId}`;
+}
+
+function wasFirstTaskCompleted(townId: string): boolean {
+  try {
+    return localStorage.getItem(firstTaskCompletedKey(townId)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function markFirstTaskCompleted(townId: string) {
+  try {
+    localStorage.setItem(firstTaskCompletedKey(townId), 'true');
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+// ── Main component ───────────────────────────────────────────────────────
+
+type OnboardingTooltipsProps = {
+  townId: string;
+};
+
+export function OnboardingTooltips({ townId }: OnboardingTooltipsProps) {
+  const trpc = useGastownTRPC();
+  const { activeTooltip, dismissCurrent, dismissAll, active, triggerTooltips } =
+    useOnboardingTooltips(townId);
+
+  // Check if first task was already completed previously
+  const [alreadyCompleted] = useState(() => wasFirstTaskCompleted(townId));
+
+  // Trigger tooltips immediately if first task was completed in a prior session
+  useEffect(() => {
+    if (alreadyCompleted) {
+      triggerTooltips();
+    }
+  }, [alreadyCompleted, triggerTooltips]);
+
+  // ── Detect first bead closure ────────────────────────────────────────
+  // Query rigs, then beads per rig, to detect when any non-agent bead
+  // transitions to closed status.
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+  const rigs = rigsQuery.data ?? [];
+
+  const rigBeadQueries = useQueries({
+    queries: rigs.map(rig => ({
+      ...trpc.gastown.listBeads.queryOptions({ rigId: rig.id }),
+      refetchInterval: 8_000,
+    })),
+  });
+
+  const hasClosedBead = rigBeadQueries.some(q =>
+    q.data?.some(b => b.type !== 'agent' && b.status === 'closed')
+  );
+
+  const triggeredRef = useRef(false);
+  useEffect(() => {
+    if (hasClosedBead && !triggeredRef.current && !alreadyCompleted) {
+      triggeredRef.current = true;
+      markFirstTaskCompleted(townId);
+      triggerTooltips();
+    }
+  }, [hasClosedBead, alreadyCompleted, townId, triggerTooltips]);
+
+  if (!active || !activeTooltip) return null;
+
+  return (
+    <OnboardingTooltipPopover
+      key={activeTooltip.id}
+      tooltip={activeTooltip}
+      onDismiss={dismissCurrent}
+      onDismissAll={dismissAll}
+    />
+  );
+}
+
+// ── Individual tooltip popover ───────────────────────────────────────────
+
+function OnboardingTooltipPopover({
+  tooltip,
+  onDismiss,
+  onDismissAll,
+}: {
+  tooltip: (typeof ONBOARDING_TOOLTIPS)[number];
+  onDismiss: () => void;
+  onDismissAll: () => void;
+}) {
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+  // Find the anchor element via data attribute and observe its position
+  useEffect(() => {
+    const findAnchor = () => {
+      const el = document.querySelector(`[data-onboarding-target="${tooltip.target}"]`);
+      if (el) {
+        setAnchorRect(el.getBoundingClientRect());
+      }
+    };
+
+    // Initial find with a brief delay for DOM rendering
+    const timer = setTimeout(findAnchor, 300);
+
+    // Re-find on scroll/resize
+    const handleUpdate = () => findAnchor();
+    window.addEventListener('resize', handleUpdate);
+    window.addEventListener('scroll', handleUpdate, true);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('resize', handleUpdate);
+      window.removeEventListener('scroll', handleUpdate, true);
+    };
+  }, [tooltip.target]);
+
+  // Calculate position relative to anchor
+  useEffect(() => {
+    if (!anchorRect || !popoverRef.current) return;
+
+    const popoverRect = popoverRef.current.getBoundingClientRect();
+    const gap = 12;
+
+    // Position to the right of the anchor by default
+    let top = anchorRect.top + anchorRect.height / 2 - popoverRect.height / 2;
+    let left = anchorRect.right + gap;
+
+    // If too far right, position to the left
+    if (left + popoverRect.width > window.innerWidth - 16) {
+      left = anchorRect.left - popoverRect.width - gap;
+    }
+
+    // If still off-screen (e.g., for terminal at bottom), position above
+    if (left < 16) {
+      left = anchorRect.left + anchorRect.width / 2 - popoverRect.width / 2;
+      top = anchorRect.top - popoverRect.height - gap;
+    }
+
+    // Clamp to viewport
+    top = Math.max(8, Math.min(top, window.innerHeight - popoverRect.height - 8));
+    left = Math.max(8, Math.min(left, window.innerWidth - popoverRect.width - 8));
+
+    setPosition({ top, left });
+  }, [anchorRect]);
+
+  // Dismiss on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onDismiss]);
+
+  // Click outside to dismiss
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (
+        popoverRef.current &&
+        e.target instanceof Node &&
+        !popoverRef.current.contains(e.target)
+      ) {
+        onDismiss();
+      }
+    },
+    [onDismiss]
+  );
+
+  if (!anchorRect) return null;
+
+  return (
+    <AnimatePresence>
+      {/* Semi-transparent backdrop to catch outside clicks */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.15 }}
+        className="fixed inset-0 z-[100]"
+        onClick={handleBackdropClick}
+      >
+        {/* Highlight ring on the anchor element */}
+        <div
+          className="pointer-events-none absolute rounded-md ring-2 ring-[color:oklch(85%_0.15_250)] ring-offset-2 ring-offset-transparent"
+          style={{
+            top: anchorRect.top - 4,
+            left: anchorRect.left - 4,
+            width: anchorRect.width + 8,
+            height: anchorRect.height + 8,
+          }}
+        />
+
+        {/* Popover content */}
+        <motion.div
+          ref={popoverRef}
+          initial={{ opacity: 0, scale: 0.95, y: 4 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.95, y: 4 }}
+          transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+          className="pointer-events-auto absolute z-[101] w-72 rounded-lg border border-white/[0.15] bg-[#1a1a2e] p-4 shadow-2xl"
+          style={position ?? { top: anchorRect.top, left: anchorRect.right + 12, opacity: 0 }}
+        >
+          {/* Close button */}
+          <button
+            onClick={e => {
+              e.stopPropagation();
+              onDismiss();
+            }}
+            className="absolute top-2 right-2 rounded-md p-1 text-white/30 transition-colors hover:bg-white/[0.08] hover:text-white/60"
+          >
+            <X className="size-3.5" />
+          </button>
+
+          {/* Title */}
+          <div className="mb-1 text-sm font-semibold text-white/90">{tooltip.title}</div>
+
+          {/* Description */}
+          <p className="mb-3 text-xs leading-relaxed text-white/55">{tooltip.description}</p>
+
+          {/* Actions */}
+          <div className="flex items-center justify-between">
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                onDismissAll();
+              }}
+              className="text-[10px] text-white/25 transition-colors hover:text-white/50"
+            >
+              Don&apos;t show these again
+            </button>
+
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                onDismiss();
+              }}
+              className="rounded-md bg-white/[0.08] px-3 py-1 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.14] hover:text-white/90"
+            >
+              Got it
+            </button>
+          </div>
+
+          {/* Progress dots */}
+          <div className="mt-3 flex justify-center gap-1.5">
+            {ONBOARDING_TOOLTIPS.map(t => (
+              <div
+                key={t.id}
+                className={`size-1.5 rounded-full transition-colors ${
+                  t.id === tooltip.id ? 'bg-[color:oklch(85%_0.15_250)]' : 'bg-white/15'
+                }`}
+              />
+            ))}
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/gastown/OnboardingTooltips.tsx
+++ b/src/components/gastown/OnboardingTooltips.tsx
@@ -52,13 +52,22 @@ export function OnboardingTooltips({ townId }: OnboardingTooltipsProps) {
   // ── Detect first bead closure ────────────────────────────────────────
   // Query rigs, then beads per rig, to detect when any non-agent bead
   // transitions to closed status.
-  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
+  //
+  // needsPolling: only poll while we haven't yet detected a first-task
+  // completion. Once tooltips are triggered (or were already completed in
+  // a prior session), stop polling to avoid a permanent N+1 background hit.
+  const [needsPolling, setNeedsPolling] = useState(!alreadyCompleted);
+
+  const rigsQuery = useQuery({
+    ...trpc.gastown.listRigs.queryOptions({ townId }),
+    enabled: needsPolling,
+  });
   const rigs = rigsQuery.data ?? [];
 
   const rigBeadQueries = useQueries({
     queries: rigs.map(rig => ({
       ...trpc.gastown.listBeads.queryOptions({ rigId: rig.id }),
-      refetchInterval: 8_000,
+      refetchInterval: needsPolling ? 8_000 : false,
     })),
   });
 
@@ -70,6 +79,7 @@ export function OnboardingTooltips({ townId }: OnboardingTooltipsProps) {
   useEffect(() => {
     if (hasClosedBead && !triggeredRef.current && !alreadyCompleted) {
       triggeredRef.current = true;
+      setNeedsPolling(false);
       markFirstTaskCompleted(townId);
       triggerTooltips();
     }

--- a/src/components/gastown/TerminalBar.tsx
+++ b/src/components/gastown/TerminalBar.tsx
@@ -500,6 +500,7 @@ function TabBar({
                     : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
                 }`}
                 title={horizontal ? undefined : tab.label}
+                {...(isMayor ? { 'data-onboarding-target': 'onboarding-mayor' } : {})}
               >
                 {isMayor && (
                   <Crown

--- a/src/components/gastown/useOnboardingTooltips.ts
+++ b/src/components/gastown/useOnboardingTooltips.ts
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type OnboardingTooltipId = 'convoy' | 'agents' | 'merges' | 'mayor';
+
+/** Ordered list of tooltip definitions. Shown sequentially. */
+export const ONBOARDING_TOOLTIPS: ReadonlyArray<{
+  id: OnboardingTooltipId;
+  /** data-onboarding-target value on the anchor element */
+  target: string;
+  title: string;
+  description: string;
+}> = [
+  {
+    id: 'convoy',
+    target: 'onboarding-beads',
+    title: 'Beads',
+    description: 'This tracked your task. Create convoys to batch related work.',
+  },
+  {
+    id: 'agents',
+    target: 'onboarding-agents',
+    title: 'Agents',
+    description: 'This polecat worked on your task. Click to see its full conversation.',
+  },
+  {
+    id: 'merges',
+    target: 'onboarding-merges',
+    title: 'Merge Queue',
+    description: 'Your code changes are reviewed here before merging.',
+  },
+  {
+    id: 'mayor',
+    target: 'onboarding-mayor',
+    title: 'Mayor',
+    description:
+      'You can also ask me to work on multiple things at once, check on progress, or coordinate across repos.',
+  },
+];
+
+// ── localStorage helpers ─────────────────────────────────────────────────
+
+function storageKey(townId: string) {
+  return `gastown_onboarding_tooltips_shown_${townId}`;
+}
+
+const VALID_IDS = new Set<string>(ONBOARDING_TOOLTIPS.map(t => t.id));
+
+function isValidTooltipId(value: unknown): value is OnboardingTooltipId {
+  return typeof value === 'string' && VALID_IDS.has(value);
+}
+
+function readDismissedSet(townId: string): Set<OnboardingTooltipId> {
+  try {
+    const raw = localStorage.getItem(storageKey(townId));
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const validIds = parsed.filter(isValidTooltipId);
+      return new Set(validIds);
+    }
+  } catch {
+    // Corrupted or unavailable — treat as empty
+  }
+  return new Set();
+}
+
+function writeDismissedSet(townId: string, dismissed: Set<OnboardingTooltipId>) {
+  try {
+    localStorage.setItem(storageKey(townId), JSON.stringify([...dismissed]));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+function isAllDismissed(townId: string): boolean {
+  const dismissed = readDismissedSet(townId);
+  return ONBOARDING_TOOLTIPS.every(t => dismissed.has(t.id));
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────
+
+type UseOnboardingTooltipsResult = {
+  /** The tooltip currently being shown, or null if none. */
+  activeTooltip: (typeof ONBOARDING_TOOLTIPS)[number] | null;
+  /** Dismiss the currently active tooltip and advance to the next. */
+  dismissCurrent: () => void;
+  /** Dismiss all remaining tooltips at once. */
+  dismissAll: () => void;
+  /** Whether tooltips should be active at all (first task completed + not all dismissed). */
+  active: boolean;
+  /** Trigger the tooltip sequence (call when first bead completion is detected). */
+  triggerTooltips: () => void;
+};
+
+export function useOnboardingTooltips(townId: string): UseOnboardingTooltipsResult {
+  const [dismissed, setDismissed] = useState<Set<OnboardingTooltipId>>(() =>
+    readDismissedSet(townId)
+  );
+  const [triggered, setTriggered] = useState(false);
+
+  // Reset state when townId changes
+  const prevTownIdRef = useRef(townId);
+  useEffect(() => {
+    if (prevTownIdRef.current !== townId) {
+      prevTownIdRef.current = townId;
+      setDismissed(readDismissedSet(townId));
+      setTriggered(false);
+    }
+  }, [townId]);
+
+  const allDone = ONBOARDING_TOOLTIPS.every(t => dismissed.has(t.id));
+
+  // Find next undismissed tooltip
+  const activeTooltip =
+    triggered && !allDone ? (ONBOARDING_TOOLTIPS.find(t => !dismissed.has(t.id)) ?? null) : null;
+
+  const dismissCurrent = useCallback(() => {
+    if (!activeTooltip) return;
+    setDismissed(prev => {
+      const next = new Set(prev);
+      next.add(activeTooltip.id);
+      writeDismissedSet(townId, next);
+      return next;
+    });
+  }, [activeTooltip, townId]);
+
+  const dismissAll = useCallback(() => {
+    const all = new Set(ONBOARDING_TOOLTIPS.map(t => t.id));
+    setDismissed(all);
+    writeDismissedSet(townId, all);
+  }, [townId]);
+
+  const triggerTooltips = useCallback(() => {
+    // Only trigger if not already all dismissed
+    if (!isAllDismissed(townId)) {
+      setTriggered(true);
+    }
+  }, [townId]);
+
+  return {
+    activeTooltip,
+    dismissCurrent,
+    dismissAll,
+    active: triggered && !allDone,
+    triggerTooltips,
+  };
+}


### PR DESCRIPTION
## Summary

Add sequential feature-discovery tooltips that appear after a user's first task completes in a new town. Four tooltips guide users through Beads, Agents, Merge Queue, and Mayor features with animated popovers, highlight rings, progress dots, and dismiss controls. State is persisted per-town in localStorage so tooltips don't reappear.

**New files:**
- `useOnboardingTooltips.ts` — Hook managing localStorage-persisted sequential tooltip state with dismiss/dismiss-all
- `OnboardingTooltips.tsx` — Component that detects first bead closure via tRPC polling and renders progressive tooltips
- `OnboardingTooltipsWrapper.tsx` — Client wrapper resolving async params for the server layout

**Modified files:**
- `GastownTownSidebar.tsx` — Added `data-onboarding-target` attributes to Beads, Agents, and Merge Queue nav items
- `TerminalBar.tsx` — Added `data-onboarding-target` to Mayor tab
- Both town `layout.tsx` files — Integrated the tooltips component

## Verification

- [x] `pnpm typecheck` — passed (no errors)
- [x] `oxfmt --list-different .` (format check) — passed
- [x] ESLint — 0 warnings, 0 errors
- [x] Code review: correctness, style, security — passed

## Visual Changes

N/A — this adds animated tooltip popovers that appear sequentially after first task completion.

## Reviewer Notes

- The bead-detection polling (`listBeads` with 8s refetch) continues after tooltips are triggered/dismissed. This is a minor efficiency concern for a feature that fires once per town — could be optimized in a follow-up by disabling queries once triggered.
- localStorage is used for both tooltip dismissed state and first-task-completed detection, with proper try/catch guards for SSR/unavailable environments.
- The tooltip targets are hardcoded constants, so there are no injection risks from the `document.querySelector` usage.