### PR TITLE
fix(sidebar): deduplicate projects in filter dropdown

### DIFF
--- a/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -66,12 +66,17 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
 
   const recentProjects = useMemo(() => {
     if (!recentReposData?.repositories) return [];
+    const seen = new Set<string>();
     return recentReposData.repositories
       .map(r => ({
         gitUrl: r.gitUrl,
         displayName: extractRepoFromGitUrl(r.gitUrl) ?? r.gitUrl,
       }))
-      .filter(r => r.displayName);
+      .filter(r => {
+        if (!r.displayName || seen.has(r.displayName)) return false;
+        seen.add(r.displayName);
+        return true;
+      });
   }, [recentReposData?.repositories]);
   const queryClient = useQueryClient();
   const deleteSessionFromStore = useSetAtom(deleteSessionFromStoreAtom);


### PR DESCRIPTION
## Summary

Deduplicate projects in the sidebar project filter dropdown. The same repository can be stored with different `git_url` formats across `cli_sessions` and `cli_sessions_v2` (e.g., `https://github.com/Org/repo` vs `https://github.com/Org/repo.git`). The SQL query groups by exact `git_url`, but `extractRepoFromGitUrl()` normalizes both to the same display name, resulting in visually identical duplicate entries in the filter.

The fix deduplicates by `displayName` after mapping, keeping the first (most recently used) entry since the query results are already ordered by `last_used_at DESC`.

## Verification

- [x] `pnpm typecheck` — passed
- [ ] Manual verification of the project filter dropdown

## Visual Changes

| Before | After |
| ------ | ----- |
| Duplicate project entries in sidebar filter dropdown | Each project appears once |

## Reviewer Notes

The deduplication is done client-side in the `useMemo` that builds `recentProjects`. An alternative would be normalizing `git_url` in the SQL query before grouping, but the client-side approach is simpler and doesn't risk breaking other consumers of the raw `git_url` data.