### PR TITLE
(kiloclaw) fix local dev script

### DIFF
--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -277,8 +277,9 @@ refresh_fly_token() {
     echo "ERROR: 'fly' CLI not found. Install it: https://fly.io/docs/flyctl/install/"
     exit 1
   fi
-  NEW_TOKEN="$(fly tokens create org "$FLY_ORG" 2>&1)"
-  if [ $? -ne 0 ] || [ -z "$NEW_TOKEN" ]; then
+  local token_rc=0
+  NEW_TOKEN="$(fly tokens create org "$FLY_ORG" 2>&1)" || token_rc=$?
+  if [ "$token_rc" -ne 0 ] || [ -z "$NEW_TOKEN" ]; then
     echo "ERROR: Failed to create Fly token. Are you logged in? Try 'fly auth login'."
     echo "$NEW_TOKEN"
     exit 1
@@ -717,8 +718,8 @@ case "$DISPLAY_MODE" in
         "KiloClaw worker" "$WORKER_CMD"
     else
       # Quick tunnel already running in its own tab; put Next.js + worker in splits
-      local safe_nextjs="${NEXTJS_CMD//\\/\\\\}"; safe_nextjs="${safe_nextjs//\"/\\\"}"
-      local safe_worker="${WORKER_CMD//\\/\\\\}"; safe_worker="${safe_worker//\"/\\\"}"
+      safe_nextjs="${NEXTJS_CMD//\\/\\\\}"; safe_nextjs="${safe_nextjs//\"/\\\"}"
+      safe_worker="${WORKER_CMD//\\/\\\\}"; safe_worker="${safe_worker//\"/\\\"}"
       osascript <<EOF
 tell application "iTerm"
   activate

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -443,6 +443,10 @@ open_terminal_tab() {
   local title="$1"
   local cmd="$2"
 
+  # Escape backslashes and double quotes so $cmd is safe inside AppleScript strings
+  local safe_cmd="${cmd//\\/\\\\}"
+  safe_cmd="${safe_cmd//\"/\\\"}"
+
   if osascript -e 'tell application "System Events" to (name of processes) contains "iTerm2"' 2>/dev/null | grep -q true; then
     osascript <<EOF
 tell application "iTerm"
@@ -451,7 +455,7 @@ tell application "iTerm"
     create tab with default profile
     tell current session
       set name to "$title"
-      write text "echo '--- $title ---'; $cmd"
+      write text "echo '--- $title ---'; $safe_cmd"
     end tell
   end tell
 end tell
@@ -460,7 +464,7 @@ EOF
     osascript <<EOF
 tell application "Terminal"
   activate
-  do script "printf '\\\\e]0;$title\\\\a'; $cmd"
+  do script "printf '\\\\e]0;$title\\\\a'; $safe_cmd"
 end tell
 EOF
   fi
@@ -477,6 +481,11 @@ open_split_screen() {
   local title2="$3" cmd2="$4"
   local title3="$5" cmd3="$6"
 
+  # Escape backslashes and double quotes so commands are safe inside AppleScript strings
+  local safe1="${cmd1//\\/\\\\}"; safe1="${safe1//\"/\\\"}"
+  local safe2="${cmd2//\\/\\\\}"; safe2="${safe2//\"/\\\"}"
+  local safe3="${cmd3//\\/\\\\}"; safe3="${safe3//\"/\\\"}"
+
   osascript <<EOF
 tell application "iTerm"
   activate
@@ -486,7 +495,7 @@ tell application "iTerm"
     -- Left pane: tunnel (named "KiloClaw Dev" so the tab title is readable)
     tell current session
       set name to "KiloClaw Dev"
-      write text "echo '--- $title1 ---'; $cmd1"
+      write text "echo '--- $title1 ---'; $safe1"
 
       -- Split right
       set rightSession to (split vertically with default profile)
@@ -495,7 +504,7 @@ tell application "iTerm"
     -- Top-right pane: Next.js
     tell rightSession
       set name to "$title2"
-      write text "echo '--- $title2 ---'; $cmd2"
+      write text "echo '--- $title2 ---'; $safe2"
 
       -- Split bottom
       set bottomRightSession to (split horizontally with default profile)
@@ -504,7 +513,7 @@ tell application "iTerm"
     -- Bottom-right pane: worker
     tell bottomRightSession
       set name to "$title3"
-      write text "echo '--- $title3 ---'; $cmd3"
+      write text "echo '--- $title3 ---'; $safe3"
     end tell
   end tell
 end tell
@@ -708,6 +717,8 @@ case "$DISPLAY_MODE" in
         "KiloClaw worker" "$WORKER_CMD"
     else
       # Quick tunnel already running in its own tab; put Next.js + worker in splits
+      local safe_nextjs="${NEXTJS_CMD//\\/\\\\}"; safe_nextjs="${safe_nextjs//\"/\\\"}"
+      local safe_worker="${WORKER_CMD//\\/\\\\}"; safe_worker="${safe_worker//\"/\\\"}"
       osascript <<EOF
 tell application "iTerm"
   activate
@@ -716,13 +727,13 @@ tell application "iTerm"
 
     tell current session
       set name to "Next.js"
-      write text "echo '--- Next.js ---'; $NEXTJS_CMD"
+      write text "echo '--- Next.js ---'; $safe_nextjs"
       set workerSession to (split horizontally with default profile)
     end tell
 
     tell workerSession
       set name to "KiloClaw worker"
-      write text "echo '--- KiloClaw worker ---'; $WORKER_CMD"
+      write text "echo '--- KiloClaw worker ---'; $safe_worker"
     end tell
   end tell
 end tell


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

  - Escape backslashes and double quotes in shell commands before interpolating them into AppleScript write text / do script strings
  - Fixes broken terminal tabs/panes when NVM_PREFIX contains escaped paths (e.g. \"$(nvm which ...)\")
  - Applied consistently across open_terminal_tab(), open_split_screen(), and the inline split-pane osascript block