### PR TITLE
feat(session-ingest): send heartbeat_ack to CLI on heartbeat

### DIFF
--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.test.ts
@@ -344,6 +344,16 @@ describe('UserConnectionDO', () => {
       sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
       expect(ctx.storage.setAlarm).toHaveBeenCalled();
     });
+
+    it('sends heartbeat_ack to CLI socket', () => {
+      const { doInstance, mockCtx } = setup();
+      const cliWs = addCliSocket(mockCtx, 'cli-1');
+
+      sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+
+      const msgs = allSent(cliWs);
+      expect(msgs).toContainEqual({ type: 'heartbeat_ack' });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
+++ b/cloudflare-session-ingest/src/dos/UserConnectionDO.ts
@@ -314,6 +314,8 @@ export class UserConnectionDO extends DurableObject<Env> {
         this.sendToWeb(ws2, msg);
       }
     }
+
+    this.sendToCli(ws, { type: 'heartbeat_ack' });
   }
 
   private handleCliEvent(

--- a/cloudflare-session-ingest/src/types/user-connection-protocol.test.ts
+++ b/cloudflare-session-ingest/src/types/user-connection-protocol.test.ts
@@ -139,6 +139,12 @@ describe('CLIInboundMessageSchema', () => {
     const result = CLIInboundMessageSchema.safeParse(msg);
     expect(result.success).toBe(false);
   });
+
+  it('parses valid heartbeat_ack', () => {
+    const msg = { type: 'heartbeat_ack' };
+    const result = CLIInboundMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('WebOutboundMessageSchema', () => {

--- a/cloudflare-session-ingest/src/types/user-connection-protocol.ts
+++ b/cloudflare-session-ingest/src/types/user-connection-protocol.ts
@@ -57,6 +57,9 @@ export const CLIInboundMessageSchema = z.discriminatedUnion('type', [
     event: z.string(),
     data: z.unknown(),
   }),
+  z.object({
+    type: z.literal('heartbeat_ack'),
+  }),
 ]);
 
 // -- Web UI → DO (WebOutbound) ------------------------------------------------


### PR DESCRIPTION
## Summary

When the CLI sends a `heartbeat` to the `UserConnectionDO`, the DO now replies with a `{ type: 'heartbeat_ack' }` message. This gives idle CLI connections inbound traffic that confirms the WebSocket is alive, preventing proxies and load balancers from closing connections that only send outbound heartbeats.

Changes:
- Added `heartbeat_ack` variant to `CLIInboundMessageSchema` (DO → CLI protocol)
- Added `sendToCli(ws, { type: 'heartbeat_ack' })` at the end of `handleHeartbeat()` in `UserConnectionDO`
- Added schema-level and behavior-level tests

The ack carries no payload and is always sent regardless of web subscribers. Older CLI clients that don't recognize the message type will silently ignore it (backward compatible).

## Verification

- [x] `pnpm test` in `cloudflare-session-ingest` — 189 tests passed (10 files)
- [x] `pnpm typecheck` — passed, no type errors
- [x] Code review — no issues found

## Visual Changes

N/A

## Reviewer Notes

- The `heartbeat_ack` is sent at the very end of `handleHeartbeat()`, after all session bookkeeping and web fan-out, so it does not affect existing logic.
- Existing tests are unaffected because they either don't assert on CLI send counts or clear mocks before relevant assertions.