### PR TITLE
fix(kiloclaw): stack subscription tier cards on mobile

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -7,7 +7,12 @@ import {
   STARTUP_TIMEOUT_SECONDS,
   STALE_PROVISION_THRESHOLD_MS,
 } from '../../config';
-import { parseRegions, deprioritizeRegion, resolveRegions, evictCapacityRegionFromKV } from '../regions';
+import {
+  parseRegions,
+  deprioritizeRegion,
+  resolveRegions,
+  evictCapacityRegionFromKV,
+} from '../regions';
 import { guestFromSize, volumeNameFromSandboxId } from '../machine-config';
 import type { InstanceMutableState } from './types';
 import { storageUpdate } from './state';
@@ -38,7 +43,7 @@ export async function ensureVolume(
     },
     regions,
     {
-      onCapacityError: (failedRegion) => {
+      onCapacityError: failedRegion => {
         void evictCapacityRegionFromKV(env.KV_CLAW_CACHE, env, failedRegion);
       },
     }

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -7,7 +7,7 @@ import {
   STARTUP_TIMEOUT_SECONDS,
   STALE_PROVISION_THRESHOLD_MS,
 } from '../../config';
-import { parseRegions, deprioritizeRegion, resolveRegions } from '../regions';
+import { parseRegions, deprioritizeRegion, resolveRegions, evictCapacityRegionFromKV } from '../regions';
 import { guestFromSize, volumeNameFromSandboxId } from '../machine-config';
 import type { InstanceMutableState } from './types';
 import { storageUpdate } from './state';
@@ -36,7 +36,12 @@ export async function ensureVolume(
       size_gb: DEFAULT_VOLUME_SIZE_GB,
       compute: guestFromSize(state.machineSize),
     },
-    regions
+    regions,
+    {
+      onCapacityError: (failedRegion) => {
+        void evictCapacityRegionFromKV(env.KV_CLAW_CACHE, env, failedRegion);
+      },
+    }
   );
 
   state.flyVolumeId = volume.id;
@@ -94,6 +99,12 @@ export async function replaceStrandedVolume(
     }
   }
 
+  const capacityErrorCallback = {
+    onCapacityError: (failedRegion: string) => {
+      void evictCapacityRegionFromKV(env.KV_CLAW_CACHE, env, failedRegion);
+    },
+  };
+
   if (hasUserData) {
     const forkedVolume = await fly.createVolumeWithFallback(
       flyConfig,
@@ -102,7 +113,8 @@ export async function replaceStrandedVolume(
         source_volume_id: oldVolumeId,
         compute,
       },
-      regions
+      regions,
+      capacityErrorCallback
     );
     state.flyVolumeId = forkedVolume.id;
     state.flyRegion = forkedVolume.region;
@@ -125,7 +137,8 @@ export async function replaceStrandedVolume(
         size_gb: DEFAULT_VOLUME_SIZE_GB,
         compute,
       },
-      regions
+      regions,
+      capacityErrorCallback
     );
     state.flyVolumeId = freshVolume.id;
     state.flyRegion = freshVolume.region;

--- a/kiloclaw/src/durable-objects/regions.eviction.test.ts
+++ b/kiloclaw/src/durable-objects/regions.eviction.test.ts
@@ -74,11 +74,19 @@ describe('evictCapacityRegionFromKV', () => {
     expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,ord');
   });
 
-  it('preserves duplicate entries when evicting (duplicates are intentional weighting)', async () => {
+  it('preserves duplicate entries when multiple distinct named regions remain', async () => {
     const { kv, putMock } = makeKv('dfw,dfw,ord,iad');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    // all iad occurrences removed, duplicates of other regions preserved
+    // 2 distinct named regions remain (dfw, ord), so duplicates are preserved
     expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,dfw,ord');
+  });
+
+  it('falls back to meta when eviction leaves only one distinct named region (with duplicates)', async () => {
+    // iad,dfw,dfw — evicting iad leaves dfw,dfw (only 1 distinct named region)
+    const { kv, putMock, store } = makeKv('iad,dfw,dfw');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,eu,us');
+    expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,eu,us');
   });
 
   it('writes "lastRegion,eu,us" when evicting the second-to-last named region', async () => {

--- a/kiloclaw/src/durable-objects/regions.eviction.test.ts
+++ b/kiloclaw/src/durable-objects/regions.eviction.test.ts
@@ -74,11 +74,11 @@ describe('evictCapacityRegionFromKV', () => {
     expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,ord');
   });
 
-  it('deduplicates before writing when evicting from a list with duplicates', async () => {
-    const { kv, putMock } = makeKv('iad,dfw,iad,ord');
+  it('preserves duplicate entries when evicting (duplicates are intentional weighting)', async () => {
+    const { kv, putMock } = makeKv('dfw,dfw,ord,iad');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    // remaining after evicting both iad occurrences: dfw,ord (deduplicated)
-    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
+    // all iad occurrences removed, duplicates of other regions preserved
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,dfw,ord');
   });
 
   it('writes "lastRegion,eu,us" when evicting the second-to-last named region', async () => {
@@ -88,18 +88,18 @@ describe('evictCapacityRegionFromKV', () => {
     expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,eu,us');
   });
 
-  it('writes "failedRegion,eu,us" when evicting the only named region', async () => {
+  it('writes "eu,us" when evicting the only named region', async () => {
     const { kv, putMock, store } = makeKv('iad');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
-    expect(store.get(FLY_REGIONS_KV_KEY)).toBe('iad,eu,us');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'eu,us');
+    expect(store.get(FLY_REGIONS_KV_KEY)).toBe('eu,us');
   });
 
-  it('writes "failedRegion,eu,us" when evicting the only named region mixed with meta-regions', async () => {
+  it('writes "eu,us" when evicting the only named region mixed with meta-regions', async () => {
     // iad is the only named region, eu is meta — after evicting iad, no named regions remain
     const { kv, putMock } = makeKv('iad,eu');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'eu,us');
   });
 
   it('logs a warning after a successful eviction', async () => {

--- a/kiloclaw/src/durable-objects/regions.eviction.test.ts
+++ b/kiloclaw/src/durable-objects/regions.eviction.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { evictCapacityRegionFromKV, FLY_REGIONS_KV_KEY } from './regions';
+
+function makeKv(initialValue: string | null = null): {
+  store: Map<string, string>;
+  kv: KVNamespace;
+} {
+  const store = new Map<string, string>();
+  if (initialValue !== null) {
+    store.set(FLY_REGIONS_KV_KEY, initialValue);
+  }
+  const kv = {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+  return { store, kv };
+}
+
+const noopEnv: { KILOCLAW_AE?: AnalyticsEngineDataset } = {};
+
+describe('evictCapacityRegionFromKV', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('is a no-op when KV read fails (no throw)', async () => {
+    const kv = {
+      get: vi.fn().mockRejectedValue(new Error('KV unavailable')),
+      put: vi.fn(),
+    } as unknown as KVNamespace;
+
+    await expect(evictCapacityRegionFromKV(kv, noopEnv, 'iad')).resolves.toBeUndefined();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when KV key is null', async () => {
+    const { kv } = makeKv(null);
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when KV key is empty string', async () => {
+    const { kv } = makeKv('');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a pure meta-region list', async () => {
+    const { kv } = makeKv('eu,us');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'eu');
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when failedRegion is not in the list', async () => {
+    const { kv } = makeKv('iad,dfw,ord');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'lhr');
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it('evicts one region from a list with multiple remaining named regions', async () => {
+    const { kv, store } = makeKv('iad,dfw,ord');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
+    expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,ord');
+  });
+
+  it('deduplicates before writing when evicting from a list with duplicates', async () => {
+    const { kv } = makeKv('iad,dfw,iad,ord');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    // remaining after evicting both iad occurrences: dfw,ord (deduplicated)
+    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
+  });
+
+  it('writes "lastRegion,eu,us" when evicting the second-to-last named region', async () => {
+    const { kv, store } = makeKv('iad,dfw');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,eu,us');
+    expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,eu,us');
+  });
+
+  it('writes "failedRegion,eu,us" when evicting the only named region', async () => {
+    const { kv, store } = makeKv('iad');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
+    expect(store.get(FLY_REGIONS_KV_KEY)).toBe('iad,eu,us');
+  });
+
+  it('writes "failedRegion,eu,us" when evicting the only named region mixed with meta-regions', async () => {
+    // iad is the only named region, eu is meta — after evicting iad, no named regions remain
+    const { kv } = makeKv('iad,eu');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
+  });
+
+  it('logs a warning after a successful eviction', async () => {
+    const { kv } = makeKv('iad,dfw,ord');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[regions] capacity eviction: removed iad')
+    );
+  });
+
+  it('logs a revert-to-meta warning when last named region is evicted', async () => {
+    const { kv } = makeKv('iad');
+    await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('reverting to meta-regions')
+    );
+  });
+
+  it('emits analytics event when KILOCLAW_AE binding is present', async () => {
+    const writeDataPoint = vi.fn();
+    const env = {
+      KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
+    };
+    const { kv } = makeKv('iad,dfw,ord');
+    await evictCapacityRegionFromKV(kv, env, 'iad');
+    expect(writeDataPoint).toHaveBeenCalledOnce();
+    const call = writeDataPoint.mock.calls[0][0];
+    expect(call.blobs[0]).toBe('region.capacity_eviction');
+    expect(call.blobs[11]).toBe('iad'); // flyRegion
+    expect(call.blobs[12]).toBe('evicted'); // label
+  });
+
+  it('emits "reverted_to_meta" label in analytics when last named region evicted', async () => {
+    const writeDataPoint = vi.fn();
+    const env = {
+      KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
+    };
+    const { kv } = makeKv('iad');
+    await evictCapacityRegionFromKV(kv, env, 'iad');
+    expect(writeDataPoint).toHaveBeenCalledOnce();
+    const call = writeDataPoint.mock.calls[0][0];
+    expect(call.blobs[12]).toBe('reverted_to_meta'); // label
+  });
+
+  it('does not throw and logs a warning when KV put fails', async () => {
+    const kv = {
+      get: vi.fn().mockResolvedValue('iad,dfw'),
+      put: vi.fn().mockRejectedValue(new Error('KV write error')),
+    } as unknown as KVNamespace;
+
+    await expect(evictCapacityRegionFromKV(kv, noopEnv, 'iad')).resolves.toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to write updated region list to KV')
+    );
+  });
+
+  it('does not emit analytics when KV put fails', async () => {
+    const writeDataPoint = vi.fn();
+    const env = {
+      KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
+    };
+    const kv = {
+      get: vi.fn().mockResolvedValue('iad,dfw'),
+      put: vi.fn().mockRejectedValue(new Error('KV write error')),
+    } as unknown as KVNamespace;
+
+    await evictCapacityRegionFromKV(kv, env, 'iad');
+    expect(writeDataPoint).not.toHaveBeenCalled();
+  });
+});

--- a/kiloclaw/src/durable-objects/regions.eviction.test.ts
+++ b/kiloclaw/src/durable-objects/regions.eviction.test.ts
@@ -117,7 +117,7 @@ describe('evictCapacityRegionFromKV', () => {
   });
 
   it('emits analytics event when KILOCLAW_AE binding is present', async () => {
-    const writeDataPoint = vi.fn<[AnalyticsEngineDataPoint], void>();
+    const writeDataPoint = vi.fn<(event: AnalyticsEngineDataPoint) => void>();
     const env = {
       KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
     };
@@ -147,7 +147,7 @@ describe('evictCapacityRegionFromKV', () => {
   });
 
   it('emits "reverted_to_meta" label in analytics when last named region evicted', async () => {
-    const writeDataPoint = vi.fn<[AnalyticsEngineDataPoint], void>();
+    const writeDataPoint = vi.fn<(event: AnalyticsEngineDataPoint) => void>();
     const env = {
       KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
     };
@@ -187,7 +187,7 @@ describe('evictCapacityRegionFromKV', () => {
   });
 
   it('does not emit analytics when KV put fails', async () => {
-    const writeDataPoint = vi.fn<[AnalyticsEngineDataPoint], void>();
+    const writeDataPoint = vi.fn<(event: AnalyticsEngineDataPoint) => void>();
     const env = {
       KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
     };

--- a/kiloclaw/src/durable-objects/regions.eviction.test.ts
+++ b/kiloclaw/src/durable-objects/regions.eviction.test.ts
@@ -1,24 +1,30 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { evictCapacityRegionFromKV, FLY_REGIONS_KV_KEY } from './regions';
 
-function makeKv(initialValue: string | null = null): {
+type MockKv = {
   store: Map<string, string>;
+  getMock: Mock;
+  putMock: Mock;
   kv: KVNamespace;
-} {
+};
+
+function makeKv(initialValue: string | null = null): MockKv {
   const store = new Map<string, string>();
   if (initialValue !== null) {
     store.set(FLY_REGIONS_KV_KEY, initialValue);
   }
+  const getMock = vi.fn(async (key: string) => store.get(key) ?? null);
+  const putMock = vi.fn(async (key: string, value: string) => {
+    store.set(key, value);
+  });
   const kv = {
-    get: vi.fn(async (key: string) => store.get(key) ?? null),
-    put: vi.fn(async (key: string, value: string) => {
-      store.set(key, value);
-    }),
+    get: getMock,
+    put: putMock,
     delete: vi.fn(),
     list: vi.fn(),
     getWithMetadata: vi.fn(),
   } as unknown as KVNamespace;
-  return { store, kv };
+  return { store, getMock, putMock, kv };
 }
 
 const noopEnv: { KILOCLAW_AE?: AnalyticsEngineDataset } = {};
@@ -29,72 +35,71 @@ describe('evictCapacityRegionFromKV', () => {
   });
 
   it('is a no-op when KV read fails (no throw)', async () => {
-    const kv = {
-      get: vi.fn().mockRejectedValue(new Error('KV unavailable')),
-      put: vi.fn(),
-    } as unknown as KVNamespace;
+    const getMock = vi.fn().mockRejectedValue(new Error('KV unavailable'));
+    const putMock = vi.fn();
+    const kv = { get: getMock, put: putMock } as unknown as KVNamespace;
 
     await expect(evictCapacityRegionFromKV(kv, noopEnv, 'iad')).resolves.toBeUndefined();
-    expect(kv.put).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
   });
 
   it('is a no-op when KV key is null', async () => {
-    const { kv } = makeKv(null);
+    const { kv, putMock } = makeKv(null);
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(kv.put).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
   });
 
   it('is a no-op when KV key is empty string', async () => {
-    const { kv } = makeKv('');
+    const { kv, putMock } = makeKv('');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(kv.put).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
   });
 
   it('is a no-op for a pure meta-region list', async () => {
-    const { kv } = makeKv('eu,us');
+    const { kv, putMock } = makeKv('eu,us');
     await evictCapacityRegionFromKV(kv, noopEnv, 'eu');
-    expect(kv.put).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
   });
 
   it('is a no-op when failedRegion is not in the list', async () => {
-    const { kv } = makeKv('iad,dfw,ord');
+    const { kv, putMock } = makeKv('iad,dfw,ord');
     await evictCapacityRegionFromKV(kv, noopEnv, 'lhr');
-    expect(kv.put).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
   });
 
   it('evicts one region from a list with multiple remaining named regions', async () => {
-    const { kv, store } = makeKv('iad,dfw,ord');
+    const { kv, putMock, store } = makeKv('iad,dfw,ord');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
     expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,ord');
   });
 
   it('deduplicates before writing when evicting from a list with duplicates', async () => {
-    const { kv } = makeKv('iad,dfw,iad,ord');
+    const { kv, putMock } = makeKv('iad,dfw,iad,ord');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
     // remaining after evicting both iad occurrences: dfw,ord (deduplicated)
-    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,ord');
   });
 
   it('writes "lastRegion,eu,us" when evicting the second-to-last named region', async () => {
-    const { kv, store } = makeKv('iad,dfw');
+    const { kv, putMock, store } = makeKv('iad,dfw');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,eu,us');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'dfw,eu,us');
     expect(store.get(FLY_REGIONS_KV_KEY)).toBe('dfw,eu,us');
   });
 
   it('writes "failedRegion,eu,us" when evicting the only named region', async () => {
-    const { kv, store } = makeKv('iad');
+    const { kv, putMock, store } = makeKv('iad');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
     expect(store.get(FLY_REGIONS_KV_KEY)).toBe('iad,eu,us');
   });
 
   it('writes "failedRegion,eu,us" when evicting the only named region mixed with meta-regions', async () => {
     // iad is the only named region, eu is meta — after evicting iad, no named regions remain
-    const { kv } = makeKv('iad,eu');
+    const { kv, putMock } = makeKv('iad,eu');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(kv.put).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
+    expect(putMock).toHaveBeenCalledWith(FLY_REGIONS_KV_KEY, 'iad,eu,us');
   });
 
   it('logs a warning after a successful eviction', async () => {
@@ -108,42 +113,72 @@ describe('evictCapacityRegionFromKV', () => {
   it('logs a revert-to-meta warning when last named region is evicted', async () => {
     const { kv } = makeKv('iad');
     await evictCapacityRegionFromKV(kv, noopEnv, 'iad');
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('reverting to meta-regions')
-    );
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('reverting to meta-regions'));
   });
 
   it('emits analytics event when KILOCLAW_AE binding is present', async () => {
-    const writeDataPoint = vi.fn();
+    const writeDataPoint = vi.fn<[AnalyticsEngineDataPoint], void>();
     const env = {
       KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
     };
     const { kv } = makeKv('iad,dfw,ord');
     await evictCapacityRegionFromKV(kv, env, 'iad');
-    expect(writeDataPoint).toHaveBeenCalledOnce();
-    const call = writeDataPoint.mock.calls[0][0];
-    expect(call.blobs[0]).toBe('region.capacity_eviction');
-    expect(call.blobs[11]).toBe('iad'); // flyRegion
-    expect(call.blobs[12]).toBe('evicted'); // label
+    // writeEvent emits: blobs[0]=event, blobs[11]=flyRegion, blobs[12]=label
+    const expectedDataPoint: AnalyticsEngineDataPoint = {
+      blobs: [
+        'region.capacity_eviction',
+        '',
+        'do',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        'iad',
+        'evicted',
+      ],
+      doubles: [0, 0],
+      indexes: ['region.capacity_eviction'],
+    };
+    expect(writeDataPoint).toHaveBeenCalledWith(expectedDataPoint);
   });
 
   it('emits "reverted_to_meta" label in analytics when last named region evicted', async () => {
-    const writeDataPoint = vi.fn();
+    const writeDataPoint = vi.fn<[AnalyticsEngineDataPoint], void>();
     const env = {
       KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
     };
     const { kv } = makeKv('iad');
     await evictCapacityRegionFromKV(kv, env, 'iad');
-    expect(writeDataPoint).toHaveBeenCalledOnce();
-    const call = writeDataPoint.mock.calls[0][0];
-    expect(call.blobs[12]).toBe('reverted_to_meta'); // label
+    const expectedDataPoint: AnalyticsEngineDataPoint = {
+      blobs: [
+        'region.capacity_eviction',
+        '',
+        'do',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        'iad',
+        'reverted_to_meta',
+      ],
+      doubles: [0, 0],
+      indexes: ['region.capacity_eviction'],
+    };
+    expect(writeDataPoint).toHaveBeenCalledWith(expectedDataPoint);
   });
 
   it('does not throw and logs a warning when KV put fails', async () => {
-    const kv = {
-      get: vi.fn().mockResolvedValue('iad,dfw'),
-      put: vi.fn().mockRejectedValue(new Error('KV write error')),
-    } as unknown as KVNamespace;
+    const getMock = vi.fn().mockResolvedValue('iad,dfw');
+    const putMock = vi.fn().mockRejectedValue(new Error('KV write error'));
+    const kv = { get: getMock, put: putMock } as unknown as KVNamespace;
 
     await expect(evictCapacityRegionFromKV(kv, noopEnv, 'iad')).resolves.toBeUndefined();
     expect(console.warn).toHaveBeenCalledWith(
@@ -152,14 +187,13 @@ describe('evictCapacityRegionFromKV', () => {
   });
 
   it('does not emit analytics when KV put fails', async () => {
-    const writeDataPoint = vi.fn();
+    const writeDataPoint = vi.fn<[AnalyticsEngineDataPoint], void>();
     const env = {
       KILOCLAW_AE: { writeDataPoint } as unknown as AnalyticsEngineDataset,
     };
-    const kv = {
-      get: vi.fn().mockResolvedValue('iad,dfw'),
-      put: vi.fn().mockRejectedValue(new Error('KV write error')),
-    } as unknown as KVNamespace;
+    const getMock = vi.fn().mockResolvedValue('iad,dfw');
+    const putMock = vi.fn().mockRejectedValue(new Error('KV write error'));
+    const kv = { get: getMock, put: putMock } as unknown as KVNamespace;
 
     await evictCapacityRegionFromKV(kv, env, 'iad');
     expect(writeDataPoint).not.toHaveBeenCalled();

--- a/kiloclaw/src/durable-objects/regions.ts
+++ b/kiloclaw/src/durable-objects/regions.ts
@@ -122,18 +122,17 @@ export async function evictCapacityRegionFromKV(
   if (!wasPresent) return;
 
   const remaining = regions.filter(r => r !== failedRegion);
-  const deduplicated = [...new Set(remaining)];
-  const namedRemaining = deduplicated.filter(r => !isMetaRegion(r));
+  const namedRemaining = remaining.filter(r => !isMetaRegion(r));
 
   let newKvValue: string;
   let revertedToMeta: boolean;
 
   if (namedRemaining.length > 1) {
-    newKvValue = deduplicated.join(',');
+    newKvValue = remaining.join(',');
     revertedToMeta = false;
   } else {
-    const lastRegion = namedRemaining[0] ?? failedRegion;
-    newKvValue = `${lastRegion},eu,us`;
+    const lastRegion = namedRemaining[0];
+    newKvValue = lastRegion ? `${lastRegion},eu,us` : 'eu,us';
     revertedToMeta = true;
   }
 

--- a/kiloclaw/src/durable-objects/regions.ts
+++ b/kiloclaw/src/durable-objects/regions.ts
@@ -123,11 +123,12 @@ export async function evictCapacityRegionFromKV(
 
   const remaining = regions.filter(r => r !== failedRegion);
   const namedRemaining = remaining.filter(r => !isMetaRegion(r));
+  const distinctNamedCount = new Set(namedRemaining).size;
 
   let newKvValue: string;
   let revertedToMeta: boolean;
 
-  if (namedRemaining.length > 1) {
+  if (distinctNamedCount > 1) {
     newKvValue = remaining.join(',');
     revertedToMeta = false;
   } else {

--- a/kiloclaw/src/durable-objects/regions.ts
+++ b/kiloclaw/src/durable-objects/regions.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FLY_REGION } from '../config';
+import { writeEvent } from '../utils/analytics';
 
 /** KV key used to store the runtime region configuration. */
 export const FLY_REGIONS_KV_KEY = 'fly-regions';
@@ -91,6 +92,74 @@ export function isMetaRegion(region: string): boolean {
 export function prepareRegions(regions: string[]): string[] {
   const hasSpecific = regions.some(r => !isMetaRegion(r));
   return hasSpecific ? shuffleRegions([...regions]) : regions;
+}
+
+/**
+ * Evict a capacity-exhausted region from the KV region list.
+ *
+ * If the region is not present, or the list is all meta-regions, this is a no-op.
+ * When eviction leaves ≤1 distinct named region, a meta-region fallback is written
+ * so provisioning continues to work globally.
+ */
+export async function evictCapacityRegionFromKV(
+  kv: KVNamespace,
+  env: { KILOCLAW_AE?: AnalyticsEngineDataset },
+  failedRegion: string
+): Promise<void> {
+  let raw: string | null;
+  try {
+    raw = await kv.get(FLY_REGIONS_KV_KEY);
+  } catch {
+    return;
+  }
+
+  if (!raw) return;
+
+  const regions = parseRegions(raw);
+  if (regions.every(r => isMetaRegion(r))) return;
+
+  const wasPresent = regions.some(r => r === failedRegion);
+  if (!wasPresent) return;
+
+  const remaining = regions.filter(r => r !== failedRegion);
+  const deduplicated = [...new Set(remaining)];
+  const namedRemaining = deduplicated.filter(r => !isMetaRegion(r));
+
+  let newKvValue: string;
+  let revertedToMeta: boolean;
+
+  if (namedRemaining.length > 1) {
+    newKvValue = deduplicated.join(',');
+    revertedToMeta = false;
+  } else {
+    const lastRegion = namedRemaining[0] ?? failedRegion;
+    newKvValue = `${lastRegion},eu,us`;
+    revertedToMeta = true;
+  }
+
+  try {
+    await kv.put(FLY_REGIONS_KV_KEY, newKvValue);
+  } catch {
+    console.warn(`[regions] capacity eviction: failed to write updated region list to KV`);
+    return;
+  }
+
+  if (revertedToMeta) {
+    console.warn(
+      `[regions] capacity eviction: ${failedRegion} was last named region, reverting to meta-regions → "${newKvValue}"`
+    );
+  } else {
+    console.warn(
+      `[regions] capacity eviction: removed ${failedRegion} from KV region list → "${newKvValue}"`
+    );
+  }
+
+  writeEvent(env, {
+    event: 'region.capacity_eviction',
+    delivery: 'do',
+    flyRegion: failedRegion,
+    label: revertedToMeta ? 'reverted_to_meta' : 'evicted',
+  });
 }
 
 /**

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -227,7 +227,7 @@ export async function createVolumeWithFallback(
       lastError = err;
       if (!isFlyInsufficientResources(err)) throw err;
       console.warn(`[fly] Volume creation failed in ${region} (capacity), trying next region`);
-      options?.onCapacityError?.(region);
+      void options?.onCapacityError?.(region);
     }
   }
 

--- a/kiloclaw/src/fly/client.ts
+++ b/kiloclaw/src/fly/client.ts
@@ -204,11 +204,16 @@ export async function createVolume(
  *
  * On capacity-related 412 errors the next region is tried.
  * Any other error is thrown immediately.
+ *
+ * The optional `onCapacityError` callback is fired-and-forgotten for each
+ * capacity failure so callers can evict the exhausted region from their KV
+ * list without blocking the provisioning path.
  */
 export async function createVolumeWithFallback(
   config: FlyClientConfig,
   request: CreateVolumeRequestWithoutRegion,
-  regions: string[]
+  regions: string[],
+  options?: { onCapacityError?: (failedRegion: string) => void | Promise<void> }
 ): Promise<FlyVolume> {
   if (regions.length === 0) {
     throw new Error('createVolumeWithFallback: no regions provided');
@@ -222,6 +227,7 @@ export async function createVolumeWithFallback(
       lastError = err;
       if (!isFlyInsufficientResources(err)) throw err;
       console.warn(`[fly] Volume creation failed in ${region} (capacity), trying next region`);
+      options?.onCapacityError?.(region);
     }
   }
 

--- a/kiloclaw/src/utils/analytics.ts
+++ b/kiloclaw/src/utils/analytics.ts
@@ -62,6 +62,8 @@ export type KiloClawEventName =
   | 'reconcile.recover_bound_machine_for_destroy'
   | 'reconcile.restart_self_healed'
   | 'reconcile.destroy_complete'
+  // Region capacity management
+  | 'region.capacity_eviction'
   // HTTP-derived (open string) and additional reconcile.* events
   | (string & {});
 

--- a/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -571,7 +571,7 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
             <CadenceToggle cadence={cadence} onChange={handleCadenceChange} />
 
             {/* Tier cards */}
-            <div className="mb-3.5 grid grid-cols-3 gap-2.5">
+            <div className="mb-3.5 grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-2.5">
               {TIERS.map(tier => (
                 <TierCard
                   key={tier}


### PR DESCRIPTION
## Summary
- Subscription modal tier cards (Starter/Pro/Expert) used a fixed 3-column grid at all viewport widths, making each card ~89px wide on mobile — text wrapping was unreadable
- Changed `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` so cards stack vertically on mobile and go side-by-side at 640px+

## Mobile — Before vs After (375×812, Playwright)

| Before | After |
|:---:|:---:|
| <img src="https://github.com/Kilo-Org/cloud/releases/download/untagged-18414cb4c08071340671/mobile-before.png" width="300" /> | <img src="https://github.com/Kilo-Org/cloud/releases/download/untagged-18414cb4c08071340671/mobile-after-v2.png" width="300" /> |

## Desktop (1280×800, Playwright)

<img src="https://github.com/Kilo-Org/cloud/releases/download/untagged-18414cb4c08071340671/desktop.png" width="800" />

## Test plan
- [x] Playwright screenshots at mobile (375×812) and desktop (1280×800) viewports
- [x] Manual verification on device