### PR TITLE
fix(kiloclaw): fix mobile layout overflow on /claw dashboard

### DIFF
--- a/src/app/(app)/claw/components/ChangelogTab.tsx
+++ b/src/app/(app)/claw/components/ChangelogTab.tsx
@@ -33,7 +33,7 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
   const deployHint = entry.deployHint ? DEPLOY_HINT_STYLES[entry.deployHint] : null;
 
   return (
-    <div className="flex flex-col gap-1 py-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+    <div className="flex flex-col gap-1 py-5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
       <div className="flex min-w-0 flex-1 items-start gap-2">
         {entry.category === 'feature' ? (
           <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
@@ -45,16 +45,11 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
             <p className="text-muted-foreground text-xs">
               {format(parseISO(entry.date), 'MMM d, yyyy')}
             </p>
-            <div className="flex items-center gap-2 sm:hidden">
-              <Badge variant="outline" className={CATEGORY_STYLES[entry.category]}>
-                {entry.category}
+            {deployHint && (
+              <Badge variant="outline" className={`sm:hidden ${deployHint.className}`}>
+                {deployHint.label}
               </Badge>
-              {deployHint && (
-                <Badge variant="outline" className={deployHint.className}>
-                  {deployHint.label}
-                </Badge>
-              )}
-            </div>
+            )}
           </div>
           <p className="mt-0.5 text-sm">{entry.description}</p>
         </div>

--- a/src/app/(app)/claw/components/ChangelogTab.tsx
+++ b/src/app/(app)/claw/components/ChangelogTab.tsx
@@ -40,8 +40,8 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
         ) : (
           <Bug className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         )}
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:block">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center justify-between gap-y-1 sm:block sm:justify-start">
             <p className="text-muted-foreground text-xs">
               {format(parseISO(entry.date), 'MMM d, yyyy')}
             </p>

--- a/src/app/(app)/claw/components/ChangelogTab.tsx
+++ b/src/app/(app)/claw/components/ChangelogTab.tsx
@@ -33,7 +33,7 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
   const deployHint = entry.deployHint ? DEPLOY_HINT_STYLES[entry.deployHint] : null;
 
   return (
-    <div className="flex items-start justify-between gap-4 py-3">
+    <div className="flex flex-col gap-1 py-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
       <div className="flex min-w-0 flex-1 items-start gap-2">
         {entry.category === 'feature' ? (
           <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
@@ -41,13 +41,25 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
           <Bug className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         )}
         <div className="min-w-0">
-          <p className="text-muted-foreground text-xs">
-            {format(parseISO(entry.date), 'MMM d, yyyy')}
-          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:block">
+            <p className="text-muted-foreground text-xs">
+              {format(parseISO(entry.date), 'MMM d, yyyy')}
+            </p>
+            <div className="flex items-center gap-2 sm:hidden">
+              <Badge variant="outline" className={CATEGORY_STYLES[entry.category]}>
+                {entry.category}
+              </Badge>
+              {deployHint && (
+                <Badge variant="outline" className={deployHint.className}>
+                  {deployHint.label}
+                </Badge>
+              )}
+            </div>
+          </div>
           <p className="mt-0.5 text-sm">{entry.description}</p>
         </div>
       </div>
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="hidden shrink-0 items-center gap-2 sm:flex">
         <Badge variant="outline" className={CATEGORY_STYLES[entry.category]}>
           {entry.category}
         </Badge>

--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -342,7 +342,7 @@ export function ClawDashboard({
             </CardContent>
             <Tabs value={activeTab} onValueChange={handleTabChange}>
               <div className="px-5">
-                <TabsList className="mt-4 h-auto w-full justify-start gap-2 rounded-none border-b bg-transparent p-0 pb-3">
+                <TabsList className="mt-4 h-auto w-full justify-start gap-2 overflow-x-auto rounded-none border-b bg-transparent p-0 pb-3">
                   <TabsTrigger value="instance" className={tabTriggerClass}>
                     Gateway Process
                   </TabsTrigger>

--- a/src/app/(app)/claw/components/ClawHeader.tsx
+++ b/src/app/(app)/claw/components/ClawHeader.tsx
@@ -35,9 +35,9 @@ export function ClawHeader({
           </Badge>
         )}
       </SetPageTitle>
-      <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         {!isSetupWizard && region && (
-          <p className="text-muted-foreground font-mono text-sm">
+          <p className="text-muted-foreground min-w-0 truncate font-mono text-sm">
             {region.toUpperCase()} {sandboxId ? `- ${sandboxId}` : ''}
           </p>
         )}

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -169,7 +169,7 @@ export function InstanceControls({
           </Badge>
         </div>
       </div>
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
         <Button
           size="sm"
           variant="outline"

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -157,7 +157,7 @@ export function InstanceControls({
           <h3 className="text-foreground mb-1 text-sm font-medium">Instance Controls</h3>
           <p className="text-muted-foreground text-xs">Manage power state and gateway lifecycle.</p>
         </div>
-        <div className="flex w-full justify-between gap-2 sm:w-auto sm:justify-end">
+        <div className="flex w-full justify-around gap-2 sm:w-auto sm:justify-end">
           <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
             <Cpu className="h-3.5 w-3.5" />
             {status.machineSize?.cpus ?? DEFAULT_CPUS} vCPU,{' '}

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -152,7 +152,7 @@ export function InstanceControls({
           </>
         )}
       </div>
-      <div className="mb-4 flex items-start justify-between gap-4">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div>
           <h3 className="text-foreground mb-1 text-sm font-medium">Instance Controls</h3>
           <p className="text-muted-foreground text-xs">Manage power state and gateway lifecycle.</p>

--- a/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/src/app/(app)/claw/components/InstanceControls.tsx
@@ -157,7 +157,7 @@ export function InstanceControls({
           <h3 className="text-foreground mb-1 text-sm font-medium">Instance Controls</h3>
           <p className="text-muted-foreground text-xs">Manage power state and gateway lifecycle.</p>
         </div>
-        <div className="flex flex-wrap justify-end gap-2">
+        <div className="flex w-full justify-between gap-2 sm:w-auto sm:justify-end">
           <Badge variant="outline" className="text-muted-foreground gap-1.5 font-normal">
             <Cpu className="h-3.5 w-3.5" />
             {status.machineSize?.cpus ?? DEFAULT_CPUS} vCPU,{' '}

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -685,10 +685,10 @@ export function SettingsTab({
 
       {/* ── OpenClaw Instance card ── */}
       <div className="rounded-lg border px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <div className="flex items-center gap-3 min-w-0">
             <Settings className="text-muted-foreground h-5 w-5 shrink-0" />
-            <div>
+            <div className="min-w-0">
               <p className="text-sm font-medium">OpenClaw Instance</p>
               {hasVersionInfo && (
                 <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 text-xs">

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -691,69 +691,72 @@ export function SettingsTab({
             <div className="min-w-0">
               <p className="text-sm font-medium">OpenClaw Instance</p>
               {hasVersionInfo && (
-                <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 text-xs">
-                  <span>
-                    Version:{' '}
-                    <strong className="text-foreground">{runningVersion ?? trackedVersion}</strong>
-                  </span>
-                  <span className="text-muted-foreground/40">|</span>
-                  <span>
-                    Variant:{' '}
-                    <strong className="text-foreground">{status.imageVariant || 'default'}</strong>
-                  </span>
-                  <span className="text-muted-foreground/40">|</span>
-                  {isPinned ? (
-                    <span className="text-amber-400">Pinned</span>
-                  ) : (
-                    <span className="text-green-400">Following latest</span>
-                  )}
-                  {needsImageUpgrade && (
-                    <Badge
-                      variant="outline"
-                      className="border-blue-500/30 bg-blue-500/15 text-blue-400"
-                    >
-                      Upgrade required
-                    </Badge>
-                  )}
-                  {updateAvailable && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button type="button" onClick={onRequestUpgrade} className="cursor-pointer">
+                <div className="text-muted-foreground text-xs">
+                  <div className="flex flex-wrap items-center gap-x-2">
+                    <span>
+                      Version:{' '}
+                      <strong className="text-foreground">{runningVersion ?? trackedVersion}</strong>
+                    </span>
+                    <span className="text-muted-foreground/40">|</span>
+                    {isPinned ? (
+                      <span className="text-amber-400">Pinned</span>
+                    ) : (
+                      <span className="text-green-400">Following latest</span>
+                    )}
+                    {needsImageUpgrade && (
+                      <Badge
+                        variant="outline"
+                        className="border-blue-500/30 bg-blue-500/15 text-blue-400"
+                      >
+                        Upgrade required
+                      </Badge>
+                    )}
+                    {updateAvailable && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button type="button" onClick={onRequestUpgrade} className="cursor-pointer">
+                            <Badge
+                              variant="outline"
+                              className="border-orange-500/30 bg-orange-500/15 text-orange-400 hover:bg-orange-500/25"
+                            >
+                              Update available
+                            </Badge>
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>
+                            {catalogNewerThanImage
+                              ? `A newer OpenClaw version (${latestAvailableVersion}) is available — click to upgrade`
+                              : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available — click to upgrade`}
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {isModified && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
                           <Badge
                             variant="outline"
-                            className="border-orange-500/30 bg-orange-500/15 text-orange-400 hover:bg-orange-500/25"
+                            className="border-zinc-500/30 bg-zinc-500/15 text-zinc-400"
                           >
-                            Update available
+                            Modified
                           </Badge>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>
-                          {catalogNewerThanImage
-                            ? `A newer OpenClaw version (${latestAvailableVersion}) is available — click to upgrade`
-                            : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available — click to upgrade`}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                  {isModified && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge
-                          variant="outline"
-                          className="border-zinc-500/30 bg-zinc-500/15 text-zinc-400"
-                        >
-                          Modified
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>
-                          OpenClaw was self-updated on this machine — redeploying will revert to the
-                          image version ({trackedVersion})
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>
+                            OpenClaw was self-updated on this machine — redeploying will revert to the
+                            image version ({trackedVersion})
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-2">
+                    <span>
+                      Variant:{' '}
+                      <strong className="text-foreground">{status.imageVariant || 'default'}</strong>
+                    </span>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -695,7 +695,9 @@ export function SettingsTab({
                   <div className="flex flex-wrap items-center gap-x-2">
                     <span>
                       Version:{' '}
-                      <strong className="text-foreground">{runningVersion ?? trackedVersion}</strong>
+                      <strong className="text-foreground">
+                        {runningVersion ?? trackedVersion}
+                      </strong>
                     </span>
                     <span className="text-muted-foreground/40">|</span>
                     {isPinned ? (
@@ -714,7 +716,11 @@ export function SettingsTab({
                     {updateAvailable && (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <button type="button" onClick={onRequestUpgrade} className="cursor-pointer">
+                          <button
+                            type="button"
+                            onClick={onRequestUpgrade}
+                            className="cursor-pointer"
+                          >
                             <Badge
                               variant="outline"
                               className="border-orange-500/30 bg-orange-500/15 text-orange-400 hover:bg-orange-500/25"
@@ -744,8 +750,8 @@ export function SettingsTab({
                         </TooltipTrigger>
                         <TooltipContent>
                           <p>
-                            OpenClaw was self-updated on this machine — redeploying will revert to the
-                            image version ({trackedVersion})
+                            OpenClaw was self-updated on this machine — redeploying will revert to
+                            the image version ({trackedVersion})
                           </p>
                         </TooltipContent>
                       </Tooltip>
@@ -754,7 +760,9 @@ export function SettingsTab({
                   <div className="flex flex-wrap items-center gap-x-2">
                     <span>
                       Variant:{' '}
-                      <strong className="text-foreground">{status.imageVariant || 'default'}</strong>
+                      <strong className="text-foreground">
+                        {status.imageVariant || 'default'}
+                      </strong>
                     </span>
                   </div>
                 </div>

--- a/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/src/app/(app)/claw/components/SettingsTab.tsx
@@ -685,86 +685,75 @@ export function SettingsTab({
 
       {/* ── OpenClaw Instance card ── */}
       <div className="rounded-lg border px-4 py-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-          <div className="flex items-center gap-3 min-w-0">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
             <Settings className="text-muted-foreground h-5 w-5 shrink-0" />
-            <div className="min-w-0">
+            <div>
               <p className="text-sm font-medium">OpenClaw Instance</p>
               {hasVersionInfo && (
-                <div className="text-muted-foreground text-xs">
-                  <div className="flex flex-wrap items-center gap-x-2">
-                    <span>
-                      Version:{' '}
-                      <strong className="text-foreground">
-                        {runningVersion ?? trackedVersion}
-                      </strong>
-                    </span>
-                    <span className="text-muted-foreground/40">|</span>
-                    {isPinned ? (
-                      <span className="text-amber-400">Pinned</span>
-                    ) : (
-                      <span className="text-green-400">Following latest</span>
-                    )}
-                    {needsImageUpgrade && (
-                      <Badge
-                        variant="outline"
-                        className="border-blue-500/30 bg-blue-500/15 text-blue-400"
-                      >
-                        Upgrade required
-                      </Badge>
-                    )}
-                    {updateAvailable && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            onClick={onRequestUpgrade}
-                            className="cursor-pointer"
-                          >
-                            <Badge
-                              variant="outline"
-                              className="border-orange-500/30 bg-orange-500/15 text-orange-400 hover:bg-orange-500/25"
-                            >
-                              Update available
-                            </Badge>
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            {catalogNewerThanImage
-                              ? `A newer OpenClaw version (${latestAvailableVersion}) is available — click to upgrade`
-                              : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available — click to upgrade`}
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                    {isModified && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
+                <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 text-xs">
+                  <span>
+                    Version:{' '}
+                    <strong className="text-foreground">{runningVersion ?? trackedVersion}</strong>
+                  </span>
+                  <span className="text-muted-foreground/40">|</span>
+                  {isPinned ? (
+                    <span className="text-amber-400">Pinned</span>
+                  ) : (
+                    <span className="text-green-400">Following latest</span>
+                  )}
+                  {needsImageUpgrade && (
+                    <Badge
+                      variant="outline"
+                      className="border-blue-500/30 bg-blue-500/15 text-blue-400"
+                    >
+                      Upgrade required
+                    </Badge>
+                  )}
+                  {updateAvailable && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button type="button" onClick={onRequestUpgrade} className="cursor-pointer">
                           <Badge
                             variant="outline"
-                            className="border-zinc-500/30 bg-zinc-500/15 text-zinc-400"
+                            className="border-orange-500/30 bg-orange-500/15 text-orange-400 hover:bg-orange-500/25"
                           >
-                            Modified
+                            Update available
                           </Badge>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            OpenClaw was self-updated on this machine — redeploying will revert to
-                            the image version ({trackedVersion})
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-x-2">
-                    <span>
-                      Variant:{' '}
-                      <strong className="text-foreground">
-                        {status.imageVariant || 'default'}
-                      </strong>
-                    </span>
-                  </div>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          {catalogNewerThanImage
+                            ? `A newer OpenClaw version (${latestAvailableVersion}) is available — click to upgrade`
+                            : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available — click to upgrade`}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {isModified && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant="outline"
+                          className="border-zinc-500/30 bg-zinc-500/15 text-zinc-400"
+                        >
+                          Modified
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          OpenClaw was self-updated on this machine — redeploying will revert to the
+                          image version ({trackedVersion})
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  <span className="hidden sm:inline text-muted-foreground/40">|</span>
+                  <span className="basis-full sm:basis-auto">
+                    Variant:{' '}
+                    <strong className="text-foreground">{status.imageVariant || 'default'}</strong>
+                  </span>
                 </div>
               )}
             </div>

--- a/src/app/(app)/claw/components/VersionPinCard.tsx
+++ b/src/app/(app)/claw/components/VersionPinCard.tsx
@@ -124,8 +124,8 @@ export function VersionPinCard({
                 </Label>
                 <div className="flex items-center gap-2">
                   <Select value={selectedImageTag} onValueChange={setSelectedImageTag}>
-                    <SelectTrigger id="version-select">
-                      <SelectValue placeholder="Choose a version to pin..." />
+                    <SelectTrigger id="version-select" className="min-w-0 flex-1 h-10">
+                      <SelectValue placeholder="Choose version..." />
                     </SelectTrigger>
                     <SelectContent>
                       {versions?.items.map(version => (
@@ -149,9 +149,9 @@ export function VersionPinCard({
                     onClick={handlePin}
                     disabled={!selectedImageTag || isPinning}
                     size="sm"
-                    className="shrink-0"
+                    className="ml-auto shrink-0"
                   >
-                    {isPinning ? 'Pinning...' : 'Pin to this version'}
+                    {isPinning ? 'Pinning...' : 'Pin'}
                   </Button>
                 </div>
               </div>
@@ -232,7 +232,7 @@ export function VersionPinCard({
           ) : (
             <div className="space-y-3">
               <div className="flex items-center gap-2">
-                <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100">
+                <span className="rounded-full bg-green-100 px-3 py-0.5 text-center text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100">
                   Following latest
                 </span>
                 <span className="text-muted-foreground text-xs">

--- a/src/app/(app)/claw/components/VersionPinCard.tsx
+++ b/src/app/(app)/claw/components/VersionPinCard.tsx
@@ -100,7 +100,7 @@ export function VersionPinCard({
         <Pin className="size-4" />
         Version Pinning
       </h3>
-      <div className="grid grid-cols-2 items-start gap-6">
+      <div className="grid grid-cols-1 items-start gap-6 sm:grid-cols-2">
         {/* Left: Description + Pinning Controls */}
         <div className="space-y-3">
           <div className="space-y-2">

--- a/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -571,7 +571,7 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
             <CadenceToggle cadence={cadence} onChange={handleCadenceChange} />
 
             {/* Tier cards */}
-            <div className="mb-3.5 grid grid-cols-3 gap-2.5">
+            <div className="mb-3.5 grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-2.5">
               {TIERS.map(tier => (
                 <TierCard
                   key={tier}


### PR DESCRIPTION
## Summary

This PR fixes various mobile styling issues across the KiloClaw dashboard

## Visual Changes


<img width="1703" height="1510" alt="side_by_side_changelog" src="https://github.com/user-attachments/assets/a59d9a6f-cb96-476c-a21e-f71168da66da" />
<img width="1784" height="970" alt="side_by_side_dashboard" src="https://github.com/user-attachments/assets/005dfc40-3975-4d35-b5b8-f05793ebd1e7" />
<img width="1662" height="468" alt="side_by_side_header" src="https://github.com/user-attachments/assets/202e37ce-b896-4342-a337-a4156e4be5c1" />
<img width="1659" height="1510" alt="side_by_side_plan_selection" src="https://github.com/user-attachments/assets/8e8c9e3d-c2d9-42f6-b7ae-856602c3df60" />
<img width="1628" height="1522" alt="side_by_side_settings" src="https://github.com/user-attachments/assets/651be86b-315f-47e5-8841-8eb28490727f" />


## Loom — Extra Credit
https://www.loom.com/share/44411d100bc047629bcf1cf1e923e4eb