### PR TITLE
fix(gastown): propagate KILOCODE_TOKEN refresh to running containers

### DIFF
--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -220,6 +220,7 @@ app.patch('/agents/:agentId/model', async c => {
       ['github_cli_pat', 'GITHUB_CLI_PAT'],
       ['git_author_name', 'GASTOWN_GIT_AUTHOR_NAME'],
       ['git_author_email', 'GASTOWN_GIT_AUTHOR_EMAIL'],
+      ['kilocode_token', 'KILOCODE_TOKEN'],
     ];
     for (const [cfgKey, envKey] of CONFIG_ENV_MAP) {
       const val = cfg[cfgKey];

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -843,6 +843,7 @@ export async function updateAgentModel(
     'GASTOWN_GIT_AUTHOR_NAME',
     'GASTOWN_GIT_AUTHOR_EMAIL',
     'GASTOWN_DISABLE_AI_COAUTHOR',
+    'KILOCODE_TOKEN',
   ]);
   const hotSwapEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(agent.startupEnv)) {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -3335,13 +3335,24 @@ export class TownDO extends DurableObject<Env> {
 
     // Decode JWT payload (base64url, no verification)
     const parts = token.split('.');
-    if (parts.length !== 3) return;
-    let payload: { exp?: number; kiloUserId?: string; apiTokenPepper?: string | null };
-    try {
-      payload = JSON.parse(atob(parts[1]!.replace(/-/g, '+').replace(/_/g, '/')));
-    } catch {
-      return;
-    }
+    const encodedPayload = parts[1];
+    if (!encodedPayload) return;
+    const payloadSchema = z.object({
+      exp: z.number().optional(),
+      kiloUserId: z.string().optional(),
+      apiTokenPepper: z.string().nullable().optional(),
+    });
+    const parsed = payloadSchema.safeParse(
+      (() => {
+        try {
+          return JSON.parse(atob(encodedPayload.replace(/-/g, '+').replace(/_/g, '/')));
+        } catch {
+          return undefined;
+        }
+      })()
+    );
+    if (!parsed.success) return;
+    const payload = parsed.data;
 
     const exp = payload.exp;
     if (!exp) return;

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -56,6 +56,8 @@ import { query } from '../util/query.util';
 import { getAgentDOStub } from './Agent.do';
 import { getTownContainerStub } from './TownContainer.do';
 
+import { generateKiloApiToken } from '../util/kilo-token.util';
+import { resolveSecret } from '../util/secret.util';
 import { writeEvent, type GastownEventData } from '../util/analytics.util';
 import { logger, withLogTags } from '../util/log.util';
 import { BeadPriority } from '../types';
@@ -616,6 +618,7 @@ export class TownDO extends DurableObject<Env> {
       ['GASTOWN_GIT_AUTHOR_NAME', townConfig.git_author_name],
       ['GASTOWN_GIT_AUTHOR_EMAIL', townConfig.git_author_email],
       ['GASTOWN_DISABLE_AI_COAUTHOR', townConfig.disable_ai_coauthor ? '1' : undefined],
+      ['KILOCODE_TOKEN', townConfig.kilocode_token],
     ];
 
     for (const [key, value] of envMapping) {
@@ -3014,6 +3017,16 @@ export class TownDO extends DurableObject<Env> {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+
+      // Proactively remint KILOCODE_TOKEN before it expires (30-day
+      // expiry, checked daily, refreshed within 7 days of expiry).
+      try {
+        await this.refreshKilocodeTokenIfExpiring();
+      } catch (err) {
+        logger.warn('alarm: refreshKilocodeTokenIfExpiring failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     // ── Pre-phase: Observe container status for working agents ────────
@@ -3297,6 +3310,69 @@ export class TownDO extends DurableObject<Env> {
     // Only mark as refreshed after success — failed refreshes should
     // be retried on the next alarm tick, not throttled for an hour.
     this.lastContainerTokenRefreshAt = now;
+  }
+
+  /**
+   * Proactively remint KILOCODE_TOKEN when it's approaching expiry.
+   * Throttled to once per day — the 30-day token is refreshed when
+   * within 7 days of expiry, providing ample safety margin.
+   *
+   * Decodes the existing JWT payload to extract user identity (no
+   * signature verification needed — we're just reading the claims to
+   * re-sign with the same data).
+   */
+  private lastKilocodeTokenCheckAt = 0;
+  private async refreshKilocodeTokenIfExpiring(): Promise<void> {
+    const CHECK_INTERVAL_MS = 24 * 60 * 60_000; // once per day
+    const REFRESH_WINDOW_SECONDS = 7 * 24 * 60 * 60; // 7 days
+    const now = Date.now();
+    if (now - this.lastKilocodeTokenCheckAt < CHECK_INTERVAL_MS) return;
+    this.lastKilocodeTokenCheckAt = now;
+
+    const townConfig = await this.getTownConfig();
+    const token = townConfig.kilocode_token;
+    if (!token) return;
+
+    // Decode JWT payload (base64url, no verification)
+    const parts = token.split('.');
+    if (parts.length !== 3) return;
+    let payload: { exp?: number; kiloUserId?: string; apiTokenPepper?: string | null };
+    try {
+      payload = JSON.parse(atob(parts[1]!.replace(/-/g, '+').replace(/_/g, '/')));
+    } catch {
+      return;
+    }
+
+    const exp = payload.exp;
+    if (!exp) return;
+
+    const nowSeconds = Math.floor(now / 1000);
+    if (exp - nowSeconds > REFRESH_WINDOW_SECONDS) return;
+
+    // Token expires within 7 days — remint it
+    const userId = payload.kiloUserId;
+    if (!userId) return;
+
+    if (!this.env.NEXTAUTH_SECRET) {
+      logger.warn('refreshKilocodeTokenIfExpiring: NEXTAUTH_SECRET not configured');
+      return;
+    }
+    const secret = await resolveSecret(this.env.NEXTAUTH_SECRET);
+    if (!secret) {
+      logger.warn('refreshKilocodeTokenIfExpiring: failed to resolve NEXTAUTH_SECRET');
+      return;
+    }
+
+    const newToken = await generateKiloApiToken(
+      { id: userId, api_token_pepper: payload.apiTokenPepper ?? null },
+      secret
+    );
+    await this.updateTownConfig({ kilocode_token: newToken });
+    await this.syncConfigToContainer();
+    logger.info('refreshKilocodeTokenIfExpiring: reminted KILOCODE_TOKEN proactively', {
+      userId,
+      oldExp: new Date(exp * 1000).toISOString(),
+    });
   }
 
   private hasActiveWork(): boolean {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -3342,15 +3342,13 @@ export class TownDO extends DurableObject<Env> {
       kiloUserId: z.string().optional(),
       apiTokenPepper: z.string().nullable().optional(),
     });
-    const parsed = payloadSchema.safeParse(
-      (() => {
-        try {
-          return JSON.parse(atob(encodedPayload.replace(/-/g, '+').replace(/_/g, '/')));
-        } catch {
-          return undefined;
-        }
-      })()
-    );
+    let rawPayload: unknown;
+    try {
+      rawPayload = JSON.parse(atob(encodedPayload.replace(/-/g, '+').replace(/_/g, '/')));
+    } catch {
+      return;
+    }
+    const parsed = payloadSchema.safeParse(rawPayload);
     if (!parsed.success) return;
     const payload = parsed.data;
 

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -1018,6 +1018,13 @@ export const gastownRouter = router({
       }
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.forceRefreshContainerToken();
+
+      // Also remint and push KILOCODE_TOKEN — this is what actually
+      // authenticates GT tool calls and is the main reason users hit 401s.
+      const user = userFromCtx(ctx);
+      const newKilocodeToken = await mintKilocodeToken(ctx.env, user);
+      await townStub.updateTownConfig({ kilocode_token: newKilocodeToken });
+      await townStub.syncConfigToContainer();
     }),
 
   // ── Events ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes KILOCODE_TOKEN not being refreshed on running containers (#1472). Closes 4 propagation gaps where token updates were not reaching the container, plus adds proactive alarm-based refresh:

1. **syncConfigToContainer()** — Added `KILOCODE_TOKEN` to the env mapping so config updates propagate to the container via `setEnvVar`.
2. **LIVE_ENV_KEYS** — Added `KILOCODE_TOKEN` so model hot-swaps read the current `process.env` value instead of the stale startup snapshot.
3. **CONFIG_ENV_MAP** — Added `kilocode_token` → `KILOCODE_TOKEN` mapping in the model update handler so `process.env` stays current before SDK server restart.
4. **refreshContainerToken mutation** — Now also remints `KILOCODE_TOKEN` via `mintKilocodeToken` and pushes it via `updateTownConfig` + `syncConfigToContainer`, so the "Refresh Token" button actually resolves 401s.
5. **Alarm loop** — Added `refreshKilocodeTokenIfExpiring()` that checks daily and proactively remints when within 7 days of the 30-day expiry, using decoded JWT payload claims to reconstruct user identity.

## Verification

- [x] Code review: all additions follow existing patterns (CONFIG_ENV_MAP, LIVE_ENV_KEYS, syncConfigToContainer env mapping)
- [x] Verified imports resolve to existing exports (`generateKiloApiToken`, `resolveSecret`, `mintKilocodeToken`, `userFromCtx`)
- [x] Verified function signatures match call sites
- [x] No build artifacts or generated files in diff
- [x] JWT decoding uses Zod validation at IO boundary per project conventions

## Visual Changes

N/A

## Reviewer Notes

- The `refreshKilocodeTokenIfExpiring` method decodes the JWT payload without signature verification — this is intentional since the DO is reading its own stored token to extract claims for re-signing. The Zod schema validates the parsed payload shape.
- The throttle (`lastKilocodeTokenCheckAt`) resets on DO restart, which is fine — worst case is an extra check on first alarm after restart.
- All 4 propagation fixes are simple 1-line additions to existing arrays/sets; the alarm-based refresh is the only substantial new code (~70 lines).