### PR TITLE
feat(cloud-agent): add Slack to sidebar platform filters

### DIFF
--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -248,7 +248,7 @@ function SessionRow({
   );
 }
 
-const PLATFORM_FILTERS = ['all', 'cloud-agent', 'cli', 'extension'] as const;
+const PLATFORM_FILTERS = ['all', 'cloud-agent', 'cli', 'slack', 'extension'] as const;
 
 function platformFilterLabel(p: (typeof PLATFORM_FILTERS)[number]): string {
   switch (p) {
@@ -258,6 +258,8 @@ function platformFilterLabel(p: (typeof PLATFORM_FILTERS)[number]): string {
       return 'Cloud';
     case 'cli':
       return 'CLI';
+    case 'slack':
+      return 'Slack';
     case 'extension':
       return 'Ext';
   }
@@ -475,9 +477,11 @@ export function ChatSidebar({
                 ? 'Cloud'
                 : platformFilter === 'cli'
                   ? 'CLI'
-                  : platformFilter === 'extension'
-                    ? 'Ext'
-                    : platformFilter}
+                  : platformFilter === 'slack'
+                    ? 'Slack'
+                    : platformFilter === 'extension'
+                      ? 'Ext'
+                      : platformFilter}
               <X className="h-3 w-3 opacity-60" />
             </button>
           )}

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -46,6 +46,7 @@ export const KNOWN_PLATFORMS = [
   'cli',
   'agent-manager',
   'app-builder',
+  'slack',
 ] as const;
 
 const PAGE_SIZE = 10;


### PR DESCRIPTION
## Summary

Add Slack as a platform filter option in the cloud agent sidebar session list. Slack sessions already render a dedicated badge in the session list (`SessionsList.tsx`), but were not available as a filter option in the `ChatSidebar` dropdown. This also adds `'slack'` to `KNOWN_PLATFORMS` on the backend so that Slack sessions are not incorrectly caught by the "Extension" catch-all filter.

## Verification

- [x] `pnpm typecheck` — passed

## Visual Changes

| Before | After |
| ------ | ----- |
| Sidebar platform filter dropdown: All, Cloud, CLI, Ext | Sidebar platform filter dropdown: All, Cloud, CLI, Slack, Ext |

## Reviewer Notes

The "Extension" filter uses a `NOT IN (KNOWN_PLATFORMS)` query, so adding `'slack'` to `KNOWN_PLATFORMS` is required for correct filtering — otherwise selecting "Extension" would also return Slack sessions, and selecting "Slack" would fail to match anything via the backend.