### PR TITLE
fix(kiloclaw): add error boundary to enrollWithCredits mutation

### DIFF
--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1664,12 +1664,22 @@ export const kiloclawRouter = createTRPCRouter({
       // Intro pricing eligibility (spec Credit Enrollment rule 3).
       const hadPaidSubscription = await hadPriorPaidSubscription(ctx.user.id);
 
-      await enrollWithCreditsImpl({
-        userId: ctx.user.id,
-        instanceId: instance.id,
-        plan: input.plan,
-        hadPaidSubscription,
-      });
+      try {
+        await enrollWithCreditsImpl({
+          userId: ctx.user.id,
+          instanceId: instance.id,
+          plan: input.plan,
+          hadPaidSubscription,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Credit enrollment failed';
+        const code = message.includes('not found')
+          ? 'NOT_FOUND'
+          : message.includes('already exists') || message.includes('already processed')
+            ? 'CONFLICT'
+            : 'BAD_REQUEST';
+        throw new TRPCError({ code, message });
+      }
 
       return { success: true };
     }),

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1681,7 +1681,7 @@ export const kiloclawRouter = createTRPCRouter({
             : message.includes('Insufficient credit balance')
               ? 'BAD_REQUEST'
               : 'INTERNAL_SERVER_ERROR';
-        throw new TRPCError({ code, message });
+        throw new TRPCError({ code, message, cause: error });
       }
 
       return { success: true };

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -1672,12 +1672,15 @@ export const kiloclawRouter = createTRPCRouter({
           hadPaidSubscription,
         });
       } catch (error) {
+        if (error instanceof TRPCError) throw error;
         const message = error instanceof Error ? error.message : 'Credit enrollment failed';
         const code = message.includes('not found')
           ? 'NOT_FOUND'
           : message.includes('already exists') || message.includes('already processed')
             ? 'CONFLICT'
-            : 'BAD_REQUEST';
+            : message.includes('Insufficient credit balance')
+              ? 'BAD_REQUEST'
+              : 'INTERNAL_SERVER_ERROR';
         throw new TRPCError({ code, message });
       }
 


### PR DESCRIPTION
## Summary

### Problem

The `enrollWithCredits` tRPC mutation lacked a try-catch boundary. `enrollWithCreditsImpl()` throws plain `Error` objects for validation failures (user not found, active subscription exists, insufficient balance, duplicate enrollment). These propagated as unhandled exceptions through tRPC middleware, surfacing in Sentry as high-priority noise (KILOCODE-WEB-1KVM) and returning generic 500 errors to users instead of actionable messages.

### Solution

- Wrapped the `enrollWithCreditsImpl()` call in `kiloclaw-router.ts` with a try-catch that maps known error messages to appropriate `TRPCError` codes: `NOT_FOUND`, `CONFLICT`, or `BAD_REQUEST`.
- Users now receive descriptive error responses instead of generic 500s.
- Sentry will record these as handled responses, eliminating the false-positive unhandled exception alerts.

### Why this approach

The alternative was throwing `TRPCError` directly from `credit-billing.ts`, which is simpler but couples the library layer to tRPC. The try-catch-in-router pattern is already established in the same file (e.g. `renameInstance` at line 598) and keeps the library transport-agnostic.

### Related issues

- Sentry: [KILOCODE-WEB-1KVM](https://kilo-code.sentry.io/issues/7374015917/)
- Incident: `2026-03-30-kiloclaw-credit-enrollment-unhandled-error`

## Verification

- [x] `pnpm typecheck` — passed

## Visual Changes

N/A

## Reviewer Notes

- The message-to-code mapping uses substring matching (`includes('not found')`, `includes('already exists')`, etc.) against the four known error messages in `credit-billing.ts`. If new error messages are added to `enrollWithCreditsImpl` in the future, they'll fall through to the `BAD_REQUEST` default, which is a safe catch-all.
- No risk of behavior change for the happy path — the try-catch only activates on errors.