### PR TITLE
feat(kilo-app): add CI workflow

### DIFF
--- a/.github/workflows/kilo-app-ci.yml
+++ b/.github/workflows/kilo-app-ci.yml
@@ -6,13 +6,17 @@ on:
     paths:
       - 'kilo-app/**'
       - 'packages/trpc/**'
+      - 'src/routers/**'
       - 'pnpm-lock.yaml'
+      - '.github/workflows/kilo-app-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'kilo-app/**'
       - 'packages/trpc/**'
+      - 'src/routers/**'
       - 'pnpm-lock.yaml'
+      - '.github/workflows/kilo-app-ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -72,6 +76,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build trpc types
+        run: pnpm --filter @kilocode/trpc run build
 
       - name: Lint
         run: pnpm --filter kilo-app run lint

--- a/.github/workflows/kilo-app-ci.yml
+++ b/.github/workflows/kilo-app-ci.yml
@@ -1,0 +1,131 @@
+name: kilo-app CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'kilo-app/**'
+      - 'packages/trpc/**'
+      - 'pnpm-lock.yaml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'kilo-app/**'
+      - 'packages/trpc/**'
+      - 'pnpm-lock.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  typecheck:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: useblacksmith/checkout@v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build trpc types
+        run: pnpm --filter @kilocode/trpc run build
+
+      - name: Typecheck
+        run: pnpm --filter kilo-app run typecheck
+
+  lint:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: useblacksmith/checkout@v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm --filter kilo-app run lint
+
+  format-check:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: useblacksmith/checkout@v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Format check
+        run: |
+          pnpm --filter kilo-app run format:check || {
+            echo "::error::oxfmt formatting check failed. Run 'cd kilo-app && pnpm format' locally and commit the changes."
+            exit 1
+          }
+
+  check-unused:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: useblacksmith/checkout@v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check unused exports
+        run: pnpm --filter kilo-app run check:unused


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/kilo-app-ci.yml` with four parallel quality gate jobs: typecheck (tsgo), lint (oxlint), format-check (oxfmt), and check-unused (knip)
- Triggers on push/PR to main when `kilo-app/**`, `packages/trpc/**`, or `pnpm-lock.yaml` change
- Follows existing CI conventions (Blacksmith runners, pnpm cache, etc.)

## Test plan
- [ ] Open a test PR touching a file in `kilo-app/src/` and verify all four jobs appear and pass
- [ ] Verify the workflow does NOT trigger on changes outside the path filter