### PR TITLE
fix(claw): handle Fly 'destroyed' state on start after admin force-delete

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -6365,3 +6365,65 @@ describe('Stream Chat backfill on restartMachine', () => {
     expect(setupDefaultStreamChatChannel).not.toHaveBeenCalled();
   });
 });
+
+// ============================================================================
+// start: handles Fly 'destroyed' state after admin force-delete
+// ============================================================================
+
+describe('start: creates new machine when existing machine is in destroyed state', () => {
+  it('clears stale flyMachineId and creates a new machine when getMachine returns destroyed', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    // First getMachine call (running check in _startInner) returns destroyed
+    // Second getMachine call (in startExistingMachine) would also return destroyed,
+    // but our fix in _startInner clears flyMachineId before reaching startExistingMachine.
+    (flyClient.getMachine as Mock).mockResolvedValue(
+      fakeMachine({ id: 'machine-1', state: 'destroyed' })
+    );
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({
+      id: 'new-machine-1',
+      region: 'iad',
+    });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    const result = await instance.start('user-1');
+
+    expect(result.started).toBe(true);
+    // Should have created a new machine, not tried to start the destroyed one
+    expect(flyClient.createMachine).toHaveBeenCalledTimes(1);
+    expect(flyClient.updateMachine).not.toHaveBeenCalled();
+    // New machine ID should be persisted
+    expect(storage._store.get('flyMachineId')).toBe('new-machine-1');
+    expect(storage._store.get('status')).toBe('running');
+  });
+
+  it('startExistingMachine creates new machine when getMachine returns destroyed', async () => {
+    const { instance, storage } = createInstance();
+    // Seed as stopped with a stale flyMachineId — this bypasses the running check
+    // and goes straight to startExistingMachine.
+    await seedProvisioned(storage, {
+      status: 'stopped',
+      flyMachineId: 'destroyed-machine',
+      lastStartedAt: Date.now() - 60000,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue(
+      fakeMachine({ id: 'destroyed-machine', state: 'destroyed' })
+    );
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({
+      id: 'fresh-machine',
+      region: 'iad',
+    });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    const result = await instance.start('user-1');
+
+    expect(result.started).toBe(true);
+    expect(flyClient.createMachine).toHaveBeenCalledTimes(1);
+    expect(storage._store.get('flyMachineId')).toBe('fresh-machine');
+    expect(storage._store.get('status')).toBe('running');
+  });
+});

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -210,7 +210,14 @@ export async function startExistingMachine(
       console.log('[DO] Machine destroyed, creating new one');
       state.flyMachineId = null;
       await ctx.storage.put(storageUpdate({ flyMachineId: null }));
-      await createNewMachine(flyConfig, ctx, state, initialMachineConfig, minSecretsVersion, envFlyRegion);
+      await createNewMachine(
+        flyConfig,
+        ctx,
+        state,
+        initialMachineConfig,
+        minSecretsVersion,
+        envFlyRegion
+      );
       return;
     }
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -203,6 +203,17 @@ export async function startExistingMachine(
       machineConfig = { ...machineConfig, guest: guestFromSize(state.machineSize) };
     }
 
+    // destroyed machines are gone — treat like a 404 and create a fresh one.
+    // This happens when a Fly machine was force-deleted (e.g. admin destroy)
+    // but the API briefly returns the machine with state='destroyed' before 404.
+    if (machine.state === 'destroyed') {
+      console.log('[DO] Machine destroyed, creating new one');
+      state.flyMachineId = null;
+      await ctx.storage.put(storageUpdate({ flyMachineId: null }));
+      await createNewMachine(flyConfig, ctx, state, initialMachineConfig, minSecretsVersion, envFlyRegion);
+      return;
+    }
+
     // failed machines are restartable via updateMachine (Fly re-launches on the next available host)
     if (machine.state === 'stopped' || machine.state === 'created' || machine.state === 'failed') {
       await fly.updateMachine(flyConfig, state.flyMachineId, machineConfig, { minSecretsVersion });

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -207,7 +207,6 @@ export async function startExistingMachine(
     // This happens when a Fly machine was force-deleted (e.g. admin destroy)
     // but the API briefly returns the machine with state='destroyed' before 404.
     if (machine.state === 'destroyed') {
-      console.log('[DO] Machine destroyed, creating new one');
       state.flyMachineId = null;
       await ctx.storage.put(storageUpdate({ flyMachineId: null }));
       await createNewMachine(
@@ -218,6 +217,7 @@ export async function startExistingMachine(
         minSecretsVersion,
         envFlyRegion
       );
+      console.log('[DO] Machine was destroyed, created new one');
       return;
     }
 

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1002,7 +1002,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           await this.scheduleAlarm();
           return { started: false };
         }
-        console.log('[DO] Status is running but machine state is:', machine.state, '-- restarting');
+        // Machine was force-deleted — clear stale ID so we take the createNewMachine path below.
+        if (machine.state === 'destroyed') {
+          console.log('[DO] Machine destroyed, clearing stale ID');
+          this.s.flyMachineId = null;
+          await this.persist({ flyMachineId: null });
+        } else {
+          console.log('[DO] Status is running but machine state is:', machine.state, '-- restarting');
+        }
       } catch (err) {
         console.log('[DO] Failed to get machine state, will recreate:', err);
       }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1002,7 +1002,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           await this.scheduleAlarm();
           return { started: false };
         }
-        // Machine was force-deleted — clear stale ID so we take the createNewMachine path below.
+        // Machine was force-deleted — clear stale ID so we take the createNewMachine path immediately.
         if (machine.state === 'destroyed') {
           console.log('[DO] Machine destroyed, clearing stale ID');
           this.s.flyMachineId = null;

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1008,7 +1008,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           this.s.flyMachineId = null;
           await this.persist({ flyMachineId: null });
         } else {
-          console.log('[DO] Status is running but machine state is:', machine.state, '-- restarting');
+          console.log(
+            '[DO] Status is running but machine state is:',
+            machine.state,
+            '-- restarting'
+          );
         }
       } catch (err) {
         console.log('[DO] Failed to get machine state, will recreate:', err);


### PR DESCRIPTION
## Summary

#1550 added a destroy machine button. If the user tries to start a destroyed machine again too quickly from the admin dashboard, it will fail until the 'destroyed' state clears and the machine 404s. This change allows a machine to instantly be created after destroy.

- After admin force-deletes a Fly machine via "Destroy Machine", the Fly API briefly returns the machine with `state: 'destroyed'` before switching to 404
- `start()` and `startExistingMachine()` didn't handle this state — fell through to `waitForState('started')` which timed out on the dead machine, leaving the DO with a stale `flyMachineId`
- The second "Start Machine" click worked because by then the API returned 404, which was already handled
- Now both `_startInner()` and `startExistingMachine()` treat `'destroyed'` the same as 404: clear `flyMachineId` and create a fresh machine

## Test plan

- [x] Existing 303 tests pass
- [x] Added 2 new tests covering both code paths (running-check in `_startInner` and `startExistingMachine` fallback)
- [ ] Manual: admin force-delete a machine, then click "Start Machine" — should succeed on the first click