### PR TITLE
fix(admin): invalidate controllerVersion on machineRedeploy and machineUpgrade success

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1221,6 +1221,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Redeploy requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
@@ -1235,6 +1242,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Upgrade to latest requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {


### PR DESCRIPTION
## Summary

Adds immediate `controllerVersion` query invalidation to the `onSuccess` callbacks of both `machineRedeploy` and `machineUpgrade` mutations in `KiloclawInstanceDetail.tsx`.

Previously, `controllerVersion` was only re-invalidated after the machine returned to `running` (via the polling `useEffect`). Now it is also eagerly invalidated at mutation success, matching the pattern already used for `gatewayStatus` via `invalidateGatewayQueries()`. The deferred re-invalidation via the polling `useEffect` is preserved — the two invalidations complement each other.

## Verification

- Code review: change is minimal and consistent with surrounding patterns.
- No quality gates configured for this rig.

## Visual Changes

N/A

## Reviewer Notes

The `if (data?.user_id)` guard mirrors the existing guard in the polling `useEffect` (line 1133) and in `invalidateGatewayQueries`. No new state or effects introduced.