### PR TITLE
chore(kiloclaw): bump @kilocode/cli to 7.1.13 and auto-upgrade at startup

### DIFF
--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -58,7 +58,7 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#catrielmuller/att
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@7.0.46
+RUN npm install -g @kilocode/cli@latest
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -58,7 +58,7 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#catrielmuller/att
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@latest
+RUN npm install -g @kilocode/cli@7.1.13
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/Dockerfile.local
+++ b/kiloclaw/Dockerfile.local
@@ -59,7 +59,7 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#catrielmuller/att
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@7.0.46
+RUN npm install -g @kilocode/cli@latest
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/Dockerfile.local
+++ b/kiloclaw/Dockerfile.local
@@ -59,7 +59,7 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#catrielmuller/att
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@latest
+RUN npm install -g @kilocode/cli@7.1.13
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/kiloclaw/controller/src/index.ts
+++ b/kiloclaw/controller/src/index.ts
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import { execFile } from 'node:child_process';
 import { Duplex, Readable } from 'node:stream';
 import { Hono } from 'hono';
 import {
@@ -416,6 +417,27 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     console.log(
       `[controller] Ready version=${CONTROLLER_VERSION} commit=${CONTROLLER_COMMIT} requireProxyToken=${config.requireProxyToken} wsIdleTimeoutMs=${config.wsIdleTimeoutMs} wsHandshakeTimeoutMs=${config.wsHandshakeTimeoutMs} maxWsConnections=${config.maxWsConnections}`
     );
+
+    // ── Background: upgrade Kilo CLI ────────────────────────────────────
+    // The Docker image bakes in a pinned version; this upgrades to the
+    // latest release in the background so the instance always has the
+    // newest CLI without requiring an image rebuild.
+    if (env.KILOCLAW_KILO_CLI === 'true') {
+      // Strip NPM_CONFIG_PREFIX so the install overwrites the system-wide
+      // binary in /usr/local/bin instead of writing to the per-user prefix.
+      const upgradeEnv = { ...process.env };
+      delete upgradeEnv.NPM_CONFIG_PREFIX;
+      execFile('npm', ['install', '-g', '@kilocode/cli@latest'], { env: upgradeEnv }, err => {
+        if (err) {
+          console.warn(
+            '[kilo-cli] Background upgrade failed (using baked-in version):',
+            err.message
+          );
+        } else {
+          console.log('[kilo-cli] Upgraded to latest version');
+        }
+      });
+    }
   } catch (err) {
     const fullError = err instanceof Error ? err.message : String(err);
     controllerState.current = { state: 'degraded', error: toPublicDegradedError('gateway-start') };


### PR DESCRIPTION
## Summary

- Updates both `kiloclaw/Dockerfile` and `kiloclaw/Dockerfile.local` to pin `@kilocode/cli@7.1.13` (latest as of today, up from `7.0.46`).
- Adds a fire-and-forget background upgrade (`npm install -g @kilocode/cli@latest`) in the controller's startup sequence (after the gateway is ready). This ensures every instance picks up the newest CLI release without requiring a Docker image rebuild.
- The baked-in version serves as a fallback if the background upgrade fails.
- The upgrade strips `NPM_CONFIG_PREFIX` from the child process env so it overwrites the system-wide binary in `/usr/local/bin` rather than the per-user prefix directory.

## Verification

- `pnpm typecheck` — passed
- `pnpm test` (kiloclaw) — 1147 tests passed
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format:check` — passed

## Visual Changes

N/A

## Reviewer Notes

The upgrade only runs when the `KILOCLAW_KILO_CLI` feature flag is `true`. It's completely non-blocking — the gateway is already serving by the time the upgrade starts, so there's zero impact on instance readiness.