### PR TITLE
fix(cloud-agent): cap prompt textarea height to prevent overflow on mobile

### DIFF
--- a/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -598,7 +598,10 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
     const ta = textareaRef.current;
     if (!ta) return;
     ta.style.height = 'auto';
-    ta.style.height = `${ta.scrollHeight}px`;
+    // Cap at 50% of dynamic viewport height so the textarea never outgrows the
+    // screen — `dvh` accounts for mobile virtual keyboards.
+    const maxHeight = window.innerHeight * 0.5;
+    ta.style.height = `${Math.min(ta.scrollHeight, maxHeight)}px`;
   }, []);
 
   const handlePromptChange = useCallback(
@@ -687,7 +690,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
         >
           <textarea
             ref={textareaRef}
-            className="w-full resize-none border-0 bg-transparent p-4 pb-2 text-sm focus:ring-0 focus:outline-none"
+            className="max-h-[50dvh] w-full resize-none overflow-y-auto border-0 bg-transparent p-4 pb-2 text-sm focus:ring-0 focus:outline-none"
             placeholder="What would you like to do?"
             rows={5}
             value={prompt}


### PR DESCRIPTION
## Summary

The Cloud Agent "New Session" prompt textarea grew unbounded — its auto-resize logic set height to `scrollHeight` with no cap, causing the textarea to push past the viewport on long inputs. This was especially problematic on mobile devices where a virtual keyboard reduces available screen space.

This adds a `50dvh` max-height cap (both in CSS via `max-h-[50dvh]` and in the JS auto-resize via `Math.min(scrollHeight, innerHeight * 0.5)`) and enables `overflow-y-auto` so content scrolls when the cap is reached. The `dvh` unit and `window.innerHeight` both account for mobile virtual keyboards automatically.

## Verification

- [x] `pnpm typecheck` — passed, no errors
- [ ] Manual verification of mobile/desktop behavior

## Visual Changes

| Before | After |
| ------ | ----- |
| Textarea grows past the viewport, pushing UI offscreen (see attached screenshot) | Textarea caps at 50% of the visible viewport and scrolls internally |

## Reviewer Notes

The approach mirrors the existing pattern in `ChatInput.tsx` (which already caps at `200px`). `50dvh` was chosen over a fixed pixel value so the cap adapts to any screen size and accounts for the virtual keyboard via the dynamic viewport unit.