### PR TITLE
fix(middleware): scope blocked client check to /api/fim/completions only

### DIFF
--- a/src/middleware/withBlockedClients.ts
+++ b/src/middleware/withBlockedClients.ts
@@ -14,7 +14,10 @@ function isClientBlocked(userAgent: string | null): boolean {
 
 export const withBlockedClients: MiddlewareFactory = (nextMiddleware: NextMiddlewareWithAuth) => {
   return async (request: NextRequestWithAuth, nextFetchEvent: NextFetchEvent) => {
-    if (isClientBlocked(request.headers.get('user-agent'))) {
+    if (
+      request.nextUrl.pathname === '/api/fim/completions' &&
+      isClientBlocked(request.headers.get('user-agent'))
+    ) {
       return NextResponse.json(
         {
           error: 'upgrade_required',


### PR DESCRIPTION
## Summary

The `withBlockedClients` middleware was rejecting **all** requests from client versions affected by an excessive-request bug (kilo 7.0.x and 7.1.0–7.1.3). This narrows the block to only `/api/fim/completions`, which is the endpoint those clients were hammering. Other API endpoints now work normally for users on those versions.

## Verification

- [x] `pnpm typecheck` — passed (no errors)
- [x] `pnpm oxfmt --list-different .` — passed
- [x] Pre-push hooks passed

## Visual Changes

N/A

## Reviewer Notes

Single-line condition change in `withBlockedClients.ts`. The path check is evaluated first (cheap string comparison) before the user-agent check, so there's no performance concern.