### PR TITLE
feat(kilo-app): add daily release pipeline

### DIFF
--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -1,0 +1,84 @@
+name: kilo-app Release
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  check-changes:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - uses: useblacksmith/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes since last release
+        id: check
+        run: |
+          # Find the latest kilo-app release tag
+          LAST_TAG=$(git tag --list 'kilo-app-release/*' --sort=-creatordate | head -n 1)
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous release tag found — first build"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Last release tag: $LAST_TAG"
+
+          # Check for changes in kilo-app or trpc since that tag
+          CHANGES=$(git diff --name-only "$LAST_TAG"..HEAD -- kilo-app/ packages/trpc/)
+
+          if [ -z "$CHANGES" ]; then
+            echo "No changes since $LAST_TAG — skipping build"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected since $LAST_TAG:"
+            echo "$CHANGES"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-submit:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_build == 'true'
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: useblacksmith/checkout@v1
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install EAS CLI
+        run: pnpm install --global eas-cli
+
+      - name: Build and submit
+        working-directory: kilo-app
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: eas build --profile production --platform all --submit --non-interactive
+
+      - name: Tag release
+        run: |
+          TAG="kilo-app-release/$(date -u +%Y-%m-%d)-$(git rev-parse --short=7 HEAD)"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: kilo-app-release
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -33,7 +37,7 @@ jobs:
           echo "Last release tag: $LAST_TAG"
 
           # Check for changes in kilo-app or trpc since that tag
-          CHANGES=$(git diff --name-only "$LAST_TAG"..HEAD -- kilo-app/ packages/trpc/)
+          CHANGES=$(git diff --name-only "$LAST_TAG"..HEAD -- kilo-app/ packages/trpc/ pnpm-lock.yaml)
 
           if [ -z "$CHANGES" ]; then
             echo "No changes since $LAST_TAG — skipping build"
@@ -48,6 +52,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.should_build == 'true'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 60
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -69,7 +74,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install EAS CLI
-        run: pnpm install --global eas-cli
+        run: pnpm install --global eas-cli@latest
 
       - name: Build and submit
         working-directory: kilo-app

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: kilo-app-release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -50,7 +50,7 @@ jobs:
 
   build-and-submit:
     needs: check-changes
-    if: needs.check-changes.outputs.should_build == 'true'
+    if: needs.check-changes.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/kilo-app-release.yml` — daily scheduled (6am UTC) + manual trigger
- Detects changes since last `kilo-app-release/*` tag in `kilo-app/`, `packages/trpc/`, and `pnpm-lock.yaml`
- Runs `eas build --profile production --platform all --submit` for both iOS and Android
- Tags the release commit for future change detection
- Includes concurrency guard and 60-minute timeout

## Prerequisites
- [ ] Add `EXPO_TOKEN` repo secret (see Expo access tokens page)

## Test plan
- [ ] After adding `EXPO_TOKEN`, trigger manually via `gh workflow run kilo-app-release.yml`
- [ ] Verify builds appear in EAS dashboard and release tag is created