### PR TITLE
fix(tracking): only resolve signup product when callbackPath was explicitly provided

### DIFF
--- a/src/app/users/after-sign-in/route.tsx
+++ b/src/app/users/after-sign-in/route.tsx
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
       // after account verification completes.
       const product = resolveSignupProduct(
         callbackPath && isValidCallbackPath(callbackPath) ? responsePath : null,
-        !!url.searchParams.get('source'),
+        !!url.searchParams.get('source')
       );
       if (product) {
         PostHogClient().capture({

--- a/src/app/users/after-sign-in/route.tsx
+++ b/src/app/users/after-sign-in/route.tsx
@@ -49,7 +49,10 @@ export async function GET(request: NextRequest) {
       // callbackPath query param, so the value cannot be user-tampered. This
       // runs exactly once per signup because has_validation_stytch is set
       // after account verification completes.
-      const product = resolveSignupProduct(responsePath, !!url.searchParams.get('source'));
+      const product = resolveSignupProduct(
+        callbackPath && isValidCallbackPath(callbackPath) ? responsePath : null,
+        !!url.searchParams.get('source'),
+      );
       if (product) {
         PostHogClient().capture({
           distinctId: user.google_user_email,


### PR DESCRIPTION
## Summary

Addresses St0rmz1's review comment on #1649.

`resolveSignupProduct` was being called with `responsePath`, which could be set by `getProfileRedirectPath(user)` when no `callbackPath` was explicitly provided. If `getProfileRedirectPath` ever returned a product-prefixed path (e.g. `/cloud-agent/...`) for a new user, they would be misattributed even though they signed up generically.

Fix: pass `null` to `resolveSignupProduct` when `callbackPath` was not explicitly provided, so the product is only resolved from an explicit entry-point signal.

## Verification

- Typecheck passes (pre-existing `stream-chat` type errors in `ChatTab.tsx`, unrelated)
- `getProfileRedirectPath` currently only returns `/profile` or `/organizations/<id>` so there is no active bug, but the fix is the right defensive posture

## Visual Changes

N/A

## Reviewer Notes

No behavioral change today — `getProfileRedirectPath` cannot currently return a product-prefixed path. This is purely a defensive fix to prevent future misattribution if that function changes.