### PR TITLE
feat(kiloclaw): mention email notification on provisioning step

### DIFF
--- a/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -237,8 +237,8 @@ export function ProvisioningStepView({ totalSteps = 4 }: { totalSteps?: number }
       <div className="flex flex-col items-center gap-2 text-center">
         <h2 className="text-foreground text-2xl font-bold">Setting up your instance</h2>
         <p className="text-muted-foreground max-w-md text-sm leading-relaxed">
-          This usually takes a minute or two. Feel free to keep this tab open and step away &mdash;
-          we&apos;ll play a sound as soon as it&apos;s ready.
+          This usually takes a minute or two. Feel free to step away &mdash; we&apos;ll send you an
+          email and play a sound when it&apos;s ready.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Update the provisioning step copy to tell users we'll send them an email when their KiloClaw instance is ready, encouraging them to step away from the tab without worrying about missing the notification.

## Verification

- [x] `pnpm typecheck` — passes
- [x] Visual review of the copy change in source

## Visual Changes

| Before | After |
| ------ | ----- |
| "This usually takes a minute or two. Feel free to keep this tab open and step away — we'll play a sound as soon as it's ready." | "This usually takes a minute or two. Feel free to step away — we'll send you an email and play a sound when it's ready." |

## Reviewer Notes

Single copy change in `ProvisioningStepView`. No logic or behavioral changes.