### PR TITLE
fix(kiloclaw): backfill Stream Chat on redeploy for pre-existing instances

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -89,12 +89,25 @@ vi.mock('../utils/env-encryption', () => ({
   encryptEnvValue: vi.fn((_key: string, value: string) => `enc:v1:fake_${value}`),
 }));
 
+// -- Mock stream-chat client --
+vi.mock('../stream-chat/client', () => ({
+  setupDefaultStreamChatChannel: vi.fn().mockResolvedValue({
+    apiKey: 'sc-api-key',
+    botUserId: 'bot-sandbox-1',
+    botUserToken: 'sc-bot-token',
+    channelId: 'default-sandbox-1',
+  }),
+  createShortLivedUserToken: vi.fn().mockResolvedValue('short-lived-token'),
+  deactivateStreamChatUsers: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { KiloClawInstance } from './kiloclaw-instance';
 import * as flyClient from '../fly/client';
 import { FlyApiError } from '../fly/client';
 import * as db from '../db';
 import * as gatewayEnv from '../gateway/env';
 import { resolveLatestVersion } from '../lib/image-version';
+import { setupDefaultStreamChatChannel } from '../stream-chat/client';
 import { verifyKiloToken } from '@kilocode/worker-utils';
 import {
   ALARM_INTERVAL_RUNNING_MS,
@@ -5816,5 +5829,217 @@ describe('tryMarkInstanceReady', () => {
 
     expect(result).toEqual({ shouldNotify: true, userId: 'user-1' });
     expect(storage._store.get('instanceReadyEmailSent')).toBe(true);
+  });
+});
+
+// ============================================================================
+// Stream Chat backfill
+// ============================================================================
+
+describe('Stream Chat backfill on provision', () => {
+  beforeEach(() => {
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-1',
+      region: 'iad',
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (setupDefaultStreamChatChannel as Mock).mockClear();
+  });
+
+  it('provisions Stream Chat on first provision when env vars are present', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage, waitUntilPromises } = createInstance(undefined, env);
+
+    await instance.provision('user-1', {});
+    await Promise.all(waitUntilPromises);
+
+    expect(setupDefaultStreamChatChannel).toHaveBeenCalledOnce();
+    expect(storage._store.get('streamChatApiKey')).toBe('sc-api-key');
+    expect(storage._store.get('streamChatBotUserId')).toBe('bot-sandbox-1');
+    expect(storage._store.get('streamChatBotUserToken')).toBe('sc-bot-token');
+    expect(storage._store.get('streamChatChannelId')).toBe('default-sandbox-1');
+  });
+
+  it('backfills Stream Chat on re-provision when DO state has no credentials', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage);
+
+    (setupDefaultStreamChatChannel as Mock).mockClear();
+    await instance.provision('user-1', { kilocodeApiKey: 'new-key' });
+
+    expect(setupDefaultStreamChatChannel).toHaveBeenCalledOnce();
+    expect(storage._store.get('streamChatApiKey')).toBe('sc-api-key');
+    expect(storage._store.get('streamChatBotUserId')).toBe('bot-sandbox-1');
+    expect(storage._store.get('streamChatBotUserToken')).toBe('sc-bot-token');
+    expect(storage._store.get('streamChatChannelId')).toBe('default-sandbox-1');
+  });
+
+  it('skips Stream Chat setup on re-provision when credentials already exist', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      streamChatApiKey: 'existing-key',
+      streamChatBotUserId: 'existing-bot',
+      streamChatBotUserToken: 'existing-token',
+      streamChatChannelId: 'existing-channel',
+    });
+
+    (setupDefaultStreamChatChannel as Mock).mockClear();
+    await instance.provision('user-1', { kilocodeApiKey: 'new-key' });
+
+    expect(setupDefaultStreamChatChannel).not.toHaveBeenCalled();
+    expect(storage._store.get('streamChatApiKey')).toBe('existing-key');
+  });
+
+  it('skips Stream Chat when worker env vars are missing', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    // Default env does not have STREAM_CHAT_API_KEY / STREAM_CHAT_API_SECRET
+
+    await instance.provision('user-1', {});
+    await Promise.all(waitUntilPromises);
+
+    expect(setupDefaultStreamChatChannel).not.toHaveBeenCalled();
+    expect(storage._store.get('streamChatApiKey')).toBeUndefined();
+  });
+
+  it('continues provisioning when Stream Chat setup fails (non-fatal)', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage, waitUntilPromises } = createInstance(undefined, env);
+
+    (setupDefaultStreamChatChannel as Mock).mockRejectedValueOnce(
+      new Error('Stream Chat API down')
+    );
+
+    await instance.provision('user-1', {});
+    await Promise.all(waitUntilPromises);
+
+    // Provision succeeded despite Stream Chat failure
+    expect(storage._store.get('status')).toBeTruthy();
+    expect(storage._store.get('streamChatApiKey')).toBeUndefined();
+  });
+});
+
+describe('Stream Chat backfill on restartMachine', () => {
+  beforeEach(() => {
+    (flyClient.updateMachine as Mock).mockResolvedValue({ instance_id: 'inst-1' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      id: 'machine-1',
+      state: 'started',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+    (setupDefaultStreamChatChannel as Mock).mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.includes('/_kilo/gateway/status')) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ state: 'running' }),
+          });
+        }
+        return Promise.resolve({ ok: true, status: 200 });
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('backfills Stream Chat on restart when DO state has no credentials', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage, waitUntilPromises } = createInstance(undefined, env);
+    await seedRunning(storage);
+
+    const result = await instance.restartMachine();
+    expect(result.success).toBe(true);
+    await Promise.all(waitUntilPromises);
+
+    expect(setupDefaultStreamChatChannel).toHaveBeenCalledOnce();
+    expect(storage._store.get('streamChatApiKey')).toBe('sc-api-key');
+    expect(storage._store.get('streamChatBotUserId')).toBe('bot-sandbox-1');
+    expect(storage._store.get('streamChatBotUserToken')).toBe('sc-bot-token');
+    expect(storage._store.get('streamChatChannelId')).toBe('default-sandbox-1');
+  });
+
+  it('skips Stream Chat backfill on restart when credentials already exist', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage, waitUntilPromises } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      streamChatApiKey: 'existing-key',
+      streamChatBotUserId: 'existing-bot',
+      streamChatBotUserToken: 'existing-token',
+      streamChatChannelId: 'existing-channel',
+    });
+
+    const result = await instance.restartMachine();
+    expect(result.success).toBe(true);
+    await Promise.all(waitUntilPromises);
+
+    expect(setupDefaultStreamChatChannel).not.toHaveBeenCalled();
+    expect(storage._store.get('streamChatApiKey')).toBe('existing-key');
+  });
+
+  it('continues restart when Stream Chat backfill fails (non-fatal)', async () => {
+    const env = createFakeEnv();
+    Object.assign(env, {
+      STREAM_CHAT_API_KEY: 'sc-key',
+      STREAM_CHAT_API_SECRET: 'sc-secret',
+    });
+    const { instance, storage, waitUntilPromises } = createInstance(undefined, env);
+    await seedRunning(storage);
+
+    (setupDefaultStreamChatChannel as Mock).mockRejectedValueOnce(
+      new Error('Stream Chat API down')
+    );
+
+    const result = await instance.restartMachine();
+    expect(result.success).toBe(true);
+    await Promise.all(waitUntilPromises);
+
+    // Restart still completes — Stream Chat failure is non-fatal
+    expect(storage._store.get('streamChatApiKey')).toBeUndefined();
+    // Machine was still updated
+    expect(flyClient.updateMachine).toHaveBeenCalled();
+  });
+
+  it('skips Stream Chat backfill when worker env vars are missing', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+    await seedRunning(storage);
+
+    const result = await instance.restartMachine();
+    expect(result.success).toBe(true);
+    await Promise.all(waitUntilPromises);
+
+    expect(setupDefaultStreamChatChannel).not.toHaveBeenCalled();
   });
 });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -393,7 +393,16 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     // The bot and channel are created server-side here so the API secret never
     // reaches the Fly Machine. Failure is non-fatal: the instance will start
     // without the Stream Chat channel rather than blocking provisioning.
-    if (isNew && this.env.STREAM_CHAT_API_KEY && this.env.STREAM_CHAT_API_SECRET) {
+    // Set up or backfill the default Stream Chat channel (best-effort).
+    // On first provision (isNew) this creates the channel from scratch.
+    // On re-provision (!isNew) this backfills instances created before the
+    // feature was added. setupDefaultStreamChatChannel is idempotent
+    // (upsert users, getOrCreate channel). Failure is non-fatal.
+    if (
+      !this.s.streamChatApiKey &&
+      this.env.STREAM_CHAT_API_KEY &&
+      this.env.STREAM_CHAT_API_SECRET
+    ) {
       try {
         const streamChat = await setupDefaultStreamChatChannel(
           this.env.STREAM_CHAT_API_KEY,
@@ -410,9 +419,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           streamChatBotUserToken: streamChat.botUserToken,
           streamChatChannelId: streamChat.channelId,
         });
-        console.log('[DO] Stream Chat default channel provisioned:', streamChat.channelId);
+        console.log(
+          `[DO] Stream Chat channel ${isNew ? 'provisioned' : 'backfilled'}:`,
+          streamChat.channelId
+        );
       } catch (err) {
-        doWarn(this.s, 'Stream Chat default channel setup failed (non-fatal)', {
+        doWarn(this.s, 'Stream Chat channel setup failed (non-fatal)', {
           error: toLoggable(err),
         });
       }
@@ -1911,6 +1923,40 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
       if (!this.s.flyMachineId) {
         throw new Error('No machine exists');
+      }
+
+      // Backfill Stream Chat for instances created before the feature was added.
+      // setupDefaultStreamChatChannel is idempotent (upsert users, getOrCreate channel).
+      if (
+        !this.s.streamChatApiKey &&
+        this.env.STREAM_CHAT_API_KEY &&
+        this.env.STREAM_CHAT_API_SECRET &&
+        this.s.sandboxId
+      ) {
+        try {
+          const streamChat = await setupDefaultStreamChatChannel(
+            this.env.STREAM_CHAT_API_KEY,
+            this.env.STREAM_CHAT_API_SECRET,
+            this.s.sandboxId
+          );
+          this.s.streamChatApiKey = streamChat.apiKey;
+          this.s.streamChatBotUserId = streamChat.botUserId;
+          this.s.streamChatBotUserToken = streamChat.botUserToken;
+          this.s.streamChatChannelId = streamChat.channelId;
+          await this.persist({
+            streamChatApiKey: streamChat.apiKey,
+            streamChatBotUserId: streamChat.botUserId,
+            streamChatBotUserToken: streamChat.botUserToken,
+            streamChatChannelId: streamChat.channelId,
+          });
+          doLog(this.s, 'Stream Chat backfilled on restart', {
+            channelId: streamChat.channelId,
+          });
+        } catch (err) {
+          doWarn(this.s, 'Stream Chat backfill failed on restart (non-fatal)', {
+            error: toLoggable(err),
+          });
+        }
       }
 
       const flyConfig = getFlyConfig(this.env, this.s);


### PR DESCRIPTION
## Summary

- Stream Chat was only provisioned during the first `provision()` call due to an `isNew` guard. Instances created before the feature was added (or where initial setup failed) never got Stream Chat credentials, so clicking "Redeploy or Upgrade" produced `openclaw.json` without `channels.streamchat`.
- Replaced the `isNew` gate in `provision()` with a `!streamChatApiKey` check so both first-provision and re-provision trigger Stream Chat setup when credentials are missing.
- Added the same backfill in `restartMachineInBackground()` (the "Redeploy or Upgrade" code path) before `buildUserEnvVars()` so the credentials are available when building the machine env vars.
- `setupDefaultStreamChatChannel()` is idempotent (upsert users, getOrCreate channel) and failure remains non-fatal in both paths.

## Verification

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 1054 tests passed (301 in the instance test file, including 9 new Stream Chat backfill tests)
- [x] `pnpm lint` — 0 warnings, 0 errors

## Visual Changes

N/A

## Reviewer Notes

- The backfill runs in two places: `provision()` (covers platform re-provision) and `restartMachineInBackground()` (covers user "Redeploy or Upgrade"). Both are non-fatal — if the Stream Chat API is down, the instance still starts/restarts without chat support.
- Reconciliation backfill was considered but not added to avoid periodic Stream Chat API load. The restart + re-provision paths cover the user-facing action.
- The `setupDefaultStreamChatChannel` function was already idempotent by design (reactivates users on re-provision after destroy, upserts users, getOrCreate channel), so calling it on existing instances is safe.