### PR TITLE
fix(kiloclaw): use dedicated NEXTJS_APP_URL for instance-ready email

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -23,6 +23,10 @@ GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
 # Fly app naming prefix ("dev-") for per-user app creation.
 WORKER_ENV=development
 
+# Backend app origin for internal API calls (e.g. instance-ready email).
+# In dev, point this at your local Next.js server.
+BACKEND_API_URL=http://localhost:3000
+
 # Tunnel URL (set automatically by the dev-start script)
 # OpenClaw's native kilocode provider hardcodes https://api.kilo.ai/api/gateway/.
 # In dev, the script sets this to the Cloudflare tunnel URL pointing to your

--- a/kiloclaw/src/routes/controller.test.ts
+++ b/kiloclaw/src/routes/controller.test.ts
@@ -57,6 +57,7 @@ function makeEnv(options?: {
           writeDataPoint: options.writeDataPoint,
         }
       : undefined,
+    BACKEND_API_URL: 'https://kilo.test',
     NEXT_PUBLIC_POSTHOG_KEY: options?.posthogKey,
     HYPERDRIVE: options?.hyperdriveConnectionString
       ? { connectionString: options.hyperdriveConnectionString }

--- a/kiloclaw/src/routes/controller.ts
+++ b/kiloclaw/src/routes/controller.ts
@@ -40,26 +40,27 @@ const CheckinSchema = z.object({
 });
 
 /**
- * Derive the Next.js app origin for internal API calls.
+ * Return the backend app origin for internal API calls.
+ * Uses the dedicated BACKEND_API_URL env var set in wrangler.jsonc.
  */
-function nextApiOrigin(kilocodeApiBaseUrl: string | undefined): string {
-  if (!kilocodeApiBaseUrl) {
-    throw new Error('KILOCODE_API_BASE_URL not defined');
+function backendApiOrigin(backendApiUrl: string | undefined): string {
+  if (!backendApiUrl) {
+    throw new Error('BACKEND_API_URL is not configured');
   }
-  return new URL(kilocodeApiBaseUrl).origin;
+  return new URL(backendApiUrl).origin;
 }
 
 /**
- * Fire-and-forget HTTP POST to the Next.js internal API to trigger
+ * Fire-and-forget HTTP POST to the backend internal API to trigger
  * the "instance ready" transactional email.
  */
 async function notifyInstanceReady(
-  nextApiUrl: string,
+  backendOrigin: string,
   internalSecret: string,
   userId: string,
   sandboxId: string
 ): Promise<void> {
-  const res = await fetch(`${nextApiUrl}/api/internal/kiloclaw/instance-ready`, {
+  const res = await fetch(`${backendOrigin}/api/internal/kiloclaw/instance-ready`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -182,6 +183,9 @@ controller.post('/checkin', async (c: Context<AppEnv>) => {
   // one-time "instance ready" email to the user via the Next.js internal API.
   if (data.loadAvg5m <= INSTANCE_READY_LOAD_THRESHOLD) {
     try {
+      // Validate config before marking the DO flag so a misconfigured env var
+      // doesn't permanently prevent the email with no way to retry.
+      const apiOrigin = backendApiOrigin(c.env.BACKEND_API_URL);
       const { shouldNotify } = await stub.tryMarkInstanceReady();
 
       if (shouldNotify && c.env.INTERNAL_API_SECRET) {
@@ -189,7 +193,6 @@ controller.post('/checkin', async (c: Context<AppEnv>) => {
           userId,
           sandboxId: data.sandboxId,
         });
-        const apiOrigin = nextApiOrigin(c.env.KILOCODE_API_BASE_URL);
         waitUntil(
           notifyInstanceReady(apiOrigin, c.env.INTERNAL_API_SECRET, userId, data.sandboxId).catch(
             err => {

--- a/kiloclaw/src/types.ts
+++ b/kiloclaw/src/types.ts
@@ -14,6 +14,9 @@ export type KiloClawEnv = {
   KV_CLAW_CACHE: KVNamespace;
   SNAPSHOT_RESTORE_QUEUE?: Queue<SnapshotRestoreMessage>;
 
+  // Backend app origin for internal API calls (e.g. instance-ready email)
+  BACKEND_API_URL?: string;
+
   // Auth secrets
   NEXTAUTH_SECRET?: string;
   INTERNAL_API_SECRET?: string;

--- a/kiloclaw/wrangler.jsonc
+++ b/kiloclaw/wrangler.jsonc
@@ -98,6 +98,7 @@
     "FLY_ORG_SLUG": "kilo-679", // Org for creating per-user Fly apps
     "FLY_IMAGE_TAG": "latest",
     "FLY_REGION": "eu,us",
+    "BACKEND_API_URL": "https://app.kilo.ai",
     "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",
     "KILOCLAW_CHECKIN_URL": "https://claw.kilosessions.ai/api/controller/checkin",
     "REQUIRE_PROXY_TOKEN": "true",


### PR DESCRIPTION
## Summary

Fix the instance-ready email being completely broken in production. `nextApiOrigin()` used `KILOCODE_API_BASE_URL` to derive the backend app origin, but that env var is intentionally unset in prod — it's a dev/staging override for machine config, not the backend app URL. Every checkin with low load was hitting `Error: KILOCODE_API_BASE_URL not defined`, silently swallowed by an empty catch block.

Introduces a dedicated `BACKEND_API_URL` env var (`https://app.kilo.ai` in prod) and fixes the call ordering so config validation happens *before* `tryMarkInstanceReady()` flips the DO flag — preventing the class of bug where the flag is permanently set but the notification never fires.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm test` (kiloclaw) — 1020 tests passed, 45 test files
- [ ] Confirm instance-ready emails start sending after deploy (check Axiom for `[controller] instance-ready: dispatching notification` logs without subsequent errors)

## Visual Changes

N/A

## Reviewer Notes

- Root cause found via Axiom query on `cloudflare-logpush` — the logging added in #1613 immediately surfaced the error on every checkin.
- `KILOCODE_API_BASE_URL` is still used for its original purpose (machine env var override in `gateway/env.ts`) — only the `nextApiOrigin()` usage is replaced.
- The call ordering fix is important: previously `tryMarkInstanceReady()` ran first, permanently setting `instanceReadyEmailSent=true` in the DO, then `nextApiOrigin()` would throw, meaning the email could never be retried.