### PR TITLE
feat(trpc): add opt-in timing middleware for procedure duration logging

### DIFF
--- a/src/lib/trpc/init.ts
+++ b/src/lib/trpc/init.ts
@@ -74,10 +74,29 @@ const sentryMiddleware = t.middleware(
   })
 );
 
+const timingMiddleware = t.middleware(async ({ path, type, ctx, next }) => {
+  if (process.env.TRPC_TIMING_LOGGING !== '1') return next();
+
+  const start = performance.now();
+  const result = await next();
+  const durationMs = performance.now() - start;
+  console.log(
+    JSON.stringify({
+      type: 'trpc_timing',
+      path,
+      procedureType: type, // 'query' | 'mutation' | 'subscription'
+      durationMs: Math.round(durationMs),
+      ok: result.ok,
+      userId: ctx.user.id,
+    })
+  );
+  return result;
+});
+
 // Base router and procedure helpers
 export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;
-export const baseProcedure = t.procedure.use(sentryMiddleware);
+export const baseProcedure = t.procedure.use(timingMiddleware).use(sentryMiddleware);
 
 // Admin-only procedure
 export const adminProcedure = baseProcedure.use(async ({ ctx, next }) => {


### PR DESCRIPTION
## Summary

Add a tRPC middleware that logs procedure execution time as structured JSON when `TRPC_TIMING_LOGGING=1` is set. The middleware is gated behind the env var so it has zero overhead in production by default — it calls `next()` immediately when the flag is absent.

When enabled, each procedure call emits a JSON log line with:
- `path` — the tRPC procedure path
- `procedureType` — `query`, `mutation`, or `subscription`
- `durationMs` — wall-clock execution time (rounded)
- `ok` — whether the procedure succeeded
- `userId` — the authenticated user

The middleware runs before the existing Sentry middleware in the chain.

## Verification

- [x] `pnpm format:check` — passed (0 warnings, 0 errors)
- [x] `oxlint` — passed (0 warnings, 0 errors)
- [x] `pnpm typecheck` — passed
- [x] Pre-push hooks passed

## Visual Changes

N/A

## Reviewer Notes

- The middleware is a no-op unless `TRPC_TIMING_LOGGING=1` — safe to merge without any production impact.
- Positioned before `sentryMiddleware` in the chain so timing captures the full procedure duration excluding Sentry overhead.