### PR TITLE
fix(cloud-agent): top-align prompt and move repo line below input

### DIFF
--- a/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -391,18 +391,6 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                     </div>
                   )}
                   <div className={activeQuestion || activePermission ? 'hidden' : ''}>
-                    {sessionConfig?.repository && (
-                      <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-1 text-xs">
-                        <GitBranch className="h-3 w-3 shrink-0" />
-                        <span className="truncate">{sessionConfig.repository}</span>
-                        {fetchedSessionData?.gitBranch && (
-                          <>
-                            <span>·</span>
-                            <span className="truncate">{fetchedSessionData.gitBranch}</span>
-                          </>
-                        )}
-                      </div>
-                    )}
                     <ChatInput
                       onSend={handleSendMessage}
                       onStop={handleStopExecution}
@@ -422,6 +410,18 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                       showToolbar={Boolean(sessionIdFromParams)}
                       initialValue={failedPrompt ?? undefined}
                     />
+                    {sessionConfig?.repository && (
+                      <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
+                        <GitBranch className="h-3 w-3 shrink-0" />
+                        <span className="truncate">{sessionConfig.repository}</span>
+                        {fetchedSessionData?.gitBranch && (
+                          <>
+                            <span>·</span>
+                            <span className="truncate">{fetchedSessionData.gitBranch}</span>
+                          </>
+                        )}
+                      </div>
+                    )}
                   </div>
                 </>
               )}

--- a/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -662,12 +662,11 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
   // Render
   // ---------------------------------------------------------------------------
   return (
-    <div className="relative flex h-full flex-col items-center px-4">
+    <div className="relative flex h-full flex-col items-center px-4 pt-16">
       <SetPageTitle title="Cloud Agent">
         <Badge variant="new">new</Badge>
       </SetPageTitle>
       <MobileSidebarToggle />
-      <div className="flex-1" />
       <div className="w-full max-w-2xl space-y-4">
         {/* Insufficient balance banner */}
         {hasInsufficientBalance && eligibilityData && (
@@ -925,7 +924,6 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
           </Popover>
         </div>
       </div>
-      <div className="flex-[1.5]" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two layout fixes to the Cloud Agent UI:

1. **Top-align the new session prompt panel** (`NewSessionPanel.tsx`): The empty-state prompt at `/cloud` used asymmetric flex spacers (`flex-1` above, `flex-[1.5]` below) to vertically center the input, causing layout inconsistencies between production and local. Replaced with `pt-16` top padding for consistent top-aligned positioning with clear separation from navigation controls.

2. **Move repo/branch line below the chat input** (`CloudChatPage.tsx`): The repo/branch indicator (e.g. `org/repo · branch-name`) was positioned above the chat input where it collided with scrollable message content. Moved it below the input with balanced bottom padding (`pb-3 md:pb-4`) matching the input's own vertical padding.

## Verification

- [x] `pnpm typecheck` — passed (via pre-push hook)
- [x] `pnpm format:check` — passed (via pre-push hook)
- [x] `pnpm lint` — passed (via pre-push hook)
- [x] Manual visual check on local dev server

## Visual Changes

| Before | After |
| ------ | ----- |
| New session prompt vertically centered with flex spacers | Prompt top-aligned with `pt-16` padding |
| Repo/branch line above chat input, colliding with messages | Repo/branch line below chat input with balanced spacing |

<img width="1038" height="319" alt="Screenshot 2026-03-31 at 14 11 53" src="https://github.com/user-attachments/assets/40653268-d960-4324-ba35-2dcb73bf7e0b" />
<img width="1432" height="666" alt="Screenshot 2026-03-31 at 14 11 59" src="https://github.com/user-attachments/assets/46eb56a5-e7b6-4eed-8c02-6e4afb1813a3" />


## Reviewer Notes

Minimal styling-only changes across two files. No logic or functionality affected.