### PR TITLE
chore(cloud-agent): bump kilocode CLI from 7.0.50 to 7.1.11

### DIFF
--- a/cloud-agent-next/Dockerfile.dev
+++ b/cloud-agent-next/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.7.13
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.0.50"
+ARG KILOCODE_CLI_VERSION="7.1.11"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -137,7 +137,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-4",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.0.50",
+        "KILOCODE_CLI_VERSION": "7.1.11",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 1800,
@@ -147,7 +147,7 @@
       "image": "./Dockerfile",
       "instance_type": "standard-2",
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.0.50",
+        "KILOCODE_CLI_VERSION": "7.1.11",
       },
       "max_instances": 100,
       "rollout_active_grace_period": 1800,
@@ -288,7 +288,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.0.50",
+            "KILOCODE_CLI_VERSION": "7.1.11",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -298,7 +298,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-2",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.0.50",
+            "KILOCODE_CLI_VERSION": "7.1.11",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,

--- a/cloud-agent-next/wrapper/package.json
+++ b/cloud-agent-next/wrapper/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@kilocode/sdk": "7.0.50"
+    "@kilocode/sdk": "7.1.11"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,8 +664,8 @@ importers:
   cloud-agent-next/wrapper:
     dependencies:
       '@kilocode/sdk':
-        specifier: 7.0.50
-        version: 7.0.50
+        specifier: 7.1.11
+        version: 7.1.11
     devDependencies:
       '@types/bun':
         specifier: latest
@@ -3923,8 +3923,8 @@ packages:
   '@kilocode/sdk@7.0.37':
     resolution: {integrity: sha512-t7HEjYpAuW3IdbEp+2VYQPFLhidYFSmWK3nl6vWri0QBNh+spQcotdMYENNmv/HQOAXr84pXgOFtc8YCEOz5wQ==}
 
-  '@kilocode/sdk@7.0.50':
-    resolution: {integrity: sha512-3d2mILMuqSNr8Csi2d9feNY8gC/bYqlErNyfMfyVxth8qYMMq1a9PvkdpoAK3FGiYs1jj4o3eixXNKhWdhUL2g==}
+  '@kilocode/sdk@7.1.11':
+    resolution: {integrity: sha512-ZebBy/M77eY3GI7/SmkNaDX9gjkCHG9w/lE0qH3wkmlEb6t2XuR2BBNvusLLmb876rPoNj6KZ6Gu4PLLMzNCKw==}
 
   '@lottiefiles/dotlottie-react@0.17.15':
     resolution: {integrity: sha512-4wYAjsJhM28eUvJ/gT3KRM6fcyT7EM9n7PDrP71LaBTacc6bSN43qFTSJc1Li3QxUiraz23p0Q8EJBzXo8DsRw==}
@@ -17380,7 +17380,7 @@ snapshots:
 
   '@kilocode/sdk@7.0.37': {}
 
-  '@kilocode/sdk@7.0.50': {}
+  '@kilocode/sdk@7.1.11': {}
 
   '@lottiefiles/dotlottie-react@0.17.15(react@19.2.4)':
     dependencies:
@@ -21701,7 +21701,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -27451,7 +27451,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.28.6
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary

Bump the Kilocode CLI version from 7.0.50 to 7.1.11 across cloud-agent-next. Updates `Dockerfile.dev`, `wrangler.jsonc` (all four container image definitions), `wrapper/package.json` (`@kilocode/sdk`), and the lockfile.

## Verification

- [x] `pnpm install` succeeds
- [x] Pre-push hooks (format check, typecheck) passed

## Visual Changes

N/A

## Reviewer Notes

Straightforward version bump — no config or logic changes.