### PR TITLE
refactor(kiloclaw): replace Linear CLI with Linear MCP server

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update \
        | gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh 1password-cli \
+    && apt-get purge -y xz-utils \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && node --version \
     && npm --version
@@ -55,13 +57,6 @@ RUN npm install -g @steipete/summarize@0.12.0
 # Install Kilo CLI (agentic coding assistant for the terminal)
 RUN npm install -g @kilocode/cli@7.0.46
 
-# Install Linear CLI (issue tracker)
-RUN npm install -g @schpet/linear-cli@1.11.1
-
-# Clean up xz-utils now that Node.js and linear-cli are installed
-RUN apt-get purge -y xz-utils \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/Dockerfile.local
+++ b/kiloclaw/Dockerfile.local
@@ -31,6 +31,8 @@ RUN apt-get update \
        | gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh 1password-cli=2.32.1-1 \
+    && apt-get purge -y xz-utils \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && node --version \
     && npm --version
@@ -55,14 +57,6 @@ RUN npm install -g mcporter@0.7.3
 
 # Install summarize (web page summarization CLI)
 RUN npm install -g @steipete/summarize@0.11.1
-
-# Install Linear CLI (issue tracker)
-RUN npm install -g @schpet/linear-cli@1.11.1
-
-# Clean up xz-utils now that Node.js and linear-cli are installed
-RUN apt-get purge -y xz-utils \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/controller/src/bootstrap.test.ts
+++ b/kiloclaw/controller/src/bootstrap.test.ts
@@ -494,174 +494,38 @@ describe('configureGitHub', () => {
 describe('configureLinear', () => {
   it('logs configured when LINEAR_API_KEY is set', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { deps } = fakeDeps();
     const env: Record<string, string | undefined> = {
       LINEAR_API_KEY: 'lin_api_test123',
     };
 
-    configureLinear(env, deps);
+    configureLinear(env);
 
     expect(env.LINEAR_API_KEY).toBe('lin_api_test123');
-    expect(logSpy).toHaveBeenCalledWith('Linear CLI configured via LINEAR_API_KEY');
+    expect(logSpy).toHaveBeenCalledWith('Linear MCP configured via LINEAR_API_KEY');
     logSpy.mockRestore();
   });
 
-  it('removes persisted config directory when no LINEAR_API_KEY', () => {
+  it('cleans up empty LINEAR_API_KEY and logs not configured', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { deps, execCalls } = fakeDeps();
-    const env: Record<string, string | undefined> = {};
-
-    configureLinear(env, deps);
-
-    expect(env.LINEAR_API_KEY).toBeUndefined();
-    expect(execCalls).toContainEqual({
-      cmd: 'rm',
-      args: ['-rf', '/root/.config/linear'],
-      input: undefined,
-    });
-    expect(execCalls).toContainEqual({
-      cmd: 'rm',
-      args: ['-f', '/root/.linear.toml'],
-      input: undefined,
-    });
-    expect(logSpy).toHaveBeenCalledWith('Linear: not configured (credentials cleared)');
-    logSpy.mockRestore();
-  });
-
-  it('still removes ~/.linear.toml when /root/.config/linear removal fails', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { deps } = fakeDeps();
-    const env: Record<string, string | undefined> = {};
-
-    // Make the first rm call throw, second should still succeed
-    const origExec = deps.execFileSync;
-    deps.execFileSync = vi.fn(
-      (cmd: string, args: string[], opts?: Parameters<BootstrapDeps['execFileSync']>[2]) => {
-        if (cmd === 'rm' && args.includes('/root/.config/linear')) {
-          throw new Error('permission denied');
-        }
-        return origExec(cmd, args, opts);
-      }
-    ) as typeof deps.execFileSync;
-
-    configureLinear(env, deps);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'WARNING: failed to remove /root/.config/linear: permission denied'
-    );
-    // Second rm should still have been attempted
-    expect(deps.execFileSync).toHaveBeenCalledWith('rm', ['-f', '/root/.linear.toml'], {
-      stdio: 'pipe',
-    });
-    logSpy.mockRestore();
-    warnSpy.mockRestore();
-  });
-
-  it('warns when /root/.config/linear removal fails', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { deps } = fakeDeps();
-    const env: Record<string, string | undefined> = {};
-
-    const origExec = deps.execFileSync;
-    deps.execFileSync = vi.fn(
-      (cmd: string, args: string[], opts?: Parameters<BootstrapDeps['execFileSync']>[2]) => {
-        if (cmd === 'rm' && args.includes('/root/.config/linear')) {
-          throw new Error('permission denied');
-        }
-        return origExec(cmd, args, opts);
-      }
-    ) as typeof deps.execFileSync;
-
-    configureLinear(env, deps);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'WARNING: failed to remove /root/.config/linear: permission denied'
-    );
-    expect(logSpy).toHaveBeenCalledWith('Linear: not configured (credentials cleared)');
-    logSpy.mockRestore();
-    warnSpy.mockRestore();
-  });
-
-  it('warns when ~/.linear.toml removal fails', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { deps } = fakeDeps();
-    const env: Record<string, string | undefined> = {};
-
-    const origExec = deps.execFileSync;
-    deps.execFileSync = vi.fn(
-      (cmd: string, args: string[], opts?: Parameters<BootstrapDeps['execFileSync']>[2]) => {
-        if (cmd === 'rm' && args.includes('/root/.linear.toml')) {
-          throw new Error('read-only filesystem');
-        }
-        return origExec(cmd, args, opts);
-      }
-    ) as typeof deps.execFileSync;
-
-    configureLinear(env, deps);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'WARNING: failed to remove /root/.linear.toml: read-only filesystem'
-    );
-    expect(logSpy).toHaveBeenCalledWith('Linear: not configured (credentials cleared)');
-    logSpy.mockRestore();
-    warnSpy.mockRestore();
-  });
-
-  it('warns for both when both rm calls fail', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { deps } = fakeDeps();
-    const env: Record<string, string | undefined> = {};
-
-    deps.execFileSync = vi.fn((cmd: string) => {
-      if (cmd === 'rm') throw new Error('disk full');
-      return '';
-    }) as typeof deps.execFileSync;
-
-    configureLinear(env, deps);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'WARNING: failed to remove /root/.config/linear: disk full'
-    );
-    expect(warnSpy).toHaveBeenCalledWith('WARNING: failed to remove /root/.linear.toml: disk full');
-    expect(logSpy).toHaveBeenCalledWith('Linear: not configured (credentials cleared)');
-    logSpy.mockRestore();
-    warnSpy.mockRestore();
-  });
-
-  it('formats non-Error thrown values in warning', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { deps } = fakeDeps();
-    const env: Record<string, string | undefined> = {};
-
-    deps.execFileSync = vi.fn((cmd: string) => {
-      if (cmd === 'rm') throw 'unexpected string error';
-      return '';
-    }) as typeof deps.execFileSync;
-
-    configureLinear(env, deps);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      'WARNING: failed to remove /root/.config/linear: unexpected string error'
-    );
-    logSpy.mockRestore();
-    warnSpy.mockRestore();
-  });
-
-  it('cleans up empty LINEAR_API_KEY', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { deps } = fakeDeps();
     const env: Record<string, string | undefined> = {
       LINEAR_API_KEY: '',
     };
 
-    configureLinear(env, deps);
+    configureLinear(env);
 
     expect(env.LINEAR_API_KEY).toBeUndefined();
+    expect(logSpy).toHaveBeenCalledWith('Linear: not configured');
+    logSpy.mockRestore();
+  });
+
+  it('logs not configured when LINEAR_API_KEY is absent', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const env: Record<string, string | undefined> = {};
+
+    configureLinear(env);
+
+    expect(env.LINEAR_API_KEY).toBeUndefined();
+    expect(logSpy).toHaveBeenCalledWith('Linear: not configured');
     logSpy.mockRestore();
   });
 });
@@ -878,7 +742,7 @@ describe('updateToolsMdLinearSection', () => {
 
     expect(harness.writeCalls).toHaveLength(1);
     expect(harness.writeCalls[0]!.data).toContain('<!-- BEGIN:linear -->');
-    expect(harness.writeCalls[0]!.data).toContain('linear issue list');
+    expect(harness.writeCalls[0]!.data).toContain('Linear MCP');
     expect(harness.writeCalls[0]!.data).toContain('<!-- END:linear -->');
   });
 

--- a/kiloclaw/controller/src/bootstrap.ts
+++ b/kiloclaw/controller/src/bootstrap.ts
@@ -566,11 +566,11 @@ ${LINEAR_MARKER_BEGIN}
 ## Linear
 
 Linear is configured as your project management tool. Use it  to track issues, plan projects, and manage product roadmaps.
-You can interact with Linear using the \`Linear MCP\` via \`mcporter\` — your MCP management tool.
+You can interact with Linear using the \`Linear MCP\` — via \`mcporter\`, your MCP management tool:
 
-Here's an example of how to list 3 issues:
 \`\`\`bash
-mcporter call linear.list_issues limit:3
+mcporter list linear --schema — list tools for a server
+mcporter call linear.<tool> — call a tool
 \`\`\`
   ${LINEAR_MARKER_END}`;
 

--- a/kiloclaw/controller/src/bootstrap.ts
+++ b/kiloclaw/controller/src/bootstrap.ts
@@ -566,12 +566,8 @@ ${LINEAR_MARKER_BEGIN}
 ## Linear
 
 Linear is configured as your project management tool. Use it  to track issues, plan projects, and manage product roadmaps.
-You can interact with Linear using the \`Linear MCP\` — via \`mcporter\`, your MCP management tool:
+You can interact with the \`Linear\` MCP server using your \`mcporter\` skill.
 
-\`\`\`bash
-mcporter list linear --schema — list tools for a server
-mcporter call linear.<tool> — call a tool
-\`\`\`
   ${LINEAR_MARKER_END}`;
 
 /**

--- a/kiloclaw/controller/src/bootstrap.ts
+++ b/kiloclaw/controller/src/bootstrap.ts
@@ -327,44 +327,17 @@ export function configureGitHub(env: EnvLike, deps: BootstrapDeps = defaultDeps)
 // ---- Step 6: Linear config ----
 
 /**
- * Configure or clean up Linear CLI access.
- * When LINEAR_API_KEY is present the CLI reads it natively.
- * When absent, clean up any on-disk credentials left by a previous
- * `linear auth login --plaintext` on the persistent volume.
- * Best-effort: logs warnings on failure, does not throw.
- *
- * The CLI stores two files under ~/.config/linear/:
- *   - credentials.toml  — workspace list + inline API keys (plaintext mode)
- *   - linear.toml        — global config that can also carry an api_key field
- * It may also create ~/.linear.toml (a project-level or legacy config file).
- * The system keyring is not available in this container (no libsecret-tools),
- * so these files are the only persistence locations.
+ * Configure or clean up Linear MCP access.
+ * Linear access is provided via the Linear MCP server configured in mcporter.
+ * When LINEAR_API_KEY is present, mcporter uses it to authenticate.
+ * When absent, we just clean up the env var. No on-disk artifacts to clean.
  */
-export function configureLinear(env: EnvLike, deps: BootstrapDeps = defaultDeps): void {
+export function configureLinear(env: EnvLike): void {
   if (env.LINEAR_API_KEY) {
-    console.log('Linear CLI configured via LINEAR_API_KEY');
+    console.log('Linear MCP configured via LINEAR_API_KEY');
   } else {
-    // Clean up env var if explicitly set to empty
     delete env.LINEAR_API_KEY;
-    // Remove any previously stored credentials from the persistent volume.
-    // The CLI recreates ~/.config/linear/ via ensureDir on next auth login.
-    // rm -rf/-f exit 0 when the target is absent, so errors here are
-    // genuine failures (permissions, I/O) worth surfacing.
-    try {
-      deps.execFileSync('rm', ['-rf', '/root/.config/linear'], { stdio: 'pipe' });
-    } catch (err) {
-      console.warn(
-        `WARNING: failed to remove /root/.config/linear: ${err instanceof Error ? err.message : err}`
-      );
-    }
-    try {
-      deps.execFileSync('rm', ['-f', '/root/.linear.toml'], { stdio: 'pipe' });
-    } catch (err) {
-      console.warn(
-        `WARNING: failed to remove /root/.linear.toml: ${err instanceof Error ? err.message : err}`
-      );
-    }
-    console.log('Linear: not configured (credentials cleared)');
+    console.log('Linear: not configured');
   }
 }
 
@@ -590,50 +563,22 @@ const LINEAR_MARKER_END = '<!-- END:linear -->';
 
 const LINEAR_TOOLS_SECTION = `
 ${LINEAR_MARKER_BEGIN}
-  ## Linear
+## Linear
 
-  The \`linear\` CLI is configured with your Linear API key. Use it to read and manage issues.
+Linear is configured as your project management tool. Use it  to track issues, plan projects, and manage product roadmaps.
+You can interact with Linear using the \`Linear MCP\` via \`mcporter\` — your MCP management tool.
 
-  - Run \`linear --help\` for full command reference; \`--help\` after any subcommand for details.
-  - If you don't know the team key, run \`linear team list\`.
-
-  ### Listing issues
-
-  Example — list all issues by priority:
-  \`\`\`
-  linear issue list --team <key> --sort priority --all-states --all-assignees
-  \`\`\`
-
-  **Flags that silently filter results when omitted:**
-  - \`--state\` defaults to \`backlog\`. Use \`--all-states\` for all, or \`--state <value>\` to filter to one: triage, backlog, unstarted, started, completed, canceled
-  - \`--assignee\` defaults to \`me\`. Use \`--all-assignees\` for all, or \`--assignee <user>\` to filter to one
-
-  ### Writing issue content
-  Use file flags for markdown with newlines or special characters:
-  - \`--description-file <path>\` for \`issue create/update\`
-  - \`--body-file <path>\` for \`comment add/update\`
-
-  ### Config file
-  Avoid repeated \`--team\` and \`--sort\` flags with \`.linear.toml\` in the project directory:
-  \`\`\`toml
-  team = "TEAM_KEY"
-  sort = "priority"
-  \`\`\`
-
-  ### Gotchas
-  - \`--no-pager\` only works on \`issue list\` — errors on other commands
-  - GraphQL non-null types (\`String!\`) require heredoc: \`linear api --variable key=val <<'GRAPHQL'\`
-
-  ### Advanced
-  - Get API token: \`linear auth token\`
-  - Direct GraphQL: \`curl -s -X POST https://api.linear.app/graphql -H "Authorization: $(linear auth token)" -d '{"query":"..."}'\`
+Here's an example of how to list 3 issues:
+\`\`\`bash
+mcporter call linear.list_issues limit:3
+\`\`\`
   ${LINEAR_MARKER_END}`;
 
 /**
  * Manage the Linear section in TOOLS.md.
  *
  * When LINEAR_API_KEY is present, append a bounded section so the agent
- * knows the linear CLI is available. When absent, remove any stale section.
+ * knows Linear MCP is available. When absent, remove any stale section.
  * Idempotent: skips if the marker is already present.
  */
 export function updateToolsMdLinearSection(env: EnvLike, deps: BootstrapDeps): void {
@@ -718,7 +663,7 @@ export async function bootstrap(
   await yieldToEventLoop();
 
   setPhase('linear');
-  configureLinear(env, deps);
+  configureLinear(env);
   await yieldToEventLoop();
 
   const configExists = deps.existsSync(CONFIG_PATH);

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -793,7 +793,7 @@ describe('writeMcporterConfig', () => {
     expect(written).toHaveLength(1);
     const config = JSON.parse(written[0].data);
     expect(config.mcpServers.linear).toEqual({
-      baseUrl: 'https://mcp.linear.app/mcp',
+      url: 'https://mcp.linear.app/mcp',
       headers: { Authorization: 'Bearer ${LINEAR_API_KEY}' },
     });
   });
@@ -802,7 +802,7 @@ describe('writeMcporterConfig', () => {
     const existing = JSON.stringify({
       mcpServers: {
         linear: {
-          baseUrl: 'https://mcp.linear.app/mcp',
+          url: 'https://mcp.linear.app/mcp',
           headers: { Authorization: 'Bearer ${LINEAR_API_KEY}' },
         },
       },

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -3,6 +3,7 @@ import {
   backupConfigFile,
   generateBaseConfig,
   writeBaseConfig,
+  writeMcporterConfig,
   MAX_CONFIG_BACKUPS,
 } from './config-writer';
 
@@ -754,5 +755,108 @@ describe('writeBaseConfig', () => {
     // From our patches
     expect(config.gateway.auth.token).toBe('test-gw-token');
     expect(config.tools.exec.host).toBe('gateway');
+  });
+});
+
+function mcporterFakeDeps(existingMcporterConfig?: string) {
+  const written: { path: string; data: string }[] = [];
+  return {
+    deps: {
+      readFileSync: vi.fn((filePath: string) => {
+        if (existingMcporterConfig !== undefined) return existingMcporterConfig;
+        throw new Error(`ENOENT: no such file: ${filePath}`);
+      }),
+      writeFileSync: vi.fn((filePath: string, data: string) => {
+        written.push({ path: filePath, data });
+      }),
+      renameSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      readdirSync: vi.fn(() => []),
+      unlinkSync: vi.fn(),
+      existsSync: vi.fn((filePath: string) => {
+        if (existingMcporterConfig !== undefined && filePath.endsWith('mcporter.json')) return true;
+        return false;
+      }),
+      execFileSync: vi.fn(),
+    },
+    written,
+  };
+}
+
+describe('writeMcporterConfig', () => {
+  it('adds Linear MCP server when LINEAR_API_KEY is set', () => {
+    const { deps, written } = mcporterFakeDeps();
+    const env = { LINEAR_API_KEY: 'lin_api_test123' };
+
+    writeMcporterConfig(env, '/tmp/mcporter.json', deps);
+
+    expect(written).toHaveLength(1);
+    const config = JSON.parse(written[0].data);
+    expect(config.mcpServers.linear).toEqual({
+      baseUrl: 'https://mcp.linear.app/mcp',
+      headers: { Authorization: 'Bearer ${LINEAR_API_KEY}' },
+    });
+  });
+
+  it('removes Linear MCP server when LINEAR_API_KEY is absent', () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        linear: {
+          baseUrl: 'https://mcp.linear.app/mcp',
+          headers: { Authorization: 'Bearer ${LINEAR_API_KEY}' },
+        },
+      },
+    });
+    const { deps, written } = mcporterFakeDeps(existing);
+    const env: Record<string, string | undefined> = {};
+
+    writeMcporterConfig(env, '/tmp/mcporter.json', deps);
+
+    expect(written).toHaveLength(1);
+    const config = JSON.parse(written[0].data);
+    expect(config.mcpServers.linear).toBeUndefined();
+  });
+
+  it('preserves user-added servers when adding Linear', () => {
+    const existing = JSON.stringify({
+      mcpServers: {
+        custom: { url: 'https://custom.example.com/mcp' },
+      },
+    });
+    const { deps, written } = mcporterFakeDeps(existing);
+    const env = { LINEAR_API_KEY: 'lin_api_test123' };
+
+    writeMcporterConfig(env, '/tmp/mcporter.json', deps);
+
+    expect(written).toHaveLength(1);
+    const config = JSON.parse(written[0].data);
+    expect(config.mcpServers.custom).toEqual({ url: 'https://custom.example.com/mcp' });
+    expect(config.mcpServers.linear).toBeDefined();
+  });
+
+  it('adds both AgentCard and Linear when both keys are set', () => {
+    const { deps, written } = mcporterFakeDeps();
+    const env = {
+      AGENTCARD_API_KEY: 'ac_test123',
+      LINEAR_API_KEY: 'lin_api_test123',
+    };
+
+    writeMcporterConfig(env, '/tmp/mcporter.json', deps);
+
+    expect(written).toHaveLength(1);
+    const config = JSON.parse(written[0].data);
+    expect(config.mcpServers.agentcard).toBeDefined();
+    expect(config.mcpServers.linear).toBeDefined();
+  });
+
+  it('uses literal ${LINEAR_API_KEY} in authorization header (not interpolated)', () => {
+    const { deps, written } = mcporterFakeDeps();
+    const env = { LINEAR_API_KEY: 'lin_api_test123' };
+
+    writeMcporterConfig(env, '/tmp/mcporter.json', deps);
+
+    const config = JSON.parse(written[0].data);
+    // The header should contain the literal string ${LINEAR_API_KEY}, not the actual value
+    expect(config.mcpServers.linear.headers.Authorization).toBe('Bearer ${LINEAR_API_KEY}');
   });
 });

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -349,6 +349,19 @@ export function writeMcporterConfig(
     }
   }
 
+  if (env.LINEAR_API_KEY) {
+    existingServers['linear'] = {
+      baseUrl: 'https://mcp.linear.app/mcp',
+      headers: { Authorization: 'Bearer ${LINEAR_API_KEY}' },
+    };
+    console.log('Linear MCP server configured (via mcporter)');
+  } else {
+    if ('linear' in existingServers) {
+      delete existingServers['linear'];
+      console.log('Linear MCP server removed from mcporter config');
+    }
+  }
+
   // Only write if there are servers to configure or we need to clean up
   if (Object.keys(existingServers).length === 0 && !deps.existsSync(configPath)) {
     return;

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -351,7 +351,7 @@ export function writeMcporterConfig(
 
   if (env.LINEAR_API_KEY) {
     existingServers['linear'] = {
-      baseUrl: 'https://mcp.linear.app/mcp',
+      url: 'https://mcp.linear.app/mcp',
       headers: { Authorization: 'Bearer ${LINEAR_API_KEY}' },
     };
     console.log('Linear MCP server configured (via mcporter)');


### PR DESCRIPTION
## Summary

A refactor targeting #1407:

After exploring other options for the Linear integration, the official Linear MCP server turned out to be a better fit than the CLI. All OpenClaw instances are already deployed with the `mcporter` package and skill, which give KiloClaw MCP abilities anyways. Importantly, unlike the CLI, mcporter also allows us to avoid ever writing our actual API key to a file, which significantly reduces the overhead for managing this integration. This PR targets feature/kiloclaw-linear-cli with the scoped changes to switch-over to this MCP integration only, to simplify the reviewer's experience.

## Changes

- Undo the changes to both `Dockerfile`s — the target branch will have no diff after this PR merges.
- Strip all on-disk credential cleanup logic from `configureLinear()` — no new files to manage anymore, so the function no longer needs `BootstrapDeps`
- Add Linear MCP server entry to `writeMcporterConfig()` when `LINEAR_API_KEY` is set; remove it when unset. Preserves existing user-configured servers. The key is stored in the file as `${LINEAR_API_KEY}` verbatim and read from the environment by mcporter. 
- Replace CLI usage documentation in the TOOLS.md agent section with a pointer to the Linear MCP server and mcporter skill
- Simplify `configureLinear` tests (no more fs/exec mocking) and add `writeMcporterConfig` tests covering add, remove, preserve, and multi-server scenarios

## Verification

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] Tests pass (`vitest` in kiloclaw workspace)
- [x] E2E tested on a fresh instance

## New Loom — Kilo Team only
https://www.loom.com/share/5ca9897104e84a3baf560818b7a3bcf7

## Action for reviewer
Please let me know your preference for merge, whether it's into the feature/kiloclaw-cli branch, or into main directly. 