### PR TITLE
feat(code-reviews): suggest free model in billing PR notice

### DIFF
--- a/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -599,5 +599,27 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         expect.stringContaining('https://app.kilo.ai/')
       );
     });
+
+    it('suggests switching to a free model in the billing notice', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockHasPRCommentWithMarker.mockResolvedValue(false);
+
+      await POST(
+        makeRequest({
+          status: 'failed',
+          errorMessage: 'Insufficient credits',
+          terminalReason: 'billing',
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockCreatePRComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        1,
+        expect.stringContaining('switch to a free model')
+      );
+    });
   });
 });

--- a/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -166,7 +166,7 @@ const BILLING_NOTICE_MARKER = '<!-- kilo-billing-notice -->';
 const BILLING_NOTICE_BODY = `${BILLING_NOTICE_MARKER}
 **Kilo Code Review could not run — your account is out of credits.**
 
-Add credits at [app.kilo.ai](https://app.kilo.ai/) to enable reviews on this change.`;
+[Add credits](https://app.kilo.ai/) or [switch to a free model](https://app.kilo.ai/code-reviews) to enable reviews on this change.`;
 
 /**
  * Read a review's usage data.


### PR DESCRIPTION
## Summary

Followup to #1332

When a code review fails due to insufficient credits, the billing notice posted on the PR/MR now also suggests switching to a free model (with a link to the code review settings page), in addition to the existing "add credits" link. This gives users a quicker path to unblock their reviews without spending money.

## Verification

- [x] `pnpm test -- 'src/app/api/internal/code-review-status/.*/route.test.ts'` — all 18 tests pass, including the new `suggests switching to a free model in the billing notice` test
- [x] Pre-push hooks (format, typecheck, lint) pass

## Visual Changes

N/A

## Reviewer Notes

The HTML comment marker (`<!-- kilo-billing-notice -->`) is unchanged, so the dedup logic still works correctly — PRs that already have the old billing notice won't get a duplicate comment.