### PR TITLE
refactor(claw): replace per-section TOOLS.md wrappers with generic updateToolsMdSection helper

### DIFF
--- a/kiloclaw/controller/src/bootstrap.test.ts
+++ b/kiloclaw/controller/src/bootstrap.test.ts
@@ -7,14 +7,16 @@ import {
   generateHooksToken,
   configureGitHub,
   configureLinear,
-  updateToolsMdLinearSection,
   runOnboardOrDoctor,
-  updateToolsMdKiloCliSection,
-  updateToolsMd1PasswordSection,
+  updateToolsMdSection,
+  GOG_SECTION_CONFIG,
+  KILO_CLI_SECTION_CONFIG,
+  OP_SECTION_CONFIG,
+  LINEAR_SECTION_CONFIG,
   buildGatewayArgs,
   bootstrap,
 } from './bootstrap';
-import type { BootstrapDeps } from './bootstrap';
+import type { BootstrapDeps, ToolsMdSectionConfig } from './bootstrap';
 
 // ---- Encryption helpers (mirrors kiloclaw/src/utils/env-encryption.ts) ----
 
@@ -612,32 +614,56 @@ describe('runOnboardOrDoctor', () => {
   });
 });
 
-// ---- updateToolsMdKiloCliSection ----
+// ---- updateToolsMdSection ----
 
-describe('updateToolsMdKiloCliSection', () => {
-  it('adds Kilo CLI section unconditionally', () => {
+describe('updateToolsMdSection', () => {
+  const testConfig: ToolsMdSectionConfig = {
+    name: 'Test',
+    beginMarker: '<!-- BEGIN:test -->',
+    endMarker: '<!-- END:test -->',
+    section: '\n<!-- BEGIN:test -->\n## Test Section\n<!-- END:test -->',
+  };
+
+  it('appends section when enabled and not present', () => {
     const harness = fakeDeps();
     (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
 
-    const env: Record<string, string | undefined> = {};
-
-    updateToolsMdKiloCliSection(env, harness.deps);
+    updateToolsMdSection(true, testConfig, harness.deps);
 
     expect(harness.writeCalls).toHaveLength(1);
-    expect(harness.writeCalls[0]!.data).toContain('<!-- BEGIN:kilo-cli -->');
-    expect(harness.writeCalls[0]!.data).toContain('kilo run --auto');
-    expect(harness.writeCalls[0]!.data).toContain('<!-- END:kilo-cli -->');
+    expect(harness.writeCalls[0]!.data).toContain('<!-- BEGIN:test -->');
+    expect(harness.writeCalls[0]!.data).toContain('## Test Section');
+    expect(harness.writeCalls[0]!.data).toContain('<!-- END:test -->');
   });
 
   it('skips adding when section already present', () => {
     const harness = fakeDeps();
     (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
-      '# TOOLS\n<!-- BEGIN:kilo-cli -->\nexisting\n<!-- END:kilo-cli -->'
+      '# TOOLS\n<!-- BEGIN:test -->\nexisting\n<!-- END:test -->'
     );
 
-    const env: Record<string, string | undefined> = {};
+    updateToolsMdSection(true, testConfig, harness.deps);
 
-    updateToolsMdKiloCliSection(env, harness.deps);
+    expect(harness.writeCalls).toHaveLength(0);
+  });
+
+  it('removes stale section when disabled', () => {
+    const harness = fakeDeps();
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      '# TOOLS\n<!-- BEGIN:test -->\nold section\n<!-- END:test -->\n'
+    );
+
+    updateToolsMdSection(false, testConfig, harness.deps);
+
+    expect(harness.writeCalls).toHaveLength(1);
+    expect(harness.writeCalls[0]!.data).not.toContain('<!-- BEGIN:test -->');
+  });
+
+  it('no-ops when disabled and no stale section exists', () => {
+    const harness = fakeDeps();
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
+
+    updateToolsMdSection(false, testConfig, harness.deps);
 
     expect(harness.writeCalls).toHaveLength(0);
   });
@@ -646,158 +672,48 @@ describe('updateToolsMdKiloCliSection', () => {
     const harness = fakeDeps();
     (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
 
-    const env: Record<string, string | undefined> = {};
-
-    updateToolsMdKiloCliSection(env, harness.deps);
+    updateToolsMdSection(true, testConfig, harness.deps);
 
     expect(harness.writeCalls).toHaveLength(0);
+  });
+
+  it('warns when BEGIN marker found but END marker missing', () => {
+    const harness = fakeDeps();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const brokenConfig: ToolsMdSectionConfig = {
+      ...testConfig,
+      endMarker: '<!-- END:nonexistent -->',
+    };
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      '# TOOLS\n<!-- BEGIN:test -->\norphaned section\n'
+    );
+
+    updateToolsMdSection(false, brokenConfig, harness.deps);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('BEGIN marker found but END marker missing')
+    );
+    expect(harness.writeCalls).toHaveLength(0);
+    warnSpy.mockRestore();
   });
 });
 
-// ---- updateToolsMd1PasswordSection ----
+// ---- section config correctness ----
 
-describe('updateToolsMd1PasswordSection', () => {
-  it('adds 1Password section when OP_SERVICE_ACCOUNT_TOKEN is set', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
+describe('TOOLS.md section configs', () => {
+  const configs: ToolsMdSectionConfig[] = [
+    GOG_SECTION_CONFIG,
+    KILO_CLI_SECTION_CONFIG,
+    OP_SECTION_CONFIG,
+    LINEAR_SECTION_CONFIG,
+  ];
 
-    const env: Record<string, string | undefined> = {
-      OP_SERVICE_ACCOUNT_TOKEN: 'ops_test123',
-    };
-
-    updateToolsMd1PasswordSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(1);
-    expect(harness.writeCalls[0]!.data).toContain('<!-- BEGIN:1password -->');
-    expect(harness.writeCalls[0]!.data).toContain('op vault list');
-    expect(harness.writeCalls[0]!.data).toContain('<!-- END:1password -->');
-  });
-
-  it('skips adding when section already present', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
-      '# TOOLS\n<!-- BEGIN:1password -->\nexisting\n<!-- END:1password -->'
-    );
-
-    const env: Record<string, string | undefined> = {
-      OP_SERVICE_ACCOUNT_TOKEN: 'ops_test123',
-    };
-
-    updateToolsMd1PasswordSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(0);
-  });
-
-  it('removes stale section when token is absent', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
-      '# TOOLS\n<!-- BEGIN:1password -->\nold section\n<!-- END:1password -->\n'
-    );
-
-    const env: Record<string, string | undefined> = {};
-
-    updateToolsMd1PasswordSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(1);
-    expect(harness.writeCalls[0]!.data).not.toContain('<!-- BEGIN:1password -->');
-  });
-
-  it('no-ops when TOOLS.md does not exist', () => {
-    const harness = fakeDeps();
-    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
-
-    const env: Record<string, string | undefined> = {
-      OP_SERVICE_ACCOUNT_TOKEN: 'ops_test123',
-    };
-
-    updateToolsMd1PasswordSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(0);
-  });
-
-  it('no-ops when token absent and no stale section exists', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
-
-    const env: Record<string, string | undefined> = {};
-
-    updateToolsMd1PasswordSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(0);
-  });
-});
-
-// ---- updateToolsMdLinearSection ----
-
-describe('updateToolsMdLinearSection', () => {
-  it('adds Linear section when LINEAR_API_KEY is set', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
-
-    const env: Record<string, string | undefined> = {
-      LINEAR_API_KEY: 'lin_api_test123',
-    };
-
-    updateToolsMdLinearSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(1);
-    expect(harness.writeCalls[0]!.data).toContain('<!-- BEGIN:linear -->');
-    expect(harness.writeCalls[0]!.data).toContain('## Linear');
-    expect(harness.writeCalls[0]!.data).toContain('<!-- END:linear -->');
-  });
-
-  it('skips adding when section already present', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
-      '# TOOLS\n<!-- BEGIN:linear -->\nexisting\n<!-- END:linear -->'
-    );
-
-    const env: Record<string, string | undefined> = {
-      LINEAR_API_KEY: 'lin_api_test123',
-    };
-
-    updateToolsMdLinearSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(0);
-  });
-
-  it('removes stale section when key is absent', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
-      '# TOOLS\n<!-- BEGIN:linear -->\nold section\n<!-- END:linear -->\n'
-    );
-
-    const env: Record<string, string | undefined> = {};
-
-    updateToolsMdLinearSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(1);
-    expect(harness.writeCalls[0]!.data).not.toContain('<!-- BEGIN:linear -->');
-  });
-
-  it('no-ops when TOOLS.md does not exist', () => {
-    const harness = fakeDeps();
-    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
-
-    const env: Record<string, string | undefined> = {
-      LINEAR_API_KEY: 'lin_api_test123',
-    };
-
-    updateToolsMdLinearSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(0);
-  });
-
-  it('no-ops when key absent and no stale section exists', () => {
-    const harness = fakeDeps();
-    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue('# TOOLS\n');
-
-    const env: Record<string, string | undefined> = {};
-
-    updateToolsMdLinearSection(env, harness.deps);
-
-    expect(harness.writeCalls).toHaveLength(0);
-  });
+  for (const config of configs) {
+    it(`${config.name}: section contains both markers`, () => {
+      expect(config.section).toContain(config.beginMarker);
+      expect(config.section).toContain(config.endMarker);
+    });
+  }
 });
 
 // ---- buildGatewayArgs ----

--- a/kiloclaw/controller/src/bootstrap.ts
+++ b/kiloclaw/controller/src/bootstrap.ts
@@ -403,13 +403,64 @@ export function runOnboardOrDoctor(env: EnvLike, deps: BootstrapDeps = defaultDe
   }
 }
 
-// ---- Step 8: TOOLS.md Google Workspace section ----
+// ---- TOOLS.md bounded-section helper ----
 
-const GOG_MARKER_BEGIN = '<!-- BEGIN:google-workspace -->';
-const GOG_MARKER_END = '<!-- END:google-workspace -->';
+export type ToolsMdSectionConfig = {
+  name: string;
+  beginMarker: string;
+  endMarker: string;
+  section: string;
+};
 
-const GOG_TOOLS_SECTION = `
-${GOG_MARKER_BEGIN}
+/**
+ * Manage a bounded section in TOOLS.md.
+ *
+ * When `enabled` is true, append the section if not already present.
+ * When `enabled` is false, remove any stale section.
+ * Idempotent: skips if the marker is already present.
+ */
+export function updateToolsMdSection(
+  enabled: boolean,
+  config: ToolsMdSectionConfig,
+  deps: BootstrapDeps
+): void {
+  if (!deps.existsSync(TOOLS_MD_DEST)) return;
+
+  const content = deps.readFileSync(TOOLS_MD_DEST, 'utf8');
+
+  if (enabled) {
+    if (!content.includes(config.beginMarker)) {
+      deps.writeFileSync(TOOLS_MD_DEST, content + config.section);
+      console.log(`TOOLS.md: added ${config.name} section`);
+    } else {
+      console.log(`TOOLS.md: ${config.name} section already present`);
+    }
+  } else {
+    if (content.includes(config.beginMarker)) {
+      const beginIdx = content.indexOf(config.beginMarker);
+      const endIdx = content.indexOf(config.endMarker);
+      if (beginIdx !== -1 && endIdx !== -1) {
+        const before = content.slice(0, beginIdx).replace(/\n+$/, '\n');
+        const after = content.slice(endIdx + config.endMarker.length).replace(/^\n+/, '');
+        deps.writeFileSync(TOOLS_MD_DEST, before + after);
+        console.log(`TOOLS.md: removed stale ${config.name} section`);
+      } else {
+        console.warn(
+          `TOOLS.md: ${config.name} BEGIN marker found but END marker missing, skipping removal`
+        );
+      }
+    }
+  }
+}
+
+// ---- TOOLS.md section configs ----
+
+export const GOG_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: 'Google Workspace',
+  beginMarker: '<!-- BEGIN:google-workspace -->',
+  endMarker: '<!-- END:google-workspace -->',
+  section: `
+<!-- BEGIN:google-workspace -->
 ## Google Workspace
 
 The \`gog\` CLI is configured and ready for Google Workspace operations (Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Forms, Chat, Classroom).
@@ -422,50 +473,15 @@ The \`gog\` CLI is configured and ready for Google Workspace operations (Gmail, 
 - Drive — list files: \`gog drive files list --account <email>\`
 - Docs — read: \`gog docs get --account <email> <doc-id>\`
 - Run \`gog --help\` and \`gog <service> --help\` for all available commands.
-${GOG_MARKER_END}`;
+<!-- END:google-workspace -->`,
+};
 
-/**
- * Manage the Google Workspace section in TOOLS.md.
- *
- * When gog credentials are present, append a bounded section so the agent
- * knows gog is available. When credentials are absent, remove any stale
- * section. Idempotent: skips if the marker is already present.
- */
-export function updateToolsMdGoogleSection(env: EnvLike, deps: BootstrapDeps): void {
-  if (!deps.existsSync(TOOLS_MD_DEST)) return;
-
-  const content = deps.readFileSync(TOOLS_MD_DEST, 'utf8');
-
-  if (env.KILOCLAW_GOG_CONFIG_TARBALL) {
-    // Google connected — add section if not already present
-    if (!content.includes(GOG_MARKER_BEGIN)) {
-      deps.writeFileSync(TOOLS_MD_DEST, content + GOG_TOOLS_SECTION);
-      console.log('TOOLS.md: added Google Workspace section');
-    } else {
-      console.log('TOOLS.md: Google Workspace section already present');
-    }
-  } else {
-    // Google not connected — remove stale section if present
-    if (content.includes(GOG_MARKER_BEGIN)) {
-      const beginIdx = content.indexOf(GOG_MARKER_BEGIN);
-      const endIdx = content.indexOf(GOG_MARKER_END);
-      if (beginIdx !== -1 && endIdx !== -1) {
-        const before = content.slice(0, beginIdx).replace(/\n+$/, '\n');
-        const after = content.slice(endIdx + GOG_MARKER_END.length).replace(/^\n+/, '');
-        deps.writeFileSync(TOOLS_MD_DEST, before + after);
-        console.log('TOOLS.md: removed stale Google Workspace section');
-      }
-    }
-  }
-}
-
-// ---- Step 8: TOOLS.md Kilo CLI section ----
-
-const KILO_CLI_MARKER_BEGIN = '<!-- BEGIN:kilo-cli -->';
-const KILO_CLI_MARKER_END = '<!-- END:kilo-cli -->';
-
-const KILO_CLI_TOOLS_SECTION = `
-${KILO_CLI_MARKER_BEGIN}
+export const KILO_CLI_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: 'Kilo CLI',
+  beginMarker: '<!-- BEGIN:kilo-cli -->',
+  endMarker: '<!-- END:kilo-cli -->',
+  section: `
+<!-- BEGIN:kilo-cli -->
 ## Kilo CLI
 
 The Kilo CLI (\`kilo\`) is an agentic coding assistant for the terminal, pre-configured with your KiloCode account.
@@ -474,35 +490,15 @@ The Kilo CLI (\`kilo\`) is an agentic coding assistant for the terminal, pre-con
 - Autonomous mode: \`kilo run --auto "your task description"\`
 - Config: \`/root/.config/kilo/opencode.json\` (customizable, persists across restarts)
 - Shares your KiloCode API key and model access with OpenClaw
-${KILO_CLI_MARKER_END}`;
+<!-- END:kilo-cli -->`,
+};
 
-/**
- * Ensure the Kilo CLI section is present in TOOLS.md.
- *
- * The kilo binary is always in the image, so this runs unconditionally
- * (not gated on a feature flag). Idempotent: skips if the marker is
- * already present.
- */
-export function updateToolsMdKiloCliSection(_env: EnvLike, deps: BootstrapDeps): void {
-  if (!deps.existsSync(TOOLS_MD_DEST)) return;
-
-  const content = deps.readFileSync(TOOLS_MD_DEST, 'utf8');
-
-  if (!content.includes(KILO_CLI_MARKER_BEGIN)) {
-    deps.writeFileSync(TOOLS_MD_DEST, content + KILO_CLI_TOOLS_SECTION);
-    console.log('TOOLS.md: added Kilo CLI section');
-  } else {
-    console.log('TOOLS.md: Kilo CLI section already present');
-  }
-}
-
-// ---- Step 9: TOOLS.md 1Password section ----
-
-const OP_MARKER_BEGIN = '<!-- BEGIN:1password -->';
-const OP_MARKER_END = '<!-- END:1password -->';
-
-const OP_TOOLS_SECTION = `
-${OP_MARKER_BEGIN}
+export const OP_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: '1Password',
+  beginMarker: '<!-- BEGIN:1password -->',
+  endMarker: '<!-- END:1password -->',
+  section: `
+<!-- BEGIN:1password -->
 ## 1Password
 
 The \`op\` CLI is configured with a 1Password service account. Use it to look up credentials, generate passwords, and manage vault items.
@@ -515,99 +511,22 @@ The \`op\` CLI is configured with a 1Password service account. Use it to look up
 - Run \`op --help\` for all available commands.
 
 **Security note:** Only access credentials the user has explicitly requested. Do not list or expose vault contents unnecessarily.
-${OP_MARKER_END}`;
+<!-- END:1password -->`,
+};
 
-/**
- * Manage the 1Password section in TOOLS.md.
- *
- * When OP_SERVICE_ACCOUNT_TOKEN is present, append a bounded section so the
- * agent knows the op CLI is available. When absent, remove any stale section.
- * Idempotent: skips if the marker is already present.
- */
-export function updateToolsMd1PasswordSection(env: EnvLike, deps: BootstrapDeps): void {
-  if (!deps.existsSync(TOOLS_MD_DEST)) return;
-
-  const content = deps.readFileSync(TOOLS_MD_DEST, 'utf8');
-
-  if (env.OP_SERVICE_ACCOUNT_TOKEN) {
-    // 1Password configured — add section if not already present
-    if (!content.includes(OP_MARKER_BEGIN)) {
-      deps.writeFileSync(TOOLS_MD_DEST, content + OP_TOOLS_SECTION);
-      console.log('TOOLS.md: added 1Password section');
-    } else {
-      console.log('TOOLS.md: 1Password section already present');
-    }
-  } else {
-    // 1Password not configured — remove stale section if present
-    if (content.includes(OP_MARKER_BEGIN)) {
-      const beginIdx = content.indexOf(OP_MARKER_BEGIN);
-      const endIdx = content.indexOf(OP_MARKER_END);
-      if (beginIdx !== -1 && endIdx !== -1) {
-        const before = content.slice(0, beginIdx).replace(/\n+$/, '\n');
-        const after = content.slice(endIdx + OP_MARKER_END.length).replace(/^\n+/, '');
-        deps.writeFileSync(TOOLS_MD_DEST, before + after);
-        console.log('TOOLS.md: removed stale 1Password section');
-      } else {
-        console.warn(
-          'TOOLS.md: 1Password BEGIN marker found but END marker missing, skipping removal'
-        );
-      }
-    }
-  }
-}
-
-// ---- Step 10: TOOLS.md Linear section ----
-
-const LINEAR_MARKER_BEGIN = '<!-- BEGIN:linear -->';
-const LINEAR_MARKER_END = '<!-- END:linear -->';
-
-const LINEAR_TOOLS_SECTION = `
-${LINEAR_MARKER_BEGIN}
+export const LINEAR_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: 'Linear',
+  beginMarker: '<!-- BEGIN:linear -->',
+  endMarker: '<!-- END:linear -->',
+  section: `
+<!-- BEGIN:linear -->
 ## Linear
 
 Linear is configured as your project management tool. Use it  to track issues, plan projects, and manage product roadmaps.
 You can interact with the \`Linear\` MCP server using your \`mcporter\` skill.
 
-  ${LINEAR_MARKER_END}`;
-
-/**
- * Manage the Linear section in TOOLS.md.
- *
- * When LINEAR_API_KEY is present, append a bounded section so the agent
- * knows Linear MCP is available. When absent, remove any stale section.
- * Idempotent: skips if the marker is already present.
- */
-export function updateToolsMdLinearSection(env: EnvLike, deps: BootstrapDeps): void {
-  if (!deps.existsSync(TOOLS_MD_DEST)) return;
-
-  const content = deps.readFileSync(TOOLS_MD_DEST, 'utf8');
-
-  if (env.LINEAR_API_KEY) {
-    // Linear configured — add section if not already present
-    if (!content.includes(LINEAR_MARKER_BEGIN)) {
-      deps.writeFileSync(TOOLS_MD_DEST, content + LINEAR_TOOLS_SECTION);
-      console.log('TOOLS.md: added Linear section');
-    } else {
-      console.log('TOOLS.md: Linear section already present');
-    }
-  } else {
-    // Linear not configured — remove stale section if present
-    if (content.includes(LINEAR_MARKER_BEGIN)) {
-      const beginIdx = content.indexOf(LINEAR_MARKER_BEGIN);
-      const endIdx = content.indexOf(LINEAR_MARKER_END);
-      if (beginIdx !== -1 && endIdx !== -1) {
-        const before = content.slice(0, beginIdx).replace(/\n+$/, '\n');
-        const after = content.slice(endIdx + LINEAR_MARKER_END.length).replace(/^\n+/, '');
-        deps.writeFileSync(TOOLS_MD_DEST, before + after);
-        console.log('TOOLS.md: removed stale Linear section');
-      } else {
-        console.warn(
-          'TOOLS.md: Linear BEGIN marker found but END marker missing, skipping removal'
-        );
-      }
-    }
-  }
-}
+  <!-- END:linear -->`,
+};
 
 // ---- Step 11: Gateway args ----
 
@@ -667,10 +586,10 @@ export async function bootstrap(
   runOnboardOrDoctor(env, deps);
   await yieldToEventLoop();
 
-  updateToolsMdKiloCliSection(env, deps);
-  updateToolsMdGoogleSection(env, deps);
-  updateToolsMd1PasswordSection(env, deps);
-  updateToolsMdLinearSection(env, deps);
+  updateToolsMdSection(true, KILO_CLI_SECTION_CONFIG, deps);
+  updateToolsMdSection(!!env.KILOCLAW_GOG_CONFIG_TARBALL, GOG_SECTION_CONFIG, deps);
+  updateToolsMdSection(!!env.OP_SERVICE_ACCOUNT_TOKEN, OP_SECTION_CONFIG, deps);
+  updateToolsMdSection(!!env.LINEAR_API_KEY, LINEAR_SECTION_CONFIG, deps);
 
   // Write mcporter config for MCP servers (AgentCard, etc.)
   writeMcporterConfig(env);


### PR DESCRIPTION
## Summary

This PR implements a helper method for adding and removing sections to TOOLS.md, and refactors the different conditional tool sections to leverage that helper in their add/remove logic. This significantly reduces the overhead of adding new tools by standardizing the behavior, and centralizes the risk of this operation in the helper method — instead of across the individual implementation for each tool. 

Result
* More maintainable
* easier to understand
* less code in this already large file

In short, this PR is following the DRY principle (Don't Repeat Yourself). 

--

- Extracted ToolsMdSectionConfig type and updateToolsMdSection() generic helper. 
- Converted all 4 section-specific wrapper functions (Google, Kilo CLI, 1Password, Linear) into exported config constants called directly from bootstrap(). 
- Replaced 4 near-identical test describe blocks with one generic helper test suite plus config correctness assertions.

---

## Proof of purity

  ### 1. Section content: IDENTICAL
  All four section strings (Google Workspace, Kilo CLI, 1Password, Linear) are **byte-identical** between old and new, confirmed programmatically by reconstructing the old template literals (with their `${MARKER}`
  interpolations) and comparing `===` against the new config `.section` values:

  ```
  === Section content comparison ===
  GOG identical: true
  KILO_CLI identical: true
  OP identical: true
  LINEAR identical: true
  ```

  ### 2. Call-site enablement conditions: IDENTICAL
  | Section | Old condition | New condition |
  |---|---|---|
  | Kilo CLI | unconditional (`_env` unused) | `true` |
  | Google | `env.KILOCLAW_GOG_CONFIG_TARBALL` (truthy) | `!!env.KILOCLAW_GOG_CONFIG_TARBALL` |
  | 1Password | `env.OP_SERVICE_ACCOUNT_TOKEN` (truthy) | `!!env.OP_SERVICE_ACCOUNT_TOKEN` |
  | Linear | `env.LINEAR_API_KEY` (truthy) | `!!env.LINEAR_API_KEY` |

  `!!x` coerces to `boolean` for the `enabled: boolean` parameter — same branching in all cases.

  ### 3. Core algorithm: IDENTICAL
  The add-if-missing / skip-if-present / remove-stale-section logic is structurally identical:
  - `existsSync` guard → same
  - `readFileSync` → same
  - `includes(beginMarker)` → same
  - `indexOf` + `slice` + `replace(/\n+$/, '\n')` + `replace(/^\n+/, '')` removal → same
  - `writeFileSync` for add/remove → same
  - `console.log` messages → same (interpolated with `config.name`)

  ### 4. One micro-difference found: new `console.warn` for Google Workspace

  The old `updateToolsMdGoogleSection` had **no `else` branch** after `if (beginIdx !== -1 && endIdx !== -1)` — it silently no-op'd when the BEGIN marker was present but the END marker was missing.

  The new generic `updateToolsMdSection` adds a `console.warn` in that `else` branch. This was already present in the old 1Password and Linear functions, so the refactor **normalizes** the Google path to match the other two.
  This is:
  - A **diagnostic-only** difference (console.warn, not a behavioral change)
  - Only reachable if TOOLS.md is corrupted (BEGIN without END) — impossible during normal operation
  - A **bug fix** by omission in the original Google code (inconsistent with 1Password/Linear)

  ### 5. Tests: 52/52 pass

  ```
   Test Files  1 passed (1)
        Tests  52 passed (52)
     Start at  09:58:12
     Duration  633ms
  ```

  ### Verdict

  The refactor is **pure DRY extraction** with one trivial normalization: a missing `console.warn` for a corrupted-file edge case in the Google section path is now present, matching the 1Password and Linear sections that
  already had it. No functional behavior changes. No content changes. No condition changes.
