### PR TITLE
fix(kilo-app): add android package and configure EAS internal testing

### DIFF
--- a/kilo-app/app.config.js
+++ b/kilo-app/app.config.js
@@ -21,6 +21,7 @@ const config = {
     backgroundColor: '#FAF74F',
   },
   android: {
+    package: 'com.kilocode.kiloapp',
     adaptiveIcon: {
       backgroundColor: '#FAF74F',
       foregroundImage: './assets/images/android-icon-foreground.png',

--- a/kilo-app/eas.json
+++ b/kilo-app/eas.json
@@ -19,6 +19,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "internal"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add missing `android.package` to `app.config.js` (required for EAS Android builds)
- Configure EAS submit to target Google Play internal testing track

## Test plan
- [ ] `eas build -p android --profile development` succeeds without package error
- [ ] `eas submit -p android --latest` targets internal testing track