### PR TITLE
feat(kiloclaw): bump openclaw to 2026.3.23

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -54,7 +54,7 @@ FLY_IMAGE_TAG=latest
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.2.9
+OPENCLAW_VERSION=2026.3.23
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.3.22 \
+RUN npm install -g openclaw@2026.3.23 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.3.13 \
+RUN npm install -g openclaw@2026.3.22 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -328,12 +328,16 @@ const DEFAULT_MCPORTER_CONFIG_PATH = '/root/.openclaw/workspace/config/mcporter.
 /**
  * Write mcporter.json with MCP server definitions derived from environment variables.
  * MCPorter is the middleware layer that lets OpenClaw agents call MCP server tools
- * via `mcporter call <server>.<tool>`. This bypasses openclaw.json's strict schema
- * validation, which does not yet support `mcp.servers` (requires OpenClaw >= 2026.3.14).
+ * via `mcporter call <server>.<tool>`.
  *
- * TODO: When the Dockerfile pins OpenClaw >= 2026.3.14, migrate MCP server config
- * into generateBaseConfig() using `config.mcp.servers` in openclaw.json instead.
- * The mcporter approach can then be removed. See PR #48611 in openclaw/openclaw.
+ * The `config.mcp.servers` schema exists in openclaw.json (since v2026.3.14), but
+ * OpenClaw's embedded Pi MCP runtime only supports StdioClientTransport — it has no
+ * HTTP/SSE transport. Since our MCP servers (AgentCard, Linear) are remote HTTP
+ * endpoints, mcporter must stay until OpenClaw adds HTTP transport support.
+ *
+ * TODO: When OpenClaw's Pi MCP bridge gains HTTP/SSE transport, migrate these
+ * definitions into generateBaseConfig() using `config.mcp.servers` and remove
+ * mcporter. See PR #48611 in openclaw/openclaw.
  */
 export function writeMcporterConfig(
   env: EnvLike,

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -93,16 +93,11 @@ function approveFail(message: string, statusHint: 400 | 500): ApproveResult {
 export const OPENCLAW_BIN = '/usr/local/bin/openclaw';
 
 // Mirrors resolveStateDir() / resolveOAuthDir() in openclaw/src/config/paths.ts
-// Includes legacy CLAWDBOT_STATE_DIR fallback (openclaw paths.ts:65)
 // Note: openclaw's full resolveStateDir() also does filesystem-existence checks for
-// legacy .clawdbot dirs — those are omitted here because the container Dockerfile
-// always creates /root/.openclaw, making the existence check unreachable in practice.
+// legacy dirs — those are omitted here because the container Dockerfile always
+// creates /root/.openclaw, making the existence check unreachable in practice.
 export function resolveOpenClawStateDir(): string {
-  return (
-    process.env.OPENCLAW_STATE_DIR?.trim() ||
-    process.env.CLAWDBOT_STATE_DIR?.trim() ||
-    '/root/.openclaw'
-  );
+  return process.env.OPENCLAW_STATE_DIR?.trim() || '/root/.openclaw';
 }
 
 export function resolveCredentialsDir(): string {
@@ -195,10 +190,12 @@ export function detectChannels(config: unknown): string[] {
   const tg = isRecord(ch.telegram) ? ch.telegram : {};
   const dc = isRecord(ch.discord) ? ch.discord : {};
   const sl = isRecord(ch.slack) ? ch.slack : {};
+  const sc = isRecord(ch.streamchat) ? ch.streamchat : {};
   const channels: string[] = [];
   if (tg.enabled && tg.botToken) channels.push('telegram');
   if (dc.enabled && dc.token) channels.push('discord');
   if (sl.enabled && (sl.botToken || sl.appToken)) channels.push('slack');
+  if (sc.enabled && sc.apiKey) channels.push('streamchat');
   return channels;
 }
 

--- a/kiloclaw/e2e/docker-image-testing.md
+++ b/kiloclaw/e2e/docker-image-testing.md
@@ -141,7 +141,7 @@ docker rm kiloclaw-gateway
 ```bash
 # Check versions
 docker run --rm kiloclaw:test node --version        # v22.13.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.2.9
+docker run --rm kiloclaw:test openclaw --version    # 2026.3.23
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -277,8 +277,9 @@ refresh_fly_token() {
     echo "ERROR: 'fly' CLI not found. Install it: https://fly.io/docs/flyctl/install/"
     exit 1
   fi
-  NEW_TOKEN="$(fly tokens create org "$FLY_ORG" 2>&1)"
-  if [ $? -ne 0 ] || [ -z "$NEW_TOKEN" ]; then
+  local token_rc=0
+  NEW_TOKEN="$(fly tokens create org "$FLY_ORG" 2>&1)" || token_rc=$?
+  if [ "$token_rc" -ne 0 ] || [ -z "$NEW_TOKEN" ]; then
     echo "ERROR: Failed to create Fly token. Are you logged in? Try 'fly auth login'."
     echo "$NEW_TOKEN"
     exit 1
@@ -717,8 +718,8 @@ case "$DISPLAY_MODE" in
         "KiloClaw worker" "$WORKER_CMD"
     else
       # Quick tunnel already running in its own tab; put Next.js + worker in splits
-      local safe_nextjs="${NEXTJS_CMD//\\/\\\\}"; safe_nextjs="${safe_nextjs//\"/\\\"}"
-      local safe_worker="${WORKER_CMD//\\/\\\\}"; safe_worker="${safe_worker//\"/\\\"}"
+      safe_nextjs="${NEXTJS_CMD//\\/\\\\}"; safe_nextjs="${safe_nextjs//\"/\\\"}"
+      safe_worker="${WORKER_CMD//\\/\\\\}"; safe_worker="${safe_worker//\"/\\\"}"
       osascript <<EOF
 tell application "iTerm"
   activate

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -443,6 +443,10 @@ open_terminal_tab() {
   local title="$1"
   local cmd="$2"
 
+  # Escape backslashes and double quotes so $cmd is safe inside AppleScript strings
+  local safe_cmd="${cmd//\\/\\\\}"
+  safe_cmd="${safe_cmd//\"/\\\"}"
+
   if osascript -e 'tell application "System Events" to (name of processes) contains "iTerm2"' 2>/dev/null | grep -q true; then
     osascript <<EOF
 tell application "iTerm"
@@ -451,7 +455,7 @@ tell application "iTerm"
     create tab with default profile
     tell current session
       set name to "$title"
-      write text "echo '--- $title ---'; $cmd"
+      write text "echo '--- $title ---'; $safe_cmd"
     end tell
   end tell
 end tell
@@ -460,7 +464,7 @@ EOF
     osascript <<EOF
 tell application "Terminal"
   activate
-  do script "printf '\\\\e]0;$title\\\\a'; $cmd"
+  do script "printf '\\\\e]0;$title\\\\a'; $safe_cmd"
 end tell
 EOF
   fi
@@ -477,6 +481,11 @@ open_split_screen() {
   local title2="$3" cmd2="$4"
   local title3="$5" cmd3="$6"
 
+  # Escape backslashes and double quotes so commands are safe inside AppleScript strings
+  local safe1="${cmd1//\\/\\\\}"; safe1="${safe1//\"/\\\"}"
+  local safe2="${cmd2//\\/\\\\}"; safe2="${safe2//\"/\\\"}"
+  local safe3="${cmd3//\\/\\\\}"; safe3="${safe3//\"/\\\"}"
+
   osascript <<EOF
 tell application "iTerm"
   activate
@@ -486,7 +495,7 @@ tell application "iTerm"
     -- Left pane: tunnel (named "KiloClaw Dev" so the tab title is readable)
     tell current session
       set name to "KiloClaw Dev"
-      write text "echo '--- $title1 ---'; $cmd1"
+      write text "echo '--- $title1 ---'; $safe1"
 
       -- Split right
       set rightSession to (split vertically with default profile)
@@ -495,7 +504,7 @@ tell application "iTerm"
     -- Top-right pane: Next.js
     tell rightSession
       set name to "$title2"
-      write text "echo '--- $title2 ---'; $cmd2"
+      write text "echo '--- $title2 ---'; $safe2"
 
       -- Split bottom
       set bottomRightSession to (split horizontally with default profile)
@@ -504,7 +513,7 @@ tell application "iTerm"
     -- Bottom-right pane: worker
     tell bottomRightSession
       set name to "$title3"
-      write text "echo '--- $title3 ---'; $cmd3"
+      write text "echo '--- $title3 ---'; $safe3"
     end tell
   end tell
 end tell
@@ -708,6 +717,8 @@ case "$DISPLAY_MODE" in
         "KiloClaw worker" "$WORKER_CMD"
     else
       # Quick tunnel already running in its own tab; put Next.js + worker in splits
+      local safe_nextjs="${NEXTJS_CMD//\\/\\\\}"; safe_nextjs="${safe_nextjs//\"/\\\"}"
+      local safe_worker="${WORKER_CMD//\\/\\\\}"; safe_worker="${safe_worker//\"/\\\"}"
       osascript <<EOF
 tell application "iTerm"
   activate
@@ -716,13 +727,13 @@ tell application "iTerm"
 
     tell current session
       set name to "Next.js"
-      write text "echo '--- Next.js ---'; $NEXTJS_CMD"
+      write text "echo '--- Next.js ---'; $safe_nextjs"
       set workerSession to (split horizontally with default profile)
     end tell
 
     tell workerSession
       set name to "KiloClaw worker"
-      write text "echo '--- KiloClaw worker ---'; $WORKER_CMD"
+      write text "echo '--- KiloClaw worker ---'; $safe_worker"
     end tell
   end tell
 end tell

--- a/kiloclaw/src/config.ts
+++ b/kiloclaw/src/config.ts
@@ -38,7 +38,7 @@ export const DEFAULT_MACHINE_GUEST = {
 export const DEFAULT_VOLUME_SIZE_GB = 10;
 
 /** Default Fly region priority list when FLY_REGION env var is not set. */
-export const DEFAULT_FLY_REGION = 'eu,us';
+export const DEFAULT_FLY_REGION = 'sjc,yyz,dfw,arn,cdg,fra,lhr';
 
 // Alarm cadence by instance status
 /** Running machines: fast health checks */


### PR DESCRIPTION
## Important Note
2026.03.22 was the initial target for this update, but it does not ship with the Control UI (it is broken).

## Summary

- Bump OpenClaw from 2026.3.13 to 2026.3.23 (covers v2026.3.13-1, v2026.3.22, and v2026.3.23)
- Remove dead `CLAWDBOT_STATE_DIR` env fallback (removed upstream in v2026.3.22)
- Add streamchat to `detectChannels()` for telemetry completeness
- Correct MCP migration TODO to reflect actual blocker (HTTP transport, not schema version)
- Update version references in `.dev.vars.example` and `e2e/docker-image-testing.md`
- Expand default Fly region list

## Upstream release notes reviewed

Full setup/onboarding impact analysis performed across all three releases (~200 changes flagged, ~136 setup-related). Key findings:

### Breaking changes (upstream)
- **Env vars**: `CLAWDBOT_*` / `MOLTBOT_*` removed — must use `OPENCLAW_*` (cleaned up in this PR)
- **Plugin SDK**: `openclaw/extension-api` removed, new surface is `openclaw/plugin-sdk/*`
- **Plugin install**: now prefers ClawHub before npm
- **Exec sandbox**: blocks JVM/glibc/.NET env vars from host exec
- **`jq` removed from safe-bin**: agents now get prompted before running `jq` (we're accepting this behavior — `jq` is still installed in the container, exec security is `allowlist` + `on-miss` so it's a prompt, not a block)

### Verified safe
- **streamchat plugin**: verified compatible — already uses `openclaw/plugin-sdk`, unique channel ID, `peerDependencies: openclaw >=2026.2.13`
- **mcporter**: not bundled with OpenClaw — still an external package we pin at `0.7.3` in our Dockerfile, unaffected by the bump

### Benefits from upgrade (no code changes needed)
- Gateway cold start ~10x faster (compiled `dist/extensions`)
- Model prewarm before channel startup (no more `Unknown model` on first message)
- `openclaw configure` no longer stalls
- Config validation crash fix (`memory-core` implicit slot)
- WS handshake timeout raised to 10s
- ~2x memory regression fix from v2026.3.13-1
- Bundled plugin sidecars restored in npm package (v2026.3.23)
- Stale `plugins.allow` IDs now warnings instead of fatal errors (v2026.3.23)

### Deferred
- **MCP migration to `config.mcp.servers`**: schema exists but OpenClaw's Pi MCP bridge only supports `StdioClientTransport` — no HTTP/SSE transport for remote servers (AgentCard, Linear). mcporter stays until upstream adds HTTP transport. TODO comment updated.

## Test plan
- [ ] Build Docker image and verify `openclaw --version` reports `2026.3.23`
- [x] Identify breaking changes
- [ ] Identify changes to default onboarding
- [ ] Start instance with telegram + streamchat channels, confirm gateway boots cleanly
- [ ] Verify MCP servers (AgentCard, Linear) still work via mcporter
- [ ] Confirm agent can use `jq` after approval prompt