### PR TITLE
Remove kilo/auto-* models (replaced by kilo-auto/*)

### DIFF
--- a/src/lib/forbidden-free-models.ts
+++ b/src/lib/forbidden-free-models.ts
@@ -9,6 +9,7 @@ const forbiddenFreeModelIds: ReadonlySet<string> = new Set([
   'google/gemma-3-4b-it:free',
   'google/gemma-3n-e2b-it:free',
   'google/gemma-3n-e4b-it:free',
+  'kilo/auto-free', // discontinued variant of kilo-auto/free
   'liquid/lfm-2.5-1.2b-instruct:free',
   'liquid/lfm-2.5-1.2b-thinking:free',
   'meta-llama/llama-3.2-3b-instruct:free',

--- a/src/lib/kilo-auto-model.ts
+++ b/src/lib/kilo-auto-model.ts
@@ -223,18 +223,8 @@ export const AUTO_MODELS = [
 ];
 
 export function isKiloAutoModel(model: string) {
-  return (
-    AUTO_MODELS.some(m => m.id === model) ||
-    (Object.hasOwn(legacyMapping, model) && legacyMapping[model] !== undefined)
-  );
+  return AUTO_MODELS.some(m => m.id === model);
 }
-
-export const KILO_AUTO_FREE_MODEL_DEPRECATED = 'kilo/auto-free';
-
-const legacyMapping: Record<string, AutoModel | undefined> = {
-  'kilo/auto': KILO_AUTO_FRONTIER_MODEL,
-  [KILO_AUTO_FREE_MODEL_DEPRECATED]: KILO_AUTO_FREE_MODEL,
-};
 
 export async function resolveAutoModel(
   model: string,
@@ -242,19 +232,17 @@ export async function resolveAutoModel(
   balancePromise: Promise<number>,
   hasImages: boolean
 ): Promise<ResolvedAutoModel> {
-  const mappedModel =
-    (Object.hasOwn(legacyMapping, model) ? legacyMapping[model] : null)?.id ?? model;
-  if (mappedModel === KILO_AUTO_FREE_MODEL.id) {
+  if (model === KILO_AUTO_FREE_MODEL.id) {
     return { model: mimo_v2_pro_free_model.public_id };
   }
-  if (mappedModel === KILO_AUTO_SMALL_MODEL.id) {
+  if (model === KILO_AUTO_SMALL_MODEL.id) {
     return {
       model: (await balancePromise) > 0 ? GPT_5_NANO_ID : gpt_oss_20b_free_model.public_id,
     };
   }
   const modeResult = modeSchema.safeParse(modeHeader?.trim() ?? '');
   const mode = modeResult.success ? modeResult.data : null;
-  if (mappedModel === KILO_AUTO_BALANCED_MODEL.id) {
+  if (model === KILO_AUTO_BALANCED_MODEL.id) {
     if (hasImages) {
       return BALANCED_IMAGE_MODEL;
     }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -6,7 +6,6 @@ import {
   isKiloAutoModel,
   KILO_AUTO_BALANCED_MODEL,
   KILO_AUTO_FREE_MODEL,
-  KILO_AUTO_FREE_MODEL_DEPRECATED,
   KILO_AUTO_FRONTIER_MODEL,
   resolveAutoModel,
 } from '@/lib/kilo-auto-model';
@@ -62,7 +61,6 @@ export function isFreeModel(model: string): boolean {
   return (
     isKiloFreeModel(model) ||
     model === KILO_AUTO_FREE_MODEL.id ||
-    model === KILO_AUTO_FREE_MODEL_DEPRECATED ||
     (model ?? '').endsWith(':free') ||
     model === 'openrouter/free' ||
     isOpenRouterStealthModel(model ?? '')


### PR DESCRIPTION
These haven't been in the model selector for a while and we've improved the 404 recently: https://github.com/Kilo-Org/cloud/pull/1748