### PR TITLE
refactor(proxy): move blocked client check from FIM route to middleware

### DIFF
--- a/src/app/api/fim/completions/route.ts
+++ b/src/app/api/fim/completions/route.ts
@@ -15,7 +15,6 @@ import {
   extractFraudAndProjectHeaders,
   invalidRequestResponse,
   temporarilyUnavailableResponse,
-  upgradeRequiredResponse,
   wrapInSafeNextResponse,
   captureProxyError,
   extractHeaderAndLimitLength,
@@ -29,18 +28,6 @@ import { getBYOKforOrganization, getBYOKforUser } from '@/lib/byok';
 const MISTRAL_FIM_URL = 'https://api.mistral.ai/v1/fim/completions';
 const INCEPTION_FIM_URL = 'https://api.inceptionlabs.ai/v1/fim/completions';
 const FIM_MAX_TOKENS_LIMIT = 1000;
-
-// These client versions had a bug that caused excessive FIM endpoint requests.
-// Block them and require users to upgrade.
-const BLOCKED_FIM_USER_AGENT_REGEX = /^kilo\/7\.0\.[0-9]+$/;
-const BLOCKED_FIM_USER_AGENTS = ['kilo/7.1.0', 'kilo/7.1.1', 'kilo/7.1.2', 'kilo/7.1.3'];
-
-function isFimClientBlocked(userAgent: string | null): boolean {
-  if (!userAgent) return false;
-  return (
-    BLOCKED_FIM_USER_AGENT_REGEX.test(userAgent) || BLOCKED_FIM_USER_AGENTS.includes(userAgent)
-  );
-}
 
 type FimProvider = 'mistral' | 'inception';
 
@@ -89,10 +76,6 @@ const FIMRequestBody = z.object({
 type FIMRequestBody = z.infer<typeof FIMRequestBody>;
 
 export async function POST(request: NextRequest) {
-  if (isFimClientBlocked(request.headers.get('user-agent'))) {
-    return upgradeRequiredResponse();
-  }
-
   const requestStartedAt = performance.now();
   const requesBodyTextPromise = request.text();
 

--- a/src/middleware/withBlockedClients.ts
+++ b/src/middleware/withBlockedClients.ts
@@ -1,0 +1,28 @@
+import { type NextFetchEvent, NextResponse } from 'next/server';
+import type { MiddlewareFactory } from '@/middleware/types';
+import type { NextMiddlewareWithAuth, NextRequestWithAuth } from 'next-auth/middleware';
+
+// These client versions had a bug that caused excessive requests.
+// Block them at the middleware level so they never reach the app.
+const BLOCKED_USER_AGENT_REGEX = /^kilo\/7\.0\.[0-9]+$/;
+const BLOCKED_USER_AGENTS = new Set(['kilo/7.1.0', 'kilo/7.1.1', 'kilo/7.1.2', 'kilo/7.1.3']);
+
+function isClientBlocked(userAgent: string | null): boolean {
+  if (!userAgent) return false;
+  return BLOCKED_USER_AGENT_REGEX.test(userAgent) || BLOCKED_USER_AGENTS.has(userAgent);
+}
+
+export const withBlockedClients: MiddlewareFactory = (nextMiddleware: NextMiddlewareWithAuth) => {
+  return async (request: NextRequestWithAuth, nextFetchEvent: NextFetchEvent) => {
+    if (isClientBlocked(request.headers.get('user-agent'))) {
+      return NextResponse.json(
+        {
+          error: 'upgrade_required',
+          message: 'Please upgrade your Kilo extension to the latest version.',
+        },
+        { status: 426 }
+      );
+    }
+    return nextMiddleware(request, nextFetchEvent);
+  };
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import type { NextRequestWithAuth } from 'next-auth/middleware';
 import { NextResponse } from 'next/server';
 import { withAuthenticatedAdminApiRoutes } from './middleware/withAuthenticatedAdminApiRoutes';
+import { withBlockedClients } from './middleware/withBlockedClients';
 import { withKiloEditorCookie } from './middleware/withKiloEditorCookie';
 
 function baseProxy(request: NextRequestWithAuth) {
@@ -13,7 +14,9 @@ function baseProxy(request: NextRequestWithAuth) {
   });
 }
 
-export const proxy = withAuthenticatedAdminApiRoutes(withKiloEditorCookie(baseProxy));
+export const proxy = withBlockedClients(
+  withAuthenticatedAdminApiRoutes(withKiloEditorCookie(baseProxy))
+);
 
 export const config = {
   /*


### PR DESCRIPTION
## Summary

- Move the `isFimClientBlocked` user-agent check from `src/app/api/fim/completions/route.ts` into a new Next.js proxy middleware (`src/middleware/withBlockedClients.ts`), so blocked clients (kilo/7.0.x, kilo/7.1.0–7.1.3) are rejected with HTTP 426 before hitting any route — not just FIM.
- The response body and status code are identical to the previous `upgradeRequiredResponse()`.

## Verification

- [x] `pnpm typecheck` — passes
- [x] Verified with `curl` against local dev server:
  - Blocked UAs (`kilo/7.0.5`, `kilo/7.1.2`) → 426 on both `/api/fim/completions` and `/`
  - Non-blocked UA (`kilo/7.2.0`) and empty UA → pass through to app

## Visual Changes

N/A

## Reviewer Notes

- `withBlockedClients` is the outermost middleware wrapper so it runs first, before auth or cookie logic.
- Used a `Set` instead of an array for the exact-match blocked UAs for O(1) lookups.