### PR TITLE
fix(bot): prevent premature stream resolution from replayed idle events

### DIFF
--- a/src/lib/cloud-agent-next/run-session.ts
+++ b/src/lib/cloud-agent-next/run-session.ts
@@ -158,6 +158,7 @@ export async function runSessionToCompletion(input: RunSessionInput): Promise<Ru
   let kiloSessionId: string | undefined;
   let hasError = false;
   let errorMessage: string | undefined;
+  let hasSeenBusy = false;
 
   // 1. Prepare
   try {
@@ -259,7 +260,12 @@ export async function runSessionToCompletion(input: RunSessionInput): Promise<Ru
         }
       },
       onSessionStatusChanged: status => {
-        if (status.type === 'idle') resolveOnce();
+        if (status.type === 'busy') {
+          hasSeenBusy = true;
+        }
+        if (status.type === 'idle' && hasSeenBusy) {
+          resolveOnce();
+        }
       },
       onError: error => {
         hasError = true;


### PR DESCRIPTION
## Summary

When the bot connects to a Cloud Agent session's WebSocket stream, the server replays the session's event history which includes an initial `session.status: idle` event from before the execution started. The `onSessionStatusChanged` callback in `run-session.ts` saw this idle and immediately resolved the stream as "done" — before any execution events arrived.

This caused `statusMessages=0, hasResult=false`: the Cloud Agent session continued running fine, but the bot had already disconnected and reported an empty result to the user.

The fix adds a `hasSeenBusy` flag so we only resolve on `idle` after the session has first transitioned to `busy`. The natural lifecycle is `idle → busy → ... → idle`, and only the second idle signals actual completion.

The `onSessionStatusChanged` callback in the event processor already filters out child/sub-agent sessions, so this only applies to root session status changes.

## Verification

- Manually tested against a live Slack bot instance — the bot now waits for the session to complete and returns the full Cloud Agent response
- `pnpm typecheck` passes

## Visual Changes

N/A

## Reviewer Notes

Minimal, targeted fix — one new variable and a guard condition. The `idle` signal is preserved as a completion fallback (rather than removing it entirely in favor of only `complete` events) since it's useful when the `complete` event is delayed or missing.