### PR TITLE
fix(kilo-app): fix invalid date in earlybird billing banner

### DIFF
--- a/kilo-app/AGENTS.md
+++ b/kilo-app/AGENTS.md
@@ -43,7 +43,7 @@ npx expo install --dev <package-name>   # devDependencies
 
 - When you need data from the backend, **always add a new tRPC procedure** rather than copying data or inventing client-side alternatives. The app uses tRPC with React Query — adding a procedure is cheap and keeps the source of truth on the server.
 - When a component takes backend data as props, derive the prop types from the tRPC router's return types (e.g., `NonNullable<ReturnType<typeof useMyQuery>['data']>`) instead of manually copying type definitions. This keeps types in sync with the backend automatically.
-- **Never use `new Date()` on timestamp strings from the backend.** Drizzle uses `mode: 'string'` for timestamps, and PostgreSQL's format (`2026-03-13 14:30:00+00`) is not parseable by Hermes. Use `parseTimestamp()` from `@/lib/utils` instead.
+- **Never use `new Date()` on any date or timestamp string from the backend.** Hermes cannot reliably parse PostgreSQL timestamps (`2026-03-13 14:30:00+00`) or date-only strings (`2026-09-26`). Always use `parseTimestamp()` from `@/lib/utils` — it handles both formats.
 
 ### Mutations
 

--- a/kilo-app/src/lib/utils.ts
+++ b/kilo-app/src/lib/utils.ts
@@ -11,6 +11,10 @@ function cn(...inputs: ClassValue[]) {
  * so we normalise the space separator to `T` before parsing.
  */
 function parseTimestamp(value: string): Date {
+  // Date-only: "2026-09-26" → treat as UTC midnight
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return new Date(`${value}T00:00:00Z`);
+  }
   // PostgreSQL: "2026-03-16 15:21:40.957+00" → need "T" separator and full tz offset "+00:00"
   const iso = value.replace(' ', 'T').replace(/([+-]\d{2})$/, '$1:00');
   return new Date(iso);


### PR DESCRIPTION
## Summary
- `parseTimestamp()` didn't handle date-only strings like `2026-09-26` (from `KILOCLAW_EARLYBIRD_EXPIRY_DATE`). On Hermes, `new Date('2026-09-26')` returns `Invalid Date`, causing the earlybird banner to show "Invalid Date"
- Added date-only detection to `parseTimestamp()` — appends `T00:00:00Z` for reliable parsing
- Updated AGENTS.md to clarify that `parseTimestamp` handles both timestamp and date-only formats

## Test plan
- [ ] Verify earlybird banner shows the correct expiry date instead of "Invalid Date"
- [ ] Verify other dates (trial, subscription) still render correctly