### PR TITLE
fix(kiloclaw): scope billing lifecycle cron sweeps by subscription id

### DIFF
--- a/src/lib/kiloclaw/billing-lifecycle-cron.test.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.test.ts
@@ -28,7 +28,7 @@ jest.mock('@/lib/stripe-client', () => {
 });
 
 jest.mock('@/lib/email', () => ({
-  send: jest.fn().mockResolvedValue({ sent: true }),
+  send: jest.fn<() => Promise<{ sent: true }>>().mockResolvedValue({ sent: true }),
 }));
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {

--- a/src/lib/kiloclaw/billing-lifecycle-cron.test.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.test.ts
@@ -1,0 +1,164 @@
+process.env.KILOCLAW_BILLING_ENFORCEMENT = 'true';
+process.env.STRIPE_KILOCLAW_COMMIT_PRICE_ID ||= 'price_commit';
+process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID ||= 'price_standard';
+process.env.STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID ||= 'price_standard_intro';
+
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import { kiloclaw_subscriptions, kiloclaw_instances } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import { sandboxIdFromUserId } from '@/lib/kiloclaw/sandbox-id';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import type { User } from '@kilocode/db/schema';
+import type { runKiloClawBillingLifecycleCron as RunCronFn } from './billing-lifecycle-cron';
+
+jest.mock('@/lib/stripe-client', () => {
+  const stripeMock = {
+    subscriptions: { retrieve: jest.fn(), update: jest.fn(), list: jest.fn() },
+    subscriptionSchedules: {
+      create: jest.fn(),
+      update: jest.fn(),
+      release: jest.fn(),
+      retrieve: jest.fn(),
+    },
+    checkout: { sessions: { create: jest.fn(), list: jest.fn(), expire: jest.fn() } },
+    billingPortal: { sessions: { create: jest.fn() } },
+  };
+  return { client: stripeMock };
+});
+
+jest.mock('@/lib/email', () => ({
+  send: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
+  const mockFn = () => jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined);
+  return {
+    KiloClawInternalClient: jest.fn<() => unknown>().mockImplementation(() => ({
+      start: mockFn(),
+      stop: mockFn(),
+      provision: mockFn(),
+      destroy: mockFn(),
+      getStatus: mockFn(),
+    })),
+    KiloClawApiError: class KiloClawApiError extends Error {
+      statusCode: number;
+      responseBody: string;
+      constructor(statusCode: number, responseBody: string) {
+        super(`KiloClawApiError: ${statusCode}`);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+      }
+    },
+  };
+});
+
+jest.mock('@/lib/kiloclaw/stripe-handlers', () => ({
+  autoResumeIfSuspended: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  ensureAutoIntroSchedule: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/kiloclaw/credit-billing', () => ({
+  KILOCLAW_PLAN_COST_MICRODOLLARS: { standard: 9_000_000, commit: 48_000_000 },
+  projectPendingKiloPassBonusMicrodollars: jest.fn<() => number>().mockReturnValue(0),
+}));
+
+jest.mock('@/lib/kilo-pass/usage-triggered-bonus', () => ({
+  maybeIssueKiloPassBonusFromUsageThreshold: jest
+    .fn<() => Promise<void>>()
+    .mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/autoTopUp', () => ({
+  maybePerformAutoTopUp: jest
+    .fn<() => Promise<{ success: boolean }>>()
+    .mockResolvedValue({ success: false }),
+}));
+
+jest.mock('@/lib/kiloclaw/stripe-price-ids.server', () => ({
+  isIntroPriceId: jest.fn<() => boolean>(() => false),
+}));
+
+// ── Test setup ──────────────────────────────────────────────────────────────
+
+let runKiloClawBillingLifecycleCron: typeof RunCronFn;
+
+let user: User;
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  user = await insertTestUser({
+    google_user_email: `cron-test-${Math.random()}@example.com`,
+  });
+
+  // Dynamic import after mocks are in place
+  const mod = await import('./billing-lifecycle-cron');
+  runKiloClawBillingLifecycleCron = mod.runKiloClawBillingLifecycleCron;
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+async function createInstance(userId: string) {
+  const [instance] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      user_id: userId,
+      sandbox_id: sandboxIdFromUserId(userId),
+    })
+    .returning();
+  return instance;
+}
+
+// ── Sweep 1: Trial Expiry targets by subscription id ────────────────────────
+
+describe('Sweep 1: Trial Expiry targeting', () => {
+  it('cancels only the expired trialing subscription, not a separate active subscription', async () => {
+    const instance = await createInstance(user.id);
+
+    // Insert an expired trialing subscription (no instance_id so it doesn't
+    // conflict with the unique partial index on instance_id).
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: null,
+      plan: 'trial',
+      status: 'trialing',
+      trial_started_at: new Date(Date.now() - 14 * 86_400_000).toISOString(),
+      trial_ends_at: new Date(Date.now() - 1 * 86_400_000).toISOString(), // expired yesterday
+    });
+
+    // Insert a separate active paid subscription with the instance
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+      current_period_start: new Date().toISOString(),
+      current_period_end: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+      credit_renewal_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+      cancel_at_period_end: false,
+    });
+
+    const summary = await runKiloClawBillingLifecycleCron(db);
+    expect(summary.sweep1_trial_expiry).toBe(1);
+
+    // Fetch all subscriptions for this user
+    const subs = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+
+    const trialSub = subs.find(s => s.plan === 'trial');
+    const activeSub = subs.find(s => s.plan === 'standard');
+
+    // The expired trial should have been canceled
+    expect(trialSub).toBeDefined();
+    expect(trialSub!.status).toBe('canceled');
+    expect(trialSub!.suspended_at).not.toBeNull();
+
+    // The active paid subscription must NOT be touched
+    expect(activeSub).toBeDefined();
+    expect(activeSub!.status).toBe('active');
+    expect(activeSub!.suspended_at).toBeNull();
+  });
+});

--- a/src/lib/kiloclaw/billing-lifecycle-cron.test.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.test.ts
@@ -28,7 +28,7 @@ jest.mock('@/lib/stripe-client', () => {
 });
 
 jest.mock('@/lib/email', () => ({
-  send: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  send: jest.fn().mockResolvedValue({ sent: true }),
 }));
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {

--- a/src/lib/kiloclaw/billing-lifecycle-cron.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.ts
@@ -672,9 +672,10 @@ export async function runKiloClawBillingLifecycleCron(
   // ── Sweep 1: Trial Expiry ──────────────────────────────────────────
   const expiredTrials = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
-      email: kilocode_users.google_user_email,
       instance_id: kiloclaw_subscriptions.instance_id,
+      email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
@@ -691,26 +692,29 @@ export async function runKiloClawBillingLifecycleCron(
       // Per spec: stop/destroy failures MUST be logged and the state
       // transition MUST proceed regardless, so transient outages don't
       // leave expired accounts active.
-      try {
-        await client.stop(row.user_id, row.instance_id ?? undefined);
-      } catch (stopError) {
-        const isExpected =
-          stopError instanceof KiloClawApiError &&
-          (stopError.statusCode === 404 || stopError.statusCode === 409);
-        if (isExpected) {
-          logInfo('Sweep 1: stop() returned expected error, proceeding with state transition', {
-            user_id: row.user_id,
-            statusCode: stopError.statusCode,
-            error: stopError.message,
-          });
-        } else {
-          captureException(stopError);
-          logError('Sweep 1: stop() failed, proceeding with state transition', {
-            user_id: row.user_id,
-            error: stopError instanceof Error ? stopError.message : String(stopError),
-          });
+      // Only stop if this subscription row owns an instance; a stale row
+      // with instance_id=null has nothing to stop.
+      if (row.instance_id)
+        try {
+          await client.stop(row.user_id, row.instance_id);
+        } catch (stopError) {
+          const isExpected =
+            stopError instanceof KiloClawApiError &&
+            (stopError.statusCode === 404 || stopError.statusCode === 409);
+          if (isExpected) {
+            logInfo('Sweep 1: stop() returned expected error, proceeding with state transition', {
+              user_id: row.user_id,
+              statusCode: stopError.statusCode,
+              error: stopError.message,
+            });
+          } else {
+            captureException(stopError);
+            logError('Sweep 1: stop() failed, proceeding with state transition', {
+              user_id: row.user_id,
+              error: stopError instanceof Error ? stopError.message : String(stopError),
+            });
+          }
         }
-      }
       const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
       await database
         .update(kiloclaw_subscriptions)
@@ -719,7 +723,7 @@ export async function runKiloClawBillingLifecycleCron(
           suspended_at: now,
           destruction_deadline: destructionDeadline.toISOString(),
         })
-        .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        .where(eq(kiloclaw_subscriptions.id, row.id));
       summary.sweep1_trial_expiry++;
 
       await trySendEmail(
@@ -747,9 +751,10 @@ export async function runKiloClawBillingLifecycleCron(
   // ── Sweep 2: Subscription Period Expiry ────────────────────────────
   const expiredSubscriptions = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
-      email: kilocode_users.google_user_email,
       instance_id: kiloclaw_subscriptions.instance_id,
+      email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
@@ -763,26 +768,27 @@ export async function runKiloClawBillingLifecycleCron(
 
   for (const row of expiredSubscriptions) {
     try {
-      try {
-        await client.stop(row.user_id, row.instance_id ?? undefined);
-      } catch (stopError) {
-        const isExpected =
-          stopError instanceof KiloClawApiError &&
-          (stopError.statusCode === 404 || stopError.statusCode === 409);
-        if (isExpected) {
-          logInfo('Sweep 2: stop() returned expected error, proceeding with state transition', {
-            user_id: row.user_id,
-            statusCode: stopError.statusCode,
-            error: stopError.message,
-          });
-        } else {
-          captureException(stopError);
-          logError('Sweep 2: stop() failed, proceeding with state transition', {
-            user_id: row.user_id,
-            error: stopError instanceof Error ? stopError.message : String(stopError),
-          });
+      if (row.instance_id)
+        try {
+          await client.stop(row.user_id, row.instance_id);
+        } catch (stopError) {
+          const isExpected =
+            stopError instanceof KiloClawApiError &&
+            (stopError.statusCode === 404 || stopError.statusCode === 409);
+          if (isExpected) {
+            logInfo('Sweep 2: stop() returned expected error, proceeding with state transition', {
+              user_id: row.user_id,
+              statusCode: stopError.statusCode,
+              error: stopError.message,
+            });
+          } else {
+            captureException(stopError);
+            logError('Sweep 2: stop() failed, proceeding with state transition', {
+              user_id: row.user_id,
+              error: stopError instanceof Error ? stopError.message : String(stopError),
+            });
+          }
         }
-      }
       const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
       await database
         .update(kiloclaw_subscriptions)
@@ -790,7 +796,7 @@ export async function runKiloClawBillingLifecycleCron(
           suspended_at: now,
           destruction_deadline: destructionDeadline.toISOString(),
         })
-        .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        .where(eq(kiloclaw_subscriptions.id, row.id));
       summary.sweep2_subscription_expiry++;
 
       await trySendEmail(
@@ -862,9 +868,10 @@ export async function runKiloClawBillingLifecycleCron(
   // ── Sweep 3: Instance Destruction ──────────────────────────────────
   const destructionCandidates = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
-      email: kilocode_users.google_user_email,
       instance_id: kiloclaw_subscriptions.instance_id,
+      email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
@@ -877,37 +884,43 @@ export async function runKiloClawBillingLifecycleCron(
 
   for (const row of destructionCandidates) {
     try {
-      try {
-        await client.destroy(row.user_id, row.instance_id ?? undefined);
-      } catch (destroyError) {
-        const isExpected =
-          destroyError instanceof KiloClawApiError &&
-          (destroyError.statusCode === 404 || destroyError.statusCode === 409);
-        if (isExpected) {
-          logInfo('Sweep 3: destroy() returned expected error, proceeding with state transition', {
-            user_id: row.user_id,
-            statusCode: destroyError.statusCode,
-            error: destroyError.message,
-          });
-        } else {
-          captureException(destroyError);
-          logError('Sweep 3: destroy() failed, proceeding with state transition', {
-            user_id: row.user_id,
-            error: destroyError instanceof Error ? destroyError.message : String(destroyError),
-          });
+      if (row.instance_id)
+        try {
+          await client.destroy(row.user_id, row.instance_id);
+        } catch (destroyError) {
+          const isExpected =
+            destroyError instanceof KiloClawApiError &&
+            (destroyError.statusCode === 404 || destroyError.statusCode === 409);
+          if (isExpected) {
+            logInfo(
+              'Sweep 3: destroy() returned expected error, proceeding with state transition',
+              {
+                user_id: row.user_id,
+                statusCode: destroyError.statusCode,
+                error: destroyError.message,
+              }
+            );
+          } else {
+            captureException(destroyError);
+            logError('Sweep 3: destroy() failed, proceeding with state transition', {
+              user_id: row.user_id,
+              error: destroyError instanceof Error ? destroyError.message : String(destroyError),
+            });
+          }
         }
+      // Mark the specific instance as destroyed
+      if (row.instance_id) {
+        await database
+          .update(kiloclaw_instances)
+          .set({ destroyed_at: now })
+          .where(
+            and(eq(kiloclaw_instances.id, row.instance_id), isNull(kiloclaw_instances.destroyed_at))
+          );
       }
-      // Mark active instances as destroyed
-      await database
-        .update(kiloclaw_instances)
-        .set({ destroyed_at: now })
-        .where(
-          and(eq(kiloclaw_instances.user_id, row.user_id), isNull(kiloclaw_instances.destroyed_at))
-        );
       await database
         .update(kiloclaw_subscriptions)
         .set({ destruction_deadline: null })
-        .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        .where(eq(kiloclaw_subscriptions.id, row.id));
       summary.sweep3_instance_destruction++;
 
       await trySendEmail(
@@ -945,9 +958,10 @@ export async function runKiloClawBillingLifecycleCron(
   const fourteenDaysAgo = new Date(Date.now() - PAST_DUE_THRESHOLD_DAYS * MS_PER_DAY).toISOString();
   const pastDueRows = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
-      email: kilocode_users.google_user_email,
       instance_id: kiloclaw_subscriptions.instance_id,
+      email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
@@ -961,26 +975,27 @@ export async function runKiloClawBillingLifecycleCron(
 
   for (const row of pastDueRows) {
     try {
-      try {
-        await client.stop(row.user_id, row.instance_id ?? undefined);
-      } catch (stopError) {
-        const isExpected =
-          stopError instanceof KiloClawApiError &&
-          (stopError.statusCode === 404 || stopError.statusCode === 409);
-        if (isExpected) {
-          logInfo('Sweep 4: stop() returned expected error, proceeding with state transition', {
-            user_id: row.user_id,
-            statusCode: stopError.statusCode,
-            error: stopError.message,
-          });
-        } else {
-          captureException(stopError);
-          logError('Sweep 4: stop() failed, proceeding with state transition', {
-            user_id: row.user_id,
-            error: stopError instanceof Error ? stopError.message : String(stopError),
-          });
+      if (row.instance_id)
+        try {
+          await client.stop(row.user_id, row.instance_id);
+        } catch (stopError) {
+          const isExpected =
+            stopError instanceof KiloClawApiError &&
+            (stopError.statusCode === 404 || stopError.statusCode === 409);
+          if (isExpected) {
+            logInfo('Sweep 4: stop() returned expected error, proceeding with state transition', {
+              user_id: row.user_id,
+              statusCode: stopError.statusCode,
+              error: stopError.message,
+            });
+          } else {
+            captureException(stopError);
+            logError('Sweep 4: stop() failed, proceeding with state transition', {
+              user_id: row.user_id,
+              error: stopError instanceof Error ? stopError.message : String(stopError),
+            });
+          }
         }
-      }
       const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
       await database
         .update(kiloclaw_subscriptions)
@@ -988,7 +1003,7 @@ export async function runKiloClawBillingLifecycleCron(
           suspended_at: now,
           destruction_deadline: destructionDeadline.toISOString(),
         })
-        .where(eq(kiloclaw_subscriptions.user_id, row.user_id));
+        .where(eq(kiloclaw_subscriptions.id, row.id));
       summary.sweep4_past_due_cleanup++;
 
       await trySendEmail(

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -497,8 +497,8 @@ export async function enrollWithCredits(params: {
           commit_ends_at: commitEndsAt,
           past_due_since: null,
           cancel_at_period_end: false,
-          trial_started_at: null,
-          trial_ends_at: null,
+          // Preserve trial_started_at / trial_ends_at so historical trial
+          // data remains visible in billing status and admin views.
         },
       });
   });

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -497,8 +497,6 @@ export async function enrollWithCredits(params: {
           commit_ends_at: commitEndsAt,
           past_due_since: null,
           cancel_at_period_end: false,
-          // Preserve trial_started_at / trial_ends_at so historical trial
-          // data remains visible in billing status and admin views.
         },
       });
   });

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -479,6 +479,8 @@ export async function enrollWithCredits(params: {
         commit_ends_at: commitEndsAt,
         past_due_since: null,
         cancel_at_period_end: false,
+        trial_started_at: null,
+        trial_ends_at: null,
         // DO NOT clear suspended_at or destruction_deadline (spec rule 5d)
       })
       .onConflictDoUpdate({
@@ -495,6 +497,8 @@ export async function enrollWithCredits(params: {
           commit_ends_at: commitEndsAt,
           past_due_since: null,
           cancel_at_period_end: false,
+          trial_started_at: null,
+          trial_ends_at: null,
         },
       });
   });

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -1938,9 +1938,9 @@ describe('enrollWithCredits', () => {
     expect(sub.stripe_subscription_id).toBeNull();
     expect(sub.credit_renewal_at).not.toBeNull();
     expect(sub.cancel_at_period_end).toBe(false);
-    // Stale trial fields must be cleared on conversion to paid
-    expect(sub.trial_started_at).toBeNull();
-    expect(sub.trial_ends_at).toBeNull();
+    // Trial dates are preserved for historical visibility in billing status / admin views
+    expect(sub.trial_started_at).not.toBeNull();
+    expect(sub.trial_ends_at).not.toBeNull();
 
     // Verify credit deduction at intro price ($4, not $9)
     const txns = await db
@@ -2100,10 +2100,9 @@ describe('enrollWithCredits', () => {
 
     expect(sub.status).toBe('active');
     expect(sub.plan).toBe('standard');
-    // Stale trial fields must be cleared so the billing lifecycle cron
-    // does not treat this paid subscription as an expired trial.
-    expect(sub.trial_started_at).toBeNull();
-    expect(sub.trial_ends_at).toBeNull();
+    // Trial dates are preserved for historical visibility
+    expect(sub.trial_started_at).not.toBeNull();
+    expect(sub.trial_ends_at).not.toBeNull();
   });
 
   it('applies intro price for canceled-trial subscriber', async () => {

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -1938,6 +1938,9 @@ describe('enrollWithCredits', () => {
     expect(sub.stripe_subscription_id).toBeNull();
     expect(sub.credit_renewal_at).not.toBeNull();
     expect(sub.cancel_at_period_end).toBe(false);
+    // Stale trial fields must be cleared on conversion to paid
+    expect(sub.trial_started_at).toBeNull();
+    expect(sub.trial_ends_at).toBeNull();
 
     // Verify credit deduction at intro price ($4, not $9)
     const txns = await db
@@ -2097,6 +2100,10 @@ describe('enrollWithCredits', () => {
 
     expect(sub.status).toBe('active');
     expect(sub.plan).toBe('standard');
+    // Stale trial fields must be cleared so the billing lifecycle cron
+    // does not treat this paid subscription as an expired trial.
+    expect(sub.trial_started_at).toBeNull();
+    expect(sub.trial_ends_at).toBeNull();
   });
 
   it('applies intro price for canceled-trial subscriber', async () => {


### PR DESCRIPTION
## Summary

### Problem

A customer purchased a KiloPass subscription that triggered `enrollWithCredits()` to create an active, credit-funded KiloClaw subscription. ~12 hours later, the billing lifecycle cron canceled and stopped the paid instance — locking the user out for 4 days. The root cause: the cron's sweep UPDATE and stop/destroy calls targeted by `user_id`, so when Sweep 1 processed an expired trial row, it canceled **all** subscription rows for that user and stopped their current active instance. Investigation found 11 users with the same multi-row pattern (stale trial + active paid), all of whom were at risk.

### Solution

- Billing lifecycle cron Sweeps 1–4 now target their UPDATE statements by `kiloclaw_subscriptions.id` (subscription primary key) instead of `user_id`, preventing one subscription's expiry from canceling/suspending a different subscription belonging to the same user.
- Sweeps 1, 2, and 4 now pass `instance_id` to `client.stop()` and guard on its presence, so a stale subscription row without an instance cannot stop the user's current active instance.
- Sweep 3 now passes `instance_id` to `client.destroy()` and scopes the `kiloclaw_instances` UPDATE by `kiloclaw_instances.id` instead of `user_id`.
- `enrollWithCredits()` INSERT path explicitly sets `trial_started_at: null` and `trial_ends_at: null` for fresh rows (no trial history). The `onConflictDoUpdate` path intentionally preserves trial dates so billing status and admin views retain historical trial data.
- Two existing `enrollWithCredits` tests now assert trial dates are preserved (not nulled) after trial-to-credit conversion.
- New `billing-lifecycle-cron.test.ts` verifies Sweep 1 cancels only the expired trialing subscription and leaves a separate active subscription untouched.

### Why this approach

Targeting by subscription `id` is strictly safer than a compound WHERE clause (`status = 'trialing' AND user_id = ?`) — it is immune to any future scenario where the SELECT and UPDATE WHERE clauses drift apart. Scoping stop/destroy by `instance_id` is the natural complement: without it, narrowing the DB update while leaving the API call broad would create a mismatch where the wrong instance gets stopped but its subscription stays active. Trial dates are preserved on conversion rather than nulled because they are harmless with id-scoped sweeps (Sweep 1 filters on `status = 'trialing'`, which excludes converted `active` rows regardless of `trial_ends_at`), and the billing status UI / admin views read them for historical display.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm exec oxlint src/lib/kiloclaw/billing-lifecycle-cron.test.ts` — 0 warnings, 0 errors
- [x] `pnpm exec oxfmt --list-different .` — no formatting issues
- [x] `jest src/routers/kiloclaw-billing-router.test.ts` — 88/88 tests pass (all `enrollWithCredits` tests pass with trial-date preservation assertions)
- [x] `jest src/lib/kiloclaw/billing-lifecycle-cron.test.ts` — 1/1 test passes (sweep targeting test)
- [x] Queried production database: 0 users found with damage signature (credit deduction + premature cancellation). 11 users found with multi-row pattern (stale trial + active paid) — all safe with the fix.

## Visual Changes

N/A

## Reviewer Notes

- **Risk area**: The `if (row.instance_id) try { ... }` pattern in sweeps 1/2/4 means a subscription row with `instance_id = null` will have its DB status updated (canceled/suspended) but no `client.stop()` call is made. This is correct — a row without an instance has nothing to stop — but worth verifying against the spec.
- **Sweep 3 instance scoping**: The `kiloclaw_instances` UPDATE changed from `WHERE user_id = ?` to `WHERE id = ? AND destroyed_at IS NULL`. If a user has multiple instances and only one is tied to the expiring subscription, the others are now left alone.
- **Trial date preservation**: The `onConflictDoUpdate` path in `enrollWithCredits()` intentionally does **not** null `trial_started_at`/`trial_ends_at`. The INSERT path does (for fresh rows with no trial history). This was a deliberate decision after reviewing all read sites — every access gate and cron query guards on `status = 'trialing'` before reading trial dates.
- **Stale trial rows**: 11 users have orphaned trial subscription rows alongside active paid subscriptions. These are inert with the fix but could be cleaned up with a targeted DELETE if desired.
- **No schema changes**: No migrations needed.