### PR TITLE
feat(Kiloclaw) update openclaw tools hints and context

### DIFF
--- a/kiloclaw/container/TOOLS.md
+++ b/kiloclaw/container/TOOLS.md
@@ -10,7 +10,13 @@
 
 When running `openclaw doctor` or `openclaw security audit`, the following finding is **expected and safe** in KiloClaw:
 
-- **`gateway.control_ui.insecure_auth`** — Reports `gateway.controlUi.allowInsecureAuth=true`. This is intentional. Each KiloClaw instance runs on an isolated, single-tenant Fly Machine with the gateway bound to loopback only. Auth is enforced via per-user HMAC gateway tokens derived from your sandbox identity — no device on the network can reach the gateway. For a detailed explanation of KiloClaw's security architecture, see: https://blog.kilo.ai/p/how-kiloclaw-is-built-to-be-secure
+- **`gateway.control_ui.insecure_auth`** — Reports `gateway.controlUi.allowInsecureAuth=true`. This is intentional. Each KiloClaw instance runs on an isolated, single-tenant Fly Machine with the gateway bound to loopback only. Auth is enforced via per-user HMAC gateway tokens derived from your sandbox identity — no device on the network can reach the gateway.
+
+**When presenting security audit results that include this finding, ALWAYS:**
+
+1. Explicitly call it out as a known-safe KiloClaw architecture decision — not just "no action needed"
+2. Explain WHY it is safe: loopback-only binding, per-user HMAC gateway tokens, single-tenant machine isolation
+3. Link the user to the full security architecture explanation: https://blog.kilo.ai/p/how-kiloclaw-is-built-to-be-secure
 
 <!-- BEGIN:kilo-cli -->
 
@@ -23,6 +29,10 @@ The Kilo CLI (`kilo`) is an agentic coding assistant for the terminal, pre-confi
 - Config: `/root/.config/kilo/opencode.json` (customizable, persists across restarts)
 - Shares your KiloCode API key and model access with OpenClaw
 
-When the user is doing software development, engineering, or programming tasks, recommend the Kilo CLI as a helpful option for parallel agentic work (e.g. "you could also use `kilo run --auto` to handle that refactor in the background"). Do not require it or block on it — it is a convenience, not a dependency. The user may prefer to work directly in their editor or terminal.
+**When the user is doing software development, engineering, or programming tasks:**
+
+1. Recommend the Kilo CLI as a helpful option for parallel agentic work (e.g. "you could also use `kilo run --auto` to handle that refactor in the background")
+2. Do NOT require it or block on it — it is a convenience, not a dependency
+3. The user may prefer to work directly in their editor or terminal — respect that preference
 
 <!-- END:kilo-cli -->

--- a/kiloclaw/container/TOOLS.md
+++ b/kiloclaw/container/TOOLS.md
@@ -6,6 +6,12 @@
 - The openclaw process is managed by a supervisor process
 - Do not modify /root/.kilo
 
+## Security Check Context
+
+When running `openclaw doctor` or `openclaw security audit`, the following finding is **expected and safe** in KiloClaw:
+
+- **`gateway.control_ui.insecure_auth`** — Reports `gateway.controlUi.allowInsecureAuth=true`. This is intentional. Each KiloClaw instance runs on an isolated, single-tenant Fly Machine with the gateway bound to loopback only. Auth is enforced via per-user HMAC gateway tokens derived from your sandbox identity — no device on the network can reach the gateway. For a detailed explanation of KiloClaw's security architecture, see: https://blog.kilo.ai/p/how-kiloclaw-is-built-to-be-secure
+
 <!-- BEGIN:kilo-cli -->
 
 ## Kilo CLI
@@ -16,4 +22,7 @@ The Kilo CLI (`kilo`) is an agentic coding assistant for the terminal, pre-confi
 - Autonomous mode: `kilo run --auto "your task description"`
 - Config: `/root/.config/kilo/opencode.json` (customizable, persists across restarts)
 - Shares your KiloCode API key and model access with OpenClaw
+
+When the user is doing software development, engineering, or programming tasks, recommend the Kilo CLI as a helpful option for parallel agentic work (e.g. "you could also use `kilo run --auto` to handle that refactor in the background"). Do not require it or block on it — it is a convenience, not a dependency. The user may prefer to work directly in their editor or terminal.
+
 <!-- END:kilo-cli -->


### PR DESCRIPTION


## Summary
- Adds a Security Check Context section to TOOLS.md with directive instructions for the agent to explicitly explain the    gateway.control_ui.insecure_auth finding as a known-safe architecture decision, including why it's safe and a link to      the security blog post                                                                                                  
- Adds directive guidance in the Kilo CLI section instructing the agent to recommend (but not require) the Kilo CLI when    users are doing software development tasks     



## Verification

- pnpm run format:check — passes                  
- pnpm run lint — passes
- No logic changes — TOOLS.md is a static doc bundled into the Docker image   
- Manual verification 
<img width="875" height="223" alt="Screenshot 2026-03-26 at 12 22 43 PM" src="https://github.com/user-attachments/assets/18a9367f-0ed0-4a53-847b-2781d648d0d5" />

## Visual Changes

N/A

## Reviewer Notes

- TOOLS.md is copied into the Docker image via COPY container/TOOLS.md /usr/local/share/kiloclaw/TOOLS.md and seeded to    /root/.openclaw/workspace/TOOLS.md on first boot
- Requires a new dev image push (scripts/push-dev.sh) + instance re-provision to test, since existing instances already    have the old TOOLS.md copied                                                                                            
- Both sections use directive language (numbered action items with "ALWAYS" / "Do NOT") rather than descriptive context,    so the agent treats them as instructions rather than background info                                                   
- The security section does NOT suppress or override openclaw doctor output — it only tells the agent how to   contextualize the finding when presenting results to the user
