### PR TITLE
fix(gastown): add dispatch circuit breaker to prevent infinite retry loops

### DIFF
--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -43,10 +43,12 @@ const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 20;
 const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
 
 /**
- * Town-level dispatch circuit breaker. Counts beads that have definitively
- * failed dispatch — either already in 'failed' status or having exhausted
- * all dispatch attempts — within the recent window. Healthy in-progress
- * beads are excluded so normal concurrent work doesn't trip the breaker.
+ * Town-level dispatch circuit breaker. Counts beads with at least one
+ * dispatch attempt in the recent window that have not yet closed
+ * successfully. This captures beads in active retry loops (in_progress
+ * after a failed container start), beads that have been explicitly
+ * failed, and beads that exhausted all attempts — while excluding
+ * beads that eventually succeeded (status = 'closed').
  */
 function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
   const rows = z
@@ -59,10 +61,8 @@ function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
           SELECT count(*) as failure_count
           FROM ${beads}
           WHERE ${beads.last_dispatch_attempt_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')
-            AND (
-              ${beads.status} = 'failed'
-              OR ${beads.dispatch_attempts} >= ${MAX_DISPATCH_ATTEMPTS}
-            )
+            AND ${beads.dispatch_attempts} > 0
+            AND ${beads.status} != 'closed'
         `,
         []
       ),


### PR DESCRIPTION
## Summary

Fixes #1653 — dispatch failures had no effective circuit breaker, causing infinite retry loops that waste compute and mask root causes.

**Per-bead dispatch attempt tracking**: Adds `dispatch_attempts` and `last_dispatch_attempt_at` columns to the beads table. The counter lives on the bead (not the agent), so it survives agent re-creation and `hookBead` cycles. The previous `dispatch_attempts = 0` reset in `hookBead` — the root cause of the infinite loop — is removed. `MAX_DISPATCH_ATTEMPTS` is lowered from 20 to 5.

**Exponential backoff**: Dispatch cooldown scales with attempt count (2 min → 5 min → 10 min → 30 min), replacing the flat 2-minute cooldown for all retries.

**Town-level circuit breaker**: If ≥ 20 beads have failed dispatch within a 30-minute window, all `dispatch_agent` actions are suppressed and the mayor is notified. Applied to both `reconcileBeads` and `reconcileReviewQueue`.

**Failure handling improvements**: Beads at the dispatch cap are failed (not reopened) in Rule 3 (stale in_progress reset), triage RESTART, and triage REASSIGN_BEAD paths. Dispatch failure analytics events now include a `reason` field (`'container returned false'` or `err.message`).

Files changed: `beads.table.ts`, `Town.do.ts`, `actions.ts`, `agents.ts`, `beads.ts`, `reconciler.ts`, `scheduling.ts`, `analytics.util.ts`.

## Verification

- [x] Code review of all 8 changed files against issue requirements
- [x] Confirmed single commit `5ac5e51e` on branch with expected diff against main
- [x] Verified no existing PR from this branch

## Visual Changes

N/A

## Reviewer Notes

- The migration in `beads.table.ts` uses `ALTER TABLE ADD COLUMN` wrapped in the existing idempotent migration loop in `beads.ts`, so re-runs on already-migrated DOs are safe.
- The `dispatch_attempts` increment happens in two places (`actions.ts` applyAction and `scheduling.ts` dispatchAgent) because these are two distinct dispatch code paths — not a double-increment bug. The rework specifically fixed a prior double-increment issue where both paths ran for the same dispatch.
- The circuit breaker query uses raw SQL string interpolation for the window minutes constant; this is safe since it's a hardcoded numeric constant, not user input.