### PR TITLE
feat(db): split EU read traffic across two replicas

### DIFF
--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -47,8 +47,8 @@ export function isUSRegion(): boolean {
 /**
  * Get the read replica URL based on deployment region.
  * - US deployments use the US replica (POSTGRES_REPLICA_US_URL) for lower latency
- * - EU deployments use the EU replica (POSTGRES_REPLICA_EU_URL) to split read
- *   traffic off the primary's connection budget (98.8% of traffic is fra1)
+ * - EU deployments randomly select one of two EU replicas to split read traffic
+ *   across ~2,200 concurrent Vercel instances (~50/50 statistical distribution)
  * - Falls back to primary if no replica URL is configured for the region
  */
 function getReplicaUrl(): string {
@@ -56,8 +56,13 @@ function getReplicaUrl(): string {
     const usReplica = getEnvVariable('POSTGRES_REPLICA_US_URL');
     if (usReplica) return usReplica;
   } else {
-    const euReplica = getEnvVariable('POSTGRES_REPLICA_EU_URL');
-    if (euReplica) return euReplica;
+    const euReplicas = [
+      getEnvVariable('POSTGRES_REPLICA_EU_URL'),
+      getEnvVariable('POSTGRES_REPLICA_EU_URL_2'),
+    ].filter(Boolean) as string[];
+    if (euReplicas.length > 0) {
+      return euReplicas[Math.floor(Math.random() * euReplicas.length)];
+    }
   }
 
   return postgresUrl;


### PR DESCRIPTION
## Summary

EU read traffic currently funnels through a single replica (`POSTGRES_REPLICA_EU_URL`), which concentrates connection pressure from ~2,200 concurrent Vercel instances onto one endpoint.

This adds support for a second EU replica (`POSTGRES_REPLICA_EU_URL_2`). At module init, `getReplicaUrl()` collects both EU replica URLs into an array and randomly selects one. Since each Vercel instance loads the module once, this distributes instances ~50/50 across the two replicas statistically, halving per-replica connection pressure.

The change is entirely contained within `getReplicaUrl()` — no downstream code (pool config, lifecycle logging, metrics, `readDb` consumers) is affected.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm test -- --run src/lib/drizzle.test.ts` — 2/2 tests pass
- [x] `pnpm format:check` — passes (pre-push hook)

## Visual Changes

N/A

## Reviewer Notes

- The `POSTGRES_REPLICA_EU_URL_2` env var needs to be set in Vercel before deploy for the second replica to take effect. If unset, `.filter(Boolean)` removes it and instances fall back to the single existing replica — no behavior change until the env var is configured.
- Trivially extensible to more replicas by adding more URLs to the array.