### PR TITLE
fix(kiloclaw): fix changelog tab mobile layout

### DIFF
--- a/src/app/(app)/claw/components/ChangelogTab.tsx
+++ b/src/app/(app)/claw/components/ChangelogTab.tsx
@@ -33,7 +33,7 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
   const deployHint = entry.deployHint ? DEPLOY_HINT_STYLES[entry.deployHint] : null;
 
   return (
-    <div className="flex flex-col gap-1 py-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+    <div className="flex flex-col gap-1 py-5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
       <div className="flex min-w-0 flex-1 items-start gap-2">
         {entry.category === 'feature' ? (
           <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
@@ -45,16 +45,11 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
             <p className="text-muted-foreground text-xs">
               {format(parseISO(entry.date), 'MMM d, yyyy')}
             </p>
-            <div className="flex items-center gap-2 sm:hidden">
-              <Badge variant="outline" className={CATEGORY_STYLES[entry.category]}>
-                {entry.category}
+            {deployHint && (
+              <Badge variant="outline" className={`sm:hidden ${deployHint.className}`}>
+                {deployHint.label}
               </Badge>
-              {deployHint && (
-                <Badge variant="outline" className={deployHint.className}>
-                  {deployHint.label}
-                </Badge>
-              )}
-            </div>
+            )}
           </div>
           <p className="mt-0.5 text-sm">{entry.description}</p>
         </div>

--- a/src/app/(app)/claw/components/ChangelogTab.tsx
+++ b/src/app/(app)/claw/components/ChangelogTab.tsx
@@ -40,8 +40,8 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
         ) : (
           <Bug className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         )}
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:block">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center justify-between gap-y-1 sm:block sm:justify-start">
             <p className="text-muted-foreground text-xs">
               {format(parseISO(entry.date), 'MMM d, yyyy')}
             </p>

--- a/src/app/(app)/claw/components/ChangelogTab.tsx
+++ b/src/app/(app)/claw/components/ChangelogTab.tsx
@@ -33,7 +33,7 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
   const deployHint = entry.deployHint ? DEPLOY_HINT_STYLES[entry.deployHint] : null;
 
   return (
-    <div className="flex items-start justify-between gap-4 py-3">
+    <div className="flex flex-col gap-1 py-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
       <div className="flex min-w-0 flex-1 items-start gap-2">
         {entry.category === 'feature' ? (
           <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
@@ -41,13 +41,25 @@ function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
           <Bug className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         )}
         <div className="min-w-0">
-          <p className="text-muted-foreground text-xs">
-            {format(parseISO(entry.date), 'MMM d, yyyy')}
-          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:block">
+            <p className="text-muted-foreground text-xs">
+              {format(parseISO(entry.date), 'MMM d, yyyy')}
+            </p>
+            <div className="flex items-center gap-2 sm:hidden">
+              <Badge variant="outline" className={CATEGORY_STYLES[entry.category]}>
+                {entry.category}
+              </Badge>
+              {deployHint && (
+                <Badge variant="outline" className={deployHint.className}>
+                  {deployHint.label}
+                </Badge>
+              )}
+            </div>
+          </div>
           <p className="mt-0.5 text-sm">{entry.description}</p>
         </div>
       </div>
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="hidden shrink-0 items-center gap-2 sm:flex">
         <Badge variant="outline" className={CATEGORY_STYLES[entry.category]}>
           {entry.category}
         </Badge>


### PR DESCRIPTION
## Summary

- Changelog rows used `justify-between` with badges on the right, squeezing description text into a narrow column on mobile (one word per line)
- Now rows stack vertically on mobile: date and deploy hint badge on the first line (badge right-aligned), description full-width below
- Category badge (feature/bugfix) hidden on mobile — the icon already conveys this — visible on desktop
- Increased row padding (`py-3` → `py-5`) for better readability
- Desktop layout unchanged

## Mobile — Before vs After (375×812, Playwright)

| Before | After |
|:---:|:---:|
| <img src="https://github.com/Kilo-Org/cloud/releases/download/untagged-3ef8f3820cb7bc5d26fd/changelog-mobile-before.png" width="300" /> | <img src="https://github.com/Kilo-Org/cloud/releases/download/untagged-3ef8f3820cb7bc5d26fd/changelog-mobile-after.png" width="300" /> |
| Badges side-by-side squeeze description to ~1 word/line | Date + deploy badge inline, description full-width |

## Desktop (1280×800, Playwright)

<img src="https://github.com/Kilo-Org/cloud/releases/download/untagged-3ef8f3820cb7bc5d26fd/changelog-desktop.png" width="800" />

Desktop layout unchanged — category + deploy hint badges right-aligned.

## Test plan

- [x] Playwright screenshots at mobile (375×812) and desktop (1280×800) with tRPC mocking
- [x] TypeScript compiles with no errors
- [x] Manual verification on mobile device at app.kilo.ai/claw#changelog