### PR TITLE
fix(admin): invalidate controllerVersion on machineRedeploy and machineUpgrade success

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1221,6 +1221,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Redeploy requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
@@ -1235,6 +1242,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Upgrade to latest requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {


### PR DESCRIPTION
## Summary

- Adds immediate `controllerVersion` query invalidation in the `onSuccess` callbacks of both `machineRedeploy` and `machineUpgrade` mutations in `KiloclawInstanceDetail.tsx`.
- The `gatewayStatus` was already invalidated via `invalidateGatewayQueries()`; the `controllerVersion` invalidation follows the same closure pattern (`data?.user_id` from the component-level instance query).
- The deferred re-invalidation via `useEffect` (polling until machine transitions back to `running`) is preserved alongside this immediate invalidation, ensuring the controller version reflects the new build both immediately on success and after the machine is fully back up.

## Verification

- Code review: diff is a clean, minimal two-hunk change — 7 lines added twice, no deletions.
- Pattern consistency verified: matches the existing `useEffect` approach and `invalidateGatewayQueries` helper pattern.
- Type safety verified: `data?.user_id` references the component-level `KiloclawInstance` query result (not the mutation return value), which has a `user_id` field. The `RestartMachineResponse` type was checked and does not have `user_id`, confirming the closure semantics are correct.

## Visual Changes

N/A

## Reviewer Notes

The `onSuccess: () => { ... }` callbacks are closures over the outer `data` variable from `useQuery(...trpc.admin.kiloclawInstances.get...)`. This is the same `data?.user_id` pattern used in the `useEffect` deferred invalidation directly above these mutations. No risk of using a wrong `data` reference.