### PR TITLE
feat(kiloclaw): support all OpenClaw user defined SecretRefs

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   backupConfigFile,
   generateBaseConfig,
+  setNestedValue,
   writeBaseConfig,
   MAX_CONFIG_BACKUPS,
 } from './config-writer';
@@ -525,6 +526,78 @@ describe('generateBaseConfig', () => {
 
     expect(config.tools.exec.security).toBe('allowlist');
     expect(config.tools.exec.ask).toBe('on-miss');
+  });
+
+  it('patches custom secrets into config via KILOCLAW_SECRET_CONFIG_PATHS', () => {
+    const { deps } = fakeDeps();
+    const config = generateBaseConfig(
+      {
+        MY_API_KEY: 'sk-test-123',
+        ANOTHER_KEY: 'value-456',
+        KILOCLAW_SECRET_CONFIG_PATHS: JSON.stringify({
+          MY_API_KEY: 'models.providers.openai.apiKey',
+          ANOTHER_KEY: 'channels.custom.token',
+        }),
+      },
+      '/root/.openclaw/openclaw.json',
+      deps
+    );
+
+    expect(config.models.providers.openai.apiKey).toBe('sk-test-123');
+    expect(config.channels.custom.token).toBe('value-456');
+  });
+
+  it('skips config path patching for missing env vars', () => {
+    const { deps } = fakeDeps();
+    const config = generateBaseConfig(
+      {
+        KILOCLAW_SECRET_CONFIG_PATHS: JSON.stringify({
+          MISSING_KEY: 'models.providers.openai.apiKey',
+        }),
+      },
+      '/root/.openclaw/openclaw.json',
+      deps
+    );
+
+    expect(config.models?.providers?.openai?.apiKey).toBeUndefined();
+  });
+
+  it('handles malformed KILOCLAW_SECRET_CONFIG_PATHS gracefully', () => {
+    const { deps } = fakeDeps();
+    // Should not throw, just warn
+    const config = generateBaseConfig(
+      { KILOCLAW_SECRET_CONFIG_PATHS: 'not-valid-json' },
+      '/root/.openclaw/openclaw.json',
+      deps
+    );
+    expect(config).toBeDefined();
+  });
+});
+
+describe('setNestedValue', () => {
+  it('sets a value at a simple path', () => {
+    const obj: Record<string, unknown> = {};
+    setNestedValue(obj, 'foo', 'bar');
+    expect(obj.foo).toBe('bar');
+  });
+
+  it('sets a value at a nested path, creating intermediates', () => {
+    const obj: Record<string, unknown> = {};
+    setNestedValue(obj, 'a.b.c', 'value');
+    expect((obj as any).a.b.c).toBe('value');
+  });
+
+  it('preserves existing sibling keys', () => {
+    const obj: Record<string, unknown> = { a: { existing: true } };
+    setNestedValue(obj, 'a.newKey', 'value');
+    expect((obj as any).a.existing).toBe(true);
+    expect((obj as any).a.newKey).toBe('value');
+  });
+
+  it('overwrites existing values', () => {
+    const obj: Record<string, unknown> = { a: { b: 'old' } };
+    setNestedValue(obj, 'a.b', 'new');
+    expect((obj as any).a.b).toBe('new');
   });
 });
 

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -661,6 +661,30 @@ describe('setNestedValue', () => {
     setNestedValue(obj, 'a.b', 'new');
     expect((obj as any).a.b).toBe('new');
   });
+
+  it('refuses to patch __proto__ segments', () => {
+    const obj: Record<string, unknown> = {};
+    setNestedValue(obj, '__proto__.polluted', 'yes');
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('refuses to patch constructor segments', () => {
+    const obj: Record<string, unknown> = {};
+    setNestedValue(obj, 'constructor.prototype.polluted', 'yes');
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('refuses to patch prototype segments', () => {
+    const obj: Record<string, unknown> = {};
+    setNestedValue(obj, 'a.prototype.b', 'yes');
+    expect((obj as any).a).toBeUndefined();
+  });
+
+  it('skips when intermediate is a non-object primitive', () => {
+    const obj: Record<string, unknown> = { a: 'string-not-object' };
+    setNestedValue(obj, 'a.b.c', 'value');
+    expect(obj.a).toBe('string-not-object');
+  });
 });
 
 describe('backupConfigFile', () => {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -325,7 +325,14 @@ export function setNestedValue(obj: ConfigObject, path: string, value: string): 
   const segments = path.split('.');
   let current = obj;
   for (let i = 0; i < segments.length - 1; i++) {
-    current[segments[i]] = current[segments[i]] ?? {};
+    const existing = current[segments[i]];
+    if (existing != null && (typeof existing !== 'object' || Array.isArray(existing))) {
+      console.warn(
+        `Cannot patch ${path}: "${segments.slice(0, i + 1).join('.')}" is not an object`
+      );
+      return;
+    }
+    current[segments[i]] = existing ?? {};
     current = current[segments[i]] as ConfigObject;
   }
   current[segments[segments.length - 1]] = value;

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -296,7 +296,39 @@ export function generateBaseConfig(
     console.log('Hooks enabled with gmail preset (dedicated token)');
   }
 
+  // Custom secret config path patching — set decrypted secret values at
+  // user-specified JSON dot-notation paths in openclaw.json.
+  if (env.KILOCLAW_SECRET_CONFIG_PATHS) {
+    try {
+      const pathMap: Record<string, string> = JSON.parse(env.KILOCLAW_SECRET_CONFIG_PATHS);
+      for (const [envVar, configPath] of Object.entries(pathMap)) {
+        const value = env[envVar];
+        if (value) {
+          setNestedValue(config, configPath, value);
+          console.log(`Patched custom secret ${envVar} → ${configPath}`);
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to parse KILOCLAW_SECRET_CONFIG_PATHS:', err);
+    }
+  }
+
   return config;
+}
+
+/**
+ * Set a value at a dot-notation path in a nested object, creating
+ * intermediate objects as needed.
+ * e.g. setNestedValue(obj, "models.providers.openai.apiKey", "sk-...")
+ */
+export function setNestedValue(obj: ConfigObject, path: string, value: string): void {
+  const segments = path.split('.');
+  let current = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    current[segments[i]] = current[segments[i]] ?? {};
+    current = current[segments[i]] as ConfigObject;
+  }
+  current[segments[segments.length - 1]] = value;
 }
 
 const DEFAULT_MCPORTER_CONFIG_PATH = '/root/.openclaw/workspace/config/mcporter.json';

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -345,8 +345,16 @@ export function generateBaseConfig(
  * intermediate objects as needed.
  * e.g. setNestedValue(obj, "models.providers.openai.apiKey", "sk-...")
  */
+const BANNED_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export function setNestedValue(obj: ConfigObject, path: string, value: string): void {
   const segments = path.split('.');
+  for (const seg of segments) {
+    if (BANNED_SEGMENTS.has(seg)) {
+      console.warn(`Refusing to patch ${path}: "${seg}" is a banned path segment`);
+      return;
+    }
+  }
   let current = obj;
   for (let i = 0; i < segments.length - 1; i++) {
     const existing = current[segments[i]];

--- a/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
+++ b/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
@@ -10,6 +10,10 @@ import {
   INTERNAL_SENSITIVE_ENV_VARS,
   getEntriesByCategory,
   getFieldKeysByCategory,
+  isValidCustomSecretKey,
+  isCustomSecretEnvVar,
+  MAX_CUSTOM_SECRETS,
+  MAX_CUSTOM_SECRET_VALUE_LENGTH,
 } from '../catalog.js';
 import { validateFieldValue } from '../validation.js';
 import type { SecretIconKey, SecretCatalogEntry } from '../types.js';
@@ -486,6 +490,73 @@ describe('Secret Catalog', () => {
       expect(discord?.fields[0].maxLength).toBe(200);
       expect(slackBot?.fields.find(f => f.key === 'slackBotToken')?.maxLength).toBe(300);
       expect(slackBot?.fields.find(f => f.key === 'slackAppToken')?.maxLength).toBe(300);
+    });
+  });
+
+  describe('isValidCustomSecretKey', () => {
+    it('accepts valid custom env var names', () => {
+      expect(isValidCustomSecretKey('MY_API_KEY')).toBe(true);
+      expect(isValidCustomSecretKey('OPENAI_API_KEY')).toBe(true);
+      expect(isValidCustomSecretKey('_PRIVATE')).toBe(true);
+      expect(isValidCustomSecretKey('key123')).toBe(true);
+      expect(isValidCustomSecretKey('A')).toBe(true);
+    });
+
+    it('rejects catalog field keys', () => {
+      expect(isValidCustomSecretKey('telegramBotToken')).toBe(false);
+      expect(isValidCustomSecretKey('discordBotToken')).toBe(false);
+      expect(isValidCustomSecretKey('githubToken')).toBe(false);
+    });
+
+    it('rejects catalog env var names', () => {
+      expect(isValidCustomSecretKey('TELEGRAM_BOT_TOKEN')).toBe(false);
+      expect(isValidCustomSecretKey('DISCORD_BOT_TOKEN')).toBe(false);
+      expect(isValidCustomSecretKey('GITHUB_TOKEN')).toBe(false);
+      expect(isValidCustomSecretKey('BRAVE_API_KEY')).toBe(false);
+    });
+
+    it('rejects reserved KILOCLAW_ prefix', () => {
+      expect(isValidCustomSecretKey('KILOCLAW_SECRET')).toBe(false);
+      expect(isValidCustomSecretKey('KILOCLAW_ENC_FOO')).toBe(false);
+    });
+
+    it('rejects invalid shell identifiers', () => {
+      expect(isValidCustomSecretKey('123_START_WITH_NUM')).toBe(false);
+      expect(isValidCustomSecretKey('has spaces')).toBe(false);
+      expect(isValidCustomSecretKey('has-dashes')).toBe(false);
+      expect(isValidCustomSecretKey('has.dots')).toBe(false);
+      expect(isValidCustomSecretKey('')).toBe(false);
+    });
+
+    it('rejects keys exceeding 128 characters', () => {
+      expect(isValidCustomSecretKey('A'.repeat(128))).toBe(true);
+      expect(isValidCustomSecretKey('A'.repeat(129))).toBe(false);
+    });
+  });
+
+  describe('isCustomSecretEnvVar', () => {
+    it('returns true for non-catalog, non-internal env var names', () => {
+      expect(isCustomSecretEnvVar('MY_CUSTOM_KEY')).toBe(true);
+      expect(isCustomSecretEnvVar('OPENAI_API_KEY')).toBe(true);
+    });
+
+    it('returns false for catalog env var names', () => {
+      expect(isCustomSecretEnvVar('TELEGRAM_BOT_TOKEN')).toBe(false);
+      expect(isCustomSecretEnvVar('GITHUB_TOKEN')).toBe(false);
+    });
+
+    it('returns false for internal sensitive env vars', () => {
+      expect(isCustomSecretEnvVar('KILOCLAW_GOG_CONFIG_TARBALL')).toBe(false);
+    });
+  });
+
+  describe('custom secret constants', () => {
+    it('MAX_CUSTOM_SECRETS is a reasonable limit', () => {
+      expect(MAX_CUSTOM_SECRETS).toBe(50);
+    });
+
+    it('MAX_CUSTOM_SECRET_VALUE_LENGTH covers JWTs and certificates', () => {
+      expect(MAX_CUSTOM_SECRET_VALUE_LENGTH).toBe(8192);
     });
   });
 });

--- a/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
+++ b/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
@@ -12,6 +12,7 @@ import {
   getFieldKeysByCategory,
   isValidCustomSecretKey,
   isCustomSecretEnvVar,
+  isValidConfigPath,
   MAX_CUSTOM_SECRETS,
   MAX_CUSTOM_SECRET_VALUE_LENGTH,
 } from '../catalog.js';
@@ -515,9 +516,24 @@ describe('Secret Catalog', () => {
       expect(isValidCustomSecretKey('BRAVE_API_KEY')).toBe(false);
     });
 
-    it('rejects reserved KILOCLAW_ prefix', () => {
+    it('rejects reserved prefixes', () => {
       expect(isValidCustomSecretKey('KILOCLAW_SECRET')).toBe(false);
       expect(isValidCustomSecretKey('KILOCLAW_ENC_FOO')).toBe(false);
+      expect(isValidCustomSecretKey('OPENCLAW_SOMETHING')).toBe(false);
+      expect(isValidCustomSecretKey('KILOCODE_API_KEY')).toBe(false);
+      expect(isValidCustomSecretKey('FLY_REGION')).toBe(false);
+      expect(isValidCustomSecretKey('NEXTAUTH_SECRET')).toBe(false);
+      expect(isValidCustomSecretKey('NODE_OPTIONS')).toBe(false);
+      expect(isValidCustomSecretKey('STREAM_CHAT_API_KEY')).toBe(false);
+    });
+
+    it('rejects denied exact env var names', () => {
+      expect(isValidCustomSecretKey('PATH')).toBe(false);
+      expect(isValidCustomSecretKey('HOME')).toBe(false);
+      expect(isValidCustomSecretKey('AUTO_APPROVE_DEVICES')).toBe(false);
+      expect(isValidCustomSecretKey('REQUIRE_PROXY_TOKEN')).toBe(false);
+      expect(isValidCustomSecretKey('TELEGRAM_DM_POLICY')).toBe(false);
+      expect(isValidCustomSecretKey('DISCORD_DM_POLICY')).toBe(false);
     });
 
     it('rejects invalid shell identifiers', () => {
@@ -557,6 +573,88 @@ describe('Secret Catalog', () => {
 
     it('MAX_CUSTOM_SECRET_VALUE_LENGTH covers JWTs and certificates', () => {
       expect(MAX_CUSTOM_SECRET_VALUE_LENGTH).toBe(8192);
+    });
+  });
+
+  describe('isValidConfigPath', () => {
+    it('accepts supported OpenClaw credential paths', () => {
+      expect(isValidConfigPath('models.providers.openai.apiKey')).toBe(true);
+      expect(isValidConfigPath('tools.web.search.apiKey')).toBe(true);
+      expect(isValidConfigPath('skills.entries.mySkill.apiKey')).toBe(true);
+      expect(isValidConfigPath('cron.webhookToken')).toBe(true);
+      expect(isValidConfigPath('talk.apiKey')).toBe(true);
+      expect(isValidConfigPath('talk.providers.custom.apiKey')).toBe(true);
+      expect(isValidConfigPath('messages.tts.providers.elevenlabs.apiKey')).toBe(true);
+      expect(isValidConfigPath('plugins.entries.brave.config.webSearch.apiKey')).toBe(true);
+      expect(isValidConfigPath('channels.irc.password')).toBe(true);
+      expect(isValidConfigPath('channels.mattermost.botToken')).toBe(true);
+      expect(isValidConfigPath('channels.matrix.password')).toBe(true);
+      expect(isValidConfigPath('channels.msteams.appPassword')).toBe(true);
+      expect(isValidConfigPath('channels.zalo.botToken')).toBe(true);
+    });
+
+    it('accepts wildcard pattern matches with concrete segments', () => {
+      // models.providers.*.apiKey
+      expect(isValidConfigPath('models.providers.anthropic.apiKey')).toBe(true);
+      expect(isValidConfigPath('models.providers.my_custom.apiKey')).toBe(true);
+      // models.providers.*.headers.*
+      expect(isValidConfigPath('models.providers.openai.headers.Authorization')).toBe(true);
+      // channels.*.accounts.*.token etc.
+      expect(isValidConfigPath('channels.discord.accounts.bot2.token')).toBe(true);
+      expect(isValidConfigPath('channels.slack.accounts.workspace1.botToken')).toBe(true);
+    });
+
+    it('rejects empty strings', () => {
+      expect(isValidConfigPath('')).toBe(false);
+    });
+
+    it('rejects paths with invalid characters', () => {
+      expect(isValidConfigPath('has spaces.foo')).toBe(false);
+      expect(isValidConfigPath('has-dashes.foo')).toBe(false);
+      expect(isValidConfigPath('foo..bar')).toBe(false);
+      expect(isValidConfigPath('.foo')).toBe(false);
+      expect(isValidConfigPath('foo.')).toBe(false);
+      expect(isValidConfigPath('123.foo')).toBe(false);
+    });
+
+    it('rejects paths not in the OpenClaw supported list', () => {
+      expect(isValidConfigPath('foo.bar')).toBe(false);
+      expect(isValidConfigPath('random.path.here')).toBe(false);
+      expect(isValidConfigPath('tools.exec.security')).toBe(false);
+      expect(isValidConfigPath('update.checkOnStart')).toBe(false);
+      expect(isValidConfigPath('browser.headless')).toBe(false);
+      expect(isValidConfigPath('tools.profile')).toBe(false);
+    });
+
+    it('rejects KiloClaw-managed paths', () => {
+      expect(isValidConfigPath('gateway.auth.token')).toBe(false);
+      expect(isValidConfigPath('gateway.auth.password')).toBe(false);
+      expect(isValidConfigPath('gateway.remote.token')).toBe(false);
+      expect(isValidConfigPath('gateway.remote.password')).toBe(false);
+    });
+
+    it('rejects catalog-managed secret paths', () => {
+      expect(isValidConfigPath('channels.telegram.botToken')).toBe(false);
+      expect(isValidConfigPath('channels.discord.token')).toBe(false);
+      expect(isValidConfigPath('channels.slack.botToken')).toBe(false);
+      expect(isValidConfigPath('channels.slack.appToken')).toBe(false);
+    });
+
+    it('rejects OpenClaw excluded credentials', () => {
+      expect(isValidConfigPath('commands.ownerDisplaySecret')).toBe(false);
+      expect(isValidConfigPath('channels.matrix.accessToken')).toBe(false);
+      expect(isValidConfigPath('hooks.token')).toBe(false);
+      expect(isValidConfigPath('hooks.gmail.pushToken')).toBe(false);
+    });
+
+    it('allows non-catalog channel account paths', () => {
+      expect(isValidConfigPath('channels.telegram.accounts.bot2.botToken')).toBe(true);
+      expect(isValidConfigPath('channels.irc.accounts.freenode.password')).toBe(true);
+    });
+
+    it('rejects paths exceeding max length', () => {
+      const tooLong = 'models.providers.' + 'a'.repeat(240) + '.apiKey';
+      expect(isValidConfigPath(tooLong)).toBe(false);
     });
   });
 });

--- a/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
+++ b/kiloclaw/packages/secret-catalog/src/__tests__/catalog.test.ts
@@ -604,6 +604,13 @@ describe('Secret Catalog', () => {
       expect(isValidConfigPath('channels.slack.accounts.workspace1.botToken')).toBe(true);
     });
 
+    it('accepts hyphenated segments for headers and channel names', () => {
+      expect(isValidConfigPath('models.providers.openai.headers.x-api-key')).toBe(true);
+      expect(isValidConfigPath('models.providers.openai.headers.anthropic-beta')).toBe(true);
+      expect(isValidConfigPath('channels.nextcloud-talk.botSecret')).toBe(true);
+      expect(isValidConfigPath('channels.nextcloud-talk.accounts.srv1.apiPassword')).toBe(true);
+    });
+
     it('rejects empty strings', () => {
       expect(isValidConfigPath('')).toBe(false);
     });

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -286,12 +286,51 @@ export const MAX_CUSTOM_SECRET_VALUE_LENGTH = 8192;
 const CUSTOM_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
+ * Env var name prefixes that are reserved for system use and cannot be
+ * set by users as custom secret env var names.
+ */
+const DENIED_ENV_VAR_PREFIXES: readonly string[] = [
+  'KILOCLAW_',
+  'OPENCLAW_',
+  'KILOCODE_',
+  'FLY_',
+  'NEXTAUTH_',
+  'NODE_',
+  'STREAM_CHAT_',
+];
+
+/**
+ * Exact env var names that are reserved for system use.
+ * Includes OS/shell vars, runtime vars, and vars we explicitly set
+ * in the env var build pipeline.
+ */
+const DENIED_ENV_VAR_NAMES: ReadonlySet<string> = new Set([
+  // OS / shell
+  'PATH',
+  'HOME',
+  'USER',
+  'SHELL',
+  'TERM',
+  'LANG',
+  'HOSTNAME',
+  'PWD',
+  'TMPDIR',
+  'TZ',
+  // KiloClaw managed (set by buildEnvVars or controller)
+  'AUTO_APPROVE_DEVICES',
+  'REQUIRE_PROXY_TOKEN',
+  'INVOCATION_ID',
+  'TELEGRAM_DM_POLICY',
+  'DISCORD_DM_POLICY',
+]);
+
+/**
  * Check whether a key is a valid custom (non-catalog) secret env var name.
  *
  * Custom keys must:
  * - Be a valid shell identifier
  * - Not collide with a catalog field key or catalog env var name
- * - Not use the reserved KILOCLAW_ prefix
+ * - Not be on the deny list (system-reserved prefixes or exact names)
  * - Be at most 128 characters
  */
 export function isValidCustomSecretKey(key: string): boolean {
@@ -299,7 +338,10 @@ export function isValidCustomSecretKey(key: string): boolean {
   if (ALL_SECRET_ENV_VARS.has(key)) return false;
   if (key.length === 0 || key.length > 128) return false;
   if (!CUSTOM_KEY_RE.test(key)) return false;
-  if (key.startsWith('KILOCLAW_')) return false;
+  if (DENIED_ENV_VAR_NAMES.has(key)) return false;
+  for (const prefix of DENIED_ENV_VAR_PREFIXES) {
+    if (key.startsWith(prefix)) return false;
+  }
   return true;
 }
 
@@ -310,4 +352,185 @@ export function isValidCustomSecretKey(key: string): boolean {
  */
 export function isCustomSecretEnvVar(envVarName: string): boolean {
   return !ALL_SECRET_ENV_VARS.has(envVarName) && !INTERNAL_SENSITIVE_ENV_VARS.has(envVarName);
+}
+
+// --- Config path helpers ---
+
+const CONFIG_PATH_RE = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+const MAX_CONFIG_PATH_LENGTH = 256;
+
+/**
+ * OpenClaw supported SecretRef path patterns (from openclaw/src/secrets/target-registry-data.ts).
+ * Wildcard `*` matches any single path segment (e.g. "models.providers.*.apiKey"
+ * matches "models.providers.openai.apiKey").
+ *
+ * Only openclaw.json paths are included — auth-profiles.json paths (profiles.*.key,
+ * profiles.*.token) target a different file and require separate handling.
+ */
+const ALLOWED_CONFIG_PATH_PATTERNS: readonly string[] = [
+  // Agents
+  'agents.defaults.memorySearch.remote.apiKey',
+  'agents.list[].memorySearch.remote.apiKey',
+  // Channels — BlueBubbles
+  'channels.bluebubbles.password',
+  'channels.bluebubbles.accounts.*.password',
+  // Channels — Discord
+  'channels.discord.token',
+  'channels.discord.pluralkit.token',
+  'channels.discord.voice.tts.providers.*.apiKey',
+  'channels.discord.accounts.*.token',
+  'channels.discord.accounts.*.pluralkit.token',
+  'channels.discord.accounts.*.voice.tts.providers.*.apiKey',
+  // Channels — Feishu
+  'channels.feishu.appSecret',
+  'channels.feishu.encryptKey',
+  'channels.feishu.verificationToken',
+  'channels.feishu.accounts.*.appSecret',
+  'channels.feishu.accounts.*.encryptKey',
+  'channels.feishu.accounts.*.verificationToken',
+  // Channels — Google Chat (sibling_ref shape — omitted, requires special handling)
+  // Channels — IRC
+  'channels.irc.password',
+  'channels.irc.nickserv.password',
+  'channels.irc.accounts.*.password',
+  'channels.irc.accounts.*.nickserv.password',
+  // Channels — Mattermost
+  'channels.mattermost.botToken',
+  'channels.mattermost.accounts.*.botToken',
+  // Channels — Matrix
+  'channels.matrix.password',
+  'channels.matrix.accounts.*.password',
+  // Channels — MS Teams
+  'channels.msteams.appPassword',
+  // Channels — Nextcloud Talk
+  'channels.nextcloud_talk.botSecret',
+  'channels.nextcloud_talk.apiPassword',
+  'channels.nextcloud_talk.accounts.*.botSecret',
+  'channels.nextcloud_talk.accounts.*.apiPassword',
+  // Channels — Slack
+  'channels.slack.botToken',
+  'channels.slack.appToken',
+  'channels.slack.userToken',
+  'channels.slack.signingSecret',
+  'channels.slack.accounts.*.botToken',
+  'channels.slack.accounts.*.appToken',
+  'channels.slack.accounts.*.userToken',
+  'channels.slack.accounts.*.signingSecret',
+  // Channels — Telegram
+  'channels.telegram.botToken',
+  'channels.telegram.webhookSecret',
+  'channels.telegram.accounts.*.botToken',
+  'channels.telegram.accounts.*.webhookSecret',
+  // Channels — Zalo
+  'channels.zalo.botToken',
+  'channels.zalo.webhookSecret',
+  'channels.zalo.accounts.*.botToken',
+  'channels.zalo.accounts.*.webhookSecret',
+  // Cron
+  'cron.webhookToken',
+  // Gateway
+  'gateway.auth.token',
+  'gateway.auth.password',
+  'gateway.remote.token',
+  'gateway.remote.password',
+  // Messages
+  'messages.tts.providers.*.apiKey',
+  // Models
+  'models.providers.*.apiKey',
+  'models.providers.*.headers.*',
+  // Skills
+  'skills.entries.*.apiKey',
+  // Talk
+  'talk.apiKey',
+  'talk.providers.*.apiKey',
+  // Tools — Web
+  'tools.web.fetch.firecrawl.apiKey',
+  'tools.web.search.apiKey',
+  'tools.web.search.gemini.apiKey',
+  'tools.web.search.grok.apiKey',
+  'tools.web.search.kimi.apiKey',
+  'tools.web.search.perplexity.apiKey',
+  // Plugins
+  'plugins.entries.brave.config.webSearch.apiKey',
+  'plugins.entries.google.config.webSearch.apiKey',
+  'plugins.entries.xai.config.webSearch.apiKey',
+  'plugins.entries.moonshot.config.webSearch.apiKey',
+  'plugins.entries.perplexity.config.webSearch.apiKey',
+  'plugins.entries.firecrawl.config.webSearch.apiKey',
+  'plugins.entries.tavily.config.webSearch.apiKey',
+];
+
+/**
+ * Config paths denied even though they're in OpenClaw's registry.
+ * Includes paths managed by KiloClaw and OpenClaw's excluded credentials.
+ */
+const DENIED_CONFIG_PATHS: ReadonlySet<string> = new Set([
+  // KiloClaw-managed: gateway auth (overwritten by generateBaseConfig on every boot)
+  'gateway.auth.token',
+  'gateway.auth.password',
+  'gateway.remote.token',
+  'gateway.remote.password',
+  // KiloClaw-managed: catalog secrets (use the dedicated Settings UI sections)
+  'channels.telegram.botToken',
+  'channels.discord.token',
+  'channels.slack.botToken',
+  'channels.slack.appToken',
+  // OpenClaw excluded: mutable or runtime-managed credentials
+  'commands.ownerDisplaySecret',
+  'channels.matrix.accessToken',
+  'hooks.token',
+  'hooks.gmail.pushToken',
+]);
+
+/**
+ * Denied config path patterns (with wildcards) from OpenClaw's excluded list.
+ */
+const DENIED_CONFIG_PATH_PATTERNS: readonly string[] = [
+  'channels.matrix.accounts.*.accessToken',
+  'hooks.mappings[].sessionKey',
+  'discord.threadBindings.*.webhookToken',
+];
+
+/**
+ * Check whether a concrete config path matches a pattern with `*` wildcards.
+ * Each `*` matches exactly one path segment.
+ * `[]` in patterns matches any segment (for array notation).
+ */
+function matchesPattern(path: string, pattern: string): boolean {
+  const pathParts = path.split('.');
+  const patternParts = pattern.split('.');
+  if (pathParts.length !== patternParts.length) return false;
+  return patternParts.every((part, i) => part === '*' || part === '[]' || part === pathParts[i]);
+}
+
+/**
+ * Check whether a config path is valid for custom secrets.
+ *
+ * Must match one of OpenClaw's supported SecretRef path patterns and
+ * must not be on the deny list (KiloClaw-managed or OpenClaw-excluded).
+ */
+export function isValidConfigPath(path: string): boolean {
+  if (path.length === 0 || path.length > MAX_CONFIG_PATH_LENGTH) return false;
+  if (!CONFIG_PATH_RE.test(path)) return false;
+
+  // Check deny list (exact matches)
+  if (DENIED_CONFIG_PATHS.has(path)) return false;
+
+  // Check deny list (pattern matches)
+  for (const pattern of DENIED_CONFIG_PATH_PATTERNS) {
+    if (matchesPattern(path, pattern)) return false;
+  }
+
+  // Must match at least one allowed pattern
+  return ALLOWED_CONFIG_PATH_PATTERNS.some(pattern => matchesPattern(path, pattern));
+}
+
+/**
+ * Return all allowed config path patterns for UI display (e.g. autocomplete).
+ * Excludes denied paths.
+ */
+export function getAllowedConfigPathPatterns(): readonly string[] {
+  return ALLOWED_CONFIG_PATH_PATTERNS.filter(
+    p => !DENIED_CONFIG_PATHS.has(p) && !DENIED_CONFIG_PATH_PATTERNS.some(dp => p === dp)
+  );
 }

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -374,8 +374,7 @@ const ALLOWED_CONFIG_PATH_PATTERNS: readonly string[] = [
   // Channels — BlueBubbles
   'channels.bluebubbles.password',
   'channels.bluebubbles.accounts.*.password',
-  // Channels — Discord
-  'channels.discord.token',
+  // Channels — Discord (channels.discord.token omitted: catalog-managed)
   'channels.discord.pluralkit.token',
   'channels.discord.voice.tts.providers.*.apiKey',
   'channels.discord.accounts.*.token',
@@ -407,17 +406,14 @@ const ALLOWED_CONFIG_PATH_PATTERNS: readonly string[] = [
   'channels.nextcloud_talk.apiPassword',
   'channels.nextcloud_talk.accounts.*.botSecret',
   'channels.nextcloud_talk.accounts.*.apiPassword',
-  // Channels — Slack
-  'channels.slack.botToken',
-  'channels.slack.appToken',
+  // Channels — Slack (botToken/appToken omitted: catalog-managed)
   'channels.slack.userToken',
   'channels.slack.signingSecret',
   'channels.slack.accounts.*.botToken',
   'channels.slack.accounts.*.appToken',
   'channels.slack.accounts.*.userToken',
   'channels.slack.accounts.*.signingSecret',
-  // Channels — Telegram
-  'channels.telegram.botToken',
+  // Channels — Telegram (channels.telegram.botToken omitted: catalog-managed)
   'channels.telegram.webhookSecret',
   'channels.telegram.accounts.*.botToken',
   'channels.telegram.accounts.*.webhookSecret',
@@ -428,11 +424,7 @@ const ALLOWED_CONFIG_PATH_PATTERNS: readonly string[] = [
   'channels.zalo.accounts.*.webhookSecret',
   // Cron
   'cron.webhookToken',
-  // Gateway
-  'gateway.auth.token',
-  'gateway.auth.password',
-  'gateway.remote.token',
-  'gateway.remote.password',
+  // Gateway — omitted: KiloClaw-managed (overwritten by generateBaseConfig on every boot)
   // Messages
   'messages.tts.providers.*.apiKey',
   // Models
@@ -527,10 +519,7 @@ export function isValidConfigPath(path: string): boolean {
 
 /**
  * Return all allowed config path patterns for UI display (e.g. autocomplete).
- * Excludes denied paths.
  */
 export function getAllowedConfigPathPatterns(): readonly string[] {
-  return ALLOWED_CONFIG_PATH_PATTERNS.filter(
-    p => !DENIED_CONFIG_PATHS.has(p) && !DENIED_CONFIG_PATH_PATTERNS.some(dp => p === dp)
-  );
+  return ALLOWED_CONFIG_PATH_PATTERNS;
 }

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -370,7 +370,8 @@ const MAX_CONFIG_PATH_LENGTH = 256;
 const ALLOWED_CONFIG_PATH_PATTERNS: readonly string[] = [
   // Agents
   'agents.defaults.memorySearch.remote.apiKey',
-  'agents.list[].memorySearch.remote.apiKey',
+  // agents.list[].memorySearch.remote.apiKey omitted: array-indexed paths
+  // can't be expressed in dot notation and CONFIG_PATH_RE rejects brackets.
   // Channels — BlueBubbles
   'channels.bluebubbles.password',
   'channels.bluebubbles.accounts.*.password',
@@ -492,7 +493,7 @@ function matchesPattern(path: string, pattern: string): boolean {
   const pathParts = path.split('.');
   const patternParts = pattern.split('.');
   if (pathParts.length !== patternParts.length) return false;
-  return patternParts.every((part, i) => part === '*' || part === '[]' || part === pathParts[i]);
+  return patternParts.every((part, i) => part === '*' || part === pathParts[i]);
 }
 
 /**

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -274,3 +274,40 @@ export function getFieldKeysByCategory(category: SecretCategory): ReadonlySet<st
     SECRET_CATALOG.filter(e => e.category === category).flatMap(e => e.fields.map(f => f.key))
   );
 }
+
+// --- Custom (non-catalog) secret helpers ---
+
+/** Maximum number of custom secrets a single instance can store. */
+export const MAX_CUSTOM_SECRETS = 50;
+
+/** Maximum value length for custom secrets (covers JWTs, certificates). */
+export const MAX_CUSTOM_SECRET_VALUE_LENGTH = 8192;
+
+const CUSTOM_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Check whether a key is a valid custom (non-catalog) secret env var name.
+ *
+ * Custom keys must:
+ * - Be a valid shell identifier
+ * - Not collide with a catalog field key or catalog env var name
+ * - Not use the reserved KILOCLAW_ prefix
+ * - Be at most 128 characters
+ */
+export function isValidCustomSecretKey(key: string): boolean {
+  if (ALL_SECRET_FIELD_KEYS.has(key)) return false;
+  if (ALL_SECRET_ENV_VARS.has(key)) return false;
+  if (key.length === 0 || key.length > 128) return false;
+  if (!CUSTOM_KEY_RE.test(key)) return false;
+  if (key.startsWith('KILOCLAW_')) return false;
+  return true;
+}
+
+/**
+ * Check whether an env var name stored in encryptedSecrets is a custom
+ * (non-catalog, non-internal) secret. Used to filter the custom secret
+ * list out of the full encryptedSecrets record.
+ */
+export function isCustomSecretEnvVar(envVarName: string): boolean {
+  return !ALL_SECRET_ENV_VARS.has(envVarName) && !INTERNAL_SENSITIVE_ENV_VARS.has(envVarName);
+}

--- a/kiloclaw/packages/secret-catalog/src/catalog.ts
+++ b/kiloclaw/packages/secret-catalog/src/catalog.ts
@@ -356,7 +356,8 @@ export function isCustomSecretEnvVar(envVarName: string): boolean {
 
 // --- Config path helpers ---
 
-const CONFIG_PATH_RE = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+// Allows hyphens in segments for header keys (x-api-key) and channel names (nextcloud-talk).
+const CONFIG_PATH_RE = /^[a-zA-Z_][a-zA-Z0-9_-]*(\.[a-zA-Z_][a-zA-Z0-9_-]*)*$/;
 const MAX_CONFIG_PATH_LENGTH = 256;
 
 /**
@@ -403,10 +404,10 @@ const ALLOWED_CONFIG_PATH_PATTERNS: readonly string[] = [
   // Channels — MS Teams
   'channels.msteams.appPassword',
   // Channels — Nextcloud Talk
-  'channels.nextcloud_talk.botSecret',
-  'channels.nextcloud_talk.apiPassword',
-  'channels.nextcloud_talk.accounts.*.botSecret',
-  'channels.nextcloud_talk.accounts.*.apiPassword',
+  'channels.nextcloud-talk.botSecret',
+  'channels.nextcloud-talk.apiPassword',
+  'channels.nextcloud-talk.accounts.*.botSecret',
+  'channels.nextcloud-talk.accounts.*.apiPassword',
   // Channels — Slack (botToken/appToken omitted: catalog-managed)
   'channels.slack.userToken',
   'channels.slack.signingSecret',

--- a/kiloclaw/packages/secret-catalog/src/index.ts
+++ b/kiloclaw/packages/secret-catalog/src/index.ts
@@ -31,6 +31,11 @@ export {
   INTERNAL_SENSITIVE_ENV_VARS,
   getEntriesByCategory,
   getFieldKeysByCategory,
+  // Custom secret helpers
+  MAX_CUSTOM_SECRETS,
+  MAX_CUSTOM_SECRET_VALUE_LENGTH,
+  isValidCustomSecretKey,
+  isCustomSecretEnvVar,
 } from './catalog';
 
 export type { SecretFieldKey } from './catalog';

--- a/kiloclaw/packages/secret-catalog/src/index.ts
+++ b/kiloclaw/packages/secret-catalog/src/index.ts
@@ -36,6 +36,8 @@ export {
   MAX_CUSTOM_SECRET_VALUE_LENGTH,
   isValidCustomSecretKey,
   isCustomSecretEnvVar,
+  isValidConfigPath,
+  getAllowedConfigPathPatterns,
 } from './catalog';
 
 export type { SecretFieldKey } from './catalog';

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2237,44 +2237,6 @@ describe('updateSecrets', () => {
 });
 
 // ============================================================================
-// listCustomSecretKeys
-// ============================================================================
-
-describe('listCustomSecretKeys', () => {
-  const fakeEnvelope = {
-    encryptedData: 'data',
-    encryptedDEK: 'dek',
-    algorithm: 'rsa-aes-256-gcm' as const,
-    version: 1 as const,
-  };
-
-  it('returns empty array when no secrets exist', async () => {
-    const { instance, storage } = createInstance();
-    await seedProvisioned(storage);
-
-    const keys = await instance.listCustomSecretKeys();
-    expect(keys).toEqual([]);
-  });
-
-  it('returns only custom (non-catalog) secret keys', async () => {
-    const { instance, storage } = createInstance();
-    await seedProvisioned(storage, {
-      encryptedSecrets: {
-        TELEGRAM_BOT_TOKEN: fakeEnvelope, // catalog
-        MY_CUSTOM_KEY: fakeEnvelope, // custom
-        ANOTHER_KEY: fakeEnvelope, // custom
-      },
-    });
-
-    const keys = await instance.listCustomSecretKeys();
-    expect(keys).toContain('MY_CUSTOM_KEY');
-    expect(keys).toContain('ANOTHER_KEY');
-    expect(keys).not.toContain('TELEGRAM_BOT_TOKEN');
-    expect(keys).toHaveLength(2);
-  });
-});
-
-// ============================================================================
 // updateGoogleCredentials
 // ============================================================================
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2104,6 +2104,174 @@ describe('updateSecrets', () => {
       'Invalid secret patch: Slack requires all fields to be set together'
     );
   });
+
+  // ─── Custom (non-catalog) secrets ─────────────────────────────────
+
+  it('stores custom secrets by env var name in encryptedSecrets', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+
+    await instance.updateSecrets({ MY_CUSTOM_KEY: customEnvelope });
+
+    const secrets = storage._store.get('encryptedSecrets') as Record<string, unknown>;
+    expect(secrets.MY_CUSTOM_KEY).toEqual(customEnvelope);
+  });
+
+  it('removes custom secrets when null is passed', async () => {
+    const { instance, storage } = createInstance();
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+    await seedProvisioned(storage, {
+      encryptedSecrets: { MY_CUSTOM_KEY: customEnvelope },
+    });
+
+    await instance.updateSecrets({ MY_CUSTOM_KEY: null });
+
+    const secrets = storage._store.get('encryptedSecrets');
+    expect(secrets).toBeNull();
+  });
+
+  it('preserves catalog secrets when adding custom secrets', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      channels: { telegramBotToken: fakeEnvelope },
+      encryptedSecrets: { TELEGRAM_BOT_TOKEN: fakeEnvelope },
+    });
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+
+    await instance.updateSecrets({ MY_CUSTOM_KEY: customEnvelope });
+
+    const secrets = storage._store.get('encryptedSecrets') as Record<string, unknown>;
+    expect(secrets.TELEGRAM_BOT_TOKEN).toEqual(fakeEnvelope);
+    expect(secrets.MY_CUSTOM_KEY).toEqual(customEnvelope);
+  });
+
+  it('preserves custom secrets when updating catalog secrets', async () => {
+    const { instance, storage } = createInstance();
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+    await seedProvisioned(storage, {
+      encryptedSecrets: { MY_CUSTOM_KEY: customEnvelope },
+    });
+
+    await instance.updateSecrets({ telegramBotToken: fakeEnvelope });
+
+    const secrets = storage._store.get('encryptedSecrets') as Record<string, unknown>;
+    expect(secrets.MY_CUSTOM_KEY).toEqual(customEnvelope);
+    expect(secrets.TELEGRAM_BOT_TOKEN).toEqual(fakeEnvelope);
+  });
+
+  it('enforces custom secret count limit', async () => {
+    const { instance, storage } = createInstance();
+    // Seed 50 custom secrets (the max)
+    const existingSecrets: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) {
+      existingSecrets[`SECRET_${i}`] = { ...fakeEnvelope, encryptedData: `val-${i}` };
+    }
+    await seedProvisioned(storage, { encryptedSecrets: existingSecrets });
+
+    // Adding one more should fail
+    await expect(
+      instance.updateSecrets({ SECRET_OVERFLOW: { ...fakeEnvelope, encryptedData: 'overflow' } })
+    ).rejects.toThrow('Custom secret limit exceeded');
+  });
+
+  it('stores config path metadata alongside secrets', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+
+    await instance.updateSecrets(
+      { MY_KEY: customEnvelope },
+      { MY_KEY: { configPath: 'models.providers.openai.apiKey' } }
+    );
+
+    const meta = storage._store.get('customSecretMeta') as Record<string, unknown>;
+    expect(meta).toEqual({ MY_KEY: { configPath: 'models.providers.openai.apiKey' } });
+  });
+
+  it('removes config path metadata when secret is deleted', async () => {
+    const { instance, storage } = createInstance();
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+    await seedProvisioned(storage, {
+      encryptedSecrets: { MY_KEY: customEnvelope },
+      customSecretMeta: { MY_KEY: { configPath: 'talk.apiKey' } },
+    });
+
+    await instance.updateSecrets({ MY_KEY: null });
+
+    const meta = storage._store.get('customSecretMeta');
+    expect(meta).toBeNull();
+  });
+
+  it('updates config path metadata without changing value', async () => {
+    const { instance, storage } = createInstance();
+    const customEnvelope = { ...fakeEnvelope, encryptedData: 'custom-value' };
+    await seedProvisioned(storage, {
+      encryptedSecrets: { MY_KEY: customEnvelope },
+      customSecretMeta: { MY_KEY: { configPath: 'talk.apiKey' } },
+    });
+
+    // Empty secrets patch, only meta update
+    await instance.updateSecrets({}, { MY_KEY: { configPath: 'cron.webhookToken' } });
+
+    const meta = storage._store.get('customSecretMeta') as Record<string, unknown>;
+    expect(meta).toEqual({ MY_KEY: { configPath: 'cron.webhookToken' } });
+    // Secret value unchanged
+    const secrets = storage._store.get('encryptedSecrets') as Record<string, unknown>;
+    expect(secrets.MY_KEY).toEqual(customEnvelope);
+  });
+
+  it('rejects duplicate config paths', async () => {
+    const { instance, storage } = createInstance();
+    const envelope1 = { ...fakeEnvelope, encryptedData: 'val-1' };
+    const envelope2 = { ...fakeEnvelope, encryptedData: 'val-2' };
+    await seedProvisioned(storage, {
+      encryptedSecrets: { KEY_A: envelope1 },
+      customSecretMeta: { KEY_A: { configPath: 'talk.apiKey' } },
+    });
+
+    await expect(
+      instance.updateSecrets({ KEY_B: envelope2 }, { KEY_B: { configPath: 'talk.apiKey' } })
+    ).rejects.toThrow('Config path "talk.apiKey" is already used by secret "KEY_A"');
+  });
+});
+
+// ============================================================================
+// listCustomSecretKeys
+// ============================================================================
+
+describe('listCustomSecretKeys', () => {
+  const fakeEnvelope = {
+    encryptedData: 'data',
+    encryptedDEK: 'dek',
+    algorithm: 'rsa-aes-256-gcm' as const,
+    version: 1 as const,
+  };
+
+  it('returns empty array when no secrets exist', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+
+    const keys = await instance.listCustomSecretKeys();
+    expect(keys).toEqual([]);
+  });
+
+  it('returns only custom (non-catalog) secret keys', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      encryptedSecrets: {
+        TELEGRAM_BOT_TOKEN: fakeEnvelope, // catalog
+        MY_CUSTOM_KEY: fakeEnvelope, // custom
+        ANOTHER_KEY: fakeEnvelope, // custom
+      },
+    });
+
+    const keys = await instance.listCustomSecretKeys();
+    expect(keys).toContain('MY_CUSTOM_KEY');
+    expect(keys).toContain('ANOTHER_KEY');
+    expect(keys).not.toContain('TELEGRAM_BOT_TOKEN');
+    expect(keys).toHaveLength(2);
+  });
 });
 
 // ============================================================================

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -146,6 +146,7 @@ export async function buildUserEnvVars(
       instanceFeatures: state.instanceFeatures,
       execSecurity: state.execSecurity ?? undefined,
       execAsk: state.execAsk ?? undefined,
+      customSecretMeta: state.customSecretMeta ?? undefined,
     }
   );
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -35,6 +35,8 @@ import {
   FIELD_KEY_TO_ENV_VAR,
   ENV_VAR_TO_FIELD_KEY,
   ALL_SECRET_FIELD_KEYS,
+  MAX_CUSTOM_SECRETS,
+  isCustomSecretEnvVar,
   type SecretFieldKey,
 } from '@kilocode/kiloclaw-secret-catalog';
 import { parseRegions, prepareRegions, resolveRegions } from '../regions';
@@ -501,35 +503,49 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   }
 
   async updateSecrets(
-    patch: Partial<Record<SecretFieldKey, EncryptedEnvelope | null>>
+    patch: Record<string, EncryptedEnvelope | null>
   ): Promise<{ configured: SecretFieldKey[] }> {
     await this.loadState();
 
+    // Separate catalog secrets (keyed by field key) from custom secrets
+    // (keyed directly by env var name).
     const currentSecrets: Record<string, EncryptedEnvelope | null> = {
       ...(this.s.channels ?? {}),
     };
-    const nonCatalogSecrets: Record<string, EncryptedEnvelope> = {};
+    const customSecrets: Record<string, EncryptedEnvelope> = {};
     if (this.s.encryptedSecrets) {
       for (const [key, value] of Object.entries(this.s.encryptedSecrets)) {
         const fieldKey = ENV_VAR_TO_FIELD_KEY.get(key);
         if (fieldKey) {
           currentSecrets[fieldKey] = value;
         } else {
-          nonCatalogSecrets[key] = value;
+          customSecrets[key] = value;
         }
       }
     }
 
+    // Apply the patch — catalog field keys go to currentSecrets, custom
+    // env var names go directly to customSecrets.
     for (const [key, value] of Object.entries(patch)) {
+      const isCatalogKey = ALL_SECRET_FIELD_KEYS.has(key);
       if (value === null) {
-        console.log('[DO] Secret removed', { fieldKey: key, operation: 'remove' });
-        delete currentSecrets[key];
+        console.log('[DO] Secret removed', { key, operation: 'remove' });
+        if (isCatalogKey) {
+          delete currentSecrets[key];
+        } else {
+          delete customSecrets[key];
+        }
       } else {
-        console.log('[DO] Secret updated', { fieldKey: key, operation: 'set' });
-        currentSecrets[key] = value;
+        console.log('[DO] Secret updated', { key, operation: 'set' });
+        if (isCatalogKey) {
+          currentSecrets[key] = value;
+        } else {
+          customSecrets[key] = value;
+        }
       }
     }
 
+    // Enforce allFieldsRequired for catalog entries (e.g., Slack needs both tokens)
     for (const entry of SECRET_CATALOG) {
       if (!entry.allFieldsRequired) continue;
       const fieldValues = entry.fields.map(f => currentSecrets[f.key]);
@@ -544,6 +560,17 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
     }
 
+    // Enforce custom secret count limit
+    const customCount = Object.keys(customSecrets).length;
+    if (customCount > MAX_CUSTOM_SECRETS) {
+      const err = new Error(
+        `Custom secret limit exceeded: ${customCount} secrets (max ${MAX_CUSTOM_SECRETS})`
+      );
+      (err as Error & { status: number }).status = 400;
+      throw err;
+    }
+
+    // Backward compat: write channel secrets to legacy channels field
     const channelKeys = new Set(
       SECRET_CATALOG.filter(e => e.category === 'channel').flatMap(e => e.fields.map(f => f.key))
     );
@@ -557,6 +584,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const hasChannels = Object.keys(channelsSubset).length > 0;
     this.s.channels = hasChannels ? (channelsSubset as PersistedState['channels']) : null;
 
+    // Build cleaned catalog secrets (non-null only)
     const cleanedSecrets: Record<string, EncryptedEnvelope> = {};
     for (const [key, value] of Object.entries(currentSecrets)) {
       if (value) {
@@ -568,7 +596,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       ALL_SECRET_FIELD_KEYS.has(k)
     );
 
-    const remappedSecrets: Record<string, EncryptedEnvelope> = { ...nonCatalogSecrets };
+    // Merge catalog secrets (remapped to env var names) with custom secrets
+    const remappedSecrets: Record<string, EncryptedEnvelope> = { ...customSecrets };
     for (const [key, value] of Object.entries(cleanedSecrets)) {
       const envName = FIELD_KEY_TO_ENV_VAR.get(key) ?? key;
       remappedSecrets[envName] = value;
@@ -582,6 +611,16 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
 
     return { configured };
+  }
+
+  /**
+   * Return the list of custom (non-catalog) secret env var names.
+   * Values are never exposed — this is for UI display only.
+   */
+  async listCustomSecretKeys(): Promise<string[]> {
+    await this.loadState();
+    if (!this.s.encryptedSecrets) return [];
+    return Object.keys(this.s.encryptedSecrets).filter(isCustomSecretEnvVar);
   }
 
   /**

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -16,6 +16,7 @@ import type {
   EncryptedEnvelope,
   GoogleCredentials,
   MachineSize,
+  CustomSecretMeta,
 } from '../../schemas/instance-config';
 import { DEFAULT_INSTANCE_FEATURES } from '../../schemas/instance-config';
 import type { FlyVolume, FlyVolumeSnapshot } from '../../fly/types';
@@ -503,7 +504,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   }
 
   async updateSecrets(
-    patch: Record<string, EncryptedEnvelope | null>
+    patch: Record<string, EncryptedEnvelope | null>,
+    meta?: Record<string, CustomSecretMeta>
   ): Promise<{ configured: SecretFieldKey[] }> {
     await this.loadState();
 
@@ -605,9 +607,41 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const hasSecrets = Object.keys(remappedSecrets).length > 0;
     this.s.encryptedSecrets = hasSecrets ? remappedSecrets : null;
 
+    // Update custom secret metadata (config paths, etc.)
+    // Always clean up metadata for deleted secrets, even without a meta param.
+    const currentMeta = { ...(this.s.customSecretMeta ?? {}) };
+    for (const [key, value] of Object.entries(patch)) {
+      if (ALL_SECRET_FIELD_KEYS.has(key)) continue;
+      if (value === null) {
+        delete currentMeta[key];
+      }
+    }
+    // Set/update metadata for any keys provided in meta
+    if (meta) {
+      for (const [key, metaValue] of Object.entries(meta)) {
+        if (ALL_SECRET_FIELD_KEYS.has(key)) continue;
+        // Reject duplicate config paths — no two secrets may target the same path
+        if (metaValue.configPath) {
+          for (const [existingKey, existingMeta] of Object.entries(currentMeta)) {
+            if (existingKey !== key && existingMeta.configPath === metaValue.configPath) {
+              const err = new Error(
+                `Config path "${metaValue.configPath}" is already used by secret "${existingKey}"`
+              );
+              (err as Error & { status: number }).status = 400;
+              throw err;
+            }
+          }
+        }
+        currentMeta[key] = metaValue;
+      }
+    }
+    const hasMeta = Object.keys(currentMeta).length > 0;
+    this.s.customSecretMeta = hasMeta ? currentMeta : null;
+
     await this.ctx.storage.put({
       channels: this.s.channels,
       encryptedSecrets: this.s.encryptedSecrets,
+      customSecretMeta: this.s.customSecretMeta,
     });
 
     return { configured };
@@ -1341,7 +1375,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     };
   }
 
-  async getConfig(): Promise<InstanceConfig> {
+  async getConfig(): Promise<
+    InstanceConfig & { customSecretMeta?: Record<string, CustomSecretMeta> | null }
+  > {
     await this.loadState();
     return {
       envVars: this.s.envVars ?? undefined,
@@ -1351,6 +1387,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       kilocodeDefaultModel: this.s.kilocodeDefaultModel ?? undefined,
       channels: this.s.channels ?? undefined,
       machineSize: this.s.machineSize ?? undefined,
+      customSecretMeta: this.s.customSecretMeta ?? undefined,
     };
   }
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -37,7 +37,6 @@ import {
   ENV_VAR_TO_FIELD_KEY,
   ALL_SECRET_FIELD_KEYS,
   MAX_CUSTOM_SECRETS,
-  isCustomSecretEnvVar,
   type SecretFieldKey,
 } from '@kilocode/kiloclaw-secret-catalog';
 import { parseRegions, prepareRegions, resolveRegions } from '../regions';
@@ -645,16 +644,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
 
     return { configured };
-  }
-
-  /**
-   * Return the list of custom (non-catalog) secret env var names.
-   * Values are never exposed — this is for UI display only.
-   */
-  async listCustomSecretKeys(): Promise<string[]> {
-    await this.loadState();
-    if (!this.s.encryptedSecrets) return [];
-    return Object.keys(this.s.encryptedSecrets).filter(isCustomSecretEnvVar);
   }
 
   /**
@@ -1375,9 +1364,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     };
   }
 
-  async getConfig(): Promise<
-    InstanceConfig & { customSecretMeta?: Record<string, CustomSecretMeta> | null }
-  > {
+  async getConfig(): Promise<InstanceConfig> {
     await this.loadState();
     return {
       envVars: this.s.envVars ?? undefined,

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -79,6 +79,7 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     // Legacy instances pre-dating this field treat absence as already-sent
     // to avoid spurious emails after deploy.
     s.instanceReadyEmailSent = 'instanceReadyEmailSent' in raw ? d.instanceReadyEmailSent : true;
+    s.customSecretMeta = d.customSecretMeta;
   } else {
     const hasAnyData = entries.size > 0;
     if (hasAnyData) {
@@ -207,6 +208,7 @@ export function createMutableState(): InstanceMutableState {
     preRestoreStatus: null,
     pendingRestoreVolumeId: null,
     instanceReadyEmailSent: false,
+    customSecretMeta: null,
     lastLiveCheckAt: null,
   };
 }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -90,6 +90,7 @@ export type InstanceMutableState = {
   preRestoreStatus: InstanceStatus | null;
   pendingRestoreVolumeId: string | null;
   instanceReadyEmailSent: boolean;
+  customSecretMeta: PersistedState['customSecretMeta'];
   /** In-memory only — throttles live Fly checks in getStatus(). */
   lastLiveCheckAt: number | null;
 };

--- a/kiloclaw/src/gateway/env.test.ts
+++ b/kiloclaw/src/gateway/env.test.ts
@@ -484,4 +484,51 @@ describe('buildEnvVars', () => {
     expect(result.env.KILOCLAW_EXEC_SECURITY).toBeUndefined();
     expect(result.env.KILOCLAW_EXEC_ASK).toBeUndefined();
   });
+
+  // ─── Custom secrets (non-catalog) ──────────────────────────────────
+
+  it('routes custom encrypted secrets to the sensitive bucket', async () => {
+    const env = createMockEnv({ AGENT_ENV_VARS_PRIVATE_KEY: testPrivateKey });
+    const customEnvelope = encryptForTest('my-secret-value', testPublicKey);
+
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      encryptedSecrets: { MY_CUSTOM_KEY: customEnvelope },
+    });
+
+    expect(result.sensitive.MY_CUSTOM_KEY).toBe('my-secret-value');
+    expect(result.env.MY_CUSTOM_KEY).toBeUndefined();
+  });
+
+  it('serializes customSecretMeta config paths as KILOCLAW_SECRET_CONFIG_PATHS', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      customSecretMeta: {
+        MY_KEY: { configPath: 'models.providers.openai.apiKey' },
+        OTHER_KEY: { configPath: 'talk.apiKey' },
+      },
+    });
+
+    expect(JSON.parse(result.env.KILOCLAW_SECRET_CONFIG_PATHS) as unknown).toEqual({
+      MY_KEY: 'models.providers.openai.apiKey',
+      OTHER_KEY: 'talk.apiKey',
+    });
+  });
+
+  it('omits KILOCLAW_SECRET_CONFIG_PATHS when no config paths exist', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      customSecretMeta: { MY_KEY: {} },
+    });
+
+    expect(result.env.KILOCLAW_SECRET_CONFIG_PATHS).toBeUndefined();
+  });
+
+  it('omits KILOCLAW_SECRET_CONFIG_PATHS when customSecretMeta is null', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      customSecretMeta: null,
+    });
+
+    expect(result.env.KILOCLAW_SECRET_CONFIG_PATHS).toBeUndefined();
+  });
 });

--- a/kiloclaw/src/gateway/env.ts
+++ b/kiloclaw/src/gateway/env.ts
@@ -30,6 +30,7 @@ export type UserConfig = {
   instanceFeatures?: string[];
   execSecurity?: string | null;
   execAsk?: string | null;
+  customSecretMeta?: Record<string, { configPath?: string }> | null;
 };
 
 /**
@@ -208,6 +209,18 @@ export async function buildEnvVars(
     for (const feature of userConfig.instanceFeatures) {
       const envVar = FEATURE_TO_ENV_VAR[feature];
       if (envVar) plainEnv[envVar] = 'true';
+    }
+  }
+
+  // Custom secret config path mapping — tells the controller which env vars
+  // to patch into openclaw.json at specific JSON paths.
+  if (userConfig?.customSecretMeta) {
+    const pathMap: Record<string, string> = {};
+    for (const [envVar, meta] of Object.entries(userConfig.customSecretMeta)) {
+      if (meta.configPath) pathMap[envVar] = meta.configPath;
+    }
+    if (Object.keys(pathMap).length > 0) {
+      plainEnv.KILOCLAW_SECRET_CONFIG_PATHS = JSON.stringify(pathMap);
     }
   }
 

--- a/kiloclaw/src/routes/kiloclaw.ts
+++ b/kiloclaw/src/routes/kiloclaw.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
-import { SECRET_CATALOG, getFieldKeysByCategory } from '@kilocode/kiloclaw-secret-catalog';
+import {
+  SECRET_CATALOG,
+  getFieldKeysByCategory,
+  isCustomSecretEnvVar,
+} from '@kilocode/kiloclaw-secret-catalog';
 import { instrumented } from '../middleware/analytics';
 
 /** Channel env var names — excluded from secretCount (channels have their own counts). */
@@ -37,6 +41,9 @@ kiloclaw.get('/config', c =>
       hasKiloCodeApiKey: !!config.kilocodeApiKey,
       kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
       configuredSecrets: buildConfiguredSecrets(config),
+      customSecretKeys: config.encryptedSecrets
+        ? Object.keys(config.encryptedSecrets).filter(isCustomSecretEnvVar)
+        : [],
     });
   })
 );

--- a/kiloclaw/src/routes/kiloclaw.ts
+++ b/kiloclaw/src/routes/kiloclaw.ts
@@ -44,6 +44,7 @@ kiloclaw.get('/config', c =>
       customSecretKeys: config.encryptedSecrets
         ? Object.keys(config.encryptedSecrets).filter(isCustomSecretEnvVar)
         : [],
+      customSecretMeta: config.customSecretMeta ?? {},
     });
   })
 );

--- a/kiloclaw/src/routes/platform.ts
+++ b/kiloclaw/src/routes/platform.ts
@@ -497,12 +497,12 @@ platform.patch('/secrets', async c => {
   const result = await parseBody(c, SecretsPatchSchema);
   if ('error' in result) return result.error;
 
-  const { userId, secrets } = result.data;
+  const { userId, secrets, meta } = result.data;
 
   try {
     const updated = await withDORetry(
       instanceStubFactory(c.env, userId),
-      stub => stub.updateSecrets(secrets),
+      stub => stub.updateSecrets(secrets, meta),
       'updateSecrets'
     );
     return c.json(updated, 200);

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ALL_SECRET_FIELD_KEYS } from '@kilocode/kiloclaw-secret-catalog';
+import { ALL_SECRET_FIELD_KEYS, isValidCustomSecretKey } from '@kilocode/kiloclaw-secret-catalog';
 import { IMAGE_TAG_RE, IMAGE_TAG_MAX_LENGTH } from '../lib/image-tag-validation';
 
 export const EncryptedEnvelopeSchema = z.object({
@@ -85,7 +85,9 @@ export const ChannelsPatchSchema = z.object({
 export const SecretsPatchSchema = z.object({
   userId: z.string().min(1),
   secrets: z.record(
-    z.string().refine(k => ALL_SECRET_FIELD_KEYS.has(k), { message: 'Unknown secret field key' }),
+    z.string().refine(k => ALL_SECRET_FIELD_KEYS.has(k) || isValidCustomSecretKey(k), {
+      message: 'Invalid secret key: must be a catalog field key or valid env var name',
+    }),
     EncryptedEnvelopeSchema.nullable()
   ),
 });

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -42,6 +42,19 @@ export const GoogleCredentialsSchema = z.object({
 
 export type GoogleCredentials = z.infer<typeof GoogleCredentialsSchema>;
 
+/** Metadata for a custom secret (e.g. config path for openclaw.json patching). */
+export const CustomSecretMetaSchema = z.object({
+  configPath: z
+    .string()
+    .refine(isValidConfigPath, {
+      message:
+        'Not a supported credential path. See https://docs.openclaw.ai/reference/secretref-credential-surface',
+    })
+    .optional(),
+});
+
+export type CustomSecretMeta = z.infer<typeof CustomSecretMetaSchema>;
+
 export const InstanceConfigSchema = z.object({
   envVars: z.record(envVarNameSchema, z.string()).optional(),
   encryptedSecrets: z.record(envVarNameSchema, EncryptedEnvelopeSchema).optional(),
@@ -68,6 +81,7 @@ export const InstanceConfigSchema = z.object({
   // If set, use this image tag instead of resolving latest from KV.
   // Set by the cloud app when the user has a version pin.
   pinnedImageTag: z.string().regex(IMAGE_TAG_RE).max(IMAGE_TAG_MAX_LENGTH).optional(),
+  customSecretMeta: z.record(z.string(), CustomSecretMetaSchema).nullable().optional(),
 });
 
 export type InstanceConfig = z.infer<typeof InstanceConfigSchema>;
@@ -86,19 +100,6 @@ export const ChannelsPatchSchema = z.object({
   }),
 });
 
-/** Metadata for a custom secret (e.g. config path for openclaw.json patching). */
-export const CustomSecretMetaSchema = z.object({
-  configPath: z
-    .string()
-    .refine(isValidConfigPath, {
-      message:
-        'Not a supported credential path. See https://docs.openclaw.ai/reference/secretref-credential-surface',
-    })
-    .optional(),
-});
-
-export type CustomSecretMeta = z.infer<typeof CustomSecretMetaSchema>;
-
 export const SecretsPatchSchema = z.object({
   userId: z.string().min(1),
   secrets: z.record(
@@ -107,7 +108,12 @@ export const SecretsPatchSchema = z.object({
     }),
     EncryptedEnvelopeSchema.nullable()
   ),
-  meta: z.record(z.string(), CustomSecretMetaSchema).optional(),
+  meta: z
+    .record(
+      z.string().refine(k => isValidCustomSecretKey(k), { message: 'Invalid meta key' }),
+      CustomSecretMetaSchema
+    )
+    .optional(),
 });
 
 export const ProvisionRequestSchema = z.object({

--- a/kiloclaw/src/schemas/instance-config.ts
+++ b/kiloclaw/src/schemas/instance-config.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { ALL_SECRET_FIELD_KEYS, isValidCustomSecretKey } from '@kilocode/kiloclaw-secret-catalog';
+import {
+  ALL_SECRET_FIELD_KEYS,
+  isValidCustomSecretKey,
+  isValidConfigPath,
+} from '@kilocode/kiloclaw-secret-catalog';
 import { IMAGE_TAG_RE, IMAGE_TAG_MAX_LENGTH } from '../lib/image-tag-validation';
 
 export const EncryptedEnvelopeSchema = z.object({
@@ -82,6 +86,19 @@ export const ChannelsPatchSchema = z.object({
   }),
 });
 
+/** Metadata for a custom secret (e.g. config path for openclaw.json patching). */
+export const CustomSecretMetaSchema = z.object({
+  configPath: z
+    .string()
+    .refine(isValidConfigPath, {
+      message:
+        'Not a supported credential path. See https://docs.openclaw.ai/reference/secretref-credential-surface',
+    })
+    .optional(),
+});
+
+export type CustomSecretMeta = z.infer<typeof CustomSecretMetaSchema>;
+
 export const SecretsPatchSchema = z.object({
   userId: z.string().min(1),
   secrets: z.record(
@@ -90,6 +107,7 @@ export const SecretsPatchSchema = z.object({
     }),
     EncryptedEnvelopeSchema.nullable()
   ),
+  meta: z.record(z.string(), CustomSecretMetaSchema).optional(),
 });
 
 export const ProvisionRequestSchema = z.object({
@@ -223,6 +241,9 @@ export const PersistedStateSchema = z.object({
   // Tracks whether the "instance ready" email has been sent for this provision lifecycle.
   // Set to true on first low-load checkin; reset on DO wipe (destroy + re-provision).
   instanceReadyEmailSent: z.boolean().default(false),
+  // Metadata for custom (non-catalog) secrets: env var name → { configPath? }.
+  // configPath is a JSON dot-notation path for patching into openclaw.json at boot.
+  customSecretMeta: z.record(z.string(), CustomSecretMetaSchema).nullable().default(null),
 });
 
 export type PersistedState = z.infer<typeof PersistedStateSchema>;

--- a/src/app/(app)/claw/components/CustomSecretsSection.tsx
+++ b/src/app/(app)/claw/components/CustomSecretsSection.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { ExternalLink, Info, Key, Plus, Save, Trash2, X } from 'lucide-react';
+import { ChevronDown, ExternalLink, Info, Key, Plus, Save, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   isValidCustomSecretKey,
+  isValidConfigPath,
   MAX_CUSTOM_SECRET_VALUE_LENGTH,
 } from '@kilocode/kiloclaw-secret-catalog';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
@@ -20,57 +21,335 @@ import { ChannelTokenInput } from './ChannelTokenInput';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
+/**
+ * Convert a dot-notation config path to a suggested env var name.
+ * e.g. "cron.webhookToken" → "CRON_WEBHOOK_TOKEN"
+ *      "models.providers.openai.apiKey" → "MODELS_PROVIDERS_OPENAI_API_KEY"
+ */
+function configPathToEnvVar(path: string): string {
+  return path
+    .replace(/\./g, '_')
+    .replace(/([a-z])([A-Z])/g, '$1_$2')
+    .toUpperCase();
+}
+
+type EditingSecret = {
+  /** The env var name being edited (null = adding new) */
+  originalName: string | null;
+  configPath: string;
+  envVarName: string;
+  envVarNameTouched: boolean;
+  envVarValue: string;
+};
+
+const EMPTY_FORM: EditingSecret = {
+  originalName: null,
+  configPath: '',
+  envVarName: '',
+  envVarNameTouched: false,
+  envVarValue: '',
+};
+
+function SecretForm({
+  editing,
+  isSaving,
+  pathError,
+  pathCollision,
+  nameError,
+  nameCollision,
+  onConfigPathChange,
+  onEnvVarNameChange,
+  onValueChange,
+  onSave,
+  onCancel,
+  onRemove,
+}: {
+  editing: EditingSecret;
+  isSaving: boolean;
+  pathError: boolean;
+  pathCollision: boolean;
+  nameError: boolean;
+  nameCollision: boolean;
+  onConfigPathChange: (value: string) => void;
+  onEnvVarNameChange: (value: string) => void;
+  onValueChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onRemove?: () => void;
+}) {
+  return (
+    <div className="space-y-3">
+      {editing.originalName && (
+        <p className="text-muted-foreground text-xs">
+          Editing <code className="bg-muted rounded px-1">{editing.originalName}</code> — leave
+          value blank to keep the existing value.
+        </p>
+      )}
+      <div>
+        <Label htmlFor="custom-secret-config-path" className="mb-1 block text-xs">
+          Config Path
+        </Label>
+        <Input
+          id="custom-secret-config-path"
+          type="text"
+          placeholder="models.providers.openai.apiKey"
+          value={editing.configPath}
+          onChange={e => onConfigPathChange(e.target.value)}
+          disabled={isSaving}
+          maxLength={256}
+          autoComplete="off"
+          className={pathError || pathCollision ? 'border-red-500' : ''}
+        />
+        {pathError && (
+          <p className="mt-1 text-[11px] text-red-400">
+            Not a supported credential path.{' '}
+            <a
+              href="https://docs.openclaw.ai/reference/secretref-credential-surface"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              See supported paths
+            </a>
+            .
+          </p>
+        )}
+        {pathCollision && (
+          <p className="mt-1 text-[11px] text-red-400">
+            Another secret already uses this config path.
+          </p>
+        )}
+        <p className="text-muted-foreground mt-1 text-[11px]">
+          The JSON path in openclaw.json where this secret will be written.
+        </p>
+      </div>
+      <div>
+        <Label htmlFor="custom-secret-value" className="mb-1 block text-xs">
+          Value
+        </Label>
+        <ChannelTokenInput
+          id="custom-secret-value"
+          placeholder={editing.originalName ? 'Leave blank to keep existing value' : 'sk-...'}
+          value={editing.envVarValue}
+          onChange={onValueChange}
+          disabled={isSaving}
+          maxLength={MAX_CUSTOM_SECRET_VALUE_LENGTH}
+        />
+      </div>
+      <div>
+        <Label htmlFor="custom-secret-name" className="mb-1 block text-xs">
+          Environment Variable Name
+        </Label>
+        <Input
+          id="custom-secret-name"
+          type="text"
+          placeholder="MY_API_KEY"
+          value={editing.envVarName}
+          onChange={e => onEnvVarNameChange(e.target.value)}
+          disabled={isSaving}
+          maxLength={128}
+          autoComplete="off"
+          className={nameError || nameCollision ? 'border-red-500' : ''}
+        />
+        {nameError && (
+          <p className="mt-1 text-[11px] text-red-400">
+            Must be a valid env var name (A-Z, 0-9, _). Cannot use KILOCLAW_ prefix or collide with
+            built-in secrets.
+          </p>
+        )}
+        {nameCollision && (
+          <p className="mt-1 text-[11px] text-red-400">A secret with this name already exists.</p>
+        )}
+        <p className="text-muted-foreground mt-1 text-[11px]">
+          Also available as this env var in the container.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={onSave}
+          disabled={
+            isSaving ||
+            !editing.configPath.trim() ||
+            !editing.envVarName.trim() ||
+            (!editing.originalName && !editing.envVarValue.trim()) ||
+            pathError ||
+            pathCollision ||
+            nameError ||
+            nameCollision
+          }
+        >
+          <Save className="h-4 w-4" />
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+        {onRemove ? (
+          <Button variant="outline" size="sm" onClick={onRemove} disabled={isSaving}>
+            <Trash2 className="h-4 w-4" />
+            Remove
+          </Button>
+        ) : (
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={isSaving}>
+            <X className="h-4 w-4" />
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function CustomSecretsSection({
   customSecretKeys,
+  customSecretMeta,
   mutations,
   onRedeploy,
 }: {
   customSecretKeys: string[];
+  customSecretMeta: Record<string, { configPath?: string }>;
   mutations: ClawMutations;
   onRedeploy?: () => void;
 }) {
-  const [showForm, setShowForm] = useState(false);
-  const [envVarName, setEnvVarName] = useState('');
-  const [envVarValue, setEnvVarValue] = useState('');
+  const [editing, setEditing] = useState<EditingSecret | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
   const isSaving = mutations.patchSecrets.isPending;
 
-  const nameError = envVarName.length > 0 && !isValidCustomSecretKey(envVarName);
+  const pathError = editing
+    ? editing.configPath.length > 0 && !isValidConfigPath(editing.configPath)
+    : false;
+  const nameError = editing
+    ? editing.envVarName.length > 0 && !isValidCustomSecretKey(editing.envVarName)
+    : false;
+  // When editing an existing secret, allow keeping the same env var name
+  const nameCollision =
+    editing &&
+    !nameError &&
+    editing.envVarName.length > 0 &&
+    customSecretKeys.includes(editing.envVarName) &&
+    editing.originalName !== editing.envVarName;
+  // Check if another secret already uses this config path
+  const pathCollision =
+    editing &&
+    !pathError &&
+    editing.configPath.length > 0 &&
+    Object.entries(customSecretMeta).some(
+      ([envVar, meta]) => meta.configPath === editing.configPath && envVar !== editing.originalName
+    );
 
-  function handleAdd() {
-    const name = envVarName.trim();
-    const value = envVarValue.trim();
+  function updateEditing(patch: Partial<EditingSecret>) {
+    setEditing(prev => (prev ? { ...prev, ...patch } : null));
+  }
 
-    if (!name || !value) {
-      toast.error('Both name and value are required.');
+  function handleConfigPathChange(value: string) {
+    if (!editing) return;
+    const patch: Partial<EditingSecret> = { configPath: value };
+    if (!editing.envVarNameTouched) {
+      const trimmed = value.trim();
+      patch.envVarName = trimmed ? configPathToEnvVar(trimmed) : '';
+    }
+    updateEditing(patch);
+  }
+
+  function handleEnvVarNameChange(value: string) {
+    updateEditing({ envVarName: value.toUpperCase(), envVarNameTouched: true });
+  }
+
+  function startNew() {
+    setEditing({ ...EMPTY_FORM });
+  }
+
+  function startEdit(name: string) {
+    const meta = customSecretMeta[name];
+    setEditing({
+      originalName: name,
+      configPath: meta?.configPath ?? '',
+      envVarName: name,
+      envVarNameTouched: true,
+      envVarValue: '',
+    });
+  }
+
+  function handleSave() {
+    if (!editing) return;
+
+    const path = editing.configPath.trim();
+    const name = editing.envVarName.trim();
+    const value = editing.envVarValue.trim();
+    const isEdit = !!editing.originalName;
+
+    if (!path) {
+      toast.error('Config path is required.');
       return;
     }
-
+    if (!isValidConfigPath(path)) {
+      toast.error('Invalid config path. Use dot notation like models.providers.openai.apiKey');
+      return;
+    }
+    if (!name) {
+      toast.error('Env var name is required.');
+      return;
+    }
+    // Value is required for new secrets, optional for edits (keeps existing value)
+    if (!isEdit && !value) {
+      toast.error('Value is required.');
+      return;
+    }
     if (!isValidCustomSecretKey(name)) {
-      toast.error(
-        'Invalid env var name. Use A-Z, 0-9, _ only. Cannot start with a number or use KILOCLAW_ prefix.'
-      );
+      toast.error('Invalid env var name.');
+      return;
+    }
+    if (nameCollision) {
+      toast.error(`Secret "${name}" already exists. Use a different name or edit that secret.`);
       return;
     }
 
-    if (customSecretKeys.includes(name)) {
-      toast.error(`Secret "${name}" already exists. Remove it first to replace.`);
+    const isRename = editing.originalName && editing.originalName !== name;
+    const secrets: Record<string, string | null> = {};
+
+    // Only include value in the patch if the user entered one.
+    // For edits with no value change, we still need to include the key
+    // if renaming (so the new name gets the value). For metadata-only
+    // updates (same name, no new value), we send an empty secrets object
+    // and rely on the meta update alone.
+    if (value) {
+      secrets[name] = value;
+    }
+    if (isRename && editing.originalName) {
+      secrets[editing.originalName] = null;
+      // If no new value provided during rename, we need to re-set the secret
+      // under the new name. But we don't have the old value — the user must
+      // provide it. Show an error.
+      if (!value) {
+        toast.error('Value is required when changing the env var name.');
+        return;
+      }
+    }
+
+    // Always send meta to update config path
+    const meta = { [name]: { configPath: path } };
+
+    // If nothing changed (same name, same path, no new value), skip
+    if (
+      isEdit &&
+      !value &&
+      !isRename &&
+      editing.configPath === (customSecretMeta[name]?.configPath ?? '')
+    ) {
+      toast.info('No changes to save.');
+      setEditing(null);
       return;
     }
 
     mutations.patchSecrets.mutate(
-      { secrets: { [name]: value } },
+      { secrets, meta },
       {
         onSuccess: () => {
-          toast.success(`Secret "${name}" saved. Redeploy to apply.`, {
+          toast.success(`Secret "${path}" ${isEdit ? 'updated' : 'saved'}. Redeploy to apply.`, {
             duration: 8000,
             ...(onRedeploy && {
               action: { label: 'Redeploy', onClick: onRedeploy },
             }),
           });
-          setEnvVarName('');
-          setEnvVarValue('');
-          setShowForm(false);
+          setEditing(null);
         },
         onError: err => toast.error(`Failed to save: ${err.message}`),
       }
@@ -82,12 +361,14 @@ export function CustomSecretsSection({
       { secrets: { [name]: null } },
       {
         onSuccess: () => {
-          toast.success(`Secret "${name}" removed. Redeploy to apply.`, {
+          toast.success(`Secret removed. Redeploy to apply.`, {
             duration: 8000,
             ...(onRedeploy && {
               action: { label: 'Redeploy', onClick: onRedeploy },
             }),
           });
+          // Close form if we were editing the deleted secret
+          if (editing?.originalName === name) setEditing(null);
         },
         onError: err => toast.error(`Failed to remove: ${err.message}`),
       }
@@ -97,14 +378,14 @@ export function CustomSecretsSection({
   return (
     <div>
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-foreground text-base font-semibold">Custom Secrets</h2>
+        <h2 className="text-foreground text-base font-semibold">Additional Secrets</h2>
         <Badge variant="secondary" className="px-1.5 py-0 text-[10px] leading-4">
           {customSecretKeys.length} secret{customSecretKeys.length !== 1 ? 's' : ''}
         </Badge>
       </div>
 
       <div className="space-y-3">
-        {/* Help / SecretRef info */}
+        {/* Help info */}
         <Collapsible open={helpOpen} onOpenChange={setHelpOpen}>
           <div className="rounded-lg border">
             <CollapsibleTrigger asChild>
@@ -114,7 +395,7 @@ export function CustomSecretsSection({
               >
                 <Info className="text-muted-foreground h-4 w-4 shrink-0" />
                 <span className="text-muted-foreground text-xs">
-                  Add encrypted environment variables for API keys, tokens, and credentials.
+                  Add encrypted secrets that are patched into your openclaw.json config.
                 </span>
               </button>
             </CollapsibleTrigger>
@@ -122,16 +403,12 @@ export function CustomSecretsSection({
               <Separator />
               <div className="space-y-2 px-4 py-3 text-xs">
                 <p className="text-muted-foreground">
-                  Custom secrets are injected as encrypted environment variables into your
-                  container. To reference a secret in your{' '}
-                  <code className="bg-muted rounded px-1">openclaw.json</code> config, use
-                  OpenClaw&apos;s SecretRef syntax:
+                  Specify a <strong>Config Path</strong> (JSON dot notation) and the secret value
+                  will be automatically written to that location in your{' '}
+                  <code className="bg-muted rounded px-1">openclaw.json</code> on every boot.
                 </p>
-                <pre className="bg-muted rounded-md p-2 text-[11px]">
-                  <code>{`{ "source": "env", "provider": "default", "id": "YOUR_KEY_NAME" }`}</code>
-                </pre>
                 <p className="text-muted-foreground">
-                  This works for any of OpenClaw&apos;s{' '}
+                  The secret is also available as an environment variable in the container. See{' '}
                   <a
                     href="https://docs.openclaw.ai/reference/secretref-credential-surface"
                     target="_blank"
@@ -141,110 +418,95 @@ export function CustomSecretsSection({
                     supported credential paths
                     <ExternalLink className="h-3 w-3" />
                   </a>{' '}
-                  (e.g. <code className="bg-muted rounded px-1">models.providers.*.apiKey</code>).
-                  Secrets are also available as plain env vars for MCP servers and custom tools.
-                </p>
-                <p className="text-muted-foreground">
-                  <a
-                    href="https://docs.openclaw.ai/gateway/secrets"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-0.5 underline"
-                  >
-                    Learn more about OpenClaw secrets
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
+                  for common paths.
                 </p>
               </div>
             </CollapsibleContent>
           </div>
         </Collapsible>
 
-        {/* Existing secrets list */}
-        {customSecretKeys.map(name => (
-          <div key={name} className="flex items-center gap-3 rounded-lg border px-4 py-3">
-            <Key className="text-muted-foreground h-4 w-4 shrink-0" />
-            <code className="min-w-0 flex-1 truncate text-sm">{name}</code>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => handleRemove(name)}
-              disabled={isSaving}
-              className="text-muted-foreground hover:text-red-400 h-8 w-8 p-0"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        ))}
-
-        {/* Add new secret form */}
-        {showForm ? (
-          <div className="space-y-3 rounded-lg border px-4 py-3">
-            <div>
-              <Label htmlFor="custom-secret-name" className="mb-1 block text-xs">
-                Environment Variable Name
-              </Label>
-              <Input
-                id="custom-secret-name"
-                type="text"
-                placeholder="MY_API_KEY"
-                value={envVarName}
-                onChange={e => setEnvVarName(e.target.value.toUpperCase())}
-                disabled={isSaving}
-                maxLength={128}
-                autoComplete="off"
-                className={nameError ? 'border-red-500' : ''}
-              />
-              {nameError && (
-                <p className="mt-1 text-[11px] text-red-400">
-                  Must be a valid env var name (A-Z, 0-9, _). Cannot use KILOCLAW_ prefix or collide
-                  with built-in secrets.
-                </p>
-              )}
-            </div>
-            <div>
-              <Label htmlFor="custom-secret-value" className="mb-1 block text-xs">
-                Value
-              </Label>
-              <ChannelTokenInput
-                id="custom-secret-value"
-                placeholder="sk-..."
-                value={envVarValue}
-                onChange={setEnvVarValue}
-                disabled={isSaving}
-                maxLength={MAX_CUSTOM_SECRET_VALUE_LENGTH}
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                onClick={handleAdd}
-                disabled={isSaving || !envVarName.trim() || !envVarValue.trim() || nameError}
-              >
-                <Save className="h-4 w-4" />
-                {isSaving ? 'Saving...' : 'Save'}
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setShowForm(false);
-                  setEnvVarName('');
-                  setEnvVarValue('');
-                }}
-                disabled={isSaving}
-              >
-                <X className="h-4 w-4" />
-                Cancel
-              </Button>
-            </div>
+        {/* Add button / New secret form — always at top */}
+        {editing && !editing.originalName ? (
+          <div className="rounded-lg border px-4 py-3">
+            <SecretForm
+              editing={editing}
+              isSaving={isSaving}
+              pathError={pathError}
+              pathCollision={!!pathCollision}
+              nameError={nameError}
+              nameCollision={!!nameCollision}
+              onConfigPathChange={handleConfigPathChange}
+              onEnvVarNameChange={handleEnvVarNameChange}
+              onValueChange={v => updateEditing({ envVarValue: v })}
+              onSave={handleSave}
+              onCancel={() => setEditing(null)}
+            />
           </div>
         ) : (
-          <Button variant="outline" size="sm" onClick={() => setShowForm(true)} className="w-full">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={startNew}
+            disabled={isSaving}
+            className="w-full"
+          >
             <Plus className="h-4 w-4" />
             Add Secret
           </Button>
         )}
+
+        {/* Existing secrets list — newest first */}
+        {[...customSecretKeys].reverse().map(name => {
+          const meta = customSecretMeta[name];
+          const isBeingEdited = editing?.originalName === name;
+          return (
+            <div key={name} className="rounded-lg border">
+              <button
+                type="button"
+                onClick={() => (isBeingEdited ? setEditing(null) : startEdit(name))}
+                disabled={isSaving}
+                className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 transition-colors"
+              >
+                <Key className="text-muted-foreground h-5 w-5 shrink-0" />
+                <div className="min-w-0 flex-1 text-left">
+                  {meta?.configPath ? (
+                    <>
+                      <span className="block truncate text-sm font-medium">{meta.configPath}</span>
+                      <span className="text-muted-foreground text-xs">env: {name}</span>
+                    </>
+                  ) : (
+                    <span className="block truncate text-sm font-medium">{name}</span>
+                  )}
+                </div>
+                <ChevronDown
+                  className={`text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200 ${isBeingEdited ? 'rotate-180' : ''}`}
+                />
+              </button>
+              {/* Inline edit form */}
+              {isBeingEdited && editing && (
+                <>
+                  <Separator />
+                  <div className="px-4 py-3">
+                    <SecretForm
+                      editing={editing}
+                      isSaving={isSaving}
+                      pathError={pathError}
+                      pathCollision={!!pathCollision}
+                      nameError={nameError}
+                      nameCollision={!!nameCollision}
+                      onConfigPathChange={handleConfigPathChange}
+                      onEnvVarNameChange={handleEnvVarNameChange}
+                      onValueChange={v => updateEditing({ envVarValue: v })}
+                      onSave={handleSave}
+                      onCancel={() => setEditing(null)}
+                      onRemove={() => handleRemove(name)}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/(app)/claw/components/CustomSecretsSection.tsx
+++ b/src/app/(app)/claw/components/CustomSecretsSection.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useState } from 'react';
+import { ExternalLink, Info, Key, Plus, Save, Trash2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  isValidCustomSecretKey,
+  MAX_CUSTOM_SECRET_VALUE_LENGTH,
+} from '@kilocode/kiloclaw-secret-catalog';
+import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+
+import { ChannelTokenInput } from './ChannelTokenInput';
+
+type ClawMutations = ReturnType<typeof useKiloClawMutations>;
+
+export function CustomSecretsSection({
+  customSecretKeys,
+  mutations,
+  onRedeploy,
+}: {
+  customSecretKeys: string[];
+  mutations: ClawMutations;
+  onRedeploy?: () => void;
+}) {
+  const [showForm, setShowForm] = useState(false);
+  const [envVarName, setEnvVarName] = useState('');
+  const [envVarValue, setEnvVarValue] = useState('');
+  const [helpOpen, setHelpOpen] = useState(false);
+  const isSaving = mutations.patchSecrets.isPending;
+
+  const nameError = envVarName.length > 0 && !isValidCustomSecretKey(envVarName);
+
+  function handleAdd() {
+    const name = envVarName.trim();
+    const value = envVarValue.trim();
+
+    if (!name || !value) {
+      toast.error('Both name and value are required.');
+      return;
+    }
+
+    if (!isValidCustomSecretKey(name)) {
+      toast.error(
+        'Invalid env var name. Use A-Z, 0-9, _ only. Cannot start with a number or use KILOCLAW_ prefix.'
+      );
+      return;
+    }
+
+    if (customSecretKeys.includes(name)) {
+      toast.error(`Secret "${name}" already exists. Remove it first to replace.`);
+      return;
+    }
+
+    mutations.patchSecrets.mutate(
+      { secrets: { [name]: value } },
+      {
+        onSuccess: () => {
+          toast.success(`Secret "${name}" saved. Redeploy to apply.`, {
+            duration: 8000,
+            ...(onRedeploy && {
+              action: { label: 'Redeploy', onClick: onRedeploy },
+            }),
+          });
+          setEnvVarName('');
+          setEnvVarValue('');
+          setShowForm(false);
+        },
+        onError: err => toast.error(`Failed to save: ${err.message}`),
+      }
+    );
+  }
+
+  function handleRemove(name: string) {
+    mutations.patchSecrets.mutate(
+      { secrets: { [name]: null } },
+      {
+        onSuccess: () => {
+          toast.success(`Secret "${name}" removed. Redeploy to apply.`, {
+            duration: 8000,
+            ...(onRedeploy && {
+              action: { label: 'Redeploy', onClick: onRedeploy },
+            }),
+          });
+        },
+        onError: err => toast.error(`Failed to remove: ${err.message}`),
+      }
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-foreground text-base font-semibold">Custom Secrets</h2>
+        <Badge variant="secondary" className="px-1.5 py-0 text-[10px] leading-4">
+          {customSecretKeys.length} secret{customSecretKeys.length !== 1 ? 's' : ''}
+        </Badge>
+      </div>
+
+      <div className="space-y-3">
+        {/* Help / SecretRef info */}
+        <Collapsible open={helpOpen} onOpenChange={setHelpOpen}>
+          <div className="rounded-lg border">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 transition-colors"
+              >
+                <Info className="text-muted-foreground h-4 w-4 shrink-0" />
+                <span className="text-muted-foreground text-xs">
+                  Add encrypted environment variables for API keys, tokens, and credentials.
+                </span>
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <Separator />
+              <div className="space-y-2 px-4 py-3 text-xs">
+                <p className="text-muted-foreground">
+                  Custom secrets are injected as encrypted environment variables into your
+                  container. To reference a secret in your{' '}
+                  <code className="bg-muted rounded px-1">openclaw.json</code> config, use
+                  OpenClaw&apos;s SecretRef syntax:
+                </p>
+                <pre className="bg-muted rounded-md p-2 text-[11px]">
+                  <code>{`{ "source": "env", "provider": "default", "id": "YOUR_KEY_NAME" }`}</code>
+                </pre>
+                <p className="text-muted-foreground">
+                  This works for any of OpenClaw&apos;s{' '}
+                  <a
+                    href="https://docs.openclaw.ai/reference/secretref-credential-surface"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-0.5 underline"
+                  >
+                    supported credential paths
+                    <ExternalLink className="h-3 w-3" />
+                  </a>{' '}
+                  (e.g. <code className="bg-muted rounded px-1">models.providers.*.apiKey</code>).
+                  Secrets are also available as plain env vars for MCP servers and custom tools.
+                </p>
+                <p className="text-muted-foreground">
+                  <a
+                    href="https://docs.openclaw.ai/gateway/secrets"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-0.5 underline"
+                  >
+                    Learn more about OpenClaw secrets
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </p>
+              </div>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+
+        {/* Existing secrets list */}
+        {customSecretKeys.map(name => (
+          <div key={name} className="flex items-center gap-3 rounded-lg border px-4 py-3">
+            <Key className="text-muted-foreground h-4 w-4 shrink-0" />
+            <code className="min-w-0 flex-1 truncate text-sm">{name}</code>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleRemove(name)}
+              disabled={isSaving}
+              className="text-muted-foreground hover:text-red-400 h-8 w-8 p-0"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+
+        {/* Add new secret form */}
+        {showForm ? (
+          <div className="space-y-3 rounded-lg border px-4 py-3">
+            <div>
+              <Label htmlFor="custom-secret-name" className="mb-1 block text-xs">
+                Environment Variable Name
+              </Label>
+              <Input
+                id="custom-secret-name"
+                type="text"
+                placeholder="MY_API_KEY"
+                value={envVarName}
+                onChange={e => setEnvVarName(e.target.value.toUpperCase())}
+                disabled={isSaving}
+                maxLength={128}
+                autoComplete="off"
+                className={nameError ? 'border-red-500' : ''}
+              />
+              {nameError && (
+                <p className="mt-1 text-[11px] text-red-400">
+                  Must be a valid env var name (A-Z, 0-9, _). Cannot use KILOCLAW_ prefix or collide
+                  with built-in secrets.
+                </p>
+              )}
+            </div>
+            <div>
+              <Label htmlFor="custom-secret-value" className="mb-1 block text-xs">
+                Value
+              </Label>
+              <ChannelTokenInput
+                id="custom-secret-value"
+                placeholder="sk-..."
+                value={envVarValue}
+                onChange={setEnvVarValue}
+                disabled={isSaving}
+                maxLength={MAX_CUSTOM_SECRET_VALUE_LENGTH}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={handleAdd}
+                disabled={isSaving || !envVarName.trim() || !envVarValue.trim() || nameError}
+              >
+                <Save className="h-4 w-4" />
+                {isSaving ? 'Saving...' : 'Save'}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setShowForm(false);
+                  setEnvVarName('');
+                  setEnvVarValue('');
+                }}
+                disabled={isSaving}
+              >
+                <X className="h-4 w-4" />
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button variant="outline" size="sm" onClick={() => setShowForm(true)} className="w-full">
+            <Plus className="h-4 w-4" />
+            Add Secret
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -962,9 +962,10 @@ export function SettingsTab({
         </div>
       </div>
 
-      {/* ── Custom Secrets ── */}
+      {/* ── Additional Secrets ── */}
       <CustomSecretsSection
         customSecretKeys={config?.customSecretKeys ?? []}
+        customSecretMeta={config?.customSecretMeta ?? {}}
         mutations={mutations}
         onRedeploy={onRedeploy}
       />

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -56,6 +56,7 @@ import { PairingSection } from './PairingSection';
 import { VersionPinCard } from './VersionPinCard';
 import { WorkspaceFileEditor } from './WorkspaceFileEditor';
 import { PermissionPresetCards } from './PermissionPresetCards';
+import { CustomSecretsSection } from './CustomSecretsSection';
 import { type ExecPreset, configToExecPreset, execPresetToConfig } from './claw.types';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
@@ -960,6 +961,13 @@ export function SettingsTab({
           />
         </div>
       </div>
+
+      {/* ── Custom Secrets ── */}
+      <CustomSecretsSection
+        customSecretKeys={config?.customSecretKeys ?? []}
+        mutations={mutations}
+        onRedeploy={onRedeploy}
+      />
 
       {/* ── Danger Zone ── */}
       <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-5">

--- a/src/app/(app)/claw/components/changelog-data.ts
+++ b/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-03-27',
+    description:
+      'Additional Secrets — all OpenClaw SecretRef credential paths are now supported. Add any API key, token, or credential in Settings > Additional Secrets and it will be encrypted and patched into your openclaw.json config at the specified path on every boot. Supports model providers, channels, plugins, web search, and more.',
+    category: 'feature',
+    deployHint: 'upgrade_required',
+  },
+  {
     date: '2026-03-24',
     description:
       'Fixed Kilo CLI discovery — OpenClaw now knows about the kilo CLI on all instances. Previously, instances provisioned before the CLI was added did not advertise it in TOOLS.md, so the agent could not find it.',

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -58,12 +58,12 @@ export type ChannelsPatchResponse = {
 
 /** Input to PATCH /api/platform/secrets */
 export type SecretsPatchInput = {
-  secrets: Partial<Record<SecretFieldKey, EncryptedEnvelope | null>>;
+  secrets: Record<string, EncryptedEnvelope | null>;
 };
 
 /** Response from PATCH /api/platform/secrets */
 export type SecretsPatchResponse = {
-  /** Field keys that have a value set after the patch */
+  /** Catalog field keys that have a value set after the patch */
   configured: SecretFieldKey[];
 };
 
@@ -200,6 +200,8 @@ export type UserConfigResponse = {
   kilocodeApiKeyExpiresAt?: string | null;
   /** Per catalog entry ID → whether all fields for that entry are configured. */
   configuredSecrets: Record<string, boolean>;
+  /** Env var names of user-defined custom (non-catalog) secrets. */
+  customSecretKeys: string[];
 };
 
 /** Response from POST /api/platform/doctor */

--- a/src/lib/kiloclaw/types.ts
+++ b/src/lib/kiloclaw/types.ts
@@ -59,6 +59,7 @@ export type ChannelsPatchResponse = {
 /** Input to PATCH /api/platform/secrets */
 export type SecretsPatchInput = {
   secrets: Record<string, EncryptedEnvelope | null>;
+  meta?: Record<string, { configPath?: string }>;
 };
 
 /** Response from PATCH /api/platform/secrets */
@@ -202,6 +203,8 @@ export type UserConfigResponse = {
   configuredSecrets: Record<string, boolean>;
   /** Env var names of user-defined custom (non-catalog) secrets. */
   customSecretKeys: string[];
+  /** Metadata for custom secrets (config paths, etc.). */
+  customSecretMeta: Record<string, { configPath?: string }>;
 };
 
 /** Response from POST /api/platform/doctor */

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -10,10 +10,10 @@ import { encryptKiloClawSecret } from '@/lib/kiloclaw/encryption';
 import {
   ALL_SECRET_FIELD_KEYS,
   FIELD_KEY_TO_ENTRY,
-  MAX_SECRET_FIELD_LENGTH,
+  MAX_CUSTOM_SECRET_VALUE_LENGTH,
   validateFieldValue,
   getEntriesByCategory,
-  type SecretFieldKey,
+  isValidCustomSecretKey,
 } from '@kilocode/kiloclaw-secret-catalog';
 import {
   KILOCLAW_API_URL,
@@ -603,56 +603,67 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   /**
-   * Generic secret patch — catalog-driven replacement for patchChannels.
-   * Validates keys against the secret catalog, enforces allFieldsRequired,
-   * validates values against catalog patterns, encrypts, and forwards to worker.
+   * Generic secret patch — supports both catalog secrets and custom user secrets.
+   *
+   * Catalog keys (in ALL_SECRET_FIELD_KEYS) are validated against catalog patterns.
+   * Custom keys (valid env var names not in catalog) skip pattern validation but
+   * enforce a generous max value length. All values are RSA-encrypted before
+   * forwarding to the worker.
    */
   patchSecrets: clawAccessProcedure
     .input(
       z.object({
         secrets: z
-          .record(z.string(), z.string().max(MAX_SECRET_FIELD_LENGTH).nullable())
-          .refine(obj => Object.keys(obj).every(k => ALL_SECRET_FIELD_KEYS.has(k)), {
-            message: 'Unknown secret field key',
-          }),
+          .record(z.string(), z.string().max(MAX_CUSTOM_SECRET_VALUE_LENGTH).nullable())
+          .refine(
+            obj =>
+              Object.keys(obj).every(
+                k => ALL_SECRET_FIELD_KEYS.has(k) || isValidCustomSecretKey(k)
+              ),
+            {
+              message:
+                'Invalid secret key: must be a catalog field key or valid env var name (A-Z, 0-9, _, no KILOCLAW_ prefix)',
+            }
+          ),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const secrets = input.secrets as Partial<Record<SecretFieldKey, string | null>>;
+      const secrets = input.secrets;
 
       // 1. allFieldsRequired is enforced by the DO on post-merge state (not here),
       //    so single-field rotations work when the other field is already stored.
 
-      // 2. Validate non-null values against catalog patterns + enforce per-field maxLength
+      // 2. Validate non-null values: catalog keys get pattern + maxLength checks,
+      //    custom keys only get the blanket max from the zod schema above.
       for (const [key, value] of Object.entries(secrets)) {
         if (value === null) continue;
 
-        const entry = FIELD_KEY_TO_ENTRY.get(key);
-        const field = entry?.fields.find(f => f.key === key);
+        if (ALL_SECRET_FIELD_KEYS.has(key)) {
+          // Catalog key — validate against catalog patterns and per-field maxLength
+          const entry = FIELD_KEY_TO_ENTRY.get(key);
+          const field = entry?.fields.find(f => f.key === key);
 
-        // Enforce per-field maxLength from catalog (falls back to 500 from zod schema above)
-        if (field?.maxLength != null && value.length > field.maxLength) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: `${field.label} exceeds maximum length of ${field.maxLength} characters`,
-          });
-        }
+          if (field?.maxLength != null && value.length > field.maxLength) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: `${field.label} exceeds maximum length of ${field.maxLength} characters`,
+            });
+          }
 
-        if (!validateFieldValue(value, field?.validationPattern)) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: field?.validationMessage ?? `Invalid value for ${key}`,
-          });
+          if (!validateFieldValue(value, field?.validationPattern)) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: field?.validationMessage ?? `Invalid value for ${key}`,
+            });
+          }
         }
+        // Custom keys: no pattern validation — the blanket zod .max() is sufficient
       }
 
       // 3. Encrypt non-null values
-      const encryptedPatch: Partial<
-        Record<SecretFieldKey, ReturnType<typeof encryptKiloClawSecret> | null>
-      > = {};
+      const encryptedPatch: Record<string, ReturnType<typeof encryptKiloClawSecret> | null> = {};
       for (const [key, value] of Object.entries(secrets)) {
-        encryptedPatch[key as SecretFieldKey] =
-          value === null ? null : encryptKiloClawSecret(value);
+        encryptedPatch[key] = value === null ? null : encryptKiloClawSecret(value);
       }
 
       // 4. Forward to worker — translate 4xx responses into TRPCErrors

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -14,6 +14,7 @@ import {
   validateFieldValue,
   getEntriesByCategory,
   isValidCustomSecretKey,
+  isValidConfigPath,
 } from '@kilocode/kiloclaw-secret-catalog';
 import {
   KILOCLAW_API_URL,
@@ -625,6 +626,20 @@ export const kiloclawRouter = createTRPCRouter({
                 'Invalid secret key: must be a catalog field key or valid env var name (A-Z, 0-9, _, no KILOCLAW_ prefix)',
             }
           ),
+        meta: z
+          .record(
+            z.string(),
+            z.object({
+              configPath: z
+                .string()
+                .refine(isValidConfigPath, {
+                  message:
+                    'Not a supported credential path. See https://docs.openclaw.ai/reference/secretref-credential-surface',
+                })
+                .optional(),
+            })
+          )
+          .optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -669,7 +684,10 @@ export const kiloclawRouter = createTRPCRouter({
       // 4. Forward to worker — translate 4xx responses into TRPCErrors
       const client = new KiloClawInternalClient();
       try {
-        return await client.patchSecrets(ctx.user.id, { secrets: encryptedPatch });
+        return await client.patchSecrets(ctx.user.id, {
+          secrets: encryptedPatch,
+          meta: input.meta,
+        });
       } catch (err) {
         if (err instanceof KiloClawApiError && err.statusCode >= 400 && err.statusCode < 500) {
           // Extract message from worker response body (JSON or plain text)


### PR DESCRIPTION
## Summary

- Add **Additional Secrets** section to Settings, allowing users to add arbitrary encrypted secrets that target any of OpenClaw's 73 supported SecretRef credential paths
- Secrets are encrypted (RSA+AES), stored in the DO, injected as encrypted env vars, and patched into `openclaw.json` at the user-specified config path on every boot
- Config paths are validated against OpenClaw's `target-registry-data.ts` allow list with wildcard pattern matching
- Security deny lists block system-managed env vars and config paths

### What's included

**Backend (secret-catalog, worker, DO, controller):**
- `isValidCustomSecretKey()` — env var name validation with deny lists (prefixes: `KILOCLAW_`, `OPENCLAW_`, `KILOCODE_`, `FLY_`, `NEXTAUTH_`, `NODE_`, `STREAM_CHAT_`; exact: `PATH`, `HOME`, etc.)
- `isValidConfigPath()` — allow list of 73 OpenClaw SecretRef patterns, deny list for KiloClaw-managed and OpenClaw-excluded paths
- `customSecretMeta` — DO persisted state for config path metadata
- `updateSecrets()` widened to accept custom keys with 50-secret limit and duplicate config path rejection
- `KILOCLAW_SECRET_CONFIG_PATHS` env var serializes path mapping for the controller
- `setNestedValue()` in controller patches values into `openclaw.json` with prototype pollution guard
- `CustomSecretMetaSchema` added to `InstanceConfig` and `SecretsPatchSchema`

**Frontend (Additional Secrets UI):**
- Config path input (required) → auto-fills env var name from dot notation
- Value input (masked, required for new, optional for edit)
- Accordion-style expand/collapse matching catalog secret sections
- Edit support: pre-filled config path and env var name, value optional to keep existing
- Inline validation with link to OpenClaw credential surface docs
- Duplicate config path prevention
- Add button always visible at top, newest secrets listed first

**Changelog:**
- "Additional Secrets" entry with `upgrade_required` deploy hint

## Verifications

- [x] 79 secret-catalog tests (validation, allow list, deny list, wildcards, hyphens)
- [x] 1090 kiloclaw worker tests (DO custom secrets, limits, metadata, duplicates, env pipeline, config patching, prototype pollution)
- [x] Typecheck clean (kiloclaw + cloud app)
- [x] Lint 0 errors
- [x] Format clean
- [x] End-to-end: added `channels.zalo.botToken` via UI → redeployed → confirmed value patched into `/root/.openclaw/openclaw.json`
- [x] Key pair mismatch identified and fixed during dev testing

## Visual Changes

**Settings tab — Additional Secrets section** (between Productivity and Danger Zone):

- "Add Secret" button at top opens inline form with Config Path, Value, and Env Var Name fields
- Existing secrets display as clickable accordion rows showing config path and env var name
- Clicking a row expands inline edit form with Save/Remove buttons
- Collapsible help section links to OpenClaw credential surface docs
- Validation errors show "Not a supported credential path" with doc link

<img width="1106" height="649" alt="Screenshot 2026-03-27 at 10 26 49 AM" src="https://github.com/user-attachments/assets/7c9147f5-a01b-459e-9270-32e61ae2fb00" />

## Reviewer Notes

- Config paths are validated against OpenClaw's `src/secrets/target-registry-data.ts` — this is a **hardcoded allow list** that will need updating when OpenClaw adds new credential paths. The maintenance burden is intentional (prevents typos) per product decision.
- `auth-profiles.json` paths (`profiles.*.key`, `profiles.*.token`) and Google Chat `serviceAccount` (sibling_ref shape) are excluded — they target different files or require special handling.
- Array-indexed patterns (`agents.list[].*`) are excluded — can't be expressed in dot notation.
- The `KILOCLAW_SECRET_CONFIG_PATHS` env var is **plaintext** (just path mappings, not values). Secret values travel through the existing `KILOCLAW_ENC_*` encrypted pipeline.
- Multi-line secrets (PEM certs) are not supported — all 73 SecretRef paths are single-line API keys/tokens. Can add textarea support later if needed.
- Requires **image upgrade** (not just redeploy) because the controller's `generateBaseConfig()` has new config patching logic.