### PR TITLE
fix(kilo-app): improve modal header padding and icon on iOS

### DIFF
--- a/kilo-app/src/components/profile-screen.tsx
+++ b/kilo-app/src/components/profile-screen.tsx
@@ -117,7 +117,7 @@ export function ProfileScreen() {
 
   return (
     <View className="flex-1 bg-background">
-      <ScreenHeader title="Profile" />
+      <ScreenHeader title="Profile" modal />
       <View className="flex-1 px-6 pt-4">
         {/* Active context */}
         <View className="gap-3">

--- a/kilo-app/src/components/screen-header.tsx
+++ b/kilo-app/src/components/screen-header.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'expo-router';
-import { ChevronLeft } from 'lucide-react-native';
-import { Pressable, View } from 'react-native';
+import { ChevronDown, ChevronLeft } from 'lucide-react-native';
+import { Platform, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Text } from '@/components/ui/text';
@@ -9,16 +9,20 @@ import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 type ScreenHeaderProps = {
   title: string;
   headerRight?: React.ReactNode;
+  modal?: boolean;
 };
 
-export function ScreenHeader({ title, headerRight }: Readonly<ScreenHeaderProps>) {
+export function ScreenHeader({ title, headerRight, modal }: Readonly<ScreenHeaderProps>) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const colors = useThemeColors();
   const canGoBack = router.canGoBack();
 
+  // iOS modals are presented as cards already inset from the status bar
+  const paddingTop = modal && Platform.OS === 'ios' ? 32 : insets.top + 8;
+
   return (
-    <View className="bg-background px-4 pb-3" style={{ paddingTop: insets.top + 8 }}>
+    <View className="bg-background px-4 pb-3" style={{ paddingTop }}>
       <View className="flex-row items-center justify-between">
         <View className="flex-1 flex-row items-center gap-1">
           {canGoBack && (
@@ -30,7 +34,11 @@ export function ScreenHeader({ title, headerRight }: Readonly<ScreenHeaderProps>
               accessibilityLabel="Go back"
               className="-ml-1 mr-1 active:opacity-70"
             >
-              <ChevronLeft size={24} color={colors.foreground} />
+              {modal && Platform.OS === 'ios' ? (
+                <ChevronDown size={24} color={colors.foreground} />
+              ) : (
+                <ChevronLeft size={24} color={colors.foreground} />
+              )}
             </Pressable>
           )}
           <Text className="text-lg font-semibold" numberOfLines={1}>


### PR DESCRIPTION
## Summary
- Add `modal` prop to `ScreenHeader` that uses fixed 32px top padding on iOS (modal cards are already inset from the status bar, so `insets.top` creates excessive padding)
- Show chevron-down icon instead of chevron-left for modal screens on iOS
- Pass `modal` from the profile screen

## Test plan
- [ ] Open profile modal on iOS — verify reduced top padding and down chevron
- [ ] Open profile on Android — verify full safe area padding and left chevron unchanged
- [ ] Verify other screens using `ScreenHeader` are unaffected