### PR TITLE
fix(observability): address review feedback on db-pool-metrics cron

### DIFF
--- a/src/app/api/cron/db-pool-metrics/route.ts
+++ b/src/app/api/cron/db-pool-metrics/route.ts
@@ -35,19 +35,40 @@ type PoolMetrics = {
   current_connections: number;
 };
 
+/** Check whether a Prometheus line's label block contains all required key="value" pairs. */
+function matchesLabels(labelBlock: string, requiredLabels: Record<string, string>): boolean {
+  for (const [key, val] of Object.entries(requiredLabels)) {
+    // Match key="value" with possible surrounding whitespace from split
+    if (!labelBlock.includes(`${key}="${val}"`)) return false;
+  }
+  return true;
+}
+
 /**
  * Extract a numeric value from Prometheus text for a given metric name,
- * filtering to lines matching the provided label substring (or none for scalars).
+ * optionally filtering to lines whose labels contain all required key-value pairs.
  */
-function extractMetricValue(lines: string[], metricName: string, labelFilter?: string): number {
+function extractMetricValue(
+  lines: string[],
+  metricName: string,
+  requiredLabels?: Record<string, string>
+): number {
   for (const line of lines) {
-    if (line.startsWith('#') || !line.startsWith(metricName)) continue;
-    if (labelFilter && !line.includes(labelFilter)) continue;
+    if (!line.startsWith(metricName)) continue;
+    // Exact name boundary: next char after the metric name must be '{' or ' '
+    const nextChar = line[metricName.length];
+    if (nextChar !== '{' && nextChar !== ' ') continue;
+
+    if (requiredLabels) {
+      const braceStart = line.indexOf('{');
+      const braceEnd = line.indexOf('}');
+      if (braceStart === -1 || braceEnd === -1) continue;
+      const labelBlock = line.slice(braceStart + 1, braceEnd);
+      if (!matchesLabels(labelBlock, requiredLabels)) continue;
+    }
 
     const parts = line.split(/\s+/);
-    const raw = parts[parts.length - 1];
-    if (raw === undefined) continue;
-    const value = Number(raw);
+    const value = Number(parts[parts.length - 1]);
     if (!Number.isNaN(value)) return value;
   }
   return 0;
@@ -58,59 +79,54 @@ function parseMetricsForDatabase(
 ): Omit<PoolMetrics, 'type' | 'database' | 'ref'> {
   const lines = prometheusText.split('\n');
 
-  // Pool metrics: filter to database="postgres",user="postgres" (the main app pool)
-  const appPoolFilter = 'database="postgres",user="postgres"';
+  // Pool metrics: filter to the main app pool
+  const appPoolLabels = { database: 'postgres', user: 'postgres' };
 
   // Config metrics: filter to the postgres database (not the pgbouncer admin db)
-  const dbFilter = 'database="postgres"';
+  const dbLabels = { database: 'postgres' };
   // pgbouncer_config_max_client_connections is a global scalar (no database label)
 
   return {
     client_active: extractMetricValue(
       lines,
       'pgbouncer_pools_client_active_connections',
-      appPoolFilter
+      appPoolLabels
     ),
     client_waiting: extractMetricValue(
       lines,
       'pgbouncer_pools_client_waiting_connections',
-      appPoolFilter
+      appPoolLabels
     ),
     server_active: extractMetricValue(
       lines,
       'pgbouncer_pools_server_active_connections',
-      appPoolFilter
+      appPoolLabels
     ),
     server_idle: extractMetricValue(
       lines,
       'pgbouncer_pools_server_idle_connections',
-      appPoolFilter
+      appPoolLabels
     ),
     server_used: extractMetricValue(
       lines,
       'pgbouncer_pools_server_used_connections',
-      appPoolFilter
+      appPoolLabels
     ),
     max_client_connections: extractMetricValue(lines, 'pgbouncer_config_max_client_connections'),
-    pool_size: extractMetricValue(lines, 'pgbouncer_databases_pool_size', dbFilter),
+    pool_size: extractMetricValue(lines, 'pgbouncer_databases_pool_size', dbLabels),
     current_connections: extractMetricValue(
       lines,
       'pgbouncer_databases_current_connections',
-      dbFilter
+      dbLabels
     ),
   };
 }
 
-/** Derive a human-readable label from a Supabase ref, e.g. "nfg...-rr-us-west-1-drobh" → "replica-us-west-1" */
+/** Derive a human-readable label from a Supabase ref, e.g. "nfg...-rr-eu-central-1-cdhuu" → "replica-eu-central-1-cdhuu" */
 function labelFromRef(ref: string): string {
   const rrIndex = ref.indexOf('-rr-');
   if (rrIndex === -1) return 'primary';
-  // Extract region from the "-rr-{region}-{suffix}" pattern
-  const afterRr = ref.slice(rrIndex + 4); // "us-west-1-drobh"
-  const parts = afterRr.split('-');
-  // Region is everything except the last segment (the random suffix)
-  const region = parts.slice(0, -1).join('-');
-  return `replica-${region}`;
+  return `replica-${ref.slice(rrIndex + 4)}`;
 }
 
 async function scrapeDatabase(
@@ -127,7 +143,9 @@ async function scrapeDatabase(
   });
 
   if (!response.ok) {
-    return { metrics: null, error: `HTTP ${response.status} from ${label} (${ref})` };
+    const error = `HTTP ${response.status} from ${label} (${ref})`;
+    captureException(new Error(error));
+    return { metrics: null, error };
   }
 
   const text = await response.text();


### PR DESCRIPTION
## Summary

Follow-up to #1764 — addresses unresolved review comments from @markijbema and the LLM-generated review, plus a bug where both EU central replicas reported the same label.

Specifically:

1. **Removed redundant `#` check** ([comment](https://github.com/Kilo-Org/cloud/pull/1764#discussion_r3014850127)) — @markijbema noted metric names don't start with `#`, making the `startsWith('#')` guard redundant since such lines already fail the `startsWith(metricName)` check.

2. **Removed unnecessary `undefined` guard** ([comment](https://github.com/Kilo-Org/cloud/pull/1764#discussion_r3014853308)) — @markijbema flagged the `if (raw === undefined) continue` as unnecessary since `String.split()` always returns at least one element.

3. **Fixed metric name prefix collision** — `startsWith(metricName)` could match `pgbouncer_pools_client_active_connections_total` when looking for `pgbouncer_pools_client_active_connections`. Now checks that the next character is `{` or ` ` to enforce an exact name boundary.

4. **Fixed label-order-dependent substring match** — `line.includes('database="postgres",user="postgres"')` assumed Prometheus labels appear in a specific order. Now parses labels as key-value pairs via `matchesLabels()`, making matching order-independent. This was the highest-risk silent failure — if label order changed, all pool metrics would silently become 0.

5. **Added Sentry capture for HTTP errors** — Non-OK HTTP responses from Supabase (401/403/500) were logged but never sent to Sentry. Now calls `captureException` so sustained failures trigger alerts.

6. **Fixed duplicate `eu-central-1` labels** — Both EU central replicas (`-rr-eu-central-1-cdhuu` and `-rr-eu-central-1-zoxpu`) produced the identical label `replica-eu-central-1` because `labelFromRef` stripped the unique suffix. Now keeps the full suffix so each replica gets a distinct label.

Sample output from the dev server after the fix — note the two EU central replicas now have distinct `database` labels:

```json
{"type":"db_pool_metrics","database":"primary","ref":"nfgbhsncmleckmvzblyn","client_active":302,"client_waiting":0,"server_active":1,"server_idle":10,"server_used":13,"max_client_connections":3000,"pool_size":320,"current_connections":28}
{"type":"db_pool_metrics","database":"replica-us-west-1-drobh","ref":"nfgbhsncmleckmvzblyn-rr-us-west-1-drobh","client_active":7,"client_waiting":0,"server_active":0,"server_idle":1,"server_used":1,"max_client_connections":3000,"pool_size":320,"current_connections":3}
{"type":"db_pool_metrics","database":"replica-eu-central-1-cdhuu","ref":"nfgbhsncmleckmvzblyn-rr-eu-central-1-cdhuu","client_active":129,"client_waiting":0,"server_active":1,"server_idle":5,"server_used":1,"max_client_connections":3000,"pool_size":320,"current_connections":10}
{"type":"db_pool_metrics","database":"replica-eu-central-1-zoxpu","ref":"nfgbhsncmleckmvzblyn-rr-eu-central-1-zoxpu","client_active":107,"client_waiting":0,"server_active":1,"server_idle":3,"server_used":4,"max_client_connections":3000,"pool_size":320,"current_connections":13}
```

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm format:check` — passes (oxfmt, eslint)
- [x] Tested locally with `curl` against dev server — all 4 databases scraped with correct distinct labels

## Visual Changes

N/A

## Reviewer Notes

- All changes are in a single file: `src/app/api/cron/db-pool-metrics/route.ts`
- The `database` field in Axiom logs will change for replicas (e.g. `replica-eu-central-1` → `replica-eu-central-1-cdhuu`). Any existing Axiom queries filtering on the old label values will need updating.