### PR TITLE
fix(kiloclaw): evict quota-hit regions during initial provision

### DIFF
--- a/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -106,6 +106,7 @@ import * as flyClient from '../fly/client';
 import { FlyApiError } from '../fly/client';
 import * as db from '../db';
 import * as gatewayEnv from '../gateway/env';
+import * as regions from './regions';
 import { resolveLatestVersion } from '../lib/image-version';
 import { setupDefaultStreamChatChannel } from '../stream-chat/client';
 import { verifyKiloToken } from '@kilocode/worker-utils';
@@ -4173,6 +4174,33 @@ describe('provision: auto-start after fresh provision', () => {
     expect(flyClient.createMachine).toHaveBeenCalled();
     expect(storage._store.get('status')).toBe('running');
     expect(storage._store.get('flyMachineId')).toBe('machine-1');
+  });
+
+  it('wires capacity eviction callback during initial volume provisioning', async () => {
+    const env = createFakeEnv();
+    const { instance, waitUntilPromises } = createInstance(undefined, env);
+    const evictSpy = vi.spyOn(regions, 'evictCapacityRegionFromKV').mockResolvedValue(undefined);
+
+    (flyClient.createVolumeWithFallback as Mock).mockImplementation(
+      async (
+        _config: unknown,
+        _request: unknown,
+        _regions: string[],
+        options?: { onCapacityError?: (failedRegion: string) => void | Promise<void> }
+      ) => {
+        await options?.onCapacityError?.('arn');
+        return { id: 'vol-1', region: 'yyz' };
+      }
+    );
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'yyz' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'yyz' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.provision('user-1', {});
+    await Promise.all(waitUntilPromises);
+
+    expect(evictSpy).toHaveBeenCalledWith(env.KV_CLAW_CACHE, env, 'arn');
+    evictSpy.mockRestore();
   });
 
   it('skips auto-start on re-provision of existing instance', async () => {

--- a/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -39,7 +39,12 @@ import {
   MAX_CUSTOM_SECRETS,
   type SecretFieldKey,
 } from '@kilocode/kiloclaw-secret-catalog';
-import { parseRegions, prepareRegions, resolveRegions } from '../regions';
+import {
+  parseRegions,
+  prepareRegions,
+  resolveRegions,
+  evictCapacityRegionFromKV,
+} from '../regions';
 import { buildMachineConfig, guestFromSize, volumeNameFromSandboxId } from '../machine-config';
 import type { GatewayProcessStatus } from '../gateway-controller-types';
 
@@ -244,7 +249,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           size_gb: DEFAULT_VOLUME_SIZE_GB,
           compute: guest,
         },
-        regions
+        regions,
+        {
+          onCapacityError: failedRegion => {
+            void evictCapacityRegionFromKV(this.env.KV_CLAW_CACHE, this.env, failedRegion);
+          },
+        }
       );
       this.s.flyVolumeId = volume.id;
       this.s.flyRegion = volume.region;


### PR DESCRIPTION
## Summary

- Wire the Fly capacity-error callback into the initial KiloClaw provision path so first-time volume creation also evicts quota-hit regions from the KV-backed region list.
- Add a regression test covering initial provisioning to verify `arn`-style quota failures trigger `evictCapacityRegionFromKV`.
- This closes the gap where recovery flows already evicted exhausted regions, but fresh provisions did not.

## Verification

- [x] `cd kiloclaw && pnpm test src/durable-objects/kiloclaw-instance.test.ts src/fly/client.test.ts src/durable-objects/regions.eviction.test.ts` — passed
- [x] `cd kiloclaw && pnpm typecheck` — passed
- [x] `pnpm install` — completed and restored missing `stream-chat` / `stream-chat-react` deps needed by repo-wide checks
- [x] `pnpm typecheck` — passed
- [x] `pnpm run format:check` — passed
- [x] `pnpm lint` — passed
- [x] `git push -u origin HEAD` — passed after hooks succeeded on the updated push

## Visual Changes

N/A

## Reviewer Notes

- The fix is intentionally narrow: only the initial inline `provision()` volume-creation path changed, to match the existing callback behavior already present in `ensureVolume()` and stranded-volume replacement flows.
- The branch was amended once after formatting the new test assertion onto a single line so the final pushed commit is `95cab0e08`.