### PR TITLE
fix(gastown): push KILOCODE_TOKEN to running process and guard remint by owner

### DIFF
--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -123,13 +123,36 @@ app.post('/dashboard-context', async c => {
 // Hot-swap the container-scoped JWT on the running process. Called by
 // the TownDO alarm to push a fresh token before the current one expires.
 // Updates process.env so all subsequent API calls use the new token.
+//
+// Also accepts an optional `kilocodeToken` field to hot-swap the
+// KILOCODE_TOKEN used by the SDK / LLM gateway. When provided,
+// process.env.KILOCODE_TOKEN is updated so long-lived agents pick up
+// the fresh value without a container restart.
 app.post('/refresh-token', async c => {
   const body: unknown = await c.req.json().catch(() => null);
-  if (!body || typeof body !== 'object' || !('token' in body) || typeof body.token !== 'string') {
-    return c.json({ error: 'Missing or invalid token field' }, 400);
+  const parsed = z
+    .object({
+      token: z.string().optional(),
+      kilocodeToken: z.string().optional(),
+    })
+    .refine(d => d.token || d.kilocodeToken, {
+      message: 'Must provide at least one of: token, kilocodeToken',
+    })
+    .safeParse(body);
+
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid request body' }, 400);
   }
-  process.env.GASTOWN_CONTAINER_TOKEN = body.token;
-  console.log('[control-server] Container token refreshed');
+
+  const { token, kilocodeToken } = parsed.data;
+  if (token) {
+    process.env.GASTOWN_CONTAINER_TOKEN = token;
+    console.log('[control-server] Container token refreshed');
+  }
+  if (kilocodeToken) {
+    process.env.KILOCODE_TOKEN = kilocodeToken;
+    console.log('[control-server] KILOCODE_TOKEN refreshed');
+  }
   return c.json({ refreshed: true });
 });
 
@@ -220,6 +243,7 @@ app.patch('/agents/:agentId/model', async c => {
       ['github_cli_pat', 'GITHUB_CLI_PAT'],
       ['git_author_name', 'GASTOWN_GIT_AUTHOR_NAME'],
       ['git_author_email', 'GASTOWN_GIT_AUTHOR_EMAIL'],
+      ['kilocode_token', 'KILOCODE_TOKEN'],
     ];
     for (const [cfgKey, envKey] of CONFIG_ENV_MAP) {
       const val = cfg[cfgKey];

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -843,6 +843,7 @@ export async function updateAgentModel(
     'GASTOWN_GIT_AUTHOR_NAME',
     'GASTOWN_GIT_AUTHOR_EMAIL',
     'GASTOWN_DISABLE_AI_COAUTHOR',
+    'KILOCODE_TOKEN',
   ]);
   const hotSwapEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(agent.startupEnv)) {

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -599,6 +599,10 @@ export class TownDO extends DurableObject<Env> {
    * Push config-derived env vars to the running container. Called after
    * updateTownConfig so that settings changes take effect without a
    * container restart. New agent processes inherit the updated values.
+   *
+   * KILOCODE_TOKEN is pushed to the running process via the /refresh-token
+   * endpoint (not just setEnvVar) so long-lived agents pick up the fresh
+   * value immediately.
    */
   async syncConfigToContainer(): Promise<void> {
     const townId = this.townId;
@@ -627,6 +631,16 @@ export class TownDO extends DurableObject<Env> {
         }
       } catch (err) {
         console.warn(`[Town.do] syncConfigToContainer: ${key} sync failed:`, err);
+      }
+    }
+
+    // Push KILOCODE_TOKEN to the running process so long-lived agents
+    // (especially the mayor) pick up the fresh token immediately.
+    if (townConfig.kilocode_token) {
+      try {
+        await dispatch.pushKilocodeTokenToContainer(this.env, townId, townConfig.kilocode_token);
+      } catch (err) {
+        console.warn('[Town.do] syncConfigToContainer: KILOCODE_TOKEN push failed:', err);
       }
     }
   }

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -185,6 +185,51 @@ export async function forceRefreshContainerToken(
   return token;
 }
 
+/**
+ * Push a fresh KILOCODE_TOKEN to the running container process via
+ * POST /refresh-token. Also persists via setEnvVar for next boot.
+ *
+ * Best-effort: tolerates a downed container (the token will be picked
+ * up on next boot via setEnvVar). Propagates non-network errors so
+ * callers can log or retry.
+ */
+export async function pushKilocodeTokenToContainer(
+  env: Env,
+  townId: string,
+  token: string
+): Promise<void> {
+  const container = getTownContainerStub(env, townId);
+
+  // Persist for next boot
+  try {
+    await container.setEnvVar('KILOCODE_TOKEN', token);
+  } catch (err) {
+    console.warn(
+      `${TOWN_LOG} pushKilocodeTokenToContainer: setEnvVar failed:`,
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  // Push to running process
+  try {
+    const resp = await container.fetch('http://container/refresh-token', {
+      method: 'POST',
+      signal: AbortSignal.timeout(10_000),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kilocodeToken: token }),
+    });
+    if (!resp.ok) {
+      console.warn(`${TOWN_LOG} pushKilocodeTokenToContainer: container returned ${resp.status}`);
+    }
+  } catch (err) {
+    // If the container isn't running, the token will be in envVars when
+    // it boots. Only propagate non-network errors.
+    const isContainerDown =
+      err instanceof TypeError || (err instanceof Error && err.message.includes('fetch'));
+    if (!isContainerDown) throw err;
+  }
+}
+
 /** Build the initial prompt for an agent from its bead. */
 export function buildPrompt(params: {
   beadTitle: string;

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -1018,6 +1018,23 @@ export const gastownRouter = router({
       }
       const townStub = getTownDOStub(ctx.env, input.townId);
       await townStub.forceRefreshContainerToken();
+
+      // Also push KILOCODE_TOKEN — this is what actually authenticates
+      // GT tool calls and is the main reason users hit 401s.
+      // Only remint if the caller is the town owner (they have the
+      // correct api_token_pepper). For org towns where a non-owner
+      // member triggers the refresh, push the existing token instead
+      // of overwriting the owner's identity.
+      const user = userFromCtx(ctx);
+      const townConfig = await townStub.getTownConfig();
+      const credentialUserId = townConfig.owner_user_id ?? user.id;
+      if (credentialUserId === user.id) {
+        const newKilocodeToken = await mintKilocodeToken(ctx.env, user);
+        await townStub.updateTownConfig({ kilocode_token: newKilocodeToken });
+      }
+      // syncConfigToContainer pushes KILOCODE_TOKEN (new or existing)
+      // to the running container process.
+      await townStub.syncConfigToContainer();
     }),
 
   // ── Events ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes 4 KILOCODE_TOKEN propagation gaps so that long-lived agents (especially the mayor) pick up fresh tokens without a container restart:

- Extended `POST /refresh-token` on the control server to accept an optional `kilocodeToken` field (backward-compatible; existing callers sending `{ token }` still work).
- Added `KILOCODE_TOKEN` to `LIVE_ENV_KEYS` in `process-manager.ts` so model hot-swaps use the live `process.env` value instead of the stale startup snapshot.
- Added `KILOCODE_TOKEN` to `CONFIG_ENV_MAP` in the model update handler so `process.env` stays current before SDK server restart.
- New `pushKilocodeTokenToContainer()` helper persists the token via `setEnvVar` for next boot and pushes it to the running process via `/refresh-token`. Best-effort: tolerates downed containers.
- `syncConfigToContainer()` now calls `pushKilocodeTokenToContainer` so config updates propagate immediately.
- `refreshContainerToken` mutation now remints `KILOCODE_TOKEN` when the caller is the town owner and pushes it via `syncConfigToContainer`. Non-owner org members push the existing token to avoid overwriting the owner's identity.

## Verification

- Code review passed: no type-safety issues (`as`/`!`), no secrets, no build artifacts, backward-compatible endpoint changes, error handling consistent with existing patterns.

## Visual Changes

N/A

## Reviewer Notes

- The `/refresh-token` endpoint schema uses a Zod `.refine()` to require at least one of `token` or `kilocodeToken`, maintaining backward compatibility with existing callers.
- The owner guard in `refreshContainerToken` (`credentialUserId === user.id`) prevents org members from overwriting the token owner's identity — this is an intentional security boundary.