### PR TITLE
fix(claw): navigate to personal dashboard from subscription dialog

### DIFF
--- a/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
+++ b/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
@@ -169,7 +169,7 @@ export function AccessLockedDialog({
   }
 
   function handleDismiss() {
-    router.push('/');
+    router.push('/profile');
   }
 
   const isCreditFunded =


### PR DESCRIPTION
## Summary

### Problem

The "Go to Dashboard" link in the KiloClaw subscription-required dialog (`AccessLockedDialog`) navigates to `/`, which uses `getProfileRedirectPath` to determine the destination. For users who belong to exactly one organization with an active subscription, this redirects to `/organizations/{orgId}` — even though KiloClaw is a personal-only feature with no org-scoped route.

### Solution

- Changed the dismiss navigation target from `/` to `/profile`, which is the personal dashboard.

### Why this approach

The only alternative was making the root redirect smarter (e.g. sniffing the referrer), but that adds complexity to a shared redirect path for a problem scoped entirely to this dialog. Hardcoding `/profile` is correct because KiloClaw has no org route — users are always in a personal context here.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` — passed
- [x] Pre-push hooks — passed

## Visual Changes

N/A

## Reviewer Notes

- Single-line navigation target swap from `/` to `/profile` in `handleDismiss`.
- The dialog's X button and backdrop click also call `handleDismiss`, so they benefit from the same fix.
- No risk to billing flows, subscription logic, or dialog rendering.