### PR TITLE
feat(cloud-agent): improve topbar, mobile UX, and session management

### DIFF
--- a/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -51,7 +51,12 @@ import {
   type IngestDOContext,
 } from '../websocket/ingest.js';
 import type { StoredEvent } from '../websocket/types.js';
-import type { WrapperCommand, PreparingStep, CloudStatusData } from '../shared/protocol.js';
+import type {
+  WrapperCommand,
+  PreparingStep,
+  PreparingEventData,
+  CloudStatusData,
+} from '../shared/protocol.js';
 import { STALE_THRESHOLD_MS, SANDBOX_SLEEP_AFTER_SECONDS } from '../core/lease.js';
 import { ExecutionOrchestrator, type OrchestratorDeps } from '../execution/orchestrator.js';
 import type {
@@ -881,6 +886,9 @@ export class CloudAgentSession extends DurableObject {
     model: string;
     variant?: string;
     kiloSessionId?: string;
+    githubRepo?: string;
+    gitUrl?: string;
+    platform?: 'github' | 'gitlab';
   }): Promise<OperationResult> {
     await this.requireSessionId(input.sessionId as SessionId);
     const existing = await this.ctx.storage.get<CloudAgentSessionState>('metadata');
@@ -899,6 +907,9 @@ export class CloudAgentSession extends DurableObject {
       model: input.model,
       variant: input.variant,
       kiloSessionId: input.kiloSessionId,
+      githubRepo: input.githubRepo,
+      gitUrl: input.gitUrl,
+      platform: input.platform,
       version: now,
       timestamp: now,
       // NOTE: preparedAt is NOT set — this is the key difference from prepare()
@@ -945,14 +956,18 @@ export class CloudAgentSession extends DurableObject {
     const prepExecutionId: EventSourceId = `prep_${input.sessionId}`;
     const env = this.env as unknown as WorkerEnv;
 
-    const emitProgress = (step: PreparingStep, message: string) => {
+    const emitProgress = (
+      step: PreparingStep,
+      message: string,
+      extra?: Omit<PreparingEventData, 'step' | 'message'>
+    ) => {
       const now = Date.now();
       // Backward-compatible preparing event
       this.broadcastVolatileEvent({
         executionId: prepExecutionId,
         sessionId: input.sessionId,
         streamEventType: 'preparing',
-        payload: JSON.stringify({ step, message }),
+        payload: JSON.stringify({ step, message, ...extra }),
         timestamp: now,
       });
       // cloud.status event derived from preparation step
@@ -1079,7 +1094,7 @@ export class CloudAgentSession extends DurableObject {
       }
 
       // 12. Emit ready — session is prepared (and initiated, if autoInitiate)
-      emitProgress('ready', 'Session ready');
+      emitProgress('ready', 'Session ready', { branch: result.branchName });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -248,6 +248,9 @@ const prepareSessionHandler = internalApiProtectedProcedure
           model: input.model,
           variant: input.variant,
           kiloSessionId,
+          githubRepo: input.githubRepo,
+          gitUrl: input.gitUrl,
+          platform: input.platform,
         });
 
         if (!registerResult.success) {

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -107,6 +107,8 @@ export type PreparingStep =
 export type PreparingEventData = {
   step: PreparingStep;
   message: string;
+  /** Branch name, included in the 'ready' step after preparation completes. */
+  branch?: string;
 };
 
 /** Cloud infrastructure status types. */

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -86,8 +86,8 @@ function createMockCtx() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSession(id: string, status = 'busy', title = 'Test') {
-  return { id, status, title };
+function makeSession(id: string, status = 'busy', title = 'Test', parentSessionId?: string) {
+  return parentSessionId ? { id, status, title, parentSessionId } : { id, status, title };
 }
 
 function parseSent(ws: MockWS, callIndex = 0): unknown {
@@ -1224,6 +1224,40 @@ describe('UserConnectionDO', () => {
 
       const result = doInstance.getActiveSessions();
       expect(result).toEqual([]);
+    });
+
+    it('excludes child sessions reported with parentSessionId in heartbeat', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      sendHeartbeat(doInstance, cliWs, [
+        makeSession('root-1', 'busy', 'Root session'),
+        makeSession('child-1', 'busy', 'Child session', 'root-1'),
+      ]);
+
+      const result = doInstance.getActiveSessions();
+      expect(result).toEqual([
+        { id: 'root-1', status: 'busy', title: 'Root session', connectionId: 'cli-1' },
+      ]);
+    });
+
+    it('cleans up child tracking when session disappears from heartbeat', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      // First heartbeat: root + child
+      sendHeartbeat(doInstance, cliWs, [
+        makeSession('root-1', 'busy', 'Root session'),
+        makeSession('child-1', 'busy', 'Child session', 'root-1'),
+      ]);
+
+      // Second heartbeat: only root (child finished)
+      sendHeartbeat(doInstance, cliWs, [makeSession('root-1', 'idle', 'Root session')]);
+
+      const result = doInstance.getActiveSessions();
+      expect(result).toEqual([
+        { id: 'root-1', status: 'idle', title: 'Root session', connectionId: 'cli-1' },
+      ]);
     });
   });
 

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -14,6 +14,7 @@ type HeartbeatSession = {
   title: string;
   gitUrl?: string;
   gitBranch?: string;
+  parentSessionId?: string;
 };
 
 type WSAttachment =
@@ -684,6 +685,7 @@ export class UserConnectionDO extends DurableObject<Env> {
     for (const [connectionId, sessions] of this.connectionSessions) {
       if (!liveConnectionIds.has(connectionId)) continue;
       for (const session of sessions) {
+        if (session.parentSessionId) continue;
         result.push({ ...session, connectionId });
       }
     }

--- a/cloudflare-session-ingest/src/types/user-connection-protocol.test.ts
+++ b/cloudflare-session-ingest/src/types/user-connection-protocol.test.ts
@@ -24,6 +24,33 @@ describe('CLIOutboundMessageSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('parses heartbeat with parentSessionId on sessions', () => {
+    const msg = {
+      type: 'heartbeat',
+      sessions: [
+        { id: 'root-1', status: 'busy', title: 'Root' },
+        { id: 'child-1', status: 'busy', title: 'Child', parentSessionId: 'root-1' },
+      ],
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success && result.data.type === 'heartbeat') {
+      expect(result.data.sessions[1]).toHaveProperty('parentSessionId', 'root-1');
+    }
+  });
+
+  it('parses heartbeat without parentSessionId (backward compat)', () => {
+    const msg = {
+      type: 'heartbeat',
+      sessions: [{ id: 'ses_1', status: 'busy', title: 'Session' }],
+    };
+    const result = CLIOutboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success && result.data.type === 'heartbeat') {
+      expect(result.data.sessions[0]).not.toHaveProperty('parentSessionId');
+    }
+  });
+
   it('rejects heartbeat with null title', () => {
     const msg = {
       type: 'heartbeat',

--- a/cloudflare-session-ingest/src/types/user-connection-protocol.ts
+++ b/cloudflare-session-ingest/src/types/user-connection-protocol.ts
@@ -16,6 +16,7 @@ export const CLIOutboundMessageSchema = z.discriminatedUnion('type', [
         title: z.string(),
         gitUrl: z.string().optional(),
         gitBranch: z.string().optional(),
+        parentSessionId: z.string().optional(),
       })
     ),
   }),

--- a/src/app/(app)/components/AppTopbar.tsx
+++ b/src/app/(app)/components/AppTopbar.tsx
@@ -10,29 +10,25 @@ import {
 } from '@/components/ui/breadcrumb';
 
 export function AppTopbar() {
-  const { title, icon, extras, hidden } = usePageTitle();
-
-  if (hidden) return null;
+  const { title, icon, extras } = usePageTitle();
 
   return (
-    <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b">
-      <div className="float-left flex h-14 aspect-square items-center justify-center">
+    <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b flex items-center">
+      <div className="flex aspect-square h-14 items-center justify-center">
         <SidebarTrigger className="-ml-1" />
       </div>
 
       {title && (
-        <div className="mx-auto h-full max-w-285 px-4 md:px-6">
-          <div className="inline-flex h-full items-center gap-2">
-            {icon}
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbPage>{title}</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
-            {extras}
-          </div>
+        <div className="flex h-full items-center gap-2">
+          {icon}
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbPage>{title}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          {extras}
         </div>
       )}
     </header>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -176,15 +176,12 @@
     @apply border-border outline-ring/50;
     color-scheme: dark;
   }
+  html {
+    scrollbar-gutter: stable;
+  }
   body {
     @apply bg-background text-foreground;
-  }
-
-  /* Desktop only: reserve space for scrollbar to prevent layout shift */
-  @media (min-width: 1024px) {
-    body {
-      scrollbar-gutter: stable;
-    }
+    scrollbar-gutter: stable;
   }
 
   /* Prevent Radix UI Dialog from removing scrollbar and causing layout shift */

--- a/src/components/cloud-agent-next/ChatHeader.tsx
+++ b/src/components/cloud-agent-next/ChatHeader.tsx
@@ -9,14 +9,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { GitBranch, ExternalLink, Menu, MoreHorizontal } from 'lucide-react';
+import { ExternalLink, MoreHorizontal } from 'lucide-react';
 import { SessionInfoDialog } from './SessionInfoDialog';
 import { SessionActionsDialog } from './SessionActionsDialog';
 import { SoundToggleButton } from '@/components/shared/SoundToggleButton';
 import { FeedbackDialog } from './FeedbackDialog';
 import { buildRepoBrowseUrl, detectGitPlatform } from './utils/git-utils';
-import { useSidebarToggle } from './CloudSidebarLayout';
-import { formatShortModelName } from '@/lib/format-model-name';
 
 type ChatHeaderProps = {
   cloudAgentSessionId: string;
@@ -49,7 +47,6 @@ export function ChatHeader({
 }: ChatHeaderProps) {
   const [showInfoDialog, setShowInfoDialog] = useState(false);
   const [showActionsDialog, setShowActionsDialog] = useState(false);
-  const { toggleMobileSidebar } = useSidebarToggle();
 
   const browseUrl = buildRepoBrowseUrl(gitUrl);
   const repoUrl =
@@ -75,81 +72,35 @@ export function ChatHeader({
         sessionTitle={sessionTitle}
         repository={repository}
       />
-      <div className="bg-background w-full border-b px-3 py-2">
-        <div className="flex items-center gap-2 overflow-hidden">
-          {/* Mobile hamburger */}
-          <Button
-            size="icon"
-            variant="ghost"
-            onClick={toggleMobileSidebar}
-            className="h-8 w-8 shrink-0 lg:hidden"
-            aria-label="Open menu"
-          >
-            <Menu className="h-4 w-4" />
-          </Button>
-
-          {/* Left: repo, branch, model, cost */}
-          <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm">
-            {repository && (
-              <>
-                <GitBranch className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                <span className="truncate font-medium">{repository}</span>
-              </>
+      <div className="flex items-center gap-1">
+        {onToggleSound && (
+          <SoundToggleButton enabled={soundEnabled} onToggle={onToggleSound} size="sm" />
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="icon" variant="ghost" className="h-8 w-8" aria-label="More options">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => setShowActionsDialog(true)}>
+              Share or Fork
+            </DropdownMenuItem>
+            {repoUrl && (
+              <DropdownMenuItem asChild>
+                <a href={repoUrl} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  Open in GitHub
+                </a>
+              </DropdownMenuItem>
             )}
-            {branch && (
-              <>
-                <span className="text-muted-foreground">·</span>
-                <span className="text-muted-foreground truncate">{branch}</span>
-              </>
-            )}
-            {model && model !== 'Unknown' && (
-              <>
-                <span className="text-muted-foreground">·</span>
-                <span className="text-muted-foreground hidden shrink-0 sm:inline">
-                  {modelDisplayName ?? formatShortModelName(model)}
-                </span>
-              </>
-            )}
-            {totalCost > 0 && (
-              <>
-                <span className="text-muted-foreground">·</span>
-                <span className="text-muted-foreground shrink-0">${totalCost.toFixed(4)}</span>
-              </>
-            )}
-          </div>
-
-          {/* Right: sound toggle + overflow menu */}
-          <div className="flex shrink-0 items-center gap-1">
-            {onToggleSound && (
-              <SoundToggleButton enabled={soundEnabled} onToggle={onToggleSound} size="sm" />
-            )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button size="icon" variant="ghost" className="h-8 w-8" aria-label="More options">
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setShowActionsDialog(true)}>
-                  Share or Fork
-                </DropdownMenuItem>
-                {repoUrl && (
-                  <DropdownMenuItem asChild>
-                    <a href={repoUrl} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      Open in GitHub
-                    </a>
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => setShowInfoDialog(true)}>
-                  Session Info
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <FeedbackDialog organizationId={organizationId} kiloSessionId={kiloSessionId} />
-          </div>
-        </div>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => setShowInfoDialog(true)}>
+              Session Info
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <FeedbackDialog organizationId={organizationId} kiloSessionId={kiloSessionId} />
       </div>
     </>
   );

--- a/src/components/cloud-agent-next/ChatInput.tsx
+++ b/src/components/cloud-agent-next/ChatInput.tsx
@@ -12,6 +12,7 @@ import { BrowseCommandsDialog } from './BrowseCommandsDialog';
 import { ModeCombobox, NEXT_MODE_OPTIONS } from '@/components/shared/ModeCombobox';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { VariantCombobox } from '@/components/shared/VariantCombobox';
+import { MobileToolbarPopover } from './MobileToolbarPopover';
 import type { AgentMode } from './types';
 
 type ChatInputProps = {
@@ -239,7 +240,7 @@ export function ChatInput({
             />
           </PopoverAnchor>
           <PopoverContent
-            className="w-[var(--radix-popover-trigger-width)] min-w-[300px] p-0"
+            className="w-[var(--radix-popover-trigger-width)] min-w-[min(300px,calc(100vw-2rem))] p-0"
             side="top"
             align="start"
             sideOffset={4}
@@ -280,35 +281,59 @@ export function ChatInput({
         </Popover>
 
         {/* Toolbar below textarea */}
-        <div className="flex items-center gap-2 px-3 py-1.5">
+        <div className="flex min-w-0 items-center gap-2 overflow-hidden px-3 py-1.5">
           {hasToolbar && (
             <>
-              <ModeCombobox
-                value={mode}
-                onValueChange={onModeChange}
-                options={NEXT_MODE_OPTIONS}
-                variant="compact"
+              {/* Mobile: single trigger that opens Mode + Model + Variant */}
+              <MobileToolbarPopover
+                mode={mode}
+                onModeChange={onModeChange}
+                model={model}
+                modelOptions={modelOptions}
+                onModelChange={onModelChange}
+                isLoadingModels={isLoadingModels}
+                variant={variant}
+                availableVariants={availableVariants}
+                onVariantChange={onVariantChange}
                 disabled={disabled || isStreaming}
+                className="md:hidden"
               />
-              <ModelCombobox
-                models={modelOptions}
-                value={model}
-                onValueChange={onModelChange}
-                variant="compact"
-                isLoading={isLoadingModels}
-                disabled={disabled || isStreaming}
-              />
-              {availableVariants.length > 0 && onVariantChange && (
-                <VariantCombobox
-                  variants={availableVariants}
-                  value={variant}
-                  onValueChange={onVariantChange}
+              {/* Desktop: individual pickers */}
+              <div className="hidden md:contents">
+                <ModeCombobox
+                  value={mode}
+                  onValueChange={onModeChange}
+                  options={NEXT_MODE_OPTIONS}
+                  variant="compact"
                   disabled={disabled || isStreaming}
+                  className="min-w-0"
                 />
-              )}
+                <ModelCombobox
+                  models={modelOptions}
+                  value={model}
+                  onValueChange={onModelChange}
+                  variant="compact"
+                  isLoading={isLoadingModels}
+                  disabled={disabled || isStreaming}
+                  className="min-w-0"
+                />
+                {availableVariants.length > 0 && onVariantChange && (
+                  <VariantCombobox
+                    variants={availableVariants}
+                    value={variant}
+                    onValueChange={onVariantChange}
+                    disabled={disabled || isStreaming}
+                    className="min-w-0"
+                  />
+                )}
+              </div>
             </>
           )}
-          {slashCommands.length > 0 && <BrowseCommandsDialog />}
+          {slashCommands.length > 0 && (
+            <div className="hidden xl:block">
+              <BrowseCommandsDialog />
+            </div>
+          )}
           <div className="flex-1" />
           {isStreaming ? (
             <UIButton

--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -5,10 +5,11 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
-import { ArrowDown } from 'lucide-react';
+import { ArrowDown, GitBranch } from 'lucide-react';
 
 import type { KiloSessionId } from '@/lib/cloud-agent-sdk';
 import { useManager } from './CloudAgentProvider';
+import { MobileSidebarToggle } from './MobileSidebarToggle';
 import { ChatHeader } from './ChatHeader';
 import { ChatInput } from './ChatInput';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
@@ -24,6 +25,7 @@ import { useOrganizationModels } from './hooks/useOrganizationModels';
 import { useSlashCommandSets } from '@/hooks/useSlashCommandSets';
 import { useCelebrationSound } from '@/hooks/useCelebrationSound';
 
+import { SetPageTitle } from '@/components/SetPageTitle';
 import { formatShortModelDisplayName } from '@/lib/format-model-name';
 import type { AgentMode } from './types';
 import type { StoredMessage } from '@/lib/cloud-agent-sdk';
@@ -90,7 +92,6 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
-
   // URL-driven session switching
   const sessionIdFromParams = searchParams?.get('sessionId');
   useEffect(() => {
@@ -143,27 +144,60 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const chatUI = useAtomValue(manager.atoms.chatUI);
   const setChatUI = useSetAtom(manager.atoms.chatUI);
 
+  // Flag to distinguish programmatic scrolls from user scrolls.
+  // Without this, auto-scroll's scrollTo fires handleScroll which re-enables
+  // shouldAutoScroll, making it impossible for the user to scroll away during streaming.
+  const isAutoScrollingRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
+
+  const autoScrollFrameRef = useRef(0);
+
   useEffect(() => {
     if (!chatUI.shouldAutoScroll) return;
     const el = scrollContainerRef.current;
     if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+    // Coalesce rapid streaming updates into one scroll per animation frame
+    cancelAnimationFrame(autoScrollFrameRef.current);
+    autoScrollFrameRef.current = requestAnimationFrame(() => {
+      isAutoScrollingRef.current = true;
+      el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+      requestAnimationFrame(() => {
+        isAutoScrollingRef.current = false;
+      });
+    });
+    return () => cancelAnimationFrame(autoScrollFrameRef.current);
   }, [dynamicMessages, chatUI.shouldAutoScroll]);
 
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const isNearBottom = distanceFromBottom < 100;
-    setShowScrollButton(!isNearBottom);
-    setChatUI({ shouldAutoScroll: isNearBottom });
+    setShowScrollButton(distanceFromBottom > 20);
+
+    if (isAutoScrollingRef.current) {
+      lastScrollTopRef.current = el.scrollTop;
+      return;
+    }
+
+    const scrolledUp = el.scrollTop < lastScrollTopRef.current;
+    lastScrollTopRef.current = el.scrollTop;
+
+    if (scrolledUp) {
+      setChatUI({ shouldAutoScroll: false });
+    } else if (distanceFromBottom < 100) {
+      setChatUI({ shouldAutoScroll: true });
+    }
   }, [setChatUI]);
 
   const scrollToBottom = useCallback(() => {
     setChatUI({ shouldAutoScroll: true });
     const el = scrollContainerRef.current;
     if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    isAutoScrollingRef.current = true;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+    requestAnimationFrame(() => {
+      isAutoScrollingRef.current = false;
+    });
   }, [setChatUI]);
 
   // -- Handlers -------------------------------------------------------------
@@ -273,26 +307,39 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
         respondToPermission={handleRespondToPermission}
       >
         <div className="flex h-full w-full flex-col overflow-hidden">
+          <SetPageTitle
+            title={fetchedSessionData?.title || sessionConfig?.repository || 'Cloud Agent'}
+          >
+            {totalCost > 0 && (
+              <span className="text-muted-foreground text-sm">${totalCost.toFixed(4)}</span>
+            )}
+          </SetPageTitle>
           {showChatInterface ? (
             <>
-              <ChatHeader
-                cloudAgentSessionId={sessionId ?? 'Starting session…'}
-                kiloSessionId={sessionIdFromParams ?? undefined}
-                organizationId={organizationId}
-                repository={sessionConfig?.repository ?? ''}
-                model={sessionConfig?.model}
-                modelDisplayName={modelDisplayName}
-                totalCost={totalCost}
-                soundEnabled={soundEnabled}
-                onToggleSound={handleToggleSound}
-              />
-
               {showLoadingIndicator && <div className="bg-primary h-0.5 w-full animate-pulse" />}
 
               <div className="relative min-h-0 flex-1">
+                {/* Mobile sidebar toggle — floating top-left */}
+                <MobileSidebarToggle />
+
+                {/* Session action buttons — floating top-right */}
+                <div className="absolute right-3 top-2 z-10">
+                  <ChatHeader
+                    cloudAgentSessionId={sessionId ?? 'Starting session…'}
+                    kiloSessionId={sessionIdFromParams ?? undefined}
+                    organizationId={organizationId}
+                    repository={sessionConfig?.repository ?? ''}
+                    model={sessionConfig?.model}
+                    modelDisplayName={modelDisplayName}
+                    totalCost={totalCost}
+                    soundEnabled={soundEnabled}
+                    onToggleSound={handleToggleSound}
+                  />
+                </div>
+
                 <div
                   ref={scrollContainerRef}
-                  className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] py-2 transition-opacity duration-150 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
+                  className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-12 transition-opacity duration-150 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
                   onScroll={handleScroll}
                 >
                   <StaticMessages messages={staticMessages} getChildMessages={getChildMessages} />
@@ -344,6 +391,18 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                     </div>
                   )}
                   <div className={activeQuestion || activePermission ? 'hidden' : ''}>
+                    {sessionConfig?.repository && (
+                      <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-1 text-xs">
+                        <GitBranch className="h-3 w-3 shrink-0" />
+                        <span className="truncate">{sessionConfig.repository}</span>
+                        {fetchedSessionData?.gitBranch && (
+                          <>
+                            <span>·</span>
+                            <span className="truncate">{fetchedSessionData.gitBranch}</span>
+                          </>
+                        )}
+                      </div>
+                    )}
                     <ChatInput
                       onSend={handleSendMessage}
                       onStop={handleStopExecution}
@@ -368,7 +427,8 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
               )}
             </>
           ) : (
-            <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2">
+            <div className="text-muted-foreground relative flex h-full flex-col items-center justify-center gap-2">
+              <MobileSidebarToggle />
               <p className="text-sm">No active session</p>
               <p className="text-xs">Select a session from the sidebar or create a new one</p>
             </div>

--- a/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -1,14 +1,6 @@
 'use client';
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
@@ -21,7 +13,6 @@ import { useActiveSessions } from './hooks/useActiveSessions';
 import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { deleteSessionFromStoreAtom } from './store/db-session-atoms';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { usePageTitle } from '@/contexts/PageTitleContext';
 
 // Context for children to toggle the mobile sidebar sheet
 type SidebarLayoutContextValue = {
@@ -50,13 +41,6 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
   const [platformFilter, setPlatformFilter] = useState<string | undefined>('cloud-agent');
   const [projectFilter, setProjectFilter] = useState<string | undefined>(undefined);
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
-
-  // Hide the app-level topbar — cloud agent pages have their own ChatHeader
-  const { setHidden } = usePageTitle();
-  useEffect(() => {
-    setHidden(true);
-    return () => setHidden(false);
-  }, [setHidden]);
 
   const { sessions, refetchSessions, renameSessionLocally } = useSidebarSessions({
     organizationId: organizationId ?? null,
@@ -157,7 +141,7 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
     <SidebarLayoutContext.Provider
       value={{ toggleMobileSidebar: () => setMobileSheetOpen(prev => !prev) }}
     >
-      <div className="flex h-dvh w-full overflow-hidden">
+      <div className="flex h-[calc(100dvh-3.5rem)] w-full overflow-hidden">
         {/* Mobile Sheet */}
         <Sheet open={mobileSheetOpen} onOpenChange={setMobileSheetOpen}>
           <SheetContent side="left" className="w-80 p-0 lg:hidden">
@@ -204,7 +188,7 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
         </div>
 
         {/* Main Content */}
-        <div className="flex-1 overflow-hidden">{children}</div>
+        <div className="h-full flex-1 overflow-hidden">{children}</div>
       </div>
     </SidebarLayoutContext.Provider>
   );

--- a/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
+import { startOfDay, subDays } from 'date-fns';
 import { extractRepoFromGitUrl } from './utils/git-utils';
 import { ChatSidebar } from './ChatSidebar';
 import { useSidebarSessions } from './hooks/useSidebarSessions';
@@ -41,6 +42,7 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
   const [platformFilter, setPlatformFilter] = useState<string | undefined>('cloud-agent');
   const [projectFilter, setProjectFilter] = useState<string | undefined>(undefined);
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
+  const repoUpdatedSince = useMemo(() => startOfDay(subDays(new Date(), 30)).toISOString(), []);
 
   const { sessions, refetchSessions, renameSessionLocally } = useSidebarSessions({
     organizationId: organizationId ?? null,
@@ -57,7 +59,7 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
   const { data: recentReposData } = useQuery({
     ...trpc.unifiedSessions.recentRepositories.queryOptions({
       organizationId,
-      recentDays: 30,
+      updatedSince: repoUpdatedSince,
     }),
     staleTime: 60_000,
   });

--- a/src/components/cloud-agent-next/MobileSidebarToggle.tsx
+++ b/src/components/cloud-agent-next/MobileSidebarToggle.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useSidebarToggle } from './CloudSidebarLayout';
+
+export function MobileSidebarToggle() {
+  const { toggleMobileSidebar } = useSidebarToggle();
+  return (
+    <button
+      type="button"
+      onClick={toggleMobileSidebar}
+      className="text-muted-foreground hover:text-foreground border-border hover:bg-accent absolute left-3 top-3 z-10 cursor-pointer rounded-md border px-2.5 py-1 text-sm transition-colors lg:hidden"
+    >
+      Session list
+    </button>
+  );
+}

--- a/src/components/cloud-agent-next/MobileToolbarPopover.tsx
+++ b/src/components/cloud-agent-next/MobileToolbarPopover.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ChevronsUpDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ModeCombobox, NEXT_MODE_OPTIONS } from '@/components/shared/ModeCombobox';
+import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import { VariantCombobox } from '@/components/shared/VariantCombobox';
+import { formatShortModelDisplayName } from '@/lib/format-model-name';
+import type { AgentMode } from './types';
+
+type MobileToolbarPopoverProps = {
+  mode?: AgentMode;
+  onModeChange?: (mode: AgentMode) => void;
+  model?: string;
+  modelOptions: ModelOption[];
+  onModelChange?: (model: string) => void;
+  isLoadingModels?: boolean;
+  variant?: string;
+  availableVariants?: string[];
+  onVariantChange?: (variant: string) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function MobileToolbarPopover({
+  mode,
+  onModeChange,
+  model,
+  modelOptions,
+  onModelChange,
+  isLoadingModels,
+  variant,
+  availableVariants = [],
+  onVariantChange,
+  disabled,
+  className,
+}: MobileToolbarPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  const selectedModel = modelOptions.find(m => m.id === model);
+  const displayName = selectedModel
+    ? formatShortModelDisplayName(selectedModel.name)
+    : 'Select model';
+
+  return (
+    <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className={cn('h-9 min-w-0 justify-between gap-1.5', className)}
+        >
+          <span className="truncate">{displayName}</span>
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[min(20rem,calc(100vw-2rem))] space-y-3 p-3"
+        align="start"
+        side="top"
+      >
+        {onModeChange && (
+          <ModeCombobox
+            value={mode}
+            onValueChange={onModeChange}
+            options={NEXT_MODE_OPTIONS}
+            label="Mode"
+          />
+        )}
+        {onModelChange && (
+          <ModelCombobox
+            models={modelOptions}
+            value={model}
+            onValueChange={onModelChange}
+            isLoading={isLoadingModels}
+            label="Model"
+          />
+        )}
+        {availableVariants.length > 0 && onVariantChange && (
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Thinking effort</label>
+            <VariantCombobox
+              variants={availableVariants}
+              value={variant}
+              onValueChange={onVariantChange}
+              className="w-full"
+            />
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -16,6 +16,7 @@ import {
   Unlock,
   Check,
 } from 'lucide-react';
+import { startOfDay, subDays } from 'date-fns';
 import { useTRPC, useRawTRPCClient } from '@/lib/trpc/utils';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Badge } from '@/components/ui/badge';
@@ -296,9 +297,11 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
         })
   );
 
+  const repoUpdatedSince = useMemo(() => startOfDay(subDays(new Date(), 5)).toISOString(), []);
   const { data: recentRepoData } = useQuery(
     trpc.unifiedSessions.recentRepositories.queryOptions({
       organizationId: organizationId ?? null,
+      updatedSince: repoUpdatedSince,
     })
   );
 

--- a/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -17,6 +17,10 @@ import {
   Check,
 } from 'lucide-react';
 import { useTRPC, useRawTRPCClient } from '@/lib/trpc/utils';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { Badge } from '@/components/ui/badge';
+import { MobileSidebarToggle } from './MobileSidebarToggle';
+import { MobileToolbarPopover } from './MobileToolbarPopover';
 
 import { useProfile, useProfiles, useCombinedProfiles } from '@/hooks/useCloudAgentProfiles';
 import { useRefreshRepositories } from '@/hooks/useRefreshRepositories';
@@ -127,6 +131,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   const [model, setModel] = useState<string>('');
   const [variant, setVariant] = useState<string | undefined>(undefined);
   const [isModelUserSelected, setIsModelUserSelected] = useState(false);
+  const [isRepoUserSelected, setIsRepoUserSelected] = useState(false);
   const [isPreparing, setIsPreparing] = useState(false);
 
   // ---------------------------------------------------------------------------
@@ -340,8 +345,9 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   const hasMultiplePlatforms = githubRepositories.length > 0 && gitlabRepositories.length > 0;
 
   const handleRepoSelect = useCallback(
-    (repoFullName: string) => {
+    (repoFullName: string, userInitiated = true) => {
       setSelectedRepo(repoFullName);
+      if (userInitiated) setIsRepoUserSelected(true);
       const repo = unifiedRepositories.find(r => r.fullName === repoFullName);
       if (repo?.platform) {
         setSelectedPlatform(repo.platform);
@@ -351,10 +357,20 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   );
 
   // ---------------------------------------------------------------------------
+  // Auto-select repo from last session (most recently used)
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (selectedRepo || isRepoUserSelected || recentRepos.length === 0) return;
+    const firstRecent = recentRepos[0];
+    if (!firstRecent) return;
+    handleRepoSelect(firstRecent.fullName, false);
+  }, [recentRepos, selectedRepo, isRepoUserSelected, handleRepoSelect]);
+
+  // ---------------------------------------------------------------------------
   // Auto-select repo from pasted GitHub/GitLab URLs
   // ---------------------------------------------------------------------------
   useEffect(() => {
-    if (selectedRepo) return;
+    if (isRepoUserSelected) return;
 
     for (const url of findAllGitPlatformUrls(prompt)) {
       const repoName = extractRepoFromGitUrl(url);
@@ -372,7 +388,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
       }
       break;
     }
-  }, [prompt, selectedRepo, unifiedRepositories]);
+  }, [prompt, isRepoUserSelected, unifiedRepositories]);
 
   const repoError = githubRepoError || gitlabRepoError;
 
@@ -485,14 +501,12 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   // Submit
   // ---------------------------------------------------------------------------
   const isFormValid =
-    prompt.trim().length > 0 &&
-    selectedRepo.length > 0 &&
-    model.length > 0 &&
-    !isPreparing &&
-    !hasInsufficientBalance;
+    prompt.trim().length > 0 && model.length > 0 && !isPreparing && !hasInsufficientBalance;
 
   const handleStartSession = useCallback(async () => {
-    if (!prompt.trim() || !selectedRepo) {
+    if (!prompt.trim()) return;
+    if (!selectedRepo) {
+      toast.error('Please select a repository');
       return;
     }
 
@@ -617,7 +631,11 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
       'Connect a GitHub or GitLab integration to select a repository for the cloud agent.';
 
     return (
-      <div className="flex h-full flex-col items-center justify-end p-4 pb-8">
+      <div className="relative flex h-full flex-col items-center justify-end p-4 pb-8">
+        <SetPageTitle title="Cloud Agent">
+          <Badge variant="new">new</Badge>
+        </SetPageTitle>
+        <MobileSidebarToggle />
         <div className="w-full max-w-2xl rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-6">
           <div className="mb-3 flex items-center gap-2">
             <AlertCircle className="h-5 w-5 text-amber-400" />
@@ -641,7 +659,11 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   // Render
   // ---------------------------------------------------------------------------
   return (
-    <div className="flex h-full flex-col items-center px-4">
+    <div className="relative flex h-full flex-col items-center px-4">
+      <SetPageTitle title="Cloud Agent">
+        <Badge variant="new">new</Badge>
+      </SetPageTitle>
+      <MobileSidebarToggle />
       <div className="flex-1" />
       <div className="w-full max-w-2xl space-y-4">
         {/* Insufficient balance banner */}
@@ -670,39 +692,64 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
             onKeyDown={handleKeyDown}
             disabled={isPreparing}
           />
-          <div className="flex items-center gap-2 px-3 py-1.5">
-            {/* Mode → Model → Variant */}
-            <ModeCombobox<AgentMode>
-              value={mode}
-              onValueChange={setMode}
-              options={NEXT_MODE_OPTIONS}
-              variant="compact"
-              disabled={isPreparing}
-            />
-            <ModelCombobox
-              models={modelOptions}
-              value={model}
-              onValueChange={newModel => {
+          <div className="flex min-w-0 items-center gap-2 px-3 py-1.5">
+            {/* Mobile: single trigger that opens Mode + Model + Variant */}
+            <MobileToolbarPopover
+              mode={mode}
+              onModeChange={setMode}
+              model={model}
+              modelOptions={modelOptions}
+              onModelChange={newModel => {
                 setModel(newModel);
                 setIsModelUserSelected(true);
-                // Reset variant to first available (typically "none") if current is invalid for new model
                 const newVariants = modelOptions.find(m => m.id === newModel)?.variants ?? [];
                 if (!variant || !newVariants.includes(variant)) {
                   setVariant(newVariants[0]);
                 }
               }}
-              isLoading={!modelsData}
-              variant="compact"
+              isLoadingModels={!modelsData}
+              variant={variant}
+              availableVariants={availableVariants}
+              onVariantChange={setVariant}
               disabled={isPreparing}
+              className="md:hidden"
             />
-            {availableVariants.length > 0 && (
-              <VariantCombobox
-                variants={availableVariants}
-                value={variant}
-                onValueChange={setVariant}
+            {/* Desktop: individual pickers */}
+            <div className="hidden md:contents">
+              <ModeCombobox<AgentMode>
+                value={mode}
+                onValueChange={setMode}
+                options={NEXT_MODE_OPTIONS}
+                variant="compact"
                 disabled={isPreparing}
+                className="min-w-0"
               />
-            )}
+              <ModelCombobox
+                models={modelOptions}
+                value={model}
+                onValueChange={newModel => {
+                  setModel(newModel);
+                  setIsModelUserSelected(true);
+                  const newVariants = modelOptions.find(m => m.id === newModel)?.variants ?? [];
+                  if (!variant || !newVariants.includes(variant)) {
+                    setVariant(newVariants[0]);
+                  }
+                }}
+                isLoading={!modelsData}
+                variant="compact"
+                disabled={isPreparing}
+                className="min-w-0"
+              />
+              {availableVariants.length > 0 && (
+                <VariantCombobox
+                  variants={availableVariants}
+                  value={variant}
+                  onValueChange={setVariant}
+                  disabled={isPreparing}
+                  className="min-w-0"
+                />
+              )}
+            </div>
 
             <div className="flex-1" />
 
@@ -728,7 +775,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
               <button
                 type="button"
                 className={cn(
-                  'text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm',
+                  'text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1 text-sm',
                   selectedRepo && 'text-foreground'
                 )}
                 disabled={isPreparing}
@@ -737,7 +784,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
                 <span className="max-w-[16rem] truncate">{selectedRepo || 'Repository'}</span>
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-80 p-0" align="start">
+            <PopoverContent className="w-[min(20rem,calc(100vw-2rem))] p-0" align="start">
               {isLoadingRepos ? (
                 <div className="text-muted-foreground p-4 text-center text-sm">
                   Loading repositories...
@@ -848,7 +895,12 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
                 Settings
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-[28rem] p-0" align="end" side="bottom" sideOffset={8}>
+            <PopoverContent
+              className="w-[min(28rem,calc(100vw-2rem))] p-0"
+              align="end"
+              side="bottom"
+              sideOffset={8}
+            >
               <div className="px-4 py-3">
                 <p className="text-sm font-medium">Advanced settings</p>
               </div>

--- a/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
+++ b/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
@@ -75,7 +75,7 @@ export function useSidebarSessions(options?: UseSidebarSessionsOptions): UseSide
   const isSearchActive = searchQuery.length > 0;
 
   // --- List query (default, non-search) ---
-  const listInput = { limit: 10, organizationId, createdOnPlatform, gitUrl };
+  const listInput = { recentDays: 5, organizationId, createdOnPlatform, gitUrl };
   const listQueryKey = trpc.unifiedSessions.list.queryKey(listInput);
 
   const { data: listData, isLoading: isListLoading } = useQuery({

--- a/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
+++ b/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
@@ -77,7 +77,13 @@ export function useSidebarSessions(options?: UseSidebarSessionsOptions): UseSide
 
   // --- List query (default, non-search) ---
   const updatedSince = useMemo(() => startOfDay(subDays(new Date(), 5)).toISOString(), []);
-  const listInput = { updatedSince, organizationId, createdOnPlatform, gitUrl };
+  const listInput = {
+    updatedSince,
+    orderBy: 'updated_at' as const,
+    organizationId,
+    createdOnPlatform,
+    gitUrl,
+  };
   const listQueryKey = trpc.unifiedSessions.list.queryKey(listInput);
 
   const { data: listData, isLoading: isListLoading } = useQuery({

--- a/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
+++ b/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
@@ -16,6 +16,7 @@ import {
   type DbSession,
   type DbSessionV2,
 } from '../store/db-session-atoms';
+import { startOfDay, subDays } from 'date-fns';
 import { extractRepoFromGitUrl } from '../utils/git-utils';
 import type { StoredSession } from '../types';
 
@@ -75,7 +76,8 @@ export function useSidebarSessions(options?: UseSidebarSessionsOptions): UseSide
   const isSearchActive = searchQuery.length > 0;
 
   // --- List query (default, non-search) ---
-  const listInput = { recentDays: 5, organizationId, createdOnPlatform, gitUrl };
+  const updatedSince = useMemo(() => startOfDay(subDays(new Date(), 5)).toISOString(), []);
+  const listInput = { updatedSince, organizationId, createdOnPlatform, gitUrl };
   const listQueryKey = trpc.unifiedSessions.list.queryKey(listInput);
 
   const { data: listData, isLoading: isListLoading } = useQuery({

--- a/src/components/shared/ModelCombobox.tsx
+++ b/src/components/shared/ModelCombobox.tsx
@@ -198,7 +198,7 @@ export function ModelCombobox({
             <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-96 p-0" align="start">
+        <PopoverContent className="w-[min(24rem,calc(100vw-2rem))] p-0" align="start">
           <Command>
             <CommandInput placeholder={searchPlaceholder} />
             <CommandEmpty>{noResultsText}</CommandEmpty>

--- a/src/components/shared/VariantCombobox.tsx
+++ b/src/components/shared/VariantCombobox.tsx
@@ -49,7 +49,7 @@ export function VariantCombobox({
           className={cn('h-9 justify-between gap-1.5', className)}
         >
           <Brain className="h-3.5 w-3.5 shrink-0 opacity-70" />
-          <span className="truncate">{selectedLabel}</span>
+          <span className="flex-1 truncate text-left">{selectedLabel}</span>
           <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>

--- a/src/contexts/PageTitleContext.tsx
+++ b/src/contexts/PageTitleContext.tsx
@@ -6,11 +6,9 @@ type PageTitleContextValue = {
   title: string;
   icon: ReactNode;
   extras: ReactNode;
-  hidden: boolean;
   setTitle: (title: string) => void;
   setIcon: (icon: ReactNode) => void;
   setExtras: (extras: ReactNode) => void;
-  setHidden: (hidden: boolean) => void;
 };
 
 const PageTitleContext = createContext<PageTitleContextValue | undefined>(undefined);
@@ -19,15 +17,11 @@ export function PageTitleProvider({ children }: { children: ReactNode }) {
   const [title, setTitleState] = useState('');
   const [icon, setIconState] = useState<ReactNode>(null);
   const [extras, setExtrasState] = useState<ReactNode>(null);
-  const [hidden, setHiddenState] = useState(false);
   const setTitle = useCallback((next: string) => setTitleState(next), []);
   const setIcon = useCallback((next: ReactNode) => setIconState(next), []);
   const setExtras = useCallback((next: ReactNode) => setExtrasState(next), []);
-  const setHidden = useCallback((next: boolean) => setHiddenState(next), []);
   return (
-    <PageTitleContext.Provider
-      value={{ title, icon, extras, hidden, setTitle, setIcon, setExtras, setHidden }}
-    >
+    <PageTitleContext.Provider value={{ title, icon, extras, setTitle, setIcon, setExtras }}>
       {children}
     </PageTitleContext.Provider>
   );

--- a/src/lib/cloud-agent-sdk/normalizer.ts
+++ b/src/lib/cloud-agent-sdk/normalizer.ts
@@ -82,7 +82,7 @@ export type ServiceEvent =
       branch?: string;
     }
   | { type: 'warning' }
-  | { type: 'preparing'; step: string; message: string }
+  | { type: 'preparing'; step: string; message: string; branch?: string }
   | { type: 'autocommit_started'; messageId: string; message?: string }
   | {
       type: 'autocommit_completed';
@@ -292,7 +292,12 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
     case 'preparing': {
       const r = preparingDataSchema.safeParse(data);
       if (!r.success) return null;
-      return { type: 'preparing', step: r.data.step, message: r.data.message };
+      return {
+        type: 'preparing',
+        step: r.data.step,
+        message: r.data.message,
+        branch: r.data.branch,
+      };
     }
 
     case 'autocommit_started': {

--- a/src/lib/cloud-agent-sdk/schemas.ts
+++ b/src/lib/cloud-agent-sdk/schemas.ts
@@ -259,6 +259,7 @@ export type WrapperDisconnectedData = z.infer<typeof wrapperDisconnectedDataSche
 export const preparingDataSchema = z.object({
   step: z.string(),
   message: z.string(),
+  branch: z.string().optional(),
 });
 export type PreparingData = z.infer<typeof preparingDataSchema>;
 

--- a/src/lib/cloud-agent-sdk/service-state.ts
+++ b/src/lib/cloud-agent-sdk/service-state.ts
@@ -201,6 +201,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   function processPreparing(event: Extract<ServiceEvent, { type: 'preparing' }>): void {
     if (event.step === 'ready') {
       cloudStatus = { type: 'ready' };
+      if (event.branch) config.onBranchChanged?.(event.branch);
       config.onPreparationReady?.();
     } else if (event.step === 'failed') {
       cloudStatus = { type: 'error', message: event.message };

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -338,6 +338,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(activePermissionAtom, null);
     store.set(failedPromptAtom, null);
     store.set(fetchedSessionDataAtom, null);
+    store.set(chatUIAtom, { shouldAutoScroll: true });
   }
 
   function subscribeToServiceState(

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -500,7 +500,13 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
         const ap = store.get(activePermissionAtom);
         if (ap?.requestId === requestId) store.set(activePermissionAtom, null);
       },
-      onBranchChanged: branch => config.onBranchChanged?.(branch),
+      onBranchChanged: branch => {
+        const currentFetched = store.get(fetchedSessionDataAtom);
+        if (currentFetched) {
+          store.set(fetchedSessionDataAtom, { ...currentFetched, gitBranch: branch });
+        }
+        config.onBranchChanged?.(branch);
+      },
       onError: message => store.set(errorAtom, message),
       onEvent: event => {
         if (event.type === 'message.updated' && event.info.role === 'assistant') {

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -265,9 +265,7 @@ export const unifiedSessionsRouter = createTRPCRouter({
       v1Where.push(sql`${cliSessions.created_on_platform} != 'app-builder'`);
 
       v2Where.push(sql`${cli_sessions_v2.git_url} IS NOT NULL`);
-      v2Where.push(
-        sql`${cli_sessions_v2.updated_at} >= ${updatedSince}`
-      );
+      v2Where.push(sql`${cli_sessions_v2.updated_at} >= ${updatedSince}`);
       v2Where.push(sql`${cli_sessions_v2.created_on_platform} != 'app-builder'`);
 
       const query = sql`

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -39,7 +39,7 @@ const ListSessionsInputSchema = z.object({
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
   gitUrl: z.string().optional(),
-  recentDays: z.number().min(1).max(30).optional(),
+  updatedSince: z.iso.datetime().optional(),
 });
 
 const SearchInputSchema = z.object({
@@ -167,7 +167,7 @@ export const unifiedSessionsRouter = createTRPCRouter({
       organizationId,
       includeSubSessions,
       gitUrl,
-      recentDays,
+      updatedSince,
     } = input;
 
     if (organizationId) {
@@ -197,14 +197,12 @@ export const unifiedSessionsRouter = createTRPCRouter({
       v2Where.push(cursorCondition(cli_sessions_v2));
     }
 
-    if (recentDays) {
-      // Use full-day boundaries: recentDays=1 means "from midnight yesterday"
-      const cutoff = sql`date_trunc('day', NOW()) - make_interval(days => ${recentDays})`;
-      v1Where.push(sql`${cliSessions.updated_at} >= ${cutoff}`);
-      v2Where.push(sql`${cli_sessions_v2.updated_at} >= ${cutoff}`);
+    if (updatedSince) {
+      v1Where.push(sql`${cliSessions.updated_at} >= ${updatedSince}`);
+      v2Where.push(sql`${cli_sessions_v2.updated_at} >= ${updatedSince}`);
     }
 
-    const effectiveLimit = recentDays ? RECENT_DAYS_LIMIT : limit;
+    const effectiveLimit = updatedSince ? RECENT_DAYS_LIMIT : limit;
 
     const query = sql`
         SELECT * FROM (
@@ -243,11 +241,11 @@ export const unifiedSessionsRouter = createTRPCRouter({
     .input(
       z.object({
         organizationId: z.uuid().nullable().optional(),
-        recentDays: z.number().min(1).max(365).optional().default(5),
+        updatedSince: z.iso.datetime(),
       })
     )
     .query(async ({ ctx, input }) => {
-      const { organizationId, recentDays } = input;
+      const { organizationId, updatedSince } = input;
 
       if (organizationId) {
         await ensureOrganizationAccess(ctx, organizationId);
@@ -263,12 +261,12 @@ export const unifiedSessionsRouter = createTRPCRouter({
       const v2Where = buildScopeFragments('cli_sessions_v2', scopeOpts);
 
       v1Where.push(sql`${cliSessions.git_url} IS NOT NULL`);
-      v1Where.push(sql`${cliSessions.updated_at} >= NOW() - make_interval(days => ${recentDays})`);
+      v1Where.push(sql`${cliSessions.updated_at} >= ${updatedSince}`);
       v1Where.push(sql`${cliSessions.created_on_platform} != 'app-builder'`);
 
       v2Where.push(sql`${cli_sessions_v2.git_url} IS NOT NULL`);
       v2Where.push(
-        sql`${cli_sessions_v2.updated_at} >= NOW() - make_interval(days => ${recentDays})`
+        sql`${cli_sessions_v2.updated_at} >= ${updatedSince}`
       );
       v2Where.push(sql`${cli_sessions_v2.created_on_platform} != 'app-builder'`);
 

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -200,8 +200,8 @@ export const unifiedSessionsRouter = createTRPCRouter({
     if (recentDays) {
       // Use full-day boundaries: recentDays=1 means "from midnight yesterday"
       const cutoff = sql`date_trunc('day', NOW()) - make_interval(days => ${recentDays})`;
-      v1Where.push(sql`${cliSessions.created_at} >= ${cutoff}`);
-      v2Where.push(sql`${cli_sessions_v2.created_at} >= ${cutoff}`);
+      v1Where.push(sql`${cliSessions.updated_at} >= ${cutoff}`);
+      v2Where.push(sql`${cli_sessions_v2.updated_at} >= ${cutoff}`);
     }
 
     const effectiveLimit = recentDays ? RECENT_DAYS_LIMIT : limit;

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -8,6 +8,7 @@ import { KNOWN_PLATFORMS } from '@/routers/cli-sessions-router';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 
 const PAGE_SIZE = 10;
+const RECENT_DAYS_LIMIT = 200;
 
 type UnifiedSession = {
   session_id: string;
@@ -38,6 +39,7 @@ const ListSessionsInputSchema = z.object({
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
   gitUrl: z.string().optional(),
+  recentDays: z.number().min(1).max(30).optional(),
 });
 
 const SearchInputSchema = z.object({
@@ -165,6 +167,7 @@ export const unifiedSessionsRouter = createTRPCRouter({
       organizationId,
       includeSubSessions,
       gitUrl,
+      recentDays,
     } = input;
 
     if (organizationId) {
@@ -194,6 +197,15 @@ export const unifiedSessionsRouter = createTRPCRouter({
       v2Where.push(cursorCondition(cli_sessions_v2));
     }
 
+    if (recentDays) {
+      // Use full-day boundaries: recentDays=1 means "from midnight yesterday"
+      const cutoff = sql`date_trunc('day', NOW()) - make_interval(days => ${recentDays})`;
+      v1Where.push(sql`${cliSessions.created_at} >= ${cutoff}`);
+      v2Where.push(sql`${cli_sessions_v2.created_at} >= ${cutoff}`);
+    }
+
+    const effectiveLimit = recentDays ? RECENT_DAYS_LIMIT : limit;
+
     const query = sql`
         SELECT * FROM (
           SELECT ${v1Columns()}
@@ -207,12 +219,12 @@ export const unifiedSessionsRouter = createTRPCRouter({
           WHERE ${joinWithAnd(v2Where)}
         ) unified
         ORDER BY ${orderColumn} DESC
-        LIMIT ${limit + 1}`;
+        LIMIT ${effectiveLimit + 1}`;
 
     const { rows } = await db.execute<UnifiedSession>(query);
 
-    const hasMore = rows.length > limit;
-    const resultSessions = hasMore ? rows.slice(0, limit) : rows;
+    const hasMore = rows.length > effectiveLimit;
+    const resultSessions = hasMore ? rows.slice(0, effectiveLimit) : rows;
 
     let nextCursor: string | null = null;
     if (hasMore && resultSessions.length > 0) {


### PR DESCRIPTION
## Summary

Integrates the cloud agent pages with the shared app topbar, adds mobile-responsive toolbar controls, and improves the new-session UX.

**Topbar integration**: Cloud agent pages now use the shared `AppTopbar` instead of hiding it. The session title (or repo name) and cost display are rendered in the topbar. `ChatHeader` is stripped down to floating action buttons (sound, menu, feedback) positioned top-right.

**Mobile toolbar**: Below the `md` breakpoint, the individual Mode/Model/Variant pickers collapse into a single `MobileToolbarPopover`. Popover widths are clamped to `min(Xrem, calc(100vw - 2rem))` to prevent overflow on small screens. A `MobileSidebarToggle` button replaces the old hamburger menu for opening the session list on mobile.

**New session UX**: The most recent repo is auto-selected. Repo selection is no longer required to start a session (shows an error toast instead). The new-session panel gets the same mobile toolbar treatment.

**Auto-scroll**: Programmatic scrolls are distinguished from user scrolls via `isAutoScrollingRef`. Rapid streaming updates are coalesced with `requestAnimationFrame`. Scrolling up disables auto-scroll; scrolling near bottom re-enables it. Session switches reset scroll state.

**Child session filtering**: Sessions with a `parentSessionId` are excluded from the active sessions list in `UserConnectionDO`. Protocol schema updated with tests.

**CSS**: `scrollbar-gutter: stable` applied globally instead of desktop-only.

## Verification

- [x] Format check passed (pre-push hook)
- [x] Lint passed (pre-push hook)
- [x] Typecheck passed (pre-push hook)

## Visual Changes

<img width="1544" height="1142" alt="Screenshot 2026-03-30 at 17 30 43" src="https://github.com/user-attachments/assets/4f38f358-e97d-427e-9d16-ad06043f133c" />



## Reviewer Notes

- The `PageTitleContext` no longer exposes `hidden`/`setHidden` — cloud agent pages now always show the topbar.
- `ChatHeader` lost most of its content (repo, branch, model, cost) since that info moved to the topbar and inline areas. It now only renders action buttons.
- The mobile breakpoint for toolbar controls is `md` (768px). The sidebar toggle breakpoint is `lg` (1024px).